### PR TITLE
utility: adding an (unused) key value store

### DIFF
--- a/envoy/common/BUILD
+++ b/envoy/common/BUILD
@@ -72,6 +72,13 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "key_value_store_interface",
+    hdrs = ["key_value_store.h"],
+    deps = [
+    ],
+)
+
+envoy_cc_library(
     name = "interval_set_interface",
     hdrs = ["interval_set.h"],
 )

--- a/envoy/common/key_value_store.h
+++ b/envoy/common/key_value_store.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+
+// A key value store, designed to periodically flush key value pairs to long
+// term storage (disk or otherwise)
+class KeyValueStore {
+public:
+  virtual ~KeyValueStore() {}
+
+  /**
+   * Adds or updates a key:value pair in the store.
+   * @param key supplies a key to add or update.
+   * @param value supplies the value to set for that key.
+   */
+  virtual void addOrUpdateKey(absl::string_view key, absl::string_view value) PURE;
+
+  /**
+   * Removes a key:value pair from the store. This is a no-op if the key is not present.
+   * @param key supplies a key to remove from the store.
+   */
+  virtual void removeKey(absl::string_view key) PURE;
+
+  /**
+   * Returns the value of the key provided.
+   * @param key supplies a key to return the value of.
+   * @return the value, if the key is in the store, empty string otherwise.
+   */
+  virtual absl::string_view getKey(absl::string_view key) PURE;
+
+  /**
+   * Flushes the store to long term storage.
+   */
+  virtual void flush() PURE;
+};
+
+} // namespace Envoy

--- a/envoy/common/key_value_store.h
+++ b/envoy/common/key_value_store.h
@@ -3,6 +3,7 @@
 #include "envoy/common/pure.h"
 
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 
@@ -10,27 +11,27 @@ namespace Envoy {
 // term storage (disk or otherwise)
 class KeyValueStore {
 public:
-  virtual ~KeyValueStore() {}
+  virtual ~KeyValueStore() = default;
 
   /**
    * Adds or updates a key:value pair in the store.
    * @param key supplies a key to add or update.
    * @param value supplies the value to set for that key.
    */
-  virtual void addOrUpdateKey(absl::string_view key, absl::string_view value) PURE;
+  virtual void addOrUpdate(absl::string_view key, absl::string_view value) PURE;
 
   /**
    * Removes a key:value pair from the store. This is a no-op if the key is not present.
    * @param key supplies a key to remove from the store.
    */
-  virtual void removeKey(absl::string_view key) PURE;
+  virtual void remove(absl::string_view key) PURE;
 
   /**
    * Returns the value of the key provided.
    * @param key supplies a key to return the value of.
-   * @return the value, if the key is in the store, empty string otherwise.
+   * @return the value, if the key is in the store, absl::nullopt otherwise.
    */
-  virtual absl::string_view getKey(absl::string_view key) PURE;
+  virtual absl::optional<absl::string_view> get(absl::string_view key) PURE;
 
   /**
    * Flushes the store to long term storage.

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -138,6 +138,17 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "key_value_store_lib",
+    srcs = ["key_value_store_base.cc"],
+    hdrs = ["key_value_store_base.h"],
+    deps = [
+        "//envoy/common:key_value_store_interface",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/filesystem:filesystem_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "linked_object",
     hdrs = ["linked_object.h"],
     deps = [":assert_lib"],

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -1,0 +1,102 @@
+#include "source/common/common/key_value_store_base.h"
+
+namespace Envoy {
+namespace {
+
+// Removes a length prefixed token from |contents| and returns the token,
+// or returns absl::nullopt on failure.
+absl::optional<absl::string_view> getToken(absl::string_view& contents) {
+  const auto it = contents.find("\n");
+  if (it == contents.npos) {
+    ENVOY_LOG_MISC(warn, "Bad file: no newline");
+    return {};
+  }
+  uint64_t length;
+  if (!absl::SimpleAtoi(contents.substr(0, it), &length)) {
+    ENVOY_LOG_MISC(warn, "Bad file: no length");
+    return {};
+  }
+  contents.remove_prefix(it + 1);
+  if (contents.size() < length) {
+    ENVOY_LOG_MISC(warn, "Bad file: insufficient contents");
+    return {};
+  }
+  absl::string_view token = contents.substr(0, length);
+  contents.remove_prefix(length);
+  return token;
+}
+
+bool tokenizeContents(absl::string_view contents,
+                      absl::flat_hash_map<std::string, std::string>& store) {
+  // Assuming |contents| is in the format
+  // [length]\n[key]\n[length]\n[value]
+  // tokenizes contents into the provided store.
+  // This is best effort, and will return false on failure without clearing
+  // partially parsed data.
+  while (!contents.empty()) {
+    absl::optional<absl::string_view> key = getToken(contents);
+    absl::optional<absl::string_view> value = getToken(contents);
+    if (!key.has_value() || !value.has_value()) {
+      return false;
+    }
+    store.emplace(std::string(key.value()), std::string(value.value()));
+  }
+  return true;
+}
+
+} // namespace
+
+KeyValueStoreBase::KeyValueStoreBase(Event::Dispatcher& dispatcher,
+                                     std::chrono::seconds flush_interval)
+    : flush_timer_(dispatcher.createTimer([this]() { flush(); })) {
+  flush_timer_->enableTimer(flush_interval);
+}
+
+void KeyValueStoreBase::addOrUpdateKey(absl::string_view key, absl::string_view value) {
+  store_.erase(key);
+  store_.emplace(key, value);
+}
+
+void KeyValueStoreBase::removeKey(absl::string_view key) { store_.erase(key); }
+absl::string_view KeyValueStoreBase::getKey(absl::string_view key) {
+  auto it = store_.find(key);
+  if (it == store_.end()) {
+    return "";
+  }
+  return it->second;
+}
+
+FileBasedKeyValueStore::FileBasedKeyValueStore(Event::Dispatcher& dispatcher,
+                                               std::chrono::seconds flush_interval,
+                                               Filesystem::Instance& file_system,
+                                               const std::string filename)
+    : KeyValueStoreBase(dispatcher, flush_interval), file_system_(file_system),
+      filename_(filename) {
+  if (!file_system_.fileExists(filename_)) {
+    return;
+  }
+  const std::string contents = file_system_.fileReadToEnd(filename_);
+  if (!tokenizeContents(contents, store_)) {
+    ENVOY_LOG_MISC(warn, "Failed to parse key value store file {}", filename);
+  }
+}
+
+void FileBasedKeyValueStore::flush() {
+  static constexpr Filesystem::FlagSet DefaultFlags{1 << Filesystem::File::Operation::Write |
+                                                    1 << Filesystem::File::Operation::Create};
+  Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, filename_};
+  auto file = file_system_.createFile(file_info);
+  if (!file || !file->open(DefaultFlags).return_value_) {
+    ENVOY_LOG_MISC(error, "Failed to flush cache to file {}", filename_);
+    return;
+  }
+  for (auto it : store_) {
+    file->write(absl::StrCat(it.first.length(), "\n"));
+    file->write(it.first);
+    file->write(absl::StrCat(it.second.length(), "\n"));
+    file->write(it.second);
+  }
+  file->close();
+}
+
+} // namespace Envoy

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -96,7 +96,7 @@ void FileBasedKeyValueStore::flush() {
     ENVOY_LOG(error, "Failed to flush cache to file {}", filename_);
     return;
   }
-  for (auto it : store_) {
+  for (const auto& it : store_) {
     file->write(absl::StrCat(it.first.length(), "\n"));
     file->write(it.first);
     file->write(absl::StrCat(it.second.length(), "\n"));

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -4,6 +4,8 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 
+#include "source/common/common/logger.h"
+
 #include "absl/container/flat_hash_map.h"
 
 namespace Envoy {
@@ -11,17 +13,25 @@ namespace Envoy {
 // This is the base implementation of the KeyValueStore. It handles the various
 // functions other than flush(), which will be implemented by subclasses.
 //
-// Note this implementation HAS UNBOUNDED SIZE
+// Note this implementation HAS UNBOUNDED SIZE.
 // It is assumed the callers manage the number of entries. Use with care.
-class KeyValueStoreBase : public KeyValueStore {
+class KeyValueStoreBase : public KeyValueStore,
+                          public Logger::Loggable<Logger::Id::key_value_store> {
 public:
   // Sets up flush() for the configured interval.
   KeyValueStoreBase(Event::Dispatcher& dispatcher, std::chrono::seconds flush_interval);
 
-  // From KeyValueStore
-  void addOrUpdateKey(absl::string_view key, absl::string_view value) override;
-  void removeKey(absl::string_view key) override;
-  absl::string_view getKey(absl::string_view key) override;
+  // If |contents| is in the form of
+  // [length]\n[key][length]\n[value]
+  // parses key value pairs from |contents| into the store provided.
+  // Returns true on success and false on failure.
+  bool parseContents(absl::string_view contents,
+                     absl::flat_hash_map<std::string, std::string>& store) const;
+  std::string error;
+  // KeyValueStore
+  void addOrUpdate(absl::string_view key, absl::string_view value) override;
+  void remove(absl::string_view key) override;
+  absl::optional<absl::string_view> get(absl::string_view key) override;
 
 protected:
   const Event::TimerPtr flush_timer_;
@@ -36,8 +46,8 @@ protected:
 class FileBasedKeyValueStore : public KeyValueStoreBase {
 public:
   FileBasedKeyValueStore(Event::Dispatcher& dispatcher, std::chrono::seconds flush_interval,
-                         Filesystem::Instance& file_system, const std::string filename);
-  // From KeyValueStore
+                         Filesystem::Instance& file_system, const std::string& filename);
+  // KeyValueStore
   void flush() override;
 
 private:

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "envoy/common/key_value_store.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/filesystem/filesystem.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace Envoy {
+
+// This is the base implementation of the KeyValueStore. It handles the various
+// functions other than flush(), which will be implemented by subclasses.
+//
+// Note this implementation HAS UNBOUNDED SIZE
+// It is assumed the callers manage the number of entries. Use with care.
+class KeyValueStoreBase : public KeyValueStore {
+public:
+  // Sets up flush() for the configured interval.
+  KeyValueStoreBase(Event::Dispatcher& dispatcher, std::chrono::seconds flush_interval);
+
+  // From KeyValueStore
+  void addOrUpdateKey(absl::string_view key, absl::string_view value) override;
+  void removeKey(absl::string_view key) override;
+  absl::string_view getKey(absl::string_view key) override;
+
+protected:
+  const Event::TimerPtr flush_timer_;
+  absl::flat_hash_map<std::string, std::string> store_;
+};
+
+// A filesystem based key value store, which loads from and flushes to the file
+// provided.
+//
+// All keys and values are flushed to a single file as
+// [length]\n[key][length]\n[value]
+class FileBasedKeyValueStore : public KeyValueStoreBase {
+public:
+  FileBasedKeyValueStore(Event::Dispatcher& dispatcher, std::chrono::seconds flush_interval,
+                         Filesystem::Instance& file_system, const std::string filename);
+  // From KeyValueStore
+  void flush() override;
+
+private:
+  Filesystem::Instance& file_system_;
+  const std::string filename_;
+};
+
+} // namespace Envoy

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -54,6 +54,7 @@ namespace Logger {
   FUNCTION(io)                                                                                     \
   FUNCTION(jwt)                                                                                    \
   FUNCTION(kafka)                                                                                  \
+  FUNCTION(key_value_store)                                                                        \
   FUNCTION(lua)                                                                                    \
   FUNCTION(main)                                                                                   \
   FUNCTION(matcher)                                                                                \

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -143,6 +143,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "key_value_store_test",
+    srcs = ["key_value_store_test.cc"],
+    deps = [
+        "//source/common/common:key_value_store_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/test_common:file_system_for_test_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "linked_object_test",
     srcs = ["linked_object_test.cc"],
     deps = [

--- a/test/common/common/key_value_store_test.cc
+++ b/test/common/common/key_value_store_test.cc
@@ -66,11 +66,13 @@ TEST_F(KeyValueStoreTest, HandleBadFile) {
   checkBadFile("3\nfoo3\nbar3\na", "Bad file: insufficient contents");
 }
 
+#ifndef WIN32
 TEST_F(KeyValueStoreTest, HandleInvalidFile) {
-  filename_ = "c://foo";
+  filename_ = "/foo";
   createStore();
-  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file c://foo", store_->flush());
+  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file /foo", store_->flush());
 }
+#endif
 
 } // namespace
 } // namespace Envoy

--- a/test/common/common/key_value_store_test.cc
+++ b/test/common/common/key_value_store_test.cc
@@ -67,9 +67,9 @@ TEST_F(KeyValueStoreTest, HandleBadFile) {
 }
 
 TEST_F(KeyValueStoreTest, HandleInvalidFile) {
-  filename_ = "/foo";
+  filename_ = "c://foo";
   createStore();
-  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file /foo", store_->flush());
+  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file c://foo", store_->flush());
 }
 
 } // namespace

--- a/test/common/common/key_value_store_test.cc
+++ b/test/common/common/key_value_store_test.cc
@@ -1,0 +1,77 @@
+#include <memory>
+#include <string>
+
+#include "source/common/common/key_value_store_base.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/file_system_for_test.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace {
+
+class KeyValueStoreTest : public testing::Test {
+protected:
+  KeyValueStoreTest() : filename_(TestEnvironment::temporaryPath("key_value_store")) {
+    TestEnvironment::removePath(filename_);
+    createStore();
+  }
+
+  void createStore() {
+    store_.reset();
+    store_ = std::make_unique<FileBasedKeyValueStore>(dispatcher_, std::chrono::seconds{5},
+                                                      Filesystem::fileSystemForTest(), filename_);
+  }
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  std::string filename_;
+  std::unique_ptr<FileBasedKeyValueStore> store_{};
+};
+
+TEST_F(KeyValueStoreTest, Basic) {
+  EXPECT_EQ("", store_->getKey("foo"));
+  store_->addOrUpdateKey("foo", "bar");
+  EXPECT_EQ("bar", store_->getKey("foo"));
+  store_->addOrUpdateKey("foo", "eep");
+  EXPECT_EQ("eep", store_->getKey("foo"));
+  store_->removeKey("foo");
+  EXPECT_EQ("", store_->getKey("foo"));
+}
+
+TEST_F(KeyValueStoreTest, Persist) {
+  store_->addOrUpdateKey("foo", "bar");
+  store_->addOrUpdateKey("baz", "eep");
+  store_->flush();
+
+  createStore();
+
+  EXPECT_EQ("bar", store_->getKey("foo"));
+  EXPECT_EQ("eep", store_->getKey("baz"));
+}
+
+TEST_F(KeyValueStoreTest, HandleBadFile) {
+  auto checkBadFile = [this](std::string file, std::string error) {
+    TestEnvironment::writeStringToFileForTest(filename_, file, true);
+    EXPECT_LOG_CONTAINS("warn", error, createStore());
+
+    // File will be parsed up until error.
+    EXPECT_EQ("bar", store_->getKey("foo"));
+  };
+  checkBadFile("3\nfoo3\nbar3", "Bad file: no newline");
+  checkBadFile("3\nfoo3\nbar\n", "Bad file: no length");
+  checkBadFile("3\nfoo3\nbarasd\n", "Bad file: no length");
+  checkBadFile("3\nfoo3\nbar3\n", "Bad file: insufficient contents");
+}
+
+TEST_F(KeyValueStoreTest, HandleInvalidFile) {
+  filename_ = "/foo";
+  createStore();
+  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file /foo", store_->flush());
+}
+
+} // namespace
+} // namespace Envoy


### PR DESCRIPTION
Doing this in 3 steps as I suspect there's going to be both naming and config bike shedding :-)
1) add K-V store
2) add factories + config, and hook into DNS module
3) I (or @goaway) add a k-v store in the mobile repo that flushes via the java prefs interface.

Risk Level: n/a (unused) 
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy-mobile/issues/1587