### PR TITLE
conn_pool: Remove startDrain() and replace it with an argument to drainConnections

### DIFF
--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -41,8 +41,8 @@ public:
  */
 enum class DrainBehavior {
   // Starts draining a pool, by gracefully completing all requests and gracefully closing all
-  // connections, in preparation for deletion.
-  // can be immediately drained.
+  // connections, in preparation for deletion. It is invalid to create new streams or
+  // connections from this pool after draining a pool with this behavior.
   DrainAndDelete,
   // Actively drain all existing connection pool connections. This can be used in cases where
   // the connection pool is not being destroyed, but the caller wishes to make sure that

--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -37,16 +37,15 @@ public:
 };
 
 /**
- * Controls the behavior when draining a connection poo.
+ * Controls the behavior when draining a connection pool.
  */
 enum class DrainBehavior {
   // Starts draining a pool, by gracefully completing all requests and gracefully closing all
-  // connections, in preparation for deletion. When the process completes, the function registered
-  // via `addIdleCallback()` is called. The callback may occur before this call returns if the pool
+  // connections, in preparation for deletion.
   // can be immediately drained.
   DrainAndDelete,
-  // Actively drain all existing connection pool connections. This method can be used in cases
-  // where the connection pool is not being destroyed, but the caller wishes to make sure that
+  // Actively drain all existing connection pool connections. This can be used in cases where
+  // the connection pool is not being destroyed, but the caller wishes to make sure that
   // all new streams take place on a new connection. For example, when a health check failure
   // occurs.
   DrainExistingConnections,
@@ -75,19 +74,10 @@ public:
   virtual bool isIdle() const PURE;
 
   /**
-   * Starts draining a pool, by gracefully completing all requests and gracefully closing all
-   * connections, in preparation for deletion. When the process completes, the function registered
-   * via `addIdleCallback()` is called. The callback may occur before this call returns if the pool
-   * can be immediately drained.
+   * Drains the connections in a pool.
+   * @param drain_behavior A DrainBehavior that controls the behavior of the draining.
    */
-
-  /**
-   * Actively drain all existing connection pool connections. This method can be used in cases
-   * where the connection pool is not being destroyed, but the caller wishes to make sure that
-   * all new streams take place on a new connection. For example, when a health check failure
-   * occurs.
-   */
-  virtual void drainConnections(bool drain_for_destruction) PURE;
+  virtual void drainConnections(DrainBehavior drain_behavior) PURE;
 
   /**
    * @return Upstream::HostDescriptionConstSharedPtr the host for which connections are pooled.

--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -37,6 +37,22 @@ public:
 };
 
 /**
+ * Controls the behavior when draining a connection poo.
+ */
+enum class DrainBehavior {
+  // Starts draining a pool, by gracefully completing all requests and gracefully closing all
+  // connections, in preparation for deletion. When the process completes, the function registered
+  // via `addIdleCallback()` is called. The callback may occur before this call returns if the pool
+  // can be immediately drained.
+  DrainAndDelete,
+  // Actively drain all existing connection pool connections. This method can be used in cases
+  // where the connection pool is not being destroyed, but the caller wishes to make sure that
+  // all new streams take place on a new connection. For example, when a health check failure
+  // occurs.
+  DrainExistingConnections,
+};
+
+/**
  * An instance of a generic connection pool.
  */
 class Instance {
@@ -64,7 +80,6 @@ public:
    * via `addIdleCallback()` is called. The callback may occur before this call returns if the pool
    * can be immediately drained.
    */
-  virtual void startDrain() PURE;
 
   /**
    * Actively drain all existing connection pool connections. This method can be used in cases
@@ -72,7 +87,7 @@ public:
    * all new streams take place on a new connection. For example, when a health check failure
    * occurs.
    */
-  virtual void drainConnections() PURE;
+  virtual void drainConnections(bool drain_for_destruction) PURE;
 
   /**
    * @return Upstream::HostDescriptionConstSharedPtr the host for which connections are pooled.

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -356,8 +356,8 @@ void ConnPoolImplBase::closeIdleConnectionsForDrainingPool() {
 
 void ConnPoolImplBase::drainConnectionsImpl(DrainBehavior drain_behavior) {
   if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
-    checkForIdleAndCloseIdleConnsIfDraining();
     is_draining_ = true;
+    checkForIdleAndCloseIdleConnsIfDraining();
     return;
   }
   closeIdleConnectionsForDrainingPool();

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -354,14 +354,13 @@ void ConnPoolImplBase::closeIdleConnectionsForDrainingPool() {
   }
 }
 
-void ConnPoolImplBase::drainConnectionsImpl(bool drain_for_destruction) {
-  if (drain_for_destruction) {
+void ConnPoolImplBase::drainConnectionsImpl(DrainBehavior drain_behavior) {
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
+    checkForIdleAndCloseIdleConnsIfDraining();
     is_draining_ = true;
-  }
-  closeIdleConnectionsForDrainingPool();
-  if (drain_for_destruction) {
     return;
   }
+  closeIdleConnectionsForDrainingPool();
 
   // closeIdleConnections() closes all connections in ready_clients_ with no active streams,
   // so all remaining entries in ready_clients_ are serving streams. Move them and all entries

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -229,6 +229,7 @@ void ConnPoolImplBase::onStreamClosed(Envoy::ConnectionPool::ActiveClient& clien
 }
 
 ConnectionPool::Cancellable* ConnPoolImplBase::newStreamImpl(AttachContext& context) {
+  ASSERT(!is_draining_);
   ASSERT(!deferred_deleting_);
 
   ASSERT(static_cast<ssize_t>(connecting_stream_capacity_) ==

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -393,7 +393,8 @@ void ConnPoolImplBase::checkForIdleAndCloseIdleConnsIfDraining() {
   }
 
   if (isIdleImpl()) {
-    ENVOY_LOG(debug, "invoking idle callbacks - is_draining_for_deletion_={}", is_draining_for_deletion_);
+    ENVOY_LOG(debug, "invoking idle callbacks - is_draining_for_deletion_={}",
+              is_draining_for_deletion_);
     for (const Instance::IdleCb& cb : idle_callbacks_) {
       cb();
     }

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -334,7 +334,7 @@ private:
 
   // Whether the connection pool is currently in the process of closing
   // all connections so that it can be gracefully deleted.
-  bool is_draining_{false};
+  bool is_draining_for_deletion_{false};
 
   // True iff this object is in the deferred delete list.
   bool deferred_deleting_{false};

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -166,7 +166,7 @@ public:
   void addIdleCallbackImpl(Instance::IdleCb cb);
   // Returns true if the pool is idle.
   bool isIdleImpl() const;
-  void drainConnectionsImpl(bool drain_for_destruction);
+  void drainConnectionsImpl(DrainBehavior drain_behavior);
   const Upstream::HostConstSharedPtr& host() const { return host_; }
   // Called if this pool is likely to be picked soon, to determine if it's worth preconnecting.
   bool maybePreconnectImpl(float global_preconnect_ratio);

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -166,8 +166,7 @@ public:
   void addIdleCallbackImpl(Instance::IdleCb cb);
   // Returns true if the pool is idle.
   bool isIdleImpl() const;
-  void startDrainImpl();
-  void drainConnectionsImpl();
+  void drainConnectionsImpl(bool drain_for_destruction);
   const Upstream::HostConstSharedPtr& host() const { return host_; }
   // Called if this pool is likely to be picked soon, to determine if it's worth preconnecting.
   bool maybePreconnectImpl(float global_preconnect_ratio);

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -61,7 +61,7 @@ public:
   // ConnectionPool::Instance
   void addIdleCallback(IdleCb cb) override { addIdleCallbackImpl(cb); }
   bool isIdle() const override { return isIdleImpl(); }
-  void drainConnections(bool drain_for_destruction) override { drainConnectionsImpl(drain_for_destruction); }
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override { drainConnectionsImpl(drain_behavior); }
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
                                          Http::ConnectionPool::Callbacks& callbacks) override;

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -61,7 +61,9 @@ public:
   // ConnectionPool::Instance
   void addIdleCallback(IdleCb cb) override { addIdleCallbackImpl(cb); }
   bool isIdle() const override { return isIdleImpl(); }
-  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override { drainConnectionsImpl(drain_behavior); }
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override {
+    drainConnectionsImpl(drain_behavior);
+  }
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
                                          Http::ConnectionPool::Callbacks& callbacks) override;

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -61,8 +61,7 @@ public:
   // ConnectionPool::Instance
   void addIdleCallback(IdleCb cb) override { addIdleCallbackImpl(cb); }
   bool isIdle() const override { return isIdleImpl(); }
-  void startDrain() override { startDrainImpl(); }
-  void drainConnections() override { drainConnectionsImpl(); }
+  void drainConnections(bool drain_for_destruction) override { drainConnectionsImpl(drain_for_destruction); }
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
                                          Http::ConnectionPool::Callbacks& callbacks) override;

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -296,24 +296,20 @@ void ConnectivityGrid::addIdleCallback(IdleCb cb) {
   idle_callbacks_.emplace_back(cb);
 }
 
-void ConnectivityGrid::startDrain() {
+void ConnectivityGrid::drainConnections(bool drain_for_destruction) {
   if (draining_) {
     // A drain callback has already been set, and only needs to happen once.
     return;
   }
 
-  // Note that no new pools can be created from this point on
-  // as createNextPool fast-fails if `draining_` is true.
-  draining_ = true;
-
-  for (auto& pool : pools_) {
-    pool->startDrain();
+  if (drain_for_destruction) {
+    // Note that no new pools can be created from this point on
+    // as createNextPool fast-fails if `draining_` is true.
+    draining_ = true;
   }
-}
 
-void ConnectivityGrid::drainConnections() {
   for (auto& pool : pools_) {
-    pool->drainConnections();
+    pool->drainConnections(drain_for_destruction);
   }
 }
 

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -296,20 +296,20 @@ void ConnectivityGrid::addIdleCallback(IdleCb cb) {
   idle_callbacks_.emplace_back(cb);
 }
 
-void ConnectivityGrid::drainConnections(bool drain_for_destruction) {
+void ConnectivityGrid::drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) {
   if (draining_) {
     // A drain callback has already been set, and only needs to happen once.
     return;
   }
 
-  if (drain_for_destruction) {
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
     // Note that no new pools can be created from this point on
     // as createNextPool fast-fails if `draining_` is true.
     draining_ = true;
   }
 
   for (auto& pool : pools_) {
-    pool->drainConnections(drain_for_destruction);
+    pool->drainConnections(drain_behavior);
   }
 }
 

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -148,7 +148,7 @@ public:
                                          ConnectionPool::Callbacks& callbacks) override;
   void addIdleCallback(IdleCb cb) override;
   bool isIdle() const override;
-  void drainConnections(bool drain_for_destruction) override;
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override;
   Upstream::HostDescriptionConstSharedPtr host() const override;
   bool maybePreconnect(float preconnect_ratio) override;
   absl::string_view protocolDescription() const override { return "connection grid"; }

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -148,8 +148,7 @@ public:
                                          ConnectionPool::Callbacks& callbacks) override;
   void addIdleCallback(IdleCb cb) override;
   bool isIdle() const override;
-  void startDrain() override;
-  void drainConnections() override;
+  void drainConnections(bool drain_for_destruction) override;
   Upstream::HostDescriptionConstSharedPtr host() const override;
   bool maybePreconnect(float preconnect_ratio) override;
   absl::string_view protocolDescription() const override { return "connection grid"; }

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -150,9 +150,11 @@ public:
 
   void addIdleCallback(IdleCb cb) override { addIdleCallbackImpl(cb); }
   bool isIdle() const override { return isIdleImpl(); }
-  void startDrain() override { startDrainImpl(); }
-  void drainConnections() override {
-    drainConnectionsImpl();
+  void drainConnections(bool drain_for_destruction) override {
+    drainConnectionsImpl(drain_for_destruction);
+    if (drain_for_destruction) {
+      return;
+    }
     // Legacy behavior for the TCP connection pool marks all connecting clients
     // as draining.
     for (auto& connecting_client : connecting_clients_) {

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -150,9 +150,9 @@ public:
 
   void addIdleCallback(IdleCb cb) override { addIdleCallbackImpl(cb); }
   bool isIdle() const override { return isIdleImpl(); }
-  void drainConnections(bool drain_for_destruction) override {
-    drainConnectionsImpl(drain_for_destruction);
-    if (drain_for_destruction) {
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override {
+    drainConnectionsImpl(drain_behavior);
+    if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
       return;
     }
     // Legacy behavior for the TCP connection pool marks all connecting clients

--- a/source/common/tcp/original_conn_pool.cc
+++ b/source/common/tcp/original_conn_pool.cc
@@ -37,7 +37,13 @@ OriginalConnPoolImpl::~OriginalConnPoolImpl() {
   dispatcher_.clearDeferredDeleteList();
 }
 
-void OriginalConnPoolImpl::drainConnections() {
+void OriginalConnPoolImpl::drainConnections(bool drain_for_destruction) {
+  if (drain_for_destruction) {
+    is_draining_ = true;
+    checkForIdleAndCloseIdleConnsIfDraining();
+    return;
+  }
+
   ENVOY_LOG(debug, "draining connections");
   while (!ready_conns_.empty()) {
     ready_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
@@ -69,11 +75,6 @@ void OriginalConnPoolImpl::closeConnections() {
 }
 
 void OriginalConnPoolImpl::addIdleCallback(IdleCb cb) { idle_callbacks_.push_back(cb); }
-
-void OriginalConnPoolImpl::startDrain() {
-  is_draining_ = true;
-  checkForIdleAndCloseIdleConnsIfDraining();
-}
 
 void OriginalConnPoolImpl::assignConnection(ActiveConn& conn,
                                             ConnectionPool::Callbacks& callbacks) {

--- a/source/common/tcp/original_conn_pool.cc
+++ b/source/common/tcp/original_conn_pool.cc
@@ -37,8 +37,8 @@ OriginalConnPoolImpl::~OriginalConnPoolImpl() {
   dispatcher_.clearDeferredDeleteList();
 }
 
-void OriginalConnPoolImpl::drainConnections(bool drain_for_destruction) {
-  if (drain_for_destruction) {
+void OriginalConnPoolImpl::drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) {
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
     is_draining_ = true;
     checkForIdleAndCloseIdleConnsIfDraining();
     return;

--- a/source/common/tcp/original_conn_pool.h
+++ b/source/common/tcp/original_conn_pool.h
@@ -34,8 +34,7 @@ public:
   // ConnectionPool::Instance
   void addIdleCallback(IdleCb cb) override;
   bool isIdle() const override;
-  void startDrain() override;
-  void drainConnections() override;
+  void drainConnections(bool drain_for_destruction) override;
   void closeConnections() override;
   ConnectionPool::Cancellable* newConnection(ConnectionPool::Callbacks& callbacks) override;
   // The old pool does not implement preconnecting.

--- a/source/common/tcp/original_conn_pool.h
+++ b/source/common/tcp/original_conn_pool.h
@@ -34,7 +34,7 @@ public:
   // ConnectionPool::Instance
   void addIdleCallback(IdleCb cb) override;
   bool isIdle() const override;
-  void drainConnections(bool drain_for_destruction) override;
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override;
   void closeConnections() override;
   ConnectionPool::Cancellable* newConnection(ConnectionPool::Callbacks& callbacks) override;
   // The old pool does not implement preconnecting.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1389,7 +1389,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainAllConnPoolsWorker(
     const auto container = getHttpConnPoolsContainer(host);
     if (container != nullptr) {
       container->do_not_delete_ = true;
-      container->pools_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
+      container->pools_->drainConnections(
+          Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
       container->do_not_delete_ = false;
 
       if (container->pools_->size() == 0) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1197,7 +1197,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
   // guarding deletion with `do_not_delete_` in the registered idle callback, and then checking
   // afterwards whether it is empty and deleting it if necessary.
   container.do_not_delete_ = true;
-  pools->drainConnections(/*drain_for_destruction=*/true);
+  pools->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   container.do_not_delete_ = false;
 
   if (container.pools_->size() == 0) {
@@ -1217,7 +1217,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainTcpConnPools(
 
   container.draining_ = true;
   for (auto pool : pools) {
-    pool->drainConnections(/*drain_for_destruction=*/true);
+    pool->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   }
 }
 
@@ -1389,7 +1389,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainAllConnPoolsWorker(
     const auto container = getHttpConnPoolsContainer(host);
     if (container != nullptr) {
       container->do_not_delete_ = true;
-      container->pools_->drainConnections();
+      container->pools_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
       container->do_not_delete_ = false;
 
       if (container->pools_->size() == 0) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1197,7 +1197,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
   // guarding deletion with `do_not_delete_` in the registered idle callback, and then checking
   // afterwards whether it is empty and deleting it if necessary.
   container.do_not_delete_ = true;
-  pools->startDrain();
+  pools->drainConnections(/*drain_for_destruction=*/true);
   container.do_not_delete_ = false;
 
   if (container.pools_->size() == 0) {
@@ -1217,7 +1217,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainTcpConnPools(
 
   container.draining_ = true;
   for (auto pool : pools) {
-    pool->startDrain();
+    pool->drainConnections(/*drain_for_destruction=*/true);
   }
 }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1418,7 +1418,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainAllConnPoolsWorker(
             ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE) {
           pool->closeConnections();
         } else {
-          pool->drainConnections();
+          pool->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
         }
       }
     }

--- a/source/common/upstream/conn_pool_map.h
+++ b/source/common/upstream/conn_pool_map.h
@@ -61,7 +61,7 @@ public:
   /**
    * See `Envoy::ConnectionPool::Instance::drainConnections()`.
    */
-  void drainConnections(bool drain_for_destruction);
+  void drainConnections(ConnectionPool::DrainBehavior drain_behavior);
 
 private:
   /**

--- a/source/common/upstream/conn_pool_map.h
+++ b/source/common/upstream/conn_pool_map.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <vector>
 
+#include "envoy/common/conn_pool.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/upstream/resource_manager.h"
 #include "envoy/upstream/upstream.h"
@@ -61,7 +62,7 @@ public:
   /**
    * See `Envoy::ConnectionPool::Instance::drainConnections()`.
    */
-  void drainConnections(ConnectionPool::DrainBehavior drain_behavior);
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior);
 
 private:
   /**

--- a/source/common/upstream/conn_pool_map.h
+++ b/source/common/upstream/conn_pool_map.h
@@ -59,14 +59,9 @@ public:
   void addIdleCallback(const IdleCb& cb);
 
   /**
-   * See `Envoy::ConnectionPool::Instance::startDrain()`.
-   */
-  void startDrain();
-
-  /**
    * See `Envoy::ConnectionPool::Instance::drainConnections()`.
    */
-  void drainConnections();
+  void drainConnections(bool drain_for_destruction);
 
 private:
   /**

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -100,7 +100,7 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb) {
 
 template <typename KEY_TYPE, typename POOL_TYPE>
 void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(
-    ConnectionPool::DrainBehavior drain_behavior) {
+    Envoy::ConnectionPool::DrainBehavior drain_behavior) {
   // Copy the `active_pools_` so that it is safe for the call to result
   // in deletion, and avoid iteration through a mutating container.
   std::vector<POOL_TYPE*> pools;

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -99,7 +99,8 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb) {
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
-void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(ConnectionPool::DrainBehavior drain_behavior) {
+void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(
+    ConnectionPool::DrainBehavior drain_behavior) {
   // Copy the `active_pools_` so that it is safe for the call to result
   // in deletion, and avoid iteration through a mutating container.
   std::vector<POOL_TYPE*> pools;

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -99,7 +99,7 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb) {
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
-void ConnPoolMap<KEY_TYPE, POOL_TYPE>::startDrain() {
+void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(bool drain_for_destruction) {
   // Copy the `active_pools_` so that it is safe for the call to result
   // in deletion, and avoid iteration through a mutating container.
   std::vector<POOL_TYPE*> pools;
@@ -109,22 +109,7 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::startDrain() {
   }
 
   for (auto* pool : pools) {
-    pool->startDrain();
-  }
-}
-
-template <typename KEY_TYPE, typename POOL_TYPE>
-void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections() {
-  // Copy the `active_pools_` so that it is safe for the call to result
-  // in deletion, and avoid iteration through a mutating container.
-  std::vector<POOL_TYPE*> pools;
-  pools.reserve(active_pools_.size());
-  for (auto& pool_pair : active_pools_) {
-    pools.push_back(pool_pair.second.get());
-  }
-
-  for (auto* pool : pools) {
-    pool->drainConnections();
+    pool->drainConnections(drain_for_destruction);
   }
 }
 

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -99,7 +99,7 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb) {
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
-void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(bool drain_for_destruction) {
+void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(ConnectionPool::DrainBehavior drain_behavior) {
   // Copy the `active_pools_` so that it is safe for the call to result
   // in deletion, and avoid iteration through a mutating container.
   std::vector<POOL_TYPE*> pools;
@@ -109,7 +109,7 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(bool drain_for_destructi
   }
 
   for (auto* pool : pools) {
-    pool->drainConnections(drain_for_destruction);
+    pool->drainConnections(drain_behavior);
   }
 }
 

--- a/source/common/upstream/priority_conn_pool_map.h
+++ b/source/common/upstream/priority_conn_pool_map.h
@@ -52,14 +52,9 @@ public:
   void addIdleCallback(const IdleCb& cb);
 
   /**
-   * See `Envoy::ConnectionPool::Instance::startDrain()`.
-   */
-  void startDrain();
-
-  /**
    * See `Envoy::ConnectionPool::Instance::drainConnections()`.
    */
-  void drainConnections();
+  void drainConnections(bool drain_for_destruction);
 
 private:
   size_t getPriorityIndex(ResourcePriority priority) const;

--- a/source/common/upstream/priority_conn_pool_map.h
+++ b/source/common/upstream/priority_conn_pool_map.h
@@ -54,7 +54,7 @@ public:
   /**
    * See `Envoy::ConnectionPool::Instance::drainConnections()`.
    */
-  void drainConnections(bool drain_for_destruction);
+  void drainConnections(ConnectionPool::DrainBehavior drain_behavior);
 
 private:
   size_t getPriorityIndex(ResourcePriority priority) const;

--- a/source/common/upstream/priority_conn_pool_map.h
+++ b/source/common/upstream/priority_conn_pool_map.h
@@ -54,7 +54,7 @@ public:
   /**
    * See `Envoy::ConnectionPool::Instance::drainConnections()`.
    */
-  void drainConnections(ConnectionPool::DrainBehavior drain_behavior);
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior);
 
 private:
   size_t getPriorityIndex(ResourcePriority priority) const;

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -55,16 +55,9 @@ void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb)
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
-void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::startDrain() {
+void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(bool drain_for_destruction) {
   for (auto& pool_map : conn_pool_maps_) {
-    pool_map->startDrain();
-  }
-}
-
-template <typename KEY_TYPE, typename POOL_TYPE>
-void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections() {
-  for (auto& pool_map : conn_pool_maps_) {
-    pool_map->drainConnections();
+    pool_map->drainConnections(drain_for_destruction);
   }
 }
 

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -55,9 +55,9 @@ void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb)
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
-void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(bool drain_for_destruction) {
+void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(ConnectionPool::DrainBehavior drain_behavior) {
   for (auto& pool_map : conn_pool_maps_) {
-    pool_map->drainConnections(drain_for_destruction);
+    pool_map->drainConnections(drain_behavior);
   }
 }
 

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -55,7 +55,8 @@ void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::addIdleCallback(const IdleCb& cb)
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
-void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(ConnectionPool::DrainBehavior drain_behavior) {
+void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(
+    ConnectionPool::DrainBehavior drain_behavior) {
   for (auto& pool_map : conn_pool_maps_) {
     pool_map->drainConnections(drain_behavior);
   }

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -227,7 +227,7 @@ TEST_F(ConnPoolImplBaseTest, PoolIdleCallbackTriggeredRemoteClose) {
   clients_.back()->onEvent(Network::ConnectionEvent::RemoteClose);
 
   EXPECT_CALL(idle_pool_callback, Call());
-  pool_.drainConnectionsImpl(/*drain_for_destruction=*/true);
+  pool_.drainConnectionsImpl(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 }
 
 // Local close simulates what would happen for an idle timeout on a connection.
@@ -255,7 +255,7 @@ TEST_F(ConnPoolImplBaseTest, PoolIdleCallbackTriggeredLocalClose) {
   clients_.back()->onEvent(Network::ConnectionEvent::LocalClose);
 
   EXPECT_CALL(idle_pool_callback, Call());
-  pool_.drainConnectionsImpl(/*drain_for_destruction=*/true);
+  pool_.drainConnectionsImpl(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 }
 
 } // namespace ConnectionPool

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -227,7 +227,7 @@ TEST_F(ConnPoolImplBaseTest, PoolIdleCallbackTriggeredRemoteClose) {
   clients_.back()->onEvent(Network::ConnectionEvent::RemoteClose);
 
   EXPECT_CALL(idle_pool_callback, Call());
-  pool_.startDrainImpl();
+  pool_.drainConnectionsImpl(/*drain_for_destruction=*/true);
 }
 
 // Local close simulates what would happen for an idle timeout on a connection.
@@ -255,7 +255,7 @@ TEST_F(ConnPoolImplBaseTest, PoolIdleCallbackTriggeredLocalClose) {
   clients_.back()->onEvent(Network::ConnectionEvent::LocalClose);
 
   EXPECT_CALL(idle_pool_callback, Call());
-  pool_.startDrainImpl();
+  pool_.drainConnectionsImpl(/*drain_for_destruction=*/true);
 }
 
 } // namespace ConnectionPool

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -382,20 +382,20 @@ TEST_F(ConnectivityGridTest, TestCancel) {
 
 // Make sure drains get sent to all active pools.
 TEST_F(ConnectivityGridTest, Drain) {
-  grid_.drainConnections();
+  grid_.drainConnections(/*drain_for_destruction=*/false);
 
   // Synthetically create a pool.
   grid_.createNextPool();
   {
-    EXPECT_CALL(*grid_.first(), drainConnections());
-    grid_.drainConnections();
+    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/false));
+    grid_.drainConnections(/*drain_for_destruction=*/false);
   }
 
   grid_.createNextPool();
   {
-    EXPECT_CALL(*grid_.first(), drainConnections());
-    EXPECT_CALL(*grid_.second(), drainConnections());
-    grid_.drainConnections();
+    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/false));
+    EXPECT_CALL(*grid_.second(), drainConnections(/*drain_for_destruction=*/false));
+    grid_.drainConnections(/*drain_for_destruction=*/false);
   }
 }
 
@@ -411,16 +411,16 @@ TEST_F(ConnectivityGridTest, DrainCallbacks) {
 
   // The first time a drain is started, both pools should start draining.
   {
-    EXPECT_CALL(*grid_.first(), startDrain());
-    EXPECT_CALL(*grid_.second(), startDrain());
-    grid_.startDrain();
+    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/true));
+    EXPECT_CALL(*grid_.second(), drainConnections(/*drain_for_destruction=*/true));
+    grid_.drainConnections(/*drain_for_destruction=*/true);
   }
 
   // The second time, the pools will not see any change.
   {
-    EXPECT_CALL(*grid_.first(), startDrain()).Times(0);
-    EXPECT_CALL(*grid_.second(), startDrain()).Times(0);
-    grid_.startDrain();
+    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/true)).Times(0);
+    EXPECT_CALL(*grid_.second(), drainConnections(/*drain_for_destruction=*/true)).Times(0);
+    grid_.drainConnections(/*drain_for_destruction=*/true);
   }
   {
     // Notify the grid the second pool has been drained. This should not be
@@ -481,7 +481,7 @@ TEST_F(ConnectivityGridTest, NoDrainOnTeardown) {
 
   {
     grid_.addIdleCallback([&drain_received]() -> void { drain_received = true; });
-    grid_.startDrain();
+    grid_.drainConnections(/*drain_for_destruction=*/true);
   }
 
   grid_.setDestroying(); // Fake being in the destructor.

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -382,20 +382,20 @@ TEST_F(ConnectivityGridTest, TestCancel) {
 
 // Make sure drains get sent to all active pools.
 TEST_F(ConnectivityGridTest, Drain) {
-  grid_.drainConnections(/*drain_for_destruction=*/false);
+  grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   // Synthetically create a pool.
   grid_.createNextPool();
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/false));
-    grid_.drainConnections(/*drain_for_destruction=*/false);
+    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   }
 
   grid_.createNextPool();
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/false));
-    EXPECT_CALL(*grid_.second(), drainConnections(/*drain_for_destruction=*/false));
-    grid_.drainConnections(/*drain_for_destruction=*/false);
+    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    EXPECT_CALL(*grid_.second(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   }
 }
 
@@ -411,16 +411,16 @@ TEST_F(ConnectivityGridTest, DrainCallbacks) {
 
   // The first time a drain is started, both pools should start draining.
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/true));
-    EXPECT_CALL(*grid_.second(), drainConnections(/*drain_for_destruction=*/true));
-    grid_.drainConnections(/*drain_for_destruction=*/true);
+    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
+    EXPECT_CALL(*grid_.second(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
+    grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   }
 
   // The second time, the pools will not see any change.
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(/*drain_for_destruction=*/true)).Times(0);
-    EXPECT_CALL(*grid_.second(), drainConnections(/*drain_for_destruction=*/true)).Times(0);
-    grid_.drainConnections(/*drain_for_destruction=*/true);
+    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).Times(0);
+    EXPECT_CALL(*grid_.second(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).Times(0);
+    grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   }
   {
     // Notify the grid the second pool has been drained. This should not be
@@ -481,7 +481,7 @@ TEST_F(ConnectivityGridTest, NoDrainOnTeardown) {
 
   {
     grid_.addIdleCallback([&drain_received]() -> void { drain_received = true; });
-    grid_.drainConnections(/*drain_for_destruction=*/true);
+    grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   }
 
   grid_.setDestroying(); // Fake being in the destructor.

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -387,14 +387,17 @@ TEST_F(ConnectivityGridTest, Drain) {
   // Synthetically create a pool.
   grid_.createNextPool();
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    EXPECT_CALL(*grid_.first(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
     grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   }
 
   grid_.createNextPool();
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
-    EXPECT_CALL(*grid_.second(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    EXPECT_CALL(*grid_.first(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    EXPECT_CALL(*grid_.second(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
     grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   }
 }
@@ -411,15 +414,21 @@ TEST_F(ConnectivityGridTest, DrainCallbacks) {
 
   // The first time a drain is started, both pools should start draining.
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
-    EXPECT_CALL(*grid_.second(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
+    EXPECT_CALL(*grid_.first(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
+    EXPECT_CALL(*grid_.second(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
     grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   }
 
   // The second time, the pools will not see any change.
   {
-    EXPECT_CALL(*grid_.first(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).Times(0);
-    EXPECT_CALL(*grid_.second(), drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).Times(0);
+    EXPECT_CALL(*grid_.first(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+        .Times(0);
+    EXPECT_CALL(*grid_.second(),
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+        .Times(0);
     grid_.drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   }
   {

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -261,7 +261,7 @@ TEST_F(Http1ConnPoolImplTest, DrainConnections) {
   r1.completeResponse(false);
 
   // This will destroy the ready client and set requests remaining to 1 on the busy client.
-  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
   conn_pool_->expectAndRunUpstreamReady();
@@ -951,7 +951,7 @@ TEST_F(Http1ConnPoolImplTest, DrainCallback) {
   ActiveTestRequest r2(*this, 0, ActiveTestRequest::Type::Pending);
 
   conn_pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  conn_pool_->drainConnections(/*drain_for_destruction=*/true);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
@@ -978,7 +978,7 @@ TEST_F(Http1ConnPoolImplTest, DrainWhileConnecting) {
   EXPECT_NE(nullptr, handle);
 
   conn_pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  conn_pool_->drainConnections(/*drain_for_destruction=*/true);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   EXPECT_CALL(*conn_pool_->test_clients_[0].connection_,
               close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(drained, ready()).Times(AtLeast(1));
@@ -1046,7 +1046,7 @@ TEST_F(Http1ConnPoolImplTest, ActiveRequestHasActiveConnectionsTrue) {
   // cleanup
   conn_pool_->expectEnableUpstreamReady();
   r1.completeResponse(false);
-  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
   conn_pool_->expectAndRunUpstreamReady();
@@ -1060,7 +1060,7 @@ TEST_F(Http1ConnPoolImplTest, ResponseCompletedConnectionReadyNoActiveConnection
 
   EXPECT_FALSE(conn_pool_->hasActiveConnections());
 
-  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
   conn_pool_->expectAndRunUpstreamReady();
@@ -1075,7 +1075,7 @@ TEST_F(Http1ConnPoolImplTest, PendingRequestIsConsideredActive) {
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
-  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   conn_pool_->test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
 

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -261,7 +261,7 @@ TEST_F(Http1ConnPoolImplTest, DrainConnections) {
   r1.completeResponse(false);
 
   // This will destroy the ready client and set requests remaining to 1 on the busy client.
-  conn_pool_->drainConnections();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
   conn_pool_->expectAndRunUpstreamReady();
@@ -951,7 +951,7 @@ TEST_F(Http1ConnPoolImplTest, DrainCallback) {
   ActiveTestRequest r2(*this, 0, ActiveTestRequest::Type::Pending);
 
   conn_pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  conn_pool_->startDrain();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/true);
 
   r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
@@ -978,7 +978,7 @@ TEST_F(Http1ConnPoolImplTest, DrainWhileConnecting) {
   EXPECT_NE(nullptr, handle);
 
   conn_pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  conn_pool_->startDrain();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/true);
   EXPECT_CALL(*conn_pool_->test_clients_[0].connection_,
               close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(drained, ready()).Times(AtLeast(1));
@@ -1046,7 +1046,7 @@ TEST_F(Http1ConnPoolImplTest, ActiveRequestHasActiveConnectionsTrue) {
   // cleanup
   conn_pool_->expectEnableUpstreamReady();
   r1.completeResponse(false);
-  conn_pool_->drainConnections();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
   conn_pool_->expectAndRunUpstreamReady();
@@ -1060,7 +1060,7 @@ TEST_F(Http1ConnPoolImplTest, ResponseCompletedConnectionReadyNoActiveConnection
 
   EXPECT_FALSE(conn_pool_->hasActiveConnections());
 
-  conn_pool_->drainConnections();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
   conn_pool_->expectAndRunUpstreamReady();
@@ -1075,7 +1075,7 @@ TEST_F(Http1ConnPoolImplTest, PendingRequestIsConsideredActive) {
   EXPECT_CALL(*conn_pool_, onClientDestroy());
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
-  conn_pool_->drainConnections();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
   conn_pool_->test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
 

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -320,7 +320,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionIdle) {
   completeRequest(r);
 
   EXPECT_CALL(*this, onClientDestroy());
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 }
 
 /**
@@ -389,7 +389,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionReadyWithRequest) {
           ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
           .ok());
 
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
   EXPECT_CALL(*this, onClientDestroy());
@@ -414,7 +414,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionBusy) {
           ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
           .ok());
 
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
   EXPECT_CALL(*this, onClientDestroy());
@@ -434,12 +434,12 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionConnecting) {
   ActiveTestRequest r(*this, 0, false);
 
   // Pending request prevents the connection from being drained
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   // Cancel the pending request, and then the connection can be closed.
   r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_CALL(*this, onClientDestroy());
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 }
 
 /**
@@ -452,7 +452,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcess) {
   ActiveTestRequest r(*this, 0, false);
 
   // Pending request prevents the connection from being drained
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   EXPECT_CALL(*this, onClientDestroy());
   r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
@@ -593,7 +593,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnections) {
   cluster_->max_requests_per_connection_ = 1;
 
   // Test drain connections call prior to any connections being created.
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
@@ -616,7 +616,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnections) {
           .ok());
 
   // This will move the second connection to draining.
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   // This will destroy the 2 draining connections.
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -1091,7 +1091,7 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectWithActiveRequest) {
           .ok());
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->startDrain();
+  pool_->drainConnections(/*drain_for_destruction=*/true);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(drained, ready());
@@ -1128,7 +1128,7 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectDrainingWithActiveRequest) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->startDrain();
+  pool_->drainConnections(/*drain_for_destruction=*/true);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
@@ -1172,7 +1172,7 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimary) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->startDrain();
+  pool_->drainConnections(/*drain_for_destruction=*/true);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
@@ -1228,7 +1228,7 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimaryNoActiveRequest) {
   ReadyWatcher drained;
   EXPECT_CALL(drained, ready());
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->startDrain();
+  pool_->drainConnections(/*drain_for_destruction=*/true);
 
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
@@ -1382,7 +1382,7 @@ TEST_F(Http2ConnPoolImplTest, DrainingConnectionsConsideredActive) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   EXPECT_TRUE(pool_->hasActiveConnections());
 
@@ -1396,7 +1396,7 @@ TEST_F(Http2ConnPoolImplTest, DrainedConnectionsNotActive) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   completeRequest(r1);
 
   EXPECT_FALSE(pool_->hasActiveConnections());
@@ -1429,7 +1429,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithoutMultiplexing) {
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   r3.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
 
   closeAllClients();
 }
@@ -1483,7 +1483,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithMultiplexing) {
   // Clean up.
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1527,7 +1527,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithSettings) {
   CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
   // Clean up.
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1553,7 +1553,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithGoaway) {
   CHECK_STATE(1 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
   // Clean up.
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1579,7 +1579,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectEvenWhenReady) {
   // Clean up.
   completeRequest(r1);
   completeRequest(r2);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1600,7 +1600,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectAfterTimeout) {
 
   // Clean up.
   completeRequest(r1);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1625,7 +1625,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcessWithPreconnect) {
 
   // Clean up.
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1638,7 +1638,7 @@ TEST_F(Http2ConnPoolImplTest, MaybePreconnect) {
   expectClientsCreate(1);
   EXPECT_TRUE(pool_->maybePreconnect(2));
 
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
 }
 
@@ -1675,7 +1675,7 @@ TEST_F(Http2ConnPoolImplTest, TestStateWithMultiplexing) {
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
   // Clean up with an outstanding stream.
-  pool_->drainConnections();
+  pool_->drainConnections(/*drain_for_destruction=*/false);
   closeAllClients();
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 }

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -320,7 +320,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionIdle) {
   completeRequest(r);
 
   EXPECT_CALL(*this, onClientDestroy());
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 /**
@@ -389,7 +389,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionReadyWithRequest) {
           ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
           .ok());
 
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
   EXPECT_CALL(*this, onClientDestroy());
@@ -414,7 +414,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionBusy) {
           ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
           .ok());
 
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   EXPECT_CALL(r.decoder_, decodeHeaders_(_, true));
   EXPECT_CALL(*this, onClientDestroy());
@@ -434,12 +434,12 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionConnecting) {
   ActiveTestRequest r(*this, 0, false);
 
   // Pending request prevents the connection from being drained
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   // Cancel the pending request, and then the connection can be closed.
   r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_CALL(*this, onClientDestroy());
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 /**
@@ -452,7 +452,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcess) {
   ActiveTestRequest r(*this, 0, false);
 
   // Pending request prevents the connection from being drained
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   EXPECT_CALL(*this, onClientDestroy());
   r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
@@ -593,7 +593,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnections) {
   cluster_->max_requests_per_connection_ = 1;
 
   // Test drain connections call prior to any connections being created.
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
@@ -616,7 +616,7 @@ TEST_F(Http2ConnPoolImplTest, DrainConnections) {
           .ok());
 
   // This will move the second connection to draining.
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   // This will destroy the 2 draining connections.
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -1091,7 +1091,7 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectWithActiveRequest) {
           .ok());
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(/*drain_for_destruction=*/true);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(drained, ready());
@@ -1128,7 +1128,7 @@ TEST_F(Http2ConnPoolImplTest, DrainDisconnectDrainingWithActiveRequest) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(/*drain_for_destruction=*/true);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
@@ -1172,7 +1172,7 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimary) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(/*drain_for_destruction=*/true);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
@@ -1228,7 +1228,7 @@ TEST_F(Http2ConnPoolImplTest, DrainPrimaryNoActiveRequest) {
   ReadyWatcher drained;
   EXPECT_CALL(drained, ready());
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(/*drain_for_destruction=*/true);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(*this, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
@@ -1382,7 +1382,7 @@ TEST_F(Http2ConnPoolImplTest, DrainingConnectionsConsideredActive) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   EXPECT_TRUE(pool_->hasActiveConnections());
 
@@ -1396,7 +1396,7 @@ TEST_F(Http2ConnPoolImplTest, DrainedConnectionsNotActive) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   completeRequest(r1);
 
   EXPECT_FALSE(pool_->hasActiveConnections());
@@ -1429,7 +1429,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithoutMultiplexing) {
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   r3.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 
   closeAllClients();
 }
@@ -1483,7 +1483,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithMultiplexing) {
   // Clean up.
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1527,7 +1527,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithSettings) {
   CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
   // Clean up.
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1553,7 +1553,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithGoaway) {
   CHECK_STATE(1 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
   // Clean up.
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1579,7 +1579,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectEvenWhenReady) {
   // Clean up.
   completeRequest(r1);
   completeRequest(r2);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1600,7 +1600,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectAfterTimeout) {
 
   // Clean up.
   completeRequest(r1);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1625,7 +1625,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcessWithPreconnect) {
 
   // Clean up.
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1638,7 +1638,7 @@ TEST_F(Http2ConnPoolImplTest, MaybePreconnect) {
   expectClientsCreate(1);
   EXPECT_TRUE(pool_->maybePreconnect(2));
 
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
 }
 
@@ -1675,7 +1675,7 @@ TEST_F(Http2ConnPoolImplTest, TestStateWithMultiplexing) {
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
   // Clean up with an outstanding stream.
-  pool_->drainConnections(/*drain_for_destruction=*/false);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 }

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -86,7 +86,7 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
     EXPECT_EQ(protocol.value(), conn_pool_->protocol());
   }
 
-  conn_pool_->drainConnections();
+  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
   connection->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
   conn_pool_.reset();

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -86,7 +86,7 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
     EXPECT_EQ(protocol.value(), conn_pool_->protocol());
   }
 
-  conn_pool_->drainConnections(/*drain_for_destruction=*/false);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   connection->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
   conn_pool_.reset();

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -976,12 +976,11 @@ TEST_P(TcpConnPoolImplTest, ConnectionStateWithConcurrentConnections) {
 TEST_P(TcpConnPoolImplTest, DrainCallback) {
   initialize();
   ReadyWatcher drained;
-  EXPECT_CALL(drained, ready());
   conn_pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
   ActiveTestConn c2(*this, 0, ActiveTestConn::Type::Pending);
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   c2.handle_->cancel(ConnectionPool::CancelPolicy::Default);
 
   EXPECT_CALL(*conn_pool_, onConnReleasedForTest());
@@ -1030,11 +1029,10 @@ TEST_P(TcpConnPoolImplTest, DrainWhileConnecting) {
 TEST_P(TcpConnPoolImplTest, DrainOnClose) {
   initialize();
   ReadyWatcher drained;
-  EXPECT_CALL(drained, ready());
   conn_pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
-
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
+
+  conn_pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(drained, ready()).Times(AtLeast(1));
   EXPECT_CALL(c1.callbacks_.callbacks_, onEvent(Network::ConnectionEvent::RemoteClose))

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -107,7 +107,9 @@ public:
 
   void addIdleCallback(IdleCb cb) override { conn_pool_->addIdleCallback(cb); }
   bool isIdle() const override { return conn_pool_->isIdle(); }
-  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override { conn_pool_->drainConnections(drain_behavior); }
+  void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override {
+    conn_pool_->drainConnections(drain_behavior);
+  }
   void closeConnections() override { conn_pool_->closeConnections(); }
   ConnectionPool::Cancellable* newConnection(Tcp::ConnectionPool::Callbacks& callbacks) override {
     return conn_pool_->newConnection(callbacks);

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1813,8 +1813,8 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   // Now remove the cluster. This should drain the connection pools, but not affect
   // tcp connections.
   EXPECT_CALL(*callbacks, onClusterRemoval(_));
-  EXPECT_CALL(*cp, startDrain());
-  EXPECT_CALL(*cp2, startDrain());
+  EXPECT_CALL(*cp, drainConnections(/*drain_for_destruction=*/true));
+  EXPECT_CALL(*cp2, drainConnections(/*drain_for_destruction=*/true));
   EXPECT_TRUE(cluster_manager_->removeCluster("fake_cluster"));
   EXPECT_EQ(nullptr, cluster_manager_->getThreadLocalCluster("fake_cluster"));
   EXPECT_EQ(0UL, cluster_manager_->clusters().active_clusters_.size());
@@ -1953,7 +1953,7 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsOnHealthFailure) {
     outlier_detector.runCallbacks(test_host);
     health_checker.runCallbacks(test_host, HealthTransition::Unchanged);
 
-    EXPECT_CALL(*cp1, drainConnections());
+    EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/false));
     test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
     outlier_detector.runCallbacks(test_host);
 
@@ -1963,8 +1963,8 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsOnHealthFailure) {
   }
 
   // Order of these calls is implementation dependent, so can't sequence them!
-  EXPECT_CALL(*cp1, drainConnections());
-  EXPECT_CALL(*cp2, drainConnections());
+  EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/false));
+  EXPECT_CALL(*cp2, drainConnections(/*drain_for_destruction=*/false));
   test_host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker.runCallbacks(test_host, HealthTransition::Changed);
 
@@ -2017,7 +2017,7 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsAndDeletePoolOnHealthFailure)
   outlier_detector.runCallbacks(test_host);
   health_checker.runCallbacks(test_host, HealthTransition::Unchanged);
 
-  EXPECT_CALL(*cp1, drainConnections()).WillOnce(Invoke([&]() { cp1->idle_cb_(); }));
+  EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/false)).WillOnce(Invoke([&]() { cp1->idle_cb_(); }));
   test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
   outlier_detector.runCallbacks(test_host);
 
@@ -2064,7 +2064,7 @@ TEST_F(ClusterManagerImplTest, CloseTcpConnectionPoolsOnHealthFailure) {
     outlier_detector.runCallbacks(test_host);
     health_checker.runCallbacks(test_host, HealthTransition::Unchanged);
 
-    EXPECT_CALL(*cp1, drainConnections());
+    EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/false));
     test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
     outlier_detector.runCallbacks(test_host);
 
@@ -2074,8 +2074,8 @@ TEST_F(ClusterManagerImplTest, CloseTcpConnectionPoolsOnHealthFailure) {
   }
 
   // Order of these calls is implementation dependent, so can't sequence them!
-  EXPECT_CALL(*cp1, drainConnections());
-  EXPECT_CALL(*cp2, drainConnections());
+  EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/false));
+  EXPECT_CALL(*cp2, drainConnections(/*drain_for_destruction=*/false));
   test_host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker.runCallbacks(test_host, HealthTransition::Changed);
 
@@ -3000,11 +3000,11 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveDefaultPriority) {
                                    ->tcpConnPool(ResourcePriority::Default, nullptr));
 
   // Immediate drain, since this can happen with the HTTP codecs.
-  EXPECT_CALL(*cp, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*cp, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     cp->idle_cb_();
     cp->idle_cb_ = nullptr;
   }));
-  EXPECT_CALL(*tcp, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*tcp, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     tcp->idle_cb_();
     tcp->idle_cb_ = nullptr;
   }));
@@ -3079,13 +3079,13 @@ TEST_F(ClusterManagerImplTest, ConnPoolDestroyWithDraining) {
   Http::ConnectionPool::Instance::IdleCb drained_cb;
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _)).WillOnce(Return(mock_cp));
   EXPECT_CALL(*mock_cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
-  EXPECT_CALL(*mock_cp, startDrain());
+  EXPECT_CALL(*mock_cp, drainConnections(/*drain_for_destruction=*/true));
 
   MockTcpConnPoolWithDestroy* mock_tcp = new NiceMock<MockTcpConnPoolWithDestroy>();
   Tcp::ConnectionPool::Instance::IdleCb tcp_drained_cb;
   EXPECT_CALL(factory_, allocateTcpConnPool_).WillOnce(Return(mock_tcp));
   EXPECT_CALL(*mock_tcp, addIdleCallback(_)).WillOnce(SaveArg<0>(&tcp_drained_cb));
-  EXPECT_CALL(*mock_tcp, startDrain());
+  EXPECT_CALL(*mock_tcp, drainConnections(/*drain_for_destruction=*/true));
 
   HttpPoolDataPeer::getPool(
       cluster_manager_->getThreadLocalCluster("cluster_1")
@@ -4647,19 +4647,19 @@ TEST_F(ClusterManagerImplTest, ConnPoolsDrainedOnHostSetChange) {
   EXPECT_NE(cp1, cp2);
   EXPECT_NE(tcp1, tcp2);
 
-  EXPECT_CALL(*cp2, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*cp2, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     cp2->idle_cb_();
     cp2->idle_cb_ = nullptr;
   }));
-  EXPECT_CALL(*cp1, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     cp1->idle_cb_();
     cp1->idle_cb_ = nullptr;
   }));
-  EXPECT_CALL(*tcp1, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*tcp1, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     tcp1->idle_cb_();
     tcp1->idle_cb_ = nullptr;
   }));
-  EXPECT_CALL(*tcp2, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*tcp2, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     tcp2->idle_cb_();
     tcp2->idle_cb_ = nullptr;
   }));
@@ -4685,11 +4685,11 @@ TEST_F(ClusterManagerImplTest, ConnPoolsDrainedOnHostSetChange) {
   HostVector hosts_added;
   hosts_added.push_back(host3);
 
-  EXPECT_CALL(*cp1, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     cp1->idle_cb_();
     cp1->idle_cb_ = nullptr;
   }));
-  EXPECT_CALL(*tcp1, startDrain()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*tcp1, drainConnections(/*drain_for_destruction=*/true)).WillOnce(Invoke([&]() {
     tcp1->idle_cb_();
     tcp1->idle_cb_ = nullptr;
   }));
@@ -4756,8 +4756,8 @@ TEST_F(ClusterManagerImplTest, ConnPoolsNotDrainedOnHostSetChange) {
   hosts_added.push_back(host2);
 
   // No connection pools should be drained.
-  EXPECT_CALL(*cp1, drainConnections()).Times(0);
-  EXPECT_CALL(*tcp1, drainConnections()).Times(0);
+  EXPECT_CALL(*cp1, drainConnections(/*drain_for_destruction=*/false)).Times(0);
+  EXPECT_CALL(*tcp1, drainConnections(/*drain_for_destruction=*/false)).Times(0);
 
   // No connection pools should be drained.
   cluster.prioritySet().updateHosts(

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1953,7 +1953,8 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsOnHealthFailure) {
     outlier_detector.runCallbacks(test_host);
     health_checker.runCallbacks(test_host, HealthTransition::Unchanged);
 
-    EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    EXPECT_CALL(*cp1,
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
     test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
     outlier_detector.runCallbacks(test_host);
 
@@ -1963,8 +1964,10 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsOnHealthFailure) {
   }
 
   // Order of these calls is implementation dependent, so can't sequence them!
-  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
-  EXPECT_CALL(*cp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*cp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*cp2,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
   test_host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker.runCallbacks(test_host, HealthTransition::Changed);
 
@@ -2017,7 +2020,9 @@ TEST_F(ClusterManagerImplTest, CloseHttpConnectionsAndDeletePoolOnHealthFailure)
   outlier_detector.runCallbacks(test_host);
   health_checker.runCallbacks(test_host, HealthTransition::Unchanged);
 
-  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections)).WillOnce(Invoke([&]() { cp1->idle_cb_(); }));
+  EXPECT_CALL(*cp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections))
+      .WillOnce(Invoke([&]() { cp1->idle_cb_(); }));
   test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
   outlier_detector.runCallbacks(test_host);
 
@@ -2064,7 +2069,8 @@ TEST_F(ClusterManagerImplTest, CloseTcpConnectionPoolsOnHealthFailure) {
     outlier_detector.runCallbacks(test_host);
     health_checker.runCallbacks(test_host, HealthTransition::Unchanged);
 
-    EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+    EXPECT_CALL(*cp1,
+                drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
     test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
     outlier_detector.runCallbacks(test_host);
 
@@ -2074,8 +2080,10 @@ TEST_F(ClusterManagerImplTest, CloseTcpConnectionPoolsOnHealthFailure) {
   }
 
   // Order of these calls is implementation dependent, so can't sequence them!
-  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
-  EXPECT_CALL(*cp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*cp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*cp2,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
   test_host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker.runCallbacks(test_host, HealthTransition::Changed);
 
@@ -3000,14 +3008,16 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveDefaultPriority) {
                                    ->tcpConnPool(ResourcePriority::Default, nullptr));
 
   // Immediate drain, since this can happen with the HTTP codecs.
-  EXPECT_CALL(*cp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    cp->idle_cb_();
-    cp->idle_cb_ = nullptr;
-  }));
-  EXPECT_CALL(*tcp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    tcp->idle_cb_();
-    tcp->idle_cb_ = nullptr;
-  }));
+  EXPECT_CALL(*cp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        cp->idle_cb_();
+        cp->idle_cb_ = nullptr;
+      }));
+  EXPECT_CALL(*tcp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        tcp->idle_cb_();
+        tcp->idle_cb_ = nullptr;
+      }));
 
   // Remove the first host, this should lead to the cp being drained, without
   // crash.
@@ -4647,22 +4657,26 @@ TEST_F(ClusterManagerImplTest, ConnPoolsDrainedOnHostSetChange) {
   EXPECT_NE(cp1, cp2);
   EXPECT_NE(tcp1, tcp2);
 
-  EXPECT_CALL(*cp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    cp2->idle_cb_();
-    cp2->idle_cb_ = nullptr;
-  }));
-  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    cp1->idle_cb_();
-    cp1->idle_cb_ = nullptr;
-  }));
-  EXPECT_CALL(*tcp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    tcp1->idle_cb_();
-    tcp1->idle_cb_ = nullptr;
-  }));
-  EXPECT_CALL(*tcp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    tcp2->idle_cb_();
-    tcp2->idle_cb_ = nullptr;
-  }));
+  EXPECT_CALL(*cp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        cp2->idle_cb_();
+        cp2->idle_cb_ = nullptr;
+      }));
+  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        cp1->idle_cb_();
+        cp1->idle_cb_ = nullptr;
+      }));
+  EXPECT_CALL(*tcp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        tcp1->idle_cb_();
+        tcp1->idle_cb_ = nullptr;
+      }));
+  EXPECT_CALL(*tcp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        tcp2->idle_cb_();
+        tcp2->idle_cb_ = nullptr;
+      }));
 
   HostVector hosts_removed;
   hosts_removed.push_back(host2);
@@ -4685,14 +4699,16 @@ TEST_F(ClusterManagerImplTest, ConnPoolsDrainedOnHostSetChange) {
   HostVector hosts_added;
   hosts_added.push_back(host3);
 
-  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    cp1->idle_cb_();
-    cp1->idle_cb_ = nullptr;
-  }));
-  EXPECT_CALL(*tcp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete)).WillOnce(Invoke([&]() {
-    tcp1->idle_cb_();
-    tcp1->idle_cb_ = nullptr;
-  }));
+  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        cp1->idle_cb_();
+        cp1->idle_cb_ = nullptr;
+      }));
+  EXPECT_CALL(*tcp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete))
+      .WillOnce(Invoke([&]() {
+        tcp1->idle_cb_();
+        tcp1->idle_cb_ = nullptr;
+      }));
 
   // Adding host3 should drain connection pool for host1.
   cluster.prioritySet().updateHosts(
@@ -4756,8 +4772,12 @@ TEST_F(ClusterManagerImplTest, ConnPoolsNotDrainedOnHostSetChange) {
   hosts_added.push_back(host2);
 
   // No connection pools should be drained.
-  EXPECT_CALL(*cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections)).Times(0);
-  EXPECT_CALL(*tcp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections)).Times(0);
+  EXPECT_CALL(*cp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections))
+      .Times(0);
+  EXPECT_CALL(*tcp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections))
+      .Times(0);
 
   // No connection pools should be drained.
   cluster.prioritySet().updateHosts(

--- a/test/common/upstream/conn_pool_map_impl_test.cc
+++ b/test/common/upstream/conn_pool_map_impl_test.cc
@@ -198,8 +198,10 @@ TEST_F(ConnPoolMapImplTest, DrainConnectionsForwarded) {
 
   test_map->getPool(1, getBasicFactory());
   test_map->getPool(2, getBasicFactory());
-  EXPECT_CALL(*mock_pools_[0], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
-  EXPECT_CALL(*mock_pools_[1], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*mock_pools_[0],
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*mock_pools_[1],
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
 
   test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }

--- a/test/common/upstream/conn_pool_map_impl_test.cc
+++ b/test/common/upstream/conn_pool_map_impl_test.cc
@@ -160,7 +160,7 @@ TEST_F(ConnPoolMapImplTest, CallbacksPassedToPools) {
 
   ReadyWatcher watcher;
   test_map->addIdleCallback([&watcher]() { watcher.ready(); });
-  test_map->startDrain();
+  test_map->drainConnections(/*drain_for_destruction=*/true);
 
   EXPECT_CALL(watcher, ready()).Times(2);
   cb1();
@@ -173,7 +173,7 @@ TEST_F(ConnPoolMapImplTest, CallbacksCachedAndPassedOnCreation) {
 
   ReadyWatcher watcher;
   test_map->addIdleCallback([&watcher]() { watcher.ready(); });
-  test_map->startDrain();
+  test_map->drainConnections(/*drain_for_destruction=*/true);
 
   Http::ConnectionPool::Instance::IdleCb cb1;
   test_map->getPool(1, getFactoryExpectIdleCb(&cb1));
@@ -189,7 +189,7 @@ TEST_F(ConnPoolMapImplTest, CallbacksCachedAndPassedOnCreation) {
 // Tests that if we drain connections on an empty map, nothing happens.
 TEST_F(ConnPoolMapImplTest, EmptyMapDrainConnectionsNop) {
   TestMapPtr test_map = makeTestMap();
-  test_map->drainConnections();
+  test_map->drainConnections(/*drain_for_destruction=*/false);
 }
 
 // Tests that we forward drainConnections to the pools.
@@ -198,10 +198,10 @@ TEST_F(ConnPoolMapImplTest, DrainConnectionsForwarded) {
 
   test_map->getPool(1, getBasicFactory());
   test_map->getPool(2, getBasicFactory());
-  EXPECT_CALL(*mock_pools_[0], drainConnections());
-  EXPECT_CALL(*mock_pools_[1], drainConnections());
+  EXPECT_CALL(*mock_pools_[0], drainConnections(false));
+  EXPECT_CALL(*mock_pools_[1], drainConnections(false));
 
-  test_map->drainConnections();
+  test_map->drainConnections(/*drain_for_destruction=*/false);
 }
 
 TEST_F(ConnPoolMapImplTest, ClearDefersDelete) {

--- a/test/common/upstream/conn_pool_map_impl_test.cc
+++ b/test/common/upstream/conn_pool_map_impl_test.cc
@@ -160,7 +160,7 @@ TEST_F(ConnPoolMapImplTest, CallbacksPassedToPools) {
 
   ReadyWatcher watcher;
   test_map->addIdleCallback([&watcher]() { watcher.ready(); });
-  test_map->drainConnections(/*drain_for_destruction=*/true);
+  test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(watcher, ready()).Times(2);
   cb1();
@@ -173,7 +173,7 @@ TEST_F(ConnPoolMapImplTest, CallbacksCachedAndPassedOnCreation) {
 
   ReadyWatcher watcher;
   test_map->addIdleCallback([&watcher]() { watcher.ready(); });
-  test_map->drainConnections(/*drain_for_destruction=*/true);
+  test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   Http::ConnectionPool::Instance::IdleCb cb1;
   test_map->getPool(1, getFactoryExpectIdleCb(&cb1));
@@ -189,7 +189,7 @@ TEST_F(ConnPoolMapImplTest, CallbacksCachedAndPassedOnCreation) {
 // Tests that if we drain connections on an empty map, nothing happens.
 TEST_F(ConnPoolMapImplTest, EmptyMapDrainConnectionsNop) {
   TestMapPtr test_map = makeTestMap();
-  test_map->drainConnections(/*drain_for_destruction=*/false);
+  test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 // Tests that we forward drainConnections to the pools.
@@ -198,10 +198,10 @@ TEST_F(ConnPoolMapImplTest, DrainConnectionsForwarded) {
 
   test_map->getPool(1, getBasicFactory());
   test_map->getPool(2, getBasicFactory());
-  EXPECT_CALL(*mock_pools_[0], drainConnections(false));
-  EXPECT_CALL(*mock_pools_[1], drainConnections(false));
+  EXPECT_CALL(*mock_pools_[0], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*mock_pools_[1], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
 
-  test_map->drainConnections(/*drain_for_destruction=*/false);
+  test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 TEST_F(ConnPoolMapImplTest, ClearDefersDelete) {

--- a/test/common/upstream/priority_conn_pool_map_impl_test.cc
+++ b/test/common/upstream/priority_conn_pool_map_impl_test.cc
@@ -156,8 +156,10 @@ TEST_F(PriorityConnPoolMapImplTest, TestDrainConnectionsProxiedThrough) {
   test_map->getPool(ResourcePriority::High, 0, getBasicFactory());
   test_map->getPool(ResourcePriority::Default, 0, getBasicFactory());
 
-  EXPECT_CALL(*mock_pools_[0], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
-  EXPECT_CALL(*mock_pools_[1], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*mock_pools_[0],
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*mock_pools_[1],
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
 
   test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }

--- a/test/common/upstream/priority_conn_pool_map_impl_test.cc
+++ b/test/common/upstream/priority_conn_pool_map_impl_test.cc
@@ -156,10 +156,10 @@ TEST_F(PriorityConnPoolMapImplTest, TestDrainConnectionsProxiedThrough) {
   test_map->getPool(ResourcePriority::High, 0, getBasicFactory());
   test_map->getPool(ResourcePriority::Default, 0, getBasicFactory());
 
-  EXPECT_CALL(*mock_pools_[0], drainConnections());
-  EXPECT_CALL(*mock_pools_[1], drainConnections());
+  EXPECT_CALL(*mock_pools_[0], drainConnections(false));
+  EXPECT_CALL(*mock_pools_[1], drainConnections(false));
 
-  test_map->drainConnections();
+  test_map->drainConnections(/*drain_for_destruction=*/false);
 }
 
 } // namespace

--- a/test/common/upstream/priority_conn_pool_map_impl_test.cc
+++ b/test/common/upstream/priority_conn_pool_map_impl_test.cc
@@ -156,10 +156,10 @@ TEST_F(PriorityConnPoolMapImplTest, TestDrainConnectionsProxiedThrough) {
   test_map->getPool(ResourcePriority::High, 0, getBasicFactory());
   test_map->getPool(ResourcePriority::Default, 0, getBasicFactory());
 
-  EXPECT_CALL(*mock_pools_[0], drainConnections(false));
-  EXPECT_CALL(*mock_pools_[1], drainConnections(false));
+  EXPECT_CALL(*mock_pools_[0], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*mock_pools_[1], drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections));
 
-  test_map->drainConnections(/*drain_for_destruction=*/false);
+  test_map->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 } // namespace

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -31,8 +31,7 @@ public:
   MOCK_METHOD(Http::Protocol, protocol, (), (const));
   MOCK_METHOD(void, addIdleCallback, (IdleCb cb));
   MOCK_METHOD(bool, isIdle, (), (const));
-  MOCK_METHOD(void, startDrain, ());
-  MOCK_METHOD(void, drainConnections, ());
+  MOCK_METHOD(void, drainConnections, (bool drain_for_destruction));
   MOCK_METHOD(bool, hasActiveConnections, (), (const));
   MOCK_METHOD(Cancellable*, newStream, (ResponseDecoder & response_decoder, Callbacks& callbacks));
   MOCK_METHOD(bool, maybePreconnect, (float));

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -31,7 +31,7 @@ public:
   MOCK_METHOD(Http::Protocol, protocol, (), (const));
   MOCK_METHOD(void, addIdleCallback, (IdleCb cb));
   MOCK_METHOD(bool, isIdle, (), (const));
-  MOCK_METHOD(void, drainConnections, (bool drain_for_destruction));
+  MOCK_METHOD(void, drainConnections, (Envoy::ConnectionPool::DrainBehavior drain_behavior));
   MOCK_METHOD(bool, hasActiveConnections, (), (const));
   MOCK_METHOD(Cancellable*, newStream, (ResponseDecoder & response_decoder, Callbacks& callbacks));
   MOCK_METHOD(bool, maybePreconnect, (float));

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -61,7 +61,7 @@ public:
   // Tcp::ConnectionPool::Instance
   MOCK_METHOD(void, addIdleCallback, (IdleCb cb));
   MOCK_METHOD(bool, isIdle, (), (const));
-  MOCK_METHOD(void, drainConnections, (bool drain_for_destruction));
+  MOCK_METHOD(void, drainConnections, (Envoy::ConnectionPool::DrainBehavior drain_behavior));
   MOCK_METHOD(void, closeConnections, ());
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
   MOCK_METHOD(bool, maybePreconnect, (float), ());

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -61,8 +61,7 @@ public:
   // Tcp::ConnectionPool::Instance
   MOCK_METHOD(void, addIdleCallback, (IdleCb cb));
   MOCK_METHOD(bool, isIdle, (), (const));
-  MOCK_METHOD(void, startDrain, ());
-  MOCK_METHOD(void, drainConnections, ());
+  MOCK_METHOD(void, drainConnections, (bool drain_for_destruction));
   MOCK_METHOD(void, closeConnections, ());
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
   MOCK_METHOD(bool, maybePreconnect, (float), ());


### PR DESCRIPTION
conn_pool: Remove startDrain() and replace it with an argument to drainConnections

Add a new DrainBehavior enum argument to drainConnections() and use that to replace startDrain().

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A