### PR TITLE
common: support parsing cookies into a map

### DIFF
--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -256,6 +256,13 @@ std::string stripQueryString(const HeaderString& path);
 std::string parseCookieValue(const HeaderMap& headers, const std::string& key);
 
 /**
+ * Parse cookies from header into a map.
+ * @param headers supplies the headers to get cookies from.
+ * @return std::map cookie map.
+ **/
+std::map<std::string, std::string> parseCookies(const RequestHeaderMap& headers);
+
+/**
  * Parse a particular value out of a set-cookie
  * @param headers supplies the headers to get the set-cookie from.
  * @param key the key for the particular set-cookie value to return

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -138,9 +138,17 @@ FilterStats FilterConfig::generateStats(const std::string& prefix, Stats::Scope&
 
 void OAuth2CookieValidator::setParams(const Http::RequestHeaderMap& headers,
                                       const std::string& secret) {
-  expires_ = Http::Utility::parseCookieValue(headers, "OauthExpires");
-  token_ = Http::Utility::parseCookieValue(headers, "BearerToken");
-  hmac_ = Http::Utility::parseCookieValue(headers, "OauthHMAC");
+  const auto& cookies = Http::Utility::parseCookies(headers);
+
+  const auto expires_it = cookies.find("OauthExpires");
+  expires_ = expires_it != cookies.end() ? expires_it->second : EMPTY_STRING;
+
+  const auto token_it = cookies.find("BearerToken");
+  token_ = token_it != cookies.end() ? token_it->second : EMPTY_STRING;
+
+  const auto hmac_it = cookies.find("OauthHMAC");
+  hmac_ = hmac_it != cookies.end() ? hmac_it->second : EMPTY_STRING;
+
   host_ = headers.Host()->value().getStringView();
 
   secret_.assign(secret.begin(), secret.end());

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -598,6 +598,21 @@ TEST(HttpUtility, TestParseCookieWithQuotes) {
   EXPECT_EQ(Utility::parseCookieValue(headers, "leadingdquote"), "\"foobar");
 }
 
+TEST(HttpUtility, TestParseCookies) {
+  TestRequestHeaderMapImpl headers{
+      {"someheader", "10.0.0.1"},
+      {"cookie", "dquote=\"; quoteddquote=\"\"\""},
+      {"cookie", "leadingdquote=\"foobar;"},
+      {"cookie", "abc=def; token=\"abc123\"; Expires=Wed, 09 Jun 2021 10:18:14 GMT"}};
+
+  const auto& cookies = Utility::parseCookies(headers);
+
+  EXPECT_EQ(cookies.at("token"), "abc123");
+  EXPECT_EQ(cookies.at("dquote"), "\"");
+  EXPECT_EQ(cookies.at("quoteddquote"), "\"");
+  EXPECT_EQ(cookies.at("leadingdquote"), "\"foobar");
+}
+
 TEST(HttpUtility, TestParseSetCookieWithQuotes) {
   TestRequestHeaderMapImpl headers{
       {"someheader", "10.0.0.1"},


### PR DESCRIPTION
Added a method to HTTP Utilities to parse out cookies into a map.

Changed oauth2 extension to lookups from a cookie map to reduce
redundant scanning of cookies.

Risk Level: Low
Testing: Existing tests pass & added a new test for coverage.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Shubham Patil <theshubhamp@gmail.com>