### PR TITLE
TSAN: RunOnAllThreads double free

### DIFF
--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -168,8 +168,11 @@ void InstanceImpl::runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_c
 
   Event::PostCbSharedPtr cb_guard(new Event::PostCb(cb),
                                   [this, all_threads_complete_cb](Event::PostCb* cb) {
-                                    main_thread_dispatcher_->post(all_threads_complete_cb);
+                                    // We need to delete the cb before posting
+                                    // to the main thread to avoid a race that
+                                    // can occur if the completion callback deletes the slot.
                                     delete cb;
+                                    main_thread_dispatcher_->post(all_threads_complete_cb);
                                   });
 
   for (Event::Dispatcher& dispatcher : registered_threads_) {

--- a/test/common/thread_local/BUILD
+++ b/test/common/thread_local/BUILD
@@ -17,5 +17,6 @@ envoy_cc_test(
         "//source/common/stats:isolated_store_lib",
         "//source/common/thread_local:thread_local_lib",
         "//test/mocks/event:event_mocks",
+        "@com_google_absl//absl/synchronization",
     ],
 )


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix TSAN race in RunOnAllThreads
Additional Description: The race occurs if the completion callback deletes the slot. The update callback which should run on all threads is shared_ptr and maintains a reference to the slot internals via a weak_ptr. We should delete the update cb before posting to the main thread to run the completion callback otherwise we can have a double free of slot internals. 
Risk Level: medium
Testing: Added unit test that demonstrated the race condition.
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA

