### PR TITLE
conn_manager: sanitize and canonicalize urls in HTTP header's referer field

### DIFF
--- a/bazel/external/googleurl.patch
+++ b/bazel/external/googleurl.patch
@@ -87,3 +87,18 @@ index f2ec8da..4e2d55b 100644
 +       "//polyfills",
 +    ]
 +)
+
+diff --git a/build_config/build_config.bzl b/build_config/build_config.bzl
+index 117bc96..d231ebc 100644
+--- a/build_config/build_config.bzl
++++ b/build_config/build_config.bzl
+@@ -22,9 +22,6 @@ _url_linkopts = select({
+ 
+ _icuuc_deps = select({
+     "//build_config:with_system_icu": [],
+-
+-    # If we don't link against system ICU library, we must provide "@org_unicode_icuuc//:common".
+-    "//conditions:default": ["@org_unicode_icuuc//:common"],
+ })
+ 
+ build_config = struct(

--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -53,7 +53,7 @@ The *server* header will be set during encoding to the value in the :ref:`server
 referer
 -------
 
-The *referer* header will be sanitized during decoding. Multiple URLs or invalid URLs will be removed.
+The *referer* header will be sanitized during decoding. Multiple URLs or invalid URLs will be removed. Non-canonical URL will be canonicalized.
 
 .. _config_http_conn_man_headers_x-client-trace-id:
 

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -305,6 +305,7 @@ envoy_cc_library(
         "//source/common/stats:timespan_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tracing:http_tracer_lib",
+        "@com_googlesource_googleurl//url",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -109,7 +109,6 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
         // A request header shouldn't have multiple referer fields.
         request_headers.remove(Http::CustomHeaders::get().Referer);
       } else {
-        // std::string url_copy = std::string(result[0]->value().getStringView());
         auto url_string_view = result[0]->value().getStringView();
         GURL referer_url(gurl_base::StringPiece(url_string_view.data(), url_string_view.length()));
         request_headers.remove(Http::CustomHeaders::get().Referer);

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -266,6 +266,21 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMultipleEntriesAreFound) {
   EXPECT_TRUE(headers.get(Http::CustomHeaders::get().Referer).empty());
 }
 
+TEST_F(ConnectionManagerUtilityTest, CanonicalizeRefererURL) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.sanitize_http_header_referer", "true"}});
+
+  connection_.stream_info_.downstream_address_provider_->setRemoteAddress(
+      std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  TestRequestHeaderMapImpl headers{{"referer", "https://example.com"}};
+  EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ("https://example.com/",
+            headers.get(Http::CustomHeaders::get().Referer)[0]->value().getStringView());
+}
+
 TEST_F(ConnectionManagerUtilityTest, ValidRefererPassesSanitization) {
   TestScopedRuntime scoped_runtime;
   Runtime::LoaderSingleton::getExisting()->mergeValues(


### PR DESCRIPTION
Commit Message: Sanitize and canonicalize invalid urls in HTTP header's referer field
Risk Level: low
Testing: unit tests
Docs Changes: docs/root/configuration/http/http_conn_man/header_sanitizing.rst
Release Notes: docs/root/version_history/current.rst
Runtime guard: envoy.reloadable_features.sanitize_http_header_referer
Fixes https://github.com/envoyproxy/envoy-mobile/issues/1551
