### PR TITLE
docs: Fix wrong IP in doc

### DIFF
--- a/docs/root/configuration/overview/_include/tagged.yaml
+++ b/docs/root/configuration/overview/_include/tagged.yaml
@@ -1,7 +1,7 @@
 !ignore dynamic_sockets:
 - &admin_address {address: 127.0.0.1, port_value: 9901}
 - &listener_address {address: 127.0.0.1, port_value: 10000}
-- &lb_address {address: 127.0.0.2, port_value: 1234}
+- &lb_address {address: 127.0.0.1, port_value: 1234}
 
 admin:
   address:

--- a/docs/root/configuration/overview/examples.rst
+++ b/docs/root/configuration/overview/examples.rst
@@ -2,7 +2,7 @@ Examples
 --------
 
 Below we will use YAML representation of the config protos and a running example
-of a service proxying HTTP from 127.0.0.1:10000 to 127.0.0.2:1234.
+of a service proxying HTTP from 127.0.0.1:10000 to 127.0.0.1:1234.
 
 Static
 ^^^^^^
@@ -50,7 +50,7 @@ A minimal fully static bootstrap config is provided below:
           - endpoint:
               address:
                 socket_address:
-                  address: 127.0.0.2
+                  address: 127.0.0.1
                   port_value: 1234
 
 Mostly static with dynamic EDS
@@ -152,7 +152,7 @@ In the above example, the EDS management server could then return a proto encodi
       - endpoint:
           address:
             socket_address:
-              address: 127.0.0.2
+              address: 127.0.0.1
               port_value: 1234
 
 
@@ -300,7 +300,7 @@ The management server could respond to EDS requests with:
       - endpoint:
           address:
             socket_address:
-              address: 127.0.0.2
+              address: 127.0.0.1
               port_value: 1234
 
 Special YAML usage

--- a/docs/root/intro/arch_overview/security/_include/ssl.yaml
+++ b/docs/root/intro/arch_overview/security/_include/ssl.yaml
@@ -38,7 +38,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.2
+                address: 127.0.0.1
                 port_value: 1234
     transport_socket:
       name: envoy.transport_sockets.tls

--- a/docs/root/intro/arch_overview/security/ssl.rst
+++ b/docs/root/intro/arch_overview/security/ssl.rst
@@ -77,7 +77,7 @@ Example configuration
 */etc/ssl/certs/ca-certificates.crt* is the default path for the system CA bundle on Debian systems.
 :ref:`trusted_ca <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>` along with
 :ref:`match_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`
-makes Envoy verify the server identity of *127.0.0.2:1234* as "foo" in the same way as e.g. cURL
+makes Envoy verify the server identity of *127.0.0.1:1234* as "foo" in the same way as e.g. cURL
 does on standard Debian installations. Common paths for system CA bundles on Linux and BSD are:
 
 * /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo etc.)


### PR DESCRIPTION
This docs https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/examples says
`example of a service proxying HTTP from 127.0.0.1:10000 to 127.0.0.2:1234` but the a few examples
use `127.0.0.1:1234` instead of `127.0.0.2:1234`.

This patch fixes the IP in the doc.

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a