### PR TITLE
proto: fix verify to point at v3 only

### DIFF
--- a/source/server/proto_descriptors.cc
+++ b/source/server/proto_descriptors.cc
@@ -39,14 +39,15 @@ void validateProtoDescriptors() {
   }
 
   const auto types = {
-      "envoy.api.v2.Cluster",           "envoy.api.v2.ClusterLoadAssignment",
-      "envoy.api.v2.Listener",          "envoy.api.v2.RouteConfiguration",
-      "envoy.api.v2.route.VirtualHost", "envoy.api.v2.auth.Secret",
+      "envoy.config.cluster.v3.Cluster",   "envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "envoy.config.listener.v3.Listener", "envoy.config.route.v3.RouteConfiguration",
+      "envoy.config.route.v3.VirtualHost", "envoy.extensions.transport_sockets.tls.v3.Secret",
   };
 
   for (const auto& type : types) {
-    RELEASE_ASSERT(
-        Protobuf::DescriptorPool::generated_pool()->FindMessageTypeByName(type) != nullptr, "");
+    RELEASE_ASSERT(Protobuf::DescriptorPool::generated_pool()->FindMessageTypeByName(type) !=
+                       nullptr,
+                   absl::StrCat("Unable to find message type for ", type));
   }
 }
 


### PR DESCRIPTION
Somehow this is not working on Envoy Mobile but still seems to work in
Envoy.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
