### PR TITLE
Cache: Implemented a basic update_headers function for simple http cache filter

### DIFF
--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -109,11 +109,16 @@ LookupContextPtr SimpleHttpCache::makeLookupContext(LookupRequest&& request) {
   return std::make_unique<SimpleLookupContext>(*this, std::move(request));
 }
 
-void SimpleHttpCache::updateHeaders(const LookupContext&, const Http::ResponseHeaderMap&,
-                                    const ResponseMetadata&) {
-  // TODO(toddmgreer): Support updating headers.
-  // Not implemented yet, however this is called during tests
-  // NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
+                                    const Http::ResponseHeaderMap& response_headers,
+                                    const ResponseMetadata& metadata) {
+    // TODO(tangsaidi) handle Vary updates properly
+    absl::WriterMutexLock lock(&mutex_);
+    const auto& simple_lookup_context = static_cast<const SimpleLookupContext&>(lookup_context);
+    const Key& key = simple_lookup_context.request().key();
+    map_[key].response_headers_ =
+        Http::createHeaderMap<Http::ResponseHeaderMapImpl>(response_headers);
+    map_[key].metadata_ = metadata;
 }
 
 SimpleHttpCache::Entry SimpleHttpCache::lookup(const LookupRequest& request) {

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -182,7 +182,19 @@ TEST_P(CacheIntegrationTest, ExpiredValidated) {
     // a freshly served response from the origin, unless the 304 response has an Age header, which
     // means it was served by an upstream cache.
     EXPECT_EQ(response_decoder->headers().get(Http::CustomHeaders::get().Age).size(), 0);
+  }
+  
+  // Advance time to get a fresh cached response
+  simTime().advanceTimeWait(Seconds(1));
 
+  // Send third request. The cached response was validated, thus it should have an Age header like
+  // fresh responses
+  {
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+    EXPECT_THAT(response_decoder->headers(),
+        HeaderHasValueRef(Http::CustomHeaders::get().Age, "1"));
+    
     // Advance time to force a log flush.
     simTime().advanceTimeWait(Seconds(1));
     EXPECT_THAT(waitForAccessLog(access_log_name_, 1),

--- a/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -344,6 +344,14 @@ TEST_F(SimpleHttpCacheTest, UpdateHeadersAndMetadata) {
     EXPECT_TRUE(expectLookupSuccessWithHeaders(lookup(RequestPath1).get(), response_headers));
 }
 
+TEST_F(SimpleHttpCacheTest, UpdateHeadersForMissingKey) {
+    const std::string RequestPath1("Name");
+    Http::TestResponseHeaderMapImpl response_headers{{"date", formatter_.fromTime(current_time_)},
+                                                     {"cache-control", "public,max-age=3600"}};
+    updateHeaders(RequestPath1, response_headers, {current_time_});
+    EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
+}
+
 } // namespace
 } // namespace Cache
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message: Added an implementation for the update_headers function
Risk Level: Low
Testing: Unit, integration test
Fixes: #15830, a to-do item instead of a bug
Signed-off-by: tangsaidi@google.com


