### PR TITLE
kafka: produce request for mesh-filter

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/BUILD
@@ -43,10 +43,12 @@ envoy_cc_library(
     deps = [
         ":abstract_command_lib",
         ":upstream_config_lib",
+        ":upstream_kafka_facade_lib",
         "//contrib/kafka/filters/network/source:kafka_request_codec_lib",
         "//contrib/kafka/filters/network/source:kafka_request_parser_lib",
         "//contrib/kafka/filters/network/source/mesh/command_handlers:api_versions_lib",
         "//contrib/kafka/filters/network/source/mesh/command_handlers:metadata_lib",
+        "//contrib/kafka/filters/network/source/mesh/command_handlers:produce_lib",
         "//source/common/common:minimal_logger_lib",
     ],
 )

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
@@ -11,6 +11,53 @@ envoy_contrib_package()
 # Handlers for particular Kafka requests that are used by Kafka-mesh filter.
 
 envoy_cc_library(
+    name = "produce_lib",
+    srcs = [
+        "produce.cc",
+    ],
+    hdrs = [
+        "produce.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":produce_outbound_record_lib",
+        ":produce_record_extractor_lib",
+        "//contrib/kafka/filters/network/source:kafka_request_parser_lib",
+        "//contrib/kafka/filters/network/source:kafka_response_parser_lib",
+        "//contrib/kafka/filters/network/source/mesh:abstract_command_lib",
+        "//contrib/kafka/filters/network/source/mesh:upstream_kafka_facade_lib",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "produce_outbound_record_lib",
+    srcs = [
+    ],
+    hdrs = [
+        "produce_outbound_record.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+    ],
+)
+
+envoy_cc_library(
+    name = "produce_record_extractor_lib",
+    srcs = [
+        "produce_record_extractor.cc",
+    ],
+    hdrs = [
+        "produce_record_extractor.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":produce_outbound_record_lib",
+        "//contrib/kafka/filters/network/source:kafka_request_parser_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "metadata_lib",
     srcs = [
         "metadata.cc",

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/produce.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/produce.cc
@@ -1,0 +1,116 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/produce.h"
+
+#include "contrib/kafka/filters/network/source/external/responses.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+constexpr static int16_t NO_ERROR = 0;
+
+ProduceRequestHolder::ProduceRequestHolder(AbstractRequestListener& filter,
+                                           UpstreamKafkaFacade& kafka_facade,
+                                           const std::shared_ptr<Request<ProduceRequest>> request)
+    : ProduceRequestHolder{filter, kafka_facade, PlaceholderRecordExtractor{}, request} {};
+
+ProduceRequestHolder::ProduceRequestHolder(AbstractRequestListener& filter,
+                                           UpstreamKafkaFacade& kafka_facade,
+                                           const RecordExtractor& record_extractor,
+                                           const std::shared_ptr<Request<ProduceRequest>> request)
+    : BaseInFlightRequest{filter}, kafka_facade_{kafka_facade}, request_{request} {
+  outbound_records_ = record_extractor.extractRecords(request_->data_.topics_);
+  expected_responses_ = outbound_records_.size();
+}
+
+void ProduceRequestHolder::startProcessing() {
+  // Main part of the proxy: for each outbound record we get the appropriate sink (effectively a
+  // facade for upstream Kafka cluster), and send the record to it.
+  for (const auto& outbound_record : outbound_records_) {
+    KafkaProducer& producer = kafka_facade_.getProducerForTopic(outbound_record.topic_);
+    // We need to provide our object as first argument, as we will want to be notified when the
+    // delivery finishes.
+    producer.send(shared_from_this(), outbound_record.topic_, outbound_record.partition_,
+                  outbound_record.key_, outbound_record.value_);
+  }
+  // Corner case handling:
+  // If we ever receive produce request without records, we need to notify the filter we are ready,
+  // because otherwise no notification will ever come from the real Kafka producer.
+  if (finished()) {
+    notifyFilter();
+  }
+}
+
+bool ProduceRequestHolder::finished() const { return 0 == expected_responses_; }
+
+// Find a record that matches provided delivery confirmation coming from Kafka producer.
+// If all the records got their delivery data filled in, we are done, and can notify the origin
+// filter.
+bool ProduceRequestHolder::accept(const DeliveryMemento& memento) {
+  for (auto& outbound_record : outbound_records_) {
+    if (outbound_record.value_.data() == memento.data_) {
+      // We have matched the downstream request that matches our confirmation from upstream Kafka.
+      outbound_record.error_code_ = memento.error_code_;
+      outbound_record.saved_offset_ = memento.offset_;
+      --expected_responses_;
+      if (finished()) {
+        // All elements had their responses matched.
+        ENVOY_LOG(trace, "All deliveries finished for produce request {}",
+                  request_->request_header_.correlation_id_);
+        notifyFilter();
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+AbstractResponseSharedPtr ProduceRequestHolder::computeAnswer() const {
+
+  // Header.
+  const RequestHeader& rh = request_->request_header_;
+  ResponseMetadata metadata = {rh.api_key_, rh.api_version_, rh.correlation_id_};
+
+  // Real answer.
+  using ErrorCodeAndOffset = std::pair<int16_t, uint32_t>;
+  std::map<std::string, std::map<int32_t, ErrorCodeAndOffset>> topic_to_partition_responses;
+  for (const auto& outbound_record : outbound_records_) {
+    auto& partition_map = topic_to_partition_responses[outbound_record.topic_];
+    auto it = partition_map.find(outbound_record.partition_);
+    if (it == partition_map.end()) {
+      partition_map[outbound_record.partition_] = {outbound_record.error_code_,
+                                                   outbound_record.saved_offset_};
+    } else {
+      // Proxy logic - aggregating multiple upstream answers into single downstream answer.
+      // Let's fail if anything fails, otherwise use the lowest offset (like Kafka would have done).
+      ErrorCodeAndOffset& curr = it->second;
+      if (NO_ERROR == curr.first) {
+        curr.first = outbound_record.error_code_;
+        curr.second = std::min(curr.second, outbound_record.saved_offset_);
+      }
+    }
+  }
+
+  std::vector<TopicProduceResponse> topic_responses;
+  for (const auto& topic_entry : topic_to_partition_responses) {
+    std::vector<PartitionProduceResponse> partition_responses;
+    for (const auto& partition_entry : topic_entry.second) {
+      const int32_t& partition = partition_entry.first;
+      const int16_t& error_code = partition_entry.second.first;
+      const int64_t& offset = partition_entry.second.second;
+      partition_responses.emplace_back(partition, error_code, offset);
+    }
+    const std::string& topic = topic_entry.first;
+    topic_responses.emplace_back(topic, partition_responses);
+  }
+
+  ProduceResponse data = {topic_responses, 0};
+  return std::make_shared<Response<ProduceResponse>>(metadata, data);
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/produce.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/produce.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "contrib/kafka/filters/network/source/external/requests.h"
+#include "contrib/kafka/filters/network/source/mesh/abstract_command.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/produce_outbound_record.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_client.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_facade.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+/**
+ * Kafka 'Produce' request, that is aimed at particular cluster.
+ * A single Produce request coming from downstream can map into multiple entries,
+ * as the topics can be hosted on different clusters.
+ */
+class ProduceRequestHolder : public BaseInFlightRequest,
+                             public ProduceFinishCb,
+                             public std::enable_shared_from_this<ProduceRequestHolder> {
+public:
+  ProduceRequestHolder(AbstractRequestListener& filter, UpstreamKafkaFacade& kafka_facade,
+                       const std::shared_ptr<Request<ProduceRequest>> request);
+
+  // Visible for testing.
+  ProduceRequestHolder(AbstractRequestListener& filter, UpstreamKafkaFacade& kafka_facade,
+                       const RecordExtractor& record_extractor,
+                       const std::shared_ptr<Request<ProduceRequest>> request);
+
+  // AbstractInFlightRequest
+  void startProcessing() override;
+
+  // AbstractInFlightRequest
+  bool finished() const override;
+
+  // AbstractInFlightRequest
+  AbstractResponseSharedPtr computeAnswer() const override;
+
+  // ProduceFinishCb
+  bool accept(const DeliveryMemento& memento) override;
+
+private:
+  // Access to Kafka producers pointing to upstream Kafka clusters.
+  UpstreamKafkaFacade& kafka_facade_;
+
+  // Original request.
+  const std::shared_ptr<Request<ProduceRequest>> request_;
+
+  // How many responses from Kafka Producer handling our request we still expect.
+  // This value decreases to 0 as we get confirmations from Kafka (successful or not).
+  int expected_responses_;
+
+  // Real records extracted out of request.
+  std::vector<OutboundRecord> outbound_records_;
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/produce_outbound_record.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/produce_outbound_record.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+// Binds a single inbound record from Kafka client with its delivery information.
+struct OutboundRecord {
+
+  // These fields were received from downstream.
+  const std::string topic_;
+  const int32_t partition_;
+  const absl::string_view key_;
+  const absl::string_view value_;
+
+  // These fields will get updated when delivery to upstream Kafka cluster finishes.
+  int16_t error_code_;
+  uint32_t saved_offset_;
+
+  OutboundRecord(const std::string& topic, const int32_t partition, const absl::string_view key,
+                 const absl::string_view value)
+      : topic_{topic}, partition_{partition}, key_{key}, value_{value}, error_code_{0},
+        saved_offset_{0} {};
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.cc
@@ -1,0 +1,18 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+std::vector<OutboundRecord>
+PlaceholderRecordExtractor::extractRecords(const std::vector<TopicProduceData>&) const {
+  return {};
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "contrib/kafka/filters/network/source/external/requests.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/produce_outbound_record.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+/**
+ * Dependency injection class responsible for extracting records out of produce request's contents.
+ */
+class RecordExtractor {
+public:
+  virtual ~RecordExtractor() = default;
+
+  virtual std::vector<OutboundRecord>
+  extractRecords(const std::vector<TopicProduceData>& data) const PURE;
+};
+
+/**
+ * Just a placeholder for now.
+ */
+class PlaceholderRecordExtractor : public RecordExtractor {
+public:
+  std::vector<OutboundRecord>
+  extractRecords(const std::vector<TopicProduceData>& data) const override;
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/filter.cc
+++ b/contrib/kafka/filters/network/source/mesh/filter.cc
@@ -14,9 +14,10 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-KafkaMeshFilter::KafkaMeshFilter(const UpstreamKafkaConfiguration& configuration)
+KafkaMeshFilter::KafkaMeshFilter(const UpstreamKafkaConfiguration& configuration,
+                                 UpstreamKafkaFacade& upstream_kafka_facade)
     : KafkaMeshFilter{std::make_shared<RequestDecoder>(std::vector<RequestCallbackSharedPtr>(
-          {std::make_shared<RequestProcessor>(*this, configuration)}))} {}
+          {std::make_shared<RequestProcessor>(*this, configuration, upstream_kafka_facade)}))} {}
 
 KafkaMeshFilter::KafkaMeshFilter(RequestDecoderSharedPtr request_decoder)
     : request_decoder_{request_decoder} {}

--- a/contrib/kafka/filters/network/source/mesh/filter.h
+++ b/contrib/kafka/filters/network/source/mesh/filter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "envoy/common/time.h"
-#include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "envoy/stats/scope.h"
 
@@ -11,6 +10,7 @@
 #include "contrib/kafka/filters/network/source/mesh/abstract_command.h"
 #include "contrib/kafka/filters/network/source/mesh/request_processor.h"
 #include "contrib/kafka/filters/network/source/mesh/upstream_config.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_facade.h"
 #include "contrib/kafka/filters/network/source/request_codec.h"
 
 namespace Envoy {
@@ -18,30 +18,43 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
+
 /**
  * Main entry point.
  * Decoded request bytes are passed to processor, that calls us back with enriched request.
- * Request then gets invoked with upstream Kafka facade, which will (in future) maintain
- * thread-local list of (enriched) Kafka producers. Filter is going to maintain a list of
- * in-flight-request so it can send responses when they finish.
+ * Request then gets invoked to starts its processing.
+ * Filter is going to maintain a list of in-flight-request so it can send responses when they
+ *finish.
  *
  *
  * +----------------+    <creates>    +-----------------------+
  * |RequestProcessor+----------------->AbstractInFlightRequest|
- * +-------^--------+                 +------^----------------+
- *         |                                 |
- *         |                                 |
- * +-------+-------+   <in-flight-reference> |
- * |KafkaMeshFilter+-------------------------+
- * +-------+-------+
+ * +-------^--------+                 +----^-----^------------+
+ *         |                               |     | <subclass>
+ *         |                               |   +-+------------------+
+ * +-------+-------+ <in-flight-reference> |   |ProduceRequestHolder|
+ * |KafkaMeshFilter+-----------------------+   +-+------------------+
+ * +-------+-------+                             |
+ *         |                                     |
+ *         |                                     |
+ * +-------v-----------+                         | <uses>
+ * |UpstreamKafkaFacade|                         |
+ * +-------+-----------+                         |
+ *         |                                     |
+ *         |                                     |
+ * +-------v--------------+       +--------------v---------+
+ * |<<ThreadLocalObject>> +------->PlaceholderKafkaProducer+
+ * |ThreadLocalKafkaFacade|       +------------------------+
+ * +----------------------+
  **/
 class KafkaMeshFilter : public Network::ReadFilter,
                         public Network::ConnectionCallbacks,
                         public AbstractRequestListener,
                         private Logger::Loggable<Logger::Id::kafka> {
 public:
-  // Proper constructor.
-  KafkaMeshFilter(const UpstreamKafkaConfiguration& configuration);
+  // Main constructor.
+  KafkaMeshFilter(const UpstreamKafkaConfiguration& configuration,
+                  UpstreamKafkaFacade& upstream_kafka_facade);
 
   // Visible for testing.
   KafkaMeshFilter(RequestDecoderSharedPtr request_decoder);

--- a/contrib/kafka/filters/network/source/mesh/request_processor.h
+++ b/contrib/kafka/filters/network/source/mesh/request_processor.h
@@ -5,6 +5,7 @@
 #include "contrib/kafka/filters/network/source/external/requests.h"
 #include "contrib/kafka/filters/network/source/mesh/abstract_command.h"
 #include "contrib/kafka/filters/network/source/mesh/upstream_config.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_facade.h"
 #include "contrib/kafka/filters/network/source/request_codec.h"
 
 namespace Envoy {
@@ -18,19 +19,21 @@ namespace Mesh {
  */
 class RequestProcessor : public RequestCallback, private Logger::Loggable<Logger::Id::kafka> {
 public:
-  RequestProcessor(AbstractRequestListener& origin,
-                   const UpstreamKafkaConfiguration& configuration);
+  RequestProcessor(AbstractRequestListener& origin, const UpstreamKafkaConfiguration& configuration,
+                   UpstreamKafkaFacade& upstream_kafka_facade);
 
   // RequestCallback
   void onMessage(AbstractRequestSharedPtr arg) override;
   void onFailedParse(RequestParseFailureSharedPtr) override;
 
 private:
+  void process(const std::shared_ptr<Request<ProduceRequest>> request) const;
   void process(const std::shared_ptr<Request<MetadataRequest>> request) const;
   void process(const std::shared_ptr<Request<ApiVersionsRequest>> request) const;
 
   AbstractRequestListener& origin_;
   const UpstreamKafkaConfiguration& configuration_;
+  UpstreamKafkaFacade& upstream_kafka_facade_;
 };
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_client.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_client.h
@@ -17,6 +17,13 @@ namespace Mesh {
 // in case of success this means offset (if acks > 0), or error code.
 struct DeliveryMemento {
 
+  // Pointer to byte array that was passed to Kafka producer.
+  // We use this to tell apart messages.
+  // Important: we do not free this memory, it's still part of the 'ProduceRequestHandler' object.
+  // Future work: adopt Kafka's opaque-pointer functionality so we use less memory instead of
+  // keeping whole payload until we receive a confirmation.
+  const void* data_;
+
   // Kafka producer error code.
   const int32_t error_code_;
 

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/BUILD
@@ -9,6 +9,17 @@ licenses(["notice"])  # Apache 2
 envoy_contrib_package()
 
 envoy_cc_test(
+    name = "produce_unit_test",
+    srcs = ["produce_unit_test.cc"],
+    tags = ["skip_on_windows"],
+    deps = [
+        "//contrib/kafka/filters/network/source/mesh/command_handlers:produce_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "metadata_unit_test",
     srcs = ["metadata_unit_test.cc"],
     tags = ["skip_on_windows"],

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
@@ -1,0 +1,270 @@
+#include <set>
+
+#include "test/test_common/utility.h"
+
+#include "contrib/kafka/filters/network/source/external/requests.h"
+#include "contrib/kafka/filters/network/source/external/responses.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/produce.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+namespace {
+
+class MockAbstractRequestListener : public AbstractRequestListener {
+public:
+  MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
+  MOCK_METHOD(void, onRequestReadyForAnswer, ());
+};
+
+class MockRecordExtractor : public RecordExtractor {
+public:
+  MOCK_METHOD((std::vector<OutboundRecord>), extractRecords, (const std::vector<TopicProduceData>&),
+              (const));
+};
+
+class MockUpstreamKafkaFacade : public UpstreamKafkaFacade {
+public:
+  MOCK_METHOD(KafkaProducer&, getProducerForTopic, (const std::string&));
+};
+
+class MockKafkaProducer : public KafkaProducer {
+public:
+  MOCK_METHOD(void, send,
+              (const ProduceFinishCbSharedPtr, const std::string&, const int32_t,
+               const absl::string_view, const absl::string_view));
+  MOCK_METHOD(void, markFinished, (), ());
+};
+
+class ProduceUnitTest : public testing::Test {
+protected:
+  MockAbstractRequestListener filter_;
+  MockUpstreamKafkaFacade upstream_kafka_facade_;
+  MockRecordExtractor extractor_;
+};
+
+// This is very odd corner case, that should never happen
+// (as ProduceRequests with no topics/records make no sense).
+TEST_F(ProduceUnitTest, ShouldHandleProduceRequestWithNoRecords) {
+  // given
+  MockRecordExtractor extractor;
+  const std::vector<OutboundRecord> records = {};
+  EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
+
+  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const ProduceRequest data = {0, 0, {}};
+  const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
+  ProduceRequestHolder testee = {filter_, upstream_kafka_facade_, extractor_, message};
+
+  // when, then - invoking should immediately notify the filter.
+  EXPECT_CALL(filter_, onRequestReadyForAnswer());
+  testee.startProcessing();
+
+  // when, then - request is finished because there was nothing to do.
+  const bool finished = testee.finished();
+  EXPECT_TRUE(finished);
+
+  // when, then - answer is empty.
+  const auto answer = testee.computeAnswer();
+  EXPECT_EQ(answer->metadata_.api_key_, header.api_key_);
+  EXPECT_EQ(answer->metadata_.correlation_id_, header.correlation_id_);
+}
+
+// Typical flow without errors.
+// The produce request has 2 records, that should be mapped to 2 different Kafka installations.
+// The response should contain the values returned by Kafka broker.
+TEST_F(ProduceUnitTest, ShouldSendRecordsInNormalFlow) {
+  // given
+  const OutboundRecord r1 = {"t1", 13, "aaa", "bbb"};
+  const OutboundRecord r2 = {"t2", 42, "ccc", "ddd"};
+  const std::vector<OutboundRecord> records = {r1, r2};
+  EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
+
+  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const ProduceRequest data = {0, 0, {}};
+  const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
+  std::shared_ptr<ProduceRequestHolder> testee =
+      std::make_shared<ProduceRequestHolder>(filter_, upstream_kafka_facade_, extractor_, message);
+
+  // when, then - invoking should use producers to send records.
+  MockKafkaProducer producer1;
+  EXPECT_CALL(producer1, send(_, r1.topic_, r1.partition_, _, _));
+  MockKafkaProducer producer2;
+  EXPECT_CALL(producer2, send(_, r2.topic_, r2.partition_, _, _));
+  EXPECT_CALL(upstream_kafka_facade_, getProducerForTopic(r1.topic_))
+      .WillOnce(ReturnRef(producer1));
+  EXPECT_CALL(upstream_kafka_facade_, getProducerForTopic(r2.topic_))
+      .WillOnce(ReturnRef(producer2));
+  testee->startProcessing();
+
+  // when, then - request is not yet finished (2 records' delivery to be confirmed).
+  EXPECT_FALSE(testee->finished());
+
+  // when, then - first record should be delivered.
+  const DeliveryMemento dm1 = {r1.value_.data(), 0, 123};
+  EXPECT_TRUE(testee->accept(dm1));
+  EXPECT_FALSE(testee->finished());
+
+  const DeliveryMemento dm2 = {r2.value_.data(), 0, 234};
+  // After all the deliveries have been confirmed, the filter is getting notified.
+  EXPECT_CALL(filter_, onRequestReadyForAnswer());
+  EXPECT_TRUE(testee->accept(dm2));
+  EXPECT_TRUE(testee->finished());
+
+  // when, then - answer gets computed and contains results.
+  const auto answer = testee->computeAnswer();
+  EXPECT_EQ(answer->metadata_.api_key_, header.api_key_);
+  EXPECT_EQ(answer->metadata_.correlation_id_, header.correlation_id_);
+
+  const auto response = std::dynamic_pointer_cast<Response<ProduceResponse>>(answer);
+  ASSERT_TRUE(response);
+  const std::vector<TopicProduceResponse> responses = response->data_.responses_;
+  EXPECT_EQ(responses.size(), 2);
+  EXPECT_EQ(responses[0].partitions_[0].error_code_, dm1.error_code_);
+  EXPECT_EQ(responses[0].partitions_[0].base_offset_, dm1.offset_);
+  EXPECT_EQ(responses[1].partitions_[0].error_code_, dm2.error_code_);
+  EXPECT_EQ(responses[1].partitions_[0].base_offset_, dm2.offset_);
+}
+
+// Typical flow without errors.
+// The produce request has 2 records, both pointing to same partition.
+// Given that usually we cannot make any guarantees on how Kafka producer is going to append the
+// records (as it depends on configuration like max number of records in flight), the first record
+// is going to be saved on a bigger offset.
+TEST_F(ProduceUnitTest, ShouldMergeOutboundRecordResponses) {
+  // given
+  const OutboundRecord r1 = {"t1", 13, "aaa", "bbb"};
+  const OutboundRecord r2 = {r1.topic_, r1.partition_, "ccc", "ddd"};
+  const std::vector<OutboundRecord> records = {r1, r2};
+  EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
+
+  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const ProduceRequest data = {0, 0, {}};
+  const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
+  std::shared_ptr<ProduceRequestHolder> testee =
+      std::make_shared<ProduceRequestHolder>(filter_, upstream_kafka_facade_, extractor_, message);
+
+  // when, then - invoking should use producers to send records.
+  MockKafkaProducer producer;
+  EXPECT_CALL(producer, send(_, r1.topic_, r1.partition_, _, _)).Times(2);
+  EXPECT_CALL(upstream_kafka_facade_, getProducerForTopic(r1.topic_))
+      .WillRepeatedly(ReturnRef(producer));
+  testee->startProcessing();
+
+  // when, then - request is not yet finished (2 records' delivery to be confirmed).
+  EXPECT_FALSE(testee->finished());
+
+  // when, then - first record should be delivered.
+  const DeliveryMemento dm1 = {r1.value_.data(), 0, 4242};
+  EXPECT_TRUE(testee->accept(dm1));
+  EXPECT_FALSE(testee->finished());
+
+  const DeliveryMemento dm2 = {r2.value_.data(), 0, 1313};
+  // After all the deliveries have been confirmed, the filter is getting notified.
+  EXPECT_CALL(filter_, onRequestReadyForAnswer());
+  EXPECT_TRUE(testee->accept(dm2));
+  EXPECT_TRUE(testee->finished());
+
+  // when, then - answer gets computed and contains results.
+  const auto answer = testee->computeAnswer();
+  EXPECT_EQ(answer->metadata_.api_key_, header.api_key_);
+  EXPECT_EQ(answer->metadata_.correlation_id_, header.correlation_id_);
+
+  const auto response = std::dynamic_pointer_cast<Response<ProduceResponse>>(answer);
+  ASSERT_TRUE(response);
+  const std::vector<TopicProduceResponse> responses = response->data_.responses_;
+  EXPECT_EQ(responses.size(), 1);
+  EXPECT_EQ(responses[0].partitions_.size(), 1);
+  EXPECT_EQ(responses[0].partitions_[0].error_code_, 0);
+  EXPECT_EQ(responses[0].partitions_[0].base_offset_, 1313);
+}
+
+// Flow with errors.
+// The produce request has 2 records, both pointing to same partition.
+// The first record is going to fail.
+// We are going to treat whole delivery as failure.
+// Bear in mind second record could get accepted, this is a difference between normal client and
+// proxy (this is going to be amended when we manage to send whole record batch).
+TEST_F(ProduceUnitTest, ShouldHandleDeliveryErrors) {
+  // given
+  const OutboundRecord r1 = {"t1", 13, "aaa", "bbb"};
+  const OutboundRecord r2 = {r1.topic_, r1.partition_, "ccc", "ddd"};
+  const std::vector<OutboundRecord> records = {r1, r2};
+  EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
+
+  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const ProduceRequest data = {0, 0, {}};
+  const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
+  std::shared_ptr<ProduceRequestHolder> testee =
+      std::make_shared<ProduceRequestHolder>(filter_, upstream_kafka_facade_, extractor_, message);
+
+  // when, then - invoking should use producers to send records.
+  MockKafkaProducer producer;
+  EXPECT_CALL(producer, send(_, r1.topic_, r1.partition_, _, _)).Times(2);
+  EXPECT_CALL(upstream_kafka_facade_, getProducerForTopic(r1.topic_))
+      .WillRepeatedly(ReturnRef(producer));
+  testee->startProcessing();
+
+  // when, then - request is not yet finished (2 records' delivery to be confirmed).
+  EXPECT_FALSE(testee->finished());
+
+  // when, then - first record fails.
+  const DeliveryMemento dm1 = {r1.value_.data(), 42, 0};
+  EXPECT_TRUE(testee->accept(dm1));
+  EXPECT_FALSE(testee->finished());
+
+  // when, then - second record succeeds (we are going to ignore the result).
+  const DeliveryMemento dm2 = {r2.value_.data(), 0, 234};
+  // After all the deliveries have been confirmed, the filter is getting notified.
+  EXPECT_CALL(filter_, onRequestReadyForAnswer());
+  EXPECT_TRUE(testee->accept(dm2));
+  EXPECT_TRUE(testee->finished());
+
+  // when, then - answer gets computed and contains results.
+  const auto answer = testee->computeAnswer();
+  EXPECT_EQ(answer->metadata_.api_key_, header.api_key_);
+  EXPECT_EQ(answer->metadata_.correlation_id_, header.correlation_id_);
+
+  const auto response = std::dynamic_pointer_cast<Response<ProduceResponse>>(answer);
+  ASSERT_TRUE(response);
+  const std::vector<TopicProduceResponse> responses = response->data_.responses_;
+  EXPECT_EQ(responses.size(), 1);
+  EXPECT_EQ(responses[0].partitions_[0].error_code_, dm1.error_code_);
+}
+
+// As with current version of Kafka library we have no capability of linking producer's notification
+// to sent record (other than data address), the owner of this request is going to do a check across
+// all owned requests. What means sometimes we might get asked to accept a memento of record that
+// did not originate in this request, so it should be ignored.
+TEST_F(ProduceUnitTest, ShouldIgnoreMementoFromAnotherRequest) {
+  // given
+  const OutboundRecord r1 = {"t1", 13, "aaa", "bbb"};
+  const std::vector<OutboundRecord> records = {r1};
+  EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
+
+  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const ProduceRequest data = {0, 0, {}};
+  const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
+  std::shared_ptr<ProduceRequestHolder> testee =
+      std::make_shared<ProduceRequestHolder>(filter_, upstream_kafka_facade_, extractor_, message);
+
+  // when, then - this record will not match anything.
+  const DeliveryMemento dm = {nullptr, 0, 42};
+  EXPECT_FALSE(testee->accept(dm));
+  EXPECT_FALSE(testee->finished());
+}
+
+} // namespace
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/test/mesh/filter_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/filter_unit_test.cc
@@ -184,12 +184,18 @@ public:
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };
 
+class MockUpstreamKafkaFacade : public UpstreamKafkaFacade {
+public:
+  MOCK_METHOD(KafkaProducer&, getProducerForTopic, (const std::string&));
+};
+
 TEST(Filter, ShouldBeConstructable) {
   // given
   MockUpstreamKafkaConfiguration configuration;
+  MockUpstreamKafkaFacade upstream_kafka_facade;
 
   // when
-  KafkaMeshFilter filter = KafkaMeshFilter(configuration);
+  KafkaMeshFilter filter = KafkaMeshFilter(configuration, upstream_kafka_facade);
 
   // then - no exceptions.
 }


### PR DESCRIPTION
Commit Message: kafka: produce request for mesh-filter
Additional Description: add produce handler for mesh filter; produce handler needs to extract records out of produce requests' bytes, send the records upstream (using Kafka producer), and will wait until it gets notifications (`onDelivery`) to finally find out that the processing has finished, and we can notify the filter (== send the response to downstream Kafka client).
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
