### PR TITLE
cluster_manager: Make ClusterEntry a class instead of a struct

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -913,7 +913,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPool(
     ResourcePriority priority, absl::optional<Http::Protocol> protocol,
     LoadBalancerContext* context) {
   // Select a host and create a connection pool for it if it does not already exist.
-  auto pool = httpConnPool(priority, protocol, context, false);
+  auto pool = httpConnPoolImpl(priority, protocol, context, false);
   if (pool == nullptr) {
     return absl::nullopt;
   }
@@ -923,7 +923,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPool(
         // Now that a new stream is being established, attempt to preconnect.
         maybePreconnect(*this, parent_.cluster_manager_state_,
                         [this, &priority, &protocol, &context]() {
-                          return httpConnPool(priority, protocol, context, true);
+                          return httpConnPoolImpl(priority, protocol, context, true);
                         });
       },
       pool);
@@ -934,7 +934,7 @@ absl::optional<TcpPoolData>
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
     ResourcePriority priority, LoadBalancerContext* context) {
   // Select a host and create a connection pool for it if it does not already exist.
-  auto pool = tcpConnPool(priority, context, false);
+  auto pool = tcpConnPoolImpl(priority, context, false);
   if (pool == nullptr) {
     return absl::nullopt;
   }
@@ -942,7 +942,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
   TcpPoolData data(
       [this, priority, context]() -> void {
         maybePreconnect(*this, parent_.cluster_manager_state_, [this, &priority, &context]() {
-          return tcpConnPool(priority, context, true);
+          return tcpConnPoolImpl(priority, context, true);
         });
       },
       pool);
@@ -1388,7 +1388,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry()
 }
 
 Http::ConnectionPool::Instance*
-ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPool(
+ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPoolImpl(
     ResourcePriority priority, absl::optional<Http::Protocol> downstream_protocol,
     LoadBalancerContext* context, bool peek) {
   HostConstSharedPtr host = (peek ? lb_->peekAnotherHost(context) : lb_->chooseHost(context));
@@ -1500,7 +1500,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::httpConnPoolIsIdle(
 }
 
 Tcp::ConnectionPool::Instance*
-ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
+ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPoolImpl(
     ResourcePriority priority, LoadBalancerContext* context, bool peek) {
   HostConstSharedPtr host = (peek ? lb_->peekAnotherHost(context) : lb_->chooseHost(context));
   if (!host) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -913,7 +913,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPool(
     ResourcePriority priority, absl::optional<Http::Protocol> protocol,
     LoadBalancerContext* context) {
   // Select a host and create a connection pool for it if it does not already exist.
-  auto pool = connPool(priority, protocol, context, false);
+  auto pool = httpConnPool(priority, protocol, context, false);
   if (pool == nullptr) {
     return absl::nullopt;
   }
@@ -923,7 +923,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPool(
         // Now that a new stream is being established, attempt to preconnect.
         maybePreconnect(*this, parent_.cluster_manager_state_,
                         [this, &priority, &protocol, &context]() {
-                          return connPool(priority, protocol, context, true);
+                          return httpConnPool(priority, protocol, context, true);
                         });
       },
       pool);
@@ -1388,7 +1388,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry()
 }
 
 Http::ConnectionPool::Instance*
-ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::connPool(
+ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPool(
     ResourcePriority priority, absl::optional<Http::Protocol> downstream_protocol,
     LoadBalancerContext* context, bool peek) {
   HostConstSharedPtr host = (peek ? lb_->peekAnotherHost(context) : lb_->chooseHost(context));

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1043,16 +1043,14 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpAsyncClient
 }
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::updateHosts(
-    const std::string& name,
-    uint32_t priority, PrioritySet::UpdateHostsParams&& update_hosts_params,
-    LocalityWeightsConstSharedPtr locality_weights,
-    const HostVector& hosts_added, const HostVector& hosts_removed,
-    absl::optional<uint32_t> overprovisioning_factor) {
+    const std::string& name, uint32_t priority,
+    PrioritySet::UpdateHostsParams&& update_hosts_params,
+    LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
+    const HostVector& hosts_removed, absl::optional<uint32_t> overprovisioning_factor) {
   ENVOY_LOG(debug, "membership update for TLS cluster {} added {} removed {}", name,
             hosts_added.size(), hosts_removed.size());
-  priority_set_.updateHosts(priority, std::move(update_hosts_params),
-                            std::move(locality_weights), hosts_added, hosts_removed,
-                            overprovisioning_factor);
+  priority_set_.updateHosts(priority, std::move(update_hosts_params), std::move(locality_weights),
+                            hosts_added, hosts_removed, overprovisioning_factor);
   // If an LB is thread aware, create a new worker local LB on membership changes.
   if (lb_factory_ != nullptr) {
     ENVOY_LOG(debug, "re-creating local LB for TLS cluster {}", name);
@@ -1060,7 +1058,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::updateHost
   }
 }
 
-void ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::drainConnPools(const HostVector& hosts_removed) {
+void ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::drainConnPools(
+    const HostVector& hosts_removed) {
   parent_.drainConnPools(hosts_removed);
 }
 
@@ -1229,8 +1228,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
   ASSERT(thread_local_clusters_.find(name) != thread_local_clusters_.end());
   const auto& cluster_entry = thread_local_clusters_[name];
   cluster_entry->updateHosts(name, priority, std::move(update_hosts_params),
-                                           std::move(locality_weights), hosts_added, hosts_removed,
-                                           overprovisioning_factor);
+                             std::move(locality_weights), hosts_added, hosts_removed,
+                             overprovisioning_factor);
 }
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::onHostHealthFailure(

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -428,9 +428,9 @@ private:
       void drainConnPools(const HostVector& hosts_removed);
 
     private:
-      Http::ConnectionPool::Instance* connPool(ResourcePriority priority,
-                                               absl::optional<Http::Protocol> downstream_protocol,
-                                               LoadBalancerContext* context, bool peek);
+      Http::ConnectionPool::Instance* httpConnPool(ResourcePriority priority,
+                                                   absl::optional<Http::Protocol> downstream_protocol,
+                                                   LoadBalancerContext* context, bool peek);
 
       Tcp::ConnectionPool::Instance* tcpConnPool(ResourcePriority priority,
                                                  LoadBalancerContext* context, bool peek);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -400,17 +400,11 @@ private:
     using TcpConnectionsMap =
         absl::node_hash_map<Network::ClientConnection*, std::unique_ptr<TcpConnContainer>>;
 
-    struct ClusterEntry : public ThreadLocalCluster {
+    class ClusterEntry : public ThreadLocalCluster {
+     public:
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry() override;
-
-      Http::ConnectionPool::Instance* connPool(ResourcePriority priority,
-                                               absl::optional<Http::Protocol> downstream_protocol,
-                                               LoadBalancerContext* context, bool peek);
-
-      Tcp::ConnectionPool::Instance* tcpConnPool(ResourcePriority priority,
-                                                 LoadBalancerContext* context, bool peek);
 
       // Upstream::ThreadLocalCluster
       const PrioritySet& prioritySet() override { return priority_set_; }
@@ -423,6 +417,23 @@ private:
                                               LoadBalancerContext* context) override;
       Host::CreateConnectionData tcpConn(LoadBalancerContext* context) override;
       Http::AsyncClient& httpAsyncClient() override;
+
+      // Updates the hosts in the priority set.
+      void updateHosts(const std::string& name, uint32_t priority, PrioritySet::UpdateHostsParams&& update_hosts_params,
+                       LocalityWeightsConstSharedPtr locality_weights,
+                       const HostVector& hosts_added, const HostVector& hosts_removed,
+                       absl::optional<uint32_t> overprovisioning_factor);
+
+      // Drains any connection pools assocaited with the removed hosts.
+      void drainConnPools(const HostVector& hosts_removed);
+
+    private:
+      Http::ConnectionPool::Instance* connPool(ResourcePriority priority,
+                                               absl::optional<Http::Protocol> downstream_protocol,
+                                               LoadBalancerContext* context, bool peek);
+
+      Tcp::ConnectionPool::Instance* tcpConnPool(ResourcePriority priority,
+                                                 LoadBalancerContext* context, bool peek);
 
       ThreadLocalClusterManagerImpl& parent_;
       PrioritySetImpl priority_set_;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -401,7 +401,7 @@ private:
         absl::node_hash_map<Network::ClientConnection*, std::unique_ptr<TcpConnContainer>>;
 
     class ClusterEntry : public ThreadLocalCluster {
-     public:
+    public:
       ClusterEntry(ThreadLocalClusterManagerImpl& parent, ClusterInfoConstSharedPtr cluster,
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry() override;
@@ -419,21 +419,23 @@ private:
       Http::AsyncClient& httpAsyncClient() override;
 
       // Updates the hosts in the priority set.
-      void updateHosts(const std::string& name, uint32_t priority, PrioritySet::UpdateHostsParams&& update_hosts_params,
+      void updateHosts(const std::string& name, uint32_t priority,
+                       PrioritySet::UpdateHostsParams&& update_hosts_params,
                        LocalityWeightsConstSharedPtr locality_weights,
                        const HostVector& hosts_added, const HostVector& hosts_removed,
                        absl::optional<uint32_t> overprovisioning_factor);
 
-      // Drains any connection pools assocaited with the removed hosts.
+      // Drains any connection pools associated with the removed hosts.
       void drainConnPools(const HostVector& hosts_removed);
 
     private:
-      Http::ConnectionPool::Instance* httpConnPoolImpl(ResourcePriority priority,
-                                                   absl::optional<Http::Protocol> downstream_protocol,
-                                                   LoadBalancerContext* context, bool peek);
+      Http::ConnectionPool::Instance*
+      httpConnPoolImpl(ResourcePriority priority,
+                       absl::optional<Http::Protocol> downstream_protocol,
+                       LoadBalancerContext* context, bool peek);
 
       Tcp::ConnectionPool::Instance* tcpConnPoolImpl(ResourcePriority priority,
-                                                 LoadBalancerContext* context, bool peek);
+                                                     LoadBalancerContext* context, bool peek);
 
       ThreadLocalClusterManagerImpl& parent_;
       PrioritySetImpl priority_set_;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -428,11 +428,11 @@ private:
       void drainConnPools(const HostVector& hosts_removed);
 
     private:
-      Http::ConnectionPool::Instance* httpConnPool(ResourcePriority priority,
+      Http::ConnectionPool::Instance* httpConnPoolImpl(ResourcePriority priority,
                                                    absl::optional<Http::Protocol> downstream_protocol,
                                                    LoadBalancerContext* context, bool peek);
 
-      Tcp::ConnectionPool::Instance* tcpConnPool(ResourcePriority priority,
+      Tcp::ConnectionPool::Instance* tcpConnPoolImpl(ResourcePriority priority,
                                                  LoadBalancerContext* context, bool peek);
 
       ThreadLocalClusterManagerImpl& parent_;


### PR DESCRIPTION
cluster_manager: Make 
Upstream::ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry a class instead of a struct since it inherits from the class Upstream::ThreadLocalCluster. Made all members and two helper methods private. Private members required moving two small pieces of logic from ClusterManagerImpl::ThreadLocalClusterManagerImpl into helper methods of ClusterEntry, but the behavior is completely unchanged.

Also noticed that a method 'connPool' should have had an 'http' prefix to be parallel with the 'tcpConnPool' method. Finally, after doing this rename noticed that there were two methods named httpConnPool and two named tcpConnPool, but with different signatures. Renamed two of these to tcpConnPoolImpl and httpConnPoolImpl to make them easier to distinguish and make their intent clear.

Risk Level: Low - No behavior change
Testing: Existing tests because no behavior changed
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A