### PR TITLE
Pure static classes to namespaces

### DIFF
--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -100,8 +100,8 @@ namespace CacheHeadersUtils {
 SystemTime httpTime(const Http::HeaderEntry* header_entry);
 
 // Calculates the age of a cached response
-Seconds calculateAge(const Http::ResponseHeaderMap& response_headers,
-                     SystemTime response_time, SystemTime now);
+Seconds calculateAge(const Http::ResponseHeaderMap& response_headers, SystemTime response_time,
+                     SystemTime now);
 
 /**
  * Read a leading positive decimal integer value and advance "*str" past the
@@ -117,12 +117,11 @@ void getAllMatchingHeaderNames(const Http::HeaderMap& headers,
 
 // Parses the values of a comma-delimited list as defined per
 // https://tools.ietf.org/html/rfc7230#section-7.
-std::vector<absl::string_view>
-    parseCommaDelimitedHeader(const Http::HeaderMap::GetResult& entry);
+std::vector<absl::string_view> parseCommaDelimitedHeader(const Http::HeaderMap::GetResult& entry);
 } // namespace CacheHeadersUtils
 
 class VaryAllowList {
- public:
+public:
   // Parses the allow list from the Cache Config into the object's private allow_list_.
   VaryAllowList(
       const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list);
@@ -133,7 +132,7 @@ class VaryAllowList {
   // Checks if this vary header value is allowed to vary cache entries.
   bool allowsValue(const absl::string_view header) const;
 
- private:
+private:
   // Stores the matching rules that define whether a header is allowed to be varied.
   std::vector<Matchers::StringMatcherPtr> allow_list_;
 };

--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -94,36 +94,35 @@ struct ResponseCacheControl {
 bool operator==(const RequestCacheControl& lhs, const RequestCacheControl& rhs);
 bool operator==(const ResponseCacheControl& lhs, const ResponseCacheControl& rhs);
 
-class CacheHeadersUtils {
-public:
-  // Parses header_entry as an HTTP time. Returns SystemTime() if
-  // header_entry is null or malformed.
-  static SystemTime httpTime(const Http::HeaderEntry* header_entry);
+namespace CacheHeadersUtils {
+// Parses header_entry as an HTTP time. Returns SystemTime() if
+// header_entry is null or malformed.
+SystemTime httpTime(const Http::HeaderEntry* header_entry);
 
-  // Calculates the age of a cached response
-  static Seconds calculateAge(const Http::ResponseHeaderMap& response_headers,
-                              SystemTime response_time, SystemTime now);
+// Calculates the age of a cached response
+Seconds calculateAge(const Http::ResponseHeaderMap& response_headers,
+                     SystemTime response_time, SystemTime now);
 
-  /**
-   * Read a leading positive decimal integer value and advance "*str" past the
-   * digits read. If overflow occurs, or no digits exist, return
-   * absl::nullopt without advancing "*str".
-   */
-  static absl::optional<uint64_t> readAndRemoveLeadingDigits(absl::string_view& str);
+/**
+ * Read a leading positive decimal integer value and advance "*str" past the
+ * digits read. If overflow occurs, or no digits exist, return
+ * absl::nullopt without advancing "*str".
+ */
+absl::optional<uint64_t> readAndRemoveLeadingDigits(absl::string_view& str);
 
-  // Add to out all header names from the given map that match any of the given rules.
-  static void getAllMatchingHeaderNames(const Http::HeaderMap& headers,
-                                        const std::vector<Matchers::StringMatcherPtr>& ruleset,
-                                        absl::flat_hash_set<absl::string_view>& out);
+// Add to out all header names from the given map that match any of the given rules.
+void getAllMatchingHeaderNames(const Http::HeaderMap& headers,
+                               const std::vector<Matchers::StringMatcherPtr>& ruleset,
+                               absl::flat_hash_set<absl::string_view>& out);
 
-  // Parses the values of a comma-delimited list as defined per
-  // https://tools.ietf.org/html/rfc7230#section-7.
-  static std::vector<absl::string_view>
-  parseCommaDelimitedHeader(const Http::HeaderMap::GetResult& entry);
-};
+// Parses the values of a comma-delimited list as defined per
+// https://tools.ietf.org/html/rfc7230#section-7.
+std::vector<absl::string_view>
+    parseCommaDelimitedHeader(const Http::HeaderMap::GetResult& entry);
+} // namespace CacheHeadersUtils
 
 class VaryAllowList {
-public:
+ public:
   // Parses the allow list from the Cache Config into the object's private allow_list_.
   VaryAllowList(
       const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list);
@@ -134,7 +133,7 @@ public:
   // Checks if this vary header value is allowed to vary cache entries.
   bool allowsValue(const absl::string_view header) const;
 
-private:
+ private:
   // Stores the matching rules that define whether a header is allowed to be varied.
   std::vector<Matchers::StringMatcherPtr> allow_list_;
 };

--- a/source/extensions/filters/http/cache/cacheability_utils.h
+++ b/source/extensions/filters/http/cache/cacheability_utils.h
@@ -8,24 +8,23 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
-class CacheabilityUtils {
-public:
-  // Checks if a request can be served from cache.
-  // This does not depend on cache-control headers as
-  // request cache-control headers only decide whether
-  // validation is required and whether the response can be cached.
-  static bool canServeRequestFromCache(const Http::RequestHeaderMap& headers);
+namespace CacheabilityUtils {
+// Checks if a request can be served from cache.
+// This does not depend on cache-control headers as
+// request cache-control headers only decide whether
+// validation is required and whether the response can be cached.
+bool canServeRequestFromCache(const Http::RequestHeaderMap& headers);
 
-  // Checks if a response can be stored in cache.
-  // Note that if a request is not cacheable according to 'canServeRequestFromCache'
-  // then its response is also not cacheable.
-  // Therefore, canServeRequestFromCache, isCacheableResponse and
-  // CacheFilter::request_allows_inserts_ together should cover
-  // https://httpwg.org/specs/rfc7234.html#response.cacheability. Head requests are not
-  // cacheable. However, this function is never called for head requests.
-  static bool isCacheableResponse(const Http::ResponseHeaderMap& headers,
-                                  const VaryAllowList& vary_allow_list);
-};
+// Checks if a response can be stored in cache.
+// Note that if a request is not cacheable according to 'canServeRequestFromCache'
+// then its response is also not cacheable.
+// Therefore, canServeRequestFromCache, isCacheableResponse and
+// CacheFilter::request_allows_inserts_ together should cover
+// https://httpwg.org/specs/rfc7234.html#response.cacheability. Head requests are not
+// cacheable. However, this function is never called for head requests.
+bool isCacheableResponse(const Http::ResponseHeaderMap& headers,
+                         const VaryAllowList& vary_allow_list);
+} // namespace CacheabilityUtils
 } // namespace Cache
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
Commit Message: Reviewer prefers namespaces to static classes (Envoy style guide doesn't mention this).
Additional Description: This is a followup from comments in https://github.com/envoyproxy/envoy/pull/17728
Risk Level: Very Low
Testing: Existing