### PR TITLE
[API] Allow routing to the cluster specified in the request_header for weighted cluster case.

### DIFF
--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -340,7 +340,6 @@ message WeightedCluster {
       // .. note::
       //
       //   If the header appears multiple times only the first value is used.
-      //string cluster_header = 12;
       string cluster_header = 12
           [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
     }

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -314,16 +314,36 @@ message Route {
 message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.WeightedCluster";
 
-  // [#next-free-field: 12]
+  // [#next-free-field: 13]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.WeightedCluster.ClusterWeight";
 
     reserved 7;
 
-    // Name of the upstream cluster. The cluster must exist in the
-    // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      option (validate.required) = true;
+      // Name of the upstream cluster. The cluster must exist in the
+      // :ref:`cluster manager configuration <config_cluster_manager>`.
+      string name = 1 [(validate.rules).string = {min_len: 1}];
+
+      // Envoy will determine the cluster to route to by reading the value of the
+      // HTTP header named by cluster_header from the request headers. If the
+      // header is not found or the referenced cluster does not exist, Envoy will
+      // return a 404 response.
+      //
+      // .. attention::
+      //
+      //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+      //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+      //
+      // .. note::
+      //
+      //   If the header appears multiple times only the first value is used.
+      //string cluster_header = 12;
+      string cluster_header = 12
+          [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    }
 
     // An integer between 0 and :ref:`total_weight
     // <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>`. When a request matches the route,


### PR DESCRIPTION
Add `cluster header` to weighted cluster.  `name` and `cluster_header` will be oneof `cluster_specifiter` field.
This enable the ability of routing to the cluster specified in the request_header for weighted cluster (i.e. multiple upstreams) case.

Regarding the compatibility:
1) old config + new envoy --- It will just use `name` field as before.
2) new config + old envoy --- The new config with cluster_header will be rejected because validate.rules is enabled and it requires `name` with min_len.

Note: I have implemented the change and tested it with end-to-end
integration test/example locally. Those changes will be in a separate PR once this API change is approved.

Signed-off-by: Tianyu Xia <tyxia@google.com>
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
