### PR TITLE
apple dns: call DNS error callback for all error cases

### DIFF
--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -79,6 +79,7 @@ ActiveDnsQuery* AppleDnsResolverImpl::resolve(const std::string& dns_name,
     if (error != kDNSServiceErr_NoError) {
       ENVOY_LOG(warn, "DNS resolver error ({}) in dnsServiceGetAddrInfo for {}", error, dns_name);
       chargeGetAddrInfoErrorStats(error);
+      callback(DnsResolver::ResolutionStatus::Failure, {});
       return nullptr;
     }
 
@@ -91,6 +92,7 @@ ActiveDnsQuery* AppleDnsResolverImpl::resolve(const std::string& dns_name,
     // Otherwise, hook up the query's UDS socket to the event loop to process updates.
     if (!pending_resolution->dnsServiceRefSockFD()) {
       ENVOY_LOG(warn, "DNS resolver error in dnsServiceRefSockFD for {}", dns_name);
+      callback(DnsResolver::ResolutionStatus::Failure, {});
       return nullptr;
     }
 

--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -52,60 +52,69 @@ AppleDnsResolverStats AppleDnsResolverImpl::generateAppleDnsResolverStats(Stats:
   return {ALL_APPLE_DNS_RESOLVER_STATS(POOL_COUNTER(scope))};
 }
 
+AppleDnsResolverImpl::StartResolutionResult
+AppleDnsResolverImpl::startResolution(const std::string& dns_name,
+                                      DnsLookupFamily dns_lookup_family, ResolveCb callback) {
+  auto pending_resolution =
+      std::make_unique<PendingResolution>(*this, callback, dispatcher_, dns_name);
+
+  DNSServiceErrorType error = pending_resolution->dnsServiceGetAddrInfo(dns_lookup_family);
+  if (error != kDNSServiceErr_NoError) {
+    ENVOY_LOG(warn, "DNS resolver error ({}) in dnsServiceGetAddrInfo for {}", error, dns_name);
+    chargeGetAddrInfoErrorStats(error);
+    return {nullptr, false};
+  }
+
+  if (pending_resolution->synchronously_completed_) {
+    return {nullptr, true};
+  }
+
+  // Hook up the query's UDS socket to the event loop to process updates.
+  if (!pending_resolution->dnsServiceRefSockFD()) {
+    ENVOY_LOG(warn, "DNS resolver error in dnsServiceRefSockFD for {}", dns_name);
+    return {nullptr, false};
+  }
+
+  return {std::move(pending_resolution), true};
+}
+
 ActiveDnsQuery* AppleDnsResolverImpl::resolve(const std::string& dns_name,
                                               DnsLookupFamily dns_lookup_family,
                                               ResolveCb callback) {
   ENVOY_LOG(debug, "DNS resolver resolve={}", dns_name);
 
-  Address::InstanceConstSharedPtr address{};
-  TRY_ASSERT_MAIN_THREAD {
-    // When an IP address is submitted to c-ares in DnsResolverImpl, c-ares synchronously returns
-    // the IP without submitting a DNS query. Because Envoy has come to rely on this behavior, this
-    // resolver implements a similar resolution path to avoid making improper DNS queries for
-    // resolved IPs.
-    address = Utility::parseInternetAddress(dns_name);
+  // When an IP address is submitted to c-ares in DnsResolverImpl, c-ares synchronously returns
+  // the IP without submitting a DNS query. Because Envoy has come to rely on this behavior, this
+  // resolver implements a similar resolution path to avoid making improper DNS queries for
+  // resolved IPs.
+  auto address = Utility::parseInternetAddressNoThrow(dns_name);
+
+  if (address != nullptr) {
     ENVOY_LOG(debug, "DNS resolver resolved ({}) to ({}) without issuing call to Apple API",
               dns_name, address->asString());
-  }
-  END_TRY
-  catch (const EnvoyException& e) {
-    // Resolution via Apple APIs
-    ENVOY_LOG(trace, "DNS resolver local resolution failed with: {}", e.what());
-
-    auto pending_resolution =
-        std::make_unique<PendingResolution>(*this, callback, dispatcher_, dns_name);
-
-    DNSServiceErrorType error = pending_resolution->dnsServiceGetAddrInfo(dns_lookup_family);
-    if (error != kDNSServiceErr_NoError) {
-      ENVOY_LOG(warn, "DNS resolver error ({}) in dnsServiceGetAddrInfo for {}", error, dns_name);
-      chargeGetAddrInfoErrorStats(error);
-      callback(DnsResolver::ResolutionStatus::Failure, {});
-      return nullptr;
-    }
-
-    // If the query was synchronously resolved in the Apple API call, there is no need to return the
-    // query.
-    if (pending_resolution->synchronously_completed_) {
-      return nullptr;
-    }
-
-    // Otherwise, hook up the query's UDS socket to the event loop to process updates.
-    if (!pending_resolution->dnsServiceRefSockFD()) {
-      ENVOY_LOG(warn, "DNS resolver error in dnsServiceRefSockFD for {}", dns_name);
-      callback(DnsResolver::ResolutionStatus::Failure, {});
-      return nullptr;
-    }
-
-    pending_resolution->owned_ = true;
-    return pending_resolution.release();
+    callback(DnsResolver::ResolutionStatus::Success,
+             {DnsResponse(address, std::chrono::seconds(60))});
+    return nullptr;
   }
 
-  ASSERT(address != nullptr);
-  // Finish local, synchronous resolution. This needs to happen outside of the exception block above
-  // as the callback itself can throw.
-  callback(DnsResolver::ResolutionStatus::Success,
-           {DnsResponse(address, std::chrono::seconds(60))});
-  return nullptr;
+  ENVOY_LOG(trace, "Performing DNS resolution via Apple APIs");
+  auto pending_resolution_and_success = startResolution(dns_name, dns_lookup_family, callback);
+
+  // If we synchronously failed the resolution, trigger a failure callback.
+  if (!pending_resolution_and_success.second) {
+    callback(DnsResolver::ResolutionStatus::Failure, {});
+    return nullptr;
+  }
+
+  // We might have synchronously resolved the query, in which case return nullptr.
+  if (!pending_resolution_and_success.first) {
+    return nullptr;
+  }
+
+  // Otherwise return the active resolution query, giving it ownership over itself so that it can
+  // can clean itself up once it's done.
+  pending_resolution_and_success.first->owned_ = true;
+  return pending_resolution_and_success.first.release();
 }
 
 void AppleDnsResolverImpl::chargeGetAddrInfoErrorStats(DNSServiceErrorType error_code) {
@@ -240,7 +249,7 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
             dns_name_, flags, flags & kDNSServiceFlagsMoreComing ? "yes" : "no",
             flags & kDNSServiceFlagsAdd ? "yes" : "no", interface_index, error_code, hostname);
 
-  // Generic error handling.
+  // Make sure that we trigger the failure callback if we get an error back.
   if (error_code != kDNSServiceErr_NoError) {
     parent_.chargeGetAddrInfoErrorStats(error_code);
 

--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -92,6 +92,10 @@ AppleDnsResolverImpl::startResolution(const std::string& dns_name,
     return {nullptr, false};
   }
 
+  // Return the active resolution query, giving it ownership over itself so that it can
+  // can clean itself up once it's done.
+  pending_resolution->owned_ = true;
+
   return {std::move(pending_resolution), true};
 }
 
@@ -106,14 +110,6 @@ ActiveDnsQuery* AppleDnsResolverImpl::resolve(const std::string& dns_name,
     return nullptr;
   }
 
-  // We might have synchronously resolved the query, in which case return nullptr.
-  if (!pending_resolution_and_success.first) {
-    return nullptr;
-  }
-
-  // Otherwise return the active resolution query, giving it ownership over itself so that it can
-  // can clean itself up once it's done.
-  pending_resolution_and_success.first->owned_ = true;
   return pending_resolution_and_success.first.release();
 }
 

--- a/source/common/network/apple_dns_impl.h
+++ b/source/common/network/apple_dns_impl.h
@@ -72,6 +72,14 @@ public:
                           ResolveCb callback) override;
 
 private:
+  struct PendingResolution;
+
+  // The newly created pending resolution and whether this action was succesful. Note
+  // that {nullptr, true} is possible in the case where the resolution succeeds inline.
+  using StartResolutionResult = std::pair<std::unique_ptr<PendingResolution>, bool>;
+  StartResolutionResult startResolution(const std::string& dns_name,
+                                        DnsLookupFamily dns_lookup_family, ResolveCb callback);
+
   void chargeGetAddrInfoErrorStats(DNSServiceErrorType error_code);
 
   struct PendingResolution : public ActiveDnsQuery {

--- a/source/common/network/apple_dns_impl.h
+++ b/source/common/network/apple_dns_impl.h
@@ -74,7 +74,7 @@ public:
 private:
   struct PendingResolution;
 
-  // The newly created pending resolution and whether this action was succesful. Note
+  // The newly created pending resolution and whether this action was successful. Note
   // that {nullptr, true} is possible in the case where the resolution succeeds inline.
   using StartResolutionResult = std::pair<std::unique_ptr<PendingResolution>, bool>;
   StartResolutionResult startResolution(const std::string& dns_name,

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -273,9 +273,9 @@ public:
 
     EXPECT_EQ(nullptr, resolver_->resolve(
                            "foo.com", Network::DnsLookupFamily::Auto,
-                           [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void {
-                             // This callback should never be executed.
-                             FAIL();
+                           [](DnsResolver::ResolutionStatus status, std::list<DnsResponse>&& responses) -> void {
+                             EXPECT_EQ(DnsResolver::ResolutionStatus::Failure, status);
+                             EXPECT_TRUE(responses.empty());
                            }));
 
     checkErrorStat(error_code);

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -271,13 +271,17 @@ public:
     EXPECT_CALL(dns_service_, dnsServiceGetAddrInfo(_, _, _, _, _, _, _))
         .WillOnce(Return(error_code));
 
-    EXPECT_EQ(nullptr, resolver_->resolve(
-                           "foo.com", Network::DnsLookupFamily::Auto,
-                           [](DnsResolver::ResolutionStatus status, std::list<DnsResponse>&& responses) -> void {
-                             EXPECT_EQ(DnsResolver::ResolutionStatus::Failure, status);
-                             EXPECT_TRUE(responses.empty());
-                           }));
+    bool callback_called = false;
+    EXPECT_EQ(nullptr, resolver_->resolve("foo.com", Network::DnsLookupFamily::Auto,
+                                          [&](DnsResolver::ResolutionStatus status,
+                                              std::list<DnsResponse>&& responses) -> void {
+                                            EXPECT_EQ(DnsResolver::ResolutionStatus::Failure,
+                                                      status);
+                                            EXPECT_TRUE(responses.empty());
+                                            callback_called = true;
+                                          }));
 
+    EXPECT_TRUE(callback_called);
     checkErrorStat(error_code);
   }
 


### PR DESCRIPTION
Call the DNS callback with a failure status for immediate failures in the apple_dns_resolver. This should ensure that
we treat these as errors and retry them earlier than if we were to rely on the periodic DNS resolution interval.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Updated unit tests
Docs Changes: n/a
Release Notes: n/a
