### PR TITLE
Refactor OverloadIntegrationTest 

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1094,11 +1094,43 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test_library(
+    name = "fake_resource_monitor_lib",
+    srcs = [
+        "fake_resource_monitor.cc",
+    ],
+    hdrs = [
+        "fake_resource_monitor.h",
+    ],
+    deps = [
+        "//envoy/server:resource_monitor_config_interface",
+        "//test/common/config:dummy_config_proto_cc_proto",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "base_overload_integration_test_lib",
+    srcs = [
+        "base_overload_integration_test.cc",
+    ],
+    hdrs = [
+        "base_overload_integration_test.h",
+    ],
+    deps = [
+        ":fake_resource_monitor_lib",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/overload/v3:pkg_cc_proto",
+    ],
+)
+
 envoy_cc_test(
     name = "overload_integration_test",
     srcs = ["overload_integration_test.cc"],
     shard_count = 2,
     deps = [
+        ":base_overload_integration_test_lib",
         ":http_protocol_integration_lib",
         "//test/common/config:dummy_config_proto_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/integration/base_overload_integration_test.cc
+++ b/test/integration/base_overload_integration_test.cc
@@ -1,0 +1,23 @@
+#include "test/integration/base_overload_integration_test.h"
+
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+
+void BaseOverloadIntegrationTest::setupOverloadManagerConfig(
+    const envoy::config::overload::v3::OverloadAction& overload_action) {
+  const std::string overload_config = R"EOF(
+        refresh_interval:
+          seconds: 0
+          nanos: 1000000
+        resource_monitors:
+          - name: "envoy.resource_monitors.testonly.fake_resource_monitor"
+            typed_config:
+              "@type": type.googleapis.com/google.protobuf.Empty
+      )EOF";
+  overload_manager_config_ =
+      TestUtility::parseYaml<envoy::config::overload::v3::OverloadManager>(overload_config);
+  *overload_manager_config_.add_actions() = overload_action;
+}
+
+} // namespace Envoy

--- a/test/integration/base_overload_integration_test.h
+++ b/test/integration/base_overload_integration_test.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/overload/v3/overload.pb.h"
+
+#include "test/integration/fake_resource_monitor.h"
+#include "test/test_common/registry.h"
+
+namespace Envoy {
+
+class BaseOverloadIntegrationTest {
+protected:
+  void
+  setupOverloadManagerConfig(const envoy::config::overload::v3::OverloadAction& overload_action);
+
+  void updateResource(double pressure) {
+    auto* monitor = fake_resource_monitor_factory_.monitor();
+    ASSERT(monitor != nullptr);
+    monitor->setResourcePressure(pressure);
+  }
+
+  envoy::config::overload::v3::OverloadManager overload_manager_config_;
+  FakeResourceMonitorFactory fake_resource_monitor_factory_;
+  Registry::InjectFactory<Server::Configuration::ResourceMonitorFactory> inject_factory_{
+      fake_resource_monitor_factory_};
+};
+
+} // namespace Envoy

--- a/test/integration/fake_resource_monitor.cc
+++ b/test/integration/fake_resource_monitor.cc
@@ -1,0 +1,24 @@
+#include "test/integration/fake_resource_monitor.h"
+
+namespace Envoy {
+
+FakeResourceMonitor::~FakeResourceMonitor() { factory_.onMonitorDestroyed(this); }
+
+void FakeResourceMonitor::updateResourceUsage(Callbacks& callbacks) {
+  Server::ResourceUsage usage;
+  usage.resource_pressure_ = pressure_;
+  callbacks.onSuccess(usage);
+}
+
+void FakeResourceMonitorFactory::onMonitorDestroyed(FakeResourceMonitor* monitor) {
+  ASSERT(monitor_ == monitor);
+  monitor_ = nullptr;
+}
+Server::ResourceMonitorPtr FakeResourceMonitorFactory::createResourceMonitor(
+    const Protobuf::Message&, Server::Configuration::ResourceMonitorFactoryContext& context) {
+  auto monitor = std::make_unique<FakeResourceMonitor>(context.dispatcher(), *this);
+  monitor_ = monitor.get();
+  return monitor;
+}
+
+} // namespace Envoy

--- a/test/integration/fake_resource_monitor.h
+++ b/test/integration/fake_resource_monitor.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "envoy/server/resource_monitor.h"
+#include "envoy/server/resource_monitor_config.h"
+
+#include "test/common/config/dummy_config.pb.h"
+
+namespace Envoy {
+
+class FakeResourceMonitorFactory;
+
+class FakeResourceMonitor : public Server::ResourceMonitor {
+public:
+  FakeResourceMonitor(Event::Dispatcher& dispatcher, FakeResourceMonitorFactory& factory)
+      : dispatcher_(dispatcher), factory_(factory), pressure_(0.0) {}
+  // Server::ResourceMonitor
+  ~FakeResourceMonitor() override;
+  void updateResourceUsage(Callbacks& callbacks) override;
+
+  void setResourcePressure(double pressure) {
+    dispatcher_.post([this, pressure] { pressure_ = pressure; });
+  }
+
+private:
+  Event::Dispatcher& dispatcher_;
+  FakeResourceMonitorFactory& factory_;
+  double pressure_;
+};
+
+class FakeResourceMonitorFactory : public Server::Configuration::ResourceMonitorFactory {
+public:
+  // Server::Configuration::ResourceMonitorFactory
+  Server::ResourceMonitorPtr
+  createResourceMonitor(const Protobuf::Message& config,
+                        Server::Configuration::ResourceMonitorFactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<test::common::config::DummyConfig>();
+  }
+  std::string name() const override {
+    return "envoy.resource_monitors.testonly.fake_resource_monitor";
+  }
+
+  FakeResourceMonitor* monitor() const { return monitor_; }
+  void onMonitorDestroyed(FakeResourceMonitor* monitor);
+
+private:
+  FakeResourceMonitor* monitor_{nullptr};
+};
+
+} // namespace Envoy


### PR DESCRIPTION
Refactor OverloadIntegrationTest breaking out a test base, and the fake resource monitors.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:Refactor OverloadIntegrationTest breaking out a test base, and the fake resource monitors. 
Additional Description: These will be used in integration tests for checking that the reset stream mechanism kicks in based on Overload, resetting client streams.
Risk Level: low (test only)
Testing: ran tests (just a refactor)
Docs Changes: NA
Release Notes: NA
Platform Specific Features:NA
Related Issue: #15791
