### PR TITLE
Add retryable http health check statuses.

### DIFF
--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -127,13 +127,13 @@ message HealthCheck {
     // <arch_overview_health_checking_identity>` for more information.
     type.matcher.v3.StringMatcher service_name_matcher = 11;
 
-    // Specifies a list of HTTP response statuses considered retryable. If provided, responses in this range
+    // Specifies a list of HTTP response statuses considered retriable. If provided, responses in this range
     // will count towards the configured :ref:`unhealthy_threshold <envoy_api_field_core.HealthCheck.unhealthy_threshold>`.
     // By default all responses not in :ref:`expected_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.expected_statuses>`
     // will result in the host being considered immediately unhealthy. Ranges follow half-open semantics of
     // :ref:`Int64Range <envoy_v3_api_msg_type.v3.Int64Range>`. The start and end of each range are required.
     // Only statuses in the range [100, 600) are allowed.
-    repeated type.v3.Int64Range retryable_statuses = 12;
+    repeated type.v3.Int64Range retriable_statuses = 12;
   }
 
   message TcpHealthCheck {
@@ -253,7 +253,7 @@ message HealthCheck {
   // The number of unhealthy health checks required before a host is marked
   // unhealthy. Note that for *http* health checking if a host responds with a code not in
   // :ref:`expected_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.expected_statuses>`
-  // or :ref:`retryable_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.retryable_statuses>`,
+  // or :ref:`retriable_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.retriable_statuses>`,
   // this threshold is ignored and the host is considered immediately unhealthy.
   google.protobuf.UInt32Value unhealthy_threshold = 4 [(validate.rules).message = {required: true}];
 

--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -73,7 +73,7 @@ message HealthCheck {
     }
   }
 
-  // [#next-free-field: 12]
+  // [#next-free-field: 13]
   message HttpHealthCheck {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.core.HealthCheck.HttpHealthCheck";
@@ -126,6 +126,14 @@ message HealthCheck {
     // <envoy_v3_api_msg_type.matcher.v3.StringMatcher>`. See the :ref:`architecture overview
     // <arch_overview_health_checking_identity>` for more information.
     type.matcher.v3.StringMatcher service_name_matcher = 11;
+
+    // Specifies a list of HTTP response statuses considered retryable. If provided, responses in this range
+    // will count towards the configured :ref:`unhealthy_threshold <envoy_api_field_core.HealthCheck.unhealthy_threshold>`.
+    // By default all responses not in :ref:`expected_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.expected_statuses>`
+    // will result in the host being considered immediately unhealthy. Ranges follow half-open semantics of
+    // :ref:`Int64Range <envoy_v3_api_msg_type.v3.Int64Range>`. The start and end of each range are required.
+    // Only statuses in the range [100, 600) are allowed.
+    repeated type.v3.Int64Range retryable_statuses = 12;
   }
 
   message TcpHealthCheck {
@@ -243,8 +251,10 @@ message HealthCheck {
   uint32 interval_jitter_percent = 18;
 
   // The number of unhealthy health checks required before a host is marked
-  // unhealthy. Note that for *http* health checking if a host responds with 503
-  // this threshold is ignored and the host is considered unhealthy immediately.
+  // unhealthy. Note that for *http* health checking if a host responds with a code not in
+  // :ref:`expected_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.expected_statuses>`
+  // or :ref:`retryable_statuses <envoy_api_field_core.HealthCheck.HttpHealthCheck.retryable_statuses>`,
+  // this threshold is ignored and the host is considered immediately unhealthy.
   google.protobuf.UInt32Value unhealthy_threshold = 4 [(validate.rules).message = {required: true}];
 
   // The number of healthy health checks required before a host is marked

--- a/docs/root/intro/arch_overview/upstream/health_checking.rst
+++ b/docs/root/intro/arch_overview/upstream/health_checking.rst
@@ -12,9 +12,9 @@ checking along with various settings (check interval, failures required before m
 unhealthy, successes required before marking a host healthy, etc.):
 
 * **HTTP**: During HTTP health checking Envoy will send an HTTP request to the upstream host. By
-  default, it expects a 200 response if the host is healthy. Expected and retryable response codes are
+  default, it expects a 200 response if the host is healthy. Expected and retriable response codes are
   :ref:`configurable <envoy_v3_api_msg_config.core.v3.HealthCheck.HttpHealthCheck>`. The
-  upstream host can return a non-expected or non-retryable status code (any non-200 code by default) if
+  upstream host can return a non-expected or non-retriable status code (any non-200 code by default) if
   it wants to immediately notify downstream hosts to no longer forward traffic to it.
 * **L3/L4**: During L3/L4 health checking, Envoy will send a configurable byte buffer to the
   upstream host. It expects the byte buffer to be echoed in the response if the host is to be

--- a/docs/root/intro/arch_overview/upstream/health_checking.rst
+++ b/docs/root/intro/arch_overview/upstream/health_checking.rst
@@ -12,10 +12,10 @@ checking along with various settings (check interval, failures required before m
 unhealthy, successes required before marking a host healthy, etc.):
 
 * **HTTP**: During HTTP health checking Envoy will send an HTTP request to the upstream host. By
-  default, it expects a 200 response if the host is healthy. Expected response codes are
+  default, it expects a 200 response if the host is healthy. Expected and retryable response codes are
   :ref:`configurable <envoy_v3_api_msg_config.core.v3.HealthCheck.HttpHealthCheck>`. The
-  upstream host can return 503 if it wants to immediately notify downstream hosts to no longer
-  forward traffic to it.
+  upstream host can return a non-expected or non-retryable status code (any non-200 code by default) if
+  it wants to immediately notify downstream hosts to no longer forward traffic to it.
 * **L3/L4**: During L3/L4 health checking, Envoy will send a configurable byte buffer to the
   upstream host. It expects the byte buffer to be echoed in the response if the host is to be
   considered healthy. Envoy also supports connect only L3/L4 health checking.

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -329,13 +329,13 @@ bool networkHealthCheckFailureType(envoy::data::core::v3::HealthCheckFailureType
 } // namespace
 
 HealthTransition HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(
-    envoy::data::core::v3::HealthCheckFailureType type, bool retryable) {
+    envoy::data::core::v3::HealthCheckFailureType type, bool retriable) {
   // If we are unhealthy, reset the # of healthy to zero.
   num_healthy_ = 0;
 
   HealthTransition changed_state = HealthTransition::Unchanged;
   if (!host_->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
-    if ((!networkHealthCheckFailureType(type) && !retryable) || ++num_unhealthy_ == parent_.unhealthy_threshold_) {
+    if ((!networkHealthCheckFailureType(type) && !retriable) || ++num_unhealthy_ == parent_.unhealthy_threshold_) {
       host_->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
       parent_.decHealthy();
       changed_state = HealthTransition::Changed;
@@ -376,8 +376,8 @@ HealthTransition HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(
 }
 
 void HealthCheckerImplBase::ActiveHealthCheckSession::handleFailure(
-    envoy::data::core::v3::HealthCheckFailureType type, bool retryable) {
-  HealthTransition changed_state = setUnhealthy(type, retryable);
+    envoy::data::core::v3::HealthCheckFailureType type, bool retriable) {
+  HealthTransition changed_state = setUnhealthy(type, retriable);
   // It's possible that the previous call caused this session to be deferred deleted.
   if (timeout_timer_ != nullptr) {
     timeout_timer_->disableTimer();

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -76,7 +76,7 @@ protected:
   class ActiveHealthCheckSession : public Event::DeferredDeletable {
   public:
     ~ActiveHealthCheckSession() override;
-    HealthTransition setUnhealthy(envoy::data::core::v3::HealthCheckFailureType type, bool retryable);
+    HealthTransition setUnhealthy(envoy::data::core::v3::HealthCheckFailureType type, bool retriable);
     void onDeferredDeleteBase();
     void start() { onInitialInterval(); }
 
@@ -85,7 +85,7 @@ protected:
 
     void handleSuccess(bool degraded = false);
     void handleDegraded();
-    void handleFailure(envoy::data::core::v3::HealthCheckFailureType type, bool retryable = false);
+    void handleFailure(envoy::data::core::v3::HealthCheckFailureType type, bool retriable = false);
 
     HostSharedPtr host_;
 

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -76,7 +76,7 @@ protected:
   class ActiveHealthCheckSession : public Event::DeferredDeletable {
   public:
     ~ActiveHealthCheckSession() override;
-    HealthTransition setUnhealthy(envoy::data::core::v3::HealthCheckFailureType type);
+    HealthTransition setUnhealthy(envoy::data::core::v3::HealthCheckFailureType type, bool retryable);
     void onDeferredDeleteBase();
     void start() { onInitialInterval(); }
 
@@ -85,7 +85,7 @@ protected:
 
     void handleSuccess(bool degraded = false);
     void handleDegraded();
-    void handleFailure(envoy::data::core::v3::HealthCheckFailureType type);
+    void handleFailure(envoy::data::core::v3::HealthCheckFailureType type, bool retryable = false);
 
     HostSharedPtr host_;
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -62,15 +62,15 @@ public:
   public:
     HttpStatusChecker(
         const Protobuf::RepeatedPtrField<envoy::type::v3::Int64Range>& expected_statuses,
-        const Protobuf::RepeatedPtrField<envoy::type::v3::Int64Range>& retryable_statuses,
+        const Protobuf::RepeatedPtrField<envoy::type::v3::Int64Range>& retriable_statuses,
         uint64_t default_expected_status);
 
     bool inExpectedRange(uint64_t http_status) const;
-    bool inRetryableRange(uint64_t http_status) const;
+    bool inRetriaableRange(uint64_t http_status) const;
 
   private:
     std::vector<std::pair<uint64_t, uint64_t>> expected_ranges_;
-    std::vector<std::pair<uint64_t, uint64_t>> retryable_ranges_;
+    std::vector<std::pair<uint64_t, uint64_t>> retriable_ranges_;
   };
 
 private:
@@ -81,7 +81,7 @@ private:
     ~HttpActiveHealthCheckSession() override;
 
     void onResponseComplete();
-    enum class HealthCheckResult { Succeeded, Degraded, Failed, Retryable };
+    enum class HealthCheckResult { Succeeded, Degraded, Failed, Retriable };
     HealthCheckResult healthCheckResult();
     bool shouldClose() const;
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -62,12 +62,15 @@ public:
   public:
     HttpStatusChecker(
         const Protobuf::RepeatedPtrField<envoy::type::v3::Int64Range>& expected_statuses,
+        const Protobuf::RepeatedPtrField<envoy::type::v3::Int64Range>& retryable_statuses,
         uint64_t default_expected_status);
 
-    bool inRange(uint64_t http_status) const;
+    bool inExpectedRange(uint64_t http_status) const;
+    bool inRetryableRange(uint64_t http_status) const;
 
   private:
-    std::vector<std::pair<uint64_t, uint64_t>> ranges_;
+    std::vector<std::pair<uint64_t, uint64_t>> expected_ranges_;
+    std::vector<std::pair<uint64_t, uint64_t>> retryable_ranges_;
   };
 
 private:
@@ -78,7 +81,7 @@ private:
     ~HttpActiveHealthCheckSession() override;
 
     void onResponseComplete();
-    enum class HealthCheckResult { Succeeded, Degraded, Failed };
+    enum class HealthCheckResult { Succeeded, Degraded, Failed, Retryable };
     HealthCheckResult healthCheckResult();
     bool shouldClose() const;
 


### PR DESCRIPTION
Sorry about the confusion on whether I was working on this or not. Ended up picking it up. I'm opening this as a draft to get some initial feedback since I think there's a few ways we could go about this implementation wise. (e.g. Add a new failure type here: https://github.com/envoyproxy/envoy/blob/main/api/envoy/data/core/v3/health_check_event.proto#L21). Thoughts would be appreciated.

Still TODO: Tests, lint, etc

Commit Message: Add retriable http health check status codes. 
Additional Description:
Risk Level: Small
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/7171
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
