### PR TITLE
Mark `context_extensions` as sensitive.

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -10,6 +10,7 @@ import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
+import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -308,7 +309,7 @@ message CheckSettings {
   //
   //   These settings are only applied to a filter configured with a
   //   :ref:`grpc_service<envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`.
-  map<string, string> context_extensions = 1;
+  map<string, string> context_extensions = 1 [(udpa.annotations.sensitive) = true];
 
   // When set to true, disable the configured :ref:`with_request_body
   // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` for a route.

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -10,6 +10,7 @@ import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
+import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -308,7 +309,7 @@ message CheckSettings {
   //
   //   These settings are only applied to a filter configured with a
   //   :ref:`grpc_service<envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`.
-  map<string, string> context_extensions = 1;
+  map<string, string> context_extensions = 1 [(udpa.annotations.sensitive) = true];
 
   // When set to true, disable the configured :ref:`with_request_body
   // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` for a route.


### PR DESCRIPTION
Signed-off-by: Paul Gallagher <pgal@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Mark `context_extensions` as sensitive.
Additional Description: `context_extenstions` map has the potential to contain secrets which need to be redacted from config dumps.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
