### PR TITLE
LocalReply: fix a bug of mistakenly truncating last \n character for non-json grpc-message

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -552,7 +552,8 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
       // status.
       // JsonFormatter adds a '\n' at the end. For header value, it should be removed.
       // https://github.com/envoyproxy/envoy/blob/main/source/common/formatter/substitution_formatter.cc#L129
-      if (body_text[body_text.length() - 1] == '\n') {
+      if (content_type == Headers::get().ContentTypeValues.Json &&
+          body_text[body_text.length() - 1] == '\n') {
         body_text = body_text.substr(0, body_text.length() - 1);
       }
       response_headers->setGrpcMessage(PercentEncoding::encode(body_text));

--- a/test/integration/local_reply_integration_test.cc
+++ b/test/integration/local_reply_integration_test.cc
@@ -197,6 +197,57 @@ body_format:
       expected_grpc_message));
 }
 
+// Like MapStatusCodeAndFormatToJson4Grpc, but to non-json format.
+// When grpc is plain text, the grpc-message should remains the same and envoy
+// should not truncate the trailing '\n' characters.
+TEST_P(LocalReplyIntegrationTest, MapStatusCodeAndFormat2Text4Grpc) {
+  const std::string yaml = R"EOF(
+body_format:
+  text_format_source:
+    inline_string: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
+)EOF";
+  setLocalReplyConfig(yaml);
+  initialize();
+
+  // Note: there should be an %0A at the end.
+  const std::string expected_grpc_message =
+      "upstream connect error or disconnect/reset before headers. reset reason:"
+      " connection termination:503:path=/package.service/method%0A";
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/package.service/method"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/grpc"}});
+  auto response = std::move(encoder_decoder.second);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  ASSERT_TRUE(fake_upstream_connection_->close());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  ASSERT_TRUE(response->waitForEndStream());
+
+  if (downstream_protocol_ == Http::CodecType::HTTP1) {
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+  } else {
+    codec_client_->close();
+  }
+
+  EXPECT_FALSE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("application/grpc", response->headers().ContentType()->value().getStringView());
+  EXPECT_EQ("14", response->headers().GrpcStatus()->value().getStringView());
+  // Check if grpc-message value is same as expected
+  EXPECT_EQ(std::string(response->headers().GrpcMessage()->value().getStringView()),
+            expected_grpc_message);
+}
+
 // Matched second filter has code, headers and body rewrite and its format
 TEST_P(LocalReplyIntegrationTest, MapStatusCodeAndFormatToJsonForFirstMatchingFilter) {
   const std::string yaml = R"EOF(


### PR DESCRIPTION
Signed-off-by: Yuhao Liu <yuhaoliu@google.com>

For gprc request with non-json format (plain text, for example), the grpc-message in response header
should return the same content percentage encoded.

There was a bug when the last character is \n, it will get truncated unconditionally
(see https://github.com/envoyproxy/envoy/blob/3aaea68d276eb7e512a610d4401cbd7412058034/source/common/http/utility.cc#L555)
and the data will be corrupted. This PR will check the `content_type`, and only do the truncation if it is JSON type.

Risk Level: low
Testing: integration test