### PR TITLE
quic: remove envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -57,6 +57,7 @@ Removed Config or Runtime
 * listener: removed ``envoy.reloadable_features.disable_tls_inspector_injection`` runtime guard and legacy code paths.
 * ocsp: removed ``envoy.reloadable_features.check_ocsp_policy deprecation`` runtime guard and legacy code paths.
 * ocsp: removed ``envoy.reloadable_features.require_ocsp_response_for_must_staple_certs deprecation`` and legacy code paths.
+* quic: removed ``envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing`` runtime guard.
 
 New Features
 ------------

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -21,6 +21,8 @@
 namespace Envoy {
 namespace Quic {
 
+bool ActiveQuicListenerFactory::disable_kernel_bpf_packet_routing_for_test_ = false;
+
 ActiveQuicListener::ActiveQuicListener(
     uint32_t worker_index, uint32_t concurrency, Event::Dispatcher& dispatcher,
     Network::UdpConnectionHandler& parent, Network::ListenerConfig& listener_config,
@@ -300,8 +302,7 @@ ActiveQuicListenerFactory::ActiveQuicListenerFactory(
       {0x16, 0, 0, 0000000000},   //                 ret a
   };
   // SPELLCHECKER(on)
-  if (Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing")) {
+  if (!disable_kernel_bpf_packet_routing_for_test_) {
     if (concurrency_ > 1) {
       // Note that this option refers to the BPF program data above, which must live until the
       // option is used. The program is kept as a member variable for this purpose.

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -106,6 +106,10 @@ public:
   bool isTransportConnectionless() const override { return false; }
   const Network::Socket::OptionsSharedPtr& socketOptions() const override { return options_; }
 
+  static void setDisableKernelBpfPacketRoutingForTest(bool val) {
+    disable_kernel_bpf_packet_routing_for_test_ = val;
+  }
+
 private:
   friend class ActiveQuicListenerFactoryPeer;
 
@@ -120,6 +124,8 @@ private:
   const uint32_t packets_to_read_to_connection_count_ratio_;
   const Network::Socket::OptionsSharedPtr options_{std::make_shared<Network::Socket::Options>()};
   bool kernel_worker_routing_{};
+
+  static bool disable_kernel_bpf_packet_routing_for_test_;
 
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
   sock_fprog prog_;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -80,7 +80,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.listener_wildcard_match_ip_family",
     "envoy.reloadable_features.new_tcp_connection_pool",
     "envoy.reloadable_features.no_chunked_encoding_header_for_304",
-    "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing",
     "envoy.reloadable_features.preserve_downstream_scheme",
     "envoy.reloadable_features.remove_forked_chromium_url",
     "envoy.reloadable_features.require_strict_1xx_and_204_response_headers",

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -27,6 +27,7 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include "source/common/quic/active_quic_listener.h"
 #include "source/common/quic/client_connection_factory_impl.h"
 #include "source/common/quic/envoy_quic_client_session.h"
 #include "source/common/quic/envoy_quic_client_connection.h"
@@ -281,10 +282,14 @@ TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsDefaultMode) {
 }
 
 TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsNoBPF) {
-  // Note: This runtime override is a no-op on platforms without BPF
-  config_helper_.addRuntimeOverride(
-      "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing", "false");
+  // Note: This setting is a no-op on platforms without BPF
+  class DisableBpf {
+  public:
+    DisableBpf() { ActiveQuicListenerFactory::setDisableKernelBpfPacketRoutingForTest(true); }
+    ~DisableBpf() { ActiveQuicListenerFactory::setDisableKernelBpfPacketRoutingForTest(false); }
+  };
 
+  DisableBpf disable;
   testMultipleQuicConnections();
 }
 


### PR DESCRIPTION
Fixes #16011

Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: Low
Testing: Verified existing test coverage stays the same
Docs Changes:
Release Notes: Added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
