### PR TITLE
quiche: early fail listener config with both quic and connection_balencer

### DIFF
--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -446,7 +446,7 @@ void ListenerImpl::buildUdpListenerFactory(Network::Socket::Type socket_type,
 #ifdef ENVOY_ENABLE_QUIC
     if (config_.has_connection_balance_config()) {
       throw EnvoyException("connection_balance_config is configured for QUIC listener which "
-                           "doesn't work with connection balencer.");
+                           "doesn't work with connection balancer.");
     }
     udp_listener_config_->listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
         config_.udp_listener_config().quic_options(), concurrency, quic_stat_names_);

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -444,6 +444,10 @@ void ListenerImpl::buildUdpListenerFactory(Network::Socket::Type socket_type,
   udp_listener_config_ = std::make_unique<UdpListenerConfigImpl>(config_.udp_listener_config());
   if (config_.udp_listener_config().has_quic_options()) {
 #ifdef ENVOY_ENABLE_QUIC
+    if (config_.has_connection_balance_config()) {
+      throw EnvoyException("connection_balance_config is configured for QUIC listener which "
+                           "doesn't work with connection balencer.");
+    }
     udp_listener_config_->listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
         config_.udp_listener_config().quic_options(), concurrency, quic_stat_names_);
 #if UDP_GSO_BATCH_WRITER_COMPILETIME_SUPPORT

--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -225,6 +225,62 @@ udp_listener_config:
 #endif
 }
 
+TEST_F(ListenerManagerImplQuicOnlyTest, QuicListenerFactoryWithConnectionBalencer) {
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
+address:
+  socket_address:
+    address: 127.0.0.1
+    protocol: UDP
+    port_value: 1234
+filter_chains:
+- filter_chain_match:
+    transport_protocol: "quic"
+  filters:
+  - name: envoy.filters.network.http_connection_manager
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      codec_type: HTTP3
+      stat_prefix: hcm
+      route_config:
+        name: local_route
+      http_filters:
+        - name: envoy.filters.http.router
+  transport_socket:
+    name: envoy.transport_sockets.quic
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicDownstreamTransport
+      downstream_tls_context:
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"
+            private_key:
+              filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_key.pem"
+          validation_context:
+            trusted_ca:
+              filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
+            match_subject_alt_names:
+            - exact: localhost
+            - exact: 127.0.0.1
+udp_listener_config:
+  quic_options: {}
+connection_balance_config:
+  exact_balance: {}
+  )EOF",
+                                                       Network::Address::IpVersion::v4);
+
+  envoy::config::listener::v3::Listener listener_proto = parseListenerFromV3Yaml(yaml);
+
+#if defined(ENVOY_ENABLE_QUIC)
+  EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(listener_proto, "", true), EnvoyException,
+                          "connection_balance_config is configured for QUIC listener which doesn't "
+                          "work with connection balencer.");
+#else
+  EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(listener_proto, "", true), EnvoyException,
+                          "QUIC is configured but not enabled in the build.");
+#endif
+}
+
 } // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -274,7 +274,7 @@ connection_balance_config:
 #if defined(ENVOY_ENABLE_QUIC)
   EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(listener_proto, "", true), EnvoyException,
                           "connection_balance_config is configured for QUIC listener which doesn't "
-                          "work with connection balencer.");
+                          "work with connection balancer.");
 #else
   EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(listener_proto, "", true), EnvoyException,
                           "QUIC is configured but not enabled in the build.");


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

QUIC listener use BPF kernel routine for each packet to guarantee stable connection. [connection_balencer](https://github.com/envoyproxy/envoy/blob/ba474ac375418d5529a30a9510a8ff5f0a5ada9a/generated_api_shadow/envoy/config/listener/v3/listener.proto#L256) in Listener config undermines this purpose. So it shouldn't be used with QUIC listener.

Risk Level: low
Testing: added unit test
Fixes #13116
