### PR TITLE
thrift-proxy: fixes for mirroring support

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/router/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/config.cc
@@ -18,8 +18,9 @@ ThriftFilters::FilterFactoryCb RouterFilterConfig::createFilterFactoryFromProtoT
     const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
   UNREFERENCED_PARAMETER(proto_config);
 
-  auto shadow_writer = std::make_shared<ShadowWriterImpl>(context.clusterManager(), stat_prefix,
-                                                          context.scope(), context.dispatcher());
+  auto shadow_writer =
+      std::make_shared<ShadowWriterImpl>(context.clusterManager(), stat_prefix, context.scope(),
+                                         context.dispatcher(), context.threadLocal());
 
   return [&context, stat_prefix,
           shadow_writer](ThriftFilters::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -207,6 +207,8 @@ void Router::onDestroy() {
   for (auto& shadow_router : shadow_routers_) {
     shadow_router.get().onRouterDestroy();
   }
+
+  shadow_routers_.clear();
 }
 
 void Router::setDecoderFilterCallbacks(ThriftFilters::DecoderFilterCallbacks& callbacks) {

--- a/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc
@@ -25,8 +25,10 @@ ShadowWriterImpl::submit(const std::string& cluster_name, MessageMetadataSharedP
     return absl::nullopt;
   }
 
-  LinkedList::moveIntoList(std::move(shadow_router), active_routers_);
-  return *active_routers_.front();
+  auto& active_routers = tls_->getTyped<ActiveRouters>().activeRouters();
+
+  LinkedList::moveIntoList(std::move(shadow_router), active_routers);
+  return *active_routers.front();
 }
 
 ShadowRouterImpl::ShadowRouterImpl(ShadowWriterImpl& parent, const std::string& cluster_name,
@@ -60,9 +62,27 @@ bool ShadowRouterImpl::createUpstreamRequest() {
   return true;
 }
 
-bool ShadowRouterImpl::requestStarted() const {
-  return upstream_request_->conn_data_ != nullptr &&
-         upstream_request_->upgrade_response_ == nullptr;
+bool ShadowRouterImpl::requestStarted() {
+  const bool started =
+      upstream_request_->conn_data_ != nullptr && upstream_request_->upgrade_response_ == nullptr;
+
+  if (started) {
+    flushPendingCallbacks();
+  }
+
+  return started;
+}
+
+void ShadowRouterImpl::flushPendingCallbacks() {
+  if (pending_callbacks_.empty()) {
+    return;
+  }
+
+  for (auto& cb : pending_callbacks_) {
+    cb();
+  }
+
+  pending_callbacks_.clear();
 }
 
 FilterStatus ShadowRouterImpl::passthroughData(Buffer::Instance& data) {
@@ -316,6 +336,8 @@ bool ShadowRouterImpl::requestInProgress() {
 }
 
 void ShadowRouterImpl::onRouterDestroy() {
+  ASSERT(!deferred_deleting_);
+
   // Mark the shadow request to be destroyed when the response gets back
   // or the upstream connection finally fails.
   router_destroyed_ = true;
@@ -330,11 +352,16 @@ bool ShadowRouterImpl::waitingForConnection() const {
 }
 
 void ShadowRouterImpl::maybeCleanup() {
+  if (removed_) {
+    return;
+  }
+
+  ASSERT(!deferred_deleting_);
+
   if (router_destroyed_) {
-    upstream_request_.reset();
-    if (inserted()) {
-      removeFromList(parent_.active_routers_);
-    }
+    removed_ = true;
+    upstream_request_->resetStream();
+    parent_.remove(*this);
   }
 }
 

--- a/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.h
@@ -50,7 +50,10 @@ struct NullResponseDecoder : public DecoderCallbacks, public ProtocolConverter {
     decoder_->onData(upstream_buffer_, underflow);
     return underflow;
   }
-  MessageMetadataSharedPtr& responseMetadata() { return metadata_; }
+  MessageMetadataSharedPtr& responseMetadata() {
+    ASSERT(metadata_ != nullptr);
+    return metadata_;
+  }
   bool responseSuccess() { return success_.value_or(false); }
 
   // ProtocolConverter
@@ -150,15 +153,7 @@ public:
   Buffer::OwnedImpl& buffer() override { return upstream_request_buffer_; }
   Event::Dispatcher& dispatcher() override;
   void addSize(uint64_t size) override { request_size_ += size; }
-  void continueDecoding() override {
-    if (pending_callbacks_.empty()) {
-      return;
-    }
-
-    for (auto& cb : pending_callbacks_) {
-      cb();
-    }
-  }
+  void continueDecoding() override { flushPendingCallbacks(); }
   void resetDownstreamConnection() override {}
   void sendLocalReply(const ThriftProxy::DirectResponse&, bool) override {}
   void recordResponseDuration(uint64_t value, Stats::Histogram::Unit unit) override {
@@ -198,13 +193,15 @@ public:
   // Upstream::LoadBalancerContextBase
   const Network::Connection* downstreamConnection() const override { return nullptr; }
   const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
+  void deleteIsPending() override { deferred_deleting_ = true; }
 
 private:
   friend class ShadowWriterTest;
 
   void writeRequest();
   bool requestInProgress();
-  bool requestStarted() const;
+  bool requestStarted();
+  void flushPendingCallbacks();
 
   ShadowWriterImpl& parent_;
   const std::string cluster_name_;
@@ -225,6 +222,8 @@ private:
 
   using ConverterCallback = std::function<void()>;
   std::list<ConverterCallback> pending_callbacks_;
+  bool removed_{};
+  bool deferred_deleting_{};
 };
 
 #define ALL_SHADOW_WRITER_STATS(COUNTER, GAUGE, HISTOGRAM) COUNTER(shadow_request_submit_failure)
@@ -233,20 +232,44 @@ struct ShadowWriterStats {
   ALL_SHADOW_WRITER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
-class ShadowWriterImpl : public ShadowWriter, Logger::Loggable<Logger::Id::thrift> {
+class ActiveRouters : public ThreadLocal::ThreadLocalObject {
 public:
-  ShadowWriterImpl(Upstream::ClusterManager& cm, const std::string& stat_prefix,
-                   Stats::Scope& scope, Event::Dispatcher& dispatcher)
-      : cm_(cm), stat_prefix_(stat_prefix), scope_(scope), dispatcher_(dispatcher),
-        stats_(generateStats(stat_prefix, scope)) {}
-
-  ~ShadowWriterImpl() override {
+  ActiveRouters(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
+  ~ActiveRouters() {
     while (!active_routers_.empty()) {
       auto& router = active_routers_.front();
       router->resetStream();
       router->onRouterDestroy();
     }
   }
+
+  std::list<std::unique_ptr<ShadowRouterImpl>>& activeRouters() { return active_routers_; }
+
+  void remove(ShadowRouterImpl& router) {
+    dispatcher_.deferredDelete(router.removeFromList(active_routers_));
+  }
+
+private:
+  Event::Dispatcher& dispatcher_;
+  std::list<std::unique_ptr<ShadowRouterImpl>> active_routers_;
+};
+
+class ShadowWriterImpl : public ShadowWriter, Logger::Loggable<Logger::Id::thrift> {
+public:
+  ShadowWriterImpl(Upstream::ClusterManager& cm, const std::string& stat_prefix,
+                   Stats::Scope& scope, Event::Dispatcher& dispatcher,
+                   ThreadLocal::SlotAllocator& tls)
+      : cm_(cm), stat_prefix_(stat_prefix), scope_(scope), dispatcher_(dispatcher),
+        stats_(generateStats(stat_prefix, scope)), tls_(tls.allocateSlot()) {
+
+    tls_->set([](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return std::make_shared<ActiveRouters>(dispatcher);
+    });
+  }
+
+  ~ShadowWriterImpl() override = default;
+
+  void remove(ShadowRouterImpl& router) { tls_->getTyped<ActiveRouters>().remove(router); }
 
   // Router::ShadowWriter
   Upstream::ClusterManager& clusterManager() override { return cm_; }
@@ -270,8 +293,8 @@ private:
   const std::string stat_prefix_;
   Stats::Scope& scope_;
   Event::Dispatcher& dispatcher_;
-  std::list<std::unique_ptr<ShadowRouterImpl>> active_routers_;
   ShadowWriterStats stats_;
+  ThreadLocal::SlotPtr tls_;
 };
 
 } // namespace Router


### PR DESCRIPTION
The recently added support for mirroring requests had a few issues:

* the list of active shadow routers was global, not thread local
  (my bad for forgetting createFilterFactoryFromProtoTyped() isn't
   per worker)
* we were not flushing pending callbacks, so if the request became
  available after a few callbacks had been queued we'd not write
  those out (end result: invalid shadow request)
* when cleaning things up and closing an upstream connection, onEvent()
  might be reentrant so that needs to be handled with care

There's also the fact that passthrough isn't enabled for mirrored
requests, which makes them slower. I'll fix that in a follow-up.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
