### PR TITLE
doc:fix cache filter sandbox example output inconsistent

### DIFF
--- a/docs/root/start/sandboxes/cache.rst
+++ b/docs/root/start/sandboxes/cache.rst
@@ -50,8 +50,8 @@ Change to the ``examples/cache`` directory.
            Name                      Command            State           Ports
     ----------------------------------------------------------------------------------------------
     cache_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->8000/tcp
-    cache_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
-    cache_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
+    cache_service1_1      python3 /code/service.py       Up
+    cache_service2_1      python3 /code/service.py       Up
 
 Step 2: Test Envoy's HTTP caching capabilities
 **********************************************


### PR DESCRIPTION
fix cache filter sandbox example output inconsistent

Signed-off-by: yizhou.xu@intel.com

Commit Message: fix cache filter sandbox example output inconsistent
Additional Description:  Since start command of sandbox image have changed, command output message will changed respectively
Testing: N/A
Risk Level: low
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional API Considerations:]