### PR TITLE
Split VaryHeader into VaryAllowList and VaryUtils to organize vary-related logic

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -89,7 +89,7 @@ private:
   // of doing it per-request. A good example of such config is found in the gzip filter:
   // source/extensions/filters/http/gzip/gzip_filter.h.
   // Stores the allow list rules that decide if a header can be varied upon.
-  VaryHeader vary_allow_list_;
+  VaryAllowList vary_allow_list_;
 
   // True if the response has trailers.
   // TODO(toddmgreer): cache trailers.

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -248,7 +248,7 @@ bool VaryAllowList::allowsValue(const absl::string_view vary_value) const {
 }
 
 bool VaryAllowList::allowsHeaders(const Http::ResponseHeaderMap& headers) const {
-  if (!VaryUtils::hasVary(headers)) {
+  if (!VaryHeaderUtils::hasVary(headers)) {
     return true;
   }
 
@@ -276,14 +276,14 @@ bool VaryAllowList::allowsHeaders(const Http::ResponseHeaderMap& headers) const 
   return true;
 }
 
-bool VaryUtils::hasVary(const Http::ResponseHeaderMap& headers) {
+bool VaryHeaderUtils::hasVary(const Http::ResponseHeaderMap& headers) {
   // TODO(mattklein123): Support multiple vary headers and/or just make the vary header inline.
   const auto vary_header = headers.get(Http::CustomHeaders::get().Vary);
   return !vary_header.empty() && !vary_header[0]->value().empty();
 }
 
 absl::btree_set<absl::string_view>
-VaryUtils::getVaryValues(const Http::ResponseHeaderMap& headers) {
+VaryHeaderUtils::getVaryValues(const Http::ResponseHeaderMap& headers) {
   Http::HeaderMap::GetResult vary_headers = headers.get(Http::CustomHeaders::get().Vary);
   if (vary_headers.empty()) {
     return {};
@@ -306,7 +306,7 @@ constexpr absl::string_view inValueSeparator = "\r";
 }; // namespace
 
 absl::optional<std::string>
-VaryUtils::createVaryIdentifier(const VaryAllowList& allow_list,
+VaryHeaderUtils::createVaryIdentifier(const VaryAllowList& allow_list,
                                 const absl::btree_set<absl::string_view>& vary_header_values,
                                 const Http::RequestHeaderMap& request_headers) {
   std::string vary_identifier = "vary-id\n";

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -307,8 +307,8 @@ constexpr absl::string_view inValueSeparator = "\r";
 
 absl::optional<std::string>
 VaryHeaderUtils::createVaryIdentifier(const VaryAllowList& allow_list,
-                                const absl::btree_set<absl::string_view>& vary_header_values,
-                                const Http::RequestHeaderMap& request_headers) {
+                                      const absl::btree_set<absl::string_view>& vary_header_values,
+                                      const Http::RequestHeaderMap& request_headers) {
   std::string vary_identifier = "vary-id\n";
   if (vary_header_values.empty()) {
     return vary_identifier;

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -228,7 +228,7 @@ CacheHeadersUtils::parseCommaDelimitedHeader(const Http::HeaderMap::GetResult& e
   return values;
 }
 
-VaryHeader::VaryHeader(
+VaryAllowList::VaryAllowList(
     const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list) {
 
   for (const auto& rule : allow_list) {
@@ -238,17 +238,17 @@ VaryHeader::VaryHeader(
   }
 }
 
-bool VaryHeader::allowsHeader(const absl::string_view header) const {
+bool VaryAllowList::allowsValue(const absl::string_view vary_value) const {
   for (const auto& rule : allow_list_) {
-    if (rule->match(header)) {
+    if (rule->match(vary_value)) {
       return true;
     }
   }
   return false;
 }
 
-bool VaryHeader::isAllowed(const Http::ResponseHeaderMap& headers) const {
-  if (!VaryHeader::hasVary(headers)) {
+bool VaryAllowList::allowsHeaders(const Http::ResponseHeaderMap& headers) const {
+  if (!VaryUtils::hasVary(headers)) {
     return true;
   }
 
@@ -264,7 +264,7 @@ bool VaryHeader::isAllowed(const Http::ResponseHeaderMap& headers) const {
       return false;
     }
 
-    if (allowsHeader(header)) {
+    if (allowsValue(header)) {
       valid = true;
     }
 
@@ -276,14 +276,14 @@ bool VaryHeader::isAllowed(const Http::ResponseHeaderMap& headers) const {
   return true;
 }
 
-bool VaryHeader::hasVary(const Http::ResponseHeaderMap& headers) {
+bool VaryUtils::hasVary(const Http::ResponseHeaderMap& headers) {
   // TODO(mattklein123): Support multiple vary headers and/or just make the vary header inline.
   const auto vary_header = headers.get(Http::CustomHeaders::get().Vary);
   return !vary_header.empty() && !vary_header[0]->value().empty();
 }
 
 absl::btree_set<absl::string_view>
-VaryHeader::getVaryValues(const Http::ResponseHeaderMap& headers) {
+VaryUtils::getVaryValues(const Http::ResponseHeaderMap& headers) {
   Http::HeaderMap::GetResult vary_headers = headers.get(Http::CustomHeaders::get().Vary);
   if (vary_headers.empty()) {
     return {};
@@ -306,18 +306,20 @@ constexpr absl::string_view inValueSeparator = "\r";
 }; // namespace
 
 absl::optional<std::string>
-VaryHeader::createVaryIdentifier(const absl::btree_set<absl::string_view>& vary_header_values,
-                                 const Http::RequestHeaderMap& request_headers) const {
+VaryUtils::createVaryIdentifier(const VaryAllowList& allow_list,
+                                const absl::btree_set<absl::string_view>& vary_header_values,
+                                const Http::RequestHeaderMap& request_headers) {
   std::string vary_identifier = "vary-id\n";
   if (vary_header_values.empty()) {
     return vary_identifier;
   }
 
-  for (const absl::string_view& header : vary_header_values) {
-    if (header.empty()) {
+  for (const absl::string_view& value : vary_header_values) {
+    if (value.empty()) {
+      // Empty headers are ignored.
       continue;
     }
-    if (!allowsHeader(header)) {
+    if (!allow_list.allowsValue(value)) {
       // The backend tried to vary on a header that we don't allow, so return
       // absl::nullopt to indicate we are unable to cache this request. This
       // also may occur if the allow list has changed since an item was cached,
@@ -334,8 +336,8 @@ VaryHeader::createVaryIdentifier(const absl::btree_set<absl::string_view>& vary_
     // be used as an inspiration for some bucketing configuration. The config
     // should enable and control the bucketing wanted.
     const auto all_values = Http::HeaderUtility::getAllOfHeaderAsString(
-        request_headers, Http::LowerCaseString(std::string(header)), inValueSeparator);
-    absl::StrAppend(&vary_identifier, header, inValueSeparator,
+        request_headers, Http::LowerCaseString(std::string(value)), inValueSeparator);
+    absl::StrAppend(&vary_identifier, value, inValueSeparator,
                     all_values.result().has_value() ? all_values.result().value() : "",
                     headerSeparator);
   }

--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -145,18 +145,17 @@ bool hasVary(const Http::ResponseHeaderMap& headers);
 
 // Retrieve all the individual header values from the provided response header
 // map across all vary header entries.
-absl::btree_set<absl::string_view>
-    getVaryValues(const Envoy::Http::ResponseHeaderMap& headers);
+absl::btree_set<absl::string_view> getVaryValues(const Envoy::Http::ResponseHeaderMap& headers);
 
 // Creates a single string combining the values of the varied headers from
 // entry_headers. Returns an absl::nullopt if no valid vary key can be created
 // and the response should not be cached (eg. when disallowed vary headers are
 // present in the response).
 absl::optional<std::string>
-    createVaryIdentifier(const VaryAllowList& allow_list,
-                         const absl::btree_set<absl::string_view>& vary_header_values,
-                         const Envoy::Http::RequestHeaderMap& request_headers);
-} // namespace
+createVaryIdentifier(const VaryAllowList& allow_list,
+                     const absl::btree_set<absl::string_view>& vary_header_values,
+                     const Envoy::Http::RequestHeaderMap& request_headers);
+} // namespace VaryHeaderUtils
 
 } // namespace Cache
 } // namespace HttpFilters

--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -139,25 +139,24 @@ private:
   std::vector<Matchers::StringMatcherPtr> allow_list_;
 };
 
-class VaryUtils {
-public:
-  // Checks if the headers contain a non-empty value in the Vary header.
-  static bool hasVary(const Http::ResponseHeaderMap& headers);
+namespace VaryHeaderUtils {
+// Checks if the headers contain a non-empty value in the Vary header.
+bool hasVary(const Http::ResponseHeaderMap& headers);
 
-  // Retrieve all the individual header values from the provided response header
-  // map across all vary header entries.
-  static absl::btree_set<absl::string_view>
-  getVaryValues(const Envoy::Http::ResponseHeaderMap& headers);
+// Retrieve all the individual header values from the provided response header
+// map across all vary header entries.
+absl::btree_set<absl::string_view>
+    getVaryValues(const Envoy::Http::ResponseHeaderMap& headers);
 
-  // Creates a single string combining the values of the varied headers from
-  // entry_headers. Returns an absl::nullopt if no valid vary key can be created
-  // and the response should not be cached (eg. when disallowed vary headers are
-  // present in the response).
-  static absl::optional<std::string>
-  createVaryIdentifier(const VaryAllowList& allow_list,
-                       const absl::btree_set<absl::string_view>& vary_header_values,
-                       const Envoy::Http::RequestHeaderMap& request_headers);
-};
+// Creates a single string combining the values of the varied headers from
+// entry_headers. Returns an absl::nullopt if no valid vary key can be created
+// and the response should not be cached (eg. when disallowed vary headers are
+// present in the response).
+absl::optional<std::string>
+    createVaryIdentifier(const VaryAllowList& allow_list,
+                         const absl::btree_set<absl::string_view>& vary_header_values,
+                         const Envoy::Http::RequestHeaderMap& request_headers);
+} // namespace
 
 } // namespace Cache
 } // namespace HttpFilters

--- a/source/extensions/filters/http/cache/cacheability_utils.cc
+++ b/source/extensions/filters/http/cache/cacheability_utils.cc
@@ -57,7 +57,7 @@ bool CacheabilityUtils::canServeRequestFromCache(const Http::RequestHeaderMap& h
 }
 
 bool CacheabilityUtils::isCacheableResponse(const Http::ResponseHeaderMap& headers,
-                                            const VaryHeader& vary_allow_list) {
+                                            const VaryAllowList& vary_allow_list) {
   absl::string_view cache_control =
       headers.getInlineValue(CacheCustomHeaders::responseCacheControl());
   ResponseCacheControl response_cache_control(cache_control);
@@ -74,7 +74,7 @@ bool CacheabilityUtils::isCacheableResponse(const Http::ResponseHeaderMap& heade
 
   return !response_cache_control.no_store_ &&
          cacheableStatusCodes().contains((headers.getStatusValue())) && has_validation_data &&
-         vary_allow_list.isAllowed(headers);
+         vary_allow_list.allowsHeaders(headers);
 }
 
 } // namespace Cache

--- a/source/extensions/filters/http/cache/cacheability_utils.h
+++ b/source/extensions/filters/http/cache/cacheability_utils.h
@@ -24,7 +24,7 @@ public:
   // https://httpwg.org/specs/rfc7234.html#response.cacheability. Head requests are not
   // cacheable. However, this function is never called for head requests.
   static bool isCacheableResponse(const Http::ResponseHeaderMap& headers,
-                                  const VaryHeader& vary_allow_list);
+                                  const VaryAllowList& vary_allow_list);
 };
 } // namespace Cache
 } // namespace HttpFilters

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -24,7 +24,7 @@ namespace HttpFilters {
 namespace Cache {
 
 LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, SystemTime timestamp,
-                             const VaryHeader& vary_allow_list)
+                             const VaryAllowList& vary_allow_list)
     : request_headers_(Http::createHeaderMap<Http::RequestHeaderMapImpl>(request_headers)),
       vary_allow_list_(vary_allow_list), timestamp_(timestamp) {
   // These ASSERTs check prerequisites. A request without these headers can't be looked up in cache;

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -186,7 +186,7 @@ class LookupRequest {
 public:
   // Prereq: request_headers's Path(), Scheme(), and Host() are non-null.
   LookupRequest(const Http::RequestHeaderMap& request_headers, SystemTime timestamp,
-                const VaryHeader& vary_allow_list);
+                const VaryAllowList& vary_allow_list);
 
   const RequestCacheControl& requestCacheControl() const { return request_cache_control_; }
 
@@ -207,7 +207,7 @@ public:
                                 ResponseMetadata&& metadata, uint64_t content_length) const;
 
   const Http::RequestHeaderMap& requestHeaders() const { return *request_headers_; }
-  const VaryHeader& varyAllowList() const { return vary_allow_list_; }
+  const VaryAllowList& varyAllowList() const { return vary_allow_list_; }
 
 private:
   void initializeRequestCacheControl(const Http::RequestHeaderMap& request_headers);
@@ -217,7 +217,7 @@ private:
   Key key_;
   std::vector<RawByteRange> request_range_spec_;
   Http::RequestHeaderMapPtr request_headers_;
-  const VaryHeader& vary_allow_list_;
+  const VaryAllowList& vary_allow_list_;
   // Time when this LookupRequest was created (in response to an HTTP request).
   SystemTime timestamp_;
   RequestCacheControl request_cache_control_;

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -86,7 +86,7 @@ public:
 private:
   void commit() {
     committed_ = true;
-    if (VaryHeader::hasVary(*response_headers_)) {
+    if (VaryUtils::hasVary(*response_headers_)) {
       cache_.varyInsert(key_, std::move(response_headers_), std::move(metadata_), body_.toString(),
                         request_headers_, vary_allow_list_);
     } else {
@@ -96,7 +96,7 @@ private:
 
   Key key_;
   const Http::RequestHeaderMap& request_headers_;
-  const VaryHeader& vary_allow_list_;
+  const VaryAllowList& vary_allow_list_;
   Http::ResponseHeaderMapPtr response_headers_;
   ResponseMetadata metadata_;
   SimpleHttpCache& cache_;
@@ -124,7 +124,7 @@ SimpleHttpCache::Entry SimpleHttpCache::lookup(const LookupRequest& request) {
   }
   ASSERT(iter->second.response_headers_);
 
-  if (VaryHeader::hasVary(*iter->second.response_headers_)) {
+  if (VaryUtils::hasVary(*iter->second.response_headers_)) {
     return varyLookup(request, iter->second.response_headers_);
   } else {
     return SimpleHttpCache::Entry{
@@ -147,12 +147,12 @@ SimpleHttpCache::varyLookup(const LookupRequest& request,
   mutex_.AssertReaderHeld();
 
   absl::btree_set<absl::string_view> vary_header_values =
-      VaryHeader::getVaryValues(*response_headers);
+      VaryUtils::getVaryValues(*response_headers);
   ASSERT(!vary_header_values.empty());
 
   Key varied_request_key = request.key();
-  const absl::optional<std::string> vary_identifier =
-      request.varyAllowList().createVaryIdentifier(vary_header_values, request.requestHeaders());
+  const absl::optional<std::string> vary_identifier = VaryUtils::createVaryIdentifier(
+      request.varyAllowList(), vary_header_values, request.requestHeaders());
   if (!vary_identifier.has_value()) {
     // The vary allow list has changed and has made the vary header of this
     // cached value not cacheable.
@@ -175,17 +175,17 @@ void SimpleHttpCache::varyInsert(const Key& request_key,
                                  Http::ResponseHeaderMapPtr&& response_headers,
                                  ResponseMetadata&& metadata, std::string&& body,
                                  const Http::RequestHeaderMap& request_headers,
-                                 const VaryHeader& vary_allow_list) {
+                                 const VaryAllowList& vary_allow_list) {
   absl::WriterMutexLock lock(&mutex_);
 
   absl::btree_set<absl::string_view> vary_header_values =
-      VaryHeader::getVaryValues(*response_headers);
+      VaryUtils::getVaryValues(*response_headers);
   ASSERT(!vary_header_values.empty());
 
   // Insert the varied response.
   Key varied_request_key = request_key;
   const absl::optional<std::string> vary_identifier =
-      vary_allow_list.createVaryIdentifier(vary_header_values, request_headers);
+      VaryUtils::createVaryIdentifier(vary_allow_list, vary_header_values, request_headers);
   if (!vary_identifier.has_value()) {
     // Skip the insert if we are unable to create a vary key.
     return;

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -44,7 +44,8 @@ public:
   // Inserts a response that has been varied on certain headers.
   void varyInsert(const Key& request_key, Http::ResponseHeaderMapPtr&& response_headers,
                   ResponseMetadata&& metadata, std::string&& body,
-                  const Http::RequestHeaderMap& request_headers, const VaryHeader& vary_allow_list);
+                  const Http::RequestHeaderMap& request_headers,
+                  const VaryAllowList& vary_allow_list);
 
   absl::Mutex mutex_;
   absl::flat_hash_map<Key, Entry, MessageUtil, MessageUtil> map_ ABSL_GUARDED_BY(mutex_);

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -632,16 +632,16 @@ TEST_P(ParseCommaDelimitedHeaderTest, ParseCommaDelimitedHeader) {
 }
 
 TEST(CreateVaryIdentifier, IsStableForAllowListOrder) {
-  VaryHeader vary_allow_list1(toStringMatchers({"width", "accept", "accept-language"}));
-  VaryHeader vary_allow_list2(toStringMatchers({"accept", "width", "accept-language"}));
+  VaryAllowList vary_allow_list1(toStringMatchers({"width", "accept", "accept-language"}));
+  VaryAllowList vary_allow_list2(toStringMatchers({"accept", "width", "accept-language"}));
 
   Http::TestRequestHeaderMapImpl request_headers{
       {"accept", "image/*"}, {"accept-language", "en-us"}, {"width", "640"}};
 
-  absl::optional<std::string> vary_identifier1 = vary_allow_list1.createVaryIdentifier(
-      {"accept", "accept-language", "width"}, request_headers);
-  absl::optional<std::string> vary_identifier2 = vary_allow_list2.createVaryIdentifier(
-      {"accept", "accept-language", "width"}, request_headers);
+  absl::optional<std::string> vary_identifier1 = VaryUtils::createVaryIdentifier(
+      vary_allow_list1, {"accept", "accept-language", "width"}, request_headers);
+  absl::optional<std::string> vary_identifier2 = VaryUtils::createVaryIdentifier(
+      vary_allow_list2, {"accept", "accept-language", "width"}, request_headers);
 
   ASSERT_TRUE(vary_identifier1.has_value());
   ASSERT_TRUE(vary_identifier2.has_value());
@@ -650,25 +650,25 @@ TEST(CreateVaryIdentifier, IsStableForAllowListOrder) {
 
 TEST(GetVaryValues, noVary) {
   Http::TestResponseHeaderMapImpl headers;
-  EXPECT_EQ(0, VaryHeader::getVaryValues(headers).size());
+  EXPECT_EQ(0, VaryUtils::getVaryValues(headers).size());
 }
 
 TEST(GetVaryValues, emptyVary) {
   Http::TestResponseHeaderMapImpl headers{{"vary", ""}};
-  EXPECT_EQ(0, VaryHeader::getVaryValues(headers).size());
+  EXPECT_EQ(0, VaryUtils::getVaryValues(headers).size());
 }
 
 TEST(GetVaryValues, singleVary) {
   Http::TestResponseHeaderMapImpl headers{{"vary", "accept"}};
-  absl::btree_set<absl::string_view> result_set = VaryHeader::getVaryValues(headers);
+  absl::btree_set<absl::string_view> result_set = VaryUtils::getVaryValues(headers);
   std::vector<absl::string_view> result(result_set.begin(), result_set.end());
   std::vector<absl::string_view> expected = {"accept"};
   EXPECT_EQ(expected, result);
 }
 
-TEST(GetVaryValues, multipleVaryHeaders) {
+TEST(GetVaryValues, multipleVaryAllowLists) {
   Http::TestResponseHeaderMapImpl headers{{"vary", "accept"}, {"vary", "origin"}};
-  absl::btree_set<absl::string_view> result_set = VaryHeader::getVaryValues(headers);
+  absl::btree_set<absl::string_view> result_set = VaryUtils::getVaryValues(headers);
   std::vector<absl::string_view> result(result_set.begin(), result_set.end());
   std::vector<absl::string_view> expected = {"accept", "origin"};
   EXPECT_EQ(expected, result);
@@ -676,96 +676,97 @@ TEST(GetVaryValues, multipleVaryHeaders) {
 
 TEST(HasVary, Null) {
   Http::TestResponseHeaderMapImpl headers;
-  EXPECT_FALSE(VaryHeader::hasVary(headers));
+  EXPECT_FALSE(VaryUtils::hasVary(headers));
 }
 
 TEST(HasVary, Empty) {
   Http::TestResponseHeaderMapImpl headers{{"vary", ""}};
-  EXPECT_FALSE(VaryHeader::hasVary(headers));
+  EXPECT_FALSE(VaryUtils::hasVary(headers));
 }
 
 TEST(HasVary, NotEmpty) {
   Http::TestResponseHeaderMapImpl headers{{"vary", "accept"}};
-  EXPECT_TRUE(VaryHeader::hasVary(headers));
+  EXPECT_TRUE(VaryUtils::hasVary(headers));
 }
 
 TEST(CreateVaryIdentifier, EmptyVaryEntry) {
   Http::TestRequestHeaderMapImpl request_headers{{"accept", "image/*"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({}, request_headers), "vary-id\n");
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {}, request_headers), "vary-id\n");
 }
 
 TEST(CreateVaryIdentifier, SingleHeaderExists) {
   Http::TestRequestHeaderMapImpl request_headers{{"accept", "image/*"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({"accept"}, request_headers), "vary-id\naccept\r"
-                                                                               "image/*\n");
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"accept"}, request_headers),
+            "vary-id\naccept\r"
+            "image/*\n");
 }
 
 TEST(CreateVaryIdentifier, SingleHeaderMissing) {
   Http::TestRequestHeaderMapImpl request_headers;
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({"accept"}, request_headers),
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"accept"}, request_headers),
             "vary-id\naccept\r\n");
 }
 
 TEST(CreateVaryIdentifier, MultipleHeadersAllExist) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"accept", "image/*"}, {"accept-language", "en-us"}, {"width", "640"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(
-      vary_allow_list.createVaryIdentifier({"accept", "accept-language", "width"}, request_headers),
-      "vary-id\naccept\r"
-      "image/*\naccept-language\r"
-      "en-us\nwidth\r640\n");
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"accept", "accept-language", "width"},
+                                            request_headers),
+            "vary-id\naccept\r"
+            "image/*\naccept-language\r"
+            "en-us\nwidth\r640\n");
 }
 
 TEST(CreateVaryIdentifier, MultipleHeadersSomeExist) {
   Http::TestResponseHeaderMapImpl response_headers{{"vary", "accept, accept-language, width"}};
   Http::TestRequestHeaderMapImpl request_headers{{"accept", "image/*"}, {"width", "640"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(
-      vary_allow_list.createVaryIdentifier({"accept", "accept-language", "width"}, request_headers),
-      "vary-id\naccept\r"
-      "image/*\naccept-language\r\nwidth\r640\n");
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"accept", "accept-language", "width"},
+                                            request_headers),
+            "vary-id\naccept\r"
+            "image/*\naccept-language\r\nwidth\r640\n");
 }
 
 TEST(CreateVaryIdentifier, ExtraRequestHeaders) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"accept", "image/*"}, {"heigth", "1280"}, {"width", "640"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({"accept", "width"}, request_headers),
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"accept", "width"}, request_headers),
             "vary-id\naccept\r"
             "image/*\nwidth\r640\n");
 }
 
 TEST(CreateVaryIdentifier, MultipleHeadersNoneExist) {
   Http::TestRequestHeaderMapImpl request_headers;
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(
-      vary_allow_list.createVaryIdentifier({"accept", "accept-language", "width"}, request_headers),
-      "vary-id\naccept\r\naccept-language\r\nwidth\r\n");
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"accept", "accept-language", "width"},
+                                            request_headers),
+            "vary-id\naccept\r\naccept-language\r\nwidth\r\n");
 }
 
 TEST(CreateVaryIdentifier, DifferentHeadersSameValue) {
   // Two requests with the same value for different headers must have different
   // vary-ids.
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
   Http::TestRequestHeaderMapImpl request_headers1{{"accept", "foo"}};
-  absl::optional<std::string> vary_identifier1 =
-      vary_allow_list.createVaryIdentifier({"accept", "accept-language"}, request_headers1);
+  absl::optional<std::string> vary_identifier1 = VaryUtils::createVaryIdentifier(
+      vary_allow_list, {"accept", "accept-language"}, request_headers1);
 
   Http::TestRequestHeaderMapImpl request_headers2{{"accept-language", "foo"}};
-  absl::optional<std::string> vary_identifier2 = vary_allow_list.createVaryIdentifier(
-      {"accept", "accept-language", "width"}, request_headers2);
+  absl::optional<std::string> vary_identifier2 = VaryUtils::createVaryIdentifier(
+      vary_allow_list, {"accept", "accept-language", "width"}, request_headers2);
 
   ASSERT_TRUE(vary_identifier1.has_value());
   ASSERT_TRUE(vary_identifier2.has_value());
@@ -774,25 +775,27 @@ TEST(CreateVaryIdentifier, DifferentHeadersSameValue) {
 
 TEST(CreateVaryIdentifier, MultiValueSameHeader) {
   Http::TestRequestHeaderMapImpl request_headers{{"width", "foo"}, {"width", "bar"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({"width"}, request_headers), "vary-id\nwidth\r"
-                                                                              "foo\r"
-                                                                              "bar\n");
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"width"}, request_headers),
+            "vary-id\nwidth\r"
+            "foo\r"
+            "bar\n");
 }
 
 TEST(CreateVaryIdentifier, DisallowedHeader) {
   Http::TestRequestHeaderMapImpl request_headers{{"width", "foo"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({"disallowed"}, request_headers), absl::nullopt);
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"disallowed"}, request_headers),
+            absl::nullopt);
 }
 
 TEST(CreateVaryIdentifier, DisallowedHeaderWithAllowedHeader) {
   Http::TestRequestHeaderMapImpl request_headers{{"width", "foo"}};
-  VaryHeader vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
+  VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(vary_allow_list.createVaryIdentifier({"disallowed,width"}, request_headers),
+  EXPECT_EQ(VaryUtils::createVaryIdentifier(vary_allow_list, {"disallowed,width"}, request_headers),
             absl::nullopt);
 }
 
@@ -812,56 +815,58 @@ envoy::extensions::filters::http::cache::v3alpha::CacheConfig getConfig() {
   return config;
 }
 
-class VaryHeaderTest : public testing::Test {
+class VaryAllowListTest : public testing::Test {
 protected:
-  VaryHeaderTest() : vary_allow_list_(getConfig().allowed_vary_headers()) {}
+  VaryAllowListTest() : vary_allow_list_(getConfig().allowed_vary_headers()) {}
 
-  VaryHeader vary_allow_list_;
+  VaryAllowList vary_allow_list_;
   Http::TestRequestHeaderMapImpl request_headers_;
   Http::TestResponseHeaderMapImpl response_headers_;
 };
 
-TEST_F(VaryHeaderTest, AllowsHeaderAccept) { EXPECT_TRUE(vary_allow_list_.allowsHeader("accept")); }
-
-TEST_F(VaryHeaderTest, AllowsHeaderWrongHeader) {
-  EXPECT_FALSE(vary_allow_list_.allowsHeader("wrong-header"));
+TEST_F(VaryAllowListTest, AllowsHeaderAccept) {
+  EXPECT_TRUE(vary_allow_list_.allowsValue("accept"));
 }
 
-TEST_F(VaryHeaderTest, AllowsHeaderEmpty) { EXPECT_FALSE(vary_allow_list_.allowsHeader("")); }
-
-TEST_F(VaryHeaderTest, IsAllowedNull) {
-  EXPECT_TRUE(vary_allow_list_.isAllowed(response_headers_));
+TEST_F(VaryAllowListTest, AllowsHeaderWrongHeader) {
+  EXPECT_FALSE(vary_allow_list_.allowsValue("wrong-header"));
 }
 
-TEST_F(VaryHeaderTest, IsAllowedEmpty) {
+TEST_F(VaryAllowListTest, AllowsHeaderEmpty) { EXPECT_FALSE(vary_allow_list_.allowsValue("")); }
+
+TEST_F(VaryAllowListTest, AllowsHeadersNull) {
+  EXPECT_TRUE(vary_allow_list_.allowsHeaders(response_headers_));
+}
+
+TEST_F(VaryAllowListTest, AllowsHeadersEmpty) {
   response_headers_.addCopy("vary", "");
-  EXPECT_TRUE(vary_allow_list_.isAllowed(response_headers_));
+  EXPECT_TRUE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
-TEST_F(VaryHeaderTest, IsAllowedSingle) {
+TEST_F(VaryAllowListTest, AllowsHeadersSingle) {
   response_headers_.addCopy("vary", "accept");
-  EXPECT_TRUE(vary_allow_list_.isAllowed(response_headers_));
+  EXPECT_TRUE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
-TEST_F(VaryHeaderTest, IsAllowedMultiple) {
+TEST_F(VaryAllowListTest, AllowsHeadersMultiple) {
   response_headers_.addCopy("vary", "accept");
-  EXPECT_TRUE(vary_allow_list_.isAllowed(response_headers_));
+  EXPECT_TRUE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
-TEST_F(VaryHeaderTest, NotIsAllowedStar) {
+TEST_F(VaryAllowListTest, NotAllowsHeadersStar) {
   // Should never be allowed, regardless of the allow_list.
   response_headers_.addCopy("vary", "*");
-  EXPECT_FALSE(vary_allow_list_.isAllowed(response_headers_));
+  EXPECT_FALSE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
-TEST_F(VaryHeaderTest, NotIsAllowedSingle) {
+TEST_F(VaryAllowListTest, NotAllowsHeadersSingle) {
   response_headers_.addCopy("vary", "wrong-header");
-  EXPECT_FALSE(vary_allow_list_.isAllowed(response_headers_));
+  EXPECT_FALSE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
-TEST_F(VaryHeaderTest, NotIsAllowedMixed) {
+TEST_F(VaryAllowListTest, NotAllowsHeadersMixed) {
   response_headers_.addCopy("vary", "accept, wrong-header");
-  EXPECT_FALSE(vary_allow_list_.isAllowed(response_headers_));
+  EXPECT_FALSE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
 } // namespace

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -693,7 +693,8 @@ TEST(CreateVaryIdentifier, EmptyVaryEntry) {
   Http::TestRequestHeaderMapImpl request_headers{{"accept", "image/*"}};
   VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {}, request_headers), "vary-id\n");
+  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {}, request_headers),
+            "vary-id\n");
 }
 
 TEST(CreateVaryIdentifier, SingleHeaderExists) {
@@ -718,8 +719,8 @@ TEST(CreateVaryIdentifier, MultipleHeadersAllExist) {
       {"accept", "image/*"}, {"accept-language", "en-us"}, {"width", "640"}};
   VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"accept", "accept-language", "width"},
-                                            request_headers),
+  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(
+                vary_allow_list, {"accept", "accept-language", "width"}, request_headers),
             "vary-id\naccept\r"
             "image/*\naccept-language\r"
             "en-us\nwidth\r640\n");
@@ -730,8 +731,8 @@ TEST(CreateVaryIdentifier, MultipleHeadersSomeExist) {
   Http::TestRequestHeaderMapImpl request_headers{{"accept", "image/*"}, {"width", "640"}};
   VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"accept", "accept-language", "width"},
-                                            request_headers),
+  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(
+                vary_allow_list, {"accept", "accept-language", "width"}, request_headers),
             "vary-id\naccept\r"
             "image/*\naccept-language\r\nwidth\r640\n");
 }
@@ -741,17 +742,18 @@ TEST(CreateVaryIdentifier, ExtraRequestHeaders) {
       {"accept", "image/*"}, {"heigth", "1280"}, {"width", "640"}};
   VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"accept", "width"}, request_headers),
-            "vary-id\naccept\r"
-            "image/*\nwidth\r640\n");
+  EXPECT_EQ(
+      VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"accept", "width"}, request_headers),
+      "vary-id\naccept\r"
+      "image/*\nwidth\r640\n");
 }
 
 TEST(CreateVaryIdentifier, MultipleHeadersNoneExist) {
   Http::TestRequestHeaderMapImpl request_headers;
   VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"accept", "accept-language", "width"},
-                                            request_headers),
+  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(
+                vary_allow_list, {"accept", "accept-language", "width"}, request_headers),
             "vary-id\naccept\r\naccept-language\r\nwidth\r\n");
 }
 
@@ -795,8 +797,9 @@ TEST(CreateVaryIdentifier, DisallowedHeaderWithAllowedHeader) {
   Http::TestRequestHeaderMapImpl request_headers{{"width", "foo"}};
   VaryAllowList vary_allow_list(toStringMatchers({"accept", "accept-language", "width"}));
 
-  EXPECT_EQ(VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"disallowed,width"}, request_headers),
-            absl::nullopt);
+  EXPECT_EQ(
+      VaryHeaderUtils::createVaryIdentifier(vary_allow_list, {"disallowed,width"}, request_headers),
+      absl::nullopt);
 }
 
 envoy::extensions::filters::http::cache::v3alpha::CacheConfig getConfig() {

--- a/test/extensions/filters/http/cache/cacheability_utils_test.cc
+++ b/test/extensions/filters/http/cache/cacheability_utils_test.cc
@@ -42,7 +42,7 @@ protected:
   Http::TestResponseHeaderMapImpl response_headers_ = {{":status", "200"},
                                                        {"date", "Sun, 06 Nov 1994 08:49:37 GMT"},
                                                        {"cache-control", cache_control_}};
-  VaryHeader vary_allow_list_;
+  VaryAllowList vary_allow_list_;
 };
 
 TEST_F(CanServeRequestFromCacheTest, CacheableRequest) {

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -46,7 +46,7 @@ public:
   Http::TestRequestHeaderMapImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {":scheme", "https"}, {":authority", "example.com"}};
 
-  VaryHeader vary_allow_list_;
+  VaryAllowList vary_allow_list_;
 
   static const SystemTime& currentTime() {
     CONSTRUCT_ON_FIRST_USE(SystemTime, Event::SimulatedTimeSystem().systemTime());

--- a/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -102,7 +102,7 @@ protected:
   Event::SimulatedTimeSystem time_source_;
   SystemTime current_time_ = time_source_.systemTime();
   DateFormatter formatter_{"%a, %d %b %Y %H:%M:%S GMT"};
-  VaryHeader vary_allow_list_;
+  VaryAllowList vary_allow_list_;
 };
 
 // Simple flow of putting in an item, getting it, deleting it.
@@ -261,7 +261,7 @@ TEST_F(SimpleHttpCacheTest, VaryResponses) {
   Protobuf::RepeatedPtrField<::envoy::type::matcher::v3::StringMatcher> proto_allow_list;
   ::envoy::type::matcher::v3::StringMatcher* matcher = proto_allow_list.Add();
   matcher->set_exact("width");
-  vary_allow_list_ = VaryHeader(proto_allow_list);
+  vary_allow_list_ = VaryAllowList(proto_allow_list);
   lookup(RequestPath);
   EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
 }


### PR DESCRIPTION
Commit Message: Split VaryHeader into VaryAllowList and VaryUtils to organize vary-related logic.
Additional Description: Just a refactor.
Risk Level: Low
Testing: Existing tests
Docs Changes: None
Release Notes: N/A
Platform Specific Features: N/A