### PR TITLE
examples: pin version of go-control-plane

### DIFF
--- a/examples/dynamic-config-cp/Dockerfile-control-plane
+++ b/examples/dynamic-config-cp/Dockerfile-control-plane
@@ -8,5 +8,5 @@ RUN apt-get update \
 
 RUN git clone https://github.com/envoyproxy/go-control-plane
 ADD ./resource.go /go/go-control-plane/internal/example/resource.go
-RUN cd go-control-plane && make bin/example
+RUN cd go-control-plane && git checkout b4adc3bb5fe5288bff01cd452dad418ef98c676e && make bin/example
 WORKDIR /go/go-control-plane


### PR DESCRIPTION
This should disruptive breakages whenever go-control-plane changes its interface.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
