### PR TITLE
improve warming debug logging in ClusterImplBase

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1148,13 +1148,17 @@ void ClusterImplBase::onPreInitComplete() {
   }
   initialization_started_ = true;
 
-  ENVOY_LOG(debug, "initializing {} cluster {} completed",
+  ENVOY_LOG(debug, "pre-initializing {} cluster {} completed",
             initializePhase() == InitializePhase::Primary ? "Primary" : "Secondary",
             info()->name());
   init_manager_.initialize(init_watcher_);
 }
 
 void ClusterImplBase::onInitDone() {
+  ENVOY_LOG(debug, "initializing {} cluster {} completed",
+            initializePhase() == InitializePhase::Primary ? "Primary" : "Secondary",
+            info()->name());
+
   if (health_checker_ && pending_initialize_health_checks_ == 0) {
     for (auto& host_set : prioritySet().hostSetsPerPriority()) {
       pending_initialize_health_checks_ += host_set->hosts().size();
@@ -1183,6 +1187,9 @@ void ClusterImplBase::finishInitialization() {
   initialization_complete_callback_ = nullptr;
 
   if (health_checker_ != nullptr) {
+    ENVOY_LOG(debug, "health checks initialized for {} cluster {}",
+              initializePhase() == InitializePhase::Primary ? "Primary" : "Secondary",
+              info()->name());
     reloadHealthyHosts(nullptr);
   }
 


### PR DESCRIPTION
Signed-off-by: Michael Puncel <mpuncel@squareup.com>

Commit Message: improve warming debug logging in ClusterImplBase
Additional Description: This will help diagnose issues with clusters stuck in warming by distinguishing whether the warming cycle is stuck waiting for the init manager or health check initialization
Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none