### PR TITLE
common: fix ENVOY_LOG_EVENT_TO_LOGGER

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -466,7 +466,7 @@ public:
 
 #define ENVOY_LOG_EVENT_TO_LOGGER(LOGGER, LEVEL, EVENT_NAME, ...)                                  \
   do {                                                                                             \
-    ENVOY_LOG(LEVEL, ##__VA_ARGS__);                                                               \
+    ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ##__VA_ARGS__);                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
       ::Envoy::Logger::Registry::getSink()->logWithStableName(EVENT_NAME, #LEVEL, (LOGGER).name(), \
                                                               ##__VA_ARGS__);                      \

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::Invoke;
 
 namespace Envoy {
 namespace Logger {
@@ -177,6 +178,11 @@ TEST_F(NamedLogTest, NamedLogsAreSentToSink) {
   EXPECT_CALL(sink, log(_));
   EXPECT_CALL(sink, logWithStableName("test_event", "debug", "assert", "test log 1"));
   ENVOY_LOG_EVENT(debug, "test_event", "test {} {}", "log", 1);
+
+  // Verify that ENVOY_LOG_EVENT_TO_LOGGER does the right thing.
+  EXPECT_CALL(sink, log(_)).WillOnce(Invoke([](auto log) { EXPECT_TRUE(log.find("[misc]")); }));
+  EXPECT_CALL(sink, logWithStableName("misc_event", "debug", "misc", "log"));
+  ENVOY_LOG_EVENT_TO_LOGGER(Registry::getLog(Id::misc), debug, "misc_event", "log");
 }
 
 } // namespace Logger


### PR DESCRIPTION
This macro would always call ENVOY_LOG instead of using the provided logger for the standard log path

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
