### PR TITLE
ci: set build debug information from env

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -85,6 +85,7 @@ docker run --rm \
        -e ENVOY_BUILD_IMAGE \
        -e ENVOY_SRCDIR \
        -e ENVOY_BUILD_TARGET \
+       -e ENVOY_BUILD_DEBUG_INFORMATION \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \
        -e GITHUB_TOKEN \


### PR DESCRIPTION
Commit Message: ci: set build debug information from env
Additional Description: We build envoy with additional filters using the scripts in the ci/ folder (don't know if this is an expected use of these scripts), it would be useful to be able to override `ENVOY_BUILD_DEBUG_INFORMATION` the same way `ENVOY_BUILD_TARGET` can be.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
