### PR TITLE
hot_restart.rst: update outdated detailed information

### DIFF
--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -12,7 +12,7 @@ following general architecture:
 * The two active processes communicate with each other over unix domain sockets using a basic RPC
   protocol. All counters are from the old process to the new process over the unix domain, while part
   of gauges are transported. After hot restart finished, the gauges transported from the old process
-  will be cleanup, but special gauge like :ref:`server.hot_restart_generation statistic 
+  will be cleanup, but special gauge like :ref:`server.hot_restart_generation statistic
   <server_statistics>` is retained.
 * The new process fully initializes itself (loads the configuration, does an initial service
   discovery and health checking phase, etc.) before it asks for copies of the listen sockets from

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -9,10 +9,8 @@ Envoy can fully reload itself (both code and configuration) without dropping exi
 during the :ref:`drain process <arch_overview_draining>`. The hot restart functionality has the
 following general architecture:
 
-* Statistics and some locks are kept in a shared memory region. This means that gauges will be
-  consistent across both processes as restart is taking place.
 * The two active processes communicate with each other over unix domain sockets using a basic RPC
-  protocol.
+  protocol. Statistics will be transported from the old process to the new process over the unix domain.
 * The new process fully initializes itself (loads the configuration, does an initial service
   discovery and health checking phase, etc.) before it asks for copies of the listen sockets from
   the old process. The new process starts listening and then tells the old process to start

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -10,7 +10,10 @@ during the :ref:`drain process <arch_overview_draining>`. The hot restart functi
 following general architecture:
 
 * The two active processes communicate with each other over unix domain sockets using a basic RPC
-  protocol. All counters will be transported from the old process to the new process over the unix domain, while  gauges which marked as `NeverImport`, for example internel guages like `internal_buffer_size` etc are not transported. After hot restart finished, gauges transported from the old process will be cleanup, but special gauge like `server.hot_restart_generation` is retained.
+  protocol. All counters are from the old process to the new process over the unix domain, while part
+  of gauges are transported. After hot restart finished, the gauges transported from the old process
+  will be cleanup, but special gauge like :ref:`server.hot_restart_generation statistic 
+  <server_statistics>` is retained.
 * The new process fully initializes itself (loads the configuration, does an initial service
   discovery and health checking phase, etc.) before it asks for copies of the listen sockets from
   the old process. The new process starts listening and then tells the old process to start

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -10,10 +10,10 @@ during the :ref:`drain process <arch_overview_draining>`. The hot restart functi
 following general architecture:
 
 * The two active processes communicate with each other over unix domain sockets using a basic RPC
-  protocol. All counters are from the old process to the new process over the unix domain, while part
-  of gauges are transported. After hot restart finished, the gauges transported from the old process
-  will be cleanup, but special gauge like :ref:`server.hot_restart_generation statistic
-  <server_statistics>` is retained.
+  protocol. All counters are sent from the old process to the new process over the unix domain, and
+  gauges are transported except those marked with `NeverImport`. After hot restart is finished, the
+  gauges transported from the old process will be cleanup, but special gauge like
+  :ref:`server.hot_restart_generation statistic <server_statistics>` is retained.
 * The new process fully initializes itself (loads the configuration, does an initial service
   discovery and health checking phase, etc.) before it asks for copies of the listen sockets from
   the old process. The new process starts listening and then tells the old process to start

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -10,7 +10,7 @@ during the :ref:`drain process <arch_overview_draining>`. The hot restart functi
 following general architecture:
 
 * The two active processes communicate with each other over unix domain sockets using a basic RPC
-  protocol. Statistics will be transported from the old process to the new process over the unix domain.
+  protocol. All counters will be transported from the old process to the new process over the unix domain, while  gauges which marked as `NeverImport`, for example internel guages like `internal_buffer_size` etc are not transported. After hot restart finished, gauges transported from the old process will be cleanup, but special gauge like `server.hot_restart_generation` is retained.
 * The new process fully initializes itself (loads the configuration, does an initial service
   discovery and health checking phase, etc.) before it asks for copies of the listen sockets from
   the old process. The new process starts listening and then tells the old process to start


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
After #5910, stats are transported over unix domain rather than shared memory.

Commit Message: hot_restart.rst: update outdated detailed information
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
