### PR TITLE
bazel: remove CMAKE_BUILD_TYPE override

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -101,7 +101,6 @@ def envoy_cmake_external(
         cmake_files_dir = "$BUILD_TMPDIR/CMakeFiles",
         generate_crosstool_file = False,
         **kwargs):
-    cache_entries.update({"CMAKE_BUILD_TYPE": "Bazel"})
     cache_entries_debug = dict(cache_entries)
     cache_entries_debug.update(debug_cache_entries)
 

--- a/bazel/foreign_cc/llvm.patch
+++ b/bazel/foreign_cc/llvm.patch
@@ -1,15 +1,3 @@
-# Workaround for Envoy's CMAKE_BUILD_TYPE=Bazel.
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -247,7 +247,7 @@
- string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
- 
- if (CMAKE_BUILD_TYPE AND
--    NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL)$")
-+    NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO|MINSIZEREL|BAZEL)$")
-   message(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
- endif()
- 
 # Workaround for a missing -fuse-ld flag in CXXFLAGS, which results in
 # different linkers being used during configure and compilation phases.
 --- a/cmake/modules/HandleLLVMOptions.cmake


### PR DESCRIPTION
rules_foreign_cc sets this automatically to either Debug or Release
based on bazel's compilation_mode. Overriding this can cause issues when
deps' cmake configs expect to be in a specific subset of configs. Unlike
LLVM most cmake configs seem to silently fail in that case by not
setting an expected var correctly. I hit this issue when updating
rules_foreign_cc (I'm not sure of why the update broke it) and wamr
missing some settings for the custom Bazel config.

Fixes: https://github.com/envoyproxy/envoy/issues/17106

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>