### PR TITLE
Remove extra backquote in doc

### DIFF
--- a/docs/root/faq/debugging/why_is_envoy_sending_http2_resets.rst
+++ b/docs/root/faq/debugging/why_is_envoy_sending_http2_resets.rst
@@ -17,6 +17,6 @@ from the file "source/common/http/http2/codec_impl.cc" of the form
 for example:
 `invalid http2: Invalid HTTP header field was received: frame type: 1, stream: 1, name: [content-length], value: [3]`
 
-You can also check :ref:`HTTP/2 stats`<config_http_conn_man_stats_per_codec>`: in many cases where
+You can also check :ref:`HTTP/2 stats <config_http_conn_man_stats_per_codec>`: in many cases where
 Envoy resets streams, for example if there are more headers than allowed by configuration or flood
 detection kicks in, http2 counters will be incremented as the streams are reset.


### PR DESCRIPTION
This patch makes a super tiny fix by removing extra backquote in the doc.

You can see the extra backquote _HTTP/2 stats`_ in https://www.envoyproxy.io/docs/envoy/latest/faq/debugging/why_is_envoy_sending_http2_resets

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a