### PR TITLE
[grpc]: fix ex_authz grpc client race condition

### DIFF
--- a/envoy/grpc/async_client.h
+++ b/envoy/grpc/async_client.h
@@ -184,6 +184,11 @@ public:
                                    absl::string_view method_name,
                                    RawAsyncStreamCallbacks& callbacks,
                                    const Http::AsyncClient::StreamOptions& options) PURE;
+
+protected:
+  // The lifetime of RawAsyncClient must be in the same thread.
+  bool isThreadSafe() { return thread_id_ == std::this_thread::get_id(); }
+  std::thread::id thread_id_{std::this_thread::get_id()};
 };
 
 using RawAsyncClientPtr = std::unique_ptr<RawAsyncClient>;

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -21,6 +21,7 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterManager& cm,
           Router::HeaderParser::configure(config.initial_metadata(), /*append=*/false)) {}
 
 AsyncClientImpl::~AsyncClientImpl() {
+  ASSERT(isThreadSafe());
   while (!active_streams_.empty()) {
     active_streams_.front()->resetStream();
   }
@@ -31,6 +32,7 @@ AsyncRequest* AsyncClientImpl::sendRaw(absl::string_view service_full_name,
                                        RawAsyncRequestCallbacks& callbacks,
                                        Tracing::Span& parent_span,
                                        const Http::AsyncClient::RequestOptions& options) {
+  ASSERT(isThreadSafe());
   auto* const async_request = new AsyncRequestImpl(
       *this, service_full_name, method_name, std::move(request), callbacks, parent_span, options);
   AsyncStreamImplPtr grpc_stream{async_request};
@@ -48,6 +50,7 @@ RawAsyncStream* AsyncClientImpl::startRaw(absl::string_view service_full_name,
                                           absl::string_view method_name,
                                           RawAsyncStreamCallbacks& callbacks,
                                           const Http::AsyncClient::StreamOptions& options) {
+  ASSERT(isThreadSafe());
   auto grpc_stream =
       std::make_unique<AsyncStreamImpl>(*this, service_full_name, method_name, callbacks, options);
 

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -108,6 +108,7 @@ GoogleAsyncClientImpl::GoogleAsyncClientImpl(Event::Dispatcher& dispatcher,
 }
 
 GoogleAsyncClientImpl::~GoogleAsyncClientImpl() {
+  ASSERT(isThreadSafe());
   ENVOY_LOG(debug, "Client teardown, resetting streams");
   while (!active_streams_.empty()) {
     active_streams_.front()->resetStream();
@@ -120,6 +121,7 @@ AsyncRequest* GoogleAsyncClientImpl::sendRaw(absl::string_view service_full_name
                                              RawAsyncRequestCallbacks& callbacks,
                                              Tracing::Span& parent_span,
                                              const Http::AsyncClient::RequestOptions& options) {
+  ASSERT(isThreadSafe());
   auto* const async_request = new GoogleAsyncRequestImpl(
       *this, service_full_name, method_name, std::move(request), callbacks, parent_span, options);
   GoogleAsyncStreamImplPtr grpc_stream{async_request};
@@ -137,6 +139,7 @@ RawAsyncStream* GoogleAsyncClientImpl::startRaw(absl::string_view service_full_n
                                                 absl::string_view method_name,
                                                 RawAsyncStreamCallbacks& callbacks,
                                                 const Http::AsyncClient::StreamOptions& options) {
+  ASSERT(isThreadSafe());
   auto grpc_stream = std::make_unique<GoogleAsyncStreamImpl>(*this, service_full_name, method_name,
                                                              callbacks, options);
 

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -25,6 +25,8 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
   const auto filter_config = std::make_shared<FilterConfig>(
       proto_config, context.scope(), context.runtime(), context.httpContext(), stats_prefix,
       context.getServerFactoryContext().bootstrap());
+  // The callback is created in main thread and executed in worker thread, variables except factory
+  // context must be captured by value into the callback.
   Http::FilterFactoryCb callback;
 
   if (proto_config.has_http_service()) {

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -42,7 +42,6 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
     };
   } else if (proto_config.grpc_service().has_google_grpc()) {
     // Google gRPC client.
-
     const uint32_t timeout_ms =
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
 
@@ -57,7 +56,6 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
     };
   } else {
     // Envoy gRPC client.
-    
     const uint32_t timeout_ms =
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
     callback = [grpc_service = proto_config.grpc_service(), &context, filter_config, timeout_ms,

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -53,7 +53,7 @@ TEST_F(EnvoyAsyncClientImplTest, ThreadSafe) {
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     dispatcher_->run(Event::Dispatcher::RunType::Block);
-    // Verify we have the expected dispatcher for the new worker thread.
+    // Verify that using the grpc client in a different thread cause assertion failure.
     EXPECT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                      Http::AsyncClient::StreamOptions()),
                  "isThreadSafe");

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -51,11 +51,12 @@ TEST_F(EnvoyAsyncClientImplTest, ThreadSafe) {
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     // Verify that using the grpc client in a different thread cause assertion failure.
-    EXPECT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
+    ASSERT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                      Http::AsyncClient::StreamOptions()),
                  "isThreadSafe");
   });
   thread->join();
+  ;
 }
 
 // Validate that the host header is the cluster name in grpc config.

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -52,7 +52,7 @@ TEST_F(EnvoyAsyncClientImplTest, ThreadSafe) {
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     // Verify that using the grpc client in a different thread cause assertion failure.
-    ASSERT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
+    EXPECT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                            Http::AsyncClient::StreamOptions()),
                        "isThreadSafe");
   });

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -48,11 +48,8 @@ public:
 
 TEST_F(EnvoyAsyncClientImplTest, ThreadSafe) {
   NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> grpc_callbacks;
-  Api::ApiPtr api_(Api::createApiForTest());
-  Event::DispatcherPtr dispatcher_(api_->allocateDispatcher("worker"));
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
-    dispatcher_->run(Event::Dispatcher::RunType::Block);
     // Verify that using the grpc client in a different thread cause assertion failure.
     EXPECT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                      Http::AsyncClient::StreamOptions()),

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -94,7 +94,7 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     // Verify that using the grpc client in a different thread cause assertion failure.
-    ASSERT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
+    ASSERT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                      Http::AsyncClient::StreamOptions()),
                  "isThreadSafe");
   });

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -92,9 +92,12 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
 
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
 
+  ON_CALL(grpc_callbacks, onCreateInitialMetadata(_));
+  ON_CALL(grpc_callbacks, onReceiveTrailingMetadata_(_));
+  ON_CALL(grpc_callbacks, onRemoteClose(Status::WellKnownGrpcStatus::Unavailable, ""));
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     // Verify that using the grpc client in a different thread cause assertion failure.
-    ASSERT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
+    EXPECT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                            Http::AsyncClient::StreamOptions()),
                        "isThreadSafe");
   });

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -92,11 +92,7 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     ON_CALL(*stub_factory_.stub_, PrepareCall_(_, _, _)).WillByDefault(Return(nullptr));
-    MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
-
-    ON_CALL(grpc_callbacks, onCreateInitialMetadata(_));
-    ON_CALL(grpc_callbacks, onReceiveTrailingMetadata_(_));
-    ON_CALL(grpc_callbacks, onRemoteClose(Status::WellKnownGrpcStatus::Unavailable, ""));
+    NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> grpc_callbacks;
     // Verify that using the grpc client in a different thread cause assertion failure.
     EXPECT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                            Http::AsyncClient::StreamOptions()),

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -94,7 +94,7 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
 
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     // Verify that using the grpc client in a different thread cause assertion failure.
-    EXPECT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
+    ASSERT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                      Http::AsyncClient::StreamOptions()),
                  "isThreadSafe");
   });

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -95,8 +95,8 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
     // Verify that using the grpc client in a different thread cause assertion failure.
     ASSERT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
-                                     Http::AsyncClient::StreamOptions()),
-                 "isThreadSafe");
+                                           Http::AsyncClient::StreamOptions()),
+                       "isThreadSafe");
   });
   thread->join();
 }

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -90,12 +90,13 @@ public:
 TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
   initialize();
 
-  MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
-
-  ON_CALL(grpc_callbacks, onCreateInitialMetadata(_));
-  ON_CALL(grpc_callbacks, onReceiveTrailingMetadata_(_));
-  ON_CALL(grpc_callbacks, onRemoteClose(Status::WellKnownGrpcStatus::Unavailable, ""));
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
+    ON_CALL(*stub_factory_.stub_, PrepareCall_(_, _, _)).WillByDefault(Return(nullptr));
+    MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
+
+    ON_CALL(grpc_callbacks, onCreateInitialMetadata(_));
+    ON_CALL(grpc_callbacks, onReceiveTrailingMetadata_(_));
+    ON_CALL(grpc_callbacks, onRemoteClose(Status::WellKnownGrpcStatus::Unavailable, ""));
     // Verify that using the grpc client in a different thread cause assertion failure.
     EXPECT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                            Http::AsyncClient::StreamOptions()),

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -89,9 +89,8 @@ public:
 // Verify that grpc client check for thread consistency.
 TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
   initialize();
-
+  ON_CALL(*stub_factory_.stub_, PrepareCall_(_, _, _)).WillByDefault(Return(nullptr));
   Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread([&]() {
-    ON_CALL(*stub_factory_.stub_, PrepareCall_(_, _, _)).WillByDefault(Return(nullptr));
     NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> grpc_callbacks;
     // Verify that using the grpc client in a different thread cause assertion failure.
     EXPECT_DEBUG_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -99,7 +99,7 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, ThreadSafe) {
     // Verify we have the expected dispatcher for the new worker thread.
     EXPECT_DEATH(grpc_client_->start(*method_descriptor_, grpc_callbacks,
                                      Http::AsyncClient::StreamOptions()),
-                 "assert failure: isThreadSafe().");
+                 "isThreadSafe");
   });
   thread->join();
 }

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -45,7 +45,7 @@ public:
     return shared_stub_;
   }
 
-  MockGenericStub* stub_ = new MockGenericStub();
+  NiceMock<MockGenericStub>* stub_ = new NiceMock<MockGenericStub>();
   GoogleStubSharedPtr shared_stub_{stub_};
 };
 

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -47,8 +47,9 @@ void expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion api_version,
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   // Expect the raw async client to be created inside the callback.
-  // The creation of the filter callback is in main thread while the execution of callback is in worker thread.
-  // Because of the thread local cache of async client, it must be created in worker thread inside the callback.
+  // The creation of the filter callback is in main thread while the execution of callback is in
+  // worker thread. Because of the thread local cache of async client, it must be created in worker
+  // thread inside the callback.
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, getOrCreateRawAsyncClient(_, _, _, _))
       .WillOnce(Invoke(
           [](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool, Grpc::CacheOption) {

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -46,6 +46,9 @@ void expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion api_version,
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
+  // Expect the raw async client to be created inside the callback.
+  // The creation of the filter callback is in main thread while the execution of callback is in worker thread.
+  // Because of the thread local cache of async client, it must be created in worker thread inside the callback.
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, getOrCreateRawAsyncClient(_, _, _, _))
       .WillOnce(Invoke(
           [](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool, Grpc::CacheOption) {

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -84,8 +84,8 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoGoogleGrpc) {
   transport_api_version: {}
   )EOF";
 #ifndef ENVOY_DISABLE_DEPRECATED_FEATURES
+  // TODO(chaoqin-li1123): clean this up when we move AUTO to V3 by default.
   expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion::AUTO, google_grpc_service_yaml);
-  expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion::V2, google_grpc_service_yaml);
 #endif
   expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion::V3, google_grpc_service_yaml);
 }
@@ -100,8 +100,8 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoEnvoyGrpc) {
   transport_api_version: {}
   )EOF";
 #ifndef ENVOY_DISABLE_DEPRECATED_FEATURES
+  // TODO(chaoqin-li1123): clean this up when we move AUTO to V3 by default.
   expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion::AUTO, envoy_grpc_service_yaml);
-  expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion::V2, envoy_grpc_service_yaml);
 #endif
   expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion::V3, envoy_grpc_service_yaml);
 }


### PR DESCRIPTION
fixes commit #15745

Signed-off-by: chaoqin-li1123 <chaoqinli@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Creating the raw grpc client outside the callback cause all thread to use the same grpc client and data race.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
