### PR TITLE
test: add ASSERT indicating that gRPC stream has not been started yet

### DIFF
--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -148,6 +148,7 @@ public:
       reply_headers->addReference(value.first, value.second);
     }
     expectInitialMetadata(metadata);
+    fake_stream_->startGrpcStream(false);
     fake_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl(*reply_headers), false);
   }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -285,6 +285,8 @@ AssertionResult FakeStream::waitForReset(milliseconds timeout) {
 }
 
 void FakeStream::startGrpcStream() {
+  ASSERT(!grpc_stream_started_, "gRPC stream should not be started more than once");
+  grpc_stream_started_ = true;
   encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -284,10 +284,12 @@ AssertionResult FakeStream::waitForReset(milliseconds timeout) {
   return AssertionSuccess();
 }
 
-void FakeStream::startGrpcStream() {
+void FakeStream::startGrpcStream(bool send_headers) {
   ASSERT(!grpc_stream_started_, "gRPC stream should not be started more than once");
   grpc_stream_started_ = true;
-  encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  if (send_headers) {
+    encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  }
 }
 
 void FakeStream::finishGrpcStream(Grpc::Status::GrpcStatus status) {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -147,7 +147,7 @@ public:
   waitForReset(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
   // gRPC convenience methods.
-  void startGrpcStream();
+  void startGrpcStream(bool send_headers = true);
   void finishGrpcStream(Grpc::Status::GrpcStatus status);
   template <class T> void sendGrpcMessage(const T& message) {
     ASSERT(grpc_stream_started_,

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -150,6 +150,8 @@ public:
   void startGrpcStream();
   void finishGrpcStream(Grpc::Status::GrpcStatus status);
   template <class T> void sendGrpcMessage(const T& message) {
+    ASSERT(grpc_stream_started_,
+           "start gRPC stream by calling startGrpcStream before sending a message");
     auto serialized_response = Grpc::Common::serializeToGrpcFrame(message);
     encodeData(*serialized_response, false);
     ENVOY_LOG(debug, "Sent gRPC message: {}", message.DebugString());
@@ -249,6 +251,7 @@ private:
   absl::node_hash_map<std::string, uint64_t> duplicated_metadata_key_count_;
   std::unique_ptr<StreamInfo::StreamInfo> stream_info_;
   bool received_data_{false};
+  bool grpc_stream_started_{false};
 };
 
 using FakeStreamPtr = std::unique_ptr<FakeStream>;

--- a/test/integration/health_check_integration_test.cc
+++ b/test/integration/health_check_integration_test.cc
@@ -539,6 +539,7 @@ public:
   void sendGrpcResponse(uint32_t cluster_idx,
                         const Http::TestResponseHeaderMapImpl& response_headers,
                         const grpc::health::v1::HealthCheckResponse& health_check_response) {
+    clusters_[cluster_idx].host_stream_->startGrpcStream(false);
     clusters_[cluster_idx].host_stream_->encodeHeaders(response_headers, false);
     clusters_[cluster_idx].host_stream_->sendGrpcMessage(health_check_response);
     clusters_[cluster_idx].host_stream_->finishGrpcStream(Grpc::Status::WellKnownGrpcStatus::Ok);


### PR DESCRIPTION
This should hopefully make it clearer what's going on instead of messages being silently ignored when headers haven't been sent yet.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Commit Message:
Additional Description:
Risk Level: Low, test only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

