### PR TITLE
Fix for fuzz tests failing due to invalid corpus paths

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -303,7 +303,7 @@ envoy_proto_library(
 envoy_cc_fuzz_test(
     name = "random_load_balancer_fuzz_test",
     srcs = ["random_load_balancer_fuzz_test.cc"],
-    corpus = "//test/common/upstream:random_load_balancer_corpus",
+    corpus = "random_load_balancer_corpus",
     deps = [
         ":load_balancer_fuzz_lib",
         ":load_balancer_fuzz_proto_cc_proto",
@@ -803,7 +803,7 @@ envoy_proto_library(
 envoy_cc_fuzz_test(
     name = "round_robin_load_balancer_fuzz_test",
     srcs = ["round_robin_load_balancer_fuzz_test.cc"],
-    corpus = "//test/common/upstream:round_robin_load_balancer_corpus",
+    corpus = "round_robin_load_balancer_corpus",
     deps = [
         ":round_robin_load_balancer_fuzz_proto_cc_proto",
         ":utility_lib",
@@ -824,7 +824,7 @@ envoy_proto_library(
 envoy_cc_fuzz_test(
     name = "least_request_load_balancer_fuzz_test",
     srcs = ["least_request_load_balancer_fuzz_test.cc"],
-    corpus = "//test/common/upstream:least_request_load_balancer_corpus",
+    corpus = "least_request_load_balancer_corpus",
     deps = [
         ":least_request_load_balancer_fuzz_proto_cc_proto",
         ":utility_lib",

--- a/test/extensions/filters/common/expr/BUILD
+++ b/test/extensions/filters/common/expr/BUILD
@@ -52,7 +52,7 @@ envoy_proto_library(
 envoy_cc_fuzz_test(
     name = "evaluator_fuzz_test",
     srcs = ["evaluator_fuzz_test.cc"],
-    corpus = ":evaluator_corpus",
+    corpus = "evaluator_corpus",
     deps = [
         ":evaluator_fuzz_proto_cc_proto",
         "//source/extensions/filters/common/expr:evaluator_lib",


### PR DESCRIPTION
Risk Level: low

Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>
