### PR TITLE
api: update API compatibility exceptions

### DIFF
--- a/api/API_VERSIONING.md
+++ b/api/API_VERSIONING.md
@@ -68,7 +68,8 @@ experience a backward compatible break on a change. Specifically:
     structurally or by documentation.
 
 An exception to the above policy exists for:
-* Changes made within 14 days of the introduction of a new API field or message.
+* Changes made within 14 days of the introduction of a new API field or message, provided the new field
+or message not been included in an Envoy release.
 * API versions tagged `vNalpha`. Within an alpha major version, arbitrary breaking changes are allowed.
 * Any field, message or enum with a `[#not-implemented-hide:..` comment.
 * Any proto with a `(udpa.annotations.file_status).work_in_progress` option annotation.

--- a/api/API_VERSIONING.md
+++ b/api/API_VERSIONING.md
@@ -69,7 +69,7 @@ experience a backward compatible break on a change. Specifically:
 
 An exception to the above policy exists for:
 * Changes made within 14 days of the introduction of a new API field or message, provided the new field
-or message not been included in an Envoy release.
+or message has not been included in an Envoy release.
 * API versions tagged `vNalpha`. Within an alpha major version, arbitrary breaking changes are allowed.
 * Any field, message or enum with a `[#not-implemented-hide:..` comment.
 * Any proto with a `(udpa.annotations.file_status).work_in_progress` option annotation.


### PR DESCRIPTION
Commit Message:

Update the 14 day API compatibility exception to make it clear that
whether a field has already been included in an Envoy release may
affect whether incompatible changes should be made.

Risk Level: None
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Updates #17920.
