### PR TITLE
coverage: revert the limit on http/cache to 92.6.

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -30,7 +30,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/common/expr:96.4"
 "source/extensions/filters/common/fault:94.6"
 "source/extensions/filters/common/rbac:88.6"
-"source/extensions/filters/http/cache:92.7"
+"source/extensions/filters/http/cache:92.6"
 "source/extensions/filters/http/cache/simple_http_cache:95.6"
 "source/extensions/filters/http/grpc_json_transcoder:95.6"
 "source/extensions/filters/http/ip_tagging:91.2"


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/17757 seems to cause the coverage failure of http/cache in unrelated PRs(e.g. https://github.com/envoyproxy/envoy/pull/17357/checks?check_run_id=3406159301) and main branch(https://github.com/envoyproxy/envoy/runs/3402140077) so this PR reverts that to 92.6.

cc @alyssawilk 