### PR TITLE
ext_proc: Make tests more resilient to IPv6 support

### DIFF
--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -135,6 +135,7 @@ envoy_extension_cc_test_library(
     hdrs = ["test_processor.h"],
     extension_names = ["envoy.filters.http.ext_proc"],
     deps = [
+        "//envoy/network:address_interface",
         "@com_github_grpc_grpc//:grpc++",
         "@envoy_api//envoy/service/ext_proc/v3alpha:pkg_cc_grpc",
         "@envoy_api//envoy/service/ext_proc/v3alpha:pkg_cc_proto",

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -136,7 +136,9 @@ envoy_extension_cc_test_library(
     extension_names = ["envoy.filters.http.ext_proc"],
     deps = [
         "//envoy/network:address_interface",
+        "//test/test_common:network_utility_lib",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/strings:str_format",
         "@envoy_api//envoy/service/ext_proc/v3alpha:pkg_cc_grpc",
         "@envoy_api//envoy/service/ext_proc/v3alpha:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/ext_proc/ext_proc_grpc_fuzz.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_grpc_fuzz.cc
@@ -93,15 +93,9 @@ public:
       ConfigHelper::setHttp2(*processor_cluster);
 
       // Make sure both flavors of gRPC client use the right address.
-      if (ipVersion() == Network::Address::IpVersion::v4) {
-        const auto addr = std::make_shared<Network::Address::Ipv4Instance>(
-            Network::Test::getLoopbackAddressString(ipVersion()), test_processor_.port());
-        setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_server", addr);
-      } else {
-        const auto addr = std::make_shared<Network::Address::Ipv6Instance>(
-            Network::Test::getLoopbackAddressString(ipVersion()), test_processor_.port());
-        setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_server", addr);
-      }
+      const auto addr = Network::Test::getCanonicalLoopbackAddress(ipVersion());
+      const auto addr_port = Network::Utility::getAddressWithPort(*addr, test_processor_.port());
+      setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_server", addr_port);
 
       // Merge the filter.
       envoy::config::listener::v3::Filter ext_proc_filter;

--- a/test/extensions/filters/http/ext_proc/ext_proc_grpc_fuzz.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_grpc_fuzz.cc
@@ -252,6 +252,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   // external process to consume messages in a loop without blocking the fuzz
   // target from receiving the response.
   fuzzer.test_processor_.start(
+      fuzzer.ip_version_,
       [&fuzz_helper](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         while (true) {
           ProcessingRequest req;

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -23,6 +23,7 @@ using envoy::service::ext_proc::v3alpha::ProcessingRequest;
 using envoy::service::ext_proc::v3alpha::ProcessingResponse;
 
 using Http::LowerCaseString;
+using Network::Address::IpVersion;
 
 // The buffer size for the listeners
 static const uint32_t BufferSize = 100000;
@@ -57,7 +58,7 @@ protected:
                           ->mutable_endpoint()
                           ->mutable_address()
                           ->mutable_socket_address();
-      address->set_address("127.0.0.1");
+      address->set_address(ipVersion() == IpVersion::v4 ? "127.0.0.1" : "::1");
       address->set_port_value(test_processor_.port());
 
       // Ensure "HTTP2 with no prior knowledge." Necessary for gRPC.
@@ -66,9 +67,15 @@ protected:
       ConfigHelper::setHttp2(*processor_cluster);
 
       // Make sure both flavors of gRPC client use the right address.
-      const auto addr =
-          std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", test_processor_.port());
-      setGrpcService(*proto_config_.mutable_grpc_service(), "ext_proc_server", addr);
+      if (ipVersion() == IpVersion::v4) {
+        setGrpcService(
+            *proto_config_.mutable_grpc_service(), "ext_proc_server",
+            std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", test_processor_.port()));
+      } else {
+        setGrpcService(
+            *proto_config_.mutable_grpc_service(), "ext_proc_server",
+            std::make_shared<Network::Address::Ipv6Instance>("::1", test_processor_.port()));
+      }
 
       // Merge the filter.
       envoy::config::listener::v3::Filter ext_proc_filter;
@@ -141,7 +148,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessHeadersOnly) {
 
   // This starts the gRPC server in the background. It'll be shut down when we stop the tests.
   test_processor_.start(
-      [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+      ipVersion(), [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         // This is the same gRPC stream processing code that a "user" of ext_proc
         // would write. In this case, we expect to receive a request_headers
         // message, and then close the stream.
@@ -183,6 +190,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedRequestBody) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
+      ipVersion(),
       [total_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
@@ -223,6 +231,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBody) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
+      ipVersion(),
       [total_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         // Expect a request_headers message as the first message on the stream,
         // and send back an empty response.
@@ -274,7 +283,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyPartially) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
-      [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+      ipVersion(), [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
         ASSERT_TRUE(header_req.has_request_headers());
@@ -332,6 +341,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyAndClose) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
+      ipVersion(),
       [total_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
@@ -372,6 +382,7 @@ TEST_P(StreamingIntegrationTest, GetAndProcessBufferedResponseBody) {
   uint32_t response_size = 90000;
 
   test_processor_.start(
+      ipVersion(),
       [response_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
@@ -409,8 +420,8 @@ TEST_P(StreamingIntegrationTest, GetAndProcessStreamedResponseBody) {
   uint32_t response_size = 170000;
 
   test_processor_.start(
-      [this,
-       response_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+      ipVersion(), [this, response_size](
+                       grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
         ASSERT_TRUE(header_req.has_request_headers());
@@ -467,8 +478,8 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamBothBodies) {
   uint32_t response_size = 1700000;
 
   test_processor_.start(
-      [this, request_size,
-       response_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+      ipVersion(), [this, request_size, response_size](
+                       grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
         ASSERT_TRUE(header_req.has_request_headers());
@@ -554,7 +565,7 @@ TEST_P(StreamingIntegrationTest, PostAndStreamAndTransformBothBodies) {
   uint32_t response_size = 180000;
 
   test_processor_.start(
-      [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+      ipVersion(), [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
         ASSERT_TRUE(header_req.has_request_headers());
@@ -631,7 +642,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedRequestBodyTooBig) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
-      [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+      ipVersion(), [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
         ASSERT_TRUE(header_req.has_request_headers());
@@ -667,6 +678,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedPartialRequestBody) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
+      ipVersion(),
       [total_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));
@@ -709,6 +721,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedPartialBigRequestBody) {
   uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
+      ipVersion(),
       [total_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
         ProcessingRequest header_req;
         ASSERT_TRUE(stream->Read(&header_req));

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -23,7 +23,6 @@ using envoy::service::ext_proc::v3alpha::ProcessingRequest;
 using envoy::service::ext_proc::v3alpha::ProcessingResponse;
 
 using Http::LowerCaseString;
-using Network::Address::IpVersion;
 
 // The buffer size for the listeners
 static const uint32_t BufferSize = 100000;

--- a/test/extensions/filters/http/ext_proc/test_processor.cc
+++ b/test/extensions/filters/http/ext_proc/test_processor.cc
@@ -9,6 +9,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
+using Envoy::Network::Address::IpVersion;
+
 grpc::Status ProcessorWrapper::Process(
     grpc::ServerContext*,
     grpc::ServerReaderWriter<envoy::service::ext_proc::v3alpha::ProcessingResponse,
@@ -23,11 +25,12 @@ grpc::Status ProcessorWrapper::Process(
   return grpc::Status::OK;
 }
 
-void TestProcessor::start(ProcessingFunc cb) {
+void TestProcessor::start(IpVersion ip_version, ProcessingFunc cb) {
   wrapper_ = std::make_unique<ProcessorWrapper>(cb);
   grpc::ServerBuilder builder;
   builder.RegisterService(wrapper_.get());
-  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &listening_port_);
+  const char* address = ip_version == IpVersion::v4 ? "127.0.0.1:0" : "[::1]:0";
+  builder.AddListeningPort(address, grpc::InsecureServerCredentials(), &listening_port_);
   server_ = builder.BuildAndStart();
 }
 

--- a/test/extensions/filters/http/ext_proc/test_processor.h
+++ b/test/extensions/filters/http/ext_proc/test_processor.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <memory>
 
+#include "envoy/network/address.h"
 #include "envoy/service/ext_proc/v3alpha/external_processor.grpc.pb.h"
 #include "envoy/service/ext_proc/v3alpha/external_processor.pb.h"
 
@@ -41,10 +42,10 @@ private:
 // use ASSERT_ and EXPECT_ macros to validate test results.
 class TestProcessor {
 public:
-  // Start the processor listening on an ephemeral port (port 0) on 127.0.0.1.
+  // Start the processor listening on an ephemeral port (port 0) on the local host.
   // All new streams will be delegated to the specified function. The function
   // will be invoked in a background thread controlled by the gRPC server.
-  void start(ProcessingFunc cb);
+  void start(Network::Address::IpVersion ip_version, ProcessingFunc cb);
 
   // Stop the processor from listening once all streams are closed, and exit
   // the listening threads.

--- a/test/extensions/filters/http/ext_proc/test_processor.h
+++ b/test/extensions/filters/http/ext_proc/test_processor.h
@@ -45,7 +45,7 @@ public:
   // Start the processor listening on an ephemeral port (port 0) on the local host.
   // All new streams will be delegated to the specified function. The function
   // will be invoked in a background thread controlled by the gRPC server.
-  void start(Network::Address::IpVersion ip_version, ProcessingFunc cb);
+  void start(const Network::Address::IpVersion ip_version, ProcessingFunc cb);
 
   // Stop the processor from listening once all streams are closed, and exit
   // the listening threads.


### PR DESCRIPTION
Commit Message: ext_proc: Make tests more resilient to IPv6 support
Additional Description: Some ext_proc tests try to start a gRPC server that listens on the local
host address. The way we were doing it didn't work in IPv6-only
environments. Make the tests use the address type supplied by the
integration test framework to pick the right address.
Risk Level: Low
Testing: Makes tests more reliable
Docs Changes:
Release Notes:
Platform Specific Features:

