### PR TITLE
tooling: Add `concurrent` utility for coroutines

### DIFF
--- a/tools/base/BUILD
+++ b/tools/base/BUILD
@@ -6,7 +6,12 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_py_library("tools.base.aio")
+envoy_py_library(
+    "tools.base.aio",
+    deps = [
+        ":functional",
+    ],
+)
 
 envoy_py_library(
     "tools.base.runner",

--- a/tools/base/aio.py
+++ b/tools/base/aio.py
@@ -1,8 +1,30 @@
 import asyncio
 import concurrent.futures
+import inspect
+import os
 import subprocess
-from functools import partial
-from typing import AsyncGenerator, Iterable, Optional
+import types
+from functools import cached_property, partial
+from typing import (
+    Any, AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Iterable, Iterator, List,
+    Optional, Union)
+
+from tools.base.functional import async_property
+
+
+class AsyncParallelError(Exception):
+    """Raised when given inputs/awaitables are incorrect"""
+    pass
+
+
+class AsyncParallelIteratorError(AsyncParallelError):
+    """Raised when iteration of provided awaitables fails"""
+    pass
+
+
+class AsyncParallelExecutionError(AsyncParallelError):
+    """Raised when execution of a provided awaitable fails"""
+    pass
 
 
 class async_subprocess:  # noqa: N801
@@ -83,3 +105,386 @@ class async_subprocess:  # noqa: N801
         """
         loop = loop or asyncio.get_running_loop()
         return await loop.run_in_executor(executor, partial(subprocess.run, *args, **kwargs))
+
+
+_marker = object()
+
+
+class parallel:  # noqa: N801
+    """This utility provides very similar functionality to
+    `asyncio.as_completed` in that it runs coroutines in parallel, yielding the
+    results as they are available.
+
+    There are a couple of differences:
+
+    - `coros` can be any `iterables` including sync/async `generators`
+    - `limit` can be supplied to specify the maximum number of concurrent tasks
+
+    Setting `limit` to `-1` will make all tasks run in parallel.
+
+    The default is `number of cores + 4` to a maximum of `32`.
+
+    For network tasks it might make sense to set the concurrency `limit` lower
+    than the default, if, for example, opening many concurrent connections will trigger
+    rate-limiting or soak bandwidth.
+
+    If an error is raised while trying to iterate the provided coroutines, the
+    error is wrapped in an `AsyncParallelIteratorError` and is raised immediately.
+
+    In this case, no further handling occurs, and `yield_exceptions` has no
+    effect.
+
+    Any errors raised while trying to create or run tasks are wrapped in
+    `AsyncParallelError`.
+
+    Any errors raised during task execution are wrapped in
+    `AsyncParallelExecutionError`.
+
+    If you specify `yield_exceptions` as `True` then the wrapped errors will be
+    yielded in the results.
+
+    If `yield_exceptions` is False (the default), then the wrapped error will be
+    raised immediately.
+
+    If you use any kind of `Generator` or `AsyncGenerator` to produce the
+    awaitables, and `yield_exceptions` is `False`, in the event that an error
+    occurs, it is your responsibility to `close` remaining awaitables that you
+    might have created but which have not already been fired.
+
+    This utility is mostly useful for parallelizing io-bound (as opposed to
+    cpu-bound) tasks.
+
+    Example usage:
+
+    ```
+    import random
+
+    from tools.base import aio
+
+    async def task_to_run(i):
+        print(f"{i} starting")
+        wait = random.random() * 10
+        await asyncio.sleep(wait)
+        return i, wait
+
+    async def run(coros):
+        async for (i, wait) in aio.parallel(coros, limit=3):
+            print(f"{i} waited {wait}")
+
+    def provider():
+        for i in range(0, 10):
+            yield task_to_run(i)
+
+    asyncio.run(run(provider()))
+    ```
+    """
+
+    def __init__(
+            self,
+            coros: Union[types.AsyncGeneratorType, AsyncIterable[Awaitable],
+                         AsyncIterator[Awaitable], types.GeneratorType, Iterator[Awaitable],
+                         Iterable[Awaitable]],
+            yield_exceptions: Optional[bool] = False,
+            limit: Optional[int] = None):
+        self._coros = coros
+        self._limit = limit
+        self._running: List[asyncio.Task] = []
+        self.yield_exceptions = yield_exceptions
+
+    def __aiter__(self) -> AsyncIterator:
+        """Start a coroutine task to process the submit queue, and return
+        an async generator to deliver results back as they arrive
+        """
+        self.submit_task = asyncio.create_task(self.submit())
+        return self.output()
+
+    @property
+    def active(self) -> bool:
+        """Checks whether the iterator is active, either because it
+        hasn't finished submitting or because there are still tasks running
+        """
+        return self.submitting or self.running
+
+    @property
+    def closed(self) -> bool:
+        """If an unhandled error occurs, the generator is closed and no further
+        processing should happen
+        """
+        return self.closing_lock.locked()
+
+    @cached_property
+    def closing_lock(self) -> asyncio.Lock:
+        """Flag to indicate whether the generator has been closed"""
+        return asyncio.Lock()
+
+    @async_property
+    async def coros(self) -> AsyncIterator[Union[AsyncParallelIteratorError, Awaitable]]:
+        """An async iterator of the provided coroutines"""
+        async for coro in self.iter_coros():
+            yield coro
+
+    @property
+    def default_limit(self) -> int:
+        """Default is to use cpu+4 to a max of 32 coroutines"""
+        # This reflects the default for asyncio's `ThreadPoolExecutor`, this is a fairly
+        # arbitrary number to use, but it seems like a reasonable default.
+        return min(32, (os.cpu_count() or 0) + 4)
+
+    @cached_property
+    def is_async(self) -> bool:
+        """Provided coros is some kind of async provider"""
+        return isinstance(self._coros, (types.AsyncGeneratorType, AsyncIterator, AsyncIterable))
+
+    @cached_property
+    def is_generator(self) -> bool:
+        """Provided coros is some kind of generator"""
+        return isinstance(self._coros, (types.AsyncGeneratorType, types.GeneratorType))
+
+    @cached_property
+    def limit(self) -> int:
+        """The limit for concurrent coroutines"""
+        return self._limit or self.default_limit
+
+    @cached_property
+    def nolimit(self) -> bool:
+        """Flag indicating no limit to concurrency"""
+        return self.limit == -1
+
+    @cached_property
+    def out(self) -> asyncio.Queue:
+        """Queue of results to yield back"""
+        return asyncio.Queue()
+
+    @property
+    def running(self) -> bool:
+        """Flag to indicate whether any tasks are running"""
+        return not self.running_queue.empty()
+
+    @cached_property
+    def running_queue(self) -> asyncio.Queue:
+        """Queue which is incremented/decremented as tasks begin/end
+
+        This is for tracking when there are no longer any tasks running.
+
+        A queue is used here as opposed to other synchronization primitives, as
+        it allows us to get the size and emptiness.
+
+        The queue values are `None`.
+        """
+        return asyncio.Queue()
+
+    @cached_property
+    def running_tasks(self) -> List[asyncio.Task]:
+        """Currently running asyncio tasks"""
+        return self._running
+
+    @cached_property
+    def sem(self) -> asyncio.Semaphore:
+        """A sem lock to limit the number of concurrent tasks"""
+        return asyncio.Semaphore(self.limit)
+
+    @cached_property
+    def submission_lock(self) -> asyncio.Lock:
+        """Submission lock to indicate when submission is complete"""
+        return asyncio.Lock()
+
+    @property
+    def submitting(self) -> bool:
+        """Flag to indicate whether we are still submitting coroutines"""
+        return self.submission_lock.locked()
+
+    async def cancel(self) -> None:
+        """Stop the submission queue, cancel running tasks, close pending coroutines.
+
+        This is triggered when an unhandled error occurs and the queue should
+        stop processing and bail.
+        """
+        # Kitchen is closed
+        await self.close()
+
+        # No more waiting
+        if not self.nolimit:
+            self.sem.release()
+
+        # Cancel tasks
+        await self.cancel_tasks()
+
+        # Close pending coroutines
+        await self.close_coros()
+
+        # let the submission queue die
+        await self.submit_task
+
+    async def cancel_tasks(self) -> None:
+        """Cancel any running tasks"""
+        for running in self.running_tasks:
+            running.cancel()
+            try:
+                await running
+            finally:
+                # ignore errors, we are dying anyway
+                continue
+
+    async def close(self) -> None:
+        """Close the generator, prevent any further processing"""
+        if not self.closed:
+            await self.closing_lock.acquire()
+
+    async def close_coros(self) -> None:
+        """Close provided coroutines (unless the provided coros is a generator)"""
+        if self.is_generator:
+            # If we have a generator, dont blow/create/wait upon any more items
+            return
+
+        async for coro in self.iter_coros():
+            try:
+                # mypy reports that not all awaitables have a `close` method, but
+                # as we are asking for forgiveness anyway, no point in looking
+                # before we leap.
+                coro.close()  # type:ignore
+            finally:
+                # ignore errors, we are dying anyway
+                continue
+
+    async def create_task(self, coro: Awaitable) -> None:
+        """Create an asyncio task from the coroutine, and remember it"""
+        task = asyncio.create_task(self.task(coro))
+        self.remember_task(task)
+        self.running_queue.put_nowait(None)
+
+    async def exit_on_completion(self) -> None:
+        """Send the exit signal to the output queue"""
+        if not self.active and not self.closed:
+            await self.out.put(_marker)
+
+    def forget_task(self, task: asyncio.Task) -> None:
+        """Task? what task?"""
+        if self.closed:
+            # If we are closing, don't remove, as this has been triggered
+            # by cancellation.
+            return
+        self.running_tasks.remove(task)
+
+    async def iter_coros(self) -> AsyncIterator[Union[AsyncParallelIteratorError, Awaitable]]:
+        """Iterate provided coros either synchronously or asynchronously,
+        yielding the awaitables asynchoronously.
+        """
+        try:
+            if self.is_async:
+                async for coro in self._coros:  # type:ignore
+                    yield coro
+            else:
+                for coro in self._coros:  # type:ignore
+                    yield coro
+        except BaseException as e:
+            # Catch all errors iterating (other errors are caught elsewhere)
+            # If iterating raises, wrap the error and send it to `submit` and
+            # and `output` to close the queues.
+            yield AsyncParallelIteratorError(e)
+
+    async def on_task_complete(self, result: Any, decrement: Optional[bool] = True) -> None:
+        """Output the result, release the sem lock, decrement the running
+        count, and notify output queue if complete.
+        """
+        if self.closed:
+            # Results can come back after the queue has closed as they are
+            # cancelled.
+            # In that case, nothing further to do.
+            return
+
+        # Give result to output
+        await self.out.put(result)
+
+        if not self.nolimit:
+            # Release the sem.lock
+            self.sem.release()
+        if decrement:
+            # Decrement the running_queue if it was incremented
+            self.running_queue.get_nowait()
+        # Exit if nothing left to do
+        await self.exit_on_completion()
+
+    async def output(self) -> AsyncIterator:
+        """Asynchronously yield results as they become available"""
+        while True:
+            # Wait for some output
+            result = await self.out.get()
+            if result is _marker:
+                # All done!
+                await self.close()
+                break
+            elif self.should_error(result):
+                # Raise an error and bail!
+                await self.cancel()
+                raise result
+            yield result
+
+    async def ready(self) -> bool:
+        """Wait for the sem.lock and indicate availability in the submission
+        queue
+        """
+        if self.closed:
+            return False
+        if not self.nolimit:
+            await self.sem.acquire()
+            # We check before and after acquiring the sem.lock to see whether
+            # we are `closed` as these events can be separated in
+            # time/procedure.
+            if self.closed:
+                return False
+        return True
+
+    def remember_task(self, task: asyncio.Task) -> None:
+        """Remember a scheduled asyncio task, in case it needs to be
+        cancelled
+        """
+        self.running_tasks.append(task)
+        task.add_done_callback(self.forget_task)
+
+    def should_error(self, result: Any) -> bool:
+        """Check a result type and whether it should raise an error"""
+        return (
+            isinstance(result, AsyncParallelIteratorError)
+            or (isinstance(result, AsyncParallelError) and not self.yield_exceptions))
+
+    async def submit(self) -> None:
+        """Process the iterator of coroutines as a submission queue"""
+        await self.submission_lock.acquire()
+        async for coro in self.coros:
+            if isinstance(coro, AsyncParallelIteratorError):
+                # Iteration error, exit now
+                await self.out.put(coro)
+                break
+            # wait for the sem.lock
+            if not await self.ready():
+                # queue is closing, get out of here
+                break
+            # check the supplied coro is awaitable
+            try:
+                self.validate_coro(coro)
+            except AsyncParallelError as e:
+                await self.on_task_complete(e, decrement=False)
+                continue
+            # all good, create a task
+            await self.create_task(coro)
+        self.submission_lock.release()
+        # if cleanup of the submission queue has taken longer than processing
+        # we need to manually close
+        await self.exit_on_completion()
+
+    async def task(self, coro: Awaitable) -> None:
+        """Task wrapper to catch/wrap errors and output awaited results"""
+        try:
+            result = await coro
+        except BaseException as e:
+            result = AsyncParallelExecutionError(e)
+        finally:
+            await self.on_task_complete(result)
+
+    def validate_coro(self, coro: Awaitable) -> None:
+        """Validate that a provided coroutine is actually awaitable"""
+        if not inspect.isawaitable(coro):
+            raise AsyncParallelError(f"Provided input was not a coroutine: {coro}")
+
+        if inspect.getcoroutinestate(coro) != inspect.CORO_CREATED:
+            raise AsyncParallelError(f"Provided coroutine has already been fired: {coro}")

--- a/tools/base/checker.py
+++ b/tools/base/checker.py
@@ -278,10 +278,6 @@ class Checker(BaseChecker):
         return super().on_checks_complete()
 
 
-class ForkingChecker(runner.ForkingRunner, Checker):
-    pass
-
-
 class BazelChecker(runner.BazelRunner, Checker):
     pass
 

--- a/tools/base/tests/test_checker.py
+++ b/tools/base/tests/test_checker.py
@@ -4,17 +4,11 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 
 from tools.base.checker import (
-    AsyncChecker, BaseChecker, BazelChecker, Checker, CheckerSummary, ForkingChecker)
-from tools.base.runner import BazelRunner, ForkingRunner
+    AsyncChecker, BaseChecker, BazelChecker, Checker, CheckerSummary)
+from tools.base.runner import BazelRunner
 
 
 class DummyChecker(Checker):
-
-    def __init__(self):
-        self.args = PropertyMock()
-
-
-class DummyForkingChecker(ForkingChecker):
 
     def __init__(self):
         self.args = PropertyMock()
@@ -813,14 +807,6 @@ def test_checker_summary_print_failed(patches, problem_type, max_display, proble
     assert (
         list(list(c) for c in m_section.call_args_list)
         == expected)
-
-
-# ForkingChecker test
-
-def test_forkingchecker_constructor():
-    checker = DummyForkingChecker()
-    assert isinstance(checker, ForkingRunner)
-    assert isinstance(checker, Checker)
 
 
 # BazelChecker test

--- a/tools/base/tests/test_functional.py
+++ b/tools/base/tests/test_functional.py
@@ -42,9 +42,9 @@ async def test_functional_async_property(cache, raises, result):
             if raises:
                 await m_async()
                 raise SomeError("AN ITERATING ERROR OCCURRED")
-            _result = await m_async()
+            result = await m_async()
             for item in items:
-                yield item, _result
+                yield item, result
 
     klass = Klass()
 
@@ -65,7 +65,7 @@ async def test_functional_async_property(cache, raises, result):
             await klass.prop
 
         with pytest.raises(SomeError) as e2:
-            async for _result in klass.iter_prop:
+            async for result in klass.iter_prop:
                 pass
 
         assert (
@@ -84,17 +84,17 @@ async def test_functional_async_property(cache, raises, result):
     assert await klass.prop == result
 
     # results can also be repeatedly iterated
-    _results1 = []
-    async for _result in klass.iter_prop:
-        _results1.append(_result)
-    assert _results1 == [(item, result) for item in items]
+    results1 = []
+    async for returned_result in klass.iter_prop:
+        results1.append(returned_result)
+    assert results1 == [(item, result) for item in items]
 
-    _results2 = []
-    async for _result in klass.iter_prop:
-        _results2.append(_result)
+    results2 = []
+    async for returned_result in klass.iter_prop:
+        results2.append(returned_result)
 
     if not cache:
-        assert _results2 == _results1
+        assert results2 == results1
         assert (
             list(list(c) for c in m_async.call_args_list)
             == [[(), {}]] * 4)
@@ -116,4 +116,4 @@ async def test_functional_async_property(cache, raises, result):
         == dict(prop=m_async.return_value, iter_prop=iter_prop))
 
     # cached iterators dont give any more results once they are done
-    assert _results2 == []
+    assert results2 == []

--- a/tools/base/tests/test_functional.py
+++ b/tools/base/tests/test_functional.py
@@ -1,3 +1,4 @@
+import types
 from unittest.mock import AsyncMock
 
 import pytest
@@ -17,8 +18,12 @@ async def test_functional_async_property(cache, raises, result):
 
     if cache is None:
         decorator = functional.async_property
+        iter_decorator = functional.async_property
     else:
         decorator = functional.async_property(cache=cache)
+        iter_decorator = functional.async_property(cache=cache)
+
+    items = [f"ITEM{i}" for i in range(0, 5)]
 
     class Klass:
 
@@ -30,6 +35,16 @@ async def test_functional_async_property(cache, raises, result):
                 raise SomeError("AN ERROR OCCURRED")
             else:
                 return await m_async()
+
+        @iter_decorator
+        async def iter_prop(self):
+            """This prop also deserves some docs"""
+            if raises:
+                await m_async()
+                raise SomeError("AN ITERATING ERROR OCCURRED")
+            _result = await m_async()
+            for item in items:
+                yield item, _result
 
     klass = Klass()
 
@@ -49,22 +64,40 @@ async def test_functional_async_property(cache, raises, result):
         with pytest.raises(SomeError) as e:
             await klass.prop
 
+        with pytest.raises(SomeError) as e2:
+            async for _result in klass.iter_prop:
+                pass
+
         assert (
             e.value.args[0]
             == 'AN ERROR OCCURRED')
         assert (
-            list(m_async.call_args)
-            == [(), {}])
+            e2.value.args[0]
+            == 'AN ITERATING ERROR OCCURRED')
+        assert (
+            list(m_async.call_args_list)
+            == [[(), {}]] * 2)
         return
 
     # results can be repeatedly awaited
     assert await klass.prop == result
     assert await klass.prop == result
 
+    # results can also be repeatedly iterated
+    _results1 = []
+    async for _result in klass.iter_prop:
+        _results1.append(_result)
+    assert _results1 == [(item, result) for item in items]
+
+    _results2 = []
+    async for _result in klass.iter_prop:
+        _results2.append(_result)
+
     if not cache:
+        assert _results2 == _results1
         assert (
             list(list(c) for c in m_async.call_args_list)
-            == [[(), {}], [(), {}]])
+            == [[(), {}]] * 4)
         assert not hasattr(klass, functional.async_property.cache_name)
         return
 
@@ -74,7 +107,13 @@ async def test_functional_async_property(cache, raises, result):
     assert await klass.prop == result
     assert (
         list(list(c) for c in m_async.call_args_list)
-        == [[(), {}]])
+        == [[(), {}]] * 2)
+
+    iter_prop = getattr(klass, functional.async_property.cache_name)["iter_prop"]
+    assert isinstance(iter_prop, types.AsyncGeneratorType)
     assert (
         getattr(klass, functional.async_property.cache_name)
-        == dict(prop=m_async.return_value))
+        == dict(prop=m_async.return_value, iter_prop=iter_prop))
+
+    # cached iterators dont give any more results once they are done
+    assert _results2 == []

--- a/tools/code_format/BUILD
+++ b/tools/code_format/BUILD
@@ -15,6 +15,7 @@ exports_files([
 envoy_py_binary(
     name = "tools.code_format.python_check",
     deps = [
+        "//tools/base:aio",
         "//tools/base:checker",
         "//tools/base:utils",
         requirement("flake8"),

--- a/tools/code_format/python_check.py
+++ b/tools/code_format/python_check.py
@@ -91,7 +91,7 @@ class PythonChecker(checker.AsyncChecker):
 
     async def check_yapf(self) -> None:
         """Run flake8 on files and/or repo"""
-        futures = aio.parallel(self.yapf_format(python_file) for python_file in self.yapf_files)
+        futures = aio.concurrent(self.yapf_format(python_file) for python_file in self.yapf_files)
 
         async for (python_file, (reformatted, encoding, changed)) in futures:
             self.yapf_result(python_file, reformatted, changed)

--- a/tools/code_format/python_check.py
+++ b/tools/code_format/python_check.py
@@ -23,7 +23,7 @@ from flake8.main.application import Application as Flake8Application  # type:ign
 
 import yapf  # type:ignore
 
-from tools.base import checker, utils
+from tools.base import aio, checker, utils
 
 FLAKE8_CONFIG = '.flake8'
 YAPF_CONFIG = '.style.yapf'
@@ -32,7 +32,7 @@ YAPF_CONFIG = '.style.yapf'
 #      - isort
 
 
-class PythonChecker(checker.ForkingChecker):
+class PythonChecker(checker.AsyncChecker):
     checks = ("flake8", "yapf")
 
     @property
@@ -80,7 +80,7 @@ class PythonChecker(checker.ForkingChecker):
         parser.add_argument(
             "--diff-file", default=None, help="Specify the path to a diff file with fixes")
 
-    def check_flake8(self) -> None:
+    async def check_flake8(self) -> None:
         """Run flake8 on files and/or repo"""
         errors: List[str] = []
         with utils.buffered(stdout=errors, mangle=self._strip_lines):
@@ -89,36 +89,39 @@ class PythonChecker(checker.ForkingChecker):
         if errors:
             self.error("flake8", errors)
 
-    def check_yapf(self) -> None:
+    async def check_yapf(self) -> None:
         """Run flake8 on files and/or repo"""
-        for python_file in self.yapf_files:
-            self.yapf_run(python_file)
+        futures = aio.parallel(self.yapf_format(python_file) for python_file in self.yapf_files)
 
-    def on_check_run(self, check: str) -> None:
+        async for (python_file, (reformatted, encoding, changed)) in futures:
+            self.yapf_result(python_file, reformatted, changed)
+
+    async def on_check_run(self, check: str) -> None:
         if check not in self.failed and check not in self.warned:
             self.succeed(check, [check])
 
-    def on_checks_complete(self) -> int:
+    async def on_checks_complete(self) -> int:
         if self.diff_file_path and self.has_failed:
-            result = self.subproc_run(["git", "diff", "HEAD"])
+            result = await aio.async_subprocess.run(["git", "diff", "HEAD"],
+                                                    cwd=self.path,
+                                                    capture_output=True)
             self.diff_file_path.write_bytes(result.stdout)
-        return super().on_checks_complete()
+        return await super().on_checks_complete()
 
-    def yapf_format(self, python_file: str) -> tuple:
-        return yapf.yapf_api.FormatFile(
+    async def yapf_format(self, python_file: str) -> tuple:
+        return python_file, yapf.yapf_api.FormatFile(
             python_file,
             style_config=str(self.yapf_config_path),
             in_place=self.fix,
             print_diff=not self.fix)
 
-    def yapf_run(self, python_file: str) -> None:
-        reformatted_source, encoding, changed = self.yapf_format(python_file)
+    def yapf_result(self, python_file: str, reformatted: str, changed: bool) -> None:
         if not changed:
             return self.succeed("yapf", [python_file])
         if self.fix:
             return self.warn("yapf", [f"{python_file}: reformatted"])
-        if reformatted_source:
-            return self.warn("yapf", [f"{python_file}: diff\n{reformatted_source}"])
+        if reformatted:
+            return self.warn("yapf", [f"{python_file}: diff\n{reformatted}"])
         self.error("yapf", [python_file])
 
     def _strip_line(self, line: str) -> str:
@@ -128,7 +131,7 @@ class PythonChecker(checker.ForkingChecker):
         return [self._strip_line(line) for line in lines if line]
 
 
-def main(*args: str) -> int:
+def main(*args: str) -> Optional[int]:
     return PythonChecker(*args).run()
 
 

--- a/tools/code_format/tests/test_python_check.py
+++ b/tools/code_format/tests/test_python_check.py
@@ -197,24 +197,24 @@ async def test_python_check_yapf(patches):
         "PythonChecker.yapf_result",
         ("PythonChecker.yapf_files", dict(new_callable=PropertyMock)),
         prefix="tools.code_format.python_check")
-    _files = ["file1", "file2", "file3"]
+    files = ["file1", "file2", "file3"]
 
-    async def _concurrent(iters):
+    async def concurrent(iters):
         assert isinstance(iters, types.GeneratorType)
         for i, format_result in enumerate(iters):
             yield (format_result, (f"REFORMAT{i}", f"ENCODING{i}", f"CHANGED{i}"))
 
     with patched as (m_aio, m_yapf_format, m_yapf_result, m_yapf_files):
-        m_yapf_files.return_value = _files
-        m_aio.concurrent.side_effect = _concurrent
+        m_yapf_files.return_value = files
+        m_aio.concurrent.side_effect = concurrent
         assert not await checker.check_yapf()
 
     assert (
         list(list(c) for c in m_yapf_format.call_args_list)
-        == [[(_file,), {}] for _file in _files])
+        == [[(file,), {}] for file in files])
     assert (
         list(list(c) for c in m_yapf_result.call_args_list)
-        == [[(m_yapf_format.return_value, f"REFORMAT{i}", f"CHANGED{i}"), {}] for i, _ in enumerate(_files)])
+        == [[(m_yapf_format.return_value, f"REFORMAT{i}", f"CHANGED{i}"), {}] for i, _ in enumerate(files)])
 
 
 @pytest.mark.asyncio

--- a/tools/code_format/tests/test_python_check.py
+++ b/tools/code_format/tests/test_python_check.py
@@ -199,14 +199,14 @@ async def test_python_check_yapf(patches):
         prefix="tools.code_format.python_check")
     _files = ["file1", "file2", "file3"]
 
-    async def _parallel(iters):
+    async def _concurrent(iters):
         assert isinstance(iters, types.GeneratorType)
         for i, format_result in enumerate(iters):
             yield (format_result, (f"REFORMAT{i}", f"ENCODING{i}", f"CHANGED{i}"))
 
     with patched as (m_aio, m_yapf_format, m_yapf_result, m_yapf_files):
         m_yapf_files.return_value = _files
-        m_aio.parallel.side_effect = _parallel
+        m_aio.concurrent.side_effect = _concurrent
         assert not await checker.check_yapf()
 
     assert (

--- a/tools/code_format/tests/test_python_check.py
+++ b/tools/code_format/tests/test_python_check.py
@@ -1,5 +1,6 @@
+import types
 from contextlib import contextmanager
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import AsyncMock, patch, MagicMock, PropertyMock
 
 import pytest
 
@@ -118,7 +119,7 @@ def test_python_yapf_files(patches):
 
 def test_python_add_arguments(patches):
     checker = python_check.PythonChecker("path1", "path2", "path3")
-    add_mock = patch("tools.code_format.python_check.checker.ForkingChecker.add_arguments")
+    add_mock = patch("tools.code_format.python_check.checker.AsyncChecker.add_arguments")
     m_parser = MagicMock()
 
     with add_mock as m_add:
@@ -137,8 +138,9 @@ def test_python_add_arguments(patches):
              {'default': None, 'help': 'Specify the path to a diff file with fixes'}]])
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("errors", [[], ["err1", "err2"]])
-def test_python_check_flake8(patches, errors):
+async def test_python_check_flake8(patches, errors):
     checker = python_check.PythonChecker("path1", "path2", "path3")
 
     patched = patches(
@@ -155,7 +157,7 @@ def test_python_check_flake8(patches, errors):
 
     with patched as (m_buffered, m_error, m_mangle, m_flake8_app):
         m_buffered.side_effect = mock_buffered
-        checker.check_flake8()
+        assert not await checker.check_flake8()
 
     assert (
         list(m_buffered.call_args)
@@ -186,37 +188,41 @@ def test_python_check_recurse():
     assert "recurse" not in checker.__dict__
 
 
-def test_python_check_yapf(patches):
+@pytest.mark.asyncio
+async def test_python_check_yapf(patches):
     checker = python_check.PythonChecker("path1", "path2", "path3")
     patched = patches(
-        "PythonChecker.yapf_run",
+        "aio",
+        ("PythonChecker.yapf_format", dict(new_callable=MagicMock)),
+        "PythonChecker.yapf_result",
         ("PythonChecker.yapf_files", dict(new_callable=PropertyMock)),
         prefix="tools.code_format.python_check")
+    _files = ["file1", "file2", "file3"]
 
-    with patched as (m_yapf_run, m_yapf_files):
-        m_yapf_files.return_value = ["file1", "file2", "file3"]
-        checker.check_yapf()
+    async def _parallel(iters):
+        assert isinstance(iters, types.GeneratorType)
+        for i, format_result in enumerate(iters):
+            yield (format_result, (f"REFORMAT{i}", f"ENCODING{i}", f"CHANGED{i}"))
+
+    with patched as (m_aio, m_yapf_format, m_yapf_result, m_yapf_files):
+        m_yapf_files.return_value = _files
+        m_aio.parallel.side_effect = _parallel
+        assert not await checker.check_yapf()
 
     assert (
-        list(list(c) for c in m_yapf_files.call_args_list)
-        == [[(), {}]])
+        list(list(c) for c in m_yapf_format.call_args_list)
+        == [[(_file,), {}] for _file in _files])
     assert (
-        list(list(c) for c in m_yapf_run.call_args_list)
-        == [[('file1',), {}], [('file2',), {}], [('file3',), {}]])
+        list(list(c) for c in m_yapf_result.call_args_list)
+        == [[(m_yapf_format.return_value, f"REFORMAT{i}", f"CHANGED{i}"), {}] for i, _ in enumerate(_files)])
 
 
-TEST_CHECK_RESULTS: tuple = (
-    ("check1", [], []),
-    ("check1", ["check2", "check3"], ["check4", "check5"]),
-    ("check1", ["check1", "check3"], ["check4", "check5"]),
-    ("check1", ["check2", "check3"], ["check1", "check5"]),
-    ("check1", ["check1", "check3"], ["check1", "check5"]))
-
-
-@pytest.mark.parametrize("results", TEST_CHECK_RESULTS)
-def test_python_on_check_run(patches, results):
+@pytest.mark.asyncio
+@pytest.mark.parametrize("errors", [[], ["check2", "check3"], ["check1", "check3"]])
+@pytest.mark.parametrize("warnings", [[], ["check4", "check5"], ["check1", "check5"]])
+async def test_python_on_check_run(patches, errors, warnings):
     checker = python_check.PythonChecker("path1", "path2", "path3")
-    checkname, errors, warnings = results
+    checkname = "check1"
     patched = patches(
         "PythonChecker.succeed",
         ("PythonChecker.name", dict(new_callable=PropertyMock)),
@@ -227,7 +233,7 @@ def test_python_on_check_run(patches, results):
     with patched as (m_succeed, m_name, m_failed, m_warned):
         m_failed.return_value = errors
         m_warned.return_value = warnings
-        checker.on_check_run(checkname)
+        assert not await checker.on_check_run(checkname)
 
     if checkname in warnings or checkname in errors:
         assert not m_succeed.called
@@ -237,47 +243,45 @@ def test_python_on_check_run(patches, results):
             == [(checkname, [checkname]), {}])
 
 
-TEST_CHECKS_COMPLETE = (
-    ("DIFF1", False),
-    ("DIFF1", True),
-    ("", False),
-    ("", True))
-
-
-@pytest.mark.parametrize("results", TEST_CHECKS_COMPLETE)
-def test_python_on_checks_complete(patches, results):
+@pytest.mark.asyncio
+@pytest.mark.parametrize("diff_path", ["", "DIFF1"])
+@pytest.mark.parametrize("failed", [True, False])
+async def test_python_on_checks_complete(patches, diff_path, failed):
     checker = python_check.PythonChecker("path1", "path2", "path3")
-    diff_path, failed = results
     patched = patches(
-        "checker.ForkingChecker.subproc_run",
-        "checker.Checker.on_checks_complete",
+        "aio",
+        ("checker.AsyncChecker.on_checks_complete", dict(new_callable=AsyncMock)),
         ("PythonChecker.diff_file_path", dict(new_callable=PropertyMock)),
         ("PythonChecker.has_failed", dict(new_callable=PropertyMock)),
+        ("PythonChecker.path", dict(new_callable=PropertyMock)),
         prefix="tools.code_format.python_check")
 
-    with patched as (m_fork, m_super, m_diff, m_failed):
+    with patched as (m_aio, m_super, m_diff, m_failed, m_path):
+        m_aio.async_subprocess.run = AsyncMock()
         if not diff_path:
             m_diff.return_value = None
         m_failed.return_value = failed
-        assert checker.on_checks_complete() == m_super.return_value
+        assert await checker.on_checks_complete() == m_super.return_value
 
     if diff_path and failed:
         assert (
-            list(m_fork.call_args)
-            == [(['git', 'diff', 'HEAD'],), {}])
+            list(m_aio.async_subprocess.run.call_args)
+            == [(['git', 'diff', 'HEAD'],),
+                dict(capture_output=True, cwd=m_path.return_value)])
         assert (
             list(m_diff.return_value.write_bytes.call_args)
-            == [(m_fork.return_value.stdout,), {}])
+            == [(m_aio.async_subprocess.run.return_value.stdout,), {}])
     else:
-        assert not m_fork.called
+        assert not m_aio.async_subprocess.run.called
 
     assert (
         list(m_super.call_args)
         == [(), {}])
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("fix", [True, False])
-def test_python_yapf_format(patches, fix):
+async def test_python_yapf_format(patches, fix):
     checker = python_check.PythonChecker("path1", "path2", "path3")
     patched = patches(
         "yapf.yapf_api.FormatFile",
@@ -287,7 +291,7 @@ def test_python_yapf_format(patches, fix):
 
     with patched as (m_format, m_config, m_fix):
         m_fix.return_value = fix
-        assert checker.yapf_format("FILENAME") == m_format.return_value
+        assert await checker.yapf_format("FILENAME") == ("FILENAME", m_format.return_value)
 
     assert (
         list(m_format.call_args)
@@ -300,30 +304,21 @@ def test_python_yapf_format(patches, fix):
         == [[(), {}], [(), {}]])
 
 
-TEST_FORMAT_RESULTS = (
-    ("", "", True),
-    ("", "", False),
-    ("REFORMAT", "", True),
-    ("REFORMAT", "", False))
-
-
-@pytest.mark.parametrize("format_results", TEST_FORMAT_RESULTS)
+@pytest.mark.parametrize("reformatted", ["", "REFORMAT"])
 @pytest.mark.parametrize("fix", [True, False])
-def test_python_yapf_run(patches, fix, format_results):
+@pytest.mark.parametrize("changed", [True, False])
+def test_python_yapf_result(patches, reformatted, fix, changed):
     checker = python_check.PythonChecker("path1", "path2", "path3")
-    reformat, encoding, changed = format_results
     patched = patches(
-        "PythonChecker.yapf_format",
         "PythonChecker.succeed",
         "PythonChecker.warn",
         "PythonChecker.error",
         ("PythonChecker.fix", dict(new_callable=PropertyMock)),
         prefix="tools.code_format.python_check")
 
-    with patched as (m_format, m_succeed, m_warn, m_error, m_fix):
+    with patched as (m_succeed, m_warn, m_error, m_fix):
         m_fix.return_value = fix
-        m_format.return_value = format_results
-        checker.yapf_run("FILENAME")
+        checker.yapf_result("FILENAME", reformatted, changed)
 
     if not changed:
         assert (
@@ -341,12 +336,12 @@ def test_python_yapf_run(patches, fix, format_results):
             list(m_warn.call_args)
             == [('yapf', [f'FILENAME: reformatted']), {}])
         return
-    if reformat:
+    if reformatted:
         assert not m_error.called
         assert len(m_warn.call_args_list) == 1
         assert (
             list(m_warn.call_args)
-            == [('yapf', [f'FILENAME: diff\n{reformat}']), {}])
+            == [('yapf', [f'FILENAME: diff\n{reformatted}']), {}])
         return
     assert not m_warn.called
     assert (


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: tooling: Add parallel utility for coroutines
Additional Description:

This will allow *coroutines* to be sped up through parallelization, while limiting concurrency

mostly this is of benefit to io-bound tasks rather than cpu-bound

i have updated the implementation of `python_check.py` to make it async to allow `yapf` to use this to work in parallel

it gives a small speedup, but its fairly cpu bound so not huge, mostly updating this was as a poc and for testing

one of the fairly big advantages this has over the native asyncio methods is that it works with generators - making it a `deque` for awaitables

also works with async generators, which is v handy as these can be chained to produce a pipeline of async parallel processing queues with configurably limited concurrency.

also cleans up some now redundant code and tweaks `async_property` to allow it to be used with async generators

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
