### PR TITLE
[api] Handle previous message deps sync in contrib api

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
+++ b/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
@@ -6,9 +6,9 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//contrib/envoy/extensions/filters/network/rocketmq_proxy/v3:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
-        "//envoy/extensions/filters/network/rocketmq_proxy/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/generated_api_shadow/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
+++ b/generated_api_shadow/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
@@ -6,9 +6,9 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//contrib/envoy/extensions/filters/network/rocketmq_proxy/v3:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
-        "//envoy/extensions/filters/network/rocketmq_proxy/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -337,6 +337,10 @@ def get_previous_message_type_deps(proto_path):
         pkg = get_directory_from_package(m)
         if pkg in IGNORED_V2_PROTOS:
             continue
+
+        if 'contrib' in proto_path:
+            pkg = 'contrib/%s' % pkg
+
         deps.append('//%s:pkg' % pkg)
     return deps
 


### PR DESCRIPTION
Commit Message: Handle previous message deps sync in contrib api
Additional Description: Previously did not correctly handle generating the deps for v4alpha protos inside api contrib, which meant that generated build files could be point at incorrect targets. This was first realized in #17796, which had the v4alpha proto point at the non-contrib v3 location.
Risk Level: Low
Testing: Edit api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/ and ran proto format sync to update BUILD files, and included in the commit.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
