### PR TITLE
Add Proxy-Status HTTP response header field.

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -304,7 +304,8 @@ message HttpConnectionManager {
   // Configures the manner in which the Proxy-Status HTTP response header is
   // populated.
   //
-  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
+  // See the [Proxy-Status
+  // RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05).
   // TODO(ambuc): Update this with the non-draft URL when finalized.
   //
   // The Proxy-Status header is a string of the form:

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -321,10 +321,9 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, populates the details field of the Proxy-Status header with
-    // stream_info.response_code_details.
-    // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 1;
+    // If true, the details field of the Proxy-Status header is not populated with stream_info.response_code_details.
+    // This value defaults to `false`, i.e. the `details` field is populated by default.
+    bool remove_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -306,7 +306,7 @@ message HttpConnectionManager {
   //
   // See the [Proxy-Status
   // RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05).
-  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  // [#comment:TODO: Update this with the non-draft URL when finalized.]
   //
   // The Proxy-Status header is a string of the form:
   //

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -320,25 +320,21 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, attaches the Proxy-Status header to response headers.
-    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
-    bool attach_proxy_status = 1;
-
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
     // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 2;
+    bool attach_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 2;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 3;
   }
 
   reserved 27, 11;
@@ -748,6 +744,8 @@ message HttpConnectionManager {
   bool strip_trailing_host_dot = 47;
 
   // Proxy-Status HTTP response header configuration.
+  // If this config is set, the Proxy-Status HTTP response header field is
+  // populated. By default, it is not.
   ProxyStatusConfig proxy_status_config = 49;
 }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -325,16 +325,21 @@ message HttpConnectionManager {
     // This value defaults to `false`, i.e. the `details` field is populated by default.
     bool remove_details = 1;
 
+    // If true, the details field of the Proxy-Status header will not contain
+    // connection termination details. This value defaults to `false`, i.e. the
+    // `details` field will contain connection termination details by default.
+    bool remove_connection_termination_details = 2;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 2;
+    bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 3;
+    ProxyName proxy_name = 4;
   }
 
   reserved 27, 11;

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -301,6 +301,15 @@ message HttpConnectionManager {
     type.http.v3.PathTransformation http_filter_transformation = 2;
   }
 
+  // Configures the manner in which the Proxy-Status HTTP response header is
+  // populated.
+  //
+  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
+  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  //
+  // The Proxy-Status header is a string of the form:
+  //
+  //   "<server_name>; error=<error_type>; details=<details>"
   message ProxyStatusConfig {
     enum ProxyName {
       // Use the string "envoy".
@@ -312,18 +321,23 @@ message HttpConnectionManager {
     }
 
     // If true, attaches the Proxy-Status header to response headers.
+    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
     bool attach_proxy_status = 1;
 
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
+    // This value defaults to `false`, i.e. no `details` field is attached.
     bool attach_details = 2;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
+    // This value defaults to `false`, i.e. the HTTP response code is not
+    // overwritten.
     bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
+    // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
     ProxyName proxy_name = 4;
   }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -34,7 +34,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 49]
+// [#next-free-field: 50]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -299,6 +299,32 @@ message HttpConnectionManager {
     // respond with 400 to paths that are malformed (e.g. for paths that fail RFC 3986
     // normalization due to disallowed characters.)
     type.http.v3.PathTransformation http_filter_transformation = 2;
+  }
+
+  message ProxyStatusConfig {
+    enum ProxyName {
+      // Use the string "envoy".
+      ENVOY_LITERAL = 0;
+
+      // Use the name of the server as it appears in
+      // HttpConnectionManager.server_name.
+      SERVER_NAME = 1;
+    }
+
+    // If true, attaches the Proxy-Status header to response headers.
+    bool attach_proxy_status = 1;
+
+    // If true, populates the details field of the Proxy-Status header with
+    // stream_info.response_code_details.
+    bool attach_details = 2;
+
+    // If true, overwrites the existing Status header with the response code
+    // recommended by the Proxy-Status spec.
+    bool set_recommended_response_code = 3;
+
+    // The name of the proxy as it appears at the start of the Proxy-Status
+    // header.
+    ProxyName proxy_name = 4;
   }
 
   reserved 27, 11;
@@ -706,6 +732,9 @@ message HttpConnectionManager {
   // setting this option will strip a trailing dot, if present, from the host section,
   // leaving the port as is (e.g. host value `example.com.:443` will be updated to `example.com:443`).
   bool strip_trailing_host_dot = 47;
+
+  // Proxy-Status HTTP response header configuration.
+  ProxyStatusConfig proxy_status_config = 49;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -311,6 +311,7 @@ message HttpConnectionManager {
   // The Proxy-Status header is a string of the form:
   //
   //   "<server_name>; error=<error_type>; details=<details>"
+  // [#next-free-field: 6]
   message ProxyStatusConfig {
     enum ProxyName {
       // Use the string "envoy".
@@ -330,16 +331,21 @@ message HttpConnectionManager {
     // `details` field will contain connection termination details by default.
     bool remove_connection_termination_details = 2;
 
+    // If true, the details field of the Proxy-Status header will not contain an
+    // enumeration of the Envoy ResponseFlags. This value defaults to `false`,
+    // i.e. the `details` field will contain a list of ResponseFlags by default.
+    bool remove_response_flags = 3;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 4;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 5;
   }
 
   reserved 27, 11;

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -332,16 +332,21 @@ message HttpConnectionManager {
     // This value defaults to `false`, i.e. the `details` field is populated by default.
     bool remove_details = 1;
 
+    // If true, the details field of the Proxy-Status header will not contain
+    // connection termination details. This value defaults to `false`, i.e. the
+    // `details` field will contain connection termination details by default.
+    bool remove_connection_termination_details = 2;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 2;
+    bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 3;
+    ProxyName proxy_name = 4;
   }
 
   reserved 27, 11;

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -304,8 +304,15 @@ message HttpConnectionManager {
     type.http.v3.PathTransformation http_filter_transformation = 2;
   }
 
-  reserved 27, 11, 19;
-
+  // Configures the manner in which the Proxy-Status HTTP response header is
+  // populated.
+  //
+  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
+  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  //
+  // The Proxy-Status header is a string of the form:
+  //
+  //   "<server_name>; error=<error_type>; details=<details>"
   message ProxyStatusConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager."
@@ -321,20 +328,27 @@ message HttpConnectionManager {
     }
 
     // If true, attaches the Proxy-Status header to response headers.
+    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
     bool attach_proxy_status = 1;
 
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
+    // This value defaults to `false`, i.e. no `details` field is attached.
     bool attach_details = 2;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
+    // This value defaults to `false`, i.e. the HTTP response code is not
+    // overwritten.
     bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
+    // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
     ProxyName proxy_name = 4;
   }
+
+  reserved 27, 11;
 
   reserved "idle_timeout";
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -327,25 +327,21 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, attaches the Proxy-Status header to response headers.
-    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
-    bool attach_proxy_status = 1;
-
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
     // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 2;
+    bool attach_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 2;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 3;
   }
 
   reserved 27, 11;
@@ -754,6 +750,8 @@ message HttpConnectionManager {
   bool strip_trailing_host_dot = 47;
 
   // Proxy-Status HTTP response header configuration.
+  // If this config is set, the Proxy-Status HTTP response header field is
+  // populated. By default, the Proxy-Status HTTP response header field.
   ProxyStatusConfig proxy_status_config = 49;
 }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -314,6 +314,7 @@ message HttpConnectionManager {
   // The Proxy-Status header is a string of the form:
   //
   //   "<server_name>; error=<error_type>; details=<details>"
+  // [#next-free-field: 6]
   message ProxyStatusConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager."
@@ -337,16 +338,21 @@ message HttpConnectionManager {
     // `details` field will contain connection termination details by default.
     bool remove_connection_termination_details = 2;
 
+    // If true, the details field of the Proxy-Status header will not contain an
+    // enumeration of the Envoy ResponseFlags. This value defaults to `false`,
+    // i.e. the `details` field will contain a list of ResponseFlags by default.
+    bool remove_response_flags = 3;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 4;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 5;
   }
 
   reserved 27, 11;

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -33,7 +33,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 49]
+// [#next-free-field: 50]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager";
@@ -304,7 +304,37 @@ message HttpConnectionManager {
     type.http.v3.PathTransformation http_filter_transformation = 2;
   }
 
-  reserved 27, 11;
+  reserved 27, 11, 19;
+
+  message ProxyStatusConfig {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager."
+        "ProxyStatusConfig";
+
+    enum ProxyName {
+      // Use the string "envoy".
+      ENVOY_LITERAL = 0;
+
+      // Use the name of the server as it appears in
+      // HttpConnectionManager.server_name.
+      SERVER_NAME = 1;
+    }
+
+    // If true, attaches the Proxy-Status header to response headers.
+    bool attach_proxy_status = 1;
+
+    // If true, populates the details field of the Proxy-Status header with
+    // stream_info.response_code_details.
+    bool attach_details = 2;
+
+    // If true, overwrites the existing Status header with the response code
+    // recommended by the Proxy-Status spec.
+    bool set_recommended_response_code = 3;
+
+    // The name of the proxy as it appears at the start of the Proxy-Status
+    // header.
+    ProxyName proxy_name = 4;
+  }
 
   reserved "idle_timeout";
 
@@ -708,6 +738,9 @@ message HttpConnectionManager {
   // setting this option will strip a trailing dot, if present, from the host section,
   // leaving the port as is (e.g. host value `example.com.:443` will be updated to `example.com:443`).
   bool strip_trailing_host_dot = 47;
+
+  // Proxy-Status HTTP response header configuration.
+  ProxyStatusConfig proxy_status_config = 49;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -307,8 +307,9 @@ message HttpConnectionManager {
   // Configures the manner in which the Proxy-Status HTTP response header is
   // populated.
   //
-  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
-  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  // See the [Proxy-Status
+  // RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05).
+  // [#comment:TODO: Update this with the non-draft URL when finalized.]
   //
   // The Proxy-Status header is a string of the form:
   //
@@ -327,10 +328,9 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, populates the details field of the Proxy-Status header with
-    // stream_info.response_code_details.
-    // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 1;
+    // If true, the details field of the Proxy-Status header is not populated with stream_info.response_code_details.
+    // This value defaults to `false`, i.e. the `details` field is populated by default.
+    bool remove_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
@@ -751,7 +751,7 @@ message HttpConnectionManager {
 
   // Proxy-Status HTTP response header configuration.
   // If this config is set, the Proxy-Status HTTP response header field is
-  // populated. By default, the Proxy-Status HTTP response header field.
+  // populated. By default, it is not.
   ProxyStatusConfig proxy_status_config = 49;
 }
 

--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -354,6 +354,7 @@ private:
   HEADER_FUNC(EnvoyDecoratorOperation)                                                             \
   HEADER_FUNC(KeepAlive)                                                                           \
   HEADER_FUNC(ProxyConnection)                                                                     \
+  HEADER_FUNC(ProxyStatus)                                                                         \
   HEADER_FUNC(RequestId)                                                                           \
   HEADER_FUNC(TransferEncoding)                                                                    \
   HEADER_FUNC(Upgrade)                                                                             \

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -605,7 +605,7 @@ public:
 };
 
 // An enum representation of the Proxy-Status error space.
-enum ProxyStatusError {
+enum class ProxyStatusError {
   DnsTimeout,
   DnsError,
   DestinationNotFound,

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -604,5 +604,43 @@ public:
   virtual absl::optional<uint32_t> attemptCount() const PURE;
 };
 
+// An enum representation of the Proxy-Status error space.
+enum ProxyStatusError {
+  DnsTimeout,
+  DnsError,
+  DestinationNotFound,
+  DestinationUnavailable,
+  DestinationIpProhibited,
+  DestinationIpUnroutable,
+  ConnectionRefused,
+  ConnectionTerminated,
+  ConnectionTimeout,
+  ConnectionReadTimeout,
+  ConnectionWriteTimeout,
+  ConnectionLimitReached,
+  TlsProtocolError,
+  TlsCertificateError,
+  TlsAlertReceived,
+  HttpRequestError,
+  HttpRequestDenied,
+  HttpResponseIncomplete,
+  HttpResponseHeaderSectionSize,
+  HttpResponseHeaderSize,
+  HttpResponseBodySize,
+  HttpResponseTrailerSectionSize,
+  HttpResponseTrailerSize,
+  HttpResponseTransferCoding,
+  HttpResponseContentCoding,
+  HttpResponseTimeout,
+  HttpUpgradeFailed,
+  HttpProtocolError,
+  ProxyInternalResponse,
+  ProxyInternalError,
+  ProxyConfigurationError,
+  ProxyLoopDetected,
+  // ATTENTION: MAKE SURE THAT THIS REMAINS EQUAL TO THE LAST FLAG.
+  LastProxyStatus = ProxyLoopDetected,
+};
+
 } // namespace StreamInfo
 } // namespace Envoy

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -319,6 +319,7 @@ message HttpConnectionManager {
   // The Proxy-Status header is a string of the form:
   //
   //   "<server_name>; error=<error_type>; details=<details>"
+  // [#next-free-field: 6]
   message ProxyStatusConfig {
     enum ProxyName {
       // Use the string "envoy".
@@ -338,16 +339,21 @@ message HttpConnectionManager {
     // `details` field will contain connection termination details by default.
     bool remove_connection_termination_details = 2;
 
+    // If true, the details field of the Proxy-Status header will not contain an
+    // enumeration of the Envoy ResponseFlags. This value defaults to `false`,
+    // i.e. the `details` field will contain a list of ResponseFlags by default.
+    bool remove_response_flags = 3;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 4;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 5;
   }
 
   reserved 27;

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -312,8 +312,9 @@ message HttpConnectionManager {
   // Configures the manner in which the Proxy-Status HTTP response header is
   // populated.
   //
-  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
-  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  // See the [Proxy-Status
+  // RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05).
+  // [#comment:TODO: Update this with the non-draft URL when finalized.]
   //
   // The Proxy-Status header is a string of the form:
   //
@@ -328,10 +329,9 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, populates the details field of the Proxy-Status header with
-    // stream_info.response_code_details.
-    // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 1;
+    // If true, the details field of the Proxy-Status header is not populated with stream_info.response_code_details.
+    // This value defaults to `false`, i.e. the `details` field is populated by default.
+    bool remove_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
@@ -751,7 +751,7 @@ message HttpConnectionManager {
 
   // Proxy-Status HTTP response header configuration.
   // If this config is set, the Proxy-Status HTTP response header field is
-  // populated. By default, the Proxy-Status HTTP response header field.
+  // populated. By default, it is not.
   ProxyStatusConfig proxy_status_config = 49;
 
   google.protobuf.Duration hidden_envoy_deprecated_idle_timeout = 11 [

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -328,25 +328,21 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, attaches the Proxy-Status header to response headers.
-    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
-    bool attach_proxy_status = 1;
-
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
     // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 2;
+    bool attach_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 2;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 3;
   }
 
   reserved 27;
@@ -754,6 +750,8 @@ message HttpConnectionManager {
   bool strip_trailing_host_dot = 47;
 
   // Proxy-Status HTTP response header configuration.
+  // If this config is set, the Proxy-Status HTTP response header field is
+  // populated. By default, the Proxy-Status HTTP response header field.
   ProxyStatusConfig proxy_status_config = 49;
 
   google.protobuf.Duration hidden_envoy_deprecated_idle_timeout = 11 [

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -36,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 49]
+// [#next-free-field: 50]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -307,6 +307,32 @@ message HttpConnectionManager {
     // respond with 400 to paths that are malformed (e.g. for paths that fail RFC 3986
     // normalization due to disallowed characters.)
     type.http.v3.PathTransformation http_filter_transformation = 2;
+  }
+
+  message ProxyStatusConfig {
+    enum ProxyName {
+      // Use the string "envoy".
+      ENVOY_LITERAL = 0;
+
+      // Use the name of the server as it appears in
+      // HttpConnectionManager.server_name.
+      SERVER_NAME = 1;
+    }
+
+    // If true, attaches the Proxy-Status header to response headers.
+    bool attach_proxy_status = 1;
+
+    // If true, populates the details field of the Proxy-Status header with
+    // stream_info.response_code_details.
+    bool attach_details = 2;
+
+    // If true, overwrites the existing Status header with the response code
+    // recommended by the Proxy-Status spec.
+    bool set_recommended_response_code = 3;
+
+    // The name of the proxy as it appears at the start of the Proxy-Status
+    // header.
+    ProxyName proxy_name = 4;
   }
 
   reserved 27;
@@ -712,6 +738,9 @@ message HttpConnectionManager {
   // setting this option will strip a trailing dot, if present, from the host section,
   // leaving the port as is (e.g. host value `example.com.:443` will be updated to `example.com:443`).
   bool strip_trailing_host_dot = 47;
+
+  // Proxy-Status HTTP response header configuration.
+  ProxyStatusConfig proxy_status_config = 49;
 
   google.protobuf.Duration hidden_envoy_deprecated_idle_timeout = 11 [
     deprecated = true,

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -309,6 +309,15 @@ message HttpConnectionManager {
     type.http.v3.PathTransformation http_filter_transformation = 2;
   }
 
+  // Configures the manner in which the Proxy-Status HTTP response header is
+  // populated.
+  //
+  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
+  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  //
+  // The Proxy-Status header is a string of the form:
+  //
+  //   "<server_name>; error=<error_type>; details=<details>"
   message ProxyStatusConfig {
     enum ProxyName {
       // Use the string "envoy".
@@ -320,18 +329,23 @@ message HttpConnectionManager {
     }
 
     // If true, attaches the Proxy-Status header to response headers.
+    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
     bool attach_proxy_status = 1;
 
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
+    // This value defaults to `false`, i.e. no `details` field is attached.
     bool attach_details = 2;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
+    // This value defaults to `false`, i.e. the HTTP response code is not
+    // overwritten.
     bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
+    // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
     ProxyName proxy_name = 4;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -333,16 +333,21 @@ message HttpConnectionManager {
     // This value defaults to `false`, i.e. the `details` field is populated by default.
     bool remove_details = 1;
 
+    // If true, the details field of the Proxy-Status header will not contain
+    // connection termination details. This value defaults to `false`, i.e. the
+    // `details` field will contain connection termination details by default.
+    bool remove_connection_termination_details = 2;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 2;
+    bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 3;
+    ProxyName proxy_name = 4;
   }
 
   reserved 27;

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -332,16 +332,21 @@ message HttpConnectionManager {
     // This value defaults to `false`, i.e. the `details` field is populated by default.
     bool remove_details = 1;
 
+    // If true, the details field of the Proxy-Status header will not contain
+    // connection termination details. This value defaults to `false`, i.e. the
+    // `details` field will contain connection termination details by default.
+    bool remove_connection_termination_details = 2;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 2;
+    bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 3;
+    ProxyName proxy_name = 4;
   }
 
   reserved 27, 11;

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -33,7 +33,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 49]
+// [#next-free-field: 50]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager";
@@ -302,6 +302,36 @@ message HttpConnectionManager {
     // respond with 400 to paths that are malformed (e.g. for paths that fail RFC 3986
     // normalization due to disallowed characters.)
     type.http.v3.PathTransformation http_filter_transformation = 2;
+  }
+
+  message ProxyStatusConfig {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager."
+        "ProxyStatusConfig";
+
+    enum ProxyName {
+      // Use the string "envoy".
+      ENVOY_LITERAL = 0;
+
+      // Use the name of the server as it appears in
+      // HttpConnectionManager.server_name.
+      SERVER_NAME = 1;
+    }
+
+    // If true, attaches the Proxy-Status header to response headers.
+    bool attach_proxy_status = 1;
+
+    // If true, populates the details field of the Proxy-Status header with
+    // stream_info.response_code_details.
+    bool attach_details = 2;
+
+    // If true, overwrites the existing Status header with the response code
+    // recommended by the Proxy-Status spec.
+    bool set_recommended_response_code = 3;
+
+    // The name of the proxy as it appears at the start of the Proxy-Status
+    // header.
+    ProxyName proxy_name = 4;
   }
 
   reserved 27, 11;
@@ -708,6 +738,9 @@ message HttpConnectionManager {
   // setting this option will strip a trailing dot, if present, from the host section,
   // leaving the port as is (e.g. host value `example.com.:443` will be updated to `example.com:443`).
   bool strip_trailing_host_dot = 47;
+
+  // Proxy-Status HTTP response header configuration.
+  ProxyStatusConfig proxy_status_config = 49;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -327,25 +327,21 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, attaches the Proxy-Status header to response headers.
-    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
-    bool attach_proxy_status = 1;
-
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
     // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 2;
+    bool attach_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 2;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 3;
   }
 
   reserved 27, 11;
@@ -754,6 +750,8 @@ message HttpConnectionManager {
   bool strip_trailing_host_dot = 47;
 
   // Proxy-Status HTTP response header configuration.
+  // If this config is set, the Proxy-Status HTTP response header field is
+  // populated. By default, the Proxy-Status HTTP response header field.
   ProxyStatusConfig proxy_status_config = 49;
 }
 

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -304,6 +304,15 @@ message HttpConnectionManager {
     type.http.v3.PathTransformation http_filter_transformation = 2;
   }
 
+  // Configures the manner in which the Proxy-Status HTTP response header is
+  // populated.
+  //
+  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
+  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  //
+  // The Proxy-Status header is a string of the form:
+  //
+  //   "<server_name>; error=<error_type>; details=<details>"
   message ProxyStatusConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager."
@@ -319,18 +328,23 @@ message HttpConnectionManager {
     }
 
     // If true, attaches the Proxy-Status header to response headers.
+    // This value defaults to `false`, i.e. no Proxy-Status header is attached.
     bool attach_proxy_status = 1;
 
     // If true, populates the details field of the Proxy-Status header with
     // stream_info.response_code_details.
+    // This value defaults to `false`, i.e. no `details` field is attached.
     bool attach_details = 2;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
+    // This value defaults to `false`, i.e. the HTTP response code is not
+    // overwritten.
     bool set_recommended_response_code = 3;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
+    // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
     ProxyName proxy_name = 4;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -314,6 +314,7 @@ message HttpConnectionManager {
   // The Proxy-Status header is a string of the form:
   //
   //   "<server_name>; error=<error_type>; details=<details>"
+  // [#next-free-field: 6]
   message ProxyStatusConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager."
@@ -337,16 +338,21 @@ message HttpConnectionManager {
     // `details` field will contain connection termination details by default.
     bool remove_connection_termination_details = 2;
 
+    // If true, the details field of the Proxy-Status header will not contain an
+    // enumeration of the Envoy ResponseFlags. This value defaults to `false`,
+    // i.e. the `details` field will contain a list of ResponseFlags by default.
+    bool remove_response_flags = 3;
+
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
     // This value defaults to `false`, i.e. the HTTP response code is not
     // overwritten.
-    bool set_recommended_response_code = 3;
+    bool set_recommended_response_code = 4;
 
     // The name of the proxy as it appears at the start of the Proxy-Status
     // header.
     // This value defaults to ENVOY_LITERAL, i.e. `envoy`.
-    ProxyName proxy_name = 4;
+    ProxyName proxy_name = 5;
   }
 
   reserved 27, 11;

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -307,8 +307,9 @@ message HttpConnectionManager {
   // Configures the manner in which the Proxy-Status HTTP response header is
   // populated.
   //
-  // See the Proxy-Status RFC: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05
-  // TODO(ambuc): Update this with the non-draft URL when finalized.
+  // See the [Proxy-Status
+  // RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05).
+  // [#comment:TODO: Update this with the non-draft URL when finalized.]
   //
   // The Proxy-Status header is a string of the form:
   //
@@ -327,10 +328,9 @@ message HttpConnectionManager {
       SERVER_NAME = 1;
     }
 
-    // If true, populates the details field of the Proxy-Status header with
-    // stream_info.response_code_details.
-    // This value defaults to `false`, i.e. no `details` field is attached.
-    bool attach_details = 1;
+    // If true, the details field of the Proxy-Status header is not populated with stream_info.response_code_details.
+    // This value defaults to `false`, i.e. the `details` field is populated by default.
+    bool remove_details = 1;
 
     // If true, overwrites the existing Status header with the response code
     // recommended by the Proxy-Status spec.
@@ -751,7 +751,7 @@ message HttpConnectionManager {
 
   // Proxy-Status HTTP response header configuration.
   // If this config is set, the Proxy-Status HTTP response header field is
-  // populated. By default, the Proxy-Status HTTP response header field.
+  // populated. By default, it is not.
   ProxyStatusConfig proxy_status_config = 49;
 }
 

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -500,6 +500,10 @@ public:
    * @return maximum requests for downstream.
    */
   virtual uint64_t maxRequestsPerConnection() const PURE;
+  /**
+   * @return the config describing if/how to write the Proxy-Status HTTP response header.
+   */
+  virtual const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const PURE;
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -502,8 +502,9 @@ public:
   virtual uint64_t maxRequestsPerConnection() const PURE;
   /**
    * @return the config describing if/how to write the Proxy-Status HTTP response header.
+   * If nullptr, don't write the Proxy-Status HTTP response header.
    */
-  virtual const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const PURE;
+  virtual const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const PURE;
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1468,8 +1468,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
 
   chargeStats(headers);
 
-  if (auto& proxy_status_config = connection_manager_.config_.proxyStatusConfig();
-      proxy_status_config.attach_proxy_status()) {
+  if (auto* proxy_status_config = connection_manager_.config_.proxyStatusConfig();
+      proxy_status_config != nullptr) {
     // Writing the Proxy-Status header is gated on |attach_proxy_status|.
     // The |details| field and other internals are generated in
     // fromStreamInfo().
@@ -1478,9 +1478,9 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
         proxy_status.has_value()) {
       headers.setProxyStatus(StreamInfo::ProxyStatusUtils::toString(
           filter_manager_.streamInfo(), *proxy_status, connection_manager_.config_.serverName(),
-          proxy_status_config));
+          *proxy_status_config));
       // Apply the recommended response code, if configured and applicable.
-      if (proxy_status_config.set_recommended_response_code()) {
+      if (proxy_status_config->set_recommended_response_code()) {
         if (absl::optional<uint32_t> response_code =
                 StreamInfo::ProxyStatusUtils::recommendedHttpStatusCode(*proxy_status);
             response_code.has_value()) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1470,8 +1470,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
 
   if (auto* proxy_status_config = connection_manager_.config_.proxyStatusConfig();
       proxy_status_config != nullptr) {
-    // Writing the Proxy-Status header is gated on |attach_proxy_status|.
-    // The |details| field and other internals are generated in
+    // Writing the Proxy-Status header is gated on the existence of
+    // |proxy_status_config|. The |details| field and other internals are generated in
     // fromStreamInfo().
     if (absl::optional<StreamInfo::ProxyStatusError> proxy_status =
             StreamInfo::ProxyStatusUtils::fromStreamInfo(filter_manager_.streamInfo());

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1476,9 +1476,10 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
     if (absl::optional<StreamInfo::ProxyStatusError> proxy_status =
             StreamInfo::ProxyStatusUtils::fromStreamInfo(filter_manager_.streamInfo());
         proxy_status.has_value()) {
-      headers.setProxyStatus(StreamInfo::ProxyStatusUtils::toString(
-          filter_manager_.streamInfo(), *proxy_status, connection_manager_.config_.serverName(),
-          *proxy_status_config));
+      headers.appendProxyStatus(StreamInfo::ProxyStatusUtils::toString(
+                                    filter_manager_.streamInfo(), *proxy_status,
+                                    connection_manager_.config_.serverName(), *proxy_status_config),
+                                "; ");
       // Apply the recommended response code, if configured and applicable.
       if (proxy_status_config->set_recommended_response_code()) {
         if (absl::optional<uint32_t> response_code =

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -44,6 +44,7 @@
 #include "source/common/router/config_impl.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/stats/timespan_impl.h"
+#include "source/common/stream_info/utility.h"
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
@@ -1466,6 +1467,28 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
   }
 
   chargeStats(headers);
+
+  if (auto& proxy_status_config = connection_manager_.config_.proxyStatusConfig();
+      proxy_status_config.attach_proxy_status()) {
+    // Writing the Proxy-Status header is gated on |attach_proxy_status|.
+    // The |details| field and other internals are generated in
+    // fromStreamInfo().
+    if (absl::optional<StreamInfo::ProxyStatusError> proxy_status =
+            StreamInfo::ProxyStatusUtils::fromStreamInfo(filter_manager_.streamInfo());
+        proxy_status.has_value()) {
+      headers.setProxyStatus(StreamInfo::ProxyStatusUtils::toString(
+          filter_manager_.streamInfo(), *proxy_status, connection_manager_.config_.serverName(),
+          proxy_status_config));
+      // Apply the recommended response code, if configured and applicable.
+      if (proxy_status_config.set_recommended_response_code()) {
+        if (absl::optional<uint32_t> response_code =
+                StreamInfo::ProxyStatusUtils::recommendedHttpStatusCode(*proxy_status);
+            response_code.has_value()) {
+          headers.setStatus(std::to_string(*response_code));
+        }
+      }
+    }
+  }
 
   ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):\n{}", *this, end_stream,
                    headers);

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1479,7 +1479,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
       headers.appendProxyStatus(StreamInfo::ProxyStatusUtils::toString(
                                     filter_manager_.streamInfo(), *proxy_status,
                                     connection_manager_.config_.serverName(), *proxy_status_config),
-                                "; ");
+                                ", ");
       // Apply the recommended response code, if configured and applicable.
       if (proxy_status_config->set_recommended_response_code()) {
         if (absl::optional<uint32_t> response_code =

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -202,6 +202,7 @@ public:
   const LowerCaseString Path{":path"};
   const LowerCaseString Protocol{":protocol"};
   const LowerCaseString ProxyConnection{"proxy-connection"};
+  const LowerCaseString ProxyStatus{"proxy-status"};
   const LowerCaseString Range{"range"};
   const LowerCaseString RequestId{"x-request-id"};
   const LowerCaseString Scheme{":scheme"};

--- a/source/common/stream_info/BUILD
+++ b/source/common/stream_info/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
     deps = [
         "//envoy/common:time_interface",
         "//envoy/stream_info:stream_info_interface",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/common/stream_info/BUILD
+++ b/source/common/stream_info/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
     deps = [
         "//envoy/common:time_interface",
         "//envoy/stream_info:stream_info_interface",
+        "//source/common/http:default_server_string_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -268,7 +268,7 @@ ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
   } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamProtocolError)) {
     return ProxyStatusError::HttpProtocolError;
   } else if (stream_info.hasResponseFlag(ResponseFlag::NoClusterFound)) {
-    return ProxyStatusError::DestinationIpUnroutable;
+    return ProxyStatusError::DestinationUnavailable;
   } else {
     return absl::nullopt;
   }

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -154,6 +154,9 @@ ProxyStatusUtils::toString(const StreamInfo& stream_info, const ProxyStatusError
         stream_info.connectionTerminationDetails().has_value()) {
       details.push_back(stream_info.connectionTerminationDetails().value());
     }
+    if (!proxy_status_config.remove_response_flags() && stream_info.hasAnyResponseFlag()) {
+      details.push_back(ResponseFlagUtils::toShortString(stream_info));
+    }
     retval.push_back(absl::StrFormat("details='%s'", absl::StrJoin(details, "; ")));
   }
 

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -254,7 +254,7 @@ ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
   } else if (stream_info.hasResponseFlag(ResponseFlag::RateLimitServiceError)) {
     return ProxyStatusError::ConnectionLimitReached;
   } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRetryLimitExceeded)) {
-    return ProxyStatusError::ConnectionTerminated;
+    return ProxyStatusError::DestinationUnavailable;
   } else if (stream_info.hasResponseFlag(ResponseFlag::StreamIdleTimeout)) {
     return ProxyStatusError::HttpResponseTimeout;
   } else if (stream_info.hasResponseFlag(ResponseFlag::InvalidEnvoyRequestHeaders)) {

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -145,7 +145,7 @@ ProxyStatusUtils::toString(const StreamInfo& stream_info, const ProxyStatusError
 
   retval.append(absl::StrFormat("; error=%s", proxyStatusErrorToString(error)));
 
-  if (proxy_status_config.attach_details() && stream_info.responseCodeDetails().has_value()) {
+  if (!proxy_status_config.remove_details() && stream_info.responseCodeDetails().has_value()) {
     retval.append(absl::StrFormat("; details='%s'", stream_info.responseCodeDetails().value()));
   }
 

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -4,6 +4,8 @@
 
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 
+#include "source/common/http/default_server_string.h"
+
 #include "absl/strings/str_format.h"
 
 namespace Envoy {
@@ -138,7 +140,7 @@ ProxyStatusUtils::toString(const StreamInfo& stream_info, const ProxyStatusError
   case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       ProxyStatusConfig::ENVOY_LITERAL:
   default: {
-    retval.append("envoy");
+    retval.append(Envoy::Http::DefaultServerString::get());
     break;
   }
   }

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -2,6 +2,10 @@
 
 #include <string>
 
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+
+#include "absl/strings/str_format.h"
+
 namespace Envoy {
 namespace StreamInfo {
 
@@ -41,6 +45,225 @@ absl::optional<ResponseFlag> ResponseFlagUtils::toResponseFlag(absl::string_view
     return absl::make_optional<ResponseFlag>(it->second);
   }
   return absl::nullopt;
+}
+
+const absl::optional<uint32_t>
+ProxyStatusUtils::recommendedHttpStatusCode(const ProxyStatusError proxy_status) {
+  switch (proxy_status) {
+  case ProxyStatusError::DnsTimeout:
+    return 504;
+  case ProxyStatusError::DnsError:
+    return 502;
+  case ProxyStatusError::DestinationNotFound:
+    return 500;
+  case ProxyStatusError::DestinationUnavailable:
+    return 503;
+  case ProxyStatusError::DestinationIpProhibited:
+    return 502;
+  case ProxyStatusError::DestinationIpUnroutable:
+    return 502;
+  case ProxyStatusError::ConnectionRefused:
+    return 502;
+  case ProxyStatusError::ConnectionTerminated:
+    return 502;
+  case ProxyStatusError::ConnectionTimeout:
+    return 504;
+  case ProxyStatusError::ConnectionReadTimeout:
+    return 504;
+  case ProxyStatusError::ConnectionWriteTimeout:
+    return 504;
+  case ProxyStatusError::ConnectionLimitReached:
+    return 503;
+  case ProxyStatusError::TlsProtocolError:
+    return 502;
+  case ProxyStatusError::TlsCertificateError:
+    return 502;
+  case ProxyStatusError::TlsAlertReceived:
+    return 502;
+  case ProxyStatusError::HttpRequestDenied:
+    return 403;
+  case ProxyStatusError::HttpResponseIncomplete:
+    return 502;
+  case ProxyStatusError::HttpResponseHeaderSectionSize:
+    return 502;
+  case ProxyStatusError::HttpResponseHeaderSize:
+    return 502;
+  case ProxyStatusError::HttpResponseBodySize:
+    return 502;
+  case ProxyStatusError::HttpResponseTrailerSectionSize:
+    return 502;
+  case ProxyStatusError::HttpResponseTrailerSize:
+    return 502;
+  case ProxyStatusError::HttpResponseTransferCoding:
+    return 502;
+  case ProxyStatusError::HttpResponseContentCoding:
+    return 502;
+  case ProxyStatusError::HttpResponseTimeout:
+    return 504;
+  case ProxyStatusError::HttpUpgradeFailed:
+    return 502;
+  case ProxyStatusError::HttpProtocolError:
+    return 502;
+  case ProxyStatusError::ProxyInternalError:
+    return 500;
+  case ProxyStatusError::ProxyConfigurationError:
+    return 500;
+  case ProxyStatusError::ProxyLoopDetected:
+    return 502;
+  case ProxyStatusError::ProxyInternalResponse:
+  case ProxyStatusError::HttpRequestError:
+  default:
+    return absl::nullopt;
+  }
+}
+
+const std::string
+ProxyStatusUtils::toString(const StreamInfo& stream_info, const ProxyStatusError error,
+                           absl::string_view server_name,
+                           const envoy::extensions::filters::network::http_connection_manager::v3::
+                               HttpConnectionManager::ProxyStatusConfig& proxy_status_config) {
+  std::string retval = "";
+
+  switch (proxy_status_config.proxy_name()) {
+  case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+      ProxyStatusConfig::SERVER_NAME: {
+    retval.append(std::string(server_name));
+    break;
+  }
+  case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+      ProxyStatusConfig::ENVOY_LITERAL:
+  default: {
+    retval.append("envoy");
+    break;
+  }
+  }
+
+  retval.append(absl::StrFormat("; error=%s", proxyStatusErrorToString(error)));
+
+  if (proxy_status_config.attach_details() && stream_info.responseCodeDetails().has_value()) {
+    retval.append(absl::StrFormat("; details='%s'", stream_info.responseCodeDetails().value()));
+  }
+
+  return retval;
+}
+
+const absl::string_view
+ProxyStatusUtils::proxyStatusErrorToString(const ProxyStatusError proxy_status) {
+  switch (proxy_status) {
+  case ProxyStatusError::DnsTimeout:
+    return DNS_TIMEOUT;
+  case ProxyStatusError::DnsError:
+    return DNS_ERROR;
+  case ProxyStatusError::DestinationNotFound:
+    return DESTINATION_NOT_FOUND;
+  case ProxyStatusError::DestinationUnavailable:
+    return DESTINATION_UNAVAILABLE;
+  case ProxyStatusError::DestinationIpProhibited:
+    return DESTINATION_IP_PROHIBITED;
+  case ProxyStatusError::DestinationIpUnroutable:
+    return DESTINATION_IP_UNROUTABLE;
+  case ProxyStatusError::ConnectionRefused:
+    return CONNECTION_REFUSED;
+  case ProxyStatusError::ConnectionTerminated:
+    return CONNECTION_TERMINATED;
+  case ProxyStatusError::ConnectionTimeout:
+    return CONNECTION_TIMEOUT;
+  case ProxyStatusError::ConnectionReadTimeout:
+    return CONNECTION_READ_TIMEOUT;
+  case ProxyStatusError::ConnectionWriteTimeout:
+    return CONNECTION_WRITE_TIMEOUT;
+  case ProxyStatusError::ConnectionLimitReached:
+    return CONNECTION_LIMIT_REACHED;
+  case ProxyStatusError::TlsProtocolError:
+    return TLS_PROTOCOL_ERORR;
+  case ProxyStatusError::TlsCertificateError:
+    return TLS_CERTIFICATE_ERORR;
+  case ProxyStatusError::TlsAlertReceived:
+    return TLS_ALERT_RECEIVED;
+  case ProxyStatusError::HttpRequestError:
+    return HTTP_REQUEST_ERROR;
+  case ProxyStatusError::HttpRequestDenied:
+    return HTTP_REQUEST_DENIED;
+  case ProxyStatusError::HttpResponseIncomplete:
+    return HTTP_RESPONSE_INCOMPLETE;
+  case ProxyStatusError::HttpResponseHeaderSectionSize:
+    return HTTP_RESPONSE_HEADER_SECTION_SIZE;
+  case ProxyStatusError::HttpResponseHeaderSize:
+    return HTTP_RESPONSE_HEADER_SIZE;
+  case ProxyStatusError::HttpResponseBodySize:
+    return HTTP_RESPONSE_BODY_SIZE;
+  case ProxyStatusError::HttpResponseTrailerSectionSize:
+    return HTTP_RESPONSE_TRAILER_SECTION_SIZE;
+  case ProxyStatusError::HttpResponseTrailerSize:
+    return HTTP_RESPONSE_TRAILER_SIZE;
+  case ProxyStatusError::HttpResponseTransferCoding:
+    return HTTP_RESPONSE_TRANSFER_CODING;
+  case ProxyStatusError::HttpResponseContentCoding:
+    return HTTP_RESPONSE_CONTENT_CODING;
+  case ProxyStatusError::HttpResponseTimeout:
+    return HTTP_RESPONSE_TIMEOUT;
+  case ProxyStatusError::HttpUpgradeFailed:
+    return HTTP_UPGRADE_FAILED;
+  case ProxyStatusError::HttpProtocolError:
+    return HTTP_PROTOCOL_ERROR;
+  case ProxyStatusError::ProxyInternalResponse:
+    return PROXY_INTERNAL_RESPONSE;
+  case ProxyStatusError::ProxyInternalError:
+    return PROXY_INTERNAL_ERROR;
+  case ProxyStatusError::ProxyConfigurationError:
+    return PROXY_CONFIGURATION_ERROR;
+  case ProxyStatusError::ProxyLoopDetected:
+    return PROXY_LOOP_DETECTED;
+  }
+}
+
+const absl::optional<ProxyStatusError>
+ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
+  // NB: This mapping from Envoy-specific ResponseFlag enum to Proxy-Status
+  // error enum is lossy, since ResponseFlag is really a bitset of many
+  // responseflags. Here, we search the list of all known ResponseFlag values in
+  // enum order, returning the first matching ProxyStatusError.
+  if (stream_info.hasResponseFlag(ResponseFlag::FailedLocalHealthCheck)) {
+    return ProxyStatusError::DestinationUnavailable;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::NoHealthyUpstream)) {
+    return ProxyStatusError::DestinationUnavailable;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRequestTimeout)) {
+    return ProxyStatusError::ConnectionTimeout;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::LocalReset)) {
+    return ProxyStatusError::ConnectionTimeout;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRemoteReset)) {
+    return ProxyStatusError::ConnectionTerminated;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamConnectionFailure)) {
+    return ProxyStatusError::ConnectionRefused;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamConnectionTermination)) {
+    return ProxyStatusError::ConnectionTerminated;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamOverflow)) {
+    return ProxyStatusError::ConnectionLimitReached;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::NoRouteFound)) {
+    return ProxyStatusError::DestinationNotFound;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::RateLimited)) {
+    return ProxyStatusError::ConnectionLimitReached;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::RateLimitServiceError)) {
+    return ProxyStatusError::ConnectionLimitReached;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRetryLimitExceeded)) {
+    return ProxyStatusError::ConnectionTerminated;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::StreamIdleTimeout)) {
+    return ProxyStatusError::HttpResponseTimeout;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::InvalidEnvoyRequestHeaders)) {
+    return ProxyStatusError::HttpRequestError;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::DownstreamProtocolError)) {
+    return ProxyStatusError::HttpRequestError;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamMaxStreamDurationReached)) {
+    return ProxyStatusError::HttpResponseTimeout;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::NoFilterConfigFound)) {
+    return ProxyStatusError::ProxyConfigurationError;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamProtocolError)) {
+    return ProxyStatusError::HttpProtocolError;
+  } else if (stream_info.hasResponseFlag(ResponseFlag::NoClusterFound)) {
+    return ProxyStatusError::DestinationIpUnroutable;
+  } else {
+    return absl::nullopt;
+  }
 }
 
 const std::string&

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -220,6 +220,7 @@ ProxyStatusUtils::proxyStatusErrorToString(const ProxyStatusError proxy_status) 
   case ProxyStatusError::ProxyLoopDetected:
     return PROXY_LOOP_DETECTED;
   }
+  return "-";
 }
 
 const absl::optional<ProxyStatusError>

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -49,6 +49,11 @@ absl::optional<ResponseFlag> ResponseFlagUtils::toResponseFlag(absl::string_view
 
 const absl::optional<uint32_t>
 ProxyStatusUtils::recommendedHttpStatusCode(const ProxyStatusError proxy_status) {
+  // This switch statement was derived from the mapping from proxy error type to
+  // recommended HTTP status code in
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05#section-2.3 and below.
+  //
+  // TODO(ambuc): Replace this with the non-draft URL when finalized.
   switch (proxy_status) {
   case ProxyStatusError::DnsTimeout:
     return 504;
@@ -221,7 +226,7 @@ const absl::optional<ProxyStatusError>
 ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
   // NB: This mapping from Envoy-specific ResponseFlag enum to Proxy-Status
   // error enum is lossy, since ResponseFlag is really a bitset of many
-  // responseflags. Here, we search the list of all known ResponseFlag values in
+  // ResponseFlag enums. Here, we search the list of all known ResponseFlag values in
   // enum order, returning the first matching ProxyStatusError.
   if (stream_info.hasResponseFlag(ResponseFlag::FailedLocalHealthCheck)) {
     return ProxyStatusError::DestinationUnavailable;

--- a/source/common/stream_info/utility.h
+++ b/source/common/stream_info/utility.h
@@ -84,7 +84,7 @@ private:
   static absl::flat_hash_map<std::string, ResponseFlag> getFlagMap();
 };
 
-// Static utils for creating, consuming, and stringifiying the
+// Static utils for creating, consuming, and producing strings from the
 // Proxy-Status HTTP response header.
 class ProxyStatusUtils {
 public:
@@ -96,7 +96,7 @@ public:
   //   - server_name is either the method argument, or the name of the proxy
   //                 in |stream_info|,
   //   - error       is the error in |error|,
-  //   - detais      is |stream_info.responseCodeDetails()|, but the field is
+  //   - details     is |stream_info.responseCodeDetails()|, but the field is
   //                 present only if configured in |proxy_status_config|.
   static const std::string
   toString(const StreamInfo& stream_info, const ProxyStatusError error,
@@ -114,6 +114,13 @@ public:
 
   // Returns the recommended HTTP status code for a ProxyStatusError, or nullopt
   // if no HTTP status code is applicable.
+  //
+  // See
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05#section-2.1.1 :
+  //
+  // > Each Proxy Error Type has a Recommended HTTP Status Code. When
+  // > generating a HTTP response containing "error", its HTTP status code
+  // > SHOULD be set to the Recommended HTTP Status Code.
   static const absl::optional<uint32_t>
   recommendedHttpStatusCode(const ProxyStatusError proxy_status);
 

--- a/source/common/stream_info/utility.h
+++ b/source/common/stream_info/utility.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdint>
 
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 #include "envoy/stream_info/stream_info.h"
 
 namespace Envoy {
@@ -81,6 +82,76 @@ public:
 private:
   ResponseFlagUtils();
   static absl::flat_hash_map<std::string, ResponseFlag> getFlagMap();
+};
+
+// Static utils for creating, consuming, and stringifiying the
+// Proxy-Status HTTP response header.
+class ProxyStatusUtils {
+public:
+  // Returns a Proxy-Status request header string, of the form:
+  //
+  //     <server_name>; error=<error_type>; details=<details>
+  //
+  // where:
+  //   - server_name is either the method argument, or the name of the proxy
+  //                 in |stream_info|,
+  //   - error       is the error in |error|,
+  //   - detais      is |stream_info.responseCodeDetails()|, but the field is
+  //                 present only if configured in |proxy_status_config|.
+  static const std::string
+  toString(const StreamInfo& stream_info, const ProxyStatusError error,
+           absl::string_view server_name,
+           const envoy::extensions::filters::network::http_connection_manager::v3::
+               HttpConnectionManager::ProxyStatusConfig& proxy_status_config);
+
+  // Returns a view into the string representation of a given ProxyStatusError
+  // enum.
+  static const absl::string_view proxyStatusErrorToString(const ProxyStatusError proxy_status);
+
+  // Reads |stream_info.responseFlag| and returns an applicable ProxyStatusError, or nullopt
+  // if no ProxyStatusError is applicable.
+  static const absl::optional<ProxyStatusError> fromStreamInfo(const StreamInfo& stream_info);
+
+  // Returns the recommended HTTP status code for a ProxyStatusError, or nullopt
+  // if no HTTP status code is applicable.
+  static const absl::optional<uint32_t>
+  recommendedHttpStatusCode(const ProxyStatusError proxy_status);
+
+  constexpr static absl::string_view DNS_TIMEOUT = "dns_timeout";
+  constexpr static absl::string_view DNS_ERROR = "dns_error";
+  constexpr static absl::string_view DESTINATION_NOT_FOUND = "destination_not_found";
+  constexpr static absl::string_view DESTINATION_UNAVAILABLE = "destination_unavailable";
+  constexpr static absl::string_view DESTINATION_IP_PROHIBITED = "destination_ip_prohibited";
+  constexpr static absl::string_view DESTINATION_IP_UNROUTABLE = "destination_ip_unroutable";
+  constexpr static absl::string_view CONNECTION_REFUSED = "connection_refused";
+  constexpr static absl::string_view CONNECTION_TERMINATED = "connection_terminated";
+  constexpr static absl::string_view CONNECTION_TIMEOUT = "connection_timeout";
+  constexpr static absl::string_view CONNECTION_READ_TIMEOUT = "connection_read_timeout";
+  constexpr static absl::string_view CONNECTION_WRITE_TIMEOUT = "connection_write_timeout";
+  constexpr static absl::string_view CONNECTION_LIMIT_REACHED = "connection_limit_reached";
+  constexpr static absl::string_view TLS_PROTOCOL_ERORR = "tls_protocol_error";
+  constexpr static absl::string_view TLS_CERTIFICATE_ERORR = "tls_certificate_error";
+  constexpr static absl::string_view TLS_ALERT_RECEIVED = "tls_alert_received";
+  constexpr static absl::string_view HTTP_REQUEST_ERROR = "http_request_error";
+  constexpr static absl::string_view HTTP_REQUEST_DENIED = "http_request_denied";
+  constexpr static absl::string_view HTTP_RESPONSE_INCOMPLETE = "http_response_incomplete";
+  constexpr static absl::string_view HTTP_RESPONSE_HEADER_SECTION_SIZE =
+      "http_response_header_section_size";
+  constexpr static absl::string_view HTTP_RESPONSE_HEADER_SIZE = "http_response_header_size";
+  constexpr static absl::string_view HTTP_RESPONSE_BODY_SIZE = "http_response_body_size";
+  constexpr static absl::string_view HTTP_RESPONSE_TRAILER_SECTION_SIZE =
+      "http_response_trailer_section_size";
+  constexpr static absl::string_view HTTP_RESPONSE_TRAILER_SIZE = "http_response_trailer_size";
+  constexpr static absl::string_view HTTP_RESPONSE_TRANSFER_CODING =
+      "http_response_transfer_coding";
+  constexpr static absl::string_view HTTP_RESPONSE_CONTENT_CODING = "http_response_content_coding";
+  constexpr static absl::string_view HTTP_RESPONSE_TIMEOUT = "http_response_timeout";
+  constexpr static absl::string_view HTTP_UPGRADE_FAILED = "http_upgrade_failed";
+  constexpr static absl::string_view HTTP_PROTOCOL_ERROR = "http_protocol_error";
+  constexpr static absl::string_view PROXY_INTERNAL_RESPONSE = "proxy_internal_response";
+  constexpr static absl::string_view PROXY_INTERNAL_ERROR = "proxy_internal_error";
+  constexpr static absl::string_view PROXY_CONFIGURATION_ERROR = "proxy_configuration_error";
+  constexpr static absl::string_view PROXY_LOOP_DETECTED = "proxy_loop_detected";
 };
 
 /**

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -333,6 +333,10 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       strip_trailing_host_dot_(config.strip_trailing_host_dot()),
       max_requests_per_connection_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config.common_http_protocol_options(), max_requests_per_connection, 0)) {
+  if (config.has_proxy_status_config()) {
+    proxy_status_config_ = config.proxy_status_config();
+  }
+
   if (!idle_timeout_) {
     idle_timeout_ = std::chrono::hours(1);
   } else if (idle_timeout_.value().count() == 0) {

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -332,11 +332,11 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       path_with_escaped_slashes_action_(getPathWithEscapedSlashesAction(config, context)),
       strip_trailing_host_dot_(config.strip_trailing_host_dot()),
       max_requests_per_connection_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          config.common_http_protocol_options(), max_requests_per_connection, 0)) {
-  if (config.has_proxy_status_config()) {
-    proxy_status_config_ = config.proxy_status_config();
-  }
-
+          config.common_http_protocol_options(), max_requests_per_connection, 0)),
+      proxy_status_config_(config.has_proxy_status_config()
+                               ? std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>(
+                                     config.proxy_status_config())
+                               : nullptr) {
   if (!idle_timeout_) {
     idle_timeout_ = std::chrono::hours(1);
   } else if (idle_timeout_.value().count() == 0) {

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -218,6 +218,9 @@ public:
     return original_ip_detection_extensions_;
   }
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
+    return proxy_status_config_;
+  }
 
 private:
   enum class CodecType { HTTP1, HTTP2, HTTP3, AUTO };
@@ -313,6 +316,7 @@ private:
       PathWithEscapedSlashesAction path_with_escaped_slashes_action_;
   const bool strip_trailing_host_dot_;
   const uint64_t max_requests_per_connection_;
+  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
 };
 
 /**

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -218,8 +218,8 @@ public:
     return original_ip_detection_extensions_;
   }
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
-  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
-    return proxy_status_config_;
+  const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
+    return proxy_status_config_.get();
   }
 
 private:
@@ -316,7 +316,7 @@ private:
       PathWithEscapedSlashesAction path_with_escaped_slashes_action_;
   const bool strip_trailing_host_dot_;
   const uint64_t max_requests_per_connection_;
-  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
+  const std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
 };
 
 /**

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -206,6 +206,9 @@ public:
     };
   }
   uint64_t maxRequestsPerConnection() const override { return 0; }
+  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
+    return proxy_status_config_;
+  }
 
 private:
   /**
@@ -453,6 +456,7 @@ private:
   const LocalReply::LocalReplyPtr local_reply_;
   const std::vector<Http::OriginalIPDetectionSharedPtr> detection_extensions_{};
   const absl::optional<std::string> scheme_{};
+  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
 };
 
 } // namespace Server

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -206,8 +206,8 @@ public:
     };
   }
   uint64_t maxRequestsPerConnection() const override { return 0; }
-  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
-    return proxy_status_config_;
+  const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
+    return proxy_status_config_.get();
   }
 
 private:
@@ -456,7 +456,7 @@ private:
   const LocalReply::LocalReplyPtr local_reply_;
   const std::vector<Http::OriginalIPDetectionSharedPtr> detection_extensions_{};
   const absl::optional<std::string> scheme_{};
-  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
+  std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
 };
 
 } // namespace Server

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -217,6 +217,9 @@ public:
     return ip_detection_extensions_;
   }
   uint64_t maxRequestsPerConnection() const override { return 0; }
+  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
+    return proxy_status_config_;
+  }
 
   const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
       config_;
@@ -264,6 +267,7 @@ public:
   bool normalize_path_{true};
   LocalReply::LocalReplyPtr local_reply_;
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
+  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
 };
 
 // Internal representation of stream state. Encapsulates the stream state, mocks

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -217,8 +217,8 @@ public:
     return ip_detection_extensions_;
   }
   uint64_t maxRequestsPerConnection() const override { return 0; }
-  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
-    return proxy_status_config_;
+  const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
+    return proxy_status_config_.get();
   }
 
   const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
@@ -267,7 +267,7 @@ public:
   bool normalize_path_{true};
   LocalReply::LocalReplyPtr local_reply_;
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
-  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
+  std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
 };
 
 // Internal representation of stream state. Encapsulates the stream state, mocks

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3834,7 +3834,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusAppendToPreviousValue) {
   ASSERT_TRUE(altered_headers->ProxyStatus());
   // Expect to see the appended previous value: "SomeCDN; envoy; ...".
   EXPECT_EQ(altered_headers->getProxyStatusValue(),
-            "SomeCDN; envoy; error=connection_timeout; details='baz'");
+            "SomeCDN, envoy; error=connection_timeout; details='baz'");
 
   teardown();
 }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3698,8 +3698,8 @@ public:
     sendRequestHeadersAndData();
   }
   const ResponseHeaderMap*
-  send_request_with(int status, StreamInfo::ResponseFlag response_flag, std::string details,
-                    absl::optional<std::string> proxy_status = absl::nullopt) {
+  sendRequestWith(int status, StreamInfo::ResponseFlag response_flag, std::string details,
+                  absl::optional<std::string> proxy_status = absl::nullopt) {
     auto response_headers = new TestResponseHeaderMapImpl{{":status", std::to_string(status)}};
     if (proxy_status.has_value()) {
       response_headers->setProxyStatus(proxy_status.value());
@@ -3718,7 +3718,7 @@ TEST_F(ProxyStatusTest, NoPopulateProxyStatus) {
   initialize();
 
   const ResponseHeaderMap* altered_headers =
-      send_request_with(403, StreamInfo::ResponseFlag::FailedLocalHealthCheck, "foo");
+      sendRequestWith(403, StreamInfo::ResponseFlag::FailedLocalHealthCheck, "foo");
   ASSERT_TRUE(altered_headers);
   ASSERT_FALSE(altered_headers->ProxyStatus());
   EXPECT_EQ(altered_headers->getStatusValue(), "403"); // unchanged from request.
@@ -3735,7 +3735,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerNa
   initialize();
 
   const ResponseHeaderMap* altered_headers =
-      send_request_with(403, StreamInfo::ResponseFlag::FailedLocalHealthCheck, "foo");
+      sendRequestWith(403, StreamInfo::ResponseFlag::FailedLocalHealthCheck, "foo");
 
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
@@ -3758,7 +3758,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
   initialize();
 
   const ResponseHeaderMap* altered_headers =
-      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "bar");
+      sendRequestWith(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "bar");
 
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
@@ -3781,7 +3781,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
   initialize();
 
   const ResponseHeaderMap* altered_headers =
-      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "bar");
+      sendRequestWith(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "bar");
 
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
@@ -3805,7 +3805,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
   initialize();
 
   const ResponseHeaderMap* altered_headers =
-      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "baz");
+      sendRequestWith(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "baz");
 
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
@@ -3828,7 +3828,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusAppendToPreviousValue) {
   initialize();
 
   const ResponseHeaderMap* altered_headers =
-      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "baz", "SomeCDN");
+      sendRequestWith(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "baz", "SomeCDN");
 
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3725,7 +3725,7 @@ TEST_F(ProxyStatusTest, NoPopulateProxyStatus) {
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerName) {
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
-  proxy_status_config_->set_attach_details(true);
+  proxy_status_config_->set_remove_details(false);
   proxy_status_config_->set_set_recommended_response_code(true);
   proxy_status_config_->set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::SERVER_NAME);
 
@@ -3747,7 +3747,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerNa
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
-  proxy_status_config_->set_attach_details(true);
+  proxy_status_config_->set_remove_details(false);
   proxy_status_config_->set_set_recommended_response_code(true);
   proxy_status_config_->set_proxy_name(
       HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
@@ -3770,7 +3770,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
-  proxy_status_config_->set_attach_details(true);
+  proxy_status_config_->set_remove_details(false);
   proxy_status_config_->set_set_recommended_response_code(false);
   proxy_status_config_->set_proxy_name(
       HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
@@ -3794,7 +3794,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
-  proxy_status_config_->set_attach_details(false);
+  proxy_status_config_->set_remove_details(true);
   proxy_status_config_->set_set_recommended_response_code(false);
   proxy_status_config_->set_proxy_name(
       HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
@@ -3809,7 +3809,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
   EXPECT_EQ(altered_headers->getProxyStatusValue(), "envoy; error=connection_timeout");
   // Unchanged.
   EXPECT_EQ(altered_headers->getStatusValue(), "403");
-  // Since attach_details=false, we should not have "baz", the value of
+  // Since remove_details=true, we should not have "baz", the value of
   // response_code_details, in the Proxy-Status header.
   EXPECT_THAT(altered_headers->getProxyStatusValue(), Not(HasSubstr("baz")));
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -7,6 +7,7 @@ using testing::An;
 using testing::AnyNumber;
 using testing::AtLeast;
 using testing::Eq;
+using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
@@ -3685,6 +3686,137 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
   EXPECT_EQ(1U, listener_stats_.downstream_rq_3xx_.value());
   EXPECT_EQ(1U, stats_.named_.downstream_rq_completed_.value());
   EXPECT_EQ(1U, listener_stats_.downstream_rq_completed_.value());
+}
+
+// Tests for the presence/absence and contents of the synthesized Proxy-Status
+// HTTP response header. NB: proxy_status_config_ persists in the test base.
+class ProxyStatusTest : public HttpConnectionManagerImplTest {
+public:
+  void initialize() {
+    setup(false, servername_, false);
+    setUpEncoderAndDecoder(false, false);
+    sendRequestHeadersAndData();
+  }
+  const ResponseHeaderMap* send_request_with(int status, StreamInfo::ResponseFlag response_flag,
+                                             std::string details) {
+    return sendResponseHeaders(
+        ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", std::to_string(status)}}},
+        response_flag, details);
+  }
+  void teardown() { doRemoteClose(); }
+
+protected:
+  const std::string servername_{"custom_server_name"};
+};
+
+TEST_F(ProxyStatusTest, NoPopulateProxyStatus) {
+  proxy_status_config_.set_attach_proxy_status(false);
+  // Even if the rest of the config booleans are true, the above
+  // |attach_proxy_status| should be sufficient to disable writing Proxy-Status
+  // entirely.
+  proxy_status_config_.set_attach_details(true);
+  proxy_status_config_.set_set_recommended_response_code(true);
+  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::SERVER_NAME);
+
+  initialize();
+
+  const ResponseHeaderMap* altered_headers =
+      send_request_with(403, StreamInfo::ResponseFlag::FailedLocalHealthCheck, "foo");
+  ASSERT_TRUE(altered_headers);
+  ASSERT_FALSE(altered_headers->ProxyStatus());
+  EXPECT_EQ(altered_headers->getStatusValue(), "403"); // unchanged from request.
+
+  teardown();
+}
+
+TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerName) {
+  proxy_status_config_.set_attach_proxy_status(true);
+  proxy_status_config_.set_attach_details(true);
+  proxy_status_config_.set_set_recommended_response_code(true);
+  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::SERVER_NAME);
+
+  initialize();
+
+  const ResponseHeaderMap* altered_headers =
+      send_request_with(403, StreamInfo::ResponseFlag::FailedLocalHealthCheck, "foo");
+
+  ASSERT_TRUE(altered_headers);
+  ASSERT_TRUE(altered_headers->ProxyStatus());
+  EXPECT_EQ(altered_headers->getProxyStatusValue(),
+            "custom_server_name; error=destination_unavailable; details='foo'");
+  // Changed from request, since set_recommended_response_code is true. Here,
+  // 503 is the recommended response code for FailedLocalHealthCheck.
+  EXPECT_EQ(altered_headers->getStatusValue(), "503");
+
+  teardown();
+}
+
+TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
+  proxy_status_config_.set_attach_proxy_status(true);
+  proxy_status_config_.set_attach_details(true);
+  proxy_status_config_.set_set_recommended_response_code(true);
+  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
+
+  initialize();
+
+  const ResponseHeaderMap* altered_headers =
+      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "bar");
+
+  ASSERT_TRUE(altered_headers);
+  ASSERT_TRUE(altered_headers->ProxyStatus());
+  EXPECT_EQ(altered_headers->getProxyStatusValue(),
+            "envoy; error=connection_timeout; details='bar'");
+  // Changed from request, since set_recommended_response_code is true. Here,
+  // 504 is the recommended response code for UpstreamRequestTimeout.
+  EXPECT_EQ(altered_headers->getStatusValue(), "504");
+
+  teardown();
+}
+
+TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
+  proxy_status_config_.set_attach_proxy_status(true);
+  proxy_status_config_.set_set_recommended_response_code(false);
+  proxy_status_config_.set_attach_details(true);
+  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
+
+  initialize();
+
+  const ResponseHeaderMap* altered_headers =
+      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "bar");
+
+  ASSERT_TRUE(altered_headers);
+  ASSERT_TRUE(altered_headers->ProxyStatus());
+  EXPECT_EQ(altered_headers->getProxyStatusValue(),
+            "envoy; error=connection_timeout; details='bar'");
+  // Unchanged from request, since set_recommended_response_code is false. Here,
+  // 504 would be the recommended response code for UpstreamRequestTimeout,
+  EXPECT_NE(altered_headers->getStatusValue(), "504");
+  EXPECT_EQ(altered_headers->getStatusValue(), "403");
+
+  teardown();
+}
+
+TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
+  proxy_status_config_.set_attach_proxy_status(true);
+  proxy_status_config_.set_attach_details(false);
+  proxy_status_config_.set_set_recommended_response_code(false);
+  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
+
+  initialize();
+
+  const ResponseHeaderMap* altered_headers =
+      send_request_with(403, StreamInfo::ResponseFlag::UpstreamRequestTimeout, "baz");
+
+  ASSERT_TRUE(altered_headers);
+  ASSERT_TRUE(altered_headers->ProxyStatus());
+  EXPECT_EQ(altered_headers->getProxyStatusValue(), "envoy; error=connection_timeout");
+  // Unchanged.
+  EXPECT_EQ(altered_headers->getStatusValue(), "403");
+  // Since attach_details=false, we should not have "baz", the value of
+  // response_code_details, in the Proxy-Status header.
+  EXPECT_THAT(altered_headers->getProxyStatusValue(), Not(HasSubstr("baz")));
+
+  teardown();
 }
 
 } // namespace Http

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3710,13 +3710,7 @@ protected:
 };
 
 TEST_F(ProxyStatusTest, NoPopulateProxyStatus) {
-  proxy_status_config_.set_attach_proxy_status(false);
-  // Even if the rest of the config booleans are true, the above
-  // |attach_proxy_status| should be sufficient to disable writing Proxy-Status
-  // entirely.
-  proxy_status_config_.set_attach_details(true);
-  proxy_status_config_.set_set_recommended_response_code(true);
-  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::SERVER_NAME);
+  proxy_status_config_ = nullptr;
 
   initialize();
 
@@ -3730,10 +3724,10 @@ TEST_F(ProxyStatusTest, NoPopulateProxyStatus) {
 }
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerName) {
-  proxy_status_config_.set_attach_proxy_status(true);
-  proxy_status_config_.set_attach_details(true);
-  proxy_status_config_.set_set_recommended_response_code(true);
-  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::SERVER_NAME);
+  proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
+  proxy_status_config_->set_attach_details(true);
+  proxy_status_config_->set_set_recommended_response_code(true);
+  proxy_status_config_->set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::SERVER_NAME);
 
   initialize();
 
@@ -3752,10 +3746,11 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerNa
 }
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
-  proxy_status_config_.set_attach_proxy_status(true);
-  proxy_status_config_.set_attach_details(true);
-  proxy_status_config_.set_set_recommended_response_code(true);
-  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
+  proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
+  proxy_status_config_->set_attach_details(true);
+  proxy_status_config_->set_set_recommended_response_code(true);
+  proxy_status_config_->set_proxy_name(
+      HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
 
   initialize();
 
@@ -3774,10 +3769,11 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
 }
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
-  proxy_status_config_.set_attach_proxy_status(true);
-  proxy_status_config_.set_set_recommended_response_code(false);
-  proxy_status_config_.set_attach_details(true);
-  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
+  proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
+  proxy_status_config_->set_attach_details(true);
+  proxy_status_config_->set_set_recommended_response_code(false);
+  proxy_status_config_->set_proxy_name(
+      HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
 
   initialize();
 
@@ -3797,10 +3793,11 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
 }
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
-  proxy_status_config_.set_attach_proxy_status(true);
-  proxy_status_config_.set_attach_details(false);
-  proxy_status_config_.set_set_recommended_response_code(false);
-  proxy_status_config_.set_proxy_name(HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
+  proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
+  proxy_status_config_->set_attach_details(false);
+  proxy_status_config_->set_set_recommended_response_code(false);
+  proxy_status_config_->set_proxy_name(
+      HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
 
   initialize();
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3740,7 +3740,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerNa
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
   EXPECT_EQ(altered_headers->getProxyStatusValue(),
-            "custom_server_name; error=destination_unavailable; details='foo'");
+            "custom_server_name; error=destination_unavailable; details='foo; LH'");
   // Changed from request, since set_recommended_response_code is true. Here,
   // 503 is the recommended response code for FailedLocalHealthCheck.
   EXPECT_EQ(altered_headers->getStatusValue(), "503");
@@ -3763,7 +3763,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
   EXPECT_EQ(altered_headers->getProxyStatusValue(),
-            "envoy; error=connection_timeout; details='bar'");
+            "envoy; error=connection_timeout; details='bar; UT'");
   // Changed from request, since set_recommended_response_code is true. Here,
   // 504 is the recommended response code for UpstreamRequestTimeout.
   EXPECT_EQ(altered_headers->getStatusValue(), "504");
@@ -3774,6 +3774,8 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
   proxy_status_config_->set_remove_details(false);
+  proxy_status_config_->set_remove_connection_termination_details(false);
+  proxy_status_config_->set_remove_response_flags(false);
   proxy_status_config_->set_set_recommended_response_code(false);
   proxy_status_config_->set_proxy_name(
       HttpConnectionManagerProto::ProxyStatusConfig::ENVOY_LITERAL);
@@ -3786,7 +3788,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
   ASSERT_TRUE(altered_headers);
   ASSERT_TRUE(altered_headers->ProxyStatus());
   EXPECT_EQ(altered_headers->getProxyStatusValue(),
-            "envoy; error=connection_timeout; details='bar'");
+            "envoy; error=connection_timeout; details='bar; UT'");
   // Unchanged from request, since set_recommended_response_code is false. Here,
   // 504 would be the recommended response code for UpstreamRequestTimeout,
   EXPECT_NE(altered_headers->getStatusValue(), "504");
@@ -3834,7 +3836,7 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusAppendToPreviousValue) {
   ASSERT_TRUE(altered_headers->ProxyStatus());
   // Expect to see the appended previous value: "SomeCDN; envoy; ...".
   EXPECT_EQ(altered_headers->getProxyStatusValue(),
-            "SomeCDN, envoy; error=connection_timeout; details='baz'");
+            "SomeCDN, envoy; error=connection_timeout; details='baz; UT'");
 
   teardown();
 }

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -157,8 +157,8 @@ public:
     return ip_detection_extensions_;
   }
   uint64_t maxRequestsPerConnection() const override { return 0; }
-  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
-    return proxy_status_config_;
+  const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
+    return proxy_status_config_.get();
   }
 
   Envoy::Event::SimulatedTimeSystem test_time_;
@@ -227,7 +227,7 @@ public:
   NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool_; // for websocket tests
   RequestIDExtensionSharedPtr request_id_extension_;
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
-  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
+  std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
 
   const LocalReply::LocalReplyPtr local_reply_;
 

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -58,7 +58,10 @@ public:
 
   Event::MockTimer* setUpTimer();
   void sendRequestHeadersAndData();
-  ResponseHeaderMap* sendResponseHeaders(ResponseHeaderMapPtr&& response_headers);
+  ResponseHeaderMap*
+  sendResponseHeaders(ResponseHeaderMapPtr&& response_headers,
+                      absl::optional<StreamInfo::ResponseFlag> response_flag = absl::nullopt,
+                      std::string response_code_details = "details");
   void expectOnDestroy(bool deferred = true);
   void doRemoteClose(bool deferred = true);
   void testPathNormalization(const RequestHeaderMap& request_headers,
@@ -154,6 +157,9 @@ public:
     return ip_detection_extensions_;
   }
   uint64_t maxRequestsPerConnection() const override { return 0; }
+  const HttpConnectionManagerProto::ProxyStatusConfig& proxyStatusConfig() const override {
+    return proxy_status_config_;
+  }
 
   Envoy::Event::SimulatedTimeSystem test_time_;
   NiceMock<Router::MockRouteConfigProvider> route_config_provider_;
@@ -221,6 +227,7 @@ public:
   NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool_; // for websocket tests
   RequestIDExtensionSharedPtr request_id_extension_;
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
+  HttpConnectionManagerProto::ProxyStatusConfig proxy_status_config_;
 
   const LocalReply::LocalReplyPtr local_reply_;
 

--- a/test/common/stream_info/BUILD
+++ b/test/common/stream_info/BUILD
@@ -64,6 +64,7 @@ envoy_cc_test(
     deps = [
         "//source/common/stream_info:utility_lib",
         "//test/mocks/stream_info:stream_info_mocks",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -67,7 +67,6 @@ TEST(UtilityTest, formatDownstreamAddressNoPort) {
 class ProxyStatusTest : public ::testing::Test {
 protected:
   void SetUp() {
-    proxy_status_config_.set_attach_proxy_status(true);
     proxy_status_config_.set_attach_details(true);
     proxy_status_config_.set_proxy_name(HttpConnectionManager::ProxyStatusConfig::ENVOY_LITERAL);
   }

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -66,7 +66,7 @@ TEST(UtilityTest, formatDownstreamAddressNoPort) {
 
 class ProxyStatusTest : public ::testing::Test {
 protected:
-  void SetUp() {
+  void SetUp() override {
     proxy_status_config_.set_remove_details(false);
     proxy_status_config_.set_proxy_name(HttpConnectionManager::ProxyStatusConfig::ENVOY_LITERAL);
   }

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -67,7 +67,7 @@ TEST(UtilityTest, formatDownstreamAddressNoPort) {
 class ProxyStatusTest : public ::testing::Test {
 protected:
   void SetUp() {
-    proxy_status_config_.set_attach_details(true);
+    proxy_status_config_.set_remove_details(false);
     proxy_status_config_.set_proxy_name(HttpConnectionManager::ProxyStatusConfig::ENVOY_LITERAL);
   }
 
@@ -76,15 +76,15 @@ protected:
 };
 
 TEST_F(ProxyStatusTest, ToStringNoDetailsAvailable) {
-  proxy_status_config_.set_attach_details(true);
+  proxy_status_config_.set_remove_details(false);
   stream_info_.response_code_details_ = absl::nullopt;
   EXPECT_THAT(ProxyStatusUtils::toString(stream_info_, ProxyStatusError::ProxyConfigurationError,
                                          /*server_name=*/"UNUSED", proxy_status_config_),
               Not(HasSubstr("details=")));
 }
 
-TEST_F(ProxyStatusTest, ToStringSetAttachDetailsFalse) {
-  proxy_status_config_.set_attach_details(false);
+TEST_F(ProxyStatusTest, ToStringSetRemoveDetailsTrue) {
+  proxy_status_config_.set_remove_details(true);
   stream_info_.response_code_details_ = "some_response_code_details";
   EXPECT_THAT(ProxyStatusUtils::toString(stream_info_, ProxyStatusError::ProxyConfigurationError,
                                          /*server_name=*/"UNUSED", proxy_status_config_),
@@ -92,7 +92,7 @@ TEST_F(ProxyStatusTest, ToStringSetAttachDetailsFalse) {
 }
 
 TEST_F(ProxyStatusTest, ToStringWithDetails) {
-  proxy_status_config_.set_attach_details(true);
+  proxy_status_config_.set_remove_details(false);
   stream_info_.response_code_details_ = "some_response_code_details";
   EXPECT_THAT(ProxyStatusUtils::toString(stream_info_, ProxyStatusError::ProxyConfigurationError,
                                          /*server_name=*/"UNUSED", proxy_status_config_),

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -601,7 +601,7 @@ public:
   MOCK_METHOD(const std::vector<Http::OriginalIPDetectionSharedPtr>&, originalIpDetectionExtensions,
               (), (const));
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
-  MOCK_METHOD(const HttpConnectionManagerProto::ProxyStatusConfig&, proxyStatusConfig, (), (const));
+  MOCK_METHOD(const HttpConnectionManagerProto::ProxyStatusConfig*, proxyStatusConfig, (), (const));
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =
       std::make_unique<DefaultInternalAddressConfig>();

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -601,6 +601,7 @@ public:
   MOCK_METHOD(const std::vector<Http::OriginalIPDetectionSharedPtr>&, originalIpDetectionExtensions,
               (), (const));
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
+  MOCK_METHOD(const HttpConnectionManagerProto::ProxyStatusConfig&, proxyStatusConfig, (), (const));
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =
       std::make_unique<DefaultInternalAddressConfig>();


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

Commit Message: Add Proxy-Status HTTP response header field.
Additional Description: This PR adds the new "Proxy-Status" HTTP response header field, as proposed in https://github.com/envoyproxy/envoy/issues/17439. See the [RFC draft](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-05) for much more detail.

This new header is **off by default**.

> This new proposal "defines the Proxy-Status HTTP field to convey the details of intermediary response handling, including generated errors." Proxy-Status is meant to be generally applicable to many kinds of proxies. This response header has an error field and a more general details field.  
> 
> Envoy should generate and attach this new header to traffic.  
> 
> Implementing this new web standard will help people who use Envoy (and people who use tools which use Envoy) better understand the state of each intermediate proxy along a connection.  
> 
> The RFC is expected to be approved with minimal content changes within the next few weeks. We should **not** submit any changes until it is approved.

Risk Level: Low
Testing: Unit tests for HCM in `conn_manager_impl_test.cc` and utils unit test in `stream_info/utility_test.cc`.
Docs Changes: n/a, except for self-documenting (?) proto config changes.
Release Notes: n/a
Platform Specific Features: n/a
[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md): n/a, unsure how much to document -- this won't switch anything on by default, but users can enable a new HTTP response header field.
