### PR TITLE
CI: Add flag to skip test-result processing

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -144,8 +144,7 @@ function bazel_binary_build() {
 }
 
 function run_process_test_result() {
-  [[ -n "$CI_SKIP_PROCESS_TEST_RESULTS" ]] && return 
-  if [[ $(find "$TEST_TMPDIR" -name "*_attempt.xml" 2> /dev/null) ]]; then
+  if [[ -z "$CI_SKIP_PROCESS_TEST_RESULTS" ]] && [[ $(find "$TEST_TMPDIR" -name "*_attempt.xml" 2> /dev/null) ]]; then
       echo "running flaky test reporting script"
       "${ENVOY_SRCDIR}"/ci/flaky_test/run_process_xml.sh "$CI_TARGET"
   else

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -144,6 +144,7 @@ function bazel_binary_build() {
 }
 
 function run_process_test_result() {
+  [[ -n "$CI_SKIP_PROCESS_TEST_RESULTS" ]] && return 
   if [[ $(find "$TEST_TMPDIR" -name "*_attempt.xml" 2> /dev/null) ]]; then
       echo "running flaky test reporting script"
       "${ENVOY_SRCDIR}"/ci/flaky_test/run_process_xml.sh "$CI_TARGET"


### PR DESCRIPTION
Commit Message:

Support flag to skip test processing so that the CI jobs can be re-used
for internal builds (which may have their own test-result processing or
not want to use the default result-publishing).

Additional Description: Expand portability of CI scripts
Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
