### PR TITLE
bazel: remove py_repositories call

### DIFF
--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -1,12 +1,9 @@
-load("@rules_python//python:repositories.bzl", "py_repositories")
 load("@rules_python//python:pip.bzl", "pip_install")
 load("@proxy_wasm_cpp_host//bazel/cargo:crates.bzl", "proxy_wasm_cpp_host_fetch_remote_crates")
 load("//bazel/external/cargo:crates.bzl", "raze_fetch_remote_crates")
 
 # Python dependencies.
 def _python_deps():
-    py_repositories()
-
     pip_install(
         name = "base_pip3",
         requirements = "@envoy//tools/base:requirements.txt",


### PR DESCRIPTION
This is no longer Necessary https://github.com/bazelbuild/rules_python/blob/0824042ce695be37c17a602824f175ffa491e20d/python/repositories.bzl

This fixes one of the warnings seen when building