### PR TITLE
bazel: switch to zlib-ng by default

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -388,11 +388,11 @@ config_setting(
 )
 
 config_setting(
-    name = "zlib_ng",
+    name = "zlib_original",
     constraint_values = [
         "@bazel_tools//platforms:linux",
     ],
-    values = {"define": "zlib=ng"},
+    values = {"define": "zlib=original"},
 )
 
 # TODO: consider converting WAVM VM support to an extension (https://github.com/envoyproxy/envoy/issues/12574)

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -661,8 +661,7 @@ The following optional features can be enabled on the Bazel build command-line:
 * Process logging for Android applications can be enabled with `--define logger=android`.
 * Excluding assertions for known issues with `--define disable_known_issue_asserts=true`.
   A KNOWN_ISSUE_ASSERT is an assertion that should pass (like all assertions), but sometimes fails for some as-yet unidentified or unresolved reason. Because it is known to potentially fail, it can be compiled out even when DEBUG is true, when this flag is set. This allows Envoy to be run in production with assertions generally enabled, without crashing for known issues. KNOWN_ISSUE_ASSERT should only be used for newly-discovered issues that represent benign violations of expectations.
-* Envoy can be linked to [`zlib-ng`](https://github.com/zlib-ng/zlib-ng) instead of
-  [`zlib`](https://zlib.net) with `--define zlib=ng`.
+* Envoy can be linked to [`zlib`](https://zlib.net) instead of [`zlib-ng`](https://github.com/zlib-ng/zlib-ng) with `--define zlib=original`.
 
 ## Enabling and disabling extensions
 

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -433,8 +433,8 @@ envoy_cmake_external(
         "UNALIGNED_OK": "off",
     },
     lib_source = select({
-        "//bazel:zlib_ng": "@com_github_zlib_ng_zlib_ng//:all",
-        "//conditions:default": "@net_zlib//:all",
+        "//bazel:zlib_original": "@net_zlib//:all",
+        "//conditions:default": "@com_github_zlib_ng_zlib_ng//:all",
     }),
     static_libraries = select({
         "//bazel:windows_x86_64": ["zlib.lib"],

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -324,7 +324,7 @@ elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
     "--define" "path_normalization_by_default=true"
     "--define" "deprecated_features=disabled"
     "--define" "tcmalloc=gperftools"
-    "--define" "zlib=ng"
+    "--define" "zlib=original"
     "--@envoy//bazel:http3=False"
     "--@envoy//source/extensions/filters/http/kill_request:enabled"
     "--test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true")

--- a/docs/root/intro/arch_overview/other_features/compression/libraries.rst
+++ b/docs/root/intro/arch_overview/other_features/compression/libraries.rst
@@ -14,7 +14,7 @@ libraries.
   `zlib-ng <https://github.com/zlib-ng/zlib-ng>`_ is a fork that hosts several 3rd-party
   contributions containing new optimizations. Those optimizations are considered useful for
   `improving compression performance <https://github.com/envoyproxy/envoy/issues/8448#issuecomment-667152013>`_.
-  Envoy can be built to use `zlib-ng <https://github.com/zlib-ng/zlib-ng>`_ instead of regular
-  `zlib <http://zlib.net>`_ by using ``--define zlib=ng`` Bazel option. The relevant build options
+  Envoy builds with `zlib-ng <https://github.com/zlib-ng/zlib-ng>`_ by default, but can still use regular
+  `zlib <http://zlib.net>`_ by using ``--define zlib=original`` Bazel option. The relevant build options
   used to build `zlib-ng <https://github.com/zlib-ng/zlib-ng>`_ can be evaluated in :repo:`here
   <bazel/foreign_cc/BUILD>`. Currently, this option is only available on Linux.


### PR DESCRIPTION
First step of: https://github.com/envoyproxy/envoy/issues/13261

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>