### PR TITLE
Remove the deprecated test for `deprecated_disable_overprovisioning`

### DIFF
--- a/test/common/config/opaque_resource_decoder_impl_test.cc
+++ b/test/common/config/opaque_resource_decoder_impl_test.cc
@@ -68,29 +68,6 @@ TEST_F(OpaqueResourceDecoderImplTest, ValidateIgnored) {
   EXPECT_EQ("fare", resource_decoder_.resourceName(*decoded_resource));
 }
 
-// Handling of smuggled deprecated fields during Any conversion.
-TEST_F(OpaqueResourceDecoderImplTest, HiddenEnvoyDeprecatedFields) {
-  // This test is only valid in API-v3, and should be updated for API-v4
-  envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment =
-      TestUtility::parseYaml<envoy::config::endpoint::v3::ClusterLoadAssignment>(R"EOF(
-      cluster_name: fare
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 1.2.3.4
-                port_value: 80
-      policy:
-        overprovisioning_factor: 100
-        hidden_envoy_deprecated_disable_overprovisioning: true
-    )EOF");
-  EXPECT_THROW_WITH_REGEX(decodeTypedResource(cluster_load_assignment), ProtoValidationException,
-                          "Illegal use of hidden_envoy_deprecated_ V2 field "
-                          "'envoy.config.endpoint.v3.ClusterLoadAssignment.Policy.hidden_envoy_"
-                          "deprecated_disable_overprovisioning'");
-}
-
 // Happy path.
 TEST_F(OpaqueResourceDecoderImplTest, Success) {
   envoy::config::endpoint::v3::ClusterLoadAssignment cluster_resource;


### PR DESCRIPTION
I plan to do the related clean-up work for `illegal use of hidden_envoy_deprecated_ V2 check`(in source/common/protobuf/utility.cc where this error message is thrown) in a separate PR.

Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->


Risk Level: LOW
Testing: local unit test, CI

