### PR TITLE
Removed mutexes from AllMuxesState singletons used by muxes.

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -18,27 +18,21 @@ namespace {
 class AllMuxesState {
 public:
   void insert(GrpcMuxImpl* mux) {
-    absl::WriterMutexLock locker(&lock_);
     muxes_.insert(mux);
   }
 
   void erase(GrpcMuxImpl* mux) {
-    absl::WriterMutexLock locker(&lock_);
     muxes_.erase(mux);
   }
 
   void shutdownAll() {
-    absl::WriterMutexLock locker(&lock_);
     for (auto& mux : muxes_) {
       mux->shutdown();
     }
   }
 
 private:
-  absl::flat_hash_set<GrpcMuxImpl*> muxes_ ABSL_GUARDED_BY(lock_);
-
-  // TODO(ggreenway): can this lock be removed? Is this code only run on the main thread?
-  absl::Mutex lock_;
+  absl::flat_hash_set<GrpcMuxImpl*> muxes_;
 };
 using AllMuxes = ThreadSafeSingleton<AllMuxesState>;
 } // namespace

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -17,13 +17,9 @@ namespace Config {
 namespace {
 class AllMuxesState {
 public:
-  void insert(GrpcMuxImpl* mux) {
-    muxes_.insert(mux);
-  }
+  void insert(GrpcMuxImpl* mux) { muxes_.insert(mux); }
 
-  void erase(GrpcMuxImpl* mux) {
-    muxes_.erase(mux);
-  }
+  void erase(GrpcMuxImpl* mux) { muxes_.erase(mux); }
 
   void shutdownAll() {
     for (auto& mux : muxes_) {

--- a/source/common/config/new_grpc_mux_impl.cc
+++ b/source/common/config/new_grpc_mux_impl.cc
@@ -20,27 +20,21 @@ namespace {
 class AllMuxesState {
 public:
   void insert(NewGrpcMuxImpl* mux) {
-    absl::WriterMutexLock locker(&lock_);
     muxes_.insert(mux);
   }
 
   void erase(NewGrpcMuxImpl* mux) {
-    absl::WriterMutexLock locker(&lock_);
     muxes_.erase(mux);
   }
 
   void shutdownAll() {
-    absl::WriterMutexLock locker(&lock_);
     for (auto& mux : muxes_) {
       mux->shutdown();
     }
   }
 
 private:
-  absl::flat_hash_set<NewGrpcMuxImpl*> muxes_ ABSL_GUARDED_BY(lock_);
-
-  // TODO(ggreenway): can this lock be removed? Is this code only run on the main thread?
-  absl::Mutex lock_;
+  absl::flat_hash_set<NewGrpcMuxImpl*> muxes_;
 };
 using AllMuxes = ThreadSafeSingleton<AllMuxesState>;
 } // namespace

--- a/source/common/config/new_grpc_mux_impl.cc
+++ b/source/common/config/new_grpc_mux_impl.cc
@@ -19,13 +19,9 @@ namespace Config {
 namespace {
 class AllMuxesState {
 public:
-  void insert(NewGrpcMuxImpl* mux) {
-    muxes_.insert(mux);
-  }
+  void insert(NewGrpcMuxImpl* mux) { muxes_.insert(mux); }
 
-  void erase(NewGrpcMuxImpl* mux) {
-    muxes_.erase(mux);
-  }
+  void erase(NewGrpcMuxImpl* mux) { muxes_.erase(mux); }
 
   void shutdownAll() {
     for (auto& mux : muxes_) {


### PR DESCRIPTION
Muxes always execute on the main thread, no thread synchronization is required.

Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

ping @ggreenway, @htuch.  