### PR TITLE
ecds: create shared base class for DynamicFilterConfigProviderImpl

### DIFF
--- a/envoy/config/extension_config_provider.h
+++ b/envoy/config/extension_config_provider.h
@@ -35,9 +35,10 @@ public:
   virtual absl::optional<FactoryCallback> config() PURE;
 };
 
-template <class Factory, class FactoryCallback>
-class DynamicExtensionConfigProvider : public ExtensionConfigProvider<Factory, FactoryCallback> {
+template <class FactoryCallback> class DynamicExtensionConfigProviderBase {
 public:
+  virtual ~DynamicExtensionConfigProviderBase() = default;
+
   /**
    * Update the provider with a new configuration.
    * @param config is an extension factory callback to replace the existing configuration.
@@ -58,6 +59,10 @@ public:
    */
   virtual void applyDefaultConfiguration() PURE;
 };
+
+template <class Factory, class FactoryCallback>
+class DynamicExtensionConfigProvider : public DynamicExtensionConfigProviderBase<FactoryCallback>,
+                                       public ExtensionConfigProvider<Factory, FactoryCallback> {};
 
 } // namespace Config
 } // namespace Envoy

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -84,7 +84,7 @@ public:
   const std::string& name() override { return DynamicFilterConfigProviderImplBase::name(); }
   absl::optional<Envoy::Http::FilterFactoryCb> config() override { return tls_->config_; }
 
-  // Config::DynamicExtensionConfigProviderBase
+  // Config::DynamicExtensionConfigProvider
   void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&,
                       Config::ConfigAppliedCb cb) override {
     tls_.runOnAllThreads(

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -39,7 +39,7 @@ public:
                                       bool last_filter_in_filter_chain,
                                       const std::string& filter_chain_type);
 
-  virtual ~DynamicFilterConfigProviderImplBase();
+  ~DynamicFilterConfigProviderImplBase() override;
   const Init::Target& initTarget() const { return init_target_; }
 
   void validateTypeUrl(const std::string& type_url) const;
@@ -128,7 +128,7 @@ private:
 
   // Currently applied configuration to ensure that the main thread deletes the last reference to
   // it.
-  absl::optional<Envoy::Http::FilterFactoryCb> current_config_;
+  absl::optional<Envoy::Http::FilterFactoryCb> current_config_{absl::nullopt};
   const absl::optional<Envoy::Http::FilterFactoryCb> default_configuration_;
   ThreadLocal::TypedSlot<ThreadLocalConfig> tls_;
 };

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -29,30 +29,91 @@ class FilterConfigSubscription;
 using FilterConfigSubscriptionSharedPtr = std::shared_ptr<FilterConfigSubscription>;
 
 /**
+ * Base class for a filter config provider using discovery subscriptions.
+ **/
+class DynamicFilterConfigProviderImplBase
+    : public Config::DynamicExtensionConfigProviderBase<Envoy::Http::FilterFactoryCb> {
+public:
+  DynamicFilterConfigProviderImplBase(FilterConfigSubscriptionSharedPtr& subscription,
+                                      const absl::flat_hash_set<std::string>& require_type_urls,
+                                      bool last_filter_in_filter_chain,
+                                      const std::string& filter_chain_type);
+
+  virtual ~DynamicFilterConfigProviderImplBase();
+  const Init::Target& initTarget() const { return init_target_; }
+
+  void validateTypeUrl(const std::string& type_url) const;
+  void validateTerminalFilter(const std::string& name, const std::string& filter_type,
+                              bool is_terminal_filter);
+
+  const std::string& name();
+
+private:
+  FilterConfigSubscriptionSharedPtr subscription_;
+  const absl::flat_hash_set<std::string> require_type_urls_;
+
+  // Local initialization target to ensure that the subscription starts in
+  // case no warming is requested by any other filter config provider.
+  Init::TargetImpl init_target_;
+
+  const bool last_filter_in_filter_chain_;
+  const std::string filter_chain_type_;
+};
+
+/**
  * Implementation of a filter config provider using discovery subscriptions.
  **/
-class DynamicFilterConfigProviderImpl : public DynamicFilterConfigProvider {
+class DynamicFilterConfigProviderImpl : public DynamicFilterConfigProviderImplBase,
+                                        public DynamicFilterConfigProvider {
 public:
   DynamicFilterConfigProviderImpl(FilterConfigSubscriptionSharedPtr& subscription,
                                   const absl::flat_hash_set<std::string>& require_type_urls,
                                   Server::Configuration::FactoryContext& factory_context,
                                   Envoy::Http::FilterFactoryCb default_config,
                                   bool last_filter_in_filter_chain,
-                                  const std::string& filter_chain_type);
+                                  const std::string& filter_chain_type)
+      : DynamicFilterConfigProviderImplBase(subscription, require_type_urls,
+                                            last_filter_in_filter_chain, filter_chain_type),
+        default_configuration_(default_config ? absl::make_optional(default_config)
+                                              : absl::nullopt),
+        tls_(factory_context.threadLocal()) {
+    tls_.set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalConfig>(); });
+  };
 
-  ~DynamicFilterConfigProviderImpl() override;
-
-  void validateTypeUrl(const std::string& type_url) const;
-  void validateTerminalFilter(const std::string& name, const std::string& filter_type,
-                              bool is_terminal_filter);
   // Config::ExtensionConfigProvider
-  const std::string& name() override;
-  absl::optional<Envoy::Http::FilterFactoryCb> config() override;
+  const std::string& name() override { return DynamicFilterConfigProviderImplBase::name(); }
+  absl::optional<Envoy::Http::FilterFactoryCb> config() override { return tls_->config_; }
 
-  // Config::DynamicExtensionConfigProvider
+  // Config::DynamicExtensionConfigProviderBase
   void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&,
-                      Config::ConfigAppliedCb cb) override;
-  void onConfigRemoved(Config::ConfigAppliedCb cb) override;
+                      Config::ConfigAppliedCb cb) override {
+    tls_.runOnAllThreads(
+        [config, cb](OptRef<ThreadLocalConfig> tls) {
+          tls->config_ = config;
+          if (cb) {
+            cb();
+          }
+        },
+        [this, config]() {
+          // This happens after all workers have discarded the previous config so it can be safely
+          // deleted on the main thread by an update with the new config.
+          this->current_config_ = config;
+        });
+  }
+
+  void onConfigRemoved(Config::ConfigAppliedCb applied_on_all_threads) override {
+    tls_.runOnAllThreads(
+        [config = default_configuration_](OptRef<ThreadLocalConfig> tls) { tls->config_ = config; },
+        [this, applied_on_all_threads]() {
+          // This happens after all workers have discarded the previous config so it can be safely
+          // deleted on the main thread by an update with the new config.
+          this->current_config_ = default_configuration_;
+          if (applied_on_all_threads) {
+            applied_on_all_threads();
+          }
+        });
+  }
+
   void applyDefaultConfiguration() override {
     if (default_configuration_) {
       onConfigUpdate(*default_configuration_, "", nullptr);
@@ -65,21 +126,11 @@ private:
     absl::optional<Envoy::Http::FilterFactoryCb> config_{};
   };
 
-  FilterConfigSubscriptionSharedPtr subscription_;
-  const absl::flat_hash_set<std::string> require_type_urls_;
   // Currently applied configuration to ensure that the main thread deletes the last reference to
   // it.
-  absl::optional<Envoy::Http::FilterFactoryCb> current_config_{absl::nullopt};
+  absl::optional<Envoy::Http::FilterFactoryCb> current_config_;
   const absl::optional<Envoy::Http::FilterFactoryCb> default_configuration_;
   ThreadLocal::TypedSlot<ThreadLocalConfig> tls_;
-
-  // Local initialization target to ensure that the subscription starts in
-  // case no warming is requested by any other filter config provider.
-  Init::TargetImpl init_target_;
-
-  const bool last_filter_in_filter_chain_;
-  const std::string filter_chain_type_;
-  friend class FilterConfigProviderManagerImpl;
 };
 
 /**
@@ -156,8 +207,8 @@ private:
   // FilterConfigProviderManagerImpl maintains active subscriptions in a map.
   FilterConfigProviderManagerImpl& filter_config_provider_manager_;
   const std::string subscription_id_;
-  absl::flat_hash_set<DynamicFilterConfigProviderImpl*> filter_config_providers_;
-  friend class DynamicFilterConfigProviderImpl;
+  absl::flat_hash_set<DynamicFilterConfigProviderImplBase*> filter_config_providers_;
+  friend class DynamicFilterConfigProviderImplBase;
 
   // This must be the last since its destructor may call out to stats to report
   // on draining requests.


### PR DESCRIPTION
cc @kyessenov @lambdai

Commit Message:
ecds: create shared base class for DynamicFilterConfigProviderImpl

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description: Part of https://github.com/envoyproxy/envoy/issues/14696#issuecomment-897855672. The plan is to later change the signature of `onConfigUpdate` (as in #14717) and refactor more so that `DynamicExtensionConfigProviderBase` is no longer a template
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
#14696