### PR TITLE
test: allocate X509 objects correctly

### DIFF
--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -164,9 +164,10 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithNoValidationContex
   EXPECT_EQ(default_validator->verifyCertificate(/*cert=*/nullptr, /*verify_san_list=*/{},
                                                  /*subject_alt_name_matchers=*/{}),
             Envoy::Ssl::ClientValidationStatus::NotValidated);
-  X509 cert = {};
+  bssl::UniquePtr<X509> cert(X509_new());
   EXPECT_EQ(default_validator->doVerifyCertChain(/*store_ctx=*/nullptr,
-                                                 /*ssl_extended_info=*/nullptr, /*leaf_cert=*/cert,
+                                                 /*ssl_extended_info=*/nullptr,
+                                                 /*leaf_cert=*/*cert,
                                                  /*transport_socket_options=*/nullptr),
             0);
 }


### PR DESCRIPTION
Commit Message:
As with any other C API, simply default-initializing an X509 will not
correctly set up the object. It will also break in the future. BoringSSL
is also looking to align with OpenSSL and make the X509 type opaque, to
avoid callers reaching into private fields and breaking things.

Instead, construct an X509 way with X509_new(). It's still an empty
object, which isn't really a certificate to verify, but this test
was already doing that and doesn't seem to care.
Additional Description:
Risk Level: Test-only change
Testing: Test-only change
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
