### PR TITLE
dns: renumber dns filter fields for wire compatibility

### DIFF
--- a/api/envoy/extensions/filters/udp/dns_filter/v3alpha/BUILD
+++ b/api/envoy/extensions/filters/udp/dns_filter/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/data/dns/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
@@ -8,6 +8,7 @@ import "envoy/data/dns/v3/dns_table.proto";
 
 import "google/protobuf/duration.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -44,6 +45,8 @@ message DnsFilterConfig {
   // in a client context. This message will contain the timeouts, retry,
   // and forwarding configuration for Envoy to make DNS requests to other
   // resolvers
+  //
+  // [#next-free-field: 6]
   message ClientContextConfig {
     // Sets the maximum time we will wait for the upstream query to complete
     // We allow 5s for the upstream resolution to complete, so the minimum
@@ -51,8 +54,18 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
+    // This field was used for the `upstream_resolvers` field in Envoy 1.18 and
+    // for `dns_resolution_config` in Envoy 1.19.
+    //
+    // Control planes should set this field for Envoy 1.19.0 and 1.19.1
+    // clients, and set `dns_resolution_config` instead for later Envoy clients.
+    // Control planes that need to simultaneously support Envoy 1.18 should
+    // avoid Envoy 1.19.0 and 1.19.1.
+    config.core.v3.DnsResolutionConfig compat_dns_resolution_config = 2
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
     // DNS resolution configuration which includes the underlying dns resolver addresses and options.
-    config.core.v3.DnsResolutionConfig dns_resolution_config = 2;
+    config.core.v3.DnsResolutionConfig dns_resolution_config = 5;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external


### PR DESCRIPTION
Commit Message:

Field 2 in the `DnsFilterConfig` message was released in Envoy 1.18,
and repurposed in Envoy 1.19. Renumber the field, while leaving a
compatibility field so that control planes can gracefully migrate to a
subsequent 1.19 release.

Risk Level: Medium
Testing:  CI
Docs Changes: None
Release Notes: Probably needs something. I can come up with some text after there's consensus on the change.
Platform Specific Features:
Fixes: #17921 
