### PR TITLE
tooling: Add `async_subprocess` util

### DIFF
--- a/tools/base/BUILD
+++ b/tools/base/BUILD
@@ -6,6 +6,8 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+envoy_py_library("tools.base.aio")
+
 envoy_py_library(
     "tools.base.runner",
     deps = [

--- a/tools/base/aio.py
+++ b/tools/base/aio.py
@@ -41,7 +41,9 @@ class async_subprocess:  # noqa: N801
         # on the machine.
         with concurrent.futures.ProcessPoolExecutor() as pool:
             futures = asyncio.as_completed(
-                tuple(asyncio.ensure_future(cls.run(command, executor=pool, **kwargs)) for command in commands))
+                tuple(
+                    asyncio.ensure_future(cls.run(command, executor=pool, **kwargs))
+                    for command in commands))
             for result in futures:
                 yield await result
 

--- a/tools/base/aio.py
+++ b/tools/base/aio.py
@@ -1,0 +1,83 @@
+import asyncio
+import concurrent.futures
+import subprocess
+from functools import partial
+from typing import AsyncGenerator, Iterable, Optional
+
+
+class async_subprocess:  # noqa: N801
+
+    @classmethod
+    async def parallel(
+            cls, commands: Iterable[Iterable[str]],
+            **kwargs) -> AsyncGenerator[subprocess.CompletedProcess, Iterable[Iterable[str]]]:
+        """Run external subprocesses in parallel
+
+        Yields `subprocess.CompletedProcess` results as they are completed.
+
+        Example usage:
+
+        ```
+        import asyncio
+
+        from tools.base.aio import async_subprocess
+
+        async def run_system_commands(commands):
+            async for result in async_subprocess.parallel(commands, capture_output=True):
+                print(result.returncode)
+                print(result.stdout)
+                print(result.stderr)
+
+        asyncio.run(run_system_commands(["whoami"] for i in range(0, 5)))
+        ```
+        """
+        # Using a `ProcessPoolExecutor` or `ThreadPoolExecutor` here is somewhat
+        # arbitrary as subproc will spawn a new process regardless.
+        # Either way - using a custom executor of either type gives considerable speedup,
+        # most likely due to the number of workers allocated.
+        # In my testing, `ProcessPoolExecutor` gave a very small speedup over a large
+        # number of tasks, despite any additional overhead of creating the executor.
+        # Without `max_workers` set `ProcessPoolExecutor` defaults to the number of cpus
+        # on the machine.
+        with concurrent.futures.ProcessPoolExecutor() as pool:
+            futures = asyncio.as_completed(
+                tuple(asyncio.ensure_future(cls.run(command, executor=pool, **kwargs)) for command in commands))
+            for result in futures:
+                yield await result
+
+    @classmethod
+    async def run(
+            cls,
+            *args,
+            loop: Optional[asyncio.AbstractEventLoop] = None,
+            executor: Optional[concurrent.futures.Executor] = None,
+            **kwargs) -> subprocess.CompletedProcess:
+        """This is an asyncio wrapper for `subprocess.run`
+
+        It can be used in a similar way to `subprocess.run` but its non-blocking to
+        the main thread.
+
+        Example usage:
+
+        ```
+        import asyncio
+
+        from tools.base.aio import async_subprocess
+
+        async def run_system_command():
+            result = await async_subprocess.run(["whoami"], capture_output=True)
+            print(result.returncode)
+            print(result.stdout)
+            print(result.stderr)
+
+        asyncio.run(run_system_command())
+
+        ```
+
+        By default it will spawn the process using the main event loop, and that loop's
+        default (`ThreadPool`) executor.
+
+        You can provide the loop and/or the executor to change this behaviour.
+        """
+        loop = loop or asyncio.get_running_loop()
+        return await loop.run_in_executor(executor, partial(subprocess.run, *args, **kwargs))

--- a/tools/base/tests/test_aio.py
+++ b/tools/base/tests/test_aio.py
@@ -1,0 +1,87 @@
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tools.base import aio
+
+
+@pytest.mark.asyncio
+async def test_async_subprocess_parallel(patches):
+    patched = patches(
+        "asyncio",
+        "concurrent.futures",
+        "async_subprocess.run",
+        prefix="tools.base.aio")
+    procs = [f"PROC{i}" for i in range(0, 3)]
+    kwargs = {f"KEY{i}": f"VALUE{i}" for i in range(0, 3)}
+
+    async def _result(result):
+        return result
+
+    with patched as (m_asyncio, m_future, m_run):
+        _results = [f"RESULT{i}" for i in range(0, 5)]
+        m_asyncio.as_completed.return_value = [
+            _result(result) for result in _results]
+
+        results = []
+        async for result in aio.async_subprocess.parallel(procs, **kwargs):
+            results.append(result)
+
+    assert results == _results
+    assert (
+        list(m_future.ProcessPoolExecutor.call_args)
+        == [(), {}])
+    assert (
+        list(m_asyncio.as_completed.call_args)
+        == [(tuple(m_asyncio.ensure_future.return_value for i in range(0, len(procs))), ), {}])
+    kwargs["executor"] = m_future.ProcessPoolExecutor.return_value.__enter__.return_value
+    assert (
+        list(list(c) for c in m_run.call_args_list)
+        == [[(proc,), kwargs] for proc in procs])
+    assert (
+        list(list(c) for c in m_asyncio.ensure_future.call_args_list)
+        == [[(m_run.return_value,), {}] for proc in procs])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("loop", [True, False])
+@pytest.mark.parametrize("executor", [None, "EXECUTOR"])
+async def test_async_subprocess_run(patches, loop, executor):
+    patched = patches(
+        "asyncio",
+        "partial",
+        "subprocess",
+        prefix="tools.base.aio")
+    args = [f"ARG{i}" for i in range(0, 3)]
+    kwargs = {f"KEY{i}": f"VALUE{i}" for i in range(0, 3)}
+
+    if loop:
+        kwargs["loop"] = AsyncMock()
+
+    if executor:
+        kwargs["executor"] = executor
+
+    with patched as (m_asyncio, m_partial, m_subproc):
+        m_asyncio.get_running_loop.return_value = AsyncMock()
+        if loop:
+            _loop = kwargs["loop"]
+        else:
+            _loop = m_asyncio.get_running_loop.return_value
+
+        assert (
+            await aio.async_subprocess.run(*args, **kwargs)
+            == _loop.run_in_executor.return_value)
+
+    if loop:
+        assert not m_asyncio.get_running_loop.called
+
+    kwargs.pop("executor", None)
+    kwargs.pop("loop", None)
+
+    assert (
+        list(m_partial.call_args)
+        == [(m_subproc.run, ) + tuple(args), kwargs])
+    assert (
+        list(_loop.run_in_executor.call_args)
+        == [(executor, m_partial.return_value), {}])


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: tooling: Add `async_subprocess` util
Additional Description:

Adds:

`async_subprocess.run` - wraps `subprocess.run` in a non-blocking task
`async_subprocess.parallel` - run multiple subprocess in parallel much like `multiprocessing.pool` - results are yielded as available

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
