### PR TITLE
Delete mock for removed RouteEntry::perFilterConfig() method

### DIFF
--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -59,12 +59,12 @@ public:
   }
 
   void setRoutePolicy(const CsrfPolicy* policy) {
-    ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig(filter_name_))
+    ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(filter_name_))
         .WillByDefault(Return(policy));
   }
 
   void setVirtualHostPolicy(const CsrfPolicy* policy) {
-    ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig(filter_name_))
+    ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(filter_name_))
         .WillByDefault(Return(policy));
   }
 

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -731,8 +731,8 @@ TEST_F(ReverseBridgeTest, RouteWithTrailers) {
   filter_config_per_route.set_disabled(false);
   FilterConfigPerRoute filterConfigPerRoute(filter_config_per_route);
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_,
-          perFilterConfig("envoy.filters.http.grpc_http1_reverse_bridge"))
+  ON_CALL(*decoder_callbacks_.route_,
+          mostSpecificPerFilterConfig("envoy.filters.http.grpc_http1_reverse_bridge"))
       .WillByDefault(testing::Return(&filterConfigPerRoute));
 
   {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -389,7 +389,6 @@ public:
   MOCK_METHOD(absl::optional<std::string>, currentUrlPathAfterRewrite,
               (const Http::RequestHeaderMap&), (const));
   MOCK_METHOD(const PathMatchCriterion&, pathMatchCriterion, (), (const));
-  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
   MOCK_METHOD(bool, includeAttemptCountInRequest, (), (const));
   MOCK_METHOD(bool, includeAttemptCountInResponse, (), (const));
   MOCK_METHOD(const absl::optional<ConnectConfig>&, connectConfig, (), (const));


### PR DESCRIPTION
Risk Level: low, test only
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Signed-off-by: Yan Avlasov <yavlasov@google.com>
