### PR TITLE
ext_authz: set dynamic metadata for non-OK responses in the network filter

### DIFF
--- a/source/extensions/filters/network/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/network/ext_authz/ext_authz.cc
@@ -83,6 +83,11 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     break;
   }
 
+  if (!response->dynamic_metadata.fields().empty()) {
+    filter_callbacks_->connection().streamInfo().setDynamicMetadata(
+        NetworkFilterNames::get().ExtAuthorization, response->dynamic_metadata);
+  }
+
   // Fail open only if configured to do so and if the check status was a error.
   if (response->status == Filters::Common::ExtAuthz::CheckStatus::Denied ||
       (response->status == Filters::Common::ExtAuthz::CheckStatus::Error &&
@@ -96,11 +101,6 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
         response->status == Filters::Common::ExtAuthz::CheckStatus::Error) {
       // Status is Error and yet we are configured to allow traffic. Click a counter.
       config_->stats().failure_mode_allowed_.inc();
-    }
-
-    if (!response->dynamic_metadata.fields().empty()) {
-      filter_callbacks_->connection().streamInfo().setDynamicMetadata(
-          NetworkFilterNames::get().ExtAuthorization, response->dynamic_metadata);
     }
 
     // We can get completion inline, so only call continue if that isn't happening.

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -353,13 +353,24 @@ TEST_F(ExtAuthzFilterTest, ImmediateOK) {
 
   filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setRemoteAddress(addr_);
   filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setLocalAddress(addr_);
+  ProtobufWkt::Struct dynamic_metadata;
+  (*dynamic_metadata.mutable_fields())["baz"] = ValueUtil::stringValue("hello");
+  (*dynamic_metadata.mutable_fields())["x"] = ValueUtil::numberValue(12);
   EXPECT_CALL(filter_callbacks_, continueReading()).Times(0);
   EXPECT_CALL(*client_, check(_, _, _, _))
       .WillOnce(
           WithArgs<0>(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks) -> void {
-            callbacks.onComplete(makeAuthzResponse(Filters::Common::ExtAuthz::CheckStatus::OK));
+            Filters::Common::ExtAuthz::Response response{};
+            response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+            response.dynamic_metadata = dynamic_metadata;
+            callbacks.onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
           })));
-  EXPECT_CALL(filter_callbacks_.connection_.stream_info_, setDynamicMetadata(_, _)).Times(0);
+  EXPECT_CALL(filter_callbacks_.connection_.stream_info_, setDynamicMetadata(_, _))
+      .WillOnce(Invoke([&dynamic_metadata](const std::string& ns,
+                                           const ProtobufWkt::Struct& returned_dynamic_metadata) {
+        EXPECT_EQ(ns, NetworkFilterNames::get().ExtAuthorization);
+        EXPECT_TRUE(TestUtility::protoEqual(returned_dynamic_metadata, dynamic_metadata));
+      }));
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));


### PR DESCRIPTION
Commit Message: ext_authz: set dynamic metadata for non-OK responses in the network filter
Additional Description:
Risk Level: low
Testing: modified unit test
Docs Changes: none
Release Notes: ext_authz: the network ext_authz filter now correctly sets dynamic metdata returned by the authorization service for non-OK responses. This behavior now matches the http ext_authz filter.
Platform Specific Features:
[Optional Fixes #Issue] #17684

