### PR TITLE
fix potential failure in verify-examples

### DIFF
--- a/examples/dynamic-config-cp/Dockerfile-control-plane
+++ b/examples/dynamic-config-cp/Dockerfile-control-plane
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
-RUN git clone https://github.com/envoyproxy/go-control-plane
+RUN git clone https://github.com/envoyproxy/go-control-plane && cd go-control-plane && git checkout b4adc3bb5fe5288bff01cd452dad418ef98c676e
 ADD ./resource.go /go/go-control-plane/internal/example/resource.go
-RUN cd go-control-plane && git checkout b4adc3bb5fe5288bff01cd452dad418ef98c676e && make bin/example
+RUN cd go-control-plane && make bin/example
 WORKDIR /go/go-control-plane


### PR DESCRIPTION
If the `git checkout` of the specific tag causes `resource.go` to
change, then it will fail if it is done after adding the test copy of
`resource.go` due to discarding a local change.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
