### PR TITLE
ecds: refactor FilterConfigProviderManagerImpl into base and derived classes

### DIFF
--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -67,7 +67,8 @@ void DynamicFilterConfigProviderImplBase::validateTerminalFilter(const std::stri
 FilterConfigSubscription::FilterConfigSubscription(
     const envoy::config::core::v3::ConfigSource& config_source,
     const std::string& filter_config_name, Server::Configuration::FactoryContext& factory_context,
-    const std::string& stat_prefix, FilterConfigProviderManagerImpl& filter_config_provider_manager,
+    const std::string& stat_prefix,
+    FilterConfigProviderManagerImplBase& filter_config_provider_manager,
     const std::string& subscription_id)
     : Config::SubscriptionBase<envoy::config::core::v3::TypedExtensionConfig>(
           factory_context.messageValidationContext().dynamicValidationVisitor(), "name"),
@@ -190,7 +191,7 @@ FilterConfigSubscription::~FilterConfigSubscription() {
 
 void FilterConfigSubscription::incrementConflictCounter() { stats_.config_conflict_.inc(); }
 
-std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImpl::getSubscription(
+std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImplBase::getSubscription(
     const envoy::config::core::v3::ConfigSource& config_source, const std::string& name,
     Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix) {
   // FilterConfigSubscriptions are unique based on their config source and filter config name
@@ -209,6 +210,39 @@ std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImpl::getSu
     ASSERT(existing != nullptr,
            absl::StrCat("Cannot find subscribed filter config resource ", name));
     return existing;
+  }
+}
+
+void FilterConfigProviderManagerImplBase::applyLastOrDefaultConfig(
+    std::shared_ptr<FilterConfigSubscription>& subscription,
+    DynamicFilterConfigProviderImplBase& provider, const std::string& filter_config_name) {
+  // If the subscription already received a config, attempt to apply it.
+  // It is possible that the received extension config fails to satisfy the listener
+  // type URL constraints. This may happen if ECDS and LDS updates are racing, and the LDS
+  // update arrives first. In this case, use the default config, increment a metric,
+  // and the applied config eventually converges once ECDS update arrives.
+  bool last_config_valid = false;
+  if (subscription->lastConfig().has_value()) {
+    TRY_ASSERT_MAIN_THREAD {
+      provider.validateTypeUrl(subscription->lastTypeUrl());
+      provider.validateTerminalFilter(filter_config_name, subscription->lastFilterName(),
+                                      subscription->isLastFilterTerminal());
+      last_config_valid = true;
+    }
+    END_TRY catch (const EnvoyException& e) {
+      ENVOY_LOG(debug, "ECDS subscription {} is invalid in a listener context: {}.",
+                filter_config_name, e.what());
+      subscription->incrementConflictCounter();
+    }
+    if (last_config_valid) {
+      provider.onConfigUpdate(subscription->lastConfig().value(), subscription->lastVersionInfo(),
+                              nullptr);
+    }
+  }
+
+  // Apply the default config if none has been applied.
+  if (!last_config_valid) {
+    provider.applyDefaultConfiguration();
   }
 }
 
@@ -233,26 +267,11 @@ DynamicFilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFil
 
   Envoy::Http::FilterFactoryCb default_config = nullptr;
   if (config_source.has_default_config()) {
-    auto* default_factory =
-        Config::Utility::getFactoryByType<Server::Configuration::NamedHttpFilterConfigFactory>(
-            config_source.default_config());
-    if (default_factory == nullptr) {
-      throw EnvoyException(fmt::format("Error: cannot find filter factory {} for default filter "
-                                       "configuration with type URL {}.",
-                                       filter_config_name,
-                                       config_source.default_config().type_url()));
-    }
     validateTypeUrlHelper(Config::Utility::getFactoryType(config_source.default_config()),
                           require_type_urls);
-    ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-        config_source.default_config(), factory_context.messageValidationVisitor(),
-        *default_factory);
-    Config::Utility::validateTerminalFilters(
-        filter_config_name, default_factory->name(), filter_chain_type,
-        default_factory->isTerminalFilterByProto(*message, factory_context),
-        last_filter_in_filter_config);
     default_config =
-        default_factory->createFilterFactoryFromProto(*message, stat_prefix, factory_context);
+        getDefaultConfig(config_source.default_config(), filter_config_name, factory_context,
+                         stat_prefix, last_filter_in_filter_config, filter_chain_type);
   }
 
   auto provider = std::make_unique<DynamicFilterConfigProviderImpl>(
@@ -263,36 +282,29 @@ DynamicFilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFil
   if (config_source.apply_default_config_without_warming()) {
     factory_context.initManager().add(provider->initTarget());
   }
-
-  // If the subscription already received a config, attempt to apply it.
-  // It is possible that the received extension config fails to satisfy the listener
-  // type URL constraints. This may happen if ECDS and LDS updates are racing, and the LDS
-  // update arrives first. In this case, use the default config, increment a metric,
-  // and the applied config eventually converges once ECDS update arrives.
-  bool last_config_valid = false;
-  if (subscription->lastConfig().has_value()) {
-    TRY_ASSERT_MAIN_THREAD {
-      provider->validateTypeUrl(subscription->lastTypeUrl());
-      provider->validateTerminalFilter(filter_config_name, subscription->lastFilterName(),
-                                       subscription->isLastFilterTerminal());
-      last_config_valid = true;
-    }
-    END_TRY catch (const EnvoyException& e) {
-      ENVOY_LOG(debug, "ECDS subscription {} is invalid in a listener context: {}.",
-                filter_config_name, e.what());
-      subscription->incrementConflictCounter();
-    }
-    if (last_config_valid) {
-      provider->onConfigUpdate(subscription->lastConfig().value(), subscription->lastVersionInfo(),
-                               nullptr);
-    }
-  }
-
-  // Apply the default config if none has been applied.
-  if (!last_config_valid) {
-    provider->applyDefaultConfiguration();
-  }
+  applyLastOrDefaultConfig(subscription, *provider, filter_config_name);
   return provider;
+}
+
+Http::FilterFactoryCb HttpFilterConfigProviderManagerImpl::getDefaultConfig(
+    const ProtobufWkt::Any& proto_config, const std::string& filter_config_name,
+    Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
+    bool last_filter_in_filter_config, const std::string& filter_chain_type) const {
+  auto* default_factory =
+      Config::Utility::getFactoryByType<Server::Configuration::NamedHttpFilterConfigFactory>(
+          proto_config);
+  if (default_factory == nullptr) {
+    throw EnvoyException(fmt::format("Error: cannot find filter factory {} for default filter "
+                                     "configuration with type URL {}.",
+                                     filter_config_name, proto_config.type_url()));
+  }
+  ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
+      proto_config, factory_context.messageValidationVisitor(), *default_factory);
+  Config::Utility::validateTerminalFilters(
+      filter_config_name, default_factory->name(), filter_chain_type,
+      default_factory->isTerminalFilterByProto(*message, factory_context),
+      last_filter_in_filter_config);
+  return default_factory->createFilterFactoryFromProto(*message, stat_prefix, factory_context);
 }
 
 } // namespace Filter

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -23,6 +23,7 @@
 namespace Envoy {
 namespace Filter {
 
+class FilterConfigProviderManagerImplBase;
 class FilterConfigProviderManagerImpl;
 class FilterConfigSubscription;
 
@@ -161,7 +162,7 @@ public:
                            const std::string& filter_config_name,
                            Server::Configuration::FactoryContext& factory_context,
                            const std::string& stat_prefix,
-                           FilterConfigProviderManagerImpl& filter_config_provider_manager,
+                           FilterConfigProviderManagerImplBase& filter_config_provider_manager,
                            const std::string& subscription_id);
 
   ~FilterConfigSubscription() override;
@@ -204,8 +205,8 @@ private:
   const std::string stat_prefix_;
   ExtensionConfigDiscoveryStats stats_;
 
-  // FilterConfigProviderManagerImpl maintains active subscriptions in a map.
-  FilterConfigProviderManagerImpl& filter_config_provider_manager_;
+  // FilterConfigProviderManagerImplBase maintains active subscriptions in a map.
+  FilterConfigProviderManagerImplBase& filter_config_provider_manager_;
   const std::string subscription_id_;
   absl::flat_hash_set<DynamicFilterConfigProviderImplBase*> filter_config_providers_;
   friend class DynamicFilterConfigProviderImplBase;
@@ -234,16 +235,34 @@ private:
 };
 
 /**
+ * Base class for a FilterConfigProviderManager.
+ */
+class FilterConfigProviderManagerImplBase : Logger::Loggable<Logger::Id::filter> {
+protected:
+  std::shared_ptr<FilterConfigSubscription>
+  getSubscription(const envoy::config::core::v3::ConfigSource& config_source,
+                  const std::string& name, Server::Configuration::FactoryContext& factory_context,
+                  const std::string& stat_prefix);
+  void applyLastOrDefaultConfig(std::shared_ptr<FilterConfigSubscription>& subscription,
+                                DynamicFilterConfigProviderImplBase& provider,
+                                const std::string& filter_config_name);
+
+private:
+  absl::flat_hash_map<std::string, std::weak_ptr<FilterConfigSubscription>> subscriptions_;
+  friend class FilterConfigSubscription;
+};
+
+/**
  * An implementation of FilterConfigProviderManager.
  */
-class FilterConfigProviderManagerImpl : public FilterConfigProviderManager,
-                                        public Singleton::Instance,
-                                        Logger::Loggable<Logger::Id::filter> {
+class FilterConfigProviderManagerImpl : public FilterConfigProviderManagerImplBase,
+                                        public FilterConfigProviderManager,
+                                        public Singleton::Instance {
 public:
   DynamicFilterConfigProviderPtr createDynamicFilterConfigProvider(
       const envoy::config::core::v3::ExtensionConfigSource& config_source,
       const std::string& filter_config_name, Server::Configuration::FactoryContext& factory_context,
-      const std::string& stat_prefix, bool last_filter_in_filter_chain,
+      const std::string& stat_prefix, bool last_filter_in_filter_config,
       const std::string& filter_chain_type) override;
 
   FilterConfigProviderPtr
@@ -252,16 +271,23 @@ public:
     return std::make_unique<StaticFilterConfigProviderImpl>(config, filter_config_name);
   }
 
-private:
-  std::shared_ptr<FilterConfigSubscription>
-  getSubscription(const envoy::config::core::v3::ConfigSource& config_source,
-                  const std::string& name, Server::Configuration::FactoryContext& factory_context,
-                  const std::string& stat_prefix);
-  absl::flat_hash_map<std::string, std::weak_ptr<FilterConfigSubscription>> subscriptions_;
-  friend class FilterConfigSubscription;
+protected:
+  virtual Http::FilterFactoryCb
+  getDefaultConfig(const ProtobufWkt::Any& proto_config, const std::string& filter_config_name,
+                   Server::Configuration::FactoryContext& factory_context,
+                   const std::string& stat_prefix, bool last_filter_in_filter_config,
+                   const std::string& filter_chain_type) const PURE;
 };
 
-class HttpFilterConfigProviderManagerImpl : public FilterConfigProviderManagerImpl {};
+class HttpFilterConfigProviderManagerImpl : public FilterConfigProviderManagerImpl {
+protected:
+  Http::FilterFactoryCb getDefaultConfig(const ProtobufWkt::Any& proto_config,
+                                         const std::string& filter_config_name,
+                                         Server::Configuration::FactoryContext& factory_context,
+                                         const std::string& stat_prefix,
+                                         bool last_filter_in_filter_config,
+                                         const std::string& filter_chain_type) const override;
+};
 
 } // namespace Filter
 } // namespace Envoy

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -24,7 +24,6 @@ namespace Envoy {
 namespace Filter {
 
 class FilterConfigProviderManagerImplBase;
-class FilterConfigProviderManagerImpl;
 class FilterConfigSubscription;
 
 using FilterConfigSubscriptionSharedPtr = std::shared_ptr<FilterConfigSubscription>;

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -276,17 +276,18 @@ protected:
   getDefaultConfig(const ProtobufWkt::Any& proto_config, const std::string& filter_config_name,
                    Server::Configuration::FactoryContext& factory_context,
                    const std::string& stat_prefix, bool last_filter_in_filter_config,
-                   const std::string& filter_chain_type) const PURE;
+                   const std::string& filter_chain_type,
+                   const absl::flat_hash_set<std::string> require_type_urls) const PURE;
 };
 
 class HttpFilterConfigProviderManagerImpl : public FilterConfigProviderManagerImpl {
 protected:
-  Http::FilterFactoryCb getDefaultConfig(const ProtobufWkt::Any& proto_config,
-                                         const std::string& filter_config_name,
-                                         Server::Configuration::FactoryContext& factory_context,
-                                         const std::string& stat_prefix,
-                                         bool last_filter_in_filter_config,
-                                         const std::string& filter_chain_type) const override;
+  Http::FilterFactoryCb
+  getDefaultConfig(const ProtobufWkt::Any& proto_config, const std::string& filter_config_name,
+                   Server::Configuration::FactoryContext& factory_context,
+                   const std::string& stat_prefix, bool last_filter_in_filter_config,
+                   const std::string& filter_chain_type,
+                   const absl::flat_hash_set<std::string> require_type_urls) const override;
 };
 
 } // namespace Filter


### PR DESCRIPTION
Commit Message:
ecds: refactor FilterConfigProviderManagerImpl into base and derived classes

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description: Part of https://github.com/envoyproxy/envoy/issues/14696#issuecomment-897855672. The plan is for `FilterConfigProviderManagerImpl` to become a template
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
#14696