### PR TITLE
network: rename SocketAddressProvider as ConnectionInfoProvider

### DIFF
--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -194,8 +194,8 @@ public:
   /**
    * @return the address provider backing this connection.
    */
-  virtual const SocketAddressProvider& addressProvider() const PURE;
-  virtual SocketAddressProviderSharedPtr addressProviderSharedPtr() const PURE;
+  virtual const ConnectionInfoProvider& addressProvider() const PURE;
+  virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
 
   /**
    * Credentials of the peer of a socket as decided by SO_PEERCRED.

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -50,9 +50,9 @@ private:
  * TODO(soulxu): Since there are more than address information inside the provider, this will be
  * renamed as ConnectionInfoProvider. Ref https://github.com/envoyproxy/envoy/issues/17168
  */
-class SocketAddressProvider {
+class ConnectionInfoProvider {
 public:
-  virtual ~SocketAddressProvider() = default;
+  virtual ~ConnectionInfoProvider() = default;
 
   /**
    * @return the local address of the socket.
@@ -87,7 +87,7 @@ public:
   virtual absl::optional<uint64_t> connectionID() const PURE;
 
   /**
-   * Dumps the state of the SocketAddressProvider to the given ostream.
+   * Dumps the state of the ConnectionInfoProvider to the given ostream.
    *
    * @param os the std::ostream to dump to.
    * @param indent_level the level of indentation.
@@ -101,7 +101,7 @@ public:
   virtual Ssl::ConnectionInfoConstSharedPtr sslConnection() const PURE;
 };
 
-class SocketAddressSetter : public SocketAddressProvider {
+class SocketAddressSetter : public ConnectionInfoProvider {
 public:
   /**
    * Set the local address of the socket. On accepted sockets the local address defaults to the
@@ -146,7 +146,7 @@ public:
 };
 
 using SocketAddressSetterSharedPtr = std::shared_ptr<SocketAddressSetter>;
-using SocketAddressProviderSharedPtr = std::shared_ptr<const SocketAddressProvider>;
+using ConnectionInfoProviderSharedPtr = std::shared_ptr<const ConnectionInfoProvider>;
 
 /**
  * Base class for Sockets
@@ -164,8 +164,8 @@ public:
    * @return the address provider backing this socket.
    */
   virtual SocketAddressSetter& addressProvider() PURE;
-  virtual const SocketAddressProvider& addressProvider() const PURE;
-  virtual SocketAddressProviderSharedPtr addressProviderSharedPtr() const PURE;
+  virtual const ConnectionInfoProvider& addressProvider() const PURE;
+  virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
 
   /**
    * @return IoHandle for the underlying connection

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -101,7 +101,7 @@ public:
   virtual Ssl::ConnectionInfoConstSharedPtr sslConnection() const PURE;
 };
 
-class SocketAddressSetter : public ConnectionInfoProvider {
+class ConnectionInfoSetter : public ConnectionInfoProvider {
 public:
   /**
    * Set the local address of the socket. On accepted sockets the local address defaults to the
@@ -145,7 +145,7 @@ public:
   virtual void setSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
 };
 
-using SocketAddressSetterSharedPtr = std::shared_ptr<SocketAddressSetter>;
+using ConnectionInfoSetterSharedPtr = std::shared_ptr<ConnectionInfoSetter>;
 using ConnectionInfoProviderSharedPtr = std::shared_ptr<const ConnectionInfoProvider>;
 
 /**
@@ -163,7 +163,7 @@ public:
   /**
    * @return the address provider backing this socket.
    */
-  virtual SocketAddressSetter& addressProvider() PURE;
+  virtual ConnectionInfoSetter& addressProvider() PURE;
   virtual const ConnectionInfoProvider& addressProvider() const PURE;
   virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
 

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -466,7 +466,7 @@ public:
   /**
    * @return the downstream address provider.
    */
-  virtual const Network::SocketAddressProvider& downstreamAddressProvider() const PURE;
+  virtual const Network::ConnectionInfoProvider& downstreamAddressProvider() const PURE;
 
   /**
    * @param connection_info sets the upstream ssl connection.

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -588,7 +588,7 @@ public:
  * Private inheritance from ConnectionInfoProvider is used to make sure users get the address
  * provider via the normal getter.
  */
-class OverridableRemoteSocketAddressSetterStreamInfo : public StreamInfo::StreamInfoImpl,
+class OverridableRemoteConnectionInfoSetterStreamInfo : public StreamInfo::StreamInfoImpl,
                                                        private Network::ConnectionInfoProvider {
 public:
   using StreamInfoImpl::StreamInfoImpl;
@@ -638,7 +638,7 @@ public:
     StreamInfoImpl::dumpState(os, indent_level);
 
     const char* spaces = spacesForLevel(indent_level);
-    os << spaces << "OverridableRemoteSocketAddressSetterStreamInfo " << this
+    os << spaces << "OverridableRemoteConnectionInfoSetterStreamInfo " << this
        << DUMP_MEMBER_AS(remoteAddress(), remoteAddress()->asStringView())
        << DUMP_MEMBER_AS(directRemoteAddress(), directRemoteAddress()->asStringView())
        << DUMP_MEMBER_AS(localAddress(), localAddress()->asStringView()) << "\n";
@@ -1027,7 +1027,7 @@ private:
 
   FilterChainFactory& filter_chain_factory_;
   const LocalReply::LocalReply& local_reply_;
-  OverridableRemoteSocketAddressSetterStreamInfo stream_info_;
+  OverridableRemoteConnectionInfoSetterStreamInfo stream_info_;
   // TODO(snowp): Once FM has been moved to its own file we'll make these private classes of FM,
   // at which point they no longer need to be friends.
   friend ActiveStreamFilterBase;

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -589,7 +589,7 @@ public:
  * provider via the normal getter.
  */
 class OverridableRemoteConnectionInfoSetterStreamInfo : public StreamInfo::StreamInfoImpl,
-                                                       private Network::ConnectionInfoProvider {
+                                                        private Network::ConnectionInfoProvider {
 public:
   using StreamInfoImpl::StreamInfoImpl;
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -603,7 +603,9 @@ public:
   }
 
   // StreamInfo::StreamInfo
-  const Network::ConnectionInfoProvider& downstreamAddressProvider() const override { return *this; }
+  const Network::ConnectionInfoProvider& downstreamAddressProvider() const override {
+    return *this;
+  }
 
   // Network::ConnectionInfoProvider
   const Network::Address::InstanceConstSharedPtr& localAddress() const override {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -585,11 +585,11 @@ public:
 /**
  * This class allows the remote address to be overridden for HTTP stream info. This is used for
  * XFF handling. This is required to avoid providing stream info with a non-const address provider.
- * Private inheritance from SocketAddressProvider is used to make sure users get the address
+ * Private inheritance from ConnectionInfoProvider is used to make sure users get the address
  * provider via the normal getter.
  */
 class OverridableRemoteSocketAddressSetterStreamInfo : public StreamInfo::StreamInfoImpl,
-                                                       private Network::SocketAddressProvider {
+                                                       private Network::ConnectionInfoProvider {
 public:
   using StreamInfoImpl::StreamInfoImpl;
 
@@ -603,9 +603,9 @@ public:
   }
 
   // StreamInfo::StreamInfo
-  const Network::SocketAddressProvider& downstreamAddressProvider() const override { return *this; }
+  const Network::ConnectionInfoProvider& downstreamAddressProvider() const override { return *this; }
 
-  // Network::SocketAddressProvider
+  // Network::ConnectionInfoProvider
   const Network::Address::InstanceConstSharedPtr& localAddress() const override {
     return StreamInfoImpl::downstreamAddressProvider().localAddress();
   }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -72,10 +72,10 @@ public:
   void readDisable(bool disable) override;
   void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
   bool readEnabled() const override;
-  const SocketAddressProvider& addressProvider() const override {
+  const ConnectionInfoProvider& addressProvider() const override {
     return socket_->addressProvider();
   }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return socket_->addressProviderSharedPtr();
   }
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;

--- a/source/common/network/happy_eyeballs_connection_impl.cc
+++ b/source/common/network/happy_eyeballs_connection_impl.cc
@@ -155,11 +155,11 @@ bool HappyEyeballsConnectionImpl::readEnabled() const {
   return connections_[0]->readEnabled();
 }
 
-const SocketAddressProvider& HappyEyeballsConnectionImpl::addressProvider() const {
+const ConnectionInfoProvider& HappyEyeballsConnectionImpl::addressProvider() const {
   return connections_[0]->addressProvider();
 }
 
-SocketAddressProviderSharedPtr HappyEyeballsConnectionImpl::addressProviderSharedPtr() const {
+ConnectionInfoProviderSharedPtr HappyEyeballsConnectionImpl::addressProviderSharedPtr() const {
   return connections_[0]->addressProviderSharedPtr();
 }
 

--- a/source/common/network/happy_eyeballs_connection_impl.h
+++ b/source/common/network/happy_eyeballs_connection_impl.h
@@ -72,9 +72,9 @@ public:
   bool isHalfCloseEnabled() override;
   std::string nextProtocol() const override;
   // Note, this might change before connect finishes.
-  const SocketAddressProvider& addressProvider() const override;
+  const ConnectionInfoProvider& addressProvider() const override;
   // Note, this might change before connect finishes.
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override;
+  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override;
   // Note, this might change before connect finishes.
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;
   // Note, this might change before connect finishes.

--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -13,14 +13,14 @@ SocketImpl::SocketImpl(Socket::Type sock_type,
                        const Address::InstanceConstSharedPtr& address_for_io_handle,
                        const Address::InstanceConstSharedPtr& remote_address)
     : io_handle_(ioHandleForAddr(sock_type, address_for_io_handle)),
-      address_provider_(std::make_shared<SocketAddressSetterImpl>(nullptr, remote_address)),
+      address_provider_(std::make_shared<ConnectionInfoSetterImpl>(nullptr, remote_address)),
       sock_type_(sock_type), addr_type_(address_for_io_handle->type()) {}
 
 SocketImpl::SocketImpl(IoHandlePtr&& io_handle,
                        const Address::InstanceConstSharedPtr& local_address,
                        const Address::InstanceConstSharedPtr& remote_address)
     : io_handle_(std::move(io_handle)),
-      address_provider_(std::make_shared<SocketAddressSetterImpl>(local_address, remote_address)) {
+      address_provider_(std::make_shared<ConnectionInfoSetterImpl>(local_address, remote_address)) {
 
   if (address_provider_->localAddress() != nullptr) {
     addr_type_ = address_provider_->localAddress()->type();

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -8,9 +8,9 @@
 namespace Envoy {
 namespace Network {
 
-class SocketAddressSetterImpl : public SocketAddressSetter {
+class ConnectionInfoSetterImpl : public ConnectionInfoSetter {
 public:
-  SocketAddressSetterImpl(const Address::InstanceConstSharedPtr& local_address,
+  ConnectionInfoSetterImpl(const Address::InstanceConstSharedPtr& local_address,
                           const Address::InstanceConstSharedPtr& remote_address)
       : local_address_(local_address), remote_address_(remote_address),
         direct_remote_address_(remote_address) {}
@@ -21,14 +21,14 @@ public:
 
   void dumpState(std::ostream& os, int indent_level) const override {
     const char* spaces = spacesForLevel(indent_level);
-    os << spaces << "SocketAddressSetterImpl " << this
+    os << spaces << "ConnectionInfoSetterImpl " << this
        << DUMP_NULLABLE_MEMBER(remote_address_, remote_address_->asStringView())
        << DUMP_NULLABLE_MEMBER(direct_remote_address_, direct_remote_address_->asStringView())
        << DUMP_NULLABLE_MEMBER(local_address_, local_address_->asStringView())
        << DUMP_MEMBER(server_name_) << "\n";
   }
 
-  // SocketAddressSetter
+  // ConnectionInfoSetter
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }
   void setLocalAddress(const Address::InstanceConstSharedPtr& local_address) override {
     local_address_ = local_address;
@@ -72,7 +72,7 @@ public:
              const Address::InstanceConstSharedPtr& remote_address);
 
   // Network::Socket
-  SocketAddressSetter& addressProvider() override { return *address_provider_; }
+  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
@@ -128,7 +128,7 @@ protected:
              const Address::InstanceConstSharedPtr& remote_address);
 
   const IoHandlePtr io_handle_;
-  const std::shared_ptr<SocketAddressSetterImpl> address_provider_;
+  const std::shared_ptr<ConnectionInfoSetterImpl> address_provider_;
   OptionsSharedPtr options_;
   Socket::Type sock_type_;
   Address::Type addr_type_;

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -11,7 +11,7 @@ namespace Network {
 class ConnectionInfoSetterImpl : public ConnectionInfoSetter {
 public:
   ConnectionInfoSetterImpl(const Address::InstanceConstSharedPtr& local_address,
-                          const Address::InstanceConstSharedPtr& remote_address)
+                           const Address::InstanceConstSharedPtr& remote_address)
       : local_address_(local_address), remote_address_(remote_address),
         direct_remote_address_(remote_address) {}
 

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -73,8 +73,8 @@ public:
 
   // Network::Socket
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
-  const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   SocketPtr duplicate() override {

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -71,7 +71,7 @@ public:
   const Network::SocketAddressSetter& addressProvider() const override {
     return network_connection_->connectionSocket()->addressProvider();
   }
-  Network::SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return network_connection_->connectionSocket()->addressProviderSharedPtr();
   }
   absl::optional<Network::Connection::UnixDomainSocketPeerCredentials>

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -68,7 +68,7 @@ public:
   void readDisable(bool /*disable*/) override { ASSERT(false); }
   void detectEarlyCloseWhenReadDisabled(bool /*value*/) override { ASSERT(false); }
   bool readEnabled() const override { return true; }
-  const Network::SocketAddressSetter& addressProvider() const override {
+  const Network::ConnectionInfoSetter& addressProvider() const override {
     return network_connection_->connectionSocket()->addressProvider();
   }
   Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -36,18 +36,18 @@ const ReplacementMap& emptySpaceReplacement() {
 
 struct StreamInfoImpl : public StreamInfo {
   StreamInfoImpl(TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider,
+                 const Network::ConnectionInfoProviderSharedPtr& downstream_address_provider,
                  FilterState::LifeSpan life_span = FilterState::LifeSpan::FilterChain)
       : StreamInfoImpl(absl::nullopt, time_source, downstream_address_provider,
                        std::make_shared<FilterStateImpl>(life_span)) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider)
+                 const Network::ConnectionInfoProviderSharedPtr& downstream_address_provider)
       : StreamInfoImpl(protocol, time_source, downstream_address_provider,
                        std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider,
+                 const Network::ConnectionInfoProviderSharedPtr& downstream_address_provider,
                  FilterStateSharedPtr parent_filter_state, FilterState::LifeSpan life_span)
       : StreamInfoImpl(
             protocol, time_source, downstream_address_provider,
@@ -197,7 +197,7 @@ struct StreamInfoImpl : public StreamInfo {
 
   void healthCheck(bool is_health_check) override { health_check_request_ = is_health_check; }
 
-  const Network::SocketAddressProvider& downstreamAddressProvider() const override {
+  const Network::ConnectionInfoProvider& downstreamAddressProvider() const override {
     return *downstream_address_provider_;
   }
 
@@ -305,14 +305,14 @@ struct StreamInfoImpl : public StreamInfo {
   absl::optional<uint32_t> attempt_count_;
 
 private:
-  static Network::SocketAddressProviderSharedPtr emptyDownstreamAddressProvider() {
+  static Network::ConnectionInfoProviderSharedPtr emptyDownstreamAddressProvider() {
     MUTABLE_CONSTRUCT_ON_FIRST_USE(
-        Network::SocketAddressProviderSharedPtr,
+        Network::ConnectionInfoProviderSharedPtr,
         std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr));
   }
 
   StreamInfoImpl(absl::optional<Http::Protocol> protocol, TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider,
+                 const Network::ConnectionInfoProviderSharedPtr& downstream_address_provider,
                  FilterStateSharedPtr filter_state)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
@@ -325,7 +325,7 @@ private:
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
-  const Network::SocketAddressProviderSharedPtr downstream_address_provider_;
+  const Network::ConnectionInfoProviderSharedPtr downstream_address_provider_;
   Ssl::ConnectionInfoConstSharedPtr upstream_ssl_info_;
   std::string requested_server_name_;
   const Http::RequestHeaderMap* request_headers_{};

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -308,7 +308,7 @@ private:
   static Network::ConnectionInfoProviderSharedPtr emptyDownstreamAddressProvider() {
     MUTABLE_CONSTRUCT_ON_FIRST_USE(
         Network::ConnectionInfoProviderSharedPtr,
-        std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr));
+        std::make_shared<Network::ConnectionInfoSetterImpl>(nullptr, nullptr));
   }
 
   StreamInfoImpl(absl::optional<Http::Protocol> protocol, TimeSource& time_source,

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -205,7 +205,7 @@ HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSessio
     : ActiveHealthCheckSession(parent, host), parent_(parent),
       hostname_(getHostname(host, parent_.host_value_, parent_.cluster_.info())),
       protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)),
-      local_address_provider_(std::make_shared<Network::SocketAddressSetterImpl>(
+      local_address_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
           Network::Utility::getCanonicalIpv4LoopbackAddress(),
           Network::Utility::getCanonicalIpv4LoopbackAddress())) {}
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -141,7 +141,7 @@ private:
     Http::ResponseHeaderMapPtr response_headers_;
     const std::string& hostname_;
     const Http::Protocol protocol_;
-    Network::SocketAddressProviderSharedPtr local_address_provider_;
+    Network::ConnectionInfoProviderSharedPtr local_address_provider_;
     bool expect_reset_{};
     bool reuse_connection_ = false;
     bool request_in_flight_ = false;

--- a/source/server/active_udp_listener.cc
+++ b/source/server/active_udp_listener.cc
@@ -79,7 +79,7 @@ ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concu
     : ActiveRawUdpListener(worker_index, concurrency, parent, *listen_socket_ptr, listen_socket_ptr,
                            dispatcher, config) {}
 
-ActiveRawUdpListener:: ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
                                            Network::UdpConnectionHandler& parent,
                                            Network::Socket& listen_socket,
                                            Network::SocketSharedPtr listen_socket_ptr,

--- a/source/server/active_udp_listener.cc
+++ b/source/server/active_udp_listener.cc
@@ -79,7 +79,7 @@ ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concu
     : ActiveRawUdpListener(worker_index, concurrency, parent, *listen_socket_ptr, listen_socket_ptr,
                            dispatcher, config) {}
 
-ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+ActiveRawUdpListener:: ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
                                            Network::UdpConnectionHandler& parent,
                                            Network::Socket& listen_socket,
                                            Network::SocketSharedPtr listen_socket_ptr,

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -79,7 +79,7 @@ protected:
     class SyntheticConnection : public Network::Connection {
     public:
       SyntheticConnection(SyntheticReadCallbacks& parent)
-          : parent_(parent), address_provider_(std::make_shared<Network::SocketAddressSetterImpl>(
+          : parent_(parent), address_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
                                  parent.parent_.address_, parent.parent_.address_)),
             stream_info_(parent_.parent_.factory_context_.timeSource(), address_provider_),
             options_(std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>()) {}
@@ -120,7 +120,7 @@ protected:
       void readDisable(bool) override {}
       void detectEarlyCloseWhenReadDisabled(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
       bool readEnabled() const override { return true; }
-      const Network::SocketAddressSetter& addressProvider() const override {
+      const Network::ConnectionInfoSetter& addressProvider() const override {
         return *address_provider_;
       }
       Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
@@ -152,7 +152,7 @@ protected:
       void dumpState(std::ostream& os, int) const override { os << "SyntheticConnection"; }
 
       SyntheticReadCallbacks& parent_;
-      Network::SocketAddressSetterSharedPtr address_provider_;
+      Network::ConnectionInfoSetterSharedPtr address_provider_;
       StreamInfo::StreamInfoImpl stream_info_;
       Network::ConnectionSocket::OptionsSharedPtr options_;
       std::list<Network::ConnectionCallbacks*> callbacks_;

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -123,7 +123,7 @@ protected:
       const Network::SocketAddressSetter& addressProvider() const override {
         return *address_provider_;
       }
-      Network::SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+      Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
         return address_provider_;
       }
       absl::optional<Network::Connection::UnixDomainSocketPeerCredentials>

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -142,7 +142,7 @@ TEST_F(EnvoyAsyncClientImplTest, MetadataIsInitialized) {
       .WillOnce(Invoke([&http_callbacks](Http::HeaderMap&, bool) { http_callbacks->onReset(); }));
 
   // Prepare the parent context of this call.
-  auto address_provider = std::make_shared<Network::SocketAddressSetterImpl>(
+  auto address_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(expected_downstream_local_address), nullptr);
   StreamInfo::StreamInfoImpl stream_info{test_time_.timeSystem(), address_provider};
   Http::AsyncClient::ParentContext parent_context{&stream_info};

--- a/test/common/grpc/google_async_client_impl_test.cc
+++ b/test/common/grpc/google_async_client_impl_test.cc
@@ -135,7 +135,7 @@ TEST_F(EnvoyGoogleAsyncClientImplTest, MetadataIsInitialized) {
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::WellKnownGrpcStatus::Unavailable, ""));
 
   // Prepare the parent context of this call.
-  auto address_provider = std::make_shared<Network::SocketAddressSetterImpl>(
+  auto address_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(expected_downstream_local_address), nullptr);
   StreamInfo::StreamInfoImpl stream_info{test_time_.timeSystem(), address_provider};
   Http::AsyncClient::ParentContext parent_context{&stream_info};

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1918,7 +1918,7 @@ TEST_P(ConnectionImplTest, NetworkSocketDumpsWithoutAllocatingMemory) {
   const auto contents = ostream.contents();
   EXPECT_THAT(contents, HasSubstr("ListenSocketImpl"));
   EXPECT_THAT(contents, HasSubstr("transport_protocol_: "));
-  EXPECT_THAT(contents, HasSubstr("SocketAddressSetterImpl"));
+  EXPECT_THAT(contents, HasSubstr("ConnectionInfoSetterImpl"));
   if (GetParam() == Network::Address::IpVersion::v4) {
     EXPECT_THAT(
         contents,

--- a/test/common/network/happy_eyeballs_connection_impl_test.cc
+++ b/test/common/network/happy_eyeballs_connection_impl_test.cc
@@ -967,7 +967,7 @@ TEST_F(HappyEyeballsConnectionImplTest, AddressProvider) {
   connectFirstAttempt();
 
   const ConnectionInfoSetterImpl provider(std::make_shared<Address::Ipv4Instance>(80),
-                                         std::make_shared<Address::Ipv4Instance>(80));
+                                          std::make_shared<Address::Ipv4Instance>(80));
   EXPECT_CALL(*created_connections_[0], addressProvider()).WillOnce(ReturnRef(provider));
   impl_->addressProvider();
 }

--- a/test/common/network/happy_eyeballs_connection_impl_test.cc
+++ b/test/common/network/happy_eyeballs_connection_impl_test.cc
@@ -975,7 +975,7 @@ TEST_F(HappyEyeballsConnectionImplTest, AddressProvider) {
 TEST_F(HappyEyeballsConnectionImplTest, AddressProviderSharedPtr) {
   connectFirstAttempt();
 
-  SocketAddressProviderSharedPtr provider = std::make_shared<SocketAddressSetterImpl>(
+  ConnectionInfoProviderSharedPtr provider = std::make_shared<SocketAddressSetterImpl>(
       std::make_shared<Address::Ipv4Instance>("127.0.0.2"),
       std::make_shared<Address::Ipv4Instance>("127.0.0.1"));
   EXPECT_CALL(*created_connections_[0], addressProviderSharedPtr()).WillOnce(Return(provider));

--- a/test/common/network/happy_eyeballs_connection_impl_test.cc
+++ b/test/common/network/happy_eyeballs_connection_impl_test.cc
@@ -966,7 +966,7 @@ TEST_F(HappyEyeballsConnectionImplTest, NextProtocol) {
 TEST_F(HappyEyeballsConnectionImplTest, AddressProvider) {
   connectFirstAttempt();
 
-  const SocketAddressSetterImpl provider(std::make_shared<Address::Ipv4Instance>(80),
+  const ConnectionInfoSetterImpl provider(std::make_shared<Address::Ipv4Instance>(80),
                                          std::make_shared<Address::Ipv4Instance>(80));
   EXPECT_CALL(*created_connections_[0], addressProvider()).WillOnce(ReturnRef(provider));
   impl_->addressProvider();
@@ -975,7 +975,7 @@ TEST_F(HappyEyeballsConnectionImplTest, AddressProvider) {
 TEST_F(HappyEyeballsConnectionImplTest, AddressProviderSharedPtr) {
   connectFirstAttempt();
 
-  ConnectionInfoProviderSharedPtr provider = std::make_shared<SocketAddressSetterImpl>(
+  ConnectionInfoProviderSharedPtr provider = std::make_shared<ConnectionInfoSetterImpl>(
       std::make_shared<Address::Ipv4Instance>("127.0.0.2"),
       std::make_shared<Address::Ipv4Instance>("127.0.0.1"));
   EXPECT_CALL(*created_connections_[0], addressProviderSharedPtr()).WillOnce(Return(provider));

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -74,7 +74,7 @@ TEST_F(UpstreamRequestTest, DumpsStateWithoutAllocatingMemory) {
 
   // Check Contents
   EXPECT_THAT(ostream.contents(), HasSubstr("UpstreamRequest "));
-  EXPECT_THAT(ostream.contents(), HasSubstr("addressProvider: \n  SocketAddressSetterImpl "));
+  EXPECT_THAT(ostream.contents(), HasSubstr("addressProvider: \n  ConnectionInfoSetterImpl "));
   EXPECT_THAT(ostream.contents(), HasSubstr("request_headers: \n"));
 }
 

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -75,7 +75,7 @@ public:
   }
   bool healthCheck() const override { return health_check_request_; }
   void healthCheck(bool is_health_check) override { health_check_request_ = is_health_check; }
-  const Network::SocketAddressSetter& downstreamAddressProvider() const override {
+  const Network::ConnectionInfoSetter& downstreamAddressProvider() const override {
     return *downstream_address_provider_;
   }
 
@@ -241,8 +241,8 @@ public:
   bool health_check_request_{};
   std::string route_name_;
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
-  Network::SocketAddressSetterSharedPtr downstream_address_provider_{
-      std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr)};
+  Network::ConnectionInfoSetterSharedPtr downstream_address_provider_{
+      std::make_shared<Network::ConnectionInfoSetterImpl>(nullptr, nullptr)};
   Ssl::ConnectionInfoConstSharedPtr downstream_connection_info_;
   Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   Router::RouteConstSharedPtr route_;

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -166,7 +166,7 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
           : Network::Utility::resolveUrl("tcp://10.0.0.1:10000");
   test_stream_info->upstream_local_address_ = upstream_local_address;
   test_stream_info->downstream_address_provider_ =
-      std::make_shared<Network::SocketAddressSetterImpl>(address, address);
+      std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
   test_stream_info->downstream_address_provider_->setRequestedServerName(
       stream_info.requested_server_name());
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -65,8 +65,8 @@ public:
   MOCK_METHOD(void, readDisable, (bool disable));                                                  \
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
-  MOCK_METHOD(const ConnectionInfoProvider&, addressProvider, (), (const));                         \
-  MOCK_METHOD(ConnectionInfoProviderSharedPtr, addressProviderSharedPtr, (), (const));              \
+  MOCK_METHOD(const ConnectionInfoProvider&, addressProvider, (), (const));                        \
+  MOCK_METHOD(ConnectionInfoProviderSharedPtr, addressProviderSharedPtr, (), (const));             \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -65,8 +65,8 @@ public:
   MOCK_METHOD(void, readDisable, (bool disable));                                                  \
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
-  MOCK_METHOD(const SocketAddressProvider&, addressProvider, (), (const));                         \
-  MOCK_METHOD(SocketAddressProviderSharedPtr, addressProviderSharedPtr, (), (const));              \
+  MOCK_METHOD(const ConnectionInfoProvider&, addressProvider, (), (const));                         \
+  MOCK_METHOD(ConnectionInfoProviderSharedPtr, addressProviderSharedPtr, (), (const));              \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -133,7 +133,7 @@ MockFilterChainFactory::~MockFilterChainFactory() = default;
 
 MockListenSocket::MockListenSocket()
     : io_handle_(std::make_unique<NiceMock<MockIoHandle>>()),
-      address_provider_(std::make_shared<SocketAddressSetterImpl>(
+      address_provider_(std::make_shared<ConnectionInfoSetterImpl>(
           std::make_shared<Address::Ipv4Instance>(80), nullptr)) {
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, ioHandle()).WillByDefault(ReturnRef(*io_handle_));
@@ -158,7 +158,7 @@ MockSocketOption::~MockSocketOption() = default;
 MockConnectionSocket::MockConnectionSocket()
     : io_handle_(std::make_unique<IoSocketHandleImpl>()),
       address_provider_(
-          std::make_shared<SocketAddressSetterImpl>(std::make_shared<Address::Ipv4Instance>(80),
+          std::make_shared<ConnectionInfoSetterImpl>(std::make_shared<Address::Ipv4Instance>(80),
                                                     std::make_shared<Address::Ipv4Instance>(80))) {
   ON_CALL(*this, ioHandle()).WillByDefault(ReturnRef(*io_handle_));
   ON_CALL(testing::Const(*this), ioHandle()).WillByDefault(ReturnRef(*io_handle_));

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -159,7 +159,7 @@ MockConnectionSocket::MockConnectionSocket()
     : io_handle_(std::make_unique<IoSocketHandleImpl>()),
       address_provider_(
           std::make_shared<ConnectionInfoSetterImpl>(std::make_shared<Address::Ipv4Instance>(80),
-                                                    std::make_shared<Address::Ipv4Instance>(80))) {
+                                                     std::make_shared<Address::Ipv4Instance>(80))) {
   ON_CALL(*this, ioHandle()).WillByDefault(ReturnRef(*io_handle_));
   ON_CALL(testing::Const(*this), ioHandle()).WillByDefault(ReturnRef(*io_handle_));
   ON_CALL(*this, ipVersion())

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -243,7 +243,7 @@ public:
   void addOption(const Socket::OptionConstSharedPtr& option) override { addOption_(option); }
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
-  SocketAddressSetter& addressProvider() override { return *address_provider_; }
+  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
@@ -272,7 +272,7 @@ public:
   MOCK_METHOD(Api::SysCallIntResult, setBlockingForTest, (bool));
 
   std::unique_ptr<MockIoHandle> io_handle_;
-  Network::SocketAddressSetterSharedPtr address_provider_;
+  Network::ConnectionInfoSetterSharedPtr address_provider_;
   OptionsSharedPtr options_;
   bool socket_is_open_ = true;
 };
@@ -297,7 +297,7 @@ public:
   void addOption(const Socket::OptionConstSharedPtr& option) override { addOption_(option); }
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
-  SocketAddressSetter& addressProvider() override { return *address_provider_; }
+  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
@@ -334,7 +334,7 @@ public:
   MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));
 
   IoHandlePtr io_handle_;
-  std::shared_ptr<Network::SocketAddressSetterImpl> address_provider_;
+  std::shared_ptr<Network::ConnectionInfoSetterImpl> address_provider_;
   bool is_closed_;
 };
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -244,8 +244,8 @@ public:
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
-  const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   MOCK_METHOD(IoHandle&, ioHandle, ());
@@ -298,8 +298,8 @@ public:
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
-  const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   MOCK_METHOD(void, setDetectedTransportProtocol, (absl::string_view));

--- a/test/mocks/network/socket.h
+++ b/test/mocks/network/socket.h
@@ -15,8 +15,8 @@ public:
   ~MockSocket() override;
 
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
-  const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   IoHandle& ioHandle() override;

--- a/test/mocks/network/socket.h
+++ b/test/mocks/network/socket.h
@@ -14,7 +14,7 @@ public:
   MockSocket();
   ~MockSocket() override;
 
-  SocketAddressSetter& addressProvider() override { return *address_provider_; }
+  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
@@ -43,7 +43,7 @@ public:
   MOCK_METHOD(void, addOptions, (const Socket::OptionsSharedPtr&), (override));
 
   const std::unique_ptr<MockIoHandle> io_handle_;
-  Network::SocketAddressSetterSharedPtr address_provider_;
+  Network::ConnectionInfoSetterSharedPtr address_provider_;
 };
 
 } // namespace Network

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -18,7 +18,7 @@ namespace StreamInfo {
 MockStreamInfo::MockStreamInfo()
     : start_time_(ts_.systemTime()),
       filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
-      downstream_address_provider_(std::make_shared<Network::SocketAddressSetterImpl>(
+      downstream_address_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
           std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2"),
           std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"))) {
   ON_CALL(*this, setResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag response_flag) {

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -124,7 +124,7 @@ public:
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
-  std::shared_ptr<Network::SocketAddressSetterImpl> downstream_address_provider_;
+  std::shared_ptr<Network::ConnectionInfoSetterImpl> downstream_address_provider_;
   Ssl::ConnectionInfoConstSharedPtr downstream_connection_info_;
   Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   std::string route_name_;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -65,7 +65,7 @@ public:
   MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, upstreamLocalAddress, (), (const));
   MOCK_METHOD(bool, healthCheck, (), (const));
   MOCK_METHOD(void, healthCheck, (bool is_health_check));
-  MOCK_METHOD(const Network::SocketAddressProvider&, downstreamAddressProvider, (), (const));
+  MOCK_METHOD(const Network::ConnectionInfoProvider&, downstreamAddressProvider, (), (const));
   MOCK_METHOD(void, setUpstreamSslConnection, (const Ssl::ConnectionInfoConstSharedPtr&));
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, upstreamSslConnection, (), (const));
   MOCK_METHOD(Router::RouteConstSharedPtr, route, (), (const));

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -39,7 +39,7 @@ class MockFilterChainFactoryBuilder : public FilterChainFactoryBuilder {
 class MockConnectionSocket : public Network::ConnectionSocket {
 public:
   MockConnectionSocket()
-      : address_provider_(std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr)) {}
+      : address_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(nullptr, nullptr)) {}
 
   static std::unique_ptr<MockConnectionSocket>
   createMockConnectionSocket(uint16_t destination_port, const std::string& destination_address,
@@ -75,8 +75,8 @@ public:
   const std::vector<std::string>& requestedApplicationProtocols() const override {
     return application_protocols_;
   }
-  Network::SocketAddressSetter& addressProvider() override { return *address_provider_; }
-  const Network::SocketAddressSetter& addressProvider() const override {
+  Network::ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
+  const Network::ConnectionInfoSetter& addressProvider() const override {
     return *address_provider_;
   }
   Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
@@ -126,7 +126,7 @@ public:
 private:
   Network::IoHandlePtr io_handle_;
   OptionsSharedPtr options_;
-  std::shared_ptr<Network::SocketAddressSetterImpl> address_provider_;
+  std::shared_ptr<Network::ConnectionInfoSetterImpl> address_provider_;
   std::string server_name_;
   std::string transport_protocol_;
   std::vector<std::string> application_protocols_;

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -79,7 +79,7 @@ public:
   const Network::SocketAddressSetter& addressProvider() const override {
     return *address_provider_;
   }
-  Network::SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
 

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -247,7 +247,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
        validation_config.tests()) {
     active_runtime_ = check_config.input().runtime();
     headers_finalized_ = false;
-    auto address_provider = std::make_shared<Network::SocketAddressSetterImpl>(
+    auto address_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
         nullptr, Network::Utility::getCanonicalIpv4LoopbackAddress());
     Envoy::StreamInfo::StreamInfoImpl stream_info(Envoy::Http::Protocol::Http11,
                                                   factory_context_->dispatcher().timeSource(),


### PR DESCRIPTION
Commit Message: network: rename SocketAddressProvider as ConnectionInfoProvider
Additional Description:
Since SocketAddressProvider isn't only include the socket address info, also include the information for connection, like connection id, SSL connection info and SNI name. So rename it as ConnectionInfoProvider.
Risk Level: low
Testing: all
Docs Changes: n/a
Release Notes: n/a
Part of #17168
