### PR TITLE
dns: use dns specific log component, add log events to apple resolver

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -37,6 +37,7 @@ namespace Logger {
   FUNCTION(connection)                                                                             \
   FUNCTION(conn_handler)                                                                           \
   FUNCTION(decompression)                                                                          \
+  FUNCTION(dns)                                                                                    \
   FUNCTION(dubbo)                                                                                  \
   FUNCTION(envoy_bug)                                                                              \
   FUNCTION(ext_authz)                                                                              \

--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -55,7 +55,7 @@ AppleDnsResolverStats AppleDnsResolverImpl::generateAppleDnsResolverStats(Stats:
 AppleDnsResolverImpl::StartResolutionResult
 AppleDnsResolverImpl::startResolution(const std::string& dns_name,
                                       DnsLookupFamily dns_lookup_family, ResolveCb callback) {
-  ENVOY_LOG(debug, "DNS resolver resolve={}", dns_name);
+  ENVOY_LOG_EVENT(debug, "apple_dns_started", "DNS resolution for {} started", dns_name);
 
   // When an IP address is submitted to c-ares in DnsResolverImpl, c-ares synchronously returns
   // the IP without submitting a DNS query. Because Envoy has come to rely on this behavior, this
@@ -64,8 +64,9 @@ AppleDnsResolverImpl::startResolution(const std::string& dns_name,
   auto address = Utility::parseInternetAddressNoThrow(dns_name);
 
   if (address != nullptr) {
-    ENVOY_LOG(debug, "DNS resolver resolved ({}) to ({}) without issuing call to Apple API",
-              dns_name, address->asString());
+    ENVOY_LOG_EVENT(debug, "apple_dns_immediate_resolution",
+                    "DNS resolver resolved ({}) to ({}) without issuing call to Apple API",
+                    dns_name, address->asString());
     callback(DnsResolver::ResolutionStatus::Success,
              {DnsResponse(address, std::chrono::seconds(60))});
     return {nullptr, true};
@@ -106,6 +107,8 @@ ActiveDnsQuery* AppleDnsResolverImpl::resolve(const std::string& dns_name,
 
   // If we synchronously failed the resolution, trigger a failure callback.
   if (!pending_resolution_and_success.second) {
+    ENVOY_LOG_EVENT(debug, "apple_dns_immediate_failure", "DNS resolution for {} failed", dns_name);
+
     callback(DnsResolver::ResolutionStatus::Failure, {});
     return nullptr;
   }
@@ -183,6 +186,8 @@ void AppleDnsResolverImpl::PendingResolution::onEventCallback(uint32_t events) {
 }
 
 void AppleDnsResolverImpl::PendingResolution::finishResolve() {
+  ENVOY_LOG_EVENT(debug, "apple_dns_resolution_complete",
+                  "dns resolution for {} completed with status {}", dns_name_, pending_cb_.status_);
   callback_(pending_cb_.status_, std::move(pending_cb_.responses_));
 
   if (owned_) {

--- a/source/common/network/apple_dns_impl.h
+++ b/source/common/network/apple_dns_impl.h
@@ -61,7 +61,7 @@ struct AppleDnsResolverStats {
  * Implementation of DnsResolver that uses Apple dns_sd.h APIs. All calls and callbacks are assumed
  * to happen on the thread that owns the creating dispatcher.
  */
-class AppleDnsResolverImpl : public DnsResolver, protected Logger::Loggable<Logger::Id::upstream> {
+class AppleDnsResolverImpl : public DnsResolver, protected Logger::Loggable<Logger::Id::dns> {
 public:
   AppleDnsResolverImpl(Event::Dispatcher& dispatcher, Stats::Scope& root_scope);
 

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -105,7 +105,7 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
     // callback_ target _should_ still be around. In that case, raise the callback_ so the target
     // can be done with this query and initiate a new one.
     if (!cancelled_) {
-      ENVOY_LOG_EVENT(debug, "dns_resolution_destroyed", "dns resolution for {} destroyed",
+      ENVOY_LOG_EVENT(debug, "cares_dns_resolution_destroyed", "dns resolution for {} destroyed",
                       dns_name_);
 
       callback_(ResolutionStatus::Failure, {});
@@ -183,7 +183,7 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
       // portFromTcpUrl().
       // TODO(chaoqin-li1123): remove try catch pattern here once we figure how to handle unexpected
       // exception in fuzz tests.
-      ENVOY_LOG_EVENT(debug, "dns_resolution_complete",
+      ENVOY_LOG_EVENT(debug, "cares_dns_resolution_complete",
                       "dns resolution for {} completed with status {}", dns_name_,
                       resolution_status);
 

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -24,7 +24,7 @@ class DnsResolverImplPeer;
  * Implementation of DnsResolver that uses c-ares. All calls and callbacks are assumed to
  * happen on the thread that owns the creating dispatcher.
  */
-class DnsResolverImpl : public DnsResolver, protected Logger::Loggable<Logger::Id::upstream> {
+class DnsResolverImpl : public DnsResolver, protected Logger::Loggable<Logger::Id::dns> {
 public:
   DnsResolverImpl(Event::Dispatcher& dispatcher,
                   const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers,


### PR DESCRIPTION
Changes the c-ares and apple DNS resolver to use their own logging component and adds additional ENVOY_LOG_EVENT logs to the apple resolver to match the c-ares one. 

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Commit Message:
Additional Description:
Risk Level: Low, only changes logging
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
