### PR TITLE
doc: Fix invalid link in HTTP3 overview

### DIFF
--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -50,4 +50,4 @@ Either configuring HTTP/3 explicitly on, or using the auto_http option to use HT
 See :ref:`here <arch_overview_http3_upstream>` for more information about HTTP/3 connection pooling, including
 detailed information of where QUIC will be used, and how it fails over to TCP when QUIC use is configured to be optional.
 
-An example upstream HTTP/3 configuration file can be found :repo:`here </configs/google_com_http3_upstream_proxy.yaml`>.
+An example upstream HTTP/3 configuration file can be found :repo:`here </configs/google_com_http3_upstream_proxy.yaml>`.


### PR DESCRIPTION
The doc https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http3#http3-upstream
has a wrong link due to a wrong location of backquote(`).

This patch fixes it.

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
