### PR TITLE
h2 codec: improve logging for h2 ping

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -474,6 +474,10 @@ public:
     }                                                                                              \
   } while (0)
 
+#define ENVOY_CONN_LOG_EVENT(LEVEL, EVENT_NAME, FORMAT, CONNECTION, ...)                           \
+  ENVOY_LOG_EVENT_TO_LOGGER(ENVOY_LOGGER(), LEVEL, EVENT_NAME, "[C{}] " FORMAT, (CONNECTION).id(), \
+                            ##__VA_ARGS__);
+
 #define ENVOY_LOG_FIRST_N_TO_LOGGER(LOGGER, LEVEL, N, ...)                                         \
   do {                                                                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -675,7 +675,7 @@ void ConnectionImpl::sendKeepalive() {
 }
 
 void ConnectionImpl::onKeepaliveResponse() {
-  ENVOY_LOG_EVENT(debug, "h2_ping_ack", "[C{}] Received keepalive PING ack {}", connection_.id());
+  ENVOY_LOG_EVENT(debug, "h2_ping_ack", "[C{}] Received keepalive PING ack", connection_.id());
   // Check the timers for nullptr in case the peer sent an unsolicited PING ACK.
   if (keepalive_timeout_timer_ != nullptr) {
     keepalive_timeout_timer_->disableTimer();

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -660,8 +660,7 @@ void ConnectionImpl::sendKeepalive() {
   SystemTime now = connection_.dispatcher().timeSource().systemTime();
   uint64_t ms_since_epoch =
       std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-  ENVOY_CONN_LOG_EVENT(debug, "h2_ping_send", "Sending keepalive PING {}", connection_,
-                       ms_since_epoch);
+  ENVOY_CONN_LOG(trace, "Sending keepalive PING {}", connection_, ms_since_epoch);
 
   // The last parameter is an opaque 8-byte buffer, so this cast is safe.
   int rc = nghttp2_submit_ping(session_, 0 /*flags*/, reinterpret_cast<uint8_t*>(&ms_since_epoch));
@@ -675,7 +674,6 @@ void ConnectionImpl::sendKeepalive() {
 }
 
 void ConnectionImpl::onKeepaliveResponse() {
-  ENVOY_CONN_LOG_EVENT(debug, "h2_ping_ack", "Received keepalive PING ack", connection_);
   // Check the timers for nullptr in case the peer sent an unsolicited PING ACK.
   if (keepalive_timeout_timer_ != nullptr) {
     keepalive_timeout_timer_->disableTimer();
@@ -1654,7 +1652,6 @@ RequestEncoder& ClientConnectionImpl::newStream(ResponseDecoder& decoder) {
   if (idle_session_requires_ping_interval_.count() != 0 &&
       (connection_.dispatcher().timeSource().monotonicTime() - lastReceivedDataTime() >
        idle_session_requires_ping_interval_)) {
-    ENVOY_CONN_LOG_EVENT(debug, "h2_ping_preflight", "Sending ping preflight", connection_);
     sendKeepalive();
   }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -660,8 +660,8 @@ void ConnectionImpl::sendKeepalive() {
   SystemTime now = connection_.dispatcher().timeSource().systemTime();
   uint64_t ms_since_epoch =
       std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-  ENVOY_LOG_EVENT(debug, "h2_ping_send", "[C{}] Sending keepalive PING {}", connection_.id(),
-                  ms_since_epoch);
+  ENVOY_CONN_LOG_EVENT(debug, "h2_ping_send", "Sending keepalive PING {}", connection_,
+                       ms_since_epoch);
 
   // The last parameter is an opaque 8-byte buffer, so this cast is safe.
   int rc = nghttp2_submit_ping(session_, 0 /*flags*/, reinterpret_cast<uint8_t*>(&ms_since_epoch));
@@ -675,7 +675,7 @@ void ConnectionImpl::sendKeepalive() {
 }
 
 void ConnectionImpl::onKeepaliveResponse() {
-  ENVOY_LOG_EVENT(debug, "h2_ping_ack", "[C{}] Received keepalive PING ack", connection_.id());
+  ENVOY_CONN_LOG_EVENT(debug, "h2_ping_ack", "Received keepalive PING ack", connection_);
   // Check the timers for nullptr in case the peer sent an unsolicited PING ACK.
   if (keepalive_timeout_timer_ != nullptr) {
     keepalive_timeout_timer_->disableTimer();
@@ -691,8 +691,8 @@ void ConnectionImpl::onKeepaliveResponse() {
 }
 
 void ConnectionImpl::onKeepaliveResponseTimeout() {
-  ENVOY_LOG_EVENT(debug, "h2_ping_timeout", "[C{}] Closing connection due to keepalive timeout",
-                  connection_.id());
+  ENVOY_CONN_LOG_EVENT(debug, "h2_ping_timeout", "Closing connection due to keepalive timeout",
+                       connection_);
   stats_.keepalive_timeout_.inc();
   connection_.close(Network::ConnectionCloseType::NoFlush);
 }
@@ -1654,7 +1654,7 @@ RequestEncoder& ClientConnectionImpl::newStream(ResponseDecoder& decoder) {
   if (idle_session_requires_ping_interval_.count() != 0 &&
       (connection_.dispatcher().timeSource().monotonicTime() - lastReceivedDataTime() >
        idle_session_requires_ping_interval_)) {
-    ENVOY_LOG_EVENT(debug, "h2_ping_preflight", "[C{}] Sending ping preflight", connection_.id());
+    ENVOY_CONN_LOG_EVENT(debug, "h2_ping_preflight", "Sending ping preflight", connection_);
     sendKeepalive();
   }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -660,7 +660,8 @@ void ConnectionImpl::sendKeepalive() {
   SystemTime now = connection_.dispatcher().timeSource().systemTime();
   uint64_t ms_since_epoch =
       std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-  ENVOY_CONN_LOG(trace, "Sending keepalive PING {}", connection_, ms_since_epoch);
+  ENVOY_LOG_EVENT(debug, "h2_ping_send", "[C{}] Sending keepalive PING {}", connection_.id(),
+                  ms_since_epoch);
 
   // The last parameter is an opaque 8-byte buffer, so this cast is safe.
   int rc = nghttp2_submit_ping(session_, 0 /*flags*/, reinterpret_cast<uint8_t*>(&ms_since_epoch));
@@ -674,6 +675,7 @@ void ConnectionImpl::sendKeepalive() {
 }
 
 void ConnectionImpl::onKeepaliveResponse() {
+  ENVOY_LOG_EVENT(debug, "h2_ping_ack", "[C{}] Received keepalive PING ack {}", connection_.id());
   // Check the timers for nullptr in case the peer sent an unsolicited PING ACK.
   if (keepalive_timeout_timer_ != nullptr) {
     keepalive_timeout_timer_->disableTimer();
@@ -689,7 +691,8 @@ void ConnectionImpl::onKeepaliveResponse() {
 }
 
 void ConnectionImpl::onKeepaliveResponseTimeout() {
-  ENVOY_CONN_LOG(debug, "Closing connection due to keepalive timeout", connection_);
+  ENVOY_LOG_EVENT(debug, "h2_ping_timeout", "[C{}] Closing connection due to keepalive timeout",
+                  connection_.id());
   stats_.keepalive_timeout_.inc();
   connection_.close(Network::ConnectionCloseType::NoFlush);
 }
@@ -1651,6 +1654,7 @@ RequestEncoder& ClientConnectionImpl::newStream(ResponseDecoder& decoder) {
   if (idle_session_requires_ping_interval_.count() != 0 &&
       (connection_.dispatcher().timeSource().monotonicTime() - lastReceivedDataTime() >
        idle_session_requires_ping_interval_)) {
+    ENVOY_LOG_EVENT(debug, "h2_ping_preflight", "[C{}] Sending ping preflight", connection_.id());
     sendKeepalive();
   }
 


### PR DESCRIPTION
Commit Message: h2 codec - improve logging for h2 ping
Additional Description: use the new ENVOY_LOG_EVENT macro to get better understanding of h2 ping behavior. Adds logging for: preflight, ping send, ping ack, ping timeout.
Risk Level: low 
Testing: existing

Signed-off-by: Jose Nino <jnino@lyft.com>