### PR TITLE
ext_proc: Check validity of the :status header

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -24,6 +24,7 @@ using Http::ResponseHeaderMap;
 using Http::ResponseTrailerMap;
 
 static const std::string kErrorPrefix = "ext_proc error";
+static const int DefaultImmediateStatus = 200;
 
 void Filter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
   Http::PassThroughFilter::setDecoderFilterCallbacks(callbacks);
@@ -558,7 +559,11 @@ void Filter::cleanUpTimers() {
 }
 
 void Filter::sendImmediateResponse(const ImmediateResponse& response) {
-  const auto status_code = response.has_status() ? response.status().code() : 200;
+  auto status_code = response.has_status() ? response.status().code() : DefaultImmediateStatus;
+  if (!MutationUtils::isValidHttpStatus(status_code)) {
+    ENVOY_LOG(debug, "Ignoring attempt to set invalid HTTP status {}", status_code);
+    status_code = DefaultImmediateStatus;
+  }
   const auto grpc_status =
       response.has_grpc_status()
           ? absl::optional<Grpc::Status::GrpcStatus>(response.grpc_status().status())
@@ -570,6 +575,7 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
   };
 
   sent_immediate_response_ = true;
+  ENVOY_LOG(debug, "Sending local reply with status code {}", status_code);
   encoder_callbacks_->sendLocalReply(static_cast<Http::Code>(status_code), response.body(),
                                      mutate_headers, grpc_status, response.details());
 }

--- a/source/extensions/filters/http/ext_proc/mutation_utils.h
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.h
@@ -37,8 +37,13 @@ public:
   static void applyBodyMutations(const envoy::service::ext_proc::v3alpha::BodyMutation& mutation,
                                  Buffer::Instance& buffer);
 
+  // Determine if a particular HTTP status code is valid.
+  static bool isValidHttpStatus(int code);
+
 private:
-  static bool isSettableHeader(absl::string_view key, bool replacing_message);
+  static bool isSettableHeader(const envoy::config::core::v3::HeaderValueOption& header,
+                               bool replacing_message);
+  static bool isAppendableHeader(absl::string_view key);
 };
 
 } // namespace ExternalProcessing


### PR DESCRIPTION
Commit Message: Restrict the values of the ":status" header that an external
processor can set in both a "header mutation" in the response to a
header request, or in an "immediate response" message, to avoid setting
certain header values that will break the proxy.
Additional Description: Specifically, ignore attempts to set the header to a value < 200,
or to an invalid integer. Also ignore attempts to set multiple values
for any system header (beginning with ":").
Risk Level: Low -- reduces risk of a problem with invalid status codes
Testing: New unit and integration tests
Docs Changes:
Release Notes:
Platform Specific Features:
Signed-off-by: Gregory Brail <gregbrail@google.com>