### PR TITLE
server: expose log level parsing function on OptionsImpl

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -339,7 +339,7 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
 
 uint32_t OptionsImpl::count() const { return count_; }
 
-void OptionsImpl::logError(const std::string& error) const { throw MalformedArgvException(error); }
+void OptionsImpl::logError(const std::string& error) { throw MalformedArgvException(error); }
 
 Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   Server::CommandLineOptionsPtr command_line_options =

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -44,7 +44,8 @@ public:
   OptionsImpl(std::vector<std::string> args, const HotRestartVersionCb& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
-  // Test constructor; creates "reasonable" defaults, but desired values should be set explicitly.
+  // Default constructor; creates "reasonable" defaults, but desired values should be set
+  // explicitly.
   OptionsImpl(const std::string& service_cluster, const std::string& service_node,
               const std::string& service_zone, spdlog::level::level_enum log_level);
 
@@ -163,9 +164,15 @@ public:
   static void disableExtensions(const std::vector<std::string>&);
   static std::string allowedLogLevels();
 
+  /**
+   * Parses and validates the provided log_level, returning the corresponding
+   * spdlog::level::level_enum.
+   * @throws MalformedArgvException if the provided string is not a valid spdlog string.
+   */
+  static spdlog::level::level_enum parseAndValidateLogLevel(absl::string_view log_level);
+
 private:
-  void logError(const std::string& error) const;
-  spdlog::level::level_enum parseAndValidateLogLevel(absl::string_view log_level);
+  static void logError(const std::string& error);
 
   uint64_t base_id_{0};
   bool use_dynamic_base_id_{false};


### PR DESCRIPTION
This adjusts the visibility of a helper functon on OptionsImpl, making it possible for users to use the utility
function to construct a spdlog log level enum from a string without having to go through the full CLI parsing.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, visibility changes only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
