### PR TITLE
kafka: fix integration test

### DIFF
--- a/contrib/kafka/filters/network/test/broker/integration_test/BUILD
+++ b/contrib/kafka/filters/network/test/broker/integration_test/BUILD
@@ -9,6 +9,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
 
+# This test sets up multiple services, and this can take variable amount of time (30-60 seconds).
 envoy_py_test(
     name = "kafka_broker_integration_test",
     srcs = [
@@ -16,14 +17,13 @@ envoy_py_test(
         "@kafka_python_client//:all",
     ],
     data = [
-        "//source/exe:envoy-static",
+        "//contrib/exe:envoy-static",
         "//bazel:remote_jdk11",
         "@kafka_server_binary//:all",
     ] + glob(["*.j2"]),
     flaky = True,
     python_version = "PY3",
     srcs_version = "PY3",
-    tags = ["manual"],
     deps = [
         requirement("Jinja2"),
         requirement("MarkupSafe"),

--- a/contrib/kafka/filters/network/test/broker/integration_test/kafka_broker_integration_test.py
+++ b/contrib/kafka/filters/network/test/broker/integration_test/kafka_broker_integration_test.py
@@ -441,15 +441,15 @@ class ServicesHolder:
     @staticmethod
     def find_envoy():
         """
-    This method locates envoy binary.
-    It's present at ./source/exe/envoy-static (at least for mac/bazel-asan/bazel-tsan),
-    or at ./external/envoy/source/exe/envoy-static (for bazel-compile_time_options).
-    """
+        This method locates envoy binary.
+        It's present at ./source/exe/envoy-static (at least for mac/bazel-asan/bazel-tsan),
+        or at ./external/envoy/source/exe/envoy-static (for bazel-compile_time_options).
+        """
 
-        candidate = os.path.join('.', 'source', 'exe', 'envoy-static')
+        candidate = os.path.join('.', 'contrib', 'exe', 'envoy-static')
         if os.path.isfile(candidate):
             return candidate
-        candidate = os.path.join('.', 'external', 'envoy', 'source', 'exe', 'envoy-static')
+        candidate = os.path.join('.', 'external', 'envoy', 'contrib', 'exe', 'envoy-static')
         if os.path.isfile(candidate):
             return candidate
         raise Exception("Could not find Envoy")


### PR DESCRIPTION
Commit Message: kafka: fix integration test
Additional Description: fix broker integration test (it was referencing the normal binary) + make integration test run automatic (as it's now in contrib/)
FWIW inttest duration:
Mac i7-7820HQ + 8GB ram -> 78 seconds
Ubuntu i5-9400? + 8GB ram -> 36 seconds
CI -> 43s
Risk Level: Low
Testing: Integration tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A