### PR TITLE
tls: do not count syscall errors in connection_error stat

### DIFF
--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -197,6 +197,11 @@ void SslSocket::drainErrorQueue() {
       } else if (ERR_GET_REASON(err) == SSL_R_CERTIFICATE_VERIFY_FAILED) {
         saw_counted_error = true;
       }
+    } else if (ERR_GET_LIB(err) == ERR_LIB_SYS) {
+      // Any syscall errors that result in connection closure are already tracked in other
+      // connection related stats. We will still retain the specific syscall failure for
+      // transport failure reasons.
+      saw_counted_error = true;
     }
     saw_error = true;
 

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -266,6 +266,12 @@ public:
     return expected_transport_failure_reason_contains_;
   }
 
+  TestUtilOptions& setNotExpectedClientStats(const std::string& stat) {
+    not_expected_client_stats_ = stat;
+    return *this;
+  }
+  const std::string& notExpectedClientStats() const { return not_expected_client_stats_; }
+
 private:
   const std::string client_ctx_yaml_;
   const std::string server_ctx_yaml_;
@@ -288,6 +294,7 @@ private:
   std::string expected_ocsp_response_;
   bool ocsp_stapling_enabled_{false};
   std::string expected_transport_failure_reason_contains_;
+  std::string not_expected_client_stats_;
 };
 
 void testUtil(const TestUtilOptions& options) {
@@ -492,6 +499,10 @@ void testUtil(const TestUtilOptions& options) {
 
   if (!options.expectedServerStats().empty()) {
     EXPECT_EQ(1UL, server_stats_store.counter(options.expectedServerStats()).value());
+  }
+
+  if (!options.notExpectedClientStats().empty()) {
+    EXPECT_EQ(0, client_stats_store.counter(options.notExpectedClientStats()).value());
   }
 
   if (options.expectSuccess()) {
@@ -5454,7 +5465,8 @@ TEST_P(SslSocketTest, RsaPrivateKeyProviderAsyncDecryptCompleteFailure) {
   testUtil(failing_test_options.setPrivateKeyMethodExpected(true)
                .setExpectedServerCloseEvent(Network::ConnectionEvent::LocalClose)
                .setExpectedServerStats("ssl.connection_error")
-               .setExpectedTransportFailureReasonContains("system library"));
+               .setExpectedTransportFailureReasonContains("system library")
+               .setNotExpectedClientStats("ssl.connection_error"));
 }
 
 // Test having one cert with private key method and another with just


### PR DESCRIPTION
Follow up to https://github.com/envoyproxy/envoy/pull/17766
which started incrementing this stat due to syscall failures
(e.g., connection reset) and caused monitoring issues for some
deployments.

Risk Level: Low
Testing: Modified UT
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
