### PR TITLE
remove support of hidden_envoy_deprecated_remove_accept_encoding_header

### DIFF
--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -96,8 +96,6 @@ GzipFilterConfig::compressorConfig(const envoy::extensions::filters::http::gzip:
     compressor.add_content_type(ctype);
   }
   compressor.set_disable_on_etag_header(gzip.hidden_envoy_deprecated_disable_on_etag_header());
-  compressor.set_remove_accept_encoding_header(
-      gzip.hidden_envoy_deprecated_remove_accept_encoding_header());
   return compressor;
 }
 


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: Remove support of hidden_envoy_deprecated_remove_accept_encoding_header
Additional Description: Another PR of type remove_v2_support. first PR is #16274
Risk Level: LOW
Testing: bazel test on test/extensions/filters/http/gzip/.. 
Docs Changes: NA
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
