### PR TITLE
Fix typo in cluster.proto

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -781,7 +781,7 @@ message Cluster {
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Additional options when handling HTTP1 requests.
-  // This has been deprecated in favor of http_protocol_options fields in the in the
+  // This has been deprecated in favor of http_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
   // http_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
@@ -797,7 +797,7 @@ message Cluster {
   // supports prior knowledge for upstream connections. Even if TLS is used
   // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
   // connections to happen over plain text.
-  // This has been deprecated in favor of http2_protocol_options fields in the in the
+  // This has been deprecated in favor of http2_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>`
   // message. http2_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -782,7 +782,7 @@ message Cluster {
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Additional options when handling HTTP1 requests.
-  // This has been deprecated in favor of http_protocol_options fields in the in the
+  // This has been deprecated in favor of http_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
   // http_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
@@ -798,7 +798,7 @@ message Cluster {
   // supports prior knowledge for upstream connections. Even if TLS is used
   // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
   // connections to happen over plain text.
-  // This has been deprecated in favor of http2_protocol_options fields in the in the
+  // This has been deprecated in favor of http2_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>`
   // message. http2_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -790,7 +790,7 @@ message Cluster {
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Additional options when handling HTTP1 requests.
-  // This has been deprecated in favor of http_protocol_options fields in the in the
+  // This has been deprecated in favor of http_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
   // http_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
@@ -806,7 +806,7 @@ message Cluster {
   // supports prior knowledge for upstream connections. Even if TLS is used
   // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
   // connections to happen over plain text.
-  // This has been deprecated in favor of http2_protocol_options fields in the in the
+  // This has been deprecated in favor of http2_protocol_options fields in the
   // :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>`
   // message. http2_protocol_options can be set via the cluster's
   // :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.


### PR DESCRIPTION
This patch fixes a super tiny typo `in the in the` in the comment line.

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a