### PR TITLE
Make health check loop wait for any required SDS secrets to be loaded…

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -44,6 +44,7 @@ Bug Fixes
 
 * access log: fix ``%UPSTREAM_CLUSTER%`` when used in http upstream access logs. Previously, it was always logging as an unset value.
 * access log: fix ``%UPSTREAM_CLUSTER%`` when used in http upstream access logs. Previously, it was always logging as an unset value.
+* active health checks: health checks using a TLS transport socket and secrets delivered via :ref:`SDS <config_secret_discovery_service>` will now wait until secrets are loaded before the first health check attempt. This should improve startup times by not having to wait for the :ref:`no_traffic_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_interval>` until the next attempt.
 * aws request signer: fix the AWS Request Signer extension to correctly normalize the path and query string to be signed according to AWS' guidelines, so that the hash on the server side matches. See `AWS SigV4 documentaion <https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html>`_.
 * cluster: delete pools when they're idle to fix unbounded memory use when using PROXY protocol upstream with tcp_proxy. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.conn_pool_delete_when_idle`` runtime guard to false.
 * hcm: remove deprecation for :ref:`xff_num_trusted_hops <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>` and forbid mixing ip detection extensions with old related knobs.

--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -249,6 +249,13 @@ public:
    * negotiation.
    */
   virtual bool supportsAlpn() const { return false; }
+
+  /**
+   * @param a callback to be invoked when the secrets required by the created transport
+   * sockets are ready. Will be invoked immediately if no secrets are required or if they
+   * are already loaded.
+   */
+  virtual void addReadyCb(std::function<void()> callback) PURE;
 };
 
 using TransportSocketFactoryPtr = std::unique_ptr<TransportSocketFactory>;

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -109,6 +109,16 @@ public:
       const envoy::config::core::v3::Metadata* metadata) const PURE;
 
   /**
+   * Register a callback to be invoked when secrets are ready for the health
+   * checking transport socket that corresponds to the provided metadata.
+   * @param callback supplies the callback to be invoked.
+   * @param metadata supplies the metadata to be used for resolving transport socket matches.
+   */
+  virtual void
+  addHealthCheckingReadyCb(std::function<void()> callback,
+                           const envoy::config::core::v3::Metadata* metadata) const PURE;
+
+  /**
    * @return host specific gauges.
    */
   virtual std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>>

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -35,6 +35,7 @@ public:
   createTransportSocket(TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return false; }
+  void addReadyCb(std::function<void()> callback) override { callback(); }
 };
 
 } // namespace Network

--- a/source/common/quic/quic_transport_socket_factory.h
+++ b/source/common/quic/quic_transport_socket_factory.h
@@ -51,6 +51,7 @@ public:
   bool implementsSecureTransport() const override { return true; }
   bool usesProxyProtocolOptions() const override { return false; }
   bool supportsAlpn() const override { return true; }
+  void addReadyCb(std::function<void()> callback) override { callback(); }
 
 protected:
   virtual void onSecretUpdated() PURE;

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -78,7 +78,7 @@ protected:
     ~ActiveHealthCheckSession() override;
     HealthTransition setUnhealthy(envoy::data::core::v3::HealthCheckFailureType type);
     void onDeferredDeleteBase();
-    void start() { onInitialInterval(); }
+    void start();
 
   protected:
     ActiveHealthCheckSession(HealthCheckerImplBase& parent, HostSharedPtr host);
@@ -107,6 +107,10 @@ protected:
     uint32_t num_unhealthy_{};
     uint32_t num_healthy_{};
     bool first_check_{true};
+
+    // lifetime_guard_ is used to ensure health checks are not started via a callback after this
+    // ActiveHealthCheckSession has been deleted.
+    std::shared_ptr<uint32_t> lifetime_guard_{};
   };
 
   using ActiveHealthCheckSessionPtr = std::unique_ptr<ActiveHealthCheckSession>;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -335,6 +335,14 @@ Network::ClientConnectionPtr HostImpl::createConnection(
   return connection;
 }
 
+void HostImpl::addHealthCheckingReadyCb(std::function<void()> callback,
+                                        const envoy::config::core::v3::Metadata* metadata) const {
+  Network::TransportSocketFactory& factory =
+      (metadata != nullptr) ? resolveTransportSocketFactory(healthCheckAddress(), metadata)
+                            : transportSocketFactory();
+  factory.addReadyCb(callback);
+}
+
 void HostImpl::weight(uint32_t new_weight) { weight_ = std::max(1U, new_weight); }
 
 std::vector<HostsPerLocalityConstSharedPtr> HostsPerLocalityImpl::filter(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -226,6 +226,9 @@ public:
       Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
       const envoy::config::core::v3::Metadata* metadata) const override;
 
+  void addHealthCheckingReadyCb(std::function<void()> callback,
+                                const envoy::config::core::v3::Metadata* metadata) const override;
+
   std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>>
   gauges() const override {
     return stats().gauges();

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -137,6 +137,8 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
 
+  void addReadyCb(std::function<void()> callback) override { callback(); };
+
 private:
   HandshakerFactory handshaker_factory_;
   HandshakeValidator handshake_validator_;

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
@@ -49,6 +49,7 @@ public:
   createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return true; }
+  void addReadyCb(std::function<void()> callback) override { callback(); };
 
 private:
   Network::TransportSocketFactoryPtr transport_socket_factory_;

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -78,6 +78,9 @@ public:
   bool implementsSecureTransport() const override { return false; }
   bool usesProxyProtocolOptions() const override { return false; }
 
+  // TODO(mpuncel) only invoke callback() once secrets are ready.
+  void addReadyCb(std::function<void()> callback) override { callback(); }
+
 private:
   Network::TransportSocketFactoryPtr raw_socket_factory_;
   Network::TransportSocketFactoryPtr tls_socket_factory_;

--- a/source/extensions/transport_sockets/tap/tap.h
+++ b/source/extensions/transport_sockets/tap/tap.h
@@ -43,6 +43,9 @@ public:
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override;
 
+  // TODO(mpuncel) only invoke callback() once secrets are ready.
+  void addReadyCb(std::function<void()> callback) override { callback(); };
+
 private:
   Network::TransportSocketFactoryPtr transport_socket_factory_;
 };

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -112,6 +112,8 @@ public:
   bool usesProxyProtocolOptions() const override { return false; }
   bool supportsAlpn() const override { return true; }
 
+  void addReadyCb(std::function<void()> callback) override;
+
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;
 
@@ -126,6 +128,9 @@ private:
   Envoy::Ssl::ClientContextConfigPtr config_;
   mutable absl::Mutex ssl_ctx_mu_;
   Envoy::Ssl::ClientContextSharedPtr ssl_ctx_ ABSL_GUARDED_BY(ssl_ctx_mu_);
+  mutable absl::Mutex secrets_ready_callbacks_mu_;
+  std::list<std::function<void()>>
+      secrets_ready_callbacks_ ABSL_GUARDED_BY(secrets_ready_callbacks_mu_);
 };
 
 class ServerSslSocketFactory : public Network::TransportSocketFactory,
@@ -141,6 +146,8 @@ public:
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return false; }
 
+  void addReadyCb(std::function<void()> callback) override;
+
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;
 
@@ -152,6 +159,9 @@ private:
   const std::vector<std::string> server_names_;
   mutable absl::Mutex ssl_ctx_mu_;
   Envoy::Ssl::ServerContextSharedPtr ssl_ctx_ ABSL_GUARDED_BY(ssl_ctx_mu_);
+  mutable absl::Mutex secrets_ready_callbacks_mu_;
+  std::list<std::function<void()>>
+      secrets_ready_callbacks_ ABSL_GUARDED_BY(secrets_ready_callbacks_mu_);
 };
 
 } // namespace Tls

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -33,6 +33,7 @@ public:
   MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsConstSharedPtr), (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>));
   FakeTransportSocketFactory(std::string id) : id_(std::move(id)) {}
   std::string id() const { return id_; }
 
@@ -49,6 +50,7 @@ public:
   MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsConstSharedPtr), (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>));
 
   Network::TransportSocketFactoryPtr
   createTransportSocketFactory(const Protobuf::Message& proto,

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -59,6 +59,7 @@ using testing::ContainsRegex;
 using testing::DoAll;
 using testing::InSequence;
 using testing::Invoke;
+using testing::MockFunction;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -4701,6 +4702,12 @@ TEST_P(SslSocketTest, DownstreamNotReadySslSocket) {
   ContextManagerImpl manager(time_system_);
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                    std::vector<std::string>{});
+
+  // Add a secrets ready callback that should not be invoked.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  server_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
   auto transport_socket = server_ssl_socket_factory.createTransportSocket(nullptr);
   EXPECT_EQ(EMPTY_STRING, transport_socket->protocol());
   EXPECT_EQ(nullptr, transport_socket->ssl());
@@ -4737,6 +4744,12 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
 
   ContextManagerImpl manager(time_system_);
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
+
+  // Add a secrets ready callback that should not be invoked.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  client_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
   auto transport_socket = client_ssl_socket_factory.createTransportSocket(nullptr);
   EXPECT_EQ(EMPTY_STRING, transport_socket->protocol());
   EXPECT_EQ(nullptr, transport_socket->ssl());
@@ -4747,6 +4760,183 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
   result = transport_socket->doWrite(buffer, true);
   EXPECT_EQ(Network::PostIoAction::Close, result.action_);
   EXPECT_EQ("TLS error: Secret is not supplied by SDS", transport_socket->failureReason());
+}
+
+// Validate that secrets callbacks are invoked when secrets become ready.
+TEST_P(SslSocketTest, ClientAddSecretsReadyCallback) {
+  Stats::TestUtil::TestStore stats_store;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(factory_context, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(factory_context, stats()).WillOnce(ReturnRef(stats_store));
+  EXPECT_CALL(factory_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(factory_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  auto sds_secret_configs =
+      tls_context.mutable_common_tls_context()->mutable_tls_certificate_sds_secret_configs()->Add();
+  sds_secret_configs->set_name("abc.com");
+  sds_secret_configs->mutable_sds_config();
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context);
+  EXPECT_TRUE(client_cfg->tlsCertificates().empty());
+  EXPECT_FALSE(client_cfg->isReady());
+
+  NiceMock<Ssl::MockContextManager> context_manager;
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), context_manager,
+                                                   stats_store);
+
+  // Add a secrets ready callback. It should not be invoked until onAddOrUpdateSecret() is called.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  client_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
+  // Call onAddOrUpdateSecret, but return a null ssl_ctx. This should not invoke the callback.
+  EXPECT_CALL(context_manager, createSslClientContext(_, _, _)).WillOnce(Return(nullptr));
+  client_ssl_socket_factory.onAddOrUpdateSecret();
+
+  EXPECT_CALL(mock_callback_, Call());
+  Ssl::ClientContextSharedPtr mock_context = std::make_shared<Ssl::MockClientContext>();
+  EXPECT_CALL(context_manager, createSslClientContext(_, _, _)).WillOnce(Return(mock_context));
+  client_ssl_socket_factory.onAddOrUpdateSecret();
+
+  // Add another callback, it should be invoked immediately.
+  MockFunction<void()> second_callback_;
+  EXPECT_CALL(second_callback_, Call());
+  client_ssl_socket_factory.addReadyCb(second_callback_.AsStdFunction());
+}
+
+// Validate that secrets callbacks are invoked when secrets become ready.
+TEST_P(SslSocketTest, ServerAddSecretsReadyCallback) {
+  Stats::TestUtil::TestStore stats_store;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(factory_context, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(factory_context, stats()).WillOnce(ReturnRef(stats_store));
+  EXPECT_CALL(factory_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(factory_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  auto sds_secret_configs =
+      tls_context.mutable_common_tls_context()->mutable_tls_certificate_sds_secret_configs()->Add();
+  sds_secret_configs->set_name("abc.com");
+  sds_secret_configs->mutable_sds_config();
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, factory_context);
+  EXPECT_TRUE(server_cfg->tlsCertificates().empty());
+  EXPECT_FALSE(server_cfg->isReady());
+
+  NiceMock<Ssl::MockContextManager> context_manager;
+  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), context_manager,
+                                                   stats_store, std::vector<std::string>{});
+
+  // Add a secrets ready callback. It should not be invoked until onAddOrUpdateSecret() is called.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  server_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
+  // Call onAddOrUpdateSecret, but return a null ssl_ctx. This should not invoke the callback.
+  EXPECT_CALL(context_manager, createSslServerContext(_, _, _, _)).WillOnce(Return(nullptr));
+  server_ssl_socket_factory.onAddOrUpdateSecret();
+
+  // Now return a ssl context which should result in the callback being invoked.
+  EXPECT_CALL(mock_callback_, Call());
+  Ssl::ServerContextSharedPtr mock_context = std::make_shared<Ssl::MockServerContext>();
+  EXPECT_CALL(context_manager, createSslServerContext(_, _, _, _)).WillOnce(Return(mock_context));
+  server_ssl_socket_factory.onAddOrUpdateSecret();
+
+  // Add another callback, it should be invoked immediately.
+  MockFunction<void()> second_callback_;
+  EXPECT_CALL(second_callback_, Call());
+  server_ssl_socket_factory.addReadyCb(second_callback_.AsStdFunction());
+}
+
+// Tests adding a callback and adding secrets in parallel. This is intended to
+// catch a race condition introduced in
+// https://github.com/envoyproxy/envoy/pull/13516 where a callback would never
+// be called due to a concurrency bug.
+TEST_P(SslSocketTest, ServerAddSecretsReadyCallbackParallel) {
+  Stats::TestUtil::TestStore stats_store;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(factory_context, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(factory_context, stats()).WillOnce(ReturnRef(stats_store));
+  EXPECT_CALL(factory_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(factory_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  auto sds_secret_configs =
+      tls_context.mutable_common_tls_context()->mutable_tls_certificate_sds_secret_configs()->Add();
+  sds_secret_configs->set_name("abc.com");
+  sds_secret_configs->mutable_sds_config();
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, factory_context);
+  EXPECT_TRUE(server_cfg->tlsCertificates().empty());
+  EXPECT_FALSE(server_cfg->isReady());
+
+  NiceMock<Ssl::MockContextManager> context_manager;
+  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), context_manager,
+                                                   stats_store, std::vector<std::string>{});
+
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call());
+  Ssl::ServerContextSharedPtr mock_context = std::make_shared<Ssl::MockServerContext>();
+  EXPECT_CALL(context_manager, createSslServerContext(_, _, _, _)).WillOnce(Return(mock_context));
+
+  // Add a callback in a thread to potentially tickle the concurrency bug.
+  std::thread t([&server_ssl_socket_factory, &mock_callback_]() {
+    server_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+  });
+
+  server_ssl_socket_factory.onAddOrUpdateSecret();
+
+  t.join();
+}
+
+// Tests adding a callback and adding secrets in parallel. This is intended to
+// catch a race condition introduced in
+// https://github.com/envoyproxy/envoy/pull/13516 where a callback would never
+// be called due to a concurrency bug.
+TEST_P(SslSocketTest, ClientAddSecretsReadyCallbackParallel) {
+  Stats::TestUtil::TestStore stats_store;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(factory_context, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(factory_context, stats()).WillOnce(ReturnRef(stats_store));
+  EXPECT_CALL(factory_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(factory_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  auto sds_secret_configs =
+      tls_context.mutable_common_tls_context()->mutable_tls_certificate_sds_secret_configs()->Add();
+  sds_secret_configs->set_name("abc.com");
+  sds_secret_configs->mutable_sds_config();
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context);
+  EXPECT_TRUE(client_cfg->tlsCertificates().empty());
+  EXPECT_FALSE(client_cfg->isReady());
+
+  NiceMock<Ssl::MockContextManager> context_manager;
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), context_manager,
+                                                   stats_store);
+
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call());
+  Ssl::ClientContextSharedPtr mock_context = std::make_shared<Ssl::MockClientContext>();
+  EXPECT_CALL(context_manager, createSslClientContext(_, _, _)).WillOnce(Return(mock_context));
+
+  // Add a callback in a thread to potentially tickle the concurrency bug.
+  std::thread t([&client_ssl_socket_factory, &mock_callback_]() {
+    client_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+  });
+
+  client_ssl_socket_factory.onAddOrUpdateSecret();
+
+  t.join();
 }
 
 TEST_P(SslSocketTest, TestTransportSocketCallback) {

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -41,6 +41,7 @@ public:
   MOCK_METHOD(bool, supportsAlpn, (), (const));
   MOCK_METHOD(TransportSocketPtr, createTransportSocket, (TransportSocketOptionsConstSharedPtr),
               (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>));
 };
 
 } // namespace Network

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -22,6 +22,9 @@ MockClientContextConfig::MockClientContextConfig() {
 }
 MockClientContextConfig::~MockClientContextConfig() = default;
 
+MockServerContext::MockServerContext() = default;
+MockServerContext::~MockServerContext() = default;
+
 MockServerContextConfig::MockServerContextConfig() = default;
 MockServerContextConfig::~MockServerContextConfig() = default;
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -107,6 +107,17 @@ public:
   std::string test_{};
 };
 
+class MockServerContext : public ServerContext {
+public:
+  MockServerContext();
+  ~MockServerContext() override;
+
+  MOCK_METHOD(size_t, daysUntilFirstCertExpires, (), (const));
+  MOCK_METHOD(absl::optional<uint64_t>, secondsUntilFirstOcspResponseExpires, (), (const));
+  MOCK_METHOD(CertificateDetailsPtr, getCaCertInformation, (), (const));
+  MOCK_METHOD(std::vector<CertificateDetailsPtr>, getCertChainInformation, (), (const));
+};
+
 class MockServerContextConfig : public ServerContextConfig {
 public:
   MockServerContextConfig();

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -198,6 +198,8 @@ public:
   MOCK_METHOD(void, priority, (uint32_t));
   MOCK_METHOD(bool, warmed, (), (const));
   MOCK_METHOD(MonotonicTime, creationTime, (), (const));
+  MOCK_METHOD(void, addHealthCheckingReadyCb,
+              (std::function<void()>, const envoy::config::core::v3::Metadata*), (const));
 
   testing::NiceMock<MockClusterInfo> cluster_;
   Network::TransportSocketFactoryPtr socket_factory_;


### PR DESCRIPTION
Commit Message: Make health check loop wait for any required SDS secrets to be loaded before starting.
Additional Description: This should avoid an issue where Envoy might take over a minute to warm clusters with default settings when SDS and active health checking are used. The issue was caused by health checks starting before secrets are ready and then waiting for no_traffic_interval (default 60s) before trying again. This change makes health checks wait for SDS secrets to be ready before starting.
Risk Level: Medium
Testing: Concurrency test covers the bug that caused this to be reverted initially, and was tested locally with --runs_per_test 100, confirming test failures when the bug is present and none when it was fixed.
Docs Changes: None
Release Notes: Included
Platform Specific Features: None
Fixes #12389, #15977, #17529