### PR TITLE
fix `cache.NewSnapshot` parameters

### DIFF
--- a/examples/dynamic-config-cp/resource.go
+++ b/examples/dynamic-config-cp/resource.go
@@ -170,5 +170,6 @@ func GenerateSnapshot() cache.Snapshot {
 		[]types.Resource{makeHTTPListener(ListenerName, RouteName)},
 		[]types.Resource{}, // runtimes
 		[]types.Resource{}, // secrets
+		[]types.Resource{},
 	)
 }


### PR DESCRIPTION
```sh
# github.com/envoyproxy/go-control-plane/internal/example
internal/example/resource.go:165:26: not enough arguments in call to cache.NewSnapshot
	have (string, []types.Resource, []types.Resource, []types.Resource, []types.Resource, []types.Resource, []types.Resource)
	want (string, []types.Resource, []types.Resource, []types.Resource, []types.Resource, []types.Resource, []types.Resource, []types.Resource)
make: *** [Makefile:79: bin/example] Error 2
ERROR: Service 'go-control-plane' failed to build: The command '/bin/sh -c cd go-control-plane && make bin/example' returned a non-zero code: 2
```

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
