### PR TITLE
conn_pool: Minor cleanups to ConnPoolBaseImpl

### DIFF
--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -228,7 +228,7 @@ void ConnPoolImplBase::onStreamClosed(Envoy::ConnectionPool::ActiveClient& clien
   }
 }
 
-ConnectionPool::Cancellable* ConnPoolImplBase::newStream(AttachContext& context) {
+ConnectionPool::Cancellable* ConnPoolImplBase::newStreamImpl(AttachContext& context) {
   ASSERT(!deferred_deleting_);
 
   ASSERT(static_cast<ssize_t>(connecting_stream_capacity_) ==
@@ -277,7 +277,7 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStream(AttachContext& context)
   }
 }
 
-bool ConnPoolImplBase::maybePreconnect(float global_preconnect_ratio) {
+bool ConnPoolImplBase::maybePreconnectImpl(float global_preconnect_ratio) {
   ASSERT(!deferred_deleting_);
   return tryCreateNewConnection(global_preconnect_ratio) == ConnectionResult::CreatedNewConnection;
 }
@@ -405,61 +405,7 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     client.connect_timer_.reset();
   }
 
-  if (event == Network::ConnectionEvent::RemoteClose ||
-      event == Network::ConnectionEvent::LocalClose) {
-    state_.decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity());
-    // Make sure that onStreamClosed won't double count.
-    client.remaining_streams_ = 0;
-    // The client died.
-    ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", client, failure_reason);
-
-    Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
-    const bool incomplete_stream = client.closingWithIncompleteStream();
-    if (incomplete_stream) {
-      Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
-    }
-
-    if (client.state() == ActiveClient::State::CONNECTING) {
-      host_->cluster().stats().upstream_cx_connect_fail_.inc();
-      host_->stats().cx_connect_fail_.inc();
-
-      ConnectionPool::PoolFailureReason reason;
-      if (client.timed_out_) {
-        reason = ConnectionPool::PoolFailureReason::Timeout;
-      } else if (event == Network::ConnectionEvent::RemoteClose) {
-        reason = ConnectionPool::PoolFailureReason::RemoteConnectionFailure;
-      } else {
-        reason = ConnectionPool::PoolFailureReason::LocalConnectionFailure;
-      }
-
-      // Raw connect failures should never happen under normal circumstances. If we have an upstream
-      // that is behaving badly, streams can get stuck here in the pending state. If we see a
-      // connect failure, we purge all pending streams so that calling code can determine what to
-      // do with the stream.
-      // NOTE: We move the existing pending streams to a temporary list. This is done so that
-      //       if retry logic submits a new stream to the pool, we don't fail it inline.
-      purgePendingStreams(client.real_host_description_, failure_reason, reason);
-      // See if we should preconnect based on active connections.
-      tryCreateNewConnections();
-    }
-
-    // We need to release our resourceManager() resources before checking below for
-    // whether we can create a new connection. Normally this would happen when
-    // client's destructor runs, but this object needs to be deferredDelete'd(), so
-    // this forces part of its cleanup to happen now.
-    client.releaseResources();
-
-    dispatcher_.deferredDelete(client.removeFromList(owningList(client.state())));
-
-    checkForIdleAndCloseIdleConnsIfDraining();
-
-    client.setState(ActiveClient::State::CLOSED);
-
-    // If we have pending streams and we just lost a connection we should make a new one.
-    if (!pending_streams_.empty()) {
-      tryCreateNewConnections();
-    }
-  } else if (event == Network::ConnectionEvent::Connected) {
+  if (event == Network::ConnectionEvent::Connected) {
     client.conn_connect_ms_->complete();
     client.conn_connect_ms_.reset();
     ASSERT(client.state() == ActiveClient::State::CONNECTING);
@@ -470,6 +416,62 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     onConnected(client);
     onUpstreamReady();
     checkForIdleAndCloseIdleConnsIfDraining();
+    return;
+  }
+
+  ASSERT(event == Network::ConnectionEvent::RemoteClose ||
+         event == Network::ConnectionEvent::LocalClose);
+  state_.decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity());
+  // Make sure that onStreamClosed won't double count.
+  client.remaining_streams_ = 0;
+  // The client died.
+  ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", client, failure_reason);
+
+  Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
+  const bool incomplete_stream = client.closingWithIncompleteStream();
+  if (incomplete_stream) {
+    Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
+  }
+
+  if (client.state() == ActiveClient::State::CONNECTING) {
+    host_->cluster().stats().upstream_cx_connect_fail_.inc();
+    host_->stats().cx_connect_fail_.inc();
+
+    ConnectionPool::PoolFailureReason reason;
+    if (client.timed_out_) {
+      reason = ConnectionPool::PoolFailureReason::Timeout;
+    } else if (event == Network::ConnectionEvent::RemoteClose) {
+      reason = ConnectionPool::PoolFailureReason::RemoteConnectionFailure;
+    } else {
+      reason = ConnectionPool::PoolFailureReason::LocalConnectionFailure;
+    }
+
+    // Raw connect failures should never happen under normal circumstances. If we have an upstream
+    // that is behaving badly, streams can get stuck here in the pending state. If we see a
+    // connect failure, we purge all pending streams so that calling code can determine what to
+    // do with the stream.
+    // NOTE: We move the existing pending streams to a temporary list. This is done so that
+    //       if retry logic submits a new stream to the pool, we don't fail it inline.
+    purgePendingStreams(client.real_host_description_, failure_reason, reason);
+    // See if we should preconnect based on active connections.
+    tryCreateNewConnections();
+  }
+
+  // We need to release our resourceManager() resources before checking below for
+  // whether we can create a new connection. Normally this would happen when
+  // client's destructor runs, but this object needs to be deferredDelete'd(), so
+  // this forces part of its cleanup to happen now.
+  client.releaseResources();
+
+  dispatcher_.deferredDelete(client.removeFromList(owningList(client.state())));
+
+  checkForIdleAndCloseIdleConnsIfDraining();
+
+  client.setState(ActiveClient::State::CLOSED);
+
+  // If we have pending streams and we just lost a connection we should make a new one.
+  if (!pending_streams_.empty()) {
+    tryCreateNewConnections();
   }
 }
 

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -405,7 +405,61 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     client.connect_timer_.reset();
   }
 
-  if (event == Network::ConnectionEvent::Connected) {
+  if (event == Network::ConnectionEvent::RemoteClose ||
+      event == Network::ConnectionEvent::LocalClose) {
+    state_.decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity());
+    // Make sure that onStreamClosed won't double count.
+    client.remaining_streams_ = 0;
+    // The client died.
+    ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", client, failure_reason);
+
+    Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
+    const bool incomplete_stream = client.closingWithIncompleteStream();
+    if (incomplete_stream) {
+      Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
+    }
+
+    if (client.state() == ActiveClient::State::CONNECTING) {
+      host_->cluster().stats().upstream_cx_connect_fail_.inc();
+      host_->stats().cx_connect_fail_.inc();
+
+      ConnectionPool::PoolFailureReason reason;
+      if (client.timed_out_) {
+        reason = ConnectionPool::PoolFailureReason::Timeout;
+      } else if (event == Network::ConnectionEvent::RemoteClose) {
+        reason = ConnectionPool::PoolFailureReason::RemoteConnectionFailure;
+      } else {
+        reason = ConnectionPool::PoolFailureReason::LocalConnectionFailure;
+      }
+
+      // Raw connect failures should never happen under normal circumstances. If we have an upstream
+      // that is behaving badly, streams can get stuck here in the pending state. If we see a
+      // connect failure, we purge all pending streams so that calling code can determine what to
+      // do with the stream.
+      // NOTE: We move the existing pending streams to a temporary list. This is done so that
+      //       if retry logic submits a new stream to the pool, we don't fail it inline.
+      purgePendingStreams(client.real_host_description_, failure_reason, reason);
+      // See if we should preconnect based on active connections.
+      tryCreateNewConnections();
+    }
+
+    // We need to release our resourceManager() resources before checking below for
+    // whether we can create a new connection. Normally this would happen when
+    // client's destructor runs, but this object needs to be deferredDelete'd(), so
+    // this forces part of its cleanup to happen now.
+    client.releaseResources();
+
+    dispatcher_.deferredDelete(client.removeFromList(owningList(client.state())));
+
+    checkForIdleAndCloseIdleConnsIfDraining();
+
+    client.setState(ActiveClient::State::CLOSED);
+
+    // If we have pending streams and we just lost a connection we should make a new one.
+    if (!pending_streams_.empty()) {
+      tryCreateNewConnections();
+    }
+  } else if (event == Network::ConnectionEvent::Connected) {
     client.conn_connect_ms_->complete();
     client.conn_connect_ms_.reset();
     ASSERT(client.state() == ActiveClient::State::CONNECTING);
@@ -416,62 +470,6 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     onConnected(client);
     onUpstreamReady();
     checkForIdleAndCloseIdleConnsIfDraining();
-    return;
-  }
-
-  ASSERT(event == Network::ConnectionEvent::RemoteClose ||
-         event == Network::ConnectionEvent::LocalClose);
-  state_.decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity());
-  // Make sure that onStreamClosed won't double count.
-  client.remaining_streams_ = 0;
-  // The client died.
-  ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", client, failure_reason);
-
-  Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
-  const bool incomplete_stream = client.closingWithIncompleteStream();
-  if (incomplete_stream) {
-    Envoy::Upstream::reportUpstreamCxDestroyActiveRequest(host_, event);
-  }
-
-  if (client.state() == ActiveClient::State::CONNECTING) {
-    host_->cluster().stats().upstream_cx_connect_fail_.inc();
-    host_->stats().cx_connect_fail_.inc();
-
-    ConnectionPool::PoolFailureReason reason;
-    if (client.timed_out_) {
-      reason = ConnectionPool::PoolFailureReason::Timeout;
-    } else if (event == Network::ConnectionEvent::RemoteClose) {
-      reason = ConnectionPool::PoolFailureReason::RemoteConnectionFailure;
-    } else {
-      reason = ConnectionPool::PoolFailureReason::LocalConnectionFailure;
-    }
-
-    // Raw connect failures should never happen under normal circumstances. If we have an upstream
-    // that is behaving badly, streams can get stuck here in the pending state. If we see a
-    // connect failure, we purge all pending streams so that calling code can determine what to
-    // do with the stream.
-    // NOTE: We move the existing pending streams to a temporary list. This is done so that
-    //       if retry logic submits a new stream to the pool, we don't fail it inline.
-    purgePendingStreams(client.real_host_description_, failure_reason, reason);
-    // See if we should preconnect based on active connections.
-    tryCreateNewConnections();
-  }
-
-  // We need to release our resourceManager() resources before checking below for
-  // whether we can create a new connection. Normally this would happen when
-  // client's destructor runs, but this object needs to be deferredDelete'd(), so
-  // this forces part of its cleanup to happen now.
-  client.releaseResources();
-
-  dispatcher_.deferredDelete(client.removeFromList(owningList(client.state())));
-
-  checkForIdleAndCloseIdleConnsIfDraining();
-
-  client.setState(ActiveClient::State::CLOSED);
-
-  // If we have pending streams and we just lost a connection we should make a new one.
-  if (!pending_streams_.empty()) {
-    tryCreateNewConnections();
   }
 }
 

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -162,9 +162,15 @@ public:
                             int64_t connecting_and_connected_capacity, float preconnect_ratio,
                             bool anticipate_incoming_stream = false);
 
+  // Envoy::ConnectionPool::Instance implementation helpers
   void addIdleCallbackImpl(Instance::IdleCb cb);
+  // Returns true if the pool is idle.
+  bool isIdleImpl() const;
   void startDrainImpl();
   void drainConnectionsImpl();
+  const Upstream::HostConstSharedPtr& host() const { return host_; }
+  // Called if this pool is likely to be picked soon, to determine if it's worth preconnecting.
+  bool maybePreconnectImpl(float global_preconnect_ratio);
 
   // Closes and destroys all connections. This must be called in the destructor of
   // derived classes because the derived ActiveClient will downcast parent_ to a more
@@ -196,16 +202,11 @@ public:
   void onConnectionEvent(ActiveClient& client, absl::string_view failure_reason,
                          Network::ConnectionEvent event);
 
-  // Returns true if the pool is idle.
-  bool isIdleImpl() const;
-
   // See if the pool has gone idle. If we're draining, this will also close idle connections.
   void checkForIdleAndCloseIdleConnsIfDraining();
 
   void scheduleOnUpstreamReady();
-  ConnectionPool::Cancellable* newStream(AttachContext& context);
-  // Called if this pool is likely to be picked soon, to determine if it's worth preconnecting.
-  bool maybePreconnect(float global_preconnect_ratio);
+  ConnectionPool::Cancellable* newStreamImpl(AttachContext& context);
 
   virtual ConnectionPool::Cancellable* newPendingStream(AttachContext& context) PURE;
 
@@ -220,7 +221,6 @@ public:
   // Called by derived classes any time a stream is completed or destroyed for any reason.
   void onStreamClosed(Envoy::ConnectionPool::ActiveClient& client, bool delay_attaching_stream);
 
-  const Upstream::HostConstSharedPtr& host() const { return host_; }
   Event::Dispatcher& dispatcher() { return dispatcher_; }
   Upstream::ResourcePriority priority() const { return priority_; }
   const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() { return socket_options_; }

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -60,7 +60,7 @@ ConnectionPool::Cancellable*
 HttpConnPoolImplBase::newStream(Http::ResponseDecoder& response_decoder,
                                 Http::ConnectionPool::Callbacks& callbacks) {
   HttpAttachContext context({&response_decoder, &callbacks});
-  return Envoy::ConnectionPool::ConnPoolImplBase::newStream(context);
+  return newStreamImpl(context);
 }
 
 bool HttpConnPoolImplBase::hasActiveConnections() const {

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -66,9 +66,7 @@ public:
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
                                          Http::ConnectionPool::Callbacks& callbacks) override;
-  bool maybePreconnect(float ratio) override {
-    return Envoy::ConnectionPool::ConnPoolImplBase::maybePreconnect(ratio);
-  }
+  bool maybePreconnect(float ratio) override { return maybePreconnectImpl(ratio); }
   bool hasActiveConnections() const override;
 
   // Creates a new PendingStream and enqueues it into the queue.

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -176,10 +176,10 @@ public:
   }
   ConnectionPool::Cancellable* newConnection(Tcp::ConnectionPool::Callbacks& callbacks) override {
     TcpAttachContext context(&callbacks);
-    return Envoy::ConnectionPool::ConnPoolImplBase::newStream(context);
+    return newStreamImpl(context);
   }
   bool maybePreconnect(float preconnect_ratio) override {
-    return Envoy::ConnectionPool::ConnPoolImplBase::maybePreconnect(preconnect_ratio);
+    return maybePreconnectImpl(preconnect_ratio);
   }
 
   ConnectionPool::Cancellable*

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -52,7 +52,7 @@ private:
   using HostInfoMap = absl::flat_hash_map<std::string, HostInfo>;
 
   class LoadBalancer : public Upstream::LoadBalancer {
-   public:
+  public:
     LoadBalancer(const Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancer
@@ -61,22 +61,24 @@ private:
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }
-   private:
+
+  private:
     const Cluster& cluster_;
   };
 
   class LoadBalancerFactory : public Upstream::LoadBalancerFactory {
-   public:
+  public:
     LoadBalancerFactory(Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancerFactory
     Upstream::LoadBalancerPtr create() override { return std::make_unique<LoadBalancer>(cluster_); }
-   private:
+
+  private:
     Cluster& cluster_;
   };
 
   class ThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBalancer {
-   public:
+  public:
     ThreadAwareLoadBalancer(Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::ThreadAwareLoadBalancer
@@ -85,7 +87,7 @@ private:
     }
     void initialize() override {}
 
-   private:
+  private:
     Cluster& cluster_;
   };
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -51,7 +51,8 @@ private:
 
   using HostInfoMap = absl::flat_hash_map<std::string, HostInfo>;
 
-  struct LoadBalancer : public Upstream::LoadBalancer {
+  class LoadBalancer : public Upstream::LoadBalancer {
+   public:
     LoadBalancer(const Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancer
@@ -60,20 +61,22 @@ private:
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }
-
+   private:
     const Cluster& cluster_;
   };
 
-  struct LoadBalancerFactory : public Upstream::LoadBalancerFactory {
+  class LoadBalancerFactory : public Upstream::LoadBalancerFactory {
+   public:
     LoadBalancerFactory(Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancerFactory
     Upstream::LoadBalancerPtr create() override { return std::make_unique<LoadBalancer>(cluster_); }
-
+   private:
     Cluster& cluster_;
   };
 
-  struct ThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBalancer {
+  class ThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBalancer {
+   public:
     ThreadAwareLoadBalancer(Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::ThreadAwareLoadBalancer
@@ -82,6 +85,7 @@ private:
     }
     void initialize() override {}
 
+   private:
     Cluster& cluster_;
   };
 

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -178,17 +178,17 @@ TEST_F(ConnPoolImplBaseTest, ExplicitPreconnect) {
   EXPECT_CALL(pool_, instantiateActiveClient).Times(AnyNumber());
 
   // With global preconnect off, we won't preconnect.
-  EXPECT_FALSE(pool_.maybePreconnect(0));
+  EXPECT_FALSE(pool_.maybePreconnectImpl(0));
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*connecting capacity*/);
   // With preconnect ratio of 1.1, we'll preconnect two connections.
   // Currently, no number of subsequent calls to preconnect will increase that.
-  EXPECT_TRUE(pool_.maybePreconnect(1.1));
-  EXPECT_TRUE(pool_.maybePreconnect(1.1));
-  EXPECT_FALSE(pool_.maybePreconnect(1.1));
+  EXPECT_TRUE(pool_.maybePreconnectImpl(1.1));
+  EXPECT_TRUE(pool_.maybePreconnectImpl(1.1));
+  EXPECT_FALSE(pool_.maybePreconnectImpl(1.1));
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 2 /*connecting capacity*/);
 
   // With a higher preconnect ratio, more connections may be preconnected.
-  EXPECT_TRUE(pool_.maybePreconnect(3));
+  EXPECT_TRUE(pool_.maybePreconnectImpl(3));
 
   pool_.destructAllConnections();
 }
@@ -199,7 +199,7 @@ TEST_F(ConnPoolImplBaseTest, ExplicitPreconnectNotHealthy) {
 
   // Preconnect won't occur if the host is not healthy.
   host_->healthFlagSet(Upstream::Host::HealthFlag::DEGRADED_EDS_HEALTH);
-  EXPECT_FALSE(pool_.maybePreconnect(1));
+  EXPECT_FALSE(pool_.maybePreconnectImpl(1));
 }
 
 // Remote close simulates the peer closing the connection.

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -108,7 +108,7 @@ TEST_F(ConnPoolImplBaseTest, BasicPreconnect) {
   // On new stream, create 2 connections.
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*connecting capacity*/);
   EXPECT_CALL(pool_, instantiateActiveClient).Times(2);
-  auto cancelable = pool_.newStream(context_);
+  auto cancelable = pool_.newStreamImpl(context_);
   CHECK_STATE(0 /*active*/, 1 /*pending*/, 2 /*connecting capacity*/);
 
   cancelable->cancel(ConnectionPool::CancelPolicy::CloseExcess);
@@ -124,13 +124,13 @@ TEST_F(ConnPoolImplBaseTest, PreconnectOnDisconnect) {
 
   // On new stream, create 2 connections.
   EXPECT_CALL(pool_, instantiateActiveClient).Times(2);
-  pool_.newStream(context_);
+  pool_.newStreamImpl(context_);
   CHECK_STATE(0 /*active*/, 1 /*pending*/, 2 /*connecting capacity*/);
 
   // If a connection fails, existing connections are purged. If a retry causes
   // a new stream, make sure we create the correct number of connections.
   EXPECT_CALL(pool_, onPoolFailure).WillOnce(InvokeWithoutArgs([&]() -> void {
-    pool_.newStream(context_);
+    pool_.newStreamImpl(context_);
   }));
   EXPECT_CALL(pool_, instantiateActiveClient);
   clients_[0]->close();
@@ -149,7 +149,7 @@ TEST_F(ConnPoolImplBaseTest, NoPreconnectIfUnhealthy) {
 
   // On new stream, create 1 connection.
   EXPECT_CALL(pool_, instantiateActiveClient);
-  auto cancelable = pool_.newStream(context_);
+  auto cancelable = pool_.newStreamImpl(context_);
   CHECK_STATE(0 /*active*/, 1 /*pending*/, 1 /*connecting capacity*/);
 
   cancelable->cancel(ConnectionPool::CancelPolicy::CloseExcess);
@@ -166,7 +166,7 @@ TEST_F(ConnPoolImplBaseTest, NoPreconnectIfDegraded) {
 
   // On new stream, create 1 connection.
   EXPECT_CALL(pool_, instantiateActiveClient);
-  auto cancelable = pool_.newStream(context_);
+  auto cancelable = pool_.newStreamImpl(context_);
 
   cancelable->cancel(ConnectionPool::CancelPolicy::CloseExcess);
   pool_.destructAllConnections();
@@ -208,7 +208,7 @@ TEST_F(ConnPoolImplBaseTest, PoolIdleCallbackTriggeredRemoteClose) {
 
   // Create a new stream using the pool
   EXPECT_CALL(pool_, instantiateActiveClient);
-  pool_.newStream(context_);
+  pool_.newStreamImpl(context_);
   ASSERT_EQ(1, clients_.size());
 
   // Emulate the new upstream connection establishment
@@ -236,7 +236,7 @@ TEST_F(ConnPoolImplBaseTest, PoolIdleCallbackTriggeredLocalClose) {
 
   // Create a new stream using the pool
   EXPECT_CALL(pool_, instantiateActiveClient);
-  pool_.newStream(context_);
+  pool_.newStreamImpl(context_);
   ASSERT_EQ(1, clients_.size());
 
   // Emulate the new upstream connection establishment


### PR DESCRIPTION
A few minor cleanups.
* Add "Impl" suffix to methods in ConnPoolBaseImpl which shadow methods in ConnectionPool::Instance since ConnPoolBaseImpl does not actually implement this interfaces, but is extended by classes which *do* implement it and then need to disambiguate between the Base and Interface methods of the same name.
* Use early return to reduce nested code.
* Convert a few structs to classes since they extend classes

Risk Level: Low - No behavior change
Testing: N/A - No behavior change
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

