### PR TITLE
http: change log level to trace

### DIFF
--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -174,11 +174,11 @@ private:
       headers.removeContentLength();
       modifyContentEncoding(headers);
 
-      ENVOY_STREAM_LOG(debug, "do decompress {}: {}", callbacks, direction_config.logString(),
+      ENVOY_STREAM_LOG(trace, "do decompress {}: {}", callbacks, direction_config.logString(),
                        headers);
     } else {
       direction_config.stats().not_decompressed_.inc();
-      ENVOY_STREAM_LOG(debug, "do not decompress {}: {}", callbacks, direction_config.logString(),
+      ENVOY_STREAM_LOG(trace, "do not decompress {}: {}", callbacks, direction_config.logString(),
                        headers);
     }
 


### PR DESCRIPTION
Commit Message: change log level to trace
Additional Description: Change the log level of decompressing/not decompressing message from `debug` to `trace` since these are pretty noisy and seem to belong to `trace`, not `debug`.
Risk Level: Low 
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
