### PR TITLE
wasm: Fix potential segfault when reading filter_state

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -565,9 +565,12 @@ Context::findValue(absl::string_view name, Protobuf::Arena* arena, bool last) co
   case PropertyToken::PLUGIN_VM_ID:
     return CelValue::CreateStringView(toAbslStringView(wasm()->vm_id()));
   case PropertyToken::FILTER_STATE:
-    return Protobuf::Arena::Create<Filters::Common::Expr::FilterStateWrapper>(arena,
-                                                                              info->filterState())
-        ->Produce(arena);
+    if (info) {
+      return Protobuf::Arena::Create<Filters::Common::Expr::FilterStateWrapper>(arena,
+                                                                                info->filterState())
+          ->Produce(arena);
+    }
+    break;
   }
   return {};
 }


### PR DESCRIPTION
Signed-off-by: Scott LaVigne <lavignes@amazon.com>

Commit Message: Fix potential segfault when reading filter_state
Additional Description: Adding a needed null-check when reading the `filter_state` property from a WASM filter.
Risk Level: low
Testing: I have a repro for the crash and tested the fix via: https://github.com/lavignes/proxy-wasm-crash-example
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

I was experimenting with a WASM network filter and ran into a case where my WASM plugin was crashing Envoy. Here's a minimal repro: https://github.com/lavignes/proxy-wasm-crash-example. I also got confirmation by @PiotrSikora that it would be safe to just open a PR publicly.