### PR TITLE
tooling: updating notifier to ping first pass reviewers

### DIFF
--- a/.github/actions/pr_notifier/pr_notifier.py
+++ b/.github/actions/pr_notifier/pr_notifier.py
@@ -32,6 +32,19 @@ MAINTAINERS = {
     'rojkov': 'UH5EXLYQK',
 }
 
+# First pass reviewers who are not maintainers should get
+# notifications but not result in a PR not getting assigned a
+# maintainer owner.
+FIRST_PASS = {
+    'dmitri-d' : 'UB1883Q5S',
+    'tonya11en' : 'U989BG2CW',
+    'esmet' : 'U01BCGBUUAE',
+    'KBaichoo' : 'U016ZPU8KBK',
+    'wbpcode' : 'U017KF5C0Q6',
+    'mathetake' : 'UG9TD2FSB',
+    'RyanTheOptimist' : 'U01SW3JC8GP',
+}
+
 # Only notify API reviewers who aren't maintainers.
 # Maintainers are already notified of pending PRs.
 API_REVIEWERS = {
@@ -74,19 +87,20 @@ def pr_message(pr_age, pr_url, pr_title, delta_days, delta_hours):
 
 
 # Adds reminder lines to the appropriate assignee to review the assigned PRs
-# Returns true if one of the assignees is in the known_assignee_map, false otherwise.
-def add_reminders(assignees, assignees_and_prs, message, known_assignee_map):
-    has_known_assignee = False
+# Returns true if one of the assignees is in the primary_assignee_map, false otherwise.
+def add_reminders(assignees, assignees_and_prs, message, primary_assignee_map, first_pass_assignee_map):
+    has_primary_assignee = False
     for assignee_info in assignees:
         assignee = assignee_info.login
-        if assignee not in known_assignee_map:
-            continue
-        has_known_assignee = True
+        if assignee in primary_assignee_map:
+              has_primary_assignee = True
+        elif assignee not in first_pass_assignee_map:
+              continue
         if assignee not in assignees_and_prs.keys():
             assignees_and_prs[
                 assignee] = "Hello, %s, here are your PR reminders for the day \n" % assignee
         assignees_and_prs[assignee] = assignees_and_prs[assignee] + message
-    return has_known_assignee
+    return has_primary_assignee
 
 
 # Returns true if the PR needs an LGTM from an API shephard.
@@ -147,7 +161,7 @@ def track_prs():
         message = pr_message(delta, pr_info.html_url, pr_info.title, delta_days, delta_hours)
 
         if (needs_api_review(labels, repo, pr_info)):
-            add_reminders(pr_info.assignees, api_review_and_prs, message, API_REVIEWERS)
+          add_reminders(pr_info.assignees, api_review_and_prs, message, API_REVIEWERS, [])
 
         # If the PR has been out-SLO for over a day, inform on-call
         if delta > datetime.timedelta(hours=get_slo_hours() + 36):
@@ -155,7 +169,7 @@ def track_prs():
 
         # Add a reminder to each maintainer-assigner on the PR.
         has_maintainer_assignee = add_reminders(
-            pr_info.assignees, maintainers_and_prs, message, MAINTAINERS)
+            pr_info.assignees, maintainers_and_prs, message, MAINTAINERS, FIRST_PASS)
 
         # If there was no maintainer, track it as unassigned.
         if not has_maintainer_assignee:

--- a/.github/actions/pr_notifier/pr_notifier.py
+++ b/.github/actions/pr_notifier/pr_notifier.py
@@ -36,6 +36,7 @@ MAINTAINERS = {
 # notifications but not result in a PR not getting assigned a
 # maintainer owner.
 FIRST_PASS = {
+    'adisuissa': 'UT17EMMTP',
     'dmitri-d' : 'UB1883Q5S',
     'tonya11en' : 'U989BG2CW',
     'esmet' : 'U01BCGBUUAE',
@@ -161,7 +162,7 @@ def track_prs():
         message = pr_message(delta, pr_info.html_url, pr_info.title, delta_days, delta_hours)
 
         if (needs_api_review(labels, repo, pr_info)):
-          add_reminders(pr_info.assignees, api_review_and_prs, message, API_REVIEWERS, [])
+            add_reminders(pr_info.assignees, api_review_and_prs, message, API_REVIEWERS, [])
 
         # If the PR has been out-SLO for over a day, inform on-call
         if delta > datetime.timedelta(hours=get_slo_hours() + 36):

--- a/.github/actions/pr_notifier/pr_notifier.py
+++ b/.github/actions/pr_notifier/pr_notifier.py
@@ -37,13 +37,13 @@ MAINTAINERS = {
 # maintainer owner.
 FIRST_PASS = {
     'adisuissa': 'UT17EMMTP',
-    'dmitri-d' : 'UB1883Q5S',
-    'tonya11en' : 'U989BG2CW',
-    'esmet' : 'U01BCGBUUAE',
-    'KBaichoo' : 'U016ZPU8KBK',
-    'wbpcode' : 'U017KF5C0Q6',
-    'mathetake' : 'UG9TD2FSB',
-    'RyanTheOptimist' : 'U01SW3JC8GP',
+    'dmitri-d': 'UB1883Q5S',
+    'tonya11en': 'U989BG2CW',
+    'esmet': 'U01BCGBUUAE',
+    'KBaichoo': 'U016ZPU8KBK',
+    'wbpcode': 'U017KF5C0Q6',
+    'mathetake': 'UG9TD2FSB',
+    'RyanTheOptimist': 'U01SW3JC8GP',
 }
 
 # Only notify API reviewers who aren't maintainers.
@@ -89,14 +89,15 @@ def pr_message(pr_age, pr_url, pr_title, delta_days, delta_hours):
 
 # Adds reminder lines to the appropriate assignee to review the assigned PRs
 # Returns true if one of the assignees is in the primary_assignee_map, false otherwise.
-def add_reminders(assignees, assignees_and_prs, message, primary_assignee_map, first_pass_assignee_map):
+def add_reminders(
+        assignees, assignees_and_prs, message, primary_assignee_map, first_pass_assignee_map):
     has_primary_assignee = False
     for assignee_info in assignees:
         assignee = assignee_info.login
         if assignee in primary_assignee_map:
-              has_primary_assignee = True
+            has_primary_assignee = True
         elif assignee not in first_pass_assignee_map:
-              continue
+            continue
         if assignee not in assignees_and_prs.keys():
             assignees_and_prs[
                 assignee] = "Hello, %s, here are your PR reminders for the day \n" % assignee


### PR DESCRIPTION
Risk Level: n/a
Testing: manual
Docs Changes: n/a
Release Notes: n/a

cc @dmitri-d @tonya11en @esmet @KBaichoo @wbpcode @mathetake @RyanTheOptimist so you're not surprised if the bot sends reminders your way :-)

(email filters for to:assign@noreply.github.com helps a lot, but the slackbot nagging is superior)