### PR TITLE
thrift proxy: missing parts from the previous PR

### DIFF
--- a/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
@@ -23,6 +23,7 @@ The filter outputs generic routing error statistics in the *thrift.<stat_prefix>
   unknown_cluster, Counter, Total requests with a route that has an unknown cluster.
   upstream_rq_maintenance_mode, Counter, Total requests with a destination cluster in maintenance mode.
   no_healthy_upstream, Counter, Total requests with no healthy upstream endpoints available.
+  shadow_request_submit_failure, Counter, Total shadow requests that failed to be submitted
 
 
 The filter is also responsible for cluster-level statistics derived from routed upstream clusters.

--- a/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
@@ -23,7 +23,7 @@ The filter outputs generic routing error statistics in the *thrift.<stat_prefix>
   unknown_cluster, Counter, Total requests with a route that has an unknown cluster.
   upstream_rq_maintenance_mode, Counter, Total requests with a destination cluster in maintenance mode.
   no_healthy_upstream, Counter, Total requests with no healthy upstream endpoints available.
-  shadow_request_submit_failure, Counter, Total shadow requests that failed to be submitted
+  shadow_request_submit_failure, Counter, Total shadow requests that failed to be submitted.
 
 
 The filter is also responsible for cluster-level statistics derived from routed upstream clusters.

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -452,7 +452,7 @@ FilterStatus Router::setEnd() {
 
 void Router::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   const bool done =
-      upstream_request_->handleUpstreamData(data, end_stream, *this, *upstream_response_callbacks_);
+      upstream_request_->handleUpstreamData(data, end_stream, *upstream_response_callbacks_);
   if (done) {
     cleanup();
   }

--- a/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc
@@ -21,6 +21,7 @@ ShadowWriterImpl::submit(const std::string& cluster_name, MessageMetadataSharedP
                                                           original_transport, original_protocol);
   const bool created = shadow_router->createUpstreamRequest();
   if (!created) {
+    stats_.shadow_request_submit_failure_.inc();
     return absl::nullopt;
   }
 
@@ -339,7 +340,7 @@ void ShadowRouterImpl::maybeCleanup() {
 
 void ShadowRouterImpl::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   const bool done =
-      upstream_request_->handleUpstreamData(data, end_stream, *this, *upstream_response_callbacks_);
+      upstream_request_->handleUpstreamData(data, end_stream, *upstream_response_callbacks_);
   if (done) {
     maybeCleanup();
   }

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.h
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.h
@@ -44,10 +44,10 @@ struct UpstreamRequest : public Tcp::ConnectionPool::Callbacks,
   void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,
                    Upstream::HostDescriptionConstSharedPtr host) override;
 
-  bool handleUpstreamData(Buffer::Instance& data, bool end_stream, RequestOwner& owner,
+  bool handleUpstreamData(Buffer::Instance& data, bool end_stream,
                           UpstreamResponseCallbacks& callbacks);
   void handleUpgradeResponse(Buffer::Instance& data);
-  ThriftFilters::ResponseStatus handleRegularResponse(Buffer::Instance& data, RequestOwner& owner,
+  ThriftFilters::ResponseStatus handleRegularResponse(Buffer::Instance& data,
                                                       UpstreamResponseCallbacks& callbacks);
   uint64_t encodeAndWrite(Buffer::OwnedImpl& request_buffer);
   void onEvent(Network::ConnectionEvent event);

--- a/test/extensions/filters/network/thrift_proxy/shadow_writer_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/shadow_writer_test.cc
@@ -254,6 +254,7 @@ TEST_F(ShadowWriterTest, SubmitClusterNotFound) {
   auto router_handle = shadow_writer_->submit("shadow_cluster", metadata_, TransportType::Framed,
                                               ProtocolType::Binary);
   EXPECT_EQ(absl::nullopt, router_handle);
+  EXPECT_EQ(1U, context_.scope().counterFromString("test.shadow_request_submit_failure").value());
 }
 
 TEST_F(ShadowWriterTest, SubmitClusterInMaintenance) {
@@ -264,6 +265,7 @@ TEST_F(ShadowWriterTest, SubmitClusterInMaintenance) {
   auto router_handle = shadow_writer_->submit("shadow_cluster", metadata_, TransportType::Framed,
                                               ProtocolType::Binary);
   EXPECT_EQ(absl::nullopt, router_handle);
+  EXPECT_EQ(1U, context_.scope().counterFromString("test.shadow_request_submit_failure").value());
 }
 
 TEST_F(ShadowWriterTest, SubmitNoHealthyUpstream) {
@@ -277,6 +279,7 @@ TEST_F(ShadowWriterTest, SubmitNoHealthyUpstream) {
   auto router_handle = shadow_writer_->submit("shadow_cluster", metadata_, TransportType::Framed,
                                               ProtocolType::Binary);
   EXPECT_EQ(absl::nullopt, router_handle);
+  EXPECT_EQ(1U, context_.scope().counterFromString("test.shadow_request_submit_failure").value());
 
   // We still count the request, even if it didn't go through.
   EXPECT_EQ(


### PR DESCRIPTION
These are leftovers from the previous PR:

* adds a counter for shadow requests that failed to be created
* cleanup part of UpstreamRequest's interface

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
