### PR TITLE
[WIP]: Limit received grpc message size for out of memory protection

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -305,6 +305,8 @@ message Bootstrap {
   // field.
   // [#not-implemented-hide:]
   map<string, core.v3.TypedExtensionConfig> certificate_provider_instances = 25;
+
+  google.protobuf.Int64Value max_receive_grpc_message_size = 31;
 }
 
 // Administration interface :ref:`operations documentation

--- a/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
@@ -304,6 +304,8 @@ message Bootstrap {
   // [#not-implemented-hide:]
   map<string, core.v3.TypedExtensionConfig> certificate_provider_instances = 25;
 
+  google.protobuf.Int64Value max_receive_grpc_message_size = 31;
+
   Runtime hidden_envoy_deprecated_runtime = 11 [
     deprecated = true,
     (envoy.annotations.deprecated_at_minor_version) = "3.0",

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -32,7 +32,7 @@ public:
   GoogleAsyncClientFactoryImpl(ThreadLocal::Instance& tls, ThreadLocal::Slot* google_tls_slot,
                                Stats::Scope& scope,
                                const envoy::config::core::v3::GrpcService& config, Api::Api& api,
-                               const StatNames& stat_names);
+                               const StatNames& stat_names, int64_t max_receive_message_length);
 
   RawAsyncClientPtr create() override;
 
@@ -40,7 +40,7 @@ private:
   ThreadLocal::Instance& tls_;
   ThreadLocal::Slot* google_tls_slot_;
   Stats::ScopeSharedPtr scope_;
-  const envoy::config::core::v3::GrpcService config_;
+  envoy::config::core::v3::GrpcService config_;
   Api::Api& api_;
   const StatNames& stat_names_;
 };
@@ -48,7 +48,8 @@ private:
 class AsyncClientManagerImpl : public AsyncClientManager {
 public:
   AsyncClientManagerImpl(Upstream::ClusterManager& cm, ThreadLocal::Instance& tls,
-                         TimeSource& time_source, Api::Api& api, const StatNames& stat_names);
+                         TimeSource& time_source, Api::Api& api, const StatNames& stat_names,
+                         int64_t max_receive_message_length);
 
   // Grpc::AsyncClientManager
   AsyncClientFactoryPtr factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
@@ -62,6 +63,7 @@ private:
   TimeSource& time_source_;
   Api::Api& api_;
   const StatNames& stat_names_;
+  int64_t max_receive_message_length_;
 };
 
 } // namespace Grpc

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -286,7 +286,9 @@ ClusterManagerImpl::ClusterManagerImpl(
       subscription_factory_(local_info, main_thread_dispatcher, *this,
                             validation_context.dynamicValidationVisitor(), api) {
   async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
-      *this, tls, time_source_, api, grpc_context.statNames());
+      *this, tls, time_source_, api, grpc_context.statNames(),
+      bootstrap.has_max_receive_grpc_message_size() ? bootstrap.max_receive_grpc_message_size()
+                                                    : -1);
   const auto& cm_config = bootstrap.cluster_manager();
   if (cm_config.has_outlier_detection()) {
     const std::string event_log_file_path = cm_config.outlier_detection().event_log_path();

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -287,7 +287,7 @@ ClusterManagerImpl::ClusterManagerImpl(
                             validation_context.dynamicValidationVisitor(), api) {
   async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
       *this, tls, time_source_, api, grpc_context.statNames(),
-      bootstrap.has_max_receive_grpc_message_size() ? bootstrap.max_receive_grpc_message_size()
+      bootstrap.has_max_receive_grpc_message_size() ? bootstrap.max_receive_grpc_message_size().value()
                                                     : -1);
   const auto& cm_config = bootstrap.cluster_manager();
   if (cm_config.has_outlier_detection()) {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -654,7 +654,10 @@ void InstanceImpl::onRuntimeReady() {
   if (bootstrap_.has_hds_config()) {
     const auto& hds_config = bootstrap_.hds_config();
     async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
-        *config_.clusterManager(), thread_local_, time_source_, *api_, grpc_context_.statNames());
+        *config_.clusterManager(), thread_local_, time_source_, *api_, grpc_context_.statNames(),
+        bootstrap_.has_max_receive_grpc_message_size()
+            ? bootstrap_.has_max_receive_grpc_message_size()
+            : -1);
     TRY_ASSERT_MAIN_THREAD {
       hds_delegate_ = std::make_unique<Upstream::HdsDelegate>(
           stats_store_,

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -23,7 +23,7 @@ class AsyncClientManagerImplTest : public testing::Test {
 public:
   AsyncClientManagerImplTest()
       : api_(Api::createApiForTest()), stat_names_(scope_.symbolTable()),
-        async_client_manager_(cm_, tls_, test_time_.timeSystem(), *api_, stat_names_) {}
+        async_client_manager_(cm_, tls_, test_time_.timeSystem(), *api_, stat_names_, -1) {}
 
   Upstream::MockClusterManager cm_;
   NiceMock<ThreadLocal::MockInstance> tls_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: it is possible that envoy get out of memory when it loads a large grpc message. Protection against this scenario can be achieved by setting the maximum message size envoy will accept through the grpc channel.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
