### PR TITLE
docs: Replace the confusing word with official defination

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -73,7 +73,7 @@ message UpstreamHttpProtocolOptions {
 
 // Configures the alternate protocols cache which tracks alternate protocols that can be used to
 // make an HTTP connection to an origin server. See https://tools.ietf.org/html/rfc7838 for
-// HTTP Alternate Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
+// HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
 message AlternateProtocolsCacheOptions {
   // The name of the cache. Multiple named caches allow independent alternate protocols cache

--- a/api/envoy/config/core/v4alpha/protocol.proto
+++ b/api/envoy/config/core/v4alpha/protocol.proto
@@ -75,7 +75,7 @@ message UpstreamHttpProtocolOptions {
 
 // Configures the alternate protocols cache which tracks alternate protocols that can be used to
 // make an HTTP connection to an origin server. See https://tools.ietf.org/html/rfc7838 for
-// HTTP Alternate Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
+// HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
 message AlternateProtocolsCacheOptions {
   option (udpa.annotations.versioning).previous_message_type =

--- a/envoy/http/alternate_protocols_cache.h
+++ b/envoy/http/alternate_protocols_cache.h
@@ -17,7 +17,7 @@ namespace Http {
 
 /**
  * Tracks alternate protocols that can be used to make an HTTP connection to an origin server.
- * See https://tools.ietf.org/html/rfc7838 for HTTP Alternate Services and
+ * See https://tools.ietf.org/html/rfc7838 for HTTP Alternative Services and
  * https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04 for the
  * "HTTPS" DNS resource record.
  */

--- a/generated_api_shadow/envoy/config/core/v3/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v3/protocol.proto
@@ -73,7 +73,7 @@ message UpstreamHttpProtocolOptions {
 
 // Configures the alternate protocols cache which tracks alternate protocols that can be used to
 // make an HTTP connection to an origin server. See https://tools.ietf.org/html/rfc7838 for
-// HTTP Alternate Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
+// HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
 message AlternateProtocolsCacheOptions {
   // The name of the cache. Multiple named caches allow independent alternate protocols cache

--- a/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
@@ -76,7 +76,7 @@ message UpstreamHttpProtocolOptions {
 
 // Configures the alternate protocols cache which tracks alternate protocols that can be used to
 // make an HTTP connection to an origin server. See https://tools.ietf.org/html/rfc7838 for
-// HTTP Alternate Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
+// HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
 message AlternateProtocolsCacheOptions {
   option (udpa.annotations.versioning).previous_message_type =


### PR DESCRIPTION
Replace the confusing word with official defination

Signed-off-by: Le Yao <le.yao@intel.com>

Commit Message: Replace the confusing word with official defination
Additional Description: In the proto and doc comments, sometimes it is `HTTP Alrernate Services`, and sometimes it is `HTTP Alternative Services`. And the official defination is  `HTTP Alternative Services`, so replace it to make it more clear.
Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
