### PR TITLE
coverage: set lower limit for common/quic and common

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -17,7 +17,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/singleton:95.8"
 "source/common/thread:0.0" # Death tests don't report LCOV
 "source/common/matcher:95.0"
-"source/common/quic:91.3"
+"source/common/quic:91.2"
 "source/common/tracing:96.1"
 "source/common/watchdog:42.9" # Death tests don't report LCOV
 "source/exe:94.3"

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -3,7 +3,7 @@
 # directory:coverage_percent
 # for existing directories with low coverage.
 declare -a KNOWN_LOW_COVERAGE=(
-"source/common:96.5"
+"source/common:96.5" # Raise when QUIC coverage goes up
 "source/common/api:75.3"
 "source/common/api/posix:73.9"
 "source/common/common:96.3"

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -3,6 +3,7 @@
 # directory:coverage_percent
 # for existing directories with low coverage.
 declare -a KNOWN_LOW_COVERAGE=(
+"source/common:96.5"
 "source/common/api:75.3"
 "source/common/api/posix:73.9"
 "source/common/common:96.3"


### PR DESCRIPTION
seems like common/quic is flaky and started failing on some unrelated branches (e.g. https://dev.azure.com/cncf/envoy/_build/results?buildId=84219&view=logs&j=bbe4b42d-86e6-5e9c-8a0b-fea01d818a24&t=e00c5a13-c6dc-5e9a-6104-69976170e881 on https://github.com/envoyproxy/envoy/pull/17547) due to the recent change https://github.com/envoyproxy/envoy/pull/17564, so this PR lowers the limit for it to 91.2 according to the number reported ^ and on the main branch.
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
