### PR TITLE
http: return per route config when direct response is set

### DIFF
--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -548,21 +548,6 @@ public:
   virtual const Config& routeConfig() const PURE;
 
   /**
-   * @return const RouteSpecificFilterConfig* the per-filter config pre-processed object for
-   *  the given filter name. If there is not per-filter config, or the filter factory returns
-   *  nullptr, nullptr is returned.
-   */
-  virtual const RouteSpecificFilterConfig* perFilterConfig(const std::string& name) const PURE;
-
-  /**
-   * This is a helper on top of perFilterConfig() that casts the return object to the specified
-   * type.
-   */
-  template <class Derived> const Derived* perFilterConfigTyped(const std::string& name) const {
-    return dynamic_cast<const Derived*>(perFilterConfig(name));
-  }
-
-  /**
    * @return bool whether to include the request count header in upstream requests.
    */
   virtual bool includeAttemptCountInRequest() const PURE;
@@ -915,31 +900,6 @@ public:
   virtual const PathMatchCriterion& pathMatchCriterion() const PURE;
 
   /**
-   * @return const RouteSpecificFilterConfig* the per-filter config pre-processed object for
-   *  the given filter name. If there is not per-filter config, or the filter factory returns
-   *  nullptr, nullptr is returned.
-   */
-  virtual const RouteSpecificFilterConfig* perFilterConfig(const std::string& name) const PURE;
-
-  /**
-   * This is a helper on top of perFilterConfig() that casts the return object to the specified
-   * type.
-   */
-  template <class Derived> const Derived* perFilterConfigTyped(const std::string& name) const {
-    return dynamic_cast<const Derived*>(perFilterConfig(name));
-  };
-
-  /**
-   * This is a helper to get the route's per-filter config if it exists, otherwise the virtual
-   * host's. Or nullptr if none of them exist.
-   */
-  template <class Derived>
-  const Derived* mostSpecificPerFilterConfigTyped(const std::string& name) const {
-    const Derived* config = perFilterConfigTyped<Derived>(name);
-    return config ? config : virtualHost().perFilterConfigTyped<Derived>(name);
-  }
-
-  /**
    * True if the virtual host this RouteEntry belongs to is configured to include the attempt
    * count header.
    * @return bool whether x-envoy-attempt-count should be included on the upstream request.
@@ -1062,19 +1022,21 @@ public:
   virtual const RouteTracing* tracingConfig() const PURE;
 
   /**
-   * @return const RouteSpecificFilterConfig* the per-filter config pre-processed object for
-   *  the given filter name. If there is not per-filter config, or the filter factory returns
-   *  nullptr, nullptr is returned.
+   * This is a helper to get the route's per-filter config if it exists, otherwise the virtual
+   * host's. Or nullptr if none of them exist.
    */
-  virtual const RouteSpecificFilterConfig* perFilterConfig(const std::string& name) const PURE;
+  virtual const RouteSpecificFilterConfig*
+  mostSpecificPerFilterConfig(const std::string& name) const PURE;
 
   /**
-   * This is a helper on top of perFilterConfig() that casts the return object to the specified
-   * type.
+   * Fold all the available per route filter configs, invoking the callback with each config (if
+   * it is present). Iteration of the configs is in order of specificity. That means that the
+   * callback will be called first for a config on a Virtual host, then a route, and finally a route
+   * entry (weighted cluster). If a config is not present, the callback will not be invoked.
    */
-  template <class Derived> const Derived* perFilterConfigTyped(const std::string& name) const {
-    return dynamic_cast<const Derived*>(perFilterConfig(name));
-  }
+  virtual void traversePerFilterConfig(
+      const std::string& filter_name,
+      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const PURE;
 };
 
 using RouteConstSharedPtr = std::shared_ptr<const Route>;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -190,9 +190,6 @@ private:
     const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
     const Router::Config& routeConfig() const override { return route_configuration_; }
-    const Router::RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override {
-      return nullptr;
-    }
     bool includeAttemptCountInRequest() const override { return false; }
     bool includeAttemptCountInResponse() const override { return false; }
     uint32_t retryShadowBufferLimit() const override {
@@ -295,9 +292,6 @@ private:
       return path_match_criterion_;
     }
 
-    const Router::RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override {
-      return nullptr;
-    }
     const absl::optional<ConnectConfig>& connectConfig() const override {
       return connect_config_nullopt_;
     }
@@ -338,9 +332,13 @@ private:
     const Router::RouteEntry* routeEntry() const override { return &route_entry_; }
     const Router::Decorator* decorator() const override { return nullptr; }
     const Router::RouteTracing* tracingConfig() const override { return nullptr; }
-    const Router::RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override {
+    const Router::RouteSpecificFilterConfig*
+    mostSpecificPerFilterConfig(const std::string&) const override {
       return nullptr;
     }
+    void traversePerFilterConfig(
+        const std::string&,
+        std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
 
     RouteEntryImpl route_entry_;
   };

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -914,35 +914,6 @@ void Utility::transformUpgradeResponseFromH2toH1(ResponseHeaderMap& headers,
   }
 }
 
-void Utility::traversePerFilterConfigGeneric(
-    const std::string& filter_name, const Router::RouteConstSharedPtr& route,
-    std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
-  if (!route) {
-    return;
-  }
-
-  const Router::RouteEntry* routeEntry = route->routeEntry();
-
-  if (routeEntry != nullptr) {
-    auto maybe_vhost_config = routeEntry->virtualHost().perFilterConfig(filter_name);
-    if (maybe_vhost_config != nullptr) {
-      cb(*maybe_vhost_config);
-    }
-  }
-
-  auto maybe_route_config = route->perFilterConfig(filter_name);
-  if (maybe_route_config != nullptr) {
-    cb(*maybe_route_config);
-  }
-
-  if (routeEntry != nullptr) {
-    auto maybe_weighted_cluster_config = routeEntry->perFilterConfig(filter_name);
-    if (maybe_weighted_cluster_config != nullptr) {
-      cb(*maybe_weighted_cluster_config);
-    }
-  }
-}
-
 std::string Utility::PercentEncoding::encode(absl::string_view value,
                                              absl::string_view reserved_chars) {
   absl::flat_hash_set<char> reserved_char_set{reserved_chars.begin(), reserved_chars.end()};

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -503,40 +503,10 @@ const ConfigType* resolveMostSpecificPerFilterConfig(const std::string& filter_n
                                                      const Router::RouteConstSharedPtr& route) {
   static_assert(std::is_base_of<Router::RouteSpecificFilterConfig, ConfigType>::value,
                 "ConfigType must be a subclass of Router::RouteSpecificFilterConfig");
-  if (!route || !route->routeEntry()) {
+  if (!route) {
     return nullptr;
   }
-  return route->routeEntry()->mostSpecificPerFilterConfigTyped<ConfigType>(filter_name);
-}
-
-/**
- * The non template implementation of traversePerFilterConfig. see
- * traversePerFilterConfig for docs.
- */
-void traversePerFilterConfigGeneric(
-    const std::string& filter_name, const Router::RouteConstSharedPtr& route,
-    std::function<void(const Router::RouteSpecificFilterConfig&)> cb);
-
-/**
- * Fold all the available per route filter configs, invoking the callback with each config (if
- * it is present). Iteration of the configs is in order of specificity. That means that the callback
- * will be called first for a config on a Virtual host, then a route, and finally a route entry
- * (weighted cluster). If a config is not present, the callback will not be invoked.
- */
-template <class ConfigType>
-void traversePerFilterConfig(const std::string& filter_name,
-                             const Router::RouteConstSharedPtr& route,
-                             std::function<void(const ConfigType&)> cb) {
-  static_assert(std::is_base_of<Router::RouteSpecificFilterConfig, ConfigType>::value,
-                "ConfigType must be a subclass of Router::RouteSpecificFilterConfig");
-
-  traversePerFilterConfigGeneric(
-      filter_name, route, [&cb](const Router::RouteSpecificFilterConfig& cfg) {
-        const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(&cfg);
-        if (typed_cfg != nullptr) {
-          cb(*typed_cfg);
-        }
-      });
+  return dynamic_cast<const ConfigType*>(route->mostSpecificPerFilterConfig(filter_name));
 }
 
 /**
@@ -558,14 +528,17 @@ getMergedPerFilterConfig(const std::string& filter_name, const Router::RouteCons
 
   absl::optional<ConfigType> merged;
 
-  traversePerFilterConfig<ConfigType>(filter_name, route,
-                                      [&reduce, &merged](const ConfigType& cfg) {
-                                        if (!merged) {
-                                          merged.emplace(cfg);
-                                        } else {
-                                          reduce(merged.value(), cfg);
-                                        }
-                                      });
+  if (route) {
+    route->traversePerFilterConfig(
+        filter_name, [&reduce, &merged](const Router::RouteSpecificFilterConfig& cfg) {
+          const ConfigType* typed_cfg = dynamic_cast<const ConfigType*>(&cfg);
+          if (!merged) {
+            merged.emplace(*typed_cfg);
+          } else {
+            reduce(merged.value(), *typed_cfg);
+          }
+        });
+  }
 
   return merged;
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1001,9 +1001,24 @@ void RouteEntryImplBase::validateClusters(
   }
 }
 
-const RouteSpecificFilterConfig*
-RouteEntryImplBase::perFilterConfig(const std::string& name) const {
-  return per_filter_configs_.get(name);
+void RouteEntryImplBase::traversePerFilterConfig(
+    const std::string& filter_name,
+    std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const {
+  const Router::RouteEntry* route_entry = routeEntry();
+
+  // TODO(soulxu): This has similar bug with https://github.com/envoyproxy/envoy/issues/17377
+  // it should be fixed.
+  if (route_entry != nullptr) {
+    auto maybe_vhost_config = vhost_.perFilterConfig(filter_name);
+    if (maybe_vhost_config != nullptr) {
+      cb(*maybe_vhost_config);
+    }
+  }
+
+  auto maybe_route_config = per_filter_configs_.get(filter_name);
+  if (maybe_route_config != nullptr) {
+    cb(*maybe_route_config);
+  }
 }
 
 RouteEntryImplBase::WeightedClusterEntry::WeightedClusterEntry(
@@ -1046,10 +1061,15 @@ Http::HeaderTransforms RouteEntryImplBase::WeightedClusterEntry::responseHeaderT
   return transforms;
 }
 
-const RouteSpecificFilterConfig*
-RouteEntryImplBase::WeightedClusterEntry::perFilterConfig(const std::string& name) const {
-  const auto cfg = per_filter_configs_.get(name);
-  return cfg != nullptr ? cfg : DynamicRouteEntry::perFilterConfig(name);
+void RouteEntryImplBase::WeightedClusterEntry::traversePerFilterConfig(
+    const std::string& filter_name,
+    std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const {
+  DynamicRouteEntry::traversePerFilterConfig(filter_name, cb);
+
+  const auto* cfg = per_filter_configs_.get(filter_name);
+  if (cfg) {
+    cb(*cfg);
+  }
 }
 
 PrefixRouteEntryImpl::PrefixRouteEntryImpl(

--- a/source/common/router/delegating_route_impl.cc
+++ b/source/common/router/delegating_route_impl.cc
@@ -14,10 +14,6 @@ const Decorator* DelegatingRoute::decorator() const { return base_route_->decora
 
 const RouteTracing* DelegatingRoute::tracingConfig() const { return base_route_->tracingConfig(); }
 
-const RouteSpecificFilterConfig* DelegatingRoute::perFilterConfig(const std::string& name) const {
-  return base_route_->perFilterConfig(name);
-}
-
 // Router:DelegatingRouteEntry
 void DelegatingRouteEntry::finalizeResponseHeaders(
     Http::ResponseHeaderMap& headers, const StreamInfo::StreamInfo& stream_info) const {
@@ -156,11 +152,6 @@ const TlsContextMatchCriteria* DelegatingRouteEntry::tlsContextMatchCriteria() c
 
 const PathMatchCriterion& DelegatingRouteEntry::pathMatchCriterion() const {
   return base_route_->routeEntry()->pathMatchCriterion();
-}
-
-const RouteSpecificFilterConfig*
-DelegatingRouteEntry::perFilterConfig(const std::string& name) const {
-  return base_route_->routeEntry()->perFilterConfig(name);
 }
 
 bool DelegatingRouteEntry::includeAttemptCountInRequest() const {

--- a/source/common/router/delegating_route_impl.h
+++ b/source/common/router/delegating_route_impl.h
@@ -24,7 +24,16 @@ public:
   const Router::RouteEntry* routeEntry() const override;
   const Router::Decorator* decorator() const override;
   const Router::RouteTracing* tracingConfig() const override;
-  const Router::RouteSpecificFilterConfig* perFilterConfig(const std::string&) const override;
+
+  const RouteSpecificFilterConfig*
+  mostSpecificPerFilterConfig(const std::string& name) const override {
+    return base_route_->mostSpecificPerFilterConfig(name);
+  }
+  void traversePerFilterConfig(
+      const std::string& filter_name,
+      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const override {
+    base_route_->traversePerFilterConfig(filter_name, cb);
+  }
 
 private:
   const Router::RouteConstSharedPtr base_route_;
@@ -84,7 +93,6 @@ public:
   const envoy::config::core::v3::Metadata& metadata() const override;
   const TlsContextMatchCriteria* tlsContextMatchCriteria() const override;
   const PathMatchCriterion& pathMatchCriterion() const override;
-  const RouteSpecificFilterConfig* perFilterConfig(const std::string& name) const override;
   bool includeAttemptCountInRequest() const override;
   bool includeAttemptCountInResponse() const override;
   const UpgradeMap& upgradeMap() const override;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -1556,7 +1556,6 @@ public:
 TEST_F(AsyncClientImplUnitTest, RouteImplInitTest) {
   EXPECT_EQ(nullptr, route_impl_.decorator());
   EXPECT_EQ(nullptr, route_impl_.tracingConfig());
-  EXPECT_EQ(nullptr, route_impl_.perFilterConfig(""));
   EXPECT_EQ(Code::InternalServerError, route_impl_.routeEntry()->clusterNotFoundResponseCode());
   EXPECT_EQ(nullptr, route_impl_.routeEntry()->corsPolicy());
   EXPECT_EQ(nullptr, route_impl_.routeEntry()->hashPolicy());
@@ -1573,13 +1572,11 @@ TEST_F(AsyncClientImplUnitTest, RouteImplInitTest) {
   EXPECT_TRUE(route_impl_.routeEntry()->metadata().filter_metadata().empty());
   EXPECT_EQ(nullptr,
             route_impl_.routeEntry()->typedMetadata().get<Config::TypedMetadata::Object>("bar"));
-  EXPECT_EQ(nullptr, route_impl_.routeEntry()->perFilterConfig("bar"));
   EXPECT_TRUE(route_impl_.routeEntry()->upgradeMap().empty());
   EXPECT_EQ(false, route_impl_.routeEntry()->internalRedirectPolicy().enabled());
   EXPECT_TRUE(route_impl_.routeEntry()->shadowPolicies().empty());
   EXPECT_TRUE(route_impl_.routeEntry()->virtualHost().rateLimitPolicy().empty());
   EXPECT_EQ(nullptr, route_impl_.routeEntry()->virtualHost().corsPolicy());
-  EXPECT_EQ(nullptr, route_impl_.routeEntry()->virtualHost().perFilterConfig("bar"));
   EXPECT_FALSE(route_impl_.routeEntry()->virtualHost().includeAttemptCountInRequest());
   EXPECT_FALSE(route_impl_.routeEntry()->virtualHost().includeAttemptCountInResponse());
   EXPECT_FALSE(route_impl_.routeEntry()->virtualHost().routeConfig().usesVhds());

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1088,8 +1088,6 @@ TEST_F(HttpConnectionManagerImplTest, DelegatingRouteEntryAllCalls) {
         EXPECT_EQ(default_route->routeEntry()->pathMatchCriterion().matchType(),
                   delegating_route_foo->routeEntry()->pathMatchCriterion().matchType());
 
-        EXPECT_EQ(default_route->routeEntry()->perFilterConfig("bar"),
-                  delegating_route_foo->routeEntry()->perFilterConfig("bar"));
         EXPECT_EQ(default_route->routeEntry()->includeAttemptCountInRequest(),
                   delegating_route_foo->routeEntry()->includeAttemptCountInRequest());
         EXPECT_EQ(default_route->routeEntry()->includeAttemptCountInResponse(),

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -892,9 +892,7 @@ TEST(HttpUtility, ResolveMostSpecificPerFilterConfig) {
   const std::string filter_name = "envoy.filter";
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks;
 
-  const Router::RouteSpecificFilterConfig one;
-  const Router::RouteSpecificFilterConfig two;
-  const Router::RouteSpecificFilterConfig three;
+  const Router::RouteSpecificFilterConfig config;
 
   // Test when there's nothing on the route
   EXPECT_EQ(nullptr, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
@@ -902,85 +900,17 @@ TEST(HttpUtility, ResolveMostSpecificPerFilterConfig) {
 
   // Testing in reverse order, so that the method always returns the last object.
   // Testing per-virtualhost typed filter config
-  ON_CALL(filter_callbacks.route_->route_entry_.virtual_host_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&one));
-  EXPECT_EQ(&one, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
-                      filter_name, filter_callbacks.route()));
-
-  // Testing per-route typed filter config
-  ON_CALL(*filter_callbacks.route_, perFilterConfig(filter_name)).WillByDefault(Return(&two));
-  ON_CALL(filter_callbacks.route_->route_entry_, perFilterConfig(filter_name))
-      .WillByDefault(Invoke(
-          [&](const std::string& name) { return filter_callbacks.route_->perFilterConfig(name); }));
-  EXPECT_EQ(&two, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
-                      filter_name, filter_callbacks.route()));
-
-  // Testing per-route entry typed filter config
-  ON_CALL(filter_callbacks.route_->route_entry_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&three));
-  EXPECT_EQ(&three, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
-                        filter_name, filter_callbacks.route()));
+  ON_CALL(*filter_callbacks.route_, mostSpecificPerFilterConfig(filter_name))
+      .WillByDefault(Return(&config));
+  EXPECT_EQ(&config, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
+                         filter_name, filter_callbacks.route()));
 
   // Cover the case of no route entry
   ON_CALL(*filter_callbacks.route_, routeEntry()).WillByDefault(Return(nullptr));
-  EXPECT_EQ(nullptr, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
+  ON_CALL(*filter_callbacks.route_, mostSpecificPerFilterConfig(filter_name))
+      .WillByDefault(Return(&config));
+  EXPECT_EQ(&config, Utility::resolveMostSpecificPerFilterConfig<Router::RouteSpecificFilterConfig>(
                          filter_name, filter_callbacks.route()));
-}
-
-// Verify that traversePerFilterConfigGeneric traverses in the order of specificity.
-TEST(HttpUtility, TraversePerFilterConfigIteratesInOrder) {
-  const std::string filter_name = "envoy.filter";
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks;
-
-  // Create configs to test; to ease of testing instead of using real objects
-  // we will use pointers that are actually indexes.
-  const std::vector<Router::RouteSpecificFilterConfig> nullconfigs(5);
-  size_t num_configs = 1;
-  ON_CALL(filter_callbacks.route_->route_entry_.virtual_host_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&nullconfigs[num_configs]));
-  num_configs++;
-  ON_CALL(*filter_callbacks.route_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&nullconfigs[num_configs]));
-  num_configs++;
-  ON_CALL(filter_callbacks.route_->route_entry_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&nullconfigs[num_configs]));
-
-  // a vector to save which configs are visited by the traversePerFilterConfigGeneric
-  std::vector<size_t> visited_configs(num_configs, 0);
-
-  // Iterate; save the retrieved config index in the iteration index in visited_configs.
-  size_t index = 0;
-  Utility::traversePerFilterConfigGeneric(filter_name, filter_callbacks.route(),
-                                          [&](const Router::RouteSpecificFilterConfig& cfg) {
-                                            int cfg_index = &cfg - nullconfigs.data();
-                                            visited_configs[index] = cfg_index - 1;
-                                            index++;
-                                          });
-
-  // Make sure all methods were called, and in order.
-  for (size_t i = 0; i < visited_configs.size(); i++) {
-    EXPECT_EQ(i, visited_configs[i]);
-  }
-}
-
-// Verify that traversePerFilterConfig works and we get back the original type.
-TEST(HttpUtility, TraversePerFilterConfigTyped) {
-  TestConfig testConfig;
-
-  const std::string filter_name = "envoy.filter";
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks;
-
-  // make the file callbacks return our test config
-  ON_CALL(*filter_callbacks.route_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&testConfig));
-
-  // iterate the configs
-  size_t index = 0;
-  Utility::traversePerFilterConfig<TestConfig>(filter_name, filter_callbacks.route(),
-                                               [&](const TestConfig&) { index++; });
-
-  // make sure that the callback was called (which means that the dynamic_cast worked.)
-  EXPECT_EQ(1, index);
 }
 
 // Verify that merging works as expected and we get back the merged result.
@@ -993,11 +923,12 @@ TEST(HttpUtility, GetMergedPerFilterConfig) {
   const std::string filter_name = "envoy.filter";
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks;
 
-  // make the file callbacks return our test config
-  ON_CALL(filter_callbacks.route_->route_entry_.virtual_host_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&baseTestConfig));
-  ON_CALL(*filter_callbacks.route_, perFilterConfig(filter_name))
-      .WillByDefault(Return(&routeTestConfig));
+  EXPECT_CALL(*filter_callbacks.route_, traversePerFilterConfig(filter_name, _))
+      .WillOnce(Invoke([&](const std::string&,
+                           std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
+        cb(baseTestConfig);
+        cb(routeTestConfig);
+      }));
 
   // merge the configs
   auto merged_cfg = Utility::getMergedPerFilterConfig<TestConfig>(

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -100,7 +100,7 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
 
   setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/});
   FilterSettings route_settings{arn_, InvocationMode::Synchronous, true /*passthrough*/};
-  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.aws_lambda"))
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.aws_lambda"))
       .WillByDefault(Return(&route_settings));
 
   ON_CALL(*decoder_callbacks_.cluster_info_, metadata()).WillByDefault(ReturnRef(metadata));
@@ -122,7 +122,7 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
 TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectClusterMetadata) {
   setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/});
   FilterSettings route_settings{arn_, InvocationMode::Synchronous, true /*passthrough*/};
-  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.aws_lambda"))
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.aws_lambda"))
       .WillByDefault(Return(&route_settings));
 
   Http::TestRequestHeaderMapImpl headers;

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -37,15 +37,6 @@ public:
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
 
-  void routeLocalConfig(const Router::RouteSpecificFilterConfig* route_settings,
-                        const Router::RouteSpecificFilterConfig* vhost_settings) {
-    ON_CALL(callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.buffer"))
-        .WillByDefault(Return(route_settings));
-    ON_CALL(callbacks_.route_->route_entry_.virtual_host_,
-            perFilterConfig("envoy.filters.http.buffer"))
-        .WillByDefault(Return(vhost_settings));
-  }
-
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   BufferFilterConfigSharedPtr config_;
   BufferFilter filter_;
@@ -133,16 +124,14 @@ TEST_F(BufferFilterTest, ContentLengthPopulationAlreadyPresent) {
   EXPECT_EQ(headers.getContentLengthValue(), "3");
 }
 
-TEST_F(BufferFilterTest, RouteConfigOverride) {
-  envoy::extensions::filters::http::buffer::v3::BufferPerRoute route_cfg;
-  auto* buf = route_cfg.mutable_buffer();
+TEST_F(BufferFilterTest, PerFilterConfigOverride) {
+  envoy::extensions::filters::http::buffer::v3::BufferPerRoute per_route_cfg;
+  auto* buf = per_route_cfg.mutable_buffer();
   buf->mutable_max_request_bytes()->set_value(123);
-  envoy::extensions::filters::http::buffer::v3::BufferPerRoute vhost_cfg;
-  vhost_cfg.set_disabled(true);
-  BufferFilterSettings route_settings(route_cfg);
-  BufferFilterSettings vhost_settings(vhost_cfg);
-  routeLocalConfig(&route_settings, &vhost_settings);
+  BufferFilterSettings route_settings(per_route_cfg);
 
+  EXPECT_CALL(*callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.buffer"))
+      .WillOnce(Return(&route_settings));
   EXPECT_CALL(callbacks_, setDecoderBufferLimit(123ULL));
 
   Http::TestRequestHeaderMapImpl headers;
@@ -151,26 +140,13 @@ TEST_F(BufferFilterTest, RouteConfigOverride) {
   filter_.onDestroy();
 }
 
-TEST_F(BufferFilterTest, VHostConfigOverride) {
-  envoy::extensions::filters::http::buffer::v3::BufferPerRoute vhost_cfg;
-  auto* buf = vhost_cfg.mutable_buffer();
-  buf->mutable_max_request_bytes()->set_value(789);
-  BufferFilterSettings vhost_settings(vhost_cfg);
-  routeLocalConfig(nullptr, &vhost_settings);
+TEST_F(BufferFilterTest, PerFilterConfigDisabledConfigOverride) {
+  envoy::extensions::filters::http::buffer::v3::BufferPerRoute per_route_cfg;
+  per_route_cfg.set_disabled(true);
+  BufferFilterSettings route_settings(per_route_cfg);
 
-  EXPECT_CALL(callbacks_, setDecoderBufferLimit(789ULL));
-
-  Http::TestRequestHeaderMapImpl headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
-  filter_.onDestroy();
-}
-
-TEST_F(BufferFilterTest, RouteDisabledConfigOverride) {
-  envoy::extensions::filters::http::buffer::v3::BufferPerRoute vhost_cfg;
-  vhost_cfg.set_disabled(true);
-  BufferFilterSettings vhost_settings(vhost_cfg);
-  routeLocalConfig(nullptr, &vhost_settings);
-
+  EXPECT_CALL(*callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.buffer"))
+      .WillOnce(Return(&route_settings));
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers, false));
   Buffer::OwnedImpl data1("hello");

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -286,8 +286,8 @@ TEST_F(ProxyFilterTest, HostRewrite) {
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(false));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
-  EXPECT_CALL(callbacks_.route_->route_entry_,
-              perFilterConfig("envoy.filters.http.dynamic_forward_proxy"))
+  EXPECT_CALL(*callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.dynamic_forward_proxy"))
       .WillOnce(Return(&config));
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("bar"), 80, _))
       .WillOnce(Return(
@@ -315,8 +315,8 @@ TEST_F(ProxyFilterTest, HostRewriteViaHeader) {
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(false));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
-  EXPECT_CALL(callbacks_.route_->route_entry_,
-              perFilterConfig("envoy.filters.http.dynamic_forward_proxy"))
+  EXPECT_CALL(*callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.dynamic_forward_proxy"))
       .WillOnce(Return(&config));
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("bar:82"), 80, _))
       .WillOnce(Return(

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1487,9 +1487,6 @@ TEST_P(HttpFilterTestParam, ContextExtensions) {
       "default_route_value";
   // Initialize the virtual host's per filter config.
   FilterConfigPerRoute auth_per_vhost(settingsvhost);
-  ON_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-          perFilterConfig("envoy.filters.http.ext_authz"))
-      .WillByDefault(Return(&auth_per_vhost));
 
   // Place something in the context extensions on the route.
   envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute settingsroute;
@@ -1497,8 +1494,16 @@ TEST_P(HttpFilterTestParam, ContextExtensions) {
       "value_route";
   // Initialize the route's per filter config.
   FilterConfigPerRoute auth_per_route(settingsroute);
-  ON_CALL(filter_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.ext_authz"))
-      .WillByDefault(Return(&auth_per_route));
+
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ext_authz"))
+      .WillOnce(Return(&auth_per_route));
+  EXPECT_CALL(*filter_callbacks_.route_, traversePerFilterConfig("envoy.filters.http.ext_authz", _))
+      .WillOnce(Invoke([&](const std::string&,
+                           std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
+        cb(auth_per_vhost);
+        cb(auth_per_route);
+      }));
 
   prepareCheck();
 
@@ -1527,7 +1532,7 @@ TEST_P(HttpFilterTestParam, DisabledOnRoute) {
 
   prepareCheck();
 
-  ON_CALL(filter_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.ext_authz"))
+  ON_CALL(*filter_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.ext_authz"))
       .WillByDefault(Return(&auth_per_route));
 
   auto test_disable = [&](bool disabled) {
@@ -1558,7 +1563,7 @@ TEST_P(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
   envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute settings;
   FilterConfigPerRoute auth_per_route(settings);
 
-  ON_CALL(filter_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.ext_authz"))
+  ON_CALL(*filter_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.ext_authz"))
       .WillByDefault(Return(&auth_per_route));
 
   auto test_disable = [&](bool disabled) {
@@ -2136,7 +2141,7 @@ TEST_P(HttpFilterTestParam, NoCluster) {
       "value_route";
   // Initialize the route's per filter config.
   FilterConfigPerRoute auth_per_route(settingsroute);
-  ON_CALL(filter_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.ext_authz"))
+  ON_CALL(*filter_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.ext_authz"))
       .WillByDefault(Return(&auth_per_route));
 
   prepareCheck();
@@ -2162,7 +2167,7 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
   envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute settings;
   FilterConfigPerRoute auth_per_route(settings);
 
-  ON_CALL(filter_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.ext_authz"))
+  ON_CALL(*filter_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.ext_authz"))
       .WillByDefault(Return(&auth_per_route));
 
   auto test_disable_request_body_buffering = [&](bool bypass) {

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -146,9 +146,6 @@ public:
     EXPECT_CALL(*timer_, disableTimer());
   }
 
-  void TestPerFilterConfigFault(const Router::RouteSpecificFilterConfig* route_fault,
-                                const Router::RouteSpecificFilterConfig* vhost_fault);
-
   NiceMock<Stats::MockIsolatedStatsStore> stats_;
   FaultFilterConfigSharedPtr config_;
   std::unique_ptr<FaultFilter> filter_;
@@ -1191,16 +1188,13 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterNullRoute) {
   EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
 }
 
-void FaultFilterTest::TestPerFilterConfigFault(
-    const Router::RouteSpecificFilterConfig* route_fault,
-    const Router::RouteSpecificFilterConfig* vhost_fault) {
+TEST_F(FaultFilterTest, RouteFaultOverridesListenerFault) {
+  setUpTest(v2_empty_fault_config_yaml);
+  Fault::FaultSettings delay_fault(convertYamlStrToProtoConfig(delay_with_upstream_cluster_yaml));
 
-  ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.fault"))
-      .WillByDefault(Return(route_fault));
-  ON_CALL(decoder_filter_callbacks_.route_->route_entry_.virtual_host_,
-          perFilterConfig("envoy.filters.http.fault"))
-      .WillByDefault(Return(vhost_fault));
+  ON_CALL(*decoder_filter_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.fault"))
+      .WillByDefault(Return(&delay_fault));
 
   const std::string upstream_cluster("www1");
 
@@ -1237,34 +1231,6 @@ void FaultFilterTest::TestPerFilterConfigFault(
 
   EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
-}
-
-TEST_F(FaultFilterTest, RouteFaultOverridesListenerFault) {
-
-  Fault::FaultSettings abort_fault(convertYamlStrToProtoConfig(abort_only_yaml));
-  Fault::FaultSettings delay_fault(convertYamlStrToProtoConfig(delay_with_upstream_cluster_yaml));
-
-  // route-level fault overrides listener-level fault
-  {
-    setUpTest(v2_empty_fault_config_yaml); // This is a valid listener level fault
-    TestPerFilterConfigFault(&delay_fault, nullptr);
-  }
-
-  // virtual-host-level fault overrides listener-level fault
-  {
-    config_->stats().aborts_injected_.reset();
-    config_->stats().delays_injected_.reset();
-    setUpTest(v2_empty_fault_config_yaml);
-    TestPerFilterConfigFault(nullptr, &delay_fault);
-  }
-
-  // route-level fault overrides virtual-host-level fault
-  {
-    config_->stats().aborts_injected_.reset();
-    config_->stats().delays_injected_.reset();
-    setUpTest(v2_empty_fault_config_yaml);
-    TestPerFilterConfigFault(&delay_fault, &abort_fault);
-  }
 }
 
 class FaultFilterRateLimitTest : public FaultFilterTest {

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -614,8 +614,8 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteDisabled) {
   filter_config_per_route.set_disabled(true);
   FilterConfigPerRoute filterConfigPerRoute(filter_config_per_route);
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.grpc_http1_reverse_bridge"))
+  ON_CALL(*decoder_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.grpc_http1_reverse_bridge"))
       .WillByDefault(testing::Return(&filterConfigPerRoute));
 
   EXPECT_CALL(decoder_callbacks_, route()).Times(2);
@@ -643,8 +643,8 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteEnabled) {
   filter_config_per_route.set_disabled(false);
   FilterConfigPerRoute filterConfigPerRoute(filter_config_per_route);
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.grpc_http1_reverse_bridge"))
+  ON_CALL(*decoder_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.grpc_http1_reverse_bridge"))
       .WillByDefault(testing::Return(&filterConfigPerRoute));
 
   {

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -135,8 +135,8 @@ TEST_F(HeaderToMetadataTest, PerRouteOverride) {
   envoy::extensions::filters::http::header_to_metadata::v3::Config config_proto;
   TestUtility::loadFromYaml(request_config_yaml, config_proto);
   Config per_route_config(config_proto, true);
-  EXPECT_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.header_to_metadata"))
+  EXPECT_CALL(*decoder_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.header_to_metadata"))
       .WillOnce(Return(&per_route_config));
 
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
@@ -161,8 +161,8 @@ TEST_F(HeaderToMetadataTest, ConfigIsCached) {
   envoy::extensions::filters::http::header_to_metadata::v3::Config config_proto;
   TestUtility::loadFromYaml(request_config_yaml, config_proto);
   Config per_route_config(config_proto, true);
-  EXPECT_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.header_to_metadata"))
+  EXPECT_CALL(*decoder_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.header_to_metadata"))
       .WillOnce(Return(&per_route_config));
 
   EXPECT_TRUE(getConfig()->doRequest());

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -99,8 +99,8 @@ TEST_F(KillRequestFilterTest, KillRequestEnabledFromRouteLevelConfiguration) {
   KillSettings kill_settings = KillSettings(route_level_kill_request);
 
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
-  ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.kill_request"))
+  ON_CALL(*decoder_filter_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.kill_request"))
       .WillByDefault(Return(&kill_settings));
   EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
 }
@@ -114,8 +114,8 @@ TEST_F(KillRequestFilterTest, KillRequestDisabledRouteLevelConfiguration) {
   request_headers_.addCopy("x-envoy-kill-request", "true");
 
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
-  ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.kill_request"))
+  ON_CALL(*decoder_filter_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.kill_request"))
       .WillByDefault(Return(nullptr));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
 }
@@ -219,8 +219,8 @@ TEST_F(KillRequestFilterTest, PerRouteKillSettingFound) {
 
   // Return valid kill setting on the REQUEST direction
   const KillSettings kill_settings(route_level_kill_request);
-  ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.kill_request"))
+  ON_CALL(*decoder_filter_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.kill_request"))
       .WillByDefault(Return(&kill_settings));
   ASSERT_EQ(filter_->decodeHeaders(request_headers_, false), Http::FilterHeadersStatus::Continue);
 }

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -2185,7 +2185,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterDisabled) {
 
   EXPECT_CALL(decoder_callbacks_, clearRouteCache());
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.lua"))
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.lua"))
       .WillByDefault(Return(nullptr));
 
   Http::TestRequestHeaderMapImpl request_headers_1{{":path", "/"}};
@@ -2193,7 +2193,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterDisabled) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_1, true));
   EXPECT_EQ("world", request_headers_1.get_("hello"));
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.lua"))
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.lua"))
       .WillByDefault(Return(per_route_config_.get()));
 
   Http::TestRequestHeaderMapImpl request_headers_2{{":path", "/"}};
@@ -2229,7 +2229,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterRefSourceCodes) {
   setupConfig(proto_config, per_route_proto_config);
   setupFilter();
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.lua"))
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.lua"))
       .WillByDefault(Return(per_route_config_.get()));
 
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
@@ -2258,7 +2258,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterRefSourceCodeNotExist) {
   setupConfig(proto_config, per_route_proto_config);
   setupFilter();
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.lua"))
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.lua"))
       .WillByDefault(Return(per_route_config_.get()));
 
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -1102,8 +1102,8 @@ TEST_F(HttpRateLimitFilterTest, DEPRECATED_FEATURE_TEST(ExcludeVirtualHost)) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, empty())
@@ -1153,8 +1153,8 @@ TEST_F(HttpRateLimitFilterTest, OverrideVHRateLimitOptionWithRouteRateLimitSet) 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, empty())
@@ -1202,8 +1202,8 @@ TEST_F(HttpRateLimitFilterTest, OverrideVHRateLimitOptionWithoutRouteRateLimit) 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, empty())
@@ -1253,8 +1253,8 @@ TEST_F(HttpRateLimitFilterTest, IncludeVHRateLimitOptionWithOnlyVHRateLimitSet) 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -1303,8 +1303,8 @@ TEST_F(HttpRateLimitFilterTest, IncludeVHRateLimitOptionWithRouteAndVHRateLimitS
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -1353,8 +1353,8 @@ TEST_F(HttpRateLimitFilterTest, IgnoreVHRateLimitOptionWithRouteRateLimitSet) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -1399,8 +1399,8 @@ TEST_F(HttpRateLimitFilterTest, IgnoreVHRateLimitOptionWithOutRouteRateLimit) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())
       .WillOnce(Return(false));
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_,
-              perFilterConfig("envoy.filters.http.ratelimit"))
+  EXPECT_CALL(*filter_callbacks_.route_,
+              mostSpecificPerFilterConfig("envoy.filters.http.ratelimit"))
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -212,7 +212,7 @@ TEST_F(RoleBasedAccessControlFilterTest, RouteLocalOverride) {
   EXPECT_CALL(engine, handleAction(_, _, _, _)).WillRepeatedly(Return(true));
   EXPECT_CALL(per_route_config_, engine()).WillRepeatedly(ReturnRef(engine));
 
-  EXPECT_CALL(callbacks_.route_->route_entry_, perFilterConfig("envoy.filters.http.rbac"))
+  EXPECT_CALL(*callbacks_.route_, mostSpecificPerFilterConfig("envoy.filters.http.rbac"))
       .WillRepeatedly(Return(&per_route_config_));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers_, true));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -454,6 +454,11 @@ public:
   MOCK_METHOD(const Decorator*, decorator, (), (const));
   MOCK_METHOD(const RouteTracing*, tracingConfig, (), (const));
   MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (const std::string&),
+              (const));
+  MOCK_METHOD(void, traversePerFilterConfig,
+              (const std::string&, std::function<void(const Router::RouteSpecificFilterConfig&)>),
+              (const));
 
   testing::NiceMock<MockRouteEntry> route_entry_;
   testing::NiceMock<MockDecorator> decorator_;


### PR DESCRIPTION
Backport of #17449, e071417f12809eddbf02052504fd9953eedce8f0

Co-authored-by: He Jie Xu <hejie.xu@intel.com>
Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
