### PR TITLE
Remove `hidden_envoy_deprecated_use_http2`

### DIFF
--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -211,9 +211,6 @@ transport_socket_matches:
     health_check.mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(2);
     health_check.mutable_health_checks(0)->mutable_healthy_threshold()->set_value(2);
     health_check.mutable_health_checks(0)->mutable_grpc_health_check();
-    health_check.mutable_health_checks(0)
-        ->mutable_http_health_check()
-        ->set_hidden_envoy_deprecated_use_http2(false);
     health_check.mutable_health_checks(0)->mutable_http_health_check()->set_path("/healthcheck");
 
     return health_check;
@@ -851,9 +848,6 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   health_check->mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(2);
   health_check->mutable_health_checks(0)->mutable_healthy_threshold()->set_value(2);
   health_check->mutable_health_checks(0)->mutable_grpc_health_check();
-  health_check->mutable_health_checks(0)
-      ->mutable_http_health_check()
-      ->set_hidden_envoy_deprecated_use_http2(false);
   health_check->mutable_health_checks(0)->mutable_http_health_check()->set_path("/healthcheck");
 
   // Server asks for health checking with the new message


### PR DESCRIPTION
Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: LOW
Testing: CI

