### PR TITLE
http2: improving test coverage

### DIFF
--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -39,6 +39,8 @@ namespace Envoy {
 namespace Http {
 namespace Http2 {
 
+class Http2CodecImplTestFixture;
+
 // This is not the full client magic, but it's the smallest size that should be able to
 // differentiate between HTTP/1 and HTTP/2.
 const std::string CLIENT_MAGIC_PREFIX = "PRI * HTTP/2";
@@ -537,6 +539,8 @@ protected:
   const MonotonicTime& lastReceivedDataTime() { return last_received_data_time_; }
 
 private:
+  friend class Http2CodecImplTestFixture;
+
   virtual ConnectionCallbacks& callbacks() PURE;
   virtual Status onBeginHeaders(const nghttp2_frame* frame) PURE;
   int onData(int32_t stream_id, const uint8_t* data, size_t len);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -410,6 +410,7 @@ TEST_P(Http2CodecImplTest, TrailerStatus) {
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, true).ok());
   EXPECT_TRUE(Http2CodecImplTestFixture::slowContainsStreamId(1, *client_));
+  EXPECT_FALSE(Http2CodecImplTestFixture::slowContainsStreamId(100, *client_));
 
   TestResponseHeaderMapImpl continue_headers{{":status", "100"}};
   EXPECT_CALL(response_decoder_, decode100ContinueHeaders_(_));
@@ -422,7 +423,6 @@ TEST_P(Http2CodecImplTest, TrailerStatus) {
   // nghttp2 doesn't allow :status in trailers
   EXPECT_THROW(response_encoder_->encode100ContinueHeaders(continue_headers), ClientCodecError);
   EXPECT_EQ(1, client_stats_store_.counter("http2.rx_messaging_error").value());
-  EXPECT_FALSE(Http2CodecImplTestFixture::slowContainsStreamId(1, *client_));
 };
 
 // Multiple 100 responses are passed to the response encoder (who is responsible for coalescing).

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -52,6 +52,9 @@ namespace CommonUtility = ::Envoy::Http2::Utility;
 
 class Http2CodecImplTestFixture {
 public:
+  static bool slowContainsStreamId(int id, ConnectionImpl& connection) {
+    return connection.slowContainsStreamId(id);
+  }
   // The Http::Connection::dispatch method does not throw (any more). However unit tests in this
   // file use codecs for sending test data through mock network connections to the codec under test.
   // It is infeasible to plumb error codes returned by the dispatch() method of the codecs under
@@ -406,6 +409,7 @@ TEST_P(Http2CodecImplTest, TrailerStatus) {
   HttpTestUtility::addDefaultHeaders(request_headers);
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, true).ok());
+  EXPECT_TRUE(Http2CodecImplTestFixture::slowContainsStreamId(1, *client_));
 
   TestResponseHeaderMapImpl continue_headers{{":status", "100"}};
   EXPECT_CALL(response_decoder_, decode100ContinueHeaders_(_));
@@ -418,6 +422,7 @@ TEST_P(Http2CodecImplTest, TrailerStatus) {
   // nghttp2 doesn't allow :status in trailers
   EXPECT_THROW(response_encoder_->encode100ContinueHeaders(continue_headers), ClientCodecError);
   EXPECT_EQ(1, client_stats_store_.counter("http2.rx_messaging_error").value());
+  EXPECT_FALSE(Http2CodecImplTestFixture::slowContainsStreamId(1, *client_));
 };
 
 // Multiple 100 responses are passed to the response encoder (who is responsible for coalescing).


### PR DESCRIPTION
h2 coverage has been flaking and I figure explicit testing of the slow checks is preferable to making the coverage build slower.  LMK what you think.
