### PR TITLE
proto: fixing import path to include "contrib"

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.filters.network.rocketmq_proxy.v4alpha;
 
-import "envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto";
+import "contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto";
 
 import "google/protobuf/duration.proto";
 


### PR DESCRIPTION
Commit Message: Fixing import path to include "contrib"

Additional Description:
I tried generating Python code but got an error:
```
envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto: File not found.
contrib/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto:5:1: Import "envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto" was not found or had errors.
```

I noticed a PR (https://github.com/envoyproxy/envoy/pull/17796) a few days ago moving these `rocketmq` proto files to another directory so I'm thinking this import statement might have been missed.

Risk Level: Low
Testing: Successfully generated Python code