### PR TITLE
bazel: ignore tool_deps for dependency validation

### DIFF
--- a/tools/dependency/validate.py
+++ b/tools/dependency/validate.py
@@ -124,7 +124,7 @@ class BuildGraph(object):
     """
         deps_query = ' union '.join(f'deps({l})' for l in targets)
         try:
-            deps = subprocess.check_output(['bazel', 'query', deps_query],
+            deps = subprocess.check_output(['bazel', 'query', '--tool_deps=false', deps_query],
                                            stderr=subprocess.PIPE).decode().splitlines()
         except subprocess.CalledProcessError as exc:
             print(


### PR DESCRIPTION
When validating the different deps types and their use_categories, host
/ tool deps don't need to be included since those aren't part of the
built product. We hit this with rules_foreign_cc changes.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>