### PR TITLE
network: rename the addressProvider() to connectionInfoProvider()

### DIFF
--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -195,7 +195,7 @@ public:
    * @return the address provider backing this connection.
    */
   virtual const ConnectionInfoProvider& connectionInfoProvider() const PURE;
-  virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
+  virtual ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const PURE;
 
   /**
    * Credentials of the peer of a socket as decided by SO_PEERCRED.

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -194,7 +194,7 @@ public:
   /**
    * @return the address provider backing this connection.
    */
-  virtual const ConnectionInfoProvider& addressProvider() const PURE;
+  virtual const ConnectionInfoProvider& connectionInfoProvider() const PURE;
   virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
 
   /**

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -163,8 +163,8 @@ public:
   /**
    * @return the address provider backing this socket.
    */
-  virtual ConnectionInfoSetter& addressProvider() PURE;
-  virtual const ConnectionInfoProvider& addressProvider() const PURE;
+  virtual ConnectionInfoSetter& connectionInfoProvider() PURE;
+  virtual const ConnectionInfoProvider& connectionInfoProvider() const PURE;
   virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
 
   /**

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -165,7 +165,7 @@ public:
    */
   virtual ConnectionInfoSetter& connectionInfoProvider() PURE;
   virtual const ConnectionInfoProvider& connectionInfoProvider() const PURE;
-  virtual ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const PURE;
+  virtual ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const PURE;
 
   /**
    * @return IoHandle for the underlying connection

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -129,8 +129,8 @@ void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCal
     read_callbacks_->connection().streamInfo().filterState()->setData(
         Network::ProxyProtocolFilterState::key(),
         std::make_unique<Network::ProxyProtocolFilterState>(Network::ProxyProtocolData{
-            read_callbacks_->connection().addressProvider().remoteAddress(),
-            read_callbacks_->connection().addressProvider().localAddress()}),
+            read_callbacks_->connection().connectionInfoProvider().remoteAddress(),
+            read_callbacks_->connection().connectionInfoProvider().localAddress()}),
         StreamInfo::FilterState::StateType::ReadOnly,
         StreamInfo::FilterState::LifeSpan::Connection);
   }
@@ -821,7 +821,7 @@ const Network::Connection* ConnectionManagerImpl::ActiveStream::connection() {
 }
 
 uint32_t ConnectionManagerImpl::ActiveStream::localPort() {
-  auto ip = connection()->addressProvider().localAddress()->ip();
+  auto ip = connection()->connectionInfoProvider().localAddress()->ip();
   if (ip == nullptr) {
     return 0;
   }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -135,7 +135,8 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
       final_remote_address = connection.connectionInfoProvider().remoteAddress();
     }
     if (!config.skipXffAppend()) {
-      if (Network::Utility::isLoopbackAddress(*connection.connectionInfoProvider().remoteAddress())) {
+      if (Network::Utility::isLoopbackAddress(
+              *connection.connectionInfoProvider().remoteAddress())) {
         Utility::appendXff(request_headers, config.localAddress());
       } else {
         Utility::appendXff(request_headers, *connection.connectionInfoProvider().remoteAddress());

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -132,13 +132,13 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     // are but they didn't populate XFF properly, the trusted client address is the
     // source address of the immediate downstream's connection to us.
     if (final_remote_address == nullptr) {
-      final_remote_address = connection.addressProvider().remoteAddress();
+      final_remote_address = connection.connectionInfoProvider().remoteAddress();
     }
     if (!config.skipXffAppend()) {
-      if (Network::Utility::isLoopbackAddress(*connection.addressProvider().remoteAddress())) {
+      if (Network::Utility::isLoopbackAddress(*connection.connectionInfoProvider().remoteAddress())) {
         Utility::appendXff(request_headers, config.localAddress());
       } else {
-        Utility::appendXff(request_headers, *connection.addressProvider().remoteAddress());
+        Utility::appendXff(request_headers, *connection.connectionInfoProvider().remoteAddress());
       }
     }
     // If the prior hop is not a trusted proxy, overwrite any x-forwarded-proto value it set as
@@ -155,7 +155,7 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     // If we find one, it will be used as the downstream address for logging. It may or may not be
     // used for determining internal/external status (see below).
     OriginalIPDetectionParams params = {request_headers,
-                                        connection.addressProvider().remoteAddress()};
+                                        connection.connectionInfoProvider().remoteAddress()};
     for (const auto& detection_extension : config.originalIpDetectionExtensions()) {
       const auto result = detection_extension->detect(params);
 
@@ -208,7 +208,7 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
   // After determining internal request status, if there is no final remote address, due to no XFF,
   // busted XFF, etc., use the direct connection remote address for logging.
   if (final_remote_address == nullptr) {
-    final_remote_address = connection.addressProvider().remoteAddress();
+    final_remote_address = connection.connectionInfoProvider().remoteAddress();
   }
 
   // Edge request is the request from external clients to front Envoy.

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -667,7 +667,7 @@ public:
         connection_(connection), stream_id_(stream_id), account_(std::move(account)),
         proxy_100_continue_(proxy_100_continue), buffer_limit_(buffer_limit),
         filter_chain_factory_(filter_chain_factory), local_reply_(local_reply),
-        stream_info_(protocol, time_source, connection.addressProviderSharedPtr(),
+        stream_info_(protocol, time_source, connection.connectionInfoProviderSharedPtr(),
                      parent_filter_state, filter_state_life_span) {}
   ~FilterManager() override {
     ASSERT(state_.destroyed_);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -380,7 +380,7 @@ void StreamEncoderImpl::readDisable(bool disable) {
 uint32_t StreamEncoderImpl::bufferLimit() { return connection_.bufferLimit(); }
 
 const Network::Address::InstanceConstSharedPtr& StreamEncoderImpl::connectionLocalAddress() {
-  return connection_.connection().addressProvider().localAddress();
+  return connection_.connection().connectionInfoProvider().localAddress();
 }
 
 static const char RESPONSE_PREFIX[] = "HTTP/1.1 ";

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -221,7 +221,7 @@ protected:
     void readDisable(bool disable) override;
     uint32_t bufferLimit() override { return pending_recv_data_->highWatermark(); }
     const Network::Address::InstanceConstSharedPtr& connectionLocalAddress() override {
-      return parent_.connection_.addressProvider().localAddress();
+      return parent_.connection_.connectionInfoProvider().localAddress();
     }
     absl::string_view responseDetails() override { return details_; }
     void setAccount(Buffer::BufferMemoryAccountSharedPtr account) override;

--- a/source/common/network/base_listener_impl.cc
+++ b/source/common/network/base_listener_impl.cc
@@ -17,12 +17,12 @@ namespace Network {
 
 BaseListenerImpl::BaseListenerImpl(Event::DispatcherImpl& dispatcher, SocketSharedPtr socket)
     : local_address_(nullptr), dispatcher_(dispatcher), socket_(std::move(socket)) {
-  const auto ip = socket_->addressProvider().localAddress()->ip();
+  const auto ip = socket_->connectionInfoProvider().localAddress()->ip();
 
   // Only use the listen socket's local address for new connections if it is not the all hosts
   // address (e.g., 0.0.0.0 for IPv4).
   if (!(ip && ip->isAnyAddress())) {
-    local_address_ = socket_->addressProvider().localAddress();
+    local_address_ = socket_->connectionInfoProvider().localAddress();
   }
 }
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -878,7 +878,8 @@ ClientConnectionImpl::ClientConnectionImpl(
 void ClientConnectionImpl::connect() {
   ENVOY_CONN_LOG(debug, "connecting to {}", *this,
                  socket_->connectionInfoProvider().remoteAddress()->asString());
-  const Api::SysCallIntResult result = socket_->connect(socket_->connectionInfoProvider().remoteAddress());
+  const Api::SysCallIntResult result =
+      socket_->connect(socket_->connectionInfoProvider().remoteAddress());
   if (result.return_value_ == 0) {
     // write will become ready.
     ASSERT(connecting_);

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -98,8 +98,8 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
 
   // TODO(soulxu): generate the connection id inside the addressProvider directly,
   // then we don't need a setter or any of the optional stuff.
-  socket_->addressProvider().setConnectionID(id());
-  socket_->addressProvider().setSslConnection(transport_socket_->ssl());
+  socket_->connectionInfoProvider().setConnectionID(id());
+  socket_->connectionInfoProvider().setSslConnection(transport_socket_->ssl());
 }
 
 ConnectionImpl::~ConnectionImpl() {
@@ -854,8 +854,8 @@ ClientConnectionImpl::ClientConnectionImpl(
 
   const Network::Address::InstanceConstSharedPtr* source = &source_address;
 
-  if (socket_->addressProvider().localAddress()) {
-    source = &socket_->addressProvider().localAddress();
+  if (socket_->connectionInfoProvider().localAddress()) {
+    source = &socket_->connectionInfoProvider().localAddress();
   }
 
   if (*source != nullptr) {
@@ -877,8 +877,8 @@ ClientConnectionImpl::ClientConnectionImpl(
 
 void ClientConnectionImpl::connect() {
   ENVOY_CONN_LOG(debug, "connecting to {}", *this,
-                 socket_->addressProvider().remoteAddress()->asString());
-  const Api::SysCallIntResult result = socket_->connect(socket_->addressProvider().remoteAddress());
+                 socket_->connectionInfoProvider().remoteAddress()->asString());
+  const Api::SysCallIntResult result = socket_->connect(socket_->connectionInfoProvider().remoteAddress());
   if (result.return_value_ == 0) {
     // write will become ready.
     ASSERT(connecting_);

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -836,7 +836,7 @@ ClientConnectionImpl::ClientConnectionImpl(
     const Network::ConnectionSocket::OptionsSharedPtr& options)
     : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address, options),
                      std::move(transport_socket), stream_info_, false),
-      stream_info_(dispatcher.timeSource(), socket_->addressProviderSharedPtr()) {
+      stream_info_(dispatcher.timeSource(), socket_->connectionInfoProviderSharedPtr()) {
   // There are no meaningful socket options or source address semantics for
   // non-IP sockets, so skip.
   if (remote_address->ip() == nullptr) {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -75,8 +75,8 @@ public:
   const ConnectionInfoProvider& connectionInfoProvider() const override {
     return socket_->connectionInfoProvider();
   }
-  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
-    return socket_->addressProviderSharedPtr();
+  ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
+    return socket_->connectionInfoProviderSharedPtr();
   }
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;
   Ssl::ConnectionInfoConstSharedPtr ssl() const override { return transport_socket_->ssl(); }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -72,8 +72,8 @@ public:
   void readDisable(bool disable) override;
   void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
   bool readEnabled() const override;
-  const ConnectionInfoProvider& addressProvider() const override {
-    return socket_->addressProvider();
+  const ConnectionInfoProvider& connectionInfoProvider() const override {
+    return socket_->connectionInfoProvider();
   }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return socket_->addressProviderSharedPtr();

--- a/source/common/network/filter_matcher.h
+++ b/source/common/network/filter_matcher.h
@@ -45,7 +45,7 @@ public:
   explicit ListenerFilterDstPortMatcher(const ::envoy::type::v3::Int32Range& range)
       : start_(range.start()), end_(range.end()) {}
   bool matches(ListenerFilterCallbacks& cb) const override {
-    const auto& address = cb.socket().addressProvider().localAddress();
+    const auto& address = cb.socket().connectionInfoProvider().localAddress();
     // Match on destination port (only for IP addresses).
     if (address->type() == Address::Type::Ip) {
       const auto port = address->ip()->port();

--- a/source/common/network/happy_eyeballs_connection_impl.cc
+++ b/source/common/network/happy_eyeballs_connection_impl.cc
@@ -159,8 +159,8 @@ const ConnectionInfoProvider& HappyEyeballsConnectionImpl::connectionInfoProvide
   return connections_[0]->connectionInfoProvider();
 }
 
-ConnectionInfoProviderSharedPtr HappyEyeballsConnectionImpl::addressProviderSharedPtr() const {
-  return connections_[0]->addressProviderSharedPtr();
+ConnectionInfoProviderSharedPtr HappyEyeballsConnectionImpl::connectionInfoProviderSharedPtr() const {
+  return connections_[0]->connectionInfoProviderSharedPtr();
 }
 
 absl::optional<Connection::UnixDomainSocketPeerCredentials>

--- a/source/common/network/happy_eyeballs_connection_impl.cc
+++ b/source/common/network/happy_eyeballs_connection_impl.cc
@@ -155,8 +155,8 @@ bool HappyEyeballsConnectionImpl::readEnabled() const {
   return connections_[0]->readEnabled();
 }
 
-const ConnectionInfoProvider& HappyEyeballsConnectionImpl::addressProvider() const {
-  return connections_[0]->addressProvider();
+const ConnectionInfoProvider& HappyEyeballsConnectionImpl::connectionInfoProvider() const {
+  return connections_[0]->connectionInfoProvider();
 }
 
 ConnectionInfoProviderSharedPtr HappyEyeballsConnectionImpl::addressProviderSharedPtr() const {

--- a/source/common/network/happy_eyeballs_connection_impl.cc
+++ b/source/common/network/happy_eyeballs_connection_impl.cc
@@ -159,7 +159,8 @@ const ConnectionInfoProvider& HappyEyeballsConnectionImpl::connectionInfoProvide
   return connections_[0]->connectionInfoProvider();
 }
 
-ConnectionInfoProviderSharedPtr HappyEyeballsConnectionImpl::connectionInfoProviderSharedPtr() const {
+ConnectionInfoProviderSharedPtr
+HappyEyeballsConnectionImpl::connectionInfoProviderSharedPtr() const {
   return connections_[0]->connectionInfoProviderSharedPtr();
 }
 

--- a/source/common/network/happy_eyeballs_connection_impl.h
+++ b/source/common/network/happy_eyeballs_connection_impl.h
@@ -72,7 +72,7 @@ public:
   bool isHalfCloseEnabled() override;
   std::string nextProtocol() const override;
   // Note, this might change before connect finishes.
-  const ConnectionInfoProvider& addressProvider() const override;
+  const ConnectionInfoProvider& connectionInfoProvider() const override;
   // Note, this might change before connect finishes.
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override;
   // Note, this might change before connect finishes.

--- a/source/common/network/happy_eyeballs_connection_impl.h
+++ b/source/common/network/happy_eyeballs_connection_impl.h
@@ -74,7 +74,7 @@ public:
   // Note, this might change before connect finishes.
   const ConnectionInfoProvider& connectionInfoProvider() const override;
   // Note, this might change before connect finishes.
-  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override;
+  ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override;
   // Note, this might change before connect finishes.
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;
   // Note, this might change before connect finishes.

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -167,10 +167,10 @@ public:
 
   void setRequestedServerName(absl::string_view server_name) override {
     // Always keep the server_name_ as lower case.
-    addressProvider().setRequestedServerName(absl::AsciiStrToLower(server_name));
+    connectionInfoProvider().setRequestedServerName(absl::AsciiStrToLower(server_name));
   }
   absl::string_view requestedServerName() const override {
-    return addressProvider().requestedServerName();
+    return connectionInfoProvider().requestedServerName();
   }
 
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() override {

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -74,7 +74,7 @@ public:
   // Network::Socket
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
-  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
+  ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }
   SocketPtr duplicate() override {

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -72,8 +72,8 @@ public:
              const Address::InstanceConstSharedPtr& remote_address);
 
   // Network::Socket
-  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -73,7 +73,9 @@ public:
 
   // Network::Socket
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override {
+    return *address_provider_;
+  }
   ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }

--- a/source/common/network/udp_listener_impl.cc
+++ b/source/common/network/udp_listener_impl.cc
@@ -66,7 +66,7 @@ void UdpListenerImpl::handleReadCallback() {
   ENVOY_UDP_LOG(trace, "handleReadCallback");
   cb_.onReadReady();
   const Api::IoErrorPtr result = Utility::readPacketsFromSocket(
-      socket_->ioHandle(), *socket_->addressProvider().localAddress(), *this, time_source_,
+      socket_->ioHandle(), *socket_->connectionInfoProvider().localAddress(), *this, time_source_,
       config_.prefer_gro_, packets_dropped_);
   if (result == nullptr) {
     // No error. The number of reads was limited by read rate. There are more packets to read.
@@ -102,7 +102,7 @@ void UdpListenerImpl::handleWriteCallback() {
 Event::Dispatcher& UdpListenerImpl::dispatcher() { return dispatcher_; }
 
 const Address::InstanceConstSharedPtr& UdpListenerImpl::localAddress() const {
-  return socket_->addressProvider().localAddress();
+  return socket_->connectionInfoProvider().localAddress();
 }
 
 Api::IoCallUint64Result UdpListenerImpl::send(const UdpSendData& send_data) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -285,11 +285,11 @@ bool Utility::isSameIpOrLoopback(const ConnectionSocket& socket) {
   // - Pipes
   // - Sockets to a loopback address
   // - Sockets where the local and remote address (ignoring port) are the same
-  const auto& remote_address = socket.addressProvider().remoteAddress();
+  const auto& remote_address = socket.connectionInfoProvider().remoteAddress();
   if (remote_address->type() == Address::Type::Pipe || isLoopbackAddress(*remote_address)) {
     return true;
   }
-  const auto local_ip = socket.addressProvider().localAddress()->ip();
+  const auto local_ip = socket.connectionInfoProvider().localAddress()->ip();
   const auto remote_ip = remote_address->ip();
   if (remote_ip != nullptr && local_ip != nullptr &&
       remote_ip->addressAsString() == local_ip->addressAsString()) {

--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -95,10 +95,10 @@ void EnvoyQuicClientConnection::switchConnectionSocket(
     Network::ConnectionSocketPtr&& connection_socket) {
   auto writer = std::make_unique<EnvoyQuicPacketWriter>(
       std::make_unique<Network::UdpDefaultWriter>(connection_socket->ioHandle()));
-  quic::QuicSocketAddress self_address =
-      envoyIpAddressToQuicSocketAddress(connection_socket->connectionInfoProvider().localAddress()->ip());
-  quic::QuicSocketAddress peer_address =
-      envoyIpAddressToQuicSocketAddress(connection_socket->connectionInfoProvider().remoteAddress()->ip());
+  quic::QuicSocketAddress self_address = envoyIpAddressToQuicSocketAddress(
+      connection_socket->connectionInfoProvider().localAddress()->ip());
+  quic::QuicSocketAddress peer_address = envoyIpAddressToQuicSocketAddress(
+      connection_socket->connectionInfoProvider().remoteAddress()->ip());
 
   // The old socket is closed in this call.
   setConnectionSocket(std::move(connection_socket));
@@ -124,8 +124,9 @@ void EnvoyQuicClientConnection::onFileEvent(uint32_t events) {
   // right default for QUIC. Determine whether this should be configurable or not.
   if (connected() && (events & Event::FileReadyType::Read)) {
     Api::IoErrorPtr err = Network::Utility::readPacketsFromSocket(
-        connectionSocket()->ioHandle(), *connectionSocket()->connectionInfoProvider().localAddress(),
-        *this, dispatcher_.timeSource(), true, packets_dropped_);
+        connectionSocket()->ioHandle(),
+        *connectionSocket()->connectionInfoProvider().localAddress(), *this,
+        dispatcher_.timeSource(), true, packets_dropped_);
     if (err == nullptr) {
       connectionSocket()->ioHandle().activateFileEvents(Event::FileReadyType::Read);
       return;

--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -42,7 +42,7 @@ EnvoyQuicClientConnection::EnvoyQuicClientConnection(
     Network::ConnectionSocketPtr&& connection_socket)
     : quic::QuicConnection(server_connection_id, quic::QuicSocketAddress(),
                            envoyIpAddressToQuicSocketAddress(
-                               connection_socket->addressProvider().remoteAddress()->ip()),
+                               connection_socket->connectionInfoProvider().remoteAddress()->ip()),
                            &helper, &alarm_factory, writer, owns_writer,
                            quic::Perspective::IS_CLIENT, supported_versions),
       QuicNetworkConnection(std::move(connection_socket)), dispatcher_(dispatcher) {}
@@ -96,9 +96,9 @@ void EnvoyQuicClientConnection::switchConnectionSocket(
   auto writer = std::make_unique<EnvoyQuicPacketWriter>(
       std::make_unique<Network::UdpDefaultWriter>(connection_socket->ioHandle()));
   quic::QuicSocketAddress self_address =
-      envoyIpAddressToQuicSocketAddress(connection_socket->addressProvider().localAddress()->ip());
+      envoyIpAddressToQuicSocketAddress(connection_socket->connectionInfoProvider().localAddress()->ip());
   quic::QuicSocketAddress peer_address =
-      envoyIpAddressToQuicSocketAddress(connection_socket->addressProvider().remoteAddress()->ip());
+      envoyIpAddressToQuicSocketAddress(connection_socket->connectionInfoProvider().remoteAddress()->ip());
 
   // The old socket is closed in this call.
   setConnectionSocket(std::move(connection_socket));
@@ -124,7 +124,7 @@ void EnvoyQuicClientConnection::onFileEvent(uint32_t events) {
   // right default for QUIC. Determine whether this should be configurable or not.
   if (connected() && (events & Event::FileReadyType::Read)) {
     Api::IoErrorPtr err = Network::Utility::readPacketsFromSocket(
-        connectionSocket()->ioHandle(), *connectionSocket()->addressProvider().localAddress(),
+        connectionSocket()->ioHandle(), *connectionSocket()->connectionInfoProvider().localAddress(),
         *this, dispatcher_.timeSource(), true, packets_dropped_);
     if (err == nullptr) {
       connectionSocket()->ioHandle().activateFileEvents(Event::FileReadyType::Read);

--- a/source/common/quic/envoy_quic_server_connection.cc
+++ b/source/common/quic/envoy_quic_server_connection.cc
@@ -29,7 +29,7 @@ bool EnvoyQuicServerConnection::OnPacketHeader(const quic::QuicPacketHeader& hea
   }
   // Update local address if QUICHE has updated the self address.
   ASSERT(self_address().IsInitialized());
-  connectionSocket()->addressProvider().setLocalAddress(
+  connectionSocket()->connectionInfoProvider().setLocalAddress(
       quicAddressToEnvoyAddressInstance(self_address()));
 
   return true;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -77,7 +77,7 @@ public:
   }
   uint32_t bufferLimit() override { return send_buffer_simulation_.highWatermark(); }
   const Network::Address::InstanceConstSharedPtr& connectionLocalAddress() override {
-    return connection()->addressProvider().localAddress();
+    return connection()->connectionInfoProvider().localAddress();
   }
 
   void setAccount(Buffer::BufferMemoryAccountSharedPtr account) override {

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -148,7 +148,7 @@ createConnectionSocket(Network::Address::InstanceConstSharedPtr& peer_addr,
   }
   connection_socket->bind(local_addr);
   ASSERT(local_addr->ip());
-  local_addr = connection_socket->addressProvider().localAddress();
+  local_addr = connection_socket->connectionInfoProvider().localAddress();
   if (!Network::Socket::applyOptions(connection_socket->options(), *connection_socket,
                                      envoy::config::core::v3::SocketOption::STATE_BOUND)) {
     ENVOY_LOG_MISC(error, "Fail to apply post-bind options");

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -14,7 +14,7 @@ QuicFilterManagerConnectionImpl::QuicFilterManagerConnectionImpl(
     : Network::ConnectionImplBase(dispatcher, /*id=*/connection_id.Hash()),
       network_connection_(&connection), filter_manager_(*this, *connection.connectionSocket()),
       stream_info_(dispatcher.timeSource(),
-                   connection.connectionSocket()->addressProviderSharedPtr()),
+                   connection.connectionSocket()->connectionInfoProviderSharedPtr()),
       write_buffer_watermark_simulation_(
           send_buffer_limit / 2, send_buffer_limit, [this]() { onSendBufferLowWatermark(); },
           [this]() { onSendBufferHighWatermark(); }, ENVOY_LOGGER()) {

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -71,8 +71,8 @@ public:
   const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
     return network_connection_->connectionSocket()->connectionInfoProvider();
   }
-  Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
-    return network_connection_->connectionSocket()->addressProviderSharedPtr();
+  Network::ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
+    return network_connection_->connectionSocket()->connectionInfoProviderSharedPtr();
   }
   absl::optional<Network::Connection::UnixDomainSocketPeerCredentials>
   unixSocketPeerCredentials() const override {

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -68,8 +68,8 @@ public:
   void readDisable(bool /*disable*/) override { ASSERT(false); }
   void detectEarlyCloseWhenReadDisabled(bool /*value*/) override { ASSERT(false); }
   bool readEnabled() const override { return true; }
-  const Network::ConnectionInfoSetter& addressProvider() const override {
-    return network_connection_->connectionSocket()->addressProvider();
+  const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
+    return network_connection_->connectionSocket()->connectionInfoProvider();
   }
   Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return network_connection_->connectionSocket()->addressProviderSharedPtr();

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -408,8 +408,8 @@ public:
     std::string value;
     const Network::Connection* conn = downstreamConnection();
     // Need to check for null conn if this is ever used by Http::AsyncClient in the future.
-    value = conn->addressProvider().remoteAddress()->asString() +
-            conn->addressProvider().localAddress()->asString();
+    value = conn->connectionInfoProvider().remoteAddress()->asString() +
+            conn->connectionInfoProvider().localAddress()->asString();
 
     const std::string cookie_value = Hex::uint64ToHex(HashUtil::xxHash64(value));
     downstream_set_cookies_.emplace_back(

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -195,7 +195,7 @@ void UpstreamRequest::decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) {
 void UpstreamRequest::dumpState(std::ostream& os, int indent_level) const {
   const char* spaces = spacesForLevel(indent_level);
   os << spaces << "UpstreamRequest " << this << "\n";
-  const auto addressProvider = connection().addressProviderSharedPtr();
+  const auto addressProvider = connection().connectionInfoProviderSharedPtr();
   const Http::RequestHeaderMap* request_headers = parent_.downstreamHeaders();
   DUMP_DETAILS(addressProvider);
   DUMP_DETAILS(request_headers);

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -58,24 +58,24 @@ Config::RouteImpl::RouteImpl(
 
 bool Config::RouteImpl::matches(Network::Connection& connection) const {
   if (!source_port_ranges_.empty() &&
-      !Network::Utility::portInRangeList(*connection.addressProvider().remoteAddress(),
+      !Network::Utility::portInRangeList(*connection.connectionInfoProvider().remoteAddress(),
                                          source_port_ranges_)) {
     return false;
   }
 
   if (!source_ips_.empty() &&
-      !source_ips_.contains(*connection.addressProvider().remoteAddress())) {
+      !source_ips_.contains(*connection.connectionInfoProvider().remoteAddress())) {
     return false;
   }
 
   if (!destination_port_ranges_.empty() &&
-      !Network::Utility::portInRangeList(*connection.addressProvider().localAddress(),
+      !Network::Utility::portInRangeList(*connection.connectionInfoProvider().localAddress(),
                                          destination_port_ranges_)) {
     return false;
   }
 
   if (!destination_ips_.empty() &&
-      !destination_ips_.contains(*connection.addressProvider().localAddress())) {
+      !destination_ips_.contains(*connection.connectionInfoProvider().localAddress())) {
     return false;
   }
 
@@ -432,8 +432,8 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
       read_callbacks_->connection().streamInfo().filterState()->setData(
           Network::ProxyProtocolFilterState::key(),
           std::make_unique<Network::ProxyProtocolFilterState>(
-              Network::ProxyProtocolData{downstreamConnection()->addressProvider().remoteAddress(),
-                                         downstreamConnection()->addressProvider().localAddress()}),
+              Network::ProxyProtocolData{downstreamConnection()->connectionInfoProvider().remoteAddress(),
+                                         downstreamConnection()->connectionInfoProvider().localAddress()}),
           StreamInfo::FilterState::StateType::ReadOnly,
           StreamInfo::FilterState::LifeSpan::Connection);
     }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -431,9 +431,9 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
                  Network::ProxyProtocolFilterState::key())) {
       read_callbacks_->connection().streamInfo().filterState()->setData(
           Network::ProxyProtocolFilterState::key(),
-          std::make_unique<Network::ProxyProtocolFilterState>(
-              Network::ProxyProtocolData{downstreamConnection()->connectionInfoProvider().remoteAddress(),
-                                         downstreamConnection()->connectionInfoProvider().localAddress()}),
+          std::make_unique<Network::ProxyProtocolFilterState>(Network::ProxyProtocolData{
+              downstreamConnection()->connectionInfoProvider().remoteAddress(),
+              downstreamConnection()->connectionInfoProvider().localAddress()}),
           StreamInfo::FilterState::StateType::ReadOnly,
           StreamInfo::FilterState::LifeSpan::Connection);
     }

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -267,8 +267,8 @@ public:
     auto hash_policy = config_->hashPolicy();
     if (hash_policy) {
       return hash_policy->generateHash(
-          downstreamConnection()->addressProvider().remoteAddress().get(),
-          downstreamConnection()->addressProvider().localAddress().get());
+          downstreamConnection()->connectionInfoProvider().remoteAddress().get(),
+          downstreamConnection()->connectionInfoProvider().localAddress().get());
     }
 
     return {};

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -187,7 +187,7 @@ void TcpConnPool::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data
   auto upstream = std::make_unique<TcpUpstream>(std::move(conn_data), upstream_callbacks_);
   callbacks_->onGenericPoolReady(
       &connection.streamInfo(), std::move(upstream), host,
-      latched_data->connection().addressProvider().localAddress(),
+      latched_data->connection().connectionInfoProvider().localAddress(),
       latched_data->connection().streamInfo().downstreamAddressProvider().sslConnection());
 }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -31,8 +31,8 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       const Network::Connection* connection = context->downstreamConnection();
       // The local address of the downstream connection is the original destination address,
       // if localAddressRestored() returns 'true'.
-      if (connection && connection->addressProvider().localAddressRestored()) {
-        dst_host = connection->addressProvider().localAddress();
+      if (connection && connection->connectionInfoProvider().localAddressRestored()) {
+        dst_host = connection->connectionInfoProvider().localAddress();
       }
     }
 

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
@@ -101,8 +101,8 @@ void generateV2Header(const Network::Address::Ip& source_address,
 
 void generateProxyProtoHeader(const envoy::config::core::v3::ProxyProtocolConfig& config,
                               const Network::Connection& connection, Buffer::Instance& out) {
-  const Network::Address::Ip& dest_address = *connection.addressProvider().localAddress()->ip();
-  const Network::Address::Ip& source_address = *connection.addressProvider().remoteAddress()->ip();
+  const Network::Address::Ip& dest_address = *connection.connectionInfoProvider().localAddress()->ip();
+  const Network::Address::Ip& source_address = *connection.connectionInfoProvider().remoteAddress()->ip();
   if (config.version() == envoy::config::core::v3::ProxyProtocolConfig::V1) {
     generateV1Header(source_address, dest_address, out);
   } else if (config.version() == envoy::config::core::v3::ProxyProtocolConfig::V2) {

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
@@ -101,8 +101,10 @@ void generateV2Header(const Network::Address::Ip& source_address,
 
 void generateProxyProtoHeader(const envoy::config::core::v3::ProxyProtocolConfig& config,
                               const Network::Connection& connection, Buffer::Instance& out) {
-  const Network::Address::Ip& dest_address = *connection.connectionInfoProvider().localAddress()->ip();
-  const Network::Address::Ip& source_address = *connection.connectionInfoProvider().remoteAddress()->ip();
+  const Network::Address::Ip& dest_address =
+      *connection.connectionInfoProvider().localAddress()->ip();
+  const Network::Address::Ip& source_address =
+      *connection.connectionInfoProvider().remoteAddress()->ip();
   if (config.version() == envoy::config::core::v3::ProxyProtocolConfig::V1) {
     generateV1Header(source_address, dest_address, out);
   } else if (config.version() == envoy::config::core::v3::ProxyProtocolConfig::V2) {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -38,11 +38,11 @@ void CheckRequestUtils::setAttrContextPeer(envoy::service::auth::v3::AttributeCo
   // Set the address
   auto addr = peer.mutable_address();
   if (local) {
-    Envoy::Network::Utility::addressToProtobufAddress(*connection.connectionInfoProvider().localAddress(),
-                                                      *addr);
+    Envoy::Network::Utility::addressToProtobufAddress(
+        *connection.connectionInfoProvider().localAddress(), *addr);
   } else {
-    Envoy::Network::Utility::addressToProtobufAddress(*connection.connectionInfoProvider().remoteAddress(),
-                                                      *addr);
+    Envoy::Network::Utility::addressToProtobufAddress(
+        *connection.connectionInfoProvider().remoteAddress(), *addr);
   }
 
   // Set the principal. Preferably the URI SAN, DNS SAN or Subject in that order from the peer's

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -38,10 +38,10 @@ void CheckRequestUtils::setAttrContextPeer(envoy::service::auth::v3::AttributeCo
   // Set the address
   auto addr = peer.mutable_address();
   if (local) {
-    Envoy::Network::Utility::addressToProtobufAddress(*connection.addressProvider().localAddress(),
+    Envoy::Network::Utility::addressToProtobufAddress(*connection.connectionInfoProvider().localAddress(),
                                                       *addr);
   } else {
-    Envoy::Network::Utility::addressToProtobufAddress(*connection.addressProvider().remoteAddress(),
+    Envoy::Network::Utility::addressToProtobufAddress(*connection.connectionInfoProvider().remoteAddress(),
                                                       *addr);
   }
 

--- a/source/extensions/filters/common/original_src/original_src_socket_option.cc
+++ b/source/extensions/filters/common/original_src/original_src_socket_option.cc
@@ -21,7 +21,7 @@ bool OriginalSrcSocketOption::setOption(
     Network::Socket& socket, envoy::config::core::v3::SocketOption::SocketState state) const {
 
   if (state == envoy::config::core::v3::SocketOption::STATE_PREBIND) {
-    socket.addressProvider().setLocalAddress(src_address_);
+    socket.connectionInfoProvider().setLocalAddress(src_address_);
   }
 
   return true;

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -137,7 +137,7 @@ bool IPMatcher::matches(const Network::Connection& connection, const Envoy::Http
   Envoy::Network::Address::InstanceConstSharedPtr ip;
   switch (type_) {
   case ConnectionRemote:
-    ip = connection.addressProvider().remoteAddress();
+    ip = connection.connectionInfoProvider().remoteAddress();
     break;
   case DownstreamLocal:
     ip = info.downstreamAddressProvider().localAddress();

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -46,7 +46,7 @@ RoleBasedAccessControlFilter::decodeHeaders(Http::RequestHeaderMap& headers, boo
       "checking request: requestedServerName: {}, sourceIP: {}, directRemoteIP: {}, remoteIP: {},"
       "localAddress: {}, ssl: {}, headers: {}, dynamicMetadata: {}",
       callbacks_->connection()->requestedServerName(),
-      callbacks_->connection()->addressProvider().remoteAddress()->asString(),
+      callbacks_->connection()->connectionInfoProvider().remoteAddress()->asString(),
       callbacks_->streamInfo().downstreamAddressProvider().directRemoteAddress()->asString(),
       callbacks_->streamInfo().downstreamAddressProvider().remoteAddress()->asString(),
       callbacks_->streamInfo().downstreamAddressProvider().localAddress()->asString(),

--- a/source/extensions/filters/listener/original_dst/original_dst.cc
+++ b/source/extensions/filters/listener/original_dst/original_dst.cc
@@ -64,7 +64,7 @@ Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbac
       }
 #endif
       // Restore the local address to the original one.
-      socket.addressProvider().restoreLocalAddress(original_local_address);
+      socket.connectionInfoProvider().restoreLocalAddress(original_local_address);
     }
   }
 

--- a/source/extensions/filters/listener/original_src/original_src.cc
+++ b/source/extensions/filters/listener/original_src/original_src.cc
@@ -15,7 +15,7 @@ OriginalSrcFilter::OriginalSrcFilter(const Config& config) : config_(config) {}
 
 Network::FilterStatus OriginalSrcFilter::onAccept(Network::ListenerFilterCallbacks& cb) {
   auto& socket = cb.socket();
-  auto address = socket.addressProvider().remoteAddress();
+  auto address = socket.connectionInfoProvider().remoteAddress();
   ASSERT(address);
 
   ENVOY_LOG(debug,

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -128,9 +128,11 @@ ReadOrParseState Filter::onReadWorker() {
     // Only set the local address if it really changed, and mark it as address being restored.
     if (*proxy_protocol_header_.value().local_address_ !=
         *socket.connectionInfoProvider().localAddress()) {
-      socket.connectionInfoProvider().restoreLocalAddress(proxy_protocol_header_.value().local_address_);
+      socket.connectionInfoProvider().restoreLocalAddress(
+          proxy_protocol_header_.value().local_address_);
     }
-    socket.connectionInfoProvider().setRemoteAddress(proxy_protocol_header_.value().remote_address_);
+    socket.connectionInfoProvider().setRemoteAddress(
+        proxy_protocol_header_.value().remote_address_);
   }
 
   // Release the file event so that we do not interfere with the connection read events.

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -127,10 +127,10 @@ ReadOrParseState Filter::onReadWorker() {
 
     // Only set the local address if it really changed, and mark it as address being restored.
     if (*proxy_protocol_header_.value().local_address_ !=
-        *socket.addressProvider().localAddress()) {
-      socket.addressProvider().restoreLocalAddress(proxy_protocol_header_.value().local_address_);
+        *socket.connectionInfoProvider().localAddress()) {
+      socket.connectionInfoProvider().restoreLocalAddress(proxy_protocol_header_.value().local_address_);
     }
-    socket.addressProvider().setRemoteAddress(proxy_protocol_header_.value().remote_address_);
+    socket.connectionInfoProvider().setRemoteAddress(proxy_protocol_header_.value().remote_address_);
   }
 
   // Release the file event so that we do not interfere with the connection read events.

--- a/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
+++ b/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
@@ -113,7 +113,7 @@ void ClientSslAuthFilter::onEvent(Network::ConnectionEvent event) {
 
   ASSERT(read_callbacks_->connection().ssl());
   if (config_->ipAllowlist().contains(
-          *read_callbacks_->connection().addressProvider().remoteAddress())) {
+          *read_callbacks_->connection().connectionInfoProvider().remoteAddress())) {
     config_->stats().auth_ip_allowlist_.inc();
     read_callbacks_->continueReading();
     return;

--- a/source/extensions/filters/network/dubbo_proxy/active_message.cc
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.cc
@@ -185,7 +185,7 @@ ActiveMessage::ActiveMessage(ConnectionManager& parent)
     : parent_(parent), request_timer_(std::make_unique<Stats::HistogramCompletableTimespanImpl>(
                            parent_.stats().request_time_ms_, parent.timeSystem())),
       request_id_(-1), stream_id_(parent.randomGenerator().random()),
-      stream_info_(parent.timeSystem(), parent_.connection().addressProviderSharedPtr()),
+      stream_info_(parent.timeSystem(), parent_.connection().connectionInfoProviderSharedPtr()),
       pending_stream_decoded_(false), local_response_sent_(false) {
   parent_.stats().request_active_.inc();
 }

--- a/source/extensions/filters/network/rbac/rbac_filter.cc
+++ b/source/extensions/filters/network/rbac/rbac_filter.cc
@@ -28,7 +28,7 @@ Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bo
       "checking connection: requestedServerName: {}, sourceIP: {}, directRemoteIP: {},"
       "remoteIP: {}, localAddress: {}, ssl: {}, dynamicMetadata: {}",
       callbacks_->connection().requestedServerName(),
-      callbacks_->connection().addressProvider().remoteAddress()->asString(),
+      callbacks_->connection().connectionInfoProvider().remoteAddress()->asString(),
       callbacks_->connection()
           .streamInfo()
           .downstreamAddressProvider()

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -154,7 +154,7 @@ private:
                                parent_.stats_.request_time_ms_, parent_.time_source_)),
           stream_id_(parent_.random_generator_.random()),
           stream_info_(parent_.time_source_,
-                       parent_.read_callbacks_->connection().addressProviderSharedPtr()),
+                       parent_.read_callbacks_->connection().connectionInfoProviderSharedPtr()),
           local_response_sent_{false}, pending_transport_end_{false} {
       parent_.stats_.request_active_.inc();
     }

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -320,7 +320,7 @@ Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
   auto on_destroy_callback = [this, &stream_decoder_filter_callbacks]() {
     ENVOY_LOG(debug, "stopped sending data to hystrix dashboard on port {}",
               stream_decoder_filter_callbacks.connection()
-                  ->addressProvider()
+                  ->connectionInfoProvider()
                   .remoteAddress()
                   ->asString());
 
@@ -333,7 +333,7 @@ Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
 
   ENVOY_LOG(
       debug, "started sending data to hystrix dashboard on port {}",
-      stream_decoder_filter_callbacks.connection()->addressProvider().remoteAddress()->asString());
+      stream_decoder_filter_callbacks.connection()->connectionInfoProvider().remoteAddress()->asString());
   return Http::Code::OK;
 }
 

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -331,9 +331,11 @@ Http::Code HystrixSink::handlerHystrixEventStream(absl::string_view,
   // Add the callback to the admin_filter list of callbacks
   admin_stream.addOnDestroyCallback(std::move(on_destroy_callback));
 
-  ENVOY_LOG(
-      debug, "started sending data to hystrix dashboard on port {}",
-      stream_decoder_filter_callbacks.connection()->connectionInfoProvider().remoteAddress()->asString());
+  ENVOY_LOG(debug, "started sending data to hystrix dashboard on port {}",
+            stream_decoder_filter_callbacks.connection()
+                ->connectionInfoProvider()
+                .remoteAddress()
+                ->asString());
   return Http::Code::OK;
 }
 

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -57,8 +57,8 @@ void TsiSocket::doHandshakeNext() {
 
   if (!handshaker_) {
     handshaker_ = handshaker_factory_(callbacks_->connection().dispatcher(),
-                                      callbacks_->connection().addressProvider().localAddress(),
-                                      callbacks_->connection().addressProvider().remoteAddress());
+                                      callbacks_->connection().connectionInfoProvider().localAddress(),
+                                      callbacks_->connection().connectionInfoProvider().remoteAddress());
     if (!handshaker_) {
       ENVOY_CONN_LOG(warn, "TSI: failed to create handshaker", callbacks_->connection());
       callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -56,9 +56,10 @@ void TsiSocket::doHandshakeNext() {
                  raw_read_buffer_.length());
 
   if (!handshaker_) {
-    handshaker_ = handshaker_factory_(callbacks_->connection().dispatcher(),
-                                      callbacks_->connection().connectionInfoProvider().localAddress(),
-                                      callbacks_->connection().connectionInfoProvider().remoteAddress());
+    handshaker_ =
+        handshaker_factory_(callbacks_->connection().dispatcher(),
+                            callbacks_->connection().connectionInfoProvider().localAddress(),
+                            callbacks_->connection().connectionInfoProvider().remoteAddress());
     if (!handshaker_) {
       ENVOY_CONN_LOG(warn, "TSI: failed to create handshaker", callbacks_->connection());
       callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -52,8 +52,8 @@ void UpstreamProxyProtocolSocket::generateHeader() {
 void UpstreamProxyProtocolSocket::generateHeaderV1() {
   // Default to local addresses. Used if no downstream connection exists or
   // downstream address info is not set e.g. health checks
-  auto src_addr = callbacks_->connection().addressProvider().localAddress();
-  auto dst_addr = callbacks_->connection().addressProvider().remoteAddress();
+  auto src_addr = callbacks_->connection().connectionInfoProvider().localAddress();
+  auto dst_addr = callbacks_->connection().connectionInfoProvider().remoteAddress();
 
   if (options_ && options_->proxyProtocolOptions().has_value()) {
     const auto options = options_->proxyProtocolOptions().value();

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -29,12 +29,12 @@ PerSocketTapperImpl::PerSocketTapperImpl(SocketTapConfigSharedPtr config,
 }
 
 void PerSocketTapperImpl::fillConnectionInfo(envoy::data::tap::v3::Connection& connection) {
-  if (connection_.addressProvider().localAddress() != nullptr) {
+  if (connection_.connectionInfoProvider().localAddress() != nullptr) {
     // Local address might not be populated before a client connection is connected.
-    Network::Utility::addressToProtobufAddress(*connection_.addressProvider().localAddress(),
+    Network::Utility::addressToProtobufAddress(*connection_.connectionInfoProvider().localAddress(),
                                                *connection.mutable_local_address());
   }
-  Network::Utility::addressToProtobufAddress(*connection_.addressProvider().remoteAddress(),
+  Network::Utility::addressToProtobufAddress(*connection_.connectionInfoProvider().remoteAddress(),
                                              *connection.mutable_remote_address());
 }
 

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -27,7 +27,8 @@ void TcpConnPool::onPoolReady(Envoy::Tcp::ConnectionPool::ConnectionDataPtr&& co
   Network::Connection& latched_conn = conn_data->connection();
   auto upstream =
       std::make_unique<TcpUpstream>(&callbacks_->upstreamToDownstream(), std::move(conn_data));
-  callbacks_->onPoolReady(std::move(upstream), host, latched_conn.connectionInfoProvider().localAddress(),
+  callbacks_->onPoolReady(std::move(upstream), host,
+                          latched_conn.connectionInfoProvider().localAddress(),
                           latched_conn.streamInfo(), {});
 }
 

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -27,7 +27,7 @@ void TcpConnPool::onPoolReady(Envoy::Tcp::ConnectionPool::ConnectionDataPtr&& co
   Network::Connection& latched_conn = conn_data->connection();
   auto upstream =
       std::make_unique<TcpUpstream>(&callbacks_->upstreamToDownstream(), std::move(conn_data));
-  callbacks_->onPoolReady(std::move(upstream), host, latched_conn.addressProvider().localAddress(),
+  callbacks_->onPoolReady(std::move(upstream), host, latched_conn.connectionInfoProvider().localAddress(),
                           latched_conn.streamInfo(), {});
 }
 

--- a/source/server/active_stream_listener_base.cc
+++ b/source/server/active_stream_listener_base.cc
@@ -29,9 +29,9 @@ void ActiveStreamListenerBase::newConnection(Network::ConnectionSocketPtr&& sock
   // Find matching filter chain.
   const auto filter_chain = config_->filterChainManager().findFilterChain(*socket);
   if (filter_chain == nullptr) {
-    RELEASE_ASSERT(socket->addressProvider().remoteAddress() != nullptr, "");
+    RELEASE_ASSERT(socket->connectionInfoProvider().remoteAddress() != nullptr, "");
     ENVOY_LOG(debug, "closing connection from {}: no matching filter chain found",
-              socket->addressProvider().remoteAddress()->asString());
+              socket->connectionInfoProvider().remoteAddress()->asString());
     stats_.no_filter_chain_match_.inc();
     stream_info->setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
     stream_info->setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().FilterChainNotFound);
@@ -49,12 +49,12 @@ void ActiveStreamListenerBase::newConnection(Network::ConnectionSocketPtr&& sock
         timeout, stats_.downstream_cx_transport_socket_connect_timeout_);
   }
   server_conn_ptr->setBufferLimits(config_->perConnectionBufferLimitBytes());
-  RELEASE_ASSERT(server_conn_ptr->addressProvider().remoteAddress() != nullptr, "");
+  RELEASE_ASSERT(server_conn_ptr->connectionInfoProvider().remoteAddress() != nullptr, "");
   const bool empty_filter_chain = !config_->filterChainFactory().createNetworkFilterChain(
       *server_conn_ptr, filter_chain->networkFilterFactories());
   if (empty_filter_chain) {
     ENVOY_CONN_LOG(debug, "closing connection from {}: no filters", *server_conn_ptr,
-                   server_conn_ptr->addressProvider().remoteAddress()->asString());
+                   server_conn_ptr->connectionInfoProvider().remoteAddress()->asString());
     server_conn_ptr->close(Network::ConnectionCloseType::NoFlush);
   }
   newActiveConnection(*filter_chain, std::move(server_conn_ptr), std::move(stream_info));

--- a/source/server/active_tcp_listener.cc
+++ b/source/server/active_tcp_listener.cc
@@ -135,8 +135,9 @@ void ActiveTcpListener::newActiveConnection(const Network::FilterChain& filter_c
                                             dispatcher().timeSource(), std::move(stream_info));
   // If the connection is already closed, we can just let this connection immediately die.
   if (active_connection->connection_->state() != Network::Connection::State::Closed) {
-    ENVOY_CONN_LOG(debug, "new connection from {}", *active_connection->connection_,
-                   active_connection->connection_->connectionInfoProvider().remoteAddress()->asString());
+    ENVOY_CONN_LOG(
+        debug, "new connection from {}", *active_connection->connection_,
+        active_connection->connection_->connectionInfoProvider().remoteAddress()->asString());
     active_connection->connection_->addConnectionCallbacks(*active_connection);
     LinkedList::moveIntoList(std::move(active_connection), active_connections.connections_);
   }

--- a/source/server/active_tcp_listener.cc
+++ b/source/server/active_tcp_listener.cc
@@ -69,9 +69,9 @@ void ActiveTcpListener::updateListenerConfig(Network::ListenerConfig& config) {
 
 void ActiveTcpListener::onAccept(Network::ConnectionSocketPtr&& socket) {
   if (listenerConnectionLimitReached()) {
-    RELEASE_ASSERT(socket->addressProvider().remoteAddress() != nullptr, "");
+    RELEASE_ASSERT(socket->connectionInfoProvider().remoteAddress() != nullptr, "");
     ENVOY_LOG(trace, "closing connection from {}: listener connection limit reached for {}",
-              socket->addressProvider().remoteAddress()->asString(), config_->name());
+              socket->connectionInfoProvider().remoteAddress()->asString(), config_->name());
     socket->close();
     stats_.downstream_cx_overflow_.inc();
     return;
@@ -136,7 +136,7 @@ void ActiveTcpListener::newActiveConnection(const Network::FilterChain& filter_c
   // If the connection is already closed, we can just let this connection immediately die.
   if (active_connection->connection_->state() != Network::Connection::State::Closed) {
     ENVOY_CONN_LOG(debug, "new connection from {}", *active_connection->connection_,
-                   active_connection->connection_->addressProvider().remoteAddress()->asString());
+                   active_connection->connection_->connectionInfoProvider().remoteAddress()->asString());
     active_connection->connection_->addConnectionCallbacks(*active_connection);
     LinkedList::moveIntoList(std::move(active_connection), active_connections.connections_);
   }

--- a/source/server/active_tcp_socket.cc
+++ b/source/server/active_tcp_socket.cc
@@ -121,10 +121,10 @@ void ActiveTcpSocket::newConnection() {
   Network::BalancedConnectionHandlerOptRef new_listener;
 
   if (hand_off_restored_destination_connections_ &&
-      socket_->addressProvider().localAddressRestored()) {
+      socket_->connectionInfoProvider().localAddressRestored()) {
     // Find a listener associated with the original destination address.
     new_listener =
-        listener_.getBalancedHandlerByAddress(*socket_->addressProvider().localAddress());
+        listener_.getBalancedHandlerByAddress(*socket_->connectionInfoProvider().localAddress());
   }
   if (new_listener.has_value()) {
     // Hands off connections redirected by iptables to the listener associated with the

--- a/source/server/active_tcp_socket.cc
+++ b/source/server/active_tcp_socket.cc
@@ -15,7 +15,7 @@ ActiveTcpSocket::ActiveTcpSocket(ActiveStreamListenerBase& listener,
       hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
       iter_(accept_filters_.end()),
       stream_info_(std::make_unique<StreamInfo::StreamInfoImpl>(
-          listener_.dispatcher().timeSource(), socket_->addressProviderSharedPtr(),
+          listener_.dispatcher().timeSource(), socket_->connectionInfoProviderSharedPtr(),
           StreamInfo::FilterState::LifeSpan::Connection)) {
   listener_.stats_.downstream_pre_cx_active_.inc();
 }

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -131,14 +131,14 @@ void AdminImpl::startHttpListener(const std::list<AccessLog::InstanceSharedPtr>&
                  "listen() failed on admin listener");
   socket_factory_ = std::make_unique<AdminListenSocketFactory>(socket_);
   listener_ = std::make_unique<AdminListener>(*this, std::move(listener_scope));
-  ENVOY_LOG(info, "admin address: {}", socket().addressProvider().localAddress()->asString());
+  ENVOY_LOG(info, "admin address: {}", socket().connectionInfoProvider().localAddress()->asString());
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);
     if (!address_out_file) {
       ENVOY_LOG(critical, "cannot open admin address output file {} for writing.",
                 address_out_path);
     } else {
-      address_out_file << socket_->addressProvider().localAddress()->asString();
+      address_out_file << socket_->connectionInfoProvider().localAddress()->asString();
     }
   }
 }

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -131,7 +131,8 @@ void AdminImpl::startHttpListener(const std::list<AccessLog::InstanceSharedPtr>&
                  "listen() failed on admin listener");
   socket_factory_ = std::make_unique<AdminListenSocketFactory>(socket_);
   listener_ = std::make_unique<AdminListener>(*this, std::move(listener_scope));
-  ENVOY_LOG(info, "admin address: {}", socket().connectionInfoProvider().localAddress()->asString());
+  ENVOY_LOG(info, "admin address: {}",
+            socket().connectionInfoProvider().localAddress()->asString());
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);
     if (!address_out_file) {

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -319,7 +319,7 @@ private:
     // Network::ListenSocketFactory
     Network::Socket::Type socketType() const override { return socket_->socketType(); }
     const Network::Address::InstanceConstSharedPtr& localAddress() const override {
-      return socket_->addressProvider().localAddress();
+      return socket_->connectionInfoProvider().localAddress();
     }
     Network::SocketSharedPtr getListenSocket(uint32_t) override {
       // This is only supposed to be called once.

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -120,7 +120,7 @@ protected:
       void readDisable(bool) override {}
       void detectEarlyCloseWhenReadDisabled(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
       bool readEnabled() const override { return true; }
-      const Network::ConnectionInfoSetter& addressProvider() const override {
+      const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
         return *address_provider_;
       }
       Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -123,7 +123,7 @@ protected:
       const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
         return *address_provider_;
       }
-      Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
+      Network::ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
         return address_provider_;
       }
       absl::optional<Network::Connection::UnixDomainSocketPeerCredentials>

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -463,7 +463,7 @@ std::pair<T, std::vector<Network::Address::CidrRange>> makeCidrListEntry(const s
 
 const Network::FilterChain*
 FilterChainManagerImpl::findFilterChain(const Network::ConnectionSocket& socket) const {
-  const auto& address = socket.addressProvider().localAddress();
+  const auto& address = socket.connectionInfoProvider().localAddress();
 
   const Network::FilterChain* best_match_filter_chain = nullptr;
   // Match on destination port (only for IP addresses).
@@ -493,7 +493,7 @@ FilterChainManagerImpl::findFilterChain(const Network::ConnectionSocket& socket)
 
 const Network::FilterChain* FilterChainManagerImpl::findFilterChainForDestinationIP(
     const DestinationIPsTrie& destination_ips_trie, const Network::ConnectionSocket& socket) const {
-  auto address = socket.addressProvider().localAddress();
+  auto address = socket.connectionInfoProvider().localAddress();
   if (address->type() != Network::Address::Type::Ip) {
     address = fakeAddress();
   }
@@ -582,7 +582,7 @@ const Network::FilterChain* FilterChainManagerImpl::findFilterChainForApplicatio
 const Network::FilterChain* FilterChainManagerImpl::findFilterChainForDirectSourceIP(
     const DirectSourceIPsTrie& direct_source_ips_trie,
     const Network::ConnectionSocket& socket) const {
-  auto address = socket.addressProvider().directRemoteAddress();
+  auto address = socket.connectionInfoProvider().directRemoteAddress();
   if (address->type() != Network::Address::Type::Ip) {
     address = fakeAddress();
   }
@@ -632,7 +632,7 @@ const Network::FilterChain* FilterChainManagerImpl::findFilterChainForSourceType
 
 const Network::FilterChain* FilterChainManagerImpl::findFilterChainForSourceIpAndPort(
     const SourceIPsTrie& source_ips_trie, const Network::ConnectionSocket& socket) const {
-  auto address = socket.addressProvider().remoteAddress();
+  auto address = socket.connectionInfoProvider().remoteAddress();
   if (address->type() != Network::Address::Type::Ip) {
     address = fakeAddress();
   }

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -93,7 +93,7 @@ ListenSocketFactoryImpl::ListenSocketFactoryImpl(
   sockets_.push_back(createListenSocketAndApplyOptions(factory, socket_type, 0));
 
   if (sockets_[0] != nullptr && local_address_->ip() && local_address_->ip()->port() == 0) {
-    local_address_ = sockets_[0]->addressProvider().localAddress();
+    local_address_ = sockets_[0]->connectionInfoProvider().localAddress();
   }
   ENVOY_LOG(debug, "Set listener {} socket factory local address to {}", listener_name,
             local_address_->asString());
@@ -185,7 +185,7 @@ void ListenSocketFactoryImpl::doFinalPreWorkerInit() {
                                        envoy::config::core::v3::SocketOption::STATE_LISTENING)) {
       throw Network::SocketOptionException(
           fmt::format("cannot set post-listen socket option on socket: {}",
-                      socket->addressProvider().localAddress()->asString()));
+                      socket->connectionInfoProvider().localAddress()->asString()));
     }
   };
   // On all platforms we should listen on the first socket.

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -289,7 +289,7 @@ public:
     auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
         Network::Test::getCanonicalLoopbackAddress(GetParam()));
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-        socket->addressProvider().localAddress(), source_address_,
+        socket->connectionInfoProvider().localAddress(), source_address_,
         Network::Test::createRawBufferSocket(), nullptr);
     upstream_listener_ = dispatcher_->createListener(std::move(socket), listener_callbacks_, true);
     client_connection_ = client_connection.get();

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -2824,9 +2824,10 @@ public:
         Network::Test::getCanonicalLoopbackAddress(GetParam()));
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
 
-    client_connection_ = dispatcher_->createClientConnection(
-        socket_->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
-        Network::Test::createRawBufferSocket(), nullptr);
+    client_connection_ =
+        dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),
+                                            Network::Address::InstanceConstSharedPtr(),
+                                            Network::Test::createRawBufferSocket(), nullptr);
     client_connection_->addConnectionCallbacks(client_callbacks_);
     client_connection_->connect();
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -139,13 +139,13 @@ protected:
         Network::Test::getCanonicalLoopbackAddress(GetParam()));
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
     client_connection_ = std::make_unique<Network::TestClientConnectionImpl>(
-        *dispatcher_, socket_->addressProvider().localAddress(), source_address_,
+        *dispatcher_, socket_->connectionInfoProvider().localAddress(), source_address_,
         Network::Test::createRawBufferSocket(), socket_options_);
     client_connection_->addConnectionCallbacks(client_callbacks_);
     EXPECT_EQ(nullptr, client_connection_->ssl());
     const Network::ClientConnection& const_connection = *client_connection_;
     EXPECT_EQ(nullptr, const_connection.ssl());
-    EXPECT_FALSE(client_connection_->addressProvider().localAddressRestored());
+    EXPECT_FALSE(client_connection_->connectionInfoProvider().localAddressRestored());
   }
 
   void connect() {
@@ -378,7 +378,7 @@ TEST_P(ConnectionImplTest, ImmediateConnectError) {
   Address::InstanceConstSharedPtr broadcast_address;
   socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()));
-  if (socket_->addressProvider().localAddress()->ip()->version() == Address::IpVersion::v4) {
+  if (socket_->connectionInfoProvider().localAddress()->ip()->version() == Address::IpVersion::v4) {
     broadcast_address = std::make_shared<Address::Ipv4Instance>("224.0.0.1", 0);
   } else {
     broadcast_address = std::make_shared<Address::Ipv6Instance>("ff02::1", 0);
@@ -499,7 +499,7 @@ TEST_P(ConnectionImplTest, SocketOptions) {
         server_connection_->addReadFilter(read_filter_);
 
         upstream_connection_ = dispatcher_->createClientConnection(
-            socket_->addressProvider().localAddress(), source_address_,
+            socket_->connectionInfoProvider().localAddress(), source_address_,
             Network::Test::createRawBufferSocket(), server_connection_->socketOptions());
       }));
 
@@ -548,7 +548,7 @@ TEST_P(ConnectionImplTest, SocketOptionsFailureTest) {
         server_connection_->addReadFilter(read_filter_);
 
         upstream_connection_ = dispatcher_->createClientConnection(
-            socket_->addressProvider().localAddress(), source_address_,
+            socket_->connectionInfoProvider().localAddress(), source_address_,
             Network::Test::createRawBufferSocket(), server_connection_->socketOptions());
         upstream_connection_->addConnectionCallbacks(upstream_callbacks_);
       }));
@@ -1304,7 +1304,7 @@ TEST_P(ConnectionImplTest, BindTest) {
   setUpBasicConnection();
   connect();
   EXPECT_EQ(address_string,
-            server_connection_->addressProvider().remoteAddress()->ip()->addressAsString());
+            server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString());
 
   disconnect(true);
 }
@@ -1323,7 +1323,7 @@ TEST_P(ConnectionImplTest, BindFromSocketTest) {
   auto option = std::make_shared<NiceMock<MockSocketOption>>();
   EXPECT_CALL(*option, setOption(_, Eq(envoy::config::core::v3::SocketOption::STATE_PREBIND)))
       .WillOnce(Invoke([&](Socket& socket, envoy::config::core::v3::SocketOption::SocketState) {
-        socket.addressProvider().setLocalAddress(new_source_address);
+        socket.connectionInfoProvider().setLocalAddress(new_source_address);
         return true;
       }));
 
@@ -1332,7 +1332,7 @@ TEST_P(ConnectionImplTest, BindFromSocketTest) {
   setUpBasicConnection();
   connect();
   EXPECT_EQ(address_string,
-            server_connection_->addressProvider().remoteAddress()->ip()->addressAsString());
+            server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString());
 
   disconnect(true);
 }
@@ -1354,7 +1354,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
 
   client_connection_ = dispatcher_->createClientConnection(
-      socket_->addressProvider().localAddress(), source_address_,
+      socket_->connectionInfoProvider().localAddress(), source_address_,
       Network::Test::createRawBufferSocket(), nullptr);
 
   MockConnectionStats connection_stats;
@@ -2825,7 +2825,7 @@ public:
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
 
     client_connection_ = dispatcher_->createClientConnection(
-        socket_->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+        socket_->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
         Network::Test::createRawBufferSocket(), nullptr);
     client_connection_->addConnectionCallbacks(client_callbacks_);
     client_connection_->connect();

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -455,8 +455,8 @@ public:
     if (tcpOnly()) {
       peer_->resetChannelTcpOnly(zeroTimeout());
     }
-    ares_set_servers_ports_csv(peer_->channel(),
-                               socket_->connectionInfoProvider().localAddress()->asString().c_str());
+    ares_set_servers_ports_csv(
+        peer_->channel(), socket_->connectionInfoProvider().localAddress()->asString().c_str());
   }
 
   void TearDown() override {

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -444,7 +444,7 @@ public:
     // Create a resolver options on stack here to emulate what actually happens in envoy bootstrap.
     envoy::config::core::v3::DnsResolverOptions dns_resolver_options = dns_resolver_options_;
     if (setResolverInConstructor()) {
-      resolver_ = dispatcher_->createDnsResolver({socket_->addressProvider().localAddress()},
+      resolver_ = dispatcher_->createDnsResolver({socket_->connectionInfoProvider().localAddress()},
                                                  dns_resolver_options);
     } else {
       resolver_ = dispatcher_->createDnsResolver({}, dns_resolver_options);
@@ -456,7 +456,7 @@ public:
       peer_->resetChannelTcpOnly(zeroTimeout());
     }
     ares_set_servers_ports_csv(peer_->channel(),
-                               socket_->addressProvider().localAddress()->asString().c_str());
+                               socket_->connectionInfoProvider().localAddress()->asString().c_str());
   }
 
   void TearDown() override {
@@ -591,7 +591,7 @@ TEST_P(DnsImplTest, DestructCallback) {
   // a subsequent result to call ares_destroy.
   peer_->resetChannelTcpOnly(zeroTimeout());
   ares_set_servers_ports_csv(peer_->channel(),
-                             socket_->addressProvider().localAddress()->asString().c_str());
+                             socket_->connectionInfoProvider().localAddress()->asString().c_str());
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
@@ -719,7 +719,7 @@ TEST_P(DnsImplTest, DestroyChannelOnRefused) {
     peer_->resetChannelTcpOnly(zeroTimeout());
   }
   ares_set_servers_ports_csv(peer_->channel(),
-                             socket_->addressProvider().localAddress()->asString().c_str());
+                             socket_->connectionInfoProvider().localAddress()->asString().c_str());
 
   EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::Auto,
                                              DnsResolver::ResolutionStatus::Success,

--- a/test/common/network/happy_eyeballs_connection_impl_test.cc
+++ b/test/common/network/happy_eyeballs_connection_impl_test.cc
@@ -978,8 +978,8 @@ TEST_F(HappyEyeballsConnectionImplTest, AddressProviderSharedPtr) {
   ConnectionInfoProviderSharedPtr provider = std::make_shared<ConnectionInfoSetterImpl>(
       std::make_shared<Address::Ipv4Instance>("127.0.0.2"),
       std::make_shared<Address::Ipv4Instance>("127.0.0.1"));
-  EXPECT_CALL(*created_connections_[0], addressProviderSharedPtr()).WillOnce(Return(provider));
-  EXPECT_EQ(provider, impl_->addressProviderSharedPtr());
+  EXPECT_CALL(*created_connections_[0], connectionInfoProviderSharedPtr()).WillOnce(Return(provider));
+  EXPECT_EQ(provider, impl_->connectionInfoProviderSharedPtr());
 }
 
 TEST_F(HappyEyeballsConnectionImplTest, UnixSocketPeerCredentials) {

--- a/test/common/network/happy_eyeballs_connection_impl_test.cc
+++ b/test/common/network/happy_eyeballs_connection_impl_test.cc
@@ -978,7 +978,8 @@ TEST_F(HappyEyeballsConnectionImplTest, AddressProviderSharedPtr) {
   ConnectionInfoProviderSharedPtr provider = std::make_shared<ConnectionInfoSetterImpl>(
       std::make_shared<Address::Ipv4Instance>("127.0.0.2"),
       std::make_shared<Address::Ipv4Instance>("127.0.0.1"));
-  EXPECT_CALL(*created_connections_[0], connectionInfoProviderSharedPtr()).WillOnce(Return(provider));
+  EXPECT_CALL(*created_connections_[0], connectionInfoProviderSharedPtr())
+      .WillOnce(Return(provider));
   EXPECT_EQ(provider, impl_->connectionInfoProviderSharedPtr());
 }
 

--- a/test/common/network/happy_eyeballs_connection_impl_test.cc
+++ b/test/common/network/happy_eyeballs_connection_impl_test.cc
@@ -968,8 +968,8 @@ TEST_F(HappyEyeballsConnectionImplTest, AddressProvider) {
 
   const ConnectionInfoSetterImpl provider(std::make_shared<Address::Ipv4Instance>(80),
                                           std::make_shared<Address::Ipv4Instance>(80));
-  EXPECT_CALL(*created_connections_[0], addressProvider()).WillOnce(ReturnRef(provider));
-  impl_->addressProvider();
+  EXPECT_CALL(*created_connections_[0], connectionInfoProvider()).WillOnce(ReturnRef(provider));
+  impl_->connectionInfoProvider();
 }
 
 TEST_F(HappyEyeballsConnectionImplTest, AddressProviderSharedPtr) {

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -99,9 +99,9 @@ protected:
         EXPECT_EQ(0, socket1->listen(0).return_value_);
       }
 
-      EXPECT_EQ(addr->ip()->port(), socket1->addressProvider().localAddress()->ip()->port());
+      EXPECT_EQ(addr->ip()->port(), socket1->connectionInfoProvider().localAddress()->ip()->port());
       EXPECT_EQ(addr->ip()->addressAsString(),
-                socket1->addressProvider().localAddress()->ip()->addressAsString());
+                socket1->connectionInfoProvider().localAddress()->ip()->addressAsString());
       EXPECT_EQ(Type, socket1->socketType());
 
       auto option2 = std::make_unique<MockSocketOption>();
@@ -122,7 +122,7 @@ protected:
       Network::IoHandlePtr io_handle =
           std::make_unique<IoSocketHandleImpl>(socket_result.return_value_);
       auto socket3 = createListenSocketPtr(std::move(io_handle), addr, nullptr);
-      EXPECT_EQ(socket3->addressProvider().localAddress()->asString(), addr->asString());
+      EXPECT_EQ(socket3->connectionInfoProvider().localAddress()->asString(), addr->asString());
 
       // Test successful.
       return;
@@ -132,11 +132,11 @@ protected:
   void testBindPortZero() {
     auto loopback = Network::Test::getCanonicalLoopbackAddress(version_);
     auto socket = createListenSocketPtr(loopback, nullptr, true);
-    EXPECT_EQ(Address::Type::Ip, socket->addressProvider().localAddress()->type());
-    EXPECT_EQ(version_, socket->addressProvider().localAddress()->ip()->version());
+    EXPECT_EQ(Address::Type::Ip, socket->connectionInfoProvider().localAddress()->type());
+    EXPECT_EQ(version_, socket->connectionInfoProvider().localAddress()->ip()->version());
     EXPECT_EQ(loopback->ip()->addressAsString(),
-              socket->addressProvider().localAddress()->ip()->addressAsString());
-    EXPECT_GT(socket->addressProvider().localAddress()->ip()->port(), 0U);
+              socket->connectionInfoProvider().localAddress()->ip()->addressAsString());
+    EXPECT_GT(socket->connectionInfoProvider().localAddress()->ip()->port(), 0U);
     EXPECT_EQ(Type, socket->socketType());
   }
 };
@@ -175,9 +175,9 @@ TEST_P(ListenSocketImplTestTcp, SetLocalAddress) {
 
   TestListenSocket socket(Utility::getIpv4AnyAddress());
 
-  socket.addressProvider().setLocalAddress(address);
+  socket.connectionInfoProvider().setLocalAddress(address);
 
-  EXPECT_EQ(socket.addressProvider().localAddress(), address);
+  EXPECT_EQ(socket.connectionInfoProvider().localAddress(), address);
 }
 
 TEST_P(ListenSocketImplTestTcp, CheckIpVersionWithNullLocalAddress) {

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -38,7 +38,7 @@ static void errorCallbackTest(Address::IpVersion version) {
   Network::ListenerPtr listener = dispatcher->createListener(socket, listener_callbacks, true);
 
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->connect();
 
@@ -91,7 +91,7 @@ TEST_P(TcpListenerImplTest, UseActualDst) {
                                            listener_callbacks2, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->connect();
 
@@ -103,8 +103,8 @@ TEST_P(TcpListenerImplTest, UseActualDst) {
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
         Network::ConnectionPtr conn = dispatcher_->createServerConnection(
             std::move(accepted_socket), Network::Test::createRawBufferSocket(), stream_info);
-        EXPECT_EQ(*conn->addressProvider().localAddress(),
-                  *socket->addressProvider().localAddress());
+        EXPECT_EQ(*conn->connectionInfoProvider().localAddress(),
+                  *socket->connectionInfoProvider().localAddress());
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher_->exit();
@@ -137,7 +137,7 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitEnforcement) {
   auto initiate_connections = [&](const int count) {
     for (int i = 0; i < count; ++i) {
       client_connections.emplace_back(dispatcher_->createClientConnection(
-          socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+          socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
           Network::Test::createRawBufferSocket(), nullptr));
       client_connections.back()->connect();
     }
@@ -191,7 +191,7 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
 
   auto local_dst_address =
       Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
-                                           socket->addressProvider().localAddress()->ip()->port());
+                                           socket->connectionInfoProvider().localAddress()->ip()->port());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       local_dst_address, Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
@@ -202,7 +202,7 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::ConnectionPtr conn = dispatcher_->createServerConnection(
             std::move(socket), Network::Test::createRawBufferSocket(), stream_info);
-        EXPECT_EQ(*conn->addressProvider().localAddress(), *local_dst_address);
+        EXPECT_EQ(*conn->connectionInfoProvider().localAddress(), *local_dst_address);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher_->exit();
@@ -227,7 +227,7 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
   Network::MockTcpListenerCallbacks listener_callbacks;
   Random::MockRandomGenerator random_generator;
 
-  ASSERT_TRUE(socket->addressProvider().localAddress()->ip()->isAnyAddress());
+  ASSERT_TRUE(socket->connectionInfoProvider().localAddress()->ip()->isAnyAddress());
 
   // Do not redirect since use_original_dst is false.
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
@@ -235,10 +235,10 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
 
   auto listener_address =
       Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
-                                           socket->addressProvider().localAddress()->ip()->port());
+                                           socket->connectionInfoProvider().localAddress()->ip()->port());
   auto local_dst_address =
       Network::Utility::getAddressWithPort(*Network::Utility::getCanonicalIpv4LoopbackAddress(),
-                                           socket->addressProvider().localAddress()->ip()->port());
+                                           socket->connectionInfoProvider().localAddress()->ip()->port());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       local_dst_address, Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
@@ -249,11 +249,11 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::ConnectionPtr conn = dispatcher_->createServerConnection(
             std::move(socket), Network::Test::createRawBufferSocket(), stream_info);
-        EXPECT_EQ(conn->addressProvider().localAddress()->ip()->version(),
-                  conn->addressProvider().remoteAddress()->ip()->version());
-        EXPECT_EQ(conn->addressProvider().localAddress()->asString(),
+        EXPECT_EQ(conn->connectionInfoProvider().localAddress()->ip()->version(),
+                  conn->connectionInfoProvider().remoteAddress()->ip()->version());
+        EXPECT_EQ(conn->connectionInfoProvider().localAddress()->asString(),
                   local_dst_address->asString());
-        EXPECT_EQ(*conn->addressProvider().localAddress(), *local_dst_address);
+        EXPECT_EQ(*conn->connectionInfoProvider().localAddress(), *local_dst_address);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher_->exit();
@@ -277,7 +277,7 @@ TEST_P(TcpListenerImplTest, DisableAndEnableListener) {
   listener.disable();
 
   ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->addConnectionCallbacks(connection_callbacks);
   client_connection->connect();
@@ -325,7 +325,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionZero) {
   EXPECT_CALL(listener_callbacks, onAccept_(_)).WillOnce([&] { dispatcher_->exit(); });
 
   ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->addConnectionCallbacks(connection_callbacks);
   client_connection->connect();
@@ -363,7 +363,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
 
   {
     ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-        socket->addressProvider().localAddress(), Address::InstanceConstSharedPtr(),
+        socket->connectionInfoProvider().localAddress(), Address::InstanceConstSharedPtr(),
         Network::Test::createRawBufferSocket(), nullptr);
     client_connection->addConnectionCallbacks(connection_callbacks);
     client_connection->connect();
@@ -386,7 +386,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
 
   {
     ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-        socket->addressProvider().localAddress(), Address::InstanceConstSharedPtr(),
+        socket->connectionInfoProvider().localAddress(), Address::InstanceConstSharedPtr(),
         Network::Test::createRawBufferSocket(), nullptr);
     client_connection->addConnectionCallbacks(connection_callbacks);
     client_connection->connect();
@@ -424,7 +424,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionAll) {
   }
 
   ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->addConnectionCallbacks(connection_callbacks);
   client_connection->connect();

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -136,9 +136,10 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitEnforcement) {
 
   auto initiate_connections = [&](const int count) {
     for (int i = 0; i < count; ++i) {
-      client_connections.emplace_back(dispatcher_->createClientConnection(
-          socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
-          Network::Test::createRawBufferSocket(), nullptr));
+      client_connections.emplace_back(
+          dispatcher_->createClientConnection(socket->connectionInfoProvider().localAddress(),
+                                              Network::Address::InstanceConstSharedPtr(),
+                                              Network::Test::createRawBufferSocket(), nullptr));
       client_connections.back()->connect();
     }
   };
@@ -189,9 +190,9 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
                                         listener_callbacks, true);
 
-  auto local_dst_address =
-      Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
-                                           socket->connectionInfoProvider().localAddress()->ip()->port());
+  auto local_dst_address = Network::Utility::getAddressWithPort(
+      *Network::Test::getCanonicalLoopbackAddress(version_),
+      socket->connectionInfoProvider().localAddress()->ip()->port());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       local_dst_address, Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
@@ -233,12 +234,12 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
                                         listener_callbacks, true);
 
-  auto listener_address =
-      Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
-                                           socket->connectionInfoProvider().localAddress()->ip()->port());
-  auto local_dst_address =
-      Network::Utility::getAddressWithPort(*Network::Utility::getCanonicalIpv4LoopbackAddress(),
-                                           socket->connectionInfoProvider().localAddress()->ip()->port());
+  auto listener_address = Network::Utility::getAddressWithPort(
+      *Network::Test::getCanonicalLoopbackAddress(version_),
+      socket->connectionInfoProvider().localAddress()->ip()->port());
+  auto local_dst_address = Network::Utility::getAddressWithPort(
+      *Network::Utility::getCanonicalIpv4LoopbackAddress(),
+      socket->connectionInfoProvider().localAddress()->ip()->port());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       local_dst_address, Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);

--- a/test/common/network/udp_fuzz.cc
+++ b/test/common/network/udp_fuzz.cc
@@ -90,7 +90,7 @@ public:
                                                    dispatcherImpl().timeSource(), config);
 
     Network::Address::Instance* send_to_addr_ = new Network::Address::Ipv4Instance(
-        "127.0.0.1", server_socket_->addressProvider().localAddress()->ip()->port());
+        "127.0.0.1", server_socket_->connectionInfoProvider().localAddress()->ip()->port());
 
     // Now do all of the fuzzing
     static const int MaxPackets = 15;

--- a/test/common/network/udp_listener_impl_batch_writer_test.cc
+++ b/test/common/network/udp_listener_impl_batch_writer_test.cc
@@ -197,8 +197,9 @@ TEST_P(UdpListenerImplBatchWriterTest, WriteBlocked) {
     // First have initial payload added to the udp_packet_writer's internal buffer.
     Buffer::InstancePtr initial_buffer(new Buffer::OwnedImpl());
     initial_buffer->add(initial_payload);
-    UdpSendData initial_send_data{
-        send_to_addr_->ip(), *server_socket_->connectionInfoProvider().localAddress(), *initial_buffer};
+    UdpSendData initial_send_data{send_to_addr_->ip(),
+                                  *server_socket_->connectionInfoProvider().localAddress(),
+                                  *initial_buffer};
     auto send_result = listener_->send(initial_send_data);
     internal_buffer.append(initial_payload);
     EXPECT_TRUE(send_result.ok());
@@ -221,8 +222,9 @@ TEST_P(UdpListenerImplBatchWriterTest, WriteBlocked) {
     // Now send the following payload
     Buffer::InstancePtr following_buffer(new Buffer::OwnedImpl());
     following_buffer->add(following_payload);
-    UdpSendData following_send_data{
-        send_to_addr_->ip(), *server_socket_->connectionInfoProvider().localAddress(), *following_buffer};
+    UdpSendData following_send_data{send_to_addr_->ip(),
+                                    *server_socket_->connectionInfoProvider().localAddress(),
+                                    *following_buffer};
     send_result = listener_->send(following_send_data);
 
     if (following_payload.length() < initial_payload.length()) {

--- a/test/common/network/udp_listener_impl_batch_writer_test.cc
+++ b/test/common/network/udp_listener_impl_batch_writer_test.cc
@@ -198,7 +198,7 @@ TEST_P(UdpListenerImplBatchWriterTest, WriteBlocked) {
     Buffer::InstancePtr initial_buffer(new Buffer::OwnedImpl());
     initial_buffer->add(initial_payload);
     UdpSendData initial_send_data{
-        send_to_addr_->ip(), *server_socket_->addressProvider().localAddress(), *initial_buffer};
+        send_to_addr_->ip(), *server_socket_->connectionInfoProvider().localAddress(), *initial_buffer};
     auto send_result = listener_->send(initial_send_data);
     internal_buffer.append(initial_payload);
     EXPECT_TRUE(send_result.ok());
@@ -222,7 +222,7 @@ TEST_P(UdpListenerImplBatchWriterTest, WriteBlocked) {
     Buffer::InstancePtr following_buffer(new Buffer::OwnedImpl());
     following_buffer->add(following_payload);
     UdpSendData following_send_data{
-        send_to_addr_->ip(), *server_socket_->addressProvider().localAddress(), *following_buffer};
+        send_to_addr_->ip(), *server_socket_->connectionInfoProvider().localAddress(), *following_buffer};
     send_result = listener_->send(following_send_data);
 
     if (following_payload.length() < initial_payload.length()) {

--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -345,7 +345,7 @@ TEST_P(UdpListenerImplTest, UdpEcho) {
 TEST_P(UdpListenerImplTest, UdpListenerEnableDisable) {
   setup();
 
-  auto const* server_ip = server_socket_->addressProvider().localAddress()->ip();
+  auto const* server_ip = server_socket_->connectionInfoProvider().localAddress()->ip();
   ASSERT_NE(server_ip, nullptr);
 
   // We first disable the listener and then send two packets.
@@ -394,7 +394,7 @@ TEST_P(UdpListenerImplTest, UdpListenerEnableDisable) {
 TEST_P(UdpListenerImplTest, UdpListenerRecvMsgError) {
   setup();
 
-  auto const* server_ip = server_socket_->addressProvider().localAddress()->ip();
+  auto const* server_ip = server_socket_->connectionInfoProvider().localAddress()->ip();
   ASSERT_NE(server_ip, nullptr);
 
   // When the `receive` system call returns an error, we expect the `onReceiveError`
@@ -473,7 +473,7 @@ TEST_P(UdpListenerImplTest, SendDataError) {
   Buffer::InstancePtr buffer(new Buffer::OwnedImpl());
   buffer->add(payload);
   // send data to itself
-  UdpSendData send_data{send_to_addr_->ip(), *server_socket_->addressProvider().localAddress(),
+  UdpSendData send_data{send_to_addr_->ip(), *server_socket_->connectionInfoProvider().localAddress(),
                         *buffer};
 
   // Inject mocked OsSysCalls implementation to mock a write failure.

--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -473,8 +473,8 @@ TEST_P(UdpListenerImplTest, SendDataError) {
   Buffer::InstancePtr buffer(new Buffer::OwnedImpl());
   buffer->add(payload);
   // send data to itself
-  UdpSendData send_data{send_to_addr_->ip(), *server_socket_->connectionInfoProvider().localAddress(),
-                        *buffer};
+  UdpSendData send_data{send_to_addr_->ip(),
+                        *server_socket_->connectionInfoProvider().localAddress(), *buffer};
 
   // Inject mocked OsSysCalls implementation to mock a write failure.
   Api::MockOsSysCalls os_sys_calls;

--- a/test/common/network/udp_listener_impl_test_base.h
+++ b/test/common/network/udp_listener_impl_test_base.h
@@ -42,11 +42,11 @@ protected:
     if (version_ == Address::IpVersion::v4) {
       return new Address::Ipv4Instance(
           Network::Test::getLoopbackAddressString(version_),
-          server_socket_->addressProvider().localAddress()->ip()->port());
+          server_socket_->connectionInfoProvider().localAddress()->ip()->port());
     }
     return new Address::Ipv6Instance(
         Network::Test::getLoopbackAddressString(version_),
-        server_socket_->addressProvider().localAddress()->ip()->port());
+        server_socket_->connectionInfoProvider().localAddress()->ip()->port());
   }
 
   SocketSharedPtr createServerSocket(bool bind) {
@@ -68,7 +68,7 @@ protected:
     if (version_ == Address::IpVersion::v4) {
       // Linux kernel regards any 127.x.x.x as local address. But Mac OS doesn't.
       send_from_addr = std::make_shared<Address::Ipv4Instance>(
-          "127.0.0.1", server_socket_->addressProvider().localAddress()->ip()->port());
+          "127.0.0.1", server_socket_->connectionInfoProvider().localAddress()->ip()->port());
     } else {
       // Only use non-local v6 address if IP_FREEBIND is supported. Otherwise use
       // ::1 to avoid EINVAL error. Unfortunately this can't verify that sendmsg with
@@ -80,7 +80,7 @@ protected:
 #else
           "::1",
 #endif
-          server_socket_->addressProvider().localAddress()->ip()->port());
+          server_socket_->connectionInfoProvider().localAddress()->ip()->port());
     }
     return send_from_addr;
   }

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -209,7 +209,7 @@ protected:
     // Send a full CHLO to finish 0-RTT handshake.
     auto send_rc =
         Network::Utility::writeToSocket(client_sockets_.back()->ioHandle(), slice.data(), 1,
-                                        nullptr, *listen_socket_->addressProvider().localAddress());
+                                        nullptr, *listen_socket_->connectionInfoProvider().localAddress());
     ASSERT_EQ(slice[0].len_, send_rc.return_value_);
 
 #if defined(__APPLE__)

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -207,9 +207,9 @@ protected:
     Buffer::RawSliceVector slice = payload.getRawSlices();
     ASSERT_EQ(1u, slice.size());
     // Send a full CHLO to finish 0-RTT handshake.
-    auto send_rc =
-        Network::Utility::writeToSocket(client_sockets_.back()->ioHandle(), slice.data(), 1,
-                                        nullptr, *listen_socket_->connectionInfoProvider().localAddress());
+    auto send_rc = Network::Utility::writeToSocket(
+        client_sockets_.back()->ioHandle(), slice.data(), 1, nullptr,
+        *listen_socket_->connectionInfoProvider().localAddress());
     ASSERT_EQ(slice[0].len_, send_rc.return_value_);
 
 #if defined(__APPLE__)

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -117,7 +117,7 @@ public:
             quic::test::ConstructReceivedPacket(*encrypted_packet, clock.Now()));
 
     envoy_quic_dispatcher_.ProcessPacket(
-        envoyIpAddressToQuicSocketAddress(listen_socket_->addressProvider().localAddress()->ip()),
+        envoyIpAddressToQuicSocketAddress(listen_socket_->connectionInfoProvider().localAddress()->ip()),
         peer_addr, *received_packet);
   }
 
@@ -161,10 +161,10 @@ public:
     auto envoy_connection = static_cast<const EnvoyQuicServerSession*>(session);
     EXPECT_EQ("test.example.org", envoy_connection->requestedServerName());
     EXPECT_EQ(peer_addr, envoyIpAddressToQuicSocketAddress(
-                             envoy_connection->addressProvider().remoteAddress()->ip()));
-    ASSERT(envoy_connection->addressProvider().localAddress() != nullptr);
-    EXPECT_EQ(*listen_socket_->addressProvider().localAddress(),
-              *envoy_connection->addressProvider().localAddress());
+                             envoy_connection->connectionInfoProvider().remoteAddress()->ip()));
+    ASSERT(envoy_connection->connectionInfoProvider().localAddress() != nullptr);
+    EXPECT_EQ(*listen_socket_->connectionInfoProvider().localAddress(),
+              *envoy_connection->connectionInfoProvider().localAddress());
     EXPECT_EQ(64 * 1024, envoy_connection->max_inbound_header_list_size());
   }
 

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -117,7 +117,8 @@ public:
             quic::test::ConstructReceivedPacket(*encrypted_packet, clock.Now()));
 
     envoy_quic_dispatcher_.ProcessPacket(
-        envoyIpAddressToQuicSocketAddress(listen_socket_->connectionInfoProvider().localAddress()->ip()),
+        envoyIpAddressToQuicSocketAddress(
+            listen_socket_->connectionInfoProvider().localAddress()->ip()),
         peer_addr, *received_packet);
   }
 

--- a/test/common/quic/envoy_quic_proof_source_test.cc
+++ b/test/common/quic/envoy_quic_proof_source_test.cc
@@ -151,9 +151,9 @@ public:
     EXPECT_CALL(filter_chain_manager_, findFilterChain(_))
         .WillRepeatedly(Invoke([&](const Network::ConnectionSocket& connection_socket) {
           EXPECT_EQ(*quicAddressToEnvoyAddressInstance(server_address_),
-                    *connection_socket.addressProvider().localAddress());
+                    *connection_socket.connectionInfoProvider().localAddress());
           EXPECT_EQ(*quicAddressToEnvoyAddressInstance(client_address_),
-                    *connection_socket.addressProvider().remoteAddress());
+                    *connection_socket.connectionInfoProvider().remoteAddress());
           EXPECT_EQ("quic", connection_socket.detectedTransportProtocol());
           EXPECT_EQ("h3", connection_socket.requestedApplicationProtocols()[0]);
           return &filter_chain_;
@@ -230,9 +230,9 @@ TEST_F(EnvoyQuicProofSourceTest, GetCertChainFailBadConfig) {
   EXPECT_CALL(filter_chain_manager_, findFilterChain(_))
       .WillRepeatedly(Invoke([&](const Network::ConnectionSocket& connection_socket) {
         EXPECT_EQ(*quicAddressToEnvoyAddressInstance(server_address_),
-                  *connection_socket.addressProvider().localAddress());
+                  *connection_socket.connectionInfoProvider().localAddress());
         EXPECT_EQ(*quicAddressToEnvoyAddressInstance(client_address_),
-                  *connection_socket.addressProvider().remoteAddress());
+                  *connection_socket.connectionInfoProvider().remoteAddress());
         EXPECT_EQ("quic", connection_socket.detectedTransportProtocol());
         EXPECT_EQ("h3", connection_socket.requestedApplicationProtocols()[0]);
         return &filter_chain_;

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -434,8 +434,9 @@ TEST_F(OriginalDstClusterTest, Connection) {
   ASSERT_NE(host, nullptr);
   EXPECT_EQ(*connection.connectionInfoProvider().localAddress(), *host->address());
 
-  EXPECT_CALL(dispatcher_, createClientConnection_(
-                               PointeesEq(connection.connectionInfoProvider().localAddress()), _, _, _))
+  EXPECT_CALL(dispatcher_,
+              createClientConnection_(
+                  PointeesEq(connection.connectionInfoProvider().localAddress()), _, _, _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
   host->createConnection(dispatcher_, nullptr, nullptr);
 }

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -256,7 +256,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
   auto cluster_hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
 
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(*connection.addressProvider().localAddress(), *host->address());
+  EXPECT_EQ(*connection.connectionInfoProvider().localAddress(), *host->address());
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -266,7 +266,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
       cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   EXPECT_EQ(host, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
-  EXPECT_EQ(*connection.addressProvider().localAddress(),
+  EXPECT_EQ(*connection.connectionInfoProvider().localAddress(),
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address());
 
   // Same host is returned on the 2nd call
@@ -349,14 +349,14 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
   post_cb();
   ASSERT_NE(host1, nullptr);
-  EXPECT_EQ(*connection1.addressProvider().localAddress(), *host1->address());
+  EXPECT_EQ(*connection1.connectionInfoProvider().localAddress(), *host1->address());
 
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
   HostConstSharedPtr host2 = lb.chooseHost(&lb_context2);
   post_cb();
   ASSERT_NE(host2, nullptr);
-  EXPECT_EQ(*connection2.addressProvider().localAddress(), *host2->address());
+  EXPECT_EQ(*connection2.connectionInfoProvider().localAddress(), *host2->address());
 
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -366,11 +366,11 @@ TEST_F(OriginalDstClusterTest, Membership2) {
       cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   EXPECT_EQ(host1, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
-  EXPECT_EQ(*connection1.addressProvider().localAddress(),
+  EXPECT_EQ(*connection1.connectionInfoProvider().localAddress(),
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address());
 
   EXPECT_EQ(host2, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]);
-  EXPECT_EQ(*connection2.addressProvider().localAddress(),
+  EXPECT_EQ(*connection2.connectionInfoProvider().localAddress(),
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]->address());
 
   auto cluster_hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
@@ -432,10 +432,10 @@ TEST_F(OriginalDstClusterTest, Connection) {
   HostConstSharedPtr host = lb.chooseHost(&lb_context);
   post_cb();
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(*connection.addressProvider().localAddress(), *host->address());
+  EXPECT_EQ(*connection.connectionInfoProvider().localAddress(), *host->address());
 
   EXPECT_CALL(dispatcher_, createClientConnection_(
-                               PointeesEq(connection.addressProvider().localAddress()), _, _, _))
+                               PointeesEq(connection.connectionInfoProvider().localAddress()), _, _, _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
   host->createConnection(dispatcher_, nullptr, nullptr);
 }
@@ -482,7 +482,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   HostConstSharedPtr host = lb.chooseHost(&lb_context);
   post_cb();
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(*connection.addressProvider().localAddress(), *host->address());
+  EXPECT_EQ(*connection.connectionInfoProvider().localAddress(), *host->address());
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   // Check that 'second' also gets updated
@@ -597,7 +597,7 @@ TEST_F(OriginalDstClusterTest, UseHttpHeaderDisabled) {
   HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
   post_cb();
   ASSERT_NE(host1, nullptr);
-  EXPECT_EQ(*connection1.addressProvider().localAddress(), *host1->address());
+  EXPECT_EQ(*connection1.connectionInfoProvider().localAddress(), *host1->address());
 
   // Downstream connection without original_dst filter, HTTP header override ignored.
   NiceMock<Network::MockConnection> connection2;

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -48,10 +48,10 @@ public:
         init_manager_(nullptr) {
     EXPECT_CALL(socket_factory_, socketType()).WillOnce(Return(Network::Socket::Type::Stream));
     EXPECT_CALL(socket_factory_, localAddress())
-        .WillOnce(ReturnRef(socket_->addressProvider().localAddress()));
+        .WillOnce(ReturnRef(socket_->connectionInfoProvider().localAddress()));
     EXPECT_CALL(socket_factory_, getListenSocket(_)).WillOnce(Return(socket_));
     connection_handler_->addListener(absl::nullopt, *this);
-    conn_ = dispatcher_->createClientConnection(socket_->addressProvider().localAddress(),
+    conn_ = dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),
                                                 Network::Address::InstanceConstSharedPtr(),
                                                 Network::Test::createRawBufferSocket(), nullptr);
     conn_->addConnectionCallbacks(connection_callbacks_);
@@ -199,9 +199,9 @@ TEST_P(ProxyProtocolRegressionTest, V1Basic) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             source_addr);
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -222,9 +222,9 @@ TEST_P(ProxyProtocolRegressionTest, V2Basic) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             source_addr);
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -239,13 +239,13 @@ TEST_P(ProxyProtocolRegressionTest, V2LocalConnection) {
   expectData("more data");
 
   if (GetParam() == Envoy::Network::Address::IpVersion::v4) {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "127.0.0.1");
   } else {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "::1");
   }
-  EXPECT_FALSE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_FALSE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }

--- a/test/extensions/filters/http/original_src/original_src_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_test.cc
@@ -94,7 +94,7 @@ TEST_F(OriginalSrcHttpTest, DecodeHeadersIpv4AddressAddsOption) {
   for (const auto& option : *options) {
     option->setOption(socket, envoy::config::core::v3::SocketOption::STATE_PREBIND);
   }
-  EXPECT_EQ(*socket.addressProvider().localAddress(),
+  EXPECT_EQ(*socket.connectionInfoProvider().localAddress(),
             *callbacks_.stream_info_.downstream_address_provider_->remoteAddress());
 }
 
@@ -129,7 +129,7 @@ TEST_F(OriginalSrcHttpTest, DecodeHeadersIpv4AddressBleachesPort) {
   for (const auto& option : *options) {
     option->setOption(socket, envoy::config::core::v3::SocketOption::STATE_PREBIND);
   }
-  EXPECT_EQ(*socket.addressProvider().localAddress(), *expected_address);
+  EXPECT_EQ(*socket.connectionInfoProvider().localAddress(), *expected_address);
 }
 
 TEST_F(OriginalSrcHttpTest, FilterAddsTransparentOption) {

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.cc
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.cc
@@ -8,16 +8,16 @@ void ListenerFilterFuzzer::fuzz(
     Network::ListenerFilterPtr filter,
     const test::extensions::filters::listener::FilterFuzzTestCase& input) {
   try {
-    socket_.addressProvider().setLocalAddress(
+    socket_.connectionInfoProvider().setLocalAddress(
         Network::Utility::resolveUrl(input.sock().local_address()));
   } catch (const EnvoyException& e) {
-    socket_.addressProvider().setLocalAddress(Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
+    socket_.connectionInfoProvider().setLocalAddress(Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
   }
   try {
-    socket_.addressProvider().setRemoteAddress(
+    socket_.connectionInfoProvider().setRemoteAddress(
         Network::Utility::resolveUrl(input.sock().remote_address()));
   } catch (const EnvoyException& e) {
-    socket_.addressProvider().setRemoteAddress(Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
+    socket_.connectionInfoProvider().setRemoteAddress(Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
   }
 
   FuzzedInputStream data(input);

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.cc
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.cc
@@ -11,13 +11,15 @@ void ListenerFilterFuzzer::fuzz(
     socket_.connectionInfoProvider().setLocalAddress(
         Network::Utility::resolveUrl(input.sock().local_address()));
   } catch (const EnvoyException& e) {
-    socket_.connectionInfoProvider().setLocalAddress(Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
+    socket_.connectionInfoProvider().setLocalAddress(
+        Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
   }
   try {
     socket_.connectionInfoProvider().setRemoteAddress(
         Network::Utility::resolveUrl(input.sock().remote_address()));
   } catch (const EnvoyException& e) {
-    socket_.connectionInfoProvider().setRemoteAddress(Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
+    socket_.connectionInfoProvider().setRemoteAddress(
+        Network::Utility::resolveUrl("tcp://0.0.0.0:0"));
   }
 
   FuzzedInputStream data(input);

--- a/test/extensions/filters/listener/original_src/original_src_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_test.cc
@@ -81,8 +81,8 @@ TEST_F(OriginalSrcTest, OnNewConnectionIpv4AddressAddsOption) {
 
   NiceMock<Network::MockConnectionSocket> socket;
   options->at(0)->setOption(socket, envoy::config::core::v3::SocketOption::STATE_PREBIND);
-  EXPECT_EQ(*socket.addressProvider().localAddress(),
-            *callbacks_.socket_.addressProvider().remoteAddress());
+  EXPECT_EQ(*socket.connectionInfoProvider().localAddress(),
+            *callbacks_.socket_.connectionInfoProvider().remoteAddress());
 }
 
 TEST_F(OriginalSrcTest, OnNewConnectionIpv4AddressUsesCorrectAddress) {
@@ -115,7 +115,7 @@ TEST_F(OriginalSrcTest, OnNewConnectionIpv4AddressBleachesPort) {
   // not ideal -- we're assuming that the original_src option is first, but it's a fair assumption
   // for now.
   options->at(0)->setOption(socket, envoy::config::core::v3::SocketOption::STATE_PREBIND);
-  EXPECT_EQ(*socket.addressProvider().localAddress(), *expected_address);
+  EXPECT_EQ(*socket.connectionInfoProvider().localAddress(), *expected_address);
 }
 
 TEST_F(OriginalSrcTest, FilterAddsTransparentOption) {

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1421,7 +1421,8 @@ TEST_P(WildcardProxyProtocolTest, Basic) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->asString(), "1.2.3.4:65535");
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->asString(),
+            "1.2.3.4:65535");
   EXPECT_EQ(server_connection_->connectionInfoProvider().localAddress()->asString(),
             "254.254.254.254:1234");
   EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
@@ -1435,8 +1436,10 @@ TEST_P(WildcardProxyProtocolTest, BasicV6) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->asString(), "[1:2:3::4]:65535");
-  EXPECT_EQ(server_connection_->connectionInfoProvider().localAddress()->asString(), "[5:6::7:8]:1234");
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->asString(),
+            "[1:2:3::4]:65535");
+  EXPECT_EQ(server_connection_->connectionInfoProvider().localAddress()->asString(),
+            "[5:6::7:8]:1234");
   EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -62,10 +62,10 @@ public:
         init_manager_(nullptr) {
     EXPECT_CALL(socket_factory_, socketType()).WillOnce(Return(Network::Socket::Type::Stream));
     EXPECT_CALL(socket_factory_, localAddress())
-        .WillOnce(ReturnRef(socket_->addressProvider().localAddress()));
+        .WillOnce(ReturnRef(socket_->connectionInfoProvider().localAddress()));
     EXPECT_CALL(socket_factory_, getListenSocket(_)).WillOnce(Return(socket_));
     connection_handler_->addListener(absl::nullopt, *this);
-    conn_ = dispatcher_->createClientConnection(socket_->addressProvider().localAddress(),
+    conn_ = dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),
                                                 Network::Address::InstanceConstSharedPtr(),
                                                 Network::Test::createRawBufferSocket(), nullptr);
     conn_->addConnectionCallbacks(connection_callbacks_);
@@ -215,9 +215,9 @@ TEST_P(ProxyProtocolTest, V1Basic) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1.2.3.4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -229,13 +229,13 @@ TEST_P(ProxyProtocolTest, V1Minimal) {
   expectData("more data");
 
   if (GetParam() == Envoy::Network::Address::IpVersion::v4) {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "127.0.0.1");
   } else {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "::1");
   }
-  EXPECT_FALSE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_FALSE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -251,9 +251,9 @@ TEST_P(ProxyProtocolTest, V2Basic) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1.2.3.4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -264,9 +264,9 @@ TEST_P(ProxyProtocolTest, BasicV6) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1:2:3::4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -284,9 +284,9 @@ TEST_P(ProxyProtocolTest, V2BasicV6) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1:2:3::4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -444,16 +444,16 @@ TEST_P(ProxyProtocolTest, V2LocalConnection) {
   connect();
   write(buffer, sizeof(buffer));
   expectData("more data");
-  if (server_connection_->addressProvider().remoteAddress()->ip()->version() ==
+  if (server_connection_->connectionInfoProvider().remoteAddress()->ip()->version() ==
       Envoy::Network::Address::IpVersion::v6) {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "::1");
-  } else if (server_connection_->addressProvider().remoteAddress()->ip()->version() ==
+  } else if (server_connection_->connectionInfoProvider().remoteAddress()->ip()->version() ==
              Envoy::Network::Address::IpVersion::v4) {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "127.0.0.1");
   }
-  EXPECT_FALSE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_FALSE(server_connection_->connectionInfoProvider().localAddressRestored());
   disconnect();
 }
 
@@ -465,16 +465,16 @@ TEST_P(ProxyProtocolTest, V2LocalConnectionExtension) {
   connect();
   write(buffer, sizeof(buffer));
   expectData("more data");
-  if (server_connection_->addressProvider().remoteAddress()->ip()->version() ==
+  if (server_connection_->connectionInfoProvider().remoteAddress()->ip()->version() ==
       Envoy::Network::Address::IpVersion::v6) {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "::1");
-  } else if (server_connection_->addressProvider().remoteAddress()->ip()->version() ==
+  } else if (server_connection_->connectionInfoProvider().remoteAddress()->ip()->version() ==
              Envoy::Network::Address::IpVersion::v4) {
-    EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+    EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
               "127.0.0.1");
   }
-  EXPECT_FALSE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_FALSE(server_connection_->connectionInfoProvider().localAddressRestored());
   disconnect();
 }
 
@@ -695,9 +695,9 @@ TEST_P(ProxyProtocolTest, Fragmented) {
   // the results. Since we must have data we might as well check that we get it.
   expectData("...");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "254.254.254.254");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -717,9 +717,9 @@ TEST_P(ProxyProtocolTest, V2Fragmented1) {
   write(buffer + 20, 17);
 
   expectData("more data");
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1.2.3.4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -739,9 +739,9 @@ TEST_P(ProxyProtocolTest, V2Fragmented2) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1.2.3.4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -896,9 +896,9 @@ TEST_P(ProxyProtocolTest, PartialRead) {
 
   expectData("...");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "254.254.254.254");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -921,9 +921,9 @@ TEST_P(ProxyProtocolTest, V2PartialRead) {
 
   expectData("moredata");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->ip()->addressAsString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString(),
             "1.2.3.4");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -1290,13 +1290,13 @@ public:
             Network::Test::getAnyAddress(GetParam()))),
         local_dst_address_(Network::Utility::getAddressWithPort(
             *Network::Test::getCanonicalLoopbackAddress(GetParam()),
-            socket_->addressProvider().localAddress()->ip()->port())),
+            socket_->connectionInfoProvider().localAddress()->ip()->port())),
         connection_handler_(new Server::ConnectionHandlerImpl(*dispatcher_, absl::nullopt)),
         name_("proxy"), filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()),
         init_manager_(nullptr) {
     EXPECT_CALL(socket_factory_, socketType()).WillOnce(Return(Network::Socket::Type::Stream));
     EXPECT_CALL(socket_factory_, localAddress())
-        .WillOnce(ReturnRef(socket_->addressProvider().localAddress()));
+        .WillOnce(ReturnRef(socket_->connectionInfoProvider().localAddress()));
     EXPECT_CALL(socket_factory_, getListenSocket(_)).WillOnce(Return(socket_));
     connection_handler_->addListener(absl::nullopt, *this);
     conn_ = dispatcher_->createClientConnection(local_dst_address_,
@@ -1421,10 +1421,10 @@ TEST_P(WildcardProxyProtocolTest, Basic) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->asString(), "1.2.3.4:65535");
-  EXPECT_EQ(server_connection_->addressProvider().localAddress()->asString(),
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->asString(), "1.2.3.4:65535");
+  EXPECT_EQ(server_connection_->connectionInfoProvider().localAddress()->asString(),
             "254.254.254.254:1234");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }
@@ -1435,9 +1435,9 @@ TEST_P(WildcardProxyProtocolTest, BasicV6) {
 
   expectData("more data");
 
-  EXPECT_EQ(server_connection_->addressProvider().remoteAddress()->asString(), "[1:2:3::4]:65535");
-  EXPECT_EQ(server_connection_->addressProvider().localAddress()->asString(), "[5:6::7:8]:1234");
-  EXPECT_TRUE(server_connection_->addressProvider().localAddressRestored());
+  EXPECT_EQ(server_connection_->connectionInfoProvider().remoteAddress()->asString(), "[1:2:3::4]:65535");
+  EXPECT_EQ(server_connection_->connectionInfoProvider().localAddress()->asString(), "[5:6::7:8]:1234");
+  EXPECT_TRUE(server_connection_->connectionInfoProvider().localAddressRestored());
 
   disconnect();
 }

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -665,10 +665,10 @@ TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
   checkStats();
   envoy::config::core::v3::Address expected_local_address;
   Network::Utility::addressToProtobufAddress(
-      *codec_client_->connection()->addressProvider().remoteAddress(), expected_local_address);
+      *codec_client_->connection()->connectionInfoProvider().remoteAddress(), expected_local_address);
   envoy::config::core::v3::Address expected_remote_address;
   Network::Utility::addressToProtobufAddress(
-      *codec_client_->connection()->addressProvider().localAddress(), expected_remote_address);
+      *codec_client_->connection()->connectionInfoProvider().localAddress(), expected_remote_address);
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
   envoy::data::tap::v3::TraceWrapper trace;

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -665,10 +665,12 @@ TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
   checkStats();
   envoy::config::core::v3::Address expected_local_address;
   Network::Utility::addressToProtobufAddress(
-      *codec_client_->connection()->connectionInfoProvider().remoteAddress(), expected_local_address);
+      *codec_client_->connection()->connectionInfoProvider().remoteAddress(),
+      expected_local_address);
   envoy::config::core::v3::Address expected_remote_address;
   Network::Utility::addressToProtobufAddress(
-      *codec_client_->connection()->connectionInfoProvider().localAddress(), expected_remote_address);
+      *codec_client_->connection()->connectionInfoProvider().localAddress(),
+      expected_remote_address);
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
   envoy::data::tap::v3::TraceWrapper trace;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -344,7 +344,7 @@ void testUtil(const TestUtilOptions& options) {
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
                                                    client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   Network::ConnectionPtr server_connection;
   Network::MockConnectionCallbacks server_connection_callbacks;
@@ -665,7 +665,7 @@ void testUtilV2(const TestUtilOptionsV2& options) {
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
                                                    client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(options.transportSocketOptions()), nullptr);
 
   if (!options.clientSession().empty()) {
@@ -2443,7 +2443,7 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, true);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->connect();
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -2510,7 +2510,7 @@ TEST_P(SslSocketTest, HalfClose) {
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
                                                    client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   client_connection->enableHalfClose(true);
   client_connection->addReadFilter(client_read_filter);
@@ -2591,7 +2591,7 @@ TEST_P(SslSocketTest, ShutdownWithCloseNotify) {
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
                                                    client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   Network::MockConnectionCallbacks client_connection_callbacks;
   client_connection->enableHalfClose(true);
@@ -2678,7 +2678,7 @@ TEST_P(SslSocketTest, ShutdownWithoutCloseNotify) {
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
                                                    client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   Network::MockConnectionCallbacks client_connection_callbacks;
   client_connection->enableHalfClose(true);
@@ -2783,7 +2783,7 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   Stats::TestUtil::TestStore client_stats_store;
   ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr), nullptr);
 
   // Verify that server sent list with 2 acceptable client certificate CA names.
@@ -2879,7 +2879,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
       std::make_unique<ClientContextConfigImpl>(client_tls_context, client_factory_context);
   ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      socket1->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket1->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr), nullptr);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -2892,7 +2892,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::TransportSocketFactory& tsf =
-            socket->addressProvider().localAddress() == socket1->addressProvider().localAddress()
+            socket->connectionInfoProvider().localAddress() == socket1->connectionInfoProvider().localAddress()
                 ? server_ssl_socket_factory1
                 : server_ssl_socket_factory2;
         server_connection = dispatcher->createServerConnection(
@@ -2921,7 +2921,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   EXPECT_EQ(0UL, client_stats_store.counter("ssl.session_reused").value());
 
   client_connection = dispatcher->createClientConnection(
-      socket2->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket2->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   const SslHandshakerImpl* ssl_socket =
@@ -2936,7 +2936,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::TransportSocketFactory& tsf =
-            socket->addressProvider().localAddress() == socket1->addressProvider().localAddress()
+            socket->connectionInfoProvider().localAddress() == socket1->connectionInfoProvider().localAddress()
                 ? server_ssl_socket_factory1
                 : server_ssl_socket_factory2;
         server_connection = dispatcher->createServerConnection(
@@ -3015,7 +3015,7 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
       std::make_unique<ClientContextConfigImpl>(client_tls_context, client_factory_context);
   ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      tcp_socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      tcp_socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr), nullptr);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -3459,7 +3459,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   Stats::TestUtil::TestStore client_stats_store;
   ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr), nullptr);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -3471,8 +3471,8 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   Network::MockConnectionCallbacks server_connection_callbacks;
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
-        Network::TransportSocketFactory& tsf = accepted_socket->addressProvider().localAddress() ==
-                                                       socket->addressProvider().localAddress()
+        Network::TransportSocketFactory& tsf = accepted_socket->connectionInfoProvider().localAddress() ==
+                                                       socket->connectionInfoProvider().localAddress()
                                                    ? server_ssl_socket_factory
                                                    : server2_ssl_socket_factory;
         server_connection = dispatcher_->createServerConnection(
@@ -3500,7 +3500,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   EXPECT_EQ(1UL, client_stats_store.counter("ssl.handshake").value());
 
   client_connection = dispatcher_->createClientConnection(
-      socket2->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket2->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   const SslHandshakerImpl* ssl_socket =
@@ -3512,8 +3512,8 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
 
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
-        Network::TransportSocketFactory& tsf = accepted_socket->addressProvider().localAddress() ==
-                                                       socket->addressProvider().localAddress()
+        Network::TransportSocketFactory& tsf = accepted_socket->connectionInfoProvider().localAddress() ==
+                                                       socket->connectionInfoProvider().localAddress()
                                                    ? server_ssl_socket_factory
                                                    : server2_ssl_socket_factory;
         server_connection = dispatcher_->createServerConnection(
@@ -3576,7 +3576,7 @@ void SslSocketTest::testClientSessionResumption(const std::string& server_ctx_ya
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
                                                    client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr), nullptr);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -3638,7 +3638,7 @@ void SslSocketTest::testClientSessionResumption(const std::string& server_ctx_ya
   close_count = 0;
 
   client_connection = dispatcher->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr), nullptr);
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   client_connection->connect();
@@ -3819,7 +3819,7 @@ TEST_P(SslSocketTest, SslError) {
   Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, true);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-      socket->addressProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->connect();
   Buffer::OwnedImpl bad_data("bad_handshake_data");
@@ -4825,7 +4825,7 @@ protected:
     auto transport_socket = client_ssl_socket_factory_->createTransportSocket(nullptr);
     client_transport_socket_ = transport_socket.get();
     client_connection_ =
-        dispatcher_->createClientConnection(socket_->addressProvider().localAddress(),
+        dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),
                                             source_address_, std::move(transport_socket), nullptr);
     client_connection_->addConnectionCallbacks(client_callbacks_);
     client_connection_->connect();
@@ -5046,7 +5046,7 @@ TEST_P(SslReadBufferLimitTest, TestBind) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   EXPECT_EQ(address_string,
-            server_connection_->addressProvider().remoteAddress()->ip()->addressAsString());
+            server_connection_->connectionInfoProvider().remoteAddress()->ip()->addressAsString());
 
   disconnect();
 }

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -2892,7 +2892,8 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::TransportSocketFactory& tsf =
-            socket->connectionInfoProvider().localAddress() == socket1->connectionInfoProvider().localAddress()
+            socket->connectionInfoProvider().localAddress() ==
+                    socket1->connectionInfoProvider().localAddress()
                 ? server_ssl_socket_factory1
                 : server_ssl_socket_factory2;
         server_connection = dispatcher->createServerConnection(
@@ -2936,7 +2937,8 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
         Network::TransportSocketFactory& tsf =
-            socket->connectionInfoProvider().localAddress() == socket1->connectionInfoProvider().localAddress()
+            socket->connectionInfoProvider().localAddress() ==
+                    socket1->connectionInfoProvider().localAddress()
                 ? server_ssl_socket_factory1
                 : server_ssl_socket_factory2;
         server_connection = dispatcher->createServerConnection(
@@ -3015,8 +3017,9 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
       std::make_unique<ClientContextConfigImpl>(client_tls_context, client_factory_context);
   ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
-      tcp_socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
-      ssl_socket_factory.createTransportSocket(nullptr), nullptr);
+      tcp_socket->connectionInfoProvider().localAddress(),
+      Network::Address::InstanceConstSharedPtr(), ssl_socket_factory.createTransportSocket(nullptr),
+      nullptr);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
   client_connection->addConnectionCallbacks(client_connection_callbacks);
@@ -3471,10 +3474,11 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   Network::MockConnectionCallbacks server_connection_callbacks;
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
-        Network::TransportSocketFactory& tsf = accepted_socket->connectionInfoProvider().localAddress() ==
-                                                       socket->connectionInfoProvider().localAddress()
-                                                   ? server_ssl_socket_factory
-                                                   : server2_ssl_socket_factory;
+        Network::TransportSocketFactory& tsf =
+            accepted_socket->connectionInfoProvider().localAddress() ==
+                    socket->connectionInfoProvider().localAddress()
+                ? server_ssl_socket_factory
+                : server2_ssl_socket_factory;
         server_connection = dispatcher_->createServerConnection(
             std::move(accepted_socket), tsf.createTransportSocket(nullptr), stream_info_);
         server_connection->addConnectionCallbacks(server_connection_callbacks);
@@ -3512,10 +3516,11 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
 
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted_socket) -> void {
-        Network::TransportSocketFactory& tsf = accepted_socket->connectionInfoProvider().localAddress() ==
-                                                       socket->connectionInfoProvider().localAddress()
-                                                   ? server_ssl_socket_factory
-                                                   : server2_ssl_socket_factory;
+        Network::TransportSocketFactory& tsf =
+            accepted_socket->connectionInfoProvider().localAddress() ==
+                    socket->connectionInfoProvider().localAddress()
+                ? server_ssl_socket_factory
+                : server2_ssl_socket_factory;
         server_connection = dispatcher_->createServerConnection(
             std::move(accepted_socket), tsf.createTransportSocket(nullptr), stream_info_);
         server_connection->addConnectionCallbacks(server_connection_callbacks);

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -315,7 +315,8 @@ void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>
       registerPort(*port_it, listen_addr->ip()->port());
     }
   }
-  const auto admin_addr = test_server_->server().admin().socket().connectionInfoProvider().localAddress();
+  const auto admin_addr =
+      test_server_->server().admin().socket().connectionInfoProvider().localAddress();
   if (admin_addr->type() == Network::Address::Type::Ip) {
     registerPort("admin", admin_addr->ip()->port());
   }

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -315,7 +315,7 @@ void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>
       registerPort(*port_it, listen_addr->ip()->port());
     }
   }
-  const auto admin_addr = test_server_->server().admin().socket().addressProvider().localAddress();
+  const auto admin_addr = test_server_->server().admin().socket().connectionInfoProvider().localAddress();
   if (admin_addr->type() == Network::Address::Type::Ip) {
     registerPort("admin", admin_addr->ip()->port());
   }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -92,7 +92,7 @@ void FakeStream::encodeHeaders(const Http::HeaderMap& headers, bool end_stream) 
       Http::createHeaderMap<Http::ResponseHeaderMapImpl>(headers));
   if (add_served_by_header_) {
     headers_copy->addCopy(Http::LowerCaseString("x-served-by"),
-                          parent_.connection().addressProvider().localAddress()->asString());
+                          parent_.connection().connectionInfoProvider().localAddress()->asString());
   }
 
   postToConnectionThread([this, headers_copy, end_stream]() -> void {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -620,7 +620,7 @@ public:
   waitForRawConnection(FakeRawConnectionPtr& connection,
                        std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
   Network::Address::InstanceConstSharedPtr localAddress() const {
-    return socket_->addressProvider().localAddress();
+    return socket_->connectionInfoProvider().localAddress();
   }
 
   virtual std::unique_ptr<FakeRawConnection>
@@ -705,7 +705,7 @@ private:
     // Network::ListenSocketFactory
     Network::Socket::Type socketType() const override { return socket_->socketType(); }
     const Network::Address::InstanceConstSharedPtr& localAddress() const override {
-      return socket_->addressProvider().localAddress();
+      return socket_->connectionInfoProvider().localAddress();
     }
     Network::SocketSharedPtr getListenSocket(uint32_t) override { return socket_; }
     Network::ListenSocketFactoryPtr clone() const override { return nullptr; }

--- a/test/integration/filters/address_restore_listener_filter.cc
+++ b/test/integration/filters/address_restore_listener_filter.cc
@@ -16,11 +16,11 @@ public:
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override {
     FANCY_LOG(debug, "in FakeOriginalDstListenerFilter::onAccept");
     Network::ConnectionSocket& socket = cb.socket();
-    socket.addressProvider().restoreLocalAddress(
+    socket.connectionInfoProvider().restoreLocalAddress(
         std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2", 80));
     FANCY_LOG(debug, "current local socket address is {} restored = {}",
-              socket.addressProvider().localAddress()->asString(),
-              socket.addressProvider().localAddressRestored());
+              socket.connectionInfoProvider().localAddress()->asString(),
+              socket.connectionInfoProvider().localAddressRestored());
     return Network::FilterStatus::Continue;
   }
 };

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -68,7 +68,7 @@ TEST_P(IntegrationTest, BadPrebindSocketOptionWithReusePort) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
     listener->mutable_address()->mutable_socket_address()->set_port_value(
-        addr_socket.second->addressProvider().localAddress()->ip()->port());
+        addr_socket.second->connectionInfoProvider().localAddress()->ip()->port());
     auto socket_option = listener->add_socket_options();
     socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_PREBIND);
     socket_option->set_level(10000);     // Invalid level.
@@ -89,7 +89,7 @@ TEST_P(IntegrationTest, BadPostbindSocketOptionWithReusePort) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
     listener->mutable_address()->mutable_socket_address()->set_port_value(
-        addr_socket.second->addressProvider().localAddress()->ip()->port());
+        addr_socket.second->connectionInfoProvider().localAddress()->ip()->port());
     auto socket_option = listener->add_socket_options();
     socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_BOUND);
     socket_option->set_level(10000);     // Invalid level.
@@ -1403,7 +1403,7 @@ TEST_P(IntegrationTest, TestBind) {
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_NE(fake_upstream_connection_, nullptr);
   std::string address = fake_upstream_connection_->connection()
-                            .addressProvider()
+                            .connectionInfoProvider()
                             .remoteAddress()
                             ->ip()
                             ->addressAsString();

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -238,7 +238,7 @@ void IntegrationTestServerImpl::createAndRunEnvoyServer(
     // This is technically thread unsafe (assigning to a shared_ptr accessed
     // across threads), but because we synchronize below through serverReady(), the only
     // consumer on the main test thread in ~IntegrationTestServerImpl will not race.
-    admin_address_ = server.admin().socket().addressProvider().localAddress();
+    admin_address_ = server.admin().socket().connectionInfoProvider().localAddress();
     server_ = &server;
     stat_store_ = &stat_store;
     serverReady();

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -587,7 +587,7 @@ TEST_P(LdsIntegrationTest, NewListenerWithBadPostListenSocketOption) {
       [&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
         auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
         listener->mutable_address()->mutable_socket_address()->set_port_value(
-            addr_socket.second->addressProvider().localAddress()->ip()->port());
+            addr_socket.second->connectionInfoProvider().localAddress()->ip()->port());
         auto socket_option = listener->add_socket_options();
         socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_LISTENING);
         socket_option->set_level(10000);     // Invalid level.

--- a/test/mocks/network/connection.cc
+++ b/test/mocks/network/connection.cc
@@ -54,7 +54,7 @@ void MockConnectionBase::runLowWatermarkCallbacks() {
 }
 
 template <class T> static void initializeMockConnection(T& connection) {
-  ON_CALL(connection, addressProvider())
+  ON_CALL(connection, connectionInfoProvider())
       .WillByDefault(ReturnPointee(connection.stream_info_.downstream_address_provider_));
   ON_CALL(connection, addressProviderSharedPtr())
       .WillByDefault(ReturnPointee(&connection.stream_info_.downstream_address_provider_));

--- a/test/mocks/network/connection.cc
+++ b/test/mocks/network/connection.cc
@@ -56,7 +56,7 @@ void MockConnectionBase::runLowWatermarkCallbacks() {
 template <class T> static void initializeMockConnection(T& connection) {
   ON_CALL(connection, connectionInfoProvider())
       .WillByDefault(ReturnPointee(connection.stream_info_.downstream_address_provider_));
-  ON_CALL(connection, addressProviderSharedPtr())
+  ON_CALL(connection, connectionInfoProviderSharedPtr())
       .WillByDefault(ReturnPointee(&connection.stream_info_.downstream_address_provider_));
   ON_CALL(connection, dispatcher()).WillByDefault(ReturnRef(connection.dispatcher_));
   ON_CALL(connection, readEnabled()).WillByDefault(ReturnPointee(&connection.read_enabled_));

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -65,8 +65,8 @@ public:
   MOCK_METHOD(void, readDisable, (bool disable));                                                  \
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
-  MOCK_METHOD(const ConnectionInfoProvider&, connectionInfoProvider, (), (const));                        \
-  MOCK_METHOD(ConnectionInfoProviderSharedPtr, connectionInfoProviderSharedPtr, (), (const));             \
+  MOCK_METHOD(const ConnectionInfoProvider&, connectionInfoProvider, (), (const));                 \
+  MOCK_METHOD(ConnectionInfoProviderSharedPtr, connectionInfoProviderSharedPtr, (), (const));      \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -66,7 +66,7 @@ public:
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
   MOCK_METHOD(const ConnectionInfoProvider&, connectionInfoProvider, (), (const));                        \
-  MOCK_METHOD(ConnectionInfoProviderSharedPtr, addressProviderSharedPtr, (), (const));             \
+  MOCK_METHOD(ConnectionInfoProviderSharedPtr, connectionInfoProviderSharedPtr, (), (const));             \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -65,7 +65,7 @@ public:
   MOCK_METHOD(void, readDisable, (bool disable));                                                  \
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
-  MOCK_METHOD(const ConnectionInfoProvider&, addressProvider, (), (const));                        \
+  MOCK_METHOD(const ConnectionInfoProvider&, connectionInfoProvider, (), (const));                        \
   MOCK_METHOD(ConnectionInfoProviderSharedPtr, addressProviderSharedPtr, (), (const));             \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -37,7 +37,7 @@ MockListenerConfig::MockListenerConfig()
   ON_CALL(*this, filterChainFactory()).WillByDefault(ReturnRef(filter_chain_factory_));
   ON_CALL(*this, listenSocketFactory()).WillByDefault(ReturnRef(socket_factory_));
   ON_CALL(socket_factory_, localAddress())
-      .WillByDefault(ReturnRef(socket_->addressProvider().localAddress()));
+      .WillByDefault(ReturnRef(socket_->connectionInfoProvider().localAddress()));
   ON_CALL(socket_factory_, getListenSocket(_)).WillByDefault(Return(socket_));
   ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(scope_));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -243,8 +243,8 @@ public:
   void addOption(const Socket::OptionConstSharedPtr& option) override { addOption_(option); }
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
-  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
@@ -297,8 +297,8 @@ public:
   void addOption(const Socket::OptionConstSharedPtr& option) override { addOption_(option); }
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
-  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -244,7 +244,9 @@ public:
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override {
+    return *address_provider_;
+  }
   ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }
@@ -298,7 +300,9 @@ public:
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override {
+    return *address_provider_;
+  }
   ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -245,7 +245,7 @@ public:
 
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
-  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
+  ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }
   MOCK_METHOD(IoHandle&, ioHandle, ());
@@ -299,7 +299,7 @@ public:
 
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
-  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
+  ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }
   MOCK_METHOD(void, setDetectedTransportProtocol, (absl::string_view));

--- a/test/mocks/network/socket.h
+++ b/test/mocks/network/socket.h
@@ -16,7 +16,7 @@ public:
 
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
   const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
-  ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
+  ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }
   IoHandle& ioHandle() override;

--- a/test/mocks/network/socket.h
+++ b/test/mocks/network/socket.h
@@ -15,7 +15,9 @@ public:
   ~MockSocket() override;
 
   ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override {
+    return *address_provider_;
+  }
   ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }

--- a/test/mocks/network/socket.h
+++ b/test/mocks/network/socket.h
@@ -14,8 +14,8 @@ public:
   MockSocket();
   ~MockSocket() override;
 
-  ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
-  const ConnectionInfoProvider& addressProvider() const override { return *address_provider_; }
+  ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
+  const ConnectionInfoProvider& connectionInfoProvider() const override { return *address_provider_; }
   ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }

--- a/test/server/active_tcp_listener_test.cc
+++ b/test/server/active_tcp_listener_test.cc
@@ -189,7 +189,7 @@ TEST_F(ActiveTcpListenerTest, RedirectedRebalancer) {
       }));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
-        cb.socket().addressProvider().restoreLocalAddress(alt_address);
+        cb.socket().connectionInfoProvider().restoreLocalAddress(alt_address);
         return Network::FilterStatus::Continue;
       }));
   // Verify that listener1 hands off the connection by not creating network filter chain.

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -58,7 +58,7 @@ TEST_P(AdminInstanceTest, WriteAddressToFile) {
   std::ifstream address_file(address_out_path_);
   std::string address_from_file;
   std::getline(address_file, address_from_file);
-  EXPECT_EQ(admin_.socket().addressProvider().localAddress()->asString(), address_from_file);
+  EXPECT_EQ(admin_.socket().connectionInfoProvider().localAddress()->asString(), address_from_file);
 }
 
 TEST_P(AdminInstanceTest, AdminAddress) {

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -280,7 +280,7 @@ public:
         }));
     EXPECT_CALL(*test_filter, onAccept(_))
         .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
-          cb.socket().addressProvider().restoreLocalAddress(original_dst_address);
+          cb.socket().connectionInfoProvider().restoreLocalAddress(original_dst_address);
           return Network::FilterStatus::Continue;
         }));
     EXPECT_CALL(*test_filter, destroy_());
@@ -669,7 +669,7 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
       }));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
-        cb.socket().addressProvider().restoreLocalAddress(alt_address);
+        cb.socket().connectionInfoProvider().restoreLocalAddress(alt_address);
         return Network::FilterStatus::Continue;
       }));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(filter_chain_.get()));
@@ -739,7 +739,7 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
       new Network::Address::Ipv4Instance("127.0.0.2", 0, nullptr));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
-        cb.socket().addressProvider().restoreLocalAddress(alt_address);
+        cb.socket().connectionInfoProvider().restoreLocalAddress(alt_address);
         return Network::FilterStatus::Continue;
       }));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(filter_chain_.get()));
@@ -817,7 +817,7 @@ TEST_F(ConnectionHandlerTest, OldBehaviorMatchFirstWildcardListener) {
       new Network::Address::Ipv6Instance("::2", 80, nullptr));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
-        cb.socket().addressProvider().restoreLocalAddress(alt_address);
+        cb.socket().connectionInfoProvider().restoreLocalAddress(alt_address);
         return Network::FilterStatus::Continue;
       }));
   EXPECT_CALL(manager_, findFilterChain(_)).Times(0);
@@ -897,7 +897,7 @@ TEST_F(ConnectionHandlerTest, MatchIPv6WildcardListener) {
       new Network::Address::Ipv6Instance("::2", 80, nullptr));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
-        cb.socket().addressProvider().restoreLocalAddress(alt_address);
+        cb.socket().connectionInfoProvider().restoreLocalAddress(alt_address);
         return Network::FilterStatus::Continue;
       }));
   EXPECT_CALL(manager_, findFilterChain(_)).Times(0);

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -79,7 +79,7 @@ public:
   const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
     return *address_provider_;
   }
-  Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {
+  Network::ConnectionInfoProviderSharedPtr connectionInfoProviderSharedPtr() const override {
     return address_provider_;
   }
 

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -75,8 +75,8 @@ public:
   const std::vector<std::string>& requestedApplicationProtocols() const override {
     return application_protocols_;
   }
-  Network::ConnectionInfoSetter& addressProvider() override { return *address_provider_; }
-  const Network::ConnectionInfoSetter& addressProvider() const override {
+  Network::ConnectionInfoSetter& connectionInfoProvider() override { return *address_provider_; }
+  const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
     return *address_provider_;
   }
   Network::ConnectionInfoProviderSharedPtr addressProviderSharedPtr() const override {

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -4064,8 +4064,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterOutbound) {
       }));
 
   EXPECT_TRUE(filterChainFactory.createListenerFilterChain(manager));
-  EXPECT_TRUE(socket.addressProvider().localAddressRestored());
-  EXPECT_EQ("127.0.0.2:2345", socket.addressProvider().localAddress()->asString());
+  EXPECT_TRUE(socket.connectionInfoProvider().localAddressRestored());
+  EXPECT_EQ("127.0.0.2:2345", socket.connectionInfoProvider().localAddress()->asString());
 #endif
 }
 
@@ -4161,8 +4161,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterInbound) {
       }));
 
   EXPECT_TRUE(filterChainFactory.createListenerFilterChain(manager));
-  EXPECT_TRUE(socket.addressProvider().localAddressRestored());
-  EXPECT_EQ("127.0.0.2:2345", socket.addressProvider().localAddress()->asString());
+  EXPECT_TRUE(socket.connectionInfoProvider().localAddressRestored());
+  EXPECT_EQ("127.0.0.2:2345", socket.connectionInfoProvider().localAddress()->asString());
 #endif
 }
 
@@ -4242,8 +4242,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterIPv6) {
       }));
 
   EXPECT_TRUE(filterChainFactory.createListenerFilterChain(manager));
-  EXPECT_TRUE(socket.addressProvider().localAddressRestored());
-  EXPECT_EQ("[1::2]:2345", socket.addressProvider().localAddress()->asString());
+  EXPECT_TRUE(socket.connectionInfoProvider().localAddressRestored());
+  EXPECT_EQ("[1::2]:2345", socket.connectionInfoProvider().localAddress()->asString());
 }
 
 // Validate that when neither transparent nor freebind is not set in the

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1368,7 +1368,7 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithSocketOptions) {
   // Start Envoy instance with admin port with SO_REUSEPORT option.
   ASSERT_NO_THROW(
       initialize("test/server/test_data/server/node_bootstrap_with_admin_socket_options.yaml"));
-  const auto address = server_->admin().socket().addressProvider().localAddress();
+  const auto address = server_->admin().socket().connectionInfoProvider().localAddress();
 
   // First attempt to bind and listen socket should fail due to the lack of SO_REUSEPORT socket
   // options.

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -57,7 +57,7 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(Address::InstanceConstShared
                   << ")";
     return nullptr;
   }
-  return sock.addressProvider().localAddress();
+  return sock.connectionInfoProvider().localAddress();
 }
 
 Address::InstanceConstSharedPtr findOrCheckFreePort(const std::string& addr_port,
@@ -179,7 +179,7 @@ bindFreeLoopbackPort(Address::IpVersion version, Socket::Type type, bool reuse_p
     throw EnvoyException(msg);
   }
 
-  return std::make_pair(sock->addressProvider().localAddress(), std::move(sock));
+  return std::make_pair(sock->connectionInfoProvider().localAddress(), std::move(sock));
 }
 
 TransportSocketPtr createRawBufferSocket() { return std::make_unique<RawBufferSocket>(); }
@@ -244,7 +244,7 @@ void UdpSyncPeer::write(const std::string& buffer, const Network::Address::Insta
 void UdpSyncPeer::recv(Network::UdpRecvData& datagram) {
   if (received_datagrams_.empty()) {
     const auto rc = Network::Test::readFromSocket(socket_->ioHandle(),
-                                                  *socket_->addressProvider().localAddress(),
+                                                  *socket_->connectionInfoProvider().localAddress(),
                                                   received_datagrams_, max_rx_datagram_size_);
     ASSERT_TRUE(rc.ok());
   }

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -203,7 +203,7 @@ public:
 
   // Return the local peer's socket address.
   const Network::Address::InstanceConstSharedPtr& localAddress() {
-    return socket_->addressProvider().localAddress();
+    return socket_->connectionInfoProvider().localAddress();
   }
 
 private:


### PR DESCRIPTION
Commit Message: network: rename the addressProvider() to connectionInfoProvider()
Additional Description:
Rename the addressProvider() to connectionInfoProvider() and addressProviderSharedPtr() to connectionInfoProviderSharedPtr()
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Signed-off-by: He Jie Xu <hejie.xu@intel.com>
