### PR TITLE
[WIP]: count sent and received bytes for http stream

### DIFF
--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -396,7 +396,7 @@ public:
 
   virtual uint64_t receivedBytes() PURE;
 
-  virtual void updateReceivedBytes(size_t newly_sent_bytes) PURE;
+  virtual void updateReceivedBytes(size_t newly_received_bytes) PURE;
 };
 
 /**

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -389,6 +389,14 @@ public:
    * @param the account to assign this stream.
    */
   virtual void setAccount(Buffer::BufferMemoryAccountSharedPtr account) PURE;
+
+  virtual uint64_t sentBytes() PURE;
+
+  virtual void updateSentBytes(size_t newly_sent_bytes) PURE;
+
+  virtual uint64_t receivedBytes() PURE;
+
+  virtual void updateReceivedBytes(size_t newly_sent_bytes) PURE;
 };
 
 /**

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1328,7 +1328,7 @@ public:
    * Reset the stream. No events will fire beyond this point.
    * @param reason supplies the reset reason.
    */
-  virtual void resetStream() PURE;
+  virtual void resetStream(StreamInfo::StreamInfo&) PURE;
 
   /**
    * Sets the upstream to use the following account.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1326,15 +1326,16 @@ public:
   virtual void readDisable(bool disable) PURE;
   /**
    * Reset the stream. No events will fire beyond this point.
-   * @param reason supplies the reset reason.
    */
-  virtual void resetStream(StreamInfo::StreamInfo&) PURE;
+  virtual void resetStream() PURE;
 
   /**
    * Sets the upstream to use the following account.
    * @param the account to assign the generic upstream.
    */
   virtual void setAccount(Buffer::BufferMemoryAccountSharedPtr account) PURE;
+
+  virtual void getStreamInfomation(StreamInfo::StreamInfo& stream_info) PURE;
 };
 
 using GenericConnPoolPtr = std::unique_ptr<GenericConnPool>;

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -291,11 +291,13 @@ public:
    * @param bytes_received denotes number of bytes to add to total received bytes.
    */
   virtual void addBytesReceived(uint64_t bytes_received) PURE;
+  virtual void setWireBytesReceived(uint64_t wire_bytes_received) PURE;
 
   /**
    * @return the number of body bytes received in the request.
    */
   virtual uint64_t bytesReceived() const PURE;
+  virtual uint64_t wireBytesReceived() const PURE;
 
   /**
    * @return the protocol of the request.
@@ -415,10 +417,14 @@ public:
    */
   virtual void addBytesSent(uint64_t bytes_sent) PURE;
 
+  virtual void setWireBytesSent(uint64_t wire_bytes_sent) PURE;
+
   /**
    * @return the number of body bytes sent in the response.
    */
   virtual uint64_t bytesSent() const PURE;
+
+  virtual uint64_t wireBytesSent() const PURE;
 
   /**
    * @return whether response flag is set or not.

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -257,9 +257,7 @@ void StreamEncoderImpl::encodeData(Buffer::Instance& data, bool end_stream) {
   }
 }
 
-void StreamEncoderImpl::flushOutput() {
-    updateSentBytes(connection_.flushOutput());
-  }
+void StreamEncoderImpl::flushOutput() { updateSentBytes(connection_.flushOutput()); }
 
 void StreamEncoderImpl::encodeTrailersBase(const HeaderMap& trailers) {
   if (!connection_.enableTrailers()) {

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -560,9 +560,7 @@ Http::Status ClientConnectionImpl::dispatch(Buffer::Instance& data) {
     return codecProtocolError("http/1.1 protocol error: extraneous data after response complete");
   }
   if (pending_response_.has_value()) {
-    static_cast<StreamEncoder&>(pending_response_.value().encoder_)
-        .getStream()
-        .updateReceivedBytes(data.length());
+    pending_response_.value().encoder_.getStream().updateReceivedBytes(data.length());
   }
   return status;
 }

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <bits/stdint-uintn.h>
 #include <cstdint>
 #include <list>
 #include <memory>

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <bits/stdint-uintn.h>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -132,6 +133,8 @@ private:
   void encodeFormattedHeader(absl::string_view key, absl::string_view value,
                              HeaderKeyFormatterOptConstRef formatter);
 
+  void flushOutput();
+
   absl::string_view details_;
   uint64_t sent_bytes_{0};
   uint64_t received_bytes_{0};
@@ -212,7 +215,7 @@ public:
   /**
    * Flush all pending output from encoding.
    */
-  void flushOutput(bool end_encode = false);
+  uint64_t flushOutput(bool end_encode = false);
 
   void addToBuffer(absl::string_view data);
   void addCharToBuffer(char c);

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -79,13 +79,15 @@ public:
 
   void clearReadDisableCallsForTests() { read_disable_calls_ = 0; }
 
-  uint64_t sentBytes() override { return 0; }
+  uint64_t sentBytes() override { return sent_bytes_; }
 
-  void updateSentBytes(size_t) override {}
+  void updateSentBytes(size_t newly_sent_bytes) override { sent_bytes_ += newly_sent_bytes; }
 
-  uint64_t receivedBytes() override { return 0; }
+  uint64_t receivedBytes() override { return received_bytes_; }
 
-  void updateReceivedBytes(size_t) override {}
+  void updateReceivedBytes(size_t newly_received_bytes) override {
+    received_bytes_ += newly_received_bytes;
+  }
 
 protected:
   StreamEncoderImpl(ConnectionImpl& connection);
@@ -131,6 +133,8 @@ private:
                              HeaderKeyFormatterOptConstRef formatter);
 
   absl::string_view details_;
+  uint64_t sent_bytes_{0};
+  uint64_t received_bytes_{0};
 };
 
 /**

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -79,6 +79,14 @@ public:
 
   void clearReadDisableCallsForTests() { read_disable_calls_ = 0; }
 
+  uint64_t sentBytes() override { return 0; }
+
+  void updateSentBytes(size_t) override {}
+
+  uint64_t receivedBytes() override { return 0; }
+
+  void updateReceivedBytes(size_t) override {}
+
 protected:
   StreamEncoderImpl(ConnectionImpl& connection);
   void encodeHeadersBase(const RequestOrResponseHeaderMap& headers, absl::optional<uint64_t> status,

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1004,6 +1004,10 @@ int ConnectionImpl::onInvalidFrame(int32_t stream_id, int error_code) {
 int ConnectionImpl::onBeforeFrameSend(const nghttp2_frame* frame) {
   ENVOY_CONN_LOG(trace, "about to send frame type={}, flags={}", connection_,
                  static_cast<uint64_t>(frame->hd.type), static_cast<uint64_t>(frame->hd.flags));
+  StreamImpl* stream = getStream(frame->hd.stream_id);
+  if (stream != nullptr) {
+    stream->updateSentBytes(frame->hd.length + 9);
+  }
   ASSERT(!is_outbound_flood_monitored_control_frame_);
   // Flag flood monitored outbound control frames.
   is_outbound_flood_monitored_control_frame_ =

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -781,7 +781,10 @@ Status ConnectionImpl::onBeforeFrameReceived(const nghttp2_frame_hd* hd) {
   ENVOY_CONN_LOG(trace, "about to recv frame type={}, flags={}, stream_id={}", connection_,
                  static_cast<uint64_t>(hd->type), static_cast<uint64_t>(hd->flags), hd->stream_id);
   current_stream_id_ = hd->stream_id;
-
+  StreamImpl* stream = getStream(hd->stream_id);
+  if (stream != nullptr) {
+    stream->updateReceivedBytes(hd->length + 9);
+  }
   // Track all the frames without padding here, since this is the only callback we receive
   // for some of them (e.g. CONTINUATION frame, frames sent on closed streams, etc.).
   // HEADERS frame is tracked in onBeginHeaders(), DATA frame is tracked in onFrameReceived().

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <bits/stdint-uintn.h>
 #include <cstdint>
 #include <functional>
 #include <list>

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bits/stdint-uintn.h>
 #include <cstdint>
 #include <functional>
 #include <list>
@@ -291,10 +292,15 @@ protected:
     void encodeDataHelper(Buffer::Instance& data, bool end_stream,
                           bool skip_encoding_empty_trailers);
 
+    uint32_t sentBytes() { return sent_bytes_; }
+
+    void updateSentBytes(size_t newly_sent_bytes) { sent_bytes_ += newly_sent_bytes; }
+
     ConnectionImpl& parent_;
     int32_t stream_id_{-1};
     uint32_t unconsumed_bytes_{0};
     uint32_t read_disable_count_{0};
+    size_t sent_bytes_{0};
 
     Buffer::BufferMemoryAccountSharedPtr buffer_memory_account_;
     // Note that in current implementation the watermark callbacks of the pending_recv_data_ are

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -298,7 +298,9 @@ protected:
 
     uint64_t receivedBytes() override { return received_bytes_; }
 
-    void updateReceivedBytes(size_t newly_sent_bytes) override { sent_bytes_ += newly_sent_bytes; }
+    void updateReceivedBytes(size_t newly_received_bytes) override {
+      received_bytes_ += newly_received_bytes;
+    }
 
     ConnectionImpl& parent_;
     int32_t stream_id_{-1};

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -292,15 +292,20 @@ protected:
     void encodeDataHelper(Buffer::Instance& data, bool end_stream,
                           bool skip_encoding_empty_trailers);
 
-    uint32_t sentBytes() { return sent_bytes_; }
+    uint64_t sentBytes() override { return sent_bytes_; }
 
-    void updateSentBytes(size_t newly_sent_bytes) { sent_bytes_ += newly_sent_bytes; }
+    void updateSentBytes(size_t newly_sent_bytes) override { sent_bytes_ += newly_sent_bytes; }
+
+    uint64_t receivedBytes() override { return received_bytes_; }
+
+    void updateReceivedBytes(size_t newly_sent_bytes) override { sent_bytes_ += newly_sent_bytes; }
 
     ConnectionImpl& parent_;
     int32_t stream_id_{-1};
     uint32_t unconsumed_bytes_{0};
     uint32_t read_disable_count_{0};
-    size_t sent_bytes_{0};
+    uint64_t sent_bytes_{0};
+    uint64_t received_bytes_{0};
 
     Buffer::BufferMemoryAccountSharedPtr buffer_memory_account_;
     // Note that in current implementation the watermark callbacks of the pending_recv_data_ are

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -108,6 +108,14 @@ public:
 
   absl::string_view responseDetails() override { return details_; }
 
+  uint64_t sentBytes() override { return 0; }
+
+  void updateSentBytes(size_t) override {}
+
+  uint64_t receivedBytes() override { return 0; }
+
+  void updateReceivedBytes(size_t) override {}
+
 protected:
   virtual void switchStreamBlockState() PURE;
 

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -78,6 +78,9 @@ UpstreamRequest::~UpstreamRequest() {
   if (max_stream_duration_timer_ != nullptr) {
     max_stream_duration_timer_->disableTimer();
   }
+  if (upstream_) {
+    upstream_->getStreamInfomation(stream_info_);
+  }
   clearRequestEncoder();
 
   // If desired, fire the per-try histogram when the UpstreamRequest
@@ -292,6 +295,9 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
     span_->setTag(Tracing::Tags::get().Error, Tracing::Tags::get().True);
     span_->setTag(Tracing::Tags::get().ErrorReason, Http::Utility::resetReasonToString(reason));
   }
+  if (upstream_) {
+    upstream_->getStreamInfomation(stream_info_);
+  }
 
   clearRequestEncoder();
   awaiting_headers_ = false;
@@ -321,7 +327,8 @@ void UpstreamRequest::resetStream() {
 
   if (upstream_) {
     ENVOY_STREAM_LOG(debug, "resetting pool request", *parent_.callbacks());
-    upstream_->resetStream(stream_info_);
+    upstream_->getStreamInfomation(stream_info_);
+    upstream_->resetStream();
     clearRequestEncoder();
   }
 }

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -321,7 +321,7 @@ void UpstreamRequest::resetStream() {
 
   if (upstream_) {
     ENVOY_STREAM_LOG(debug, "resetting pool request", *parent_.callbacks());
-    upstream_->resetStream();
+    upstream_->resetStream(stream_info_);
     clearRequestEncoder();
   }
 }

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -128,6 +128,12 @@ struct StreamInfoImpl : public StreamInfo {
 
   uint64_t bytesReceived() const override { return bytes_received_; }
 
+  void setWireBytesReceived(uint64_t wire_bytes_received) override {
+    wire_bytes_received_ = wire_bytes_received;
+  }
+
+  uint64_t wireBytesReceived() const override { return wire_bytes_received_; }
+
   absl::optional<Http::Protocol> protocol() const override { return protocol_; }
 
   void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
@@ -155,6 +161,10 @@ struct StreamInfoImpl : public StreamInfo {
   void addBytesSent(uint64_t bytes_sent) override { bytes_sent_ += bytes_sent; }
 
   uint64_t bytesSent() const override { return bytes_sent_; }
+
+  void setWireBytesSent(uint64_t wire_bytes_sent) override { wire_bytes_sent_ = wire_bytes_sent; }
+
+  uint64_t wireBytesSent() const override { return wire_bytes_sent_; }
 
   void setResponseFlag(ResponseFlag response_flag) override { response_flags_ |= response_flag; }
 
@@ -322,6 +332,8 @@ private:
 
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
+  uint64_t wire_bytes_received_{0};
+  uint64_t wire_bytes_sent_{0};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   const Network::SocketAddressProviderSharedPtr downstream_address_provider_;
   Ssl::ConnectionInfoConstSharedPtr downstream_ssl_info_;

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -79,9 +79,12 @@ public:
 
   void readDisable(bool disable) override { request_encoder_->getStream().readDisable(disable); }
 
-  void resetStream() override {
-    request_encoder_->getStream().removeCallbacks(*this);
-    request_encoder_->getStream().resetStream(Envoy::Http::StreamResetReason::LocalReset);
+  void resetStream(StreamInfo::StreamInfo& stream_info) override {
+    ::Envoy::Http::Stream& stream = request_encoder_->getStream();
+    stream_info.addBytesReceived(stream.receivedBytes());
+    stream_info.addBytesSent(stream.sentBytes());
+    stream.removeCallbacks(*this);
+    stream.resetStream(Envoy::Http::StreamResetReason::LocalReset);
   }
 
   void setAccount(Buffer::BufferMemoryAccountSharedPtr account) override {

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -79,10 +79,8 @@ public:
 
   void readDisable(bool disable) override { request_encoder_->getStream().readDisable(disable); }
 
-  void resetStream(StreamInfo::StreamInfo& stream_info) override {
+  void resetStream() override {
     ::Envoy::Http::Stream& stream = request_encoder_->getStream();
-    stream_info.addBytesReceived(stream.receivedBytes());
-    stream_info.addBytesSent(stream.sentBytes());
     stream.removeCallbacks(*this);
     stream.resetStream(Envoy::Http::StreamResetReason::LocalReset);
   }
@@ -103,6 +101,15 @@ public:
 
   void onBelowWriteBufferLowWatermark() override {
     upstream_request_.onBelowWriteBufferLowWatermark();
+  }
+
+  void getStreamInfomation(StreamInfo::StreamInfo& stream_info) override {
+    if (!request_encoder_) {
+      return;
+    }
+    ::Envoy::Http::Stream& stream = request_encoder_->getStream();
+    stream_info.setWireBytesReceived(stream.receivedBytes());
+    stream_info.setWireBytesSent(stream.sentBytes());
   }
 
 private:

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -79,7 +79,7 @@ void TcpUpstream::readDisable(bool disable) {
   upstream_conn_data_->connection().readDisable(disable);
 }
 
-void TcpUpstream::resetStream() {
+void TcpUpstream::resetStream(StreamInfo::StreamInfo&) {
   upstream_request_ = nullptr;
   upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
 }

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -79,7 +79,7 @@ void TcpUpstream::readDisable(bool disable) {
   upstream_conn_data_->connection().readDisable(disable);
 }
 
-void TcpUpstream::resetStream(StreamInfo::StreamInfo&) {
+void TcpUpstream::resetStream() {
   upstream_request_ = nullptr;
   upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
 }

--- a/source/extensions/upstreams/http/tcp/upstream_request.h
+++ b/source/extensions/upstreams/http/tcp/upstream_request.h
@@ -76,7 +76,7 @@ public:
   Envoy::Http::Status encodeHeaders(const Envoy::Http::RequestHeaderMap&, bool end_stream) override;
   void encodeTrailers(const Envoy::Http::RequestTrailerMap&) override;
   void readDisable(bool disable) override;
-  void resetStream() override;
+  void resetStream(StreamInfo::StreamInfo&) override;
   void setAccount(Buffer::BufferMemoryAccountSharedPtr) override {}
 
   // Tcp::ConnectionPool::UpstreamCallbacks

--- a/source/extensions/upstreams/http/tcp/upstream_request.h
+++ b/source/extensions/upstreams/http/tcp/upstream_request.h
@@ -76,7 +76,7 @@ public:
   Envoy::Http::Status encodeHeaders(const Envoy::Http::RequestHeaderMap&, bool end_stream) override;
   void encodeTrailers(const Envoy::Http::RequestTrailerMap&) override;
   void readDisable(bool disable) override;
-  void resetStream(StreamInfo::StreamInfo&) override;
+  void resetStream() override;
   void setAccount(Buffer::BufferMemoryAccountSharedPtr) override {}
 
   // Tcp::ConnectionPool::UpstreamCallbacks
@@ -84,6 +84,7 @@ public:
   void onEvent(Network::ConnectionEvent event) override;
   void onAboveWriteBufferHighWatermark() override;
   void onBelowWriteBufferLowWatermark() override;
+  void getStreamInfomation(StreamInfo::StreamInfo&) override {}
 
 private:
   Router::UpstreamToDownstream* upstream_request_;

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -33,6 +33,8 @@ public:
 
   void addBytesReceived(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesReceived() const override { return 1; }
+  void setWireBytesReceived(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  uint64_t wireBytesReceived() const override { return 1; }
   absl::optional<Http::Protocol> protocol() const override { return protocol_; }
   void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
@@ -51,6 +53,8 @@ public:
   }
   void addBytesSent(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesSent() const override { return 2; }
+  void setWireBytesSent(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  uint64_t wireBytesSent() const override { return 2; }
   bool intersectResponseFlags(uint64_t response_flags) const override {
     return (response_flags_ & response_flags) != 0;
   }

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -38,6 +38,14 @@ public:
       callback->onBelowWriteBufferLowWatermark();
     }
   }
+
+  uint64_t sentBytes() override { return 0; }
+
+  void updateSentBytes(size_t) override {}
+
+  uint64_t receivedBytes() override { return 0; }
+
+  void updateReceivedBytes(size_t) override {}
 };
 
 } // namespace Http

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -84,11 +84,19 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, addBytesReceived(_)).WillByDefault(Invoke([this](uint64_t bytes_received) {
     bytes_received_ += bytes_received;
   }));
+  ON_CALL(*this, setWireBytesReceived(_))
+      .WillByDefault(Invoke(
+          [this](uint64_t wire_bytes_received) { wire_bytes_received_ = wire_bytes_received; }));
   ON_CALL(*this, bytesReceived()).WillByDefault(ReturnPointee(&bytes_received_));
+  ON_CALL(*this, wireBytesReceived()).WillByDefault(ReturnPointee(&wire_bytes_received_));
   ON_CALL(*this, addBytesSent(_)).WillByDefault(Invoke([this](uint64_t bytes_sent) {
     bytes_sent_ += bytes_sent;
   }));
+  ON_CALL(*this, setWireBytesSent(_)).WillByDefault(Invoke([this](uint64_t wire_bytes_sent) {
+    wire_bytes_sent_ = wire_bytes_sent;
+  }));
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
+  ON_CALL(*this, wireBytesSent()).WillByDefault(ReturnPointee(&wire_bytes_sent_));
   ON_CALL(*this, hasResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag flag) {
     return response_flags_ & flag;
   }));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -48,6 +48,8 @@ public:
   MOCK_METHOD(absl::optional<std::chrono::nanoseconds>, requestComplete, (), (const));
   MOCK_METHOD(void, addBytesReceived, (uint64_t));
   MOCK_METHOD(uint64_t, bytesReceived, (), (const));
+  MOCK_METHOD(void, setWireBytesReceived, (uint64_t));
+  MOCK_METHOD(uint64_t, wireBytesReceived, (), (const));
   MOCK_METHOD(void, setRouteName, (absl::string_view route_name));
   MOCK_METHOD(const std::string&, getRouteName, (), (const));
   MOCK_METHOD(absl::optional<Http::Protocol>, protocol, (), (const));
@@ -57,6 +59,8 @@ public:
   MOCK_METHOD(const absl::optional<std::string>&, connectionTerminationDetails, (), (const));
   MOCK_METHOD(void, addBytesSent, (uint64_t));
   MOCK_METHOD(uint64_t, bytesSent, (), (const));
+  MOCK_METHOD(void, setWireBytesSent, (uint64_t));
+  MOCK_METHOD(uint64_t, wireBytesSent, (), (const));
   MOCK_METHOD(bool, hasResponseFlag, (ResponseFlag), (const));
   MOCK_METHOD(bool, hasAnyResponseFlag, (), (const));
   MOCK_METHOD(uint64_t, responseFlags, (), (const));
@@ -121,6 +125,8 @@ public:
   FilterStateSharedPtr filter_state_;
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
+  uint64_t wire_bytes_received_{};
+  uint64_t wire_bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   std::shared_ptr<Network::SocketAddressSetterImpl> downstream_address_provider_;
   Ssl::ConnectionInfoConstSharedPtr downstream_connection_info_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Count the number of bytes sent to and received from upstream server per request and store them in stream_info for better observability.
Additional Description:NA
Risk Level:NA
Testing:will add testing for the new metric.
Docs Changes:add doc for the new metric.
Release Notes:NA
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
