### PR TITLE
listener: create per network filter chain stats scope

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -55,6 +55,7 @@ Minor Behavior Changes
   to false. As part of this change, the use of reuse_port for TCP listeners on both macOS and
   Windows has been disabled due to suboptimal behavior. See the field documentation for more
   information.
+* listener: destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 
 Bug Fixes
 ---------

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -31,7 +31,7 @@ Network::Address::InstanceConstSharedPtr fakeAddress() {
 
 PerFilterChainFactoryContextImpl::PerFilterChainFactoryContextImpl(
     Configuration::FactoryContext& parent_context, Init::Manager& init_manager)
-    : parent_context_(parent_context),
+    : parent_context_(parent_context), scope_(parent_context_.scope().createScope("")),
       filter_chain_scope_(parent_context_.listenerScope().createScope("")),
       init_manager_(init_manager) {}
 
@@ -103,7 +103,7 @@ Envoy::Runtime::Loader& PerFilterChainFactoryContextImpl::runtime() {
   return parent_context_.runtime();
 }
 
-Stats::Scope& PerFilterChainFactoryContextImpl::scope() { return parent_context_.scope(); }
+Stats::Scope& PerFilterChainFactoryContextImpl::scope() { return *scope_; }
 
 Singleton::Manager& PerFilterChainFactoryContextImpl::singletonManager() {
   return parent_context_.singletonManager();

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -31,7 +31,9 @@ Network::Address::InstanceConstSharedPtr fakeAddress() {
 
 PerFilterChainFactoryContextImpl::PerFilterChainFactoryContextImpl(
     Configuration::FactoryContext& parent_context, Init::Manager& init_manager)
-    : parent_context_(parent_context), init_manager_(init_manager) {}
+    : parent_context_(parent_context),
+      filter_chain_scope_(parent_context_.listenerScope().createScope("")),
+      init_manager_(init_manager) {}
 
 bool PerFilterChainFactoryContextImpl::drainClose() const {
   return is_draining_.load() || parent_context_.drainDecision().drainClose();
@@ -135,9 +137,7 @@ PerFilterChainFactoryContextImpl::getTransportSocketFactoryContext() const {
   return parent_context_.getTransportSocketFactoryContext();
 }
 
-Stats::Scope& PerFilterChainFactoryContextImpl::listenerScope() {
-  return parent_context_.listenerScope();
-}
+Stats::Scope& PerFilterChainFactoryContextImpl::listenerScope() { return *filter_chain_scope_; }
 
 bool PerFilterChainFactoryContextImpl::isQuicListener() const {
   return parent_context_.isQuicListener();

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -89,7 +89,7 @@ private:
   Configuration::FactoryContext& parent_context_;
   // The scope that has empty prefix.
   Stats::ScopePtr scope_;
-  // filter_chain_scope_ has the exact prefix as listener owners scope.
+  // filter_chain_scope_ has the same prefix as listener owners scope.
   Stats::ScopePtr filter_chain_scope_;
   Init::Manager& init_manager_;
   std::atomic<bool> is_draining_{false};

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -87,6 +87,8 @@ public:
 
 private:
   Configuration::FactoryContext& parent_context_;
+  // filter_chain_scope_ has the exact prefix as listener owners scope.
+  Stats::ScopePtr filter_chain_scope_;
   Init::Manager& init_manager_;
   std::atomic<bool> is_draining_{false};
 };

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -87,6 +87,8 @@ public:
 
 private:
   Configuration::FactoryContext& parent_context_;
+  // The scope that has empty prefix.
+  Stats::ScopePtr scope_;
   // filter_chain_scope_ has the exact prefix as listener owners scope.
   Stats::ScopePtr filter_chain_scope_;
   Init::Manager& init_manager_;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -462,6 +462,7 @@ public:
     notifyingStatsAllocator().waitForCounterExists(name);
   }
 
+  // TODO(#17956): Add Gauge type to NotifyingAllocator and adopt it in this method.
   void waitForGaugeDestroyed(const std::string& name) override {
     ASSERT_TRUE(TestUtility::waitForGaugeDestroyed(statStore(), name, time_system_));
   }

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -462,6 +462,12 @@ public:
     notifyingStatsAllocator().waitForCounterExists(name);
   }
 
+  void waitForGaugeDestroyed(
+      const std::string& name,
+      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) override {
+    ASSERT_TRUE(TestUtility::waitForGaugeDestroyed(statStore(), name, time_system_, timeout));
+  }
+
   void waitUntilHistogramHasSamples(
       const std::string& name,
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) override {

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -462,10 +462,8 @@ public:
     notifyingStatsAllocator().waitForCounterExists(name);
   }
 
-  void waitForGaugeDestroyed(
-      const std::string& name,
-      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) override {
-    ASSERT_TRUE(TestUtility::waitForGaugeDestroyed(statStore(), name, time_system_, timeout));
+  void waitForGaugeDestroyed(const std::string& name) override {
+    ASSERT_TRUE(TestUtility::waitForGaugeDestroyed(statStore(), name, time_system_));
   }
 
   void waitUntilHistogramHasSamples(

--- a/test/integration/server_stats.h
+++ b/test/integration/server_stats.h
@@ -67,6 +67,15 @@ public:
                  std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) PURE;
 
   /**
+   * Wait for a gauge to be destroyed. Note that MockStatStore does not destroy stat.
+   * @param name gauge name.
+   * @param timeout amount of time to wait before asserting false, or 0 for no timeout.
+   */
+  virtual void
+  waitForGaugeDestroyed(const std::string& name,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) PURE;
+
+  /**
    * Counter lookup. This is not thread safe, since we don't get a consistent
    * snapshot, uses counters() instead for this behavior.
    * @param name counter name.

--- a/test/integration/server_stats.h
+++ b/test/integration/server_stats.h
@@ -69,11 +69,8 @@ public:
   /**
    * Wait for a gauge to be destroyed. Note that MockStatStore does not destroy stat.
    * @param name gauge name.
-   * @param timeout amount of time to wait before asserting false, or 0 for no timeout.
    */
-  virtual void
-  waitForGaugeDestroyed(const std::string& name,
-                        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) PURE;
+  virtual void waitForGaugeDestroyed(const std::string& name) PURE;
 
   /**
    * Counter lookup. This is not thread safe, since we don't get a consistent

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -291,7 +291,9 @@ class LdsInplaceUpdateHttpIntegrationTest
     : public testing::TestWithParam<Network::Address::IpVersion>,
       public HttpIntegrationTest {
 public:
-  LdsInplaceUpdateHttpIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+  LdsInplaceUpdateHttpIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
+    use_real_stats_ = true;
+  }
 
   void inplaceInitialize(bool add_default_filter_chain = false) {
     autonomous_upstream_ = true;
@@ -301,6 +303,9 @@ public:
     std::string tls_inspector_config = ConfigHelper::tlsInspectorFilter();
     config_helper_.addListenerFilter(tls_inspector_config);
     config_helper_.addSslConfig();
+    config_helper_.addConfigModifier(
+        [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) { hcm.mutable_stat_prefix()->assign("hcm0"); });
     config_helper_.addConfigModifier([this, add_default_filter_chain](
                                          envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       if (!use_default_balancer_) {
@@ -335,6 +340,7 @@ public:
           ->mutable_routes(0)
           ->mutable_route()
           ->set_cluster("cluster_1");
+      hcm_config.mutable_stat_prefix()->assign("hcm1");
       config_blob->PackFrom(hcm_config);
       bootstrap.mutable_static_resources()->mutable_clusters()->Add()->MergeFrom(
           *bootstrap.mutable_static_resources()->mutable_clusters(0));
@@ -381,7 +387,7 @@ public:
     }
   }
 
-  void expectConnenctionServed(std::string alpn = "alpn0") {
+  void expectConnectionServed(std::string alpn = "alpn0") {
     auto codec_client_after_config_update = createHttpCodec(alpn);
     expectResponseHeaderConnectionClose(*codec_client_after_config_update, false);
     codec_client_after_config_update->close();
@@ -395,7 +401,7 @@ public:
 };
 
 // Verify that http response on filter chain 1 and default filter chain have "Connection: close"
-// header when these 2 filter chains are  deleted during the listener update.
+// header when these 2 filter chains are deleted during the listener update.
 TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigDeletingFilterChain) {
   inplaceInitialize(/*add_default_filter_chain=*/true);
 
@@ -403,12 +409,6 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigDeletingFilterChain) {
   auto codec_client_0 = createHttpCodec("alpn0");
   auto codec_client_default = createHttpCodec("alpndefault");
 
-  Cleanup cleanup([c1 = codec_client_1.get(), c0 = codec_client_0.get(),
-                   c_default = codec_client_default.get()]() {
-    c1->close();
-    c0->close();
-    c_default->close();
-  });
   ConfigHelper new_config_helper(
       version_, *api_, MessageUtil::getJsonStringFromMessageOrDie(config_helper_.bootstrap()));
   new_config_helper.addConfigModifier(
@@ -422,12 +422,20 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigDeletingFilterChain) {
   test_server_->waitForCounterGe("listener_manager.listener_in_place_updated", 1);
   test_server_->waitForGaugeGe("listener_manager.total_filter_chains_draining", 1);
 
+  test_server_->waitForGaugeGe("http.hcm0.downstream_cx_active", 1);
+  test_server_->waitForGaugeGe("http.hcm1.downstream_cx_active", 1);
+
   expectResponseHeaderConnectionClose(*codec_client_1, true);
   expectResponseHeaderConnectionClose(*codec_client_default, true);
 
   test_server_->waitForGaugeGe("listener_manager.total_filter_chains_draining", 0);
   expectResponseHeaderConnectionClose(*codec_client_0, false);
-  expectConnenctionServed();
+  expectConnectionServed();
+
+  codec_client_1->close();
+  test_server_->waitForGaugeDestroyed("http.hcm1.downstream_cx_active");
+  codec_client_0->close();
+  codec_client_default->close();
 }
 
 // Verify that http clients of filter chain 0 survives if new listener config adds new filter
@@ -438,15 +446,19 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigAddingFilterChain) {
 
   auto codec_client_0 = createHttpCodec("alpn0");
   Cleanup cleanup0([c0 = codec_client_0.get()]() { c0->close(); });
+  test_server_->waitForGaugeGe("http.hcm0.downstream_cx_active", 1);
+
   ConfigHelper new_config_helper(
       version_, *api_, MessageUtil::getJsonStringFromMessageOrDie(config_helper_.bootstrap()));
   new_config_helper.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap)
                                           -> void {
     auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
-    listener->mutable_filter_chains()->Add()->MergeFrom(*listener->mutable_filter_chains(1));
+    // Note that HCM2 copies the stats prefix from HCM0
+    listener->mutable_filter_chains()->Add()->MergeFrom(*listener->mutable_filter_chains(0));
     *listener->mutable_filter_chains(2)
          ->mutable_filter_chain_match()
          ->mutable_application_protocols(0) = "alpn2";
+
     auto default_filter_chain =
         bootstrap.mutable_static_resources()->mutable_listeners(0)->mutable_default_filter_chain();
     default_filter_chain->MergeFrom(*listener->mutable_filter_chains(1));
@@ -458,6 +470,9 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigAddingFilterChain) {
   auto codec_client_2 = createHttpCodec("alpn2");
   auto codec_client_default = createHttpCodec("alpndefault");
 
+  // 1 connection from filter chain 0 and 1 connection from filter chain 2.
+  test_server_->waitForGaugeGe("http.hcm0.downstream_cx_active", 2);
+
   Cleanup cleanup2([c2 = codec_client_2.get(), c_default = codec_client_default.get()]() {
     c2->close();
     c_default->close();
@@ -465,7 +480,7 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigAddingFilterChain) {
   expectResponseHeaderConnectionClose(*codec_client_2, false);
   expectResponseHeaderConnectionClose(*codec_client_default, false);
   expectResponseHeaderConnectionClose(*codec_client_0, false);
-  expectConnenctionServed();
+  expectConnectionServed();
 }
 
 // Verify that http clients of default filter chain is drained and recreated if the default filter
@@ -493,7 +508,7 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, ReloadConfigUpdatingDefaultFilterCha
   Cleanup cleanup2([c_default_v3 = codec_client_default_v3.get()]() { c_default_v3->close(); });
   expectResponseHeaderConnectionClose(*codec_client_default, true);
   expectResponseHeaderConnectionClose(*codec_client_default_v3, false);
-  expectConnenctionServed();
+  expectConnectionServed();
 }
 
 // Verify that balancer is inherited. Test only default balancer because ExactConnectionBalancer
@@ -515,7 +530,7 @@ TEST_P(LdsInplaceUpdateHttpIntegrationTest, OverlappingFilterChainServesNewConne
   new_config_helper.setLds("1");
   test_server_->waitForCounterGe("listener_manager.listener_in_place_updated", 1);
   expectResponseHeaderConnectionClose(*codec_client_0, false);
-  expectConnenctionServed();
+  expectConnectionServed();
 }
 
 // Verify default filter chain update is filter chain only update.

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -291,9 +291,7 @@ class LdsInplaceUpdateHttpIntegrationTest
     : public testing::TestWithParam<Network::Address::IpVersion>,
       public HttpIntegrationTest {
 public:
-  LdsInplaceUpdateHttpIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
-    use_real_stats_ = true;
-  }
+  LdsInplaceUpdateHttpIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
 
   void inplaceInitialize(bool add_default_filter_chain = false) {
     autonomous_upstream_ = true;

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -240,7 +240,6 @@ AssertionResult TestUtility::waitForGaugeEq(Stats::Store& store, const std::stri
 
 AssertionResult TestUtility::waitForGaugeDestroyed(Stats::Store& store, const std::string& name,
                                                    Event::TestTimeSystem& time_system) {
-  Stats::GaugeSharedPtr gauge = findGauge(store, name);
   while (findGauge(store, name) == nullptr) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
   }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -239,18 +239,10 @@ AssertionResult TestUtility::waitForGaugeEq(Stats::Store& store, const std::stri
 }
 
 AssertionResult TestUtility::waitForGaugeDestroyed(Stats::Store& store, const std::string& name,
-                                                   Event::TestTimeSystem& time_system,
-                                                   std::chrono::milliseconds timeout) {
-  Event::TestTimeSystem::RealTimeBound bound(timeout);
+                                                   Event::TestTimeSystem& time_system) {
   Stats::GaugeSharedPtr gauge = findGauge(store, name);
-  while (gauge != nullptr) {
+  while (findGauge(store, name) == nullptr) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
-    if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
-      return AssertionFailure() << fmt::format(
-                 "timed out waiting for {} destroyed, current value {}", name,
-                 absl::StrCat(gauge->value()));
-    }
-    gauge = findGauge(store, name);
   }
   return AssertionSuccess();
 }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -242,18 +242,15 @@ AssertionResult TestUtility::waitForGaugeDestroyed(Stats::Store& store, const st
                                                    Event::TestTimeSystem& time_system,
                                                    std::chrono::milliseconds timeout) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
-  while (findGauge(store, name) != nullptr) {
+  Stats::GaugeSharedPtr gauge = findGauge(store, name);
+  while (gauge != nullptr) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
     if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
-      std::string current_value;
-      if (findGauge(store, name)) {
-        current_value = absl::StrCat(findGauge(store, name)->value());
-      } else {
-        current_value = "nil";
-      }
       return AssertionFailure() << fmt::format(
-                 "timed out waiting for {} destroyed, current value {}", name, current_value);
+                 "timed out waiting for {} destroyed, current value {}", name,
+                 absl::StrCat(gauge->value()));
     }
+    gauge = findGauge(store, name);
   }
   return AssertionSuccess();
 }

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -290,6 +290,7 @@ public:
   waitForGaugeDestroyed(Stats::Store& store, const std::string& name,
                         Event::TestTimeSystem& time_system,
                         std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
+
   /**
    * Wait for a histogram to have samples.
    * @param store supplies the stats store.

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -282,14 +282,11 @@ public:
    * @param store supplies the stats store.
    * @param name gauge name.
    * @param time_system the time system to use for waiting.
-   * @param timeout the maximum time to wait before timing out, or 0 for no timeout.
    * @return AssertionSuccess() if the gauge was == to the value within the timeout, else
    * AssertionFailure().
    */
-  static AssertionResult
-  waitForGaugeDestroyed(Stats::Store& store, const std::string& name,
-                        Event::TestTimeSystem& time_system,
-                        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
+  static AssertionResult waitForGaugeDestroyed(Stats::Store& store, const std::string& name,
+                                               Event::TestTimeSystem& time_system);
 
   /**
    * Wait for a histogram to have samples.

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -278,6 +278,19 @@ public:
                  std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
 
   /**
+   * Wait for a gauge to be destroyed.
+   * @param store supplies the stats store.
+   * @param name gauge name.
+   * @param time_system the time system to use for waiting.
+   * @param timeout the maximum time to wait before timing out, or 0 for no timeout.
+   * @return AssertionSuccess() if the gauge was == to the value within the timeout, else
+   * AssertionFailure().
+   */
+  static AssertionResult
+  waitForGaugeDestroyed(Stats::Store& store, const std::string& name,
+                        Event::TestTimeSystem& time_system,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
+  /**
    * Wait for a histogram to have samples.
    * @param store supplies the stats store.
    * @param name histogram name.


### PR DESCRIPTION
Commit Message:
Maintain per network filter chain stats scope and avoid leaking stats when the owner filter chain is destroyed.

Additional Description:
The solution was discussed in this [thread](https://github.com/envoyproxy/envoy/pull/17765#discussion_r696116723)

Risk Level:
Testing: Integration test to adopt real stats that support query for destroyed stat.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fix #17690 