### PR TITLE
new interface for trace context for getting basic stream info and trace context iteration

### DIFF
--- a/envoy/tracing/trace_context.h
+++ b/envoy/tracing/trace_context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 
 #include "envoy/common/pure.h"
@@ -14,14 +15,50 @@ namespace Tracing {
  * Protocol-independent abstraction for traceable stream. It hides the differences between different
  * protocol and provides tracer driver with common methods for obtaining and setting the tracing
  * context.
- *
- * TODO(wbpcode): A new interface should be added to obtain general traceable stream information,
- * such as host, RPC method, protocol identification, etc. At the same time, a new interface needs
- * to be added to support traversal of all trace contexts.
  */
 class TraceContext {
 public:
   virtual ~TraceContext() = default;
+
+  using IterateCallback = std::function<bool(absl::string_view key, absl::string_view val)>;
+
+  /**
+   * Get context protocol.
+   *
+   * @return A string view representing the protocol of the traceable stream behind the context.
+   */
+  virtual absl::string_view contextProtocol() const PURE;
+
+  /**
+   * Get context authority.
+   *
+   * @return The authority of traceable stream. It generally consists of the host and an optional
+   * user information and an optional port.
+   */
+  virtual absl::string_view contextAuthority() const PURE;
+
+  /**
+   * Get context path.
+   *
+   * @return The path of traceable stream. The content and meaning of path are determined by
+   * specific protocol itself.
+   */
+  virtual absl::string_view contextPath() const PURE;
+
+  /**
+   * Get context method.
+   *
+   * @return The method of traceable stream. The content and meaning of method are determined by
+   * specific protocol itself.
+   */
+  virtual absl::string_view contextMethod() const PURE;
+
+  /**
+   * Iterate over all context entry.
+   *
+   * @param callback supplies the iteration callback.
+   */
+  virtual void iterateContext(IterateCallback callback) const PURE;
 
   /**
    * Get tracing context value by key.

--- a/envoy/tracing/trace_context.h
+++ b/envoy/tracing/trace_context.h
@@ -27,7 +27,7 @@ public:
    *
    * @return A string view representing the protocol of the traceable stream behind the context.
    */
-  virtual absl::string_view contextProtocol() const PURE;
+  virtual absl::string_view protocol() const PURE;
 
   /**
    * Get context authority.
@@ -35,7 +35,7 @@ public:
    * @return The authority of traceable stream. It generally consists of the host and an optional
    * user information and an optional port.
    */
-  virtual absl::string_view contextAuthority() const PURE;
+  virtual absl::string_view authority() const PURE;
 
   /**
    * Get context path.
@@ -43,7 +43,7 @@ public:
    * @return The path of traceable stream. The content and meaning of path are determined by
    * specific protocol itself.
    */
-  virtual absl::string_view contextPath() const PURE;
+  virtual absl::string_view path() const PURE;
 
   /**
    * Get context method.
@@ -51,14 +51,14 @@ public:
    * @return The method of traceable stream. The content and meaning of method are determined by
    * specific protocol itself.
    */
-  virtual absl::string_view contextMethod() const PURE;
+  virtual absl::string_view method() const PURE;
 
   /**
    * Iterate over all context entry.
    *
    * @param callback supplies the iteration callback.
    */
-  virtual void iterateContext(IterateCallback callback) const PURE;
+  virtual void forEach(IterateCallback callback) const PURE;
 
   /**
    * Get tracing context value by key.
@@ -66,7 +66,7 @@ public:
    * @param key The context key of string view type.
    * @return The optional context value of string_view type.
    */
-  virtual absl::optional<absl::string_view> getTraceContext(absl::string_view key) const PURE;
+  virtual absl::optional<absl::string_view> getByKey(absl::string_view key) const PURE;
 
   /**
    * Set new tracing context key/value pair.
@@ -74,7 +74,7 @@ public:
    * @param key The context key of string view type.
    * @param val The context value of string view type.
    */
-  virtual void setTraceContext(absl::string_view key, absl::string_view val) PURE;
+  virtual void setByKey(absl::string_view key, absl::string_view val) PURE;
 
   /**
    * Set new tracing context key/value pair. The key MUST point to data that will live beyond
@@ -83,11 +83,11 @@ public:
    * @param key The context key of string view type.
    * @param val The context value of string view type.
    */
-  virtual void setTraceContextReferenceKey(absl::string_view key, absl::string_view val) {
+  virtual void setByReferenceKey(absl::string_view key, absl::string_view val) {
     // The reference semantics of key and value are ignored by default. Derived classes that wish to
     // use reference semantics to improve performance or reduce memory overhead can override this
     // method.
-    setTraceContext(key, val);
+    setByKey(key, val);
   }
 
   /**
@@ -97,11 +97,11 @@ public:
    * @param key The context key of string view type.
    * @param val The context value of string view type.
    */
-  virtual void setTraceContextReference(absl::string_view key, absl::string_view val) {
+  virtual void setByReference(absl::string_view key, absl::string_view val) {
     // The reference semantics of key and value are ignored by default. Derived classes that wish to
     // use reference semantics to improve performance or reduce memory overhead can override this
     // method.
-    setTraceContext(key, val);
+    setByKey(key, val);
   }
 };
 

--- a/envoy/tracing/trace_context.h
+++ b/envoy/tracing/trace_context.h
@@ -83,12 +83,7 @@ public:
    * @param key The context key of string view type.
    * @param val The context value of string view type.
    */
-  virtual void setByReferenceKey(absl::string_view key, absl::string_view val) {
-    // The reference semantics of key and value are ignored by default. Derived classes that wish to
-    // use reference semantics to improve performance or reduce memory overhead can override this
-    // method.
-    setByKey(key, val);
-  }
+  virtual void setByReferenceKey(absl::string_view key, absl::string_view val) PURE;
 
   /**
    * Set new tracing context key/value pair. Both key and val MUST point to data that will live
@@ -97,12 +92,7 @@ public:
    * @param key The context key of string view type.
    * @param val The context value of string view type.
    */
-  virtual void setByReference(absl::string_view key, absl::string_view val) {
-    // The reference semantics of key and value are ignored by default. Derived classes that wish to
-    // use reference semantics to improve performance or reduce memory overhead can override this
-    // method.
-    setByKey(key, val);
-  }
+  virtual void setByReference(absl::string_view key, absl::string_view val) PURE;
 };
 
 } // namespace Tracing

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -658,6 +658,23 @@ HeaderMapImplUtility::getAllHeaderMapImplInfo() {
   return ret;
 }
 
+absl::string_view RequestHeaderMapImpl::contextProtocol() const { return getProtocolValue(); }
+
+absl::string_view RequestHeaderMapImpl::contextAuthority() const { return getHostValue(); }
+
+absl::string_view RequestHeaderMapImpl::contextPath() const { return getPathValue(); }
+
+absl::string_view RequestHeaderMapImpl::contextMethod() const { return getMethodValue(); }
+
+void RequestHeaderMapImpl::iterateContext(Tracing::TraceContext::IterateCallback callback) const {
+  HeaderMapImpl::iterate([cb = std::move(callback)](const HeaderEntry& entry) {
+    if (cb(entry.key().getStringView(), entry.value().getStringView())) {
+      return HeaderMap::Iterate::Continue;
+    }
+    return HeaderMap::Iterate::Break;
+  });
+}
+
 absl::optional<absl::string_view>
 RequestHeaderMapImpl::getTraceContext(absl::string_view key) const {
   ASSERT(validatedLowerCaseString(key));

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -658,15 +658,15 @@ HeaderMapImplUtility::getAllHeaderMapImplInfo() {
   return ret;
 }
 
-absl::string_view RequestHeaderMapImpl::contextProtocol() const { return getProtocolValue(); }
+absl::string_view RequestHeaderMapImpl::protocol() const { return getProtocolValue(); }
 
-absl::string_view RequestHeaderMapImpl::contextAuthority() const { return getHostValue(); }
+absl::string_view RequestHeaderMapImpl::authority() const { return getHostValue(); }
 
-absl::string_view RequestHeaderMapImpl::contextPath() const { return getPathValue(); }
+absl::string_view RequestHeaderMapImpl::path() const { return getPathValue(); }
 
-absl::string_view RequestHeaderMapImpl::contextMethod() const { return getMethodValue(); }
+absl::string_view RequestHeaderMapImpl::method() const { return getMethodValue(); }
 
-void RequestHeaderMapImpl::iterateContext(Tracing::TraceContext::IterateCallback callback) const {
+void RequestHeaderMapImpl::forEach(Tracing::TraceContext::IterateCallback callback) const {
   HeaderMapImpl::iterate([cb = std::move(callback)](const HeaderEntry& entry) {
     if (cb(entry.key().getStringView(), entry.value().getStringView())) {
       return HeaderMap::Iterate::Continue;
@@ -675,8 +675,7 @@ void RequestHeaderMapImpl::iterateContext(Tracing::TraceContext::IterateCallback
   });
 }
 
-absl::optional<absl::string_view>
-RequestHeaderMapImpl::getTraceContext(absl::string_view key) const {
+absl::optional<absl::string_view> RequestHeaderMapImpl::getByKey(absl::string_view key) const {
   ASSERT(validatedLowerCaseString(key));
   auto result = const_cast<RequestHeaderMapImpl*>(this)->getExisting(key);
 
@@ -686,7 +685,7 @@ RequestHeaderMapImpl::getTraceContext(absl::string_view key) const {
   return result[0]->value().getStringView();
 }
 
-void RequestHeaderMapImpl::setTraceContext(absl::string_view key, absl::string_view val) {
+void RequestHeaderMapImpl::setByKey(absl::string_view key, absl::string_view val) {
   ASSERT(validatedLowerCaseString(key));
   HeaderMapImpl::removeExisting(key);
 
@@ -698,8 +697,7 @@ void RequestHeaderMapImpl::setTraceContext(absl::string_view key, absl::string_v
   HeaderMapImpl::insertByKey(std::move(new_key), std::move(new_val));
 }
 
-void RequestHeaderMapImpl::setTraceContextReferenceKey(absl::string_view key,
-                                                       absl::string_view val) {
+void RequestHeaderMapImpl::setByReferenceKey(absl::string_view key, absl::string_view val) {
   ASSERT(validatedLowerCaseString(key));
   HeaderMapImpl::removeExisting(key);
 
@@ -709,7 +707,7 @@ void RequestHeaderMapImpl::setTraceContextReferenceKey(absl::string_view key,
   HeaderMapImpl::insertByKey(HeaderString(key), std::move(new_val));
 }
 
-void RequestHeaderMapImpl::setTraceContextReference(absl::string_view key, absl::string_view val) {
+void RequestHeaderMapImpl::setByReference(absl::string_view key, absl::string_view val) {
   ASSERT(validatedLowerCaseString(key));
   HeaderMapImpl::removeExisting(key);
 

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -484,6 +484,11 @@ public:
   INLINE_REQ_RESP_NUMERIC_HEADERS(DEFINE_INLINE_HEADER_NUMERIC_FUNCS)
 
   // Tracing::TraceContext
+  absl::string_view contextProtocol() const override;
+  absl::string_view contextAuthority() const override;
+  absl::string_view contextPath() const override;
+  absl::string_view contextMethod() const override;
+  void iterateContext(Tracing::TraceContext::IterateCallback callback) const override;
   absl::optional<absl::string_view> getTraceContext(absl::string_view key) const override;
   void setTraceContext(absl::string_view key, absl::string_view val) override;
   void setTraceContextReferenceKey(absl::string_view key, absl::string_view val) override;

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -484,15 +484,15 @@ public:
   INLINE_REQ_RESP_NUMERIC_HEADERS(DEFINE_INLINE_HEADER_NUMERIC_FUNCS)
 
   // Tracing::TraceContext
-  absl::string_view contextProtocol() const override;
-  absl::string_view contextAuthority() const override;
-  absl::string_view contextPath() const override;
-  absl::string_view contextMethod() const override;
-  void iterateContext(Tracing::TraceContext::IterateCallback callback) const override;
-  absl::optional<absl::string_view> getTraceContext(absl::string_view key) const override;
-  void setTraceContext(absl::string_view key, absl::string_view val) override;
-  void setTraceContextReferenceKey(absl::string_view key, absl::string_view val) override;
-  void setTraceContextReference(absl::string_view key, absl::string_view val) override;
+  absl::string_view protocol() const override;
+  absl::string_view authority() const override;
+  absl::string_view path() const override;
+  absl::string_view method() const override;
+  void forEach(Tracing::TraceContext::IterateCallback callback) const override;
+  absl::optional<absl::string_view> getByKey(absl::string_view key) const override;
+  void setByKey(absl::string_view key, absl::string_view val) override;
+  void setByReferenceKey(absl::string_view key, absl::string_view val) override;
+  void setByReference(absl::string_view key, absl::string_view val) override;
 
 protected:
   // NOTE: Because inline_headers_ is a variable size member, it must be the last member in the

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -306,7 +306,7 @@ absl::string_view RequestHeaderCustomTag::value(const CustomTagContext& ctx) con
     return default_value_;
   }
   // TODO(https://github.com/envoyproxy/envoy/issues/13454): Potentially populate all header values.
-  const auto entry = ctx.trace_context->getTraceContext(name_);
+  const auto entry = ctx.trace_context->getByKey(name_);
   return entry.value_or(default_value_);
 }
 

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -70,8 +70,7 @@ public:
         [cb = std::move(f)](absl::string_view key, absl::string_view val) {
           opentracing::string_view opentracing_key{key.data(), key.length()};
           opentracing::string_view opentracing_val{val.data(), val.length()};
-          cb(opentracing_key, opentracing_val);
-          return true;
+          return static_cast<bool>(cb(opentracing_key, opentracing_val));
         });
     return {};
   }

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -95,7 +95,7 @@ startSpanHelper(const std::string& name, bool traced, const Tracing::TraceContex
     bool found = false;
     switch (incoming) {
     case OpenCensusConfig::TRACE_CONTEXT: {
-      const auto entry = trace_context.getTraceContext(Constants::get().TRACEPARENT);
+      const auto entry = trace_context.getByKey(Constants::get().TRACEPARENT);
       if (entry.has_value()) {
         found = true;
         // This is an implicitly untrusted header, so only the first value is used.
@@ -104,7 +104,7 @@ startSpanHelper(const std::string& name, bool traced, const Tracing::TraceContex
       break;
     }
     case OpenCensusConfig::GRPC_TRACE_BIN: {
-      const auto entry = trace_context.getTraceContext(Constants::get().GRPC_TRACE_BIN);
+      const auto entry = trace_context.getByKey(Constants::get().GRPC_TRACE_BIN);
       if (entry.has_value()) {
         found = true;
         // This is an implicitly untrusted header, so only the first value is used.
@@ -114,7 +114,7 @@ startSpanHelper(const std::string& name, bool traced, const Tracing::TraceContex
       break;
     }
     case OpenCensusConfig::CLOUD_TRACE_CONTEXT: {
-      const auto entry = trace_context.getTraceContext(Constants::get().X_CLOUD_TRACE_CONTEXT);
+      const auto entry = trace_context.getByKey(Constants::get().X_CLOUD_TRACE_CONTEXT);
       if (entry.has_value()) {
         found = true;
         // This is an implicitly untrusted header, so only the first value is used.
@@ -128,19 +128,19 @@ startSpanHelper(const std::string& name, bool traced, const Tracing::TraceContex
       absl::string_view b3_span_id;
       absl::string_view b3_sampled;
       absl::string_view b3_flags;
-      const auto h_b3_trace_id = trace_context.getTraceContext(Constants::get().X_B3_TRACEID);
+      const auto h_b3_trace_id = trace_context.getByKey(Constants::get().X_B3_TRACEID);
       if (h_b3_trace_id.has_value()) {
         b3_trace_id = h_b3_trace_id.value();
       }
-      const auto h_b3_span_id = trace_context.getTraceContext(Constants::get().X_B3_SPANID);
+      const auto h_b3_span_id = trace_context.getByKey(Constants::get().X_B3_SPANID);
       if (h_b3_span_id.has_value()) {
         b3_span_id = h_b3_span_id.value();
       }
-      const auto h_b3_sampled = trace_context.getTraceContext(Constants::get().X_B3_SAMPLED);
+      const auto h_b3_sampled = trace_context.getByKey(Constants::get().X_B3_SAMPLED);
       if (h_b3_sampled.has_value()) {
         b3_sampled = h_b3_sampled.value();
       }
-      const auto h_b3_flags = trace_context.getTraceContext(Constants::get().X_B3_FLAGS);
+      const auto h_b3_flags = trace_context.getByKey(Constants::get().X_B3_FLAGS);
       if (h_b3_flags.has_value()) {
         b3_flags = h_b3_flags.value();
       }
@@ -207,27 +207,27 @@ void Span::injectContext(Tracing::TraceContext& trace_context) {
   for (const auto& outgoing : oc_config_.outgoing_trace_context()) {
     switch (outgoing) {
     case OpenCensusConfig::TRACE_CONTEXT:
-      trace_context.setTraceContextReferenceKey(
-          Constants::get().TRACEPARENT, ::opencensus::trace::propagation::ToTraceParentHeader(ctx));
+      trace_context.setByReferenceKey(Constants::get().TRACEPARENT,
+                                      ::opencensus::trace::propagation::ToTraceParentHeader(ctx));
       break;
     case OpenCensusConfig::GRPC_TRACE_BIN: {
       std::string val = ::opencensus::trace::propagation::ToGrpcTraceBinHeader(ctx);
       val = Base64::encode(val.data(), val.size(), /*add_padding=*/false);
-      trace_context.setTraceContextReferenceKey(Constants::get().GRPC_TRACE_BIN, val);
+      trace_context.setByReferenceKey(Constants::get().GRPC_TRACE_BIN, val);
       break;
     }
     case OpenCensusConfig::CLOUD_TRACE_CONTEXT:
-      trace_context.setTraceContextReferenceKey(
+      trace_context.setByReferenceKey(
           Constants::get().X_CLOUD_TRACE_CONTEXT,
           ::opencensus::trace::propagation::ToCloudTraceContextHeader(ctx));
       break;
     case OpenCensusConfig::B3:
-      trace_context.setTraceContextReferenceKey(
-          Constants::get().X_B3_TRACEID, ::opencensus::trace::propagation::ToB3TraceIdHeader(ctx));
-      trace_context.setTraceContextReferenceKey(
-          Constants::get().X_B3_SPANID, ::opencensus::trace::propagation::ToB3SpanIdHeader(ctx));
-      trace_context.setTraceContextReferenceKey(
-          Constants::get().X_B3_SAMPLED, ::opencensus::trace::propagation::ToB3SampledHeader(ctx));
+      trace_context.setByReferenceKey(Constants::get().X_B3_TRACEID,
+                                      ::opencensus::trace::propagation::ToB3TraceIdHeader(ctx));
+      trace_context.setByReferenceKey(Constants::get().X_B3_SPANID,
+                                      ::opencensus::trace::propagation::ToB3SpanIdHeader(ctx));
+      trace_context.setByReferenceKey(Constants::get().X_B3_SAMPLED,
+                                      ::opencensus::trace::propagation::ToB3SampledHeader(ctx));
       // OpenCensus's trace context propagation doesn't produce the
       // "X-B3-Flags:" header.
       break;

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -51,7 +51,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   auto& tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer();
   TracingContextPtr tracing_context;
   // TODO(shikugawa): support extension span header.
-  auto propagation_header = trace_context.getTraceContext(skywalkingPropagationHeaderKey());
+  auto propagation_header = trace_context.getByKey(skywalkingPropagationHeaderKey());
   if (!propagation_header.has_value()) {
     tracing_context = tracing_context_factory_->create();
     // Sampling status is always true on SkyWalking. But with disabling skip_analysis,

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -45,14 +45,13 @@ void Span::finishSpan() {
 }
 
 void Span::injectContext(Tracing::TraceContext& trace_context) {
-  const auto host = trace_context.getTraceContext(Http::Headers::get().HostLegacy).value_or("");
-
   // TODO(wbpcode): Due to https://github.com/SkyAPM/cpp2sky/issues/83 in cpp2sky, it is necessary
   // to ensure that there is '\0' at the end of the string_view parameter to ensure that the
   // corresponding trace header is generated correctly. For this reason, we cannot directly use host
   // as argument. We need create a copy of std::string based on host and std::string will
   // automatically add '\0' to the end of the string content.
-  auto sw8_header = tracing_context_->createSW8HeaderValue(std::string(host));
+  auto sw8_header =
+      tracing_context_->createSW8HeaderValue(std::string(trace_context.contextAuthority()));
   if (sw8_header.has_value()) {
     trace_context.setTraceContextReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
   }

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -50,10 +50,9 @@ void Span::injectContext(Tracing::TraceContext& trace_context) {
   // corresponding trace header is generated correctly. For this reason, we cannot directly use host
   // as argument. We need create a copy of std::string based on host and std::string will
   // automatically add '\0' to the end of the string content.
-  auto sw8_header =
-      tracing_context_->createSW8HeaderValue(std::string(trace_context.contextAuthority()));
+  auto sw8_header = tracing_context_->createSW8HeaderValue(std::string(trace_context.authority()));
   if (sw8_header.has_value()) {
-    trace_context.setTraceContextReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
+    trace_context.setByReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
   }
 }
 

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -103,7 +103,7 @@ void Span::finishSpan() {
 void Span::injectContext(Tracing::TraceContext& trace_context) {
   const std::string xray_header_value =
       fmt::format("Root={};Parent={};Sampled={}", traceId(), id(), sampled() ? "1" : "0");
-  trace_context.setTraceContextReferenceKey(XRayTraceHeader, xray_header_value);
+  trace_context.setByReferenceKey(XRayTraceHeader, xray_header_value);
 }
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& operation_name,

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -98,10 +98,8 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   }
 
   if (!should_trace.has_value()) {
-    const SamplingRequest request{
-        trace_context.getTraceContext(Http::Headers::get().HostLegacy).value_or(""),
-        trace_context.getTraceContext(Http::Headers::get().Method).value_or(""),
-        trace_context.getTraceContext(Http::Headers::get().Path).value_or("")};
+    const SamplingRequest request{trace_context.contextAuthority(), trace_context.contextMethod(),
+                                  trace_context.contextPath()};
 
     should_trace = sampling_strategy_->shouldTrace(request);
   }

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -77,7 +77,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   UNREFERENCED_PARAMETER(config);
   // TODO(marcomagdy) - how do we factor this into the logic above
   UNREFERENCED_PARAMETER(tracing_decision);
-  const auto header = trace_context.getTraceContext(XRayTraceHeader);
+  const auto header = trace_context.getByKey(XRayTraceHeader);
   absl::optional<bool> should_trace;
   XRayHeader xray_header;
   if (header.has_value()) {
@@ -98,8 +98,8 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   }
 
   if (!should_trace.has_value()) {
-    const SamplingRequest request{trace_context.contextAuthority(), trace_context.contextMethod(),
-                                  trace_context.contextPath()};
+    const SamplingRequest request{trace_context.authority(), trace_context.method(),
+                                  trace_context.path()};
 
     should_trace = sampling_strategy_->shouldTrace(request);
   }

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -35,7 +35,7 @@ SpanContextExtractor::~SpanContextExtractor() = default;
 
 bool SpanContextExtractor::extractSampled(const Tracing::Decision tracing_decision) {
   bool sampled(false);
-  auto b3_header_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().B3);
+  auto b3_header_entry = trace_context_.getByKey(ZipkinCoreConstants::get().B3);
   if (b3_header_entry.has_value()) {
     // This is an implicitly untrusted header, so only the first value is used.
     absl::string_view b3 = b3_header_entry.value();
@@ -61,7 +61,7 @@ bool SpanContextExtractor::extractSampled(const Tracing::Decision tracing_decisi
     return getSamplingFlags(b3[sampled_pos], tracing_decision);
   }
 
-  auto x_b3_sampled_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_SAMPLED);
+  auto x_b3_sampled_entry = trace_context_.getByKey(ZipkinCoreConstants::get().X_B3_SAMPLED);
   if (!x_b3_sampled_entry.has_value()) {
     return tracing_decision.traced;
   }
@@ -74,7 +74,7 @@ bool SpanContextExtractor::extractSampled(const Tracing::Decision tracing_decisi
 }
 
 std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sampled) {
-  if (trace_context_.getTraceContext(ZipkinCoreConstants::get().B3).has_value()) {
+  if (trace_context_.getByKey(ZipkinCoreConstants::get().B3).has_value()) {
     return extractSpanContextFromB3SingleFormat(is_sampled);
   }
   uint64_t trace_id(0);
@@ -82,8 +82,8 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
   uint64_t span_id(0);
   uint64_t parent_id(0);
 
-  auto b3_trace_id_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_TRACE_ID);
-  auto b3_span_id_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_SPAN_ID);
+  auto b3_trace_id_entry = trace_context_.getByKey(ZipkinCoreConstants::get().X_B3_TRACE_ID);
+  auto b3_span_id_entry = trace_context_.getByKey(ZipkinCoreConstants::get().X_B3_SPAN_ID);
   if (b3_span_id_entry.has_value() && b3_trace_id_entry.has_value()) {
     // Extract trace id - which can either be 128 or 64 bit. For 128 bit,
     // it needs to be divided into two 64 bit numbers (high and low).
@@ -108,7 +108,7 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
     }
 
     auto b3_parent_id_entry =
-        trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
+        trace_context_.getByKey(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
     if (b3_parent_id_entry.has_value() && !b3_parent_id_entry.value().empty()) {
       // This is an implicitly untrusted header, so only the first value is used.
       const std::string pspid(b3_parent_id_entry.value());
@@ -125,7 +125,7 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
 
 std::pair<SpanContext, bool>
 SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
-  auto b3_head_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().B3);
+  auto b3_head_entry = trace_context_.getByKey(ZipkinCoreConstants::get().B3);
   ASSERT(b3_head_entry.has_value());
   // This is an implicitly untrusted header, so only the first value is used.
   const std::string b3(b3_head_entry.value());

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -119,16 +119,12 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
     auto ret_span_context = extractor.extractSpanContext(sampled);
     if (!ret_span_context.second) {
       // Create a root Zipkin span. No context was found in the headers.
-      new_zipkin_span = tracer.startSpan(
-          config,
-          std::string(trace_context.getTraceContext(Http::Headers::get().HostLegacy).value_or("")),
-          start_time);
+      new_zipkin_span =
+          tracer.startSpan(config, std::string(trace_context.contextAuthority()), start_time);
       new_zipkin_span->setSampled(sampled);
     } else {
-      new_zipkin_span = tracer.startSpan(
-          config,
-          std::string(trace_context.getTraceContext(Http::Headers::get().HostLegacy).value_or("")),
-          start_time, ret_span_context.first);
+      new_zipkin_span = tracer.startSpan(config, std::string(trace_context.contextAuthority()),
+                                         start_time, ret_span_context.first);
     }
 
   } catch (const ExtractorException& e) {

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -41,20 +41,19 @@ std::string ZipkinSpan::getBaggage(absl::string_view) { return EMPTY_STRING; }
 
 void ZipkinSpan::injectContext(Tracing::TraceContext& trace_context) {
   // Set the trace-id and span-id headers properly, based on the newly-created span structure.
-  trace_context.setTraceContextReferenceKey(ZipkinCoreConstants::get().X_B3_TRACE_ID,
-                                            span_.traceIdAsHexString());
-  trace_context.setTraceContextReferenceKey(ZipkinCoreConstants::get().X_B3_SPAN_ID,
-                                            span_.idAsHexString());
+  trace_context.setByReferenceKey(ZipkinCoreConstants::get().X_B3_TRACE_ID,
+                                  span_.traceIdAsHexString());
+  trace_context.setByReferenceKey(ZipkinCoreConstants::get().X_B3_SPAN_ID, span_.idAsHexString());
 
   // Set the parent-span header properly, based on the newly-created span structure.
   if (span_.isSetParentId()) {
-    trace_context.setTraceContextReferenceKey(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID,
-                                              span_.parentIdAsHexString());
+    trace_context.setByReferenceKey(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID,
+                                    span_.parentIdAsHexString());
   }
 
   // Set the sampled header.
-  trace_context.setTraceContextReferenceKey(ZipkinCoreConstants::get().X_B3_SAMPLED,
-                                            span_.sampled() ? SAMPLED : NOT_SAMPLED);
+  trace_context.setByReferenceKey(ZipkinCoreConstants::get().X_B3_SAMPLED,
+                                  span_.sampled() ? SAMPLED : NOT_SAMPLED);
 }
 
 void ZipkinSpan::setSampled(bool sampled) { span_.setSampled(sampled); }
@@ -120,11 +119,11 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
     if (!ret_span_context.second) {
       // Create a root Zipkin span. No context was found in the headers.
       new_zipkin_span =
-          tracer.startSpan(config, std::string(trace_context.contextAuthority()), start_time);
+          tracer.startSpan(config, std::string(trace_context.authority()), start_time);
       new_zipkin_span->setSampled(sampled);
     } else {
-      new_zipkin_span = tracer.startSpan(config, std::string(trace_context.contextAuthority()),
-                                         start_time, ret_span_context.first);
+      new_zipkin_span = tracer.startSpan(config, std::string(trace_context.authority()), start_time,
+                                         ret_span_context.first);
     }
 
   } catch (const ExtractorException& e) {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -1376,30 +1376,30 @@ TEST_P(HeaderMapImplTest, HttpTraceContextTest) {
     TestRequestHeaderMapImpl request_headers;
 
     // Protocol.
-    EXPECT_EQ(request_headers.contextProtocol(), "");
+    EXPECT_EQ(request_headers.protocol(), "");
     request_headers.addCopy(Http::Headers::get().Protocol, "HTTP/x");
-    EXPECT_EQ(request_headers.contextProtocol(), "HTTP/x");
+    EXPECT_EQ(request_headers.protocol(), "HTTP/x");
 
     // Authority.
-    EXPECT_EQ(request_headers.contextAuthority(), "");
+    EXPECT_EQ(request_headers.authority(), "");
     request_headers.addCopy(Http::Headers::get().Host, "test.com:233");
-    EXPECT_EQ(request_headers.contextAuthority(), "test.com:233");
+    EXPECT_EQ(request_headers.authority(), "test.com:233");
 
     // Path.
-    EXPECT_EQ(request_headers.contextPath(), "");
+    EXPECT_EQ(request_headers.path(), "");
     request_headers.addCopy(Http::Headers::get().Path, "/anything");
-    EXPECT_EQ(request_headers.contextPath(), "/anything");
+    EXPECT_EQ(request_headers.path(), "/anything");
 
     // Method.
-    EXPECT_EQ(request_headers.contextMethod(), "");
+    EXPECT_EQ(request_headers.method(), "");
     request_headers.addCopy(Http::Headers::get().Method, Http::Headers::get().MethodValues.Options);
-    EXPECT_EQ(request_headers.contextMethod(), Http::Headers::get().MethodValues.Options);
+    EXPECT_EQ(request_headers.method(), Http::Headers::get().MethodValues.Options);
   }
 
   {
     size_t size = 0;
     TestRequestHeaderMapImpl request_headers{{"host", "foo"}, {"bar", "var"}, {"ok", "no"}};
-    request_headers.iterateContext([&size](absl::string_view key, absl::string_view val) {
+    request_headers.forEach([&size](absl::string_view key, absl::string_view val) {
       size += key.size();
       size += val.size();
       return true;
@@ -1411,19 +1411,19 @@ TEST_P(HeaderMapImplTest, HttpTraceContextTest) {
 
   {
     TestRequestHeaderMapImpl request_headers{{"host", "foo"}};
-    EXPECT_EQ(request_headers.getTraceContext("host").value(), "foo");
+    EXPECT_EQ(request_headers.getByKey("host").value(), "foo");
 
-    request_headers.setTraceContext("trace_key", "trace_value");
-    EXPECT_EQ(request_headers.getTraceContext("trace_key").value(), "trace_value");
+    request_headers.setByKey("trace_key", "trace_value");
+    EXPECT_EQ(request_headers.getByKey("trace_key").value(), "trace_value");
 
     std::string trace_ref_key = "trace_ref_key";
-    request_headers.setTraceContextReferenceKey(trace_ref_key, "trace_value");
+    request_headers.setByReferenceKey(trace_ref_key, "trace_value");
     auto* header_entry = request_headers.get(Http::LowerCaseString(trace_ref_key))[0];
     EXPECT_EQ(reinterpret_cast<intptr_t>(trace_ref_key.data()),
               reinterpret_cast<intptr_t>(header_entry->key().getStringView().data()));
 
     std::string trace_ref_value = "trace_ref_key";
-    request_headers.setTraceContextReference(trace_ref_key, trace_ref_value);
+    request_headers.setByReference(trace_ref_key, trace_ref_value);
     header_entry = request_headers.get(Http::LowerCaseString(trace_ref_key))[0];
     EXPECT_EQ(reinterpret_cast<intptr_t>(trace_ref_key.data()),
               reinterpret_cast<intptr_t>(header_entry->key().getStringView().data()));

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -891,6 +891,10 @@ public:
   void setByKey(absl::string_view key, absl::string_view val) override {
     context_map_.insert({std::string(key), std::string(val)});
   }
+  void setByReferenceKey(absl::string_view key, absl::string_view val) override {
+    setByKey(key, val);
+  }
+  void setByReference(absl::string_view key, absl::string_view val) override { setByKey(key, val); }
 
   std::string context_protocol_;
   std::string context_authority_;

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -870,25 +870,25 @@ public:
       context_map_[value.first] = value.second;
     }
   }
-  absl::string_view contextProtocol() const override { return context_protocol_; }
-  absl::string_view contextAuthority() const override { return context_authority_; }
-  absl::string_view contextPath() const override { return context_path_; }
-  absl::string_view contextMethod() const override { return context_method_; }
-  void iterateContext(IterateCallback callback) const override {
+  absl::string_view protocol() const override { return context_protocol_; }
+  absl::string_view authority() const override { return context_authority_; }
+  absl::string_view path() const override { return context_path_; }
+  absl::string_view method() const override { return context_method_; }
+  void forEach(IterateCallback callback) const override {
     for (const auto& pair : context_map_) {
       if (!callback(pair.first, pair.second)) {
         break;
       }
     }
   }
-  absl::optional<absl::string_view> getTraceContext(absl::string_view key) const override {
+  absl::optional<absl::string_view> getByKey(absl::string_view key) const override {
     auto iter = context_map_.find(key);
     if (iter == context_map_.end()) {
       return absl::nullopt;
     }
     return iter->second;
   }
-  void setTraceContext(absl::string_view key, absl::string_view val) override {
+  void setByKey(absl::string_view key, absl::string_view val) override {
     context_map_.insert({std::string(key), std::string(val)});
   }
 
@@ -1116,11 +1116,11 @@ public:
   INLINE_REQ_RESP_NUMERIC_HEADERS(DEFINE_TEST_INLINE_NUMERIC_HEADER_FUNCS)
 
   // Tracing::TraceContext
-  absl::string_view contextProtocol() const override { return header_map_->getProtocolValue(); }
-  absl::string_view contextAuthority() const override { return header_map_->getHostValue(); }
-  absl::string_view contextPath() const override { return header_map_->getPathValue(); }
-  absl::string_view contextMethod() const override { return header_map_->getMethodValue(); }
-  void iterateContext(IterateCallback callback) const override {
+  absl::string_view protocol() const override { return header_map_->getProtocolValue(); }
+  absl::string_view authority() const override { return header_map_->getHostValue(); }
+  absl::string_view path() const override { return header_map_->getPathValue(); }
+  absl::string_view method() const override { return header_map_->getMethodValue(); }
+  void forEach(IterateCallback callback) const override {
     ASSERT(header_map_);
     header_map_->iterate([cb = std::move(callback)](const HeaderEntry& entry) {
       if (cb(entry.key().getStringView(), entry.value().getStringView())) {
@@ -1129,21 +1129,21 @@ public:
       return HeaderMap::Iterate::Break;
     });
   }
-  absl::optional<absl::string_view> getTraceContext(absl::string_view key) const override {
+  absl::optional<absl::string_view> getByKey(absl::string_view key) const override {
     ASSERT(header_map_);
-    return header_map_->getTraceContext(key);
+    return header_map_->getByKey(key);
   }
-  void setTraceContext(absl::string_view key, absl::string_view value) override {
+  void setByKey(absl::string_view key, absl::string_view value) override {
     ASSERT(header_map_);
-    header_map_->setTraceContext(key, value);
+    header_map_->setByKey(key, value);
   }
-  void setTraceContextReferenceKey(absl::string_view key, absl::string_view val) override {
+  void setByReference(absl::string_view key, absl::string_view val) override {
     ASSERT(header_map_);
-    header_map_->setTraceContextReferenceKey(key, val);
+    header_map_->setByReference(key, val);
   }
-  void setTraceContextReference(absl::string_view key, absl::string_view val) override {
+  void setByReferenceKey(absl::string_view key, absl::string_view val) override {
     ASSERT(header_map_);
-    header_map_->setTraceContextReference(key, val);
+    header_map_->setByReferenceKey(key, val);
   }
 };
 


### PR DESCRIPTION
Signed-off-by: wbpcode <wbphub@live.com>

Commit Message: new interface for trace context for getting basic stream info and trace context iteration

Additional Description:

In `TraceContext`, the search interface(`getTraceContext`) is currently used to obtain basic information such as host and path. This will increase unnecessary hash searches, and **it also requires that in different protocols, it is necessary to ensure that these basic information use the same key to index**.
Some new interfaces are added to `TraceContext` to obtain the basic information of traceable stream, such as authority, path, protocol (authority, path, and protocol are the key components of uri), etc., avoid using search interfaces to obtain these basic information.

In addition, a new iteration interface has been added. 

Risk Level: Low.
Testing: Add.
Docs Changes: N/A.
Release Notes: N/A.
