### PR TITLE
dubbo: remove statuses and functions that should never be used

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/active_message.cc
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.cc
@@ -140,7 +140,6 @@ void ActiveMessageDecoderFilter::continueDecoding() {
       // If the filter stack was paused during messageEnd, handle end-of-request details.
       parent_.finalizeRequest();
     }
-    parent_.continueDecoding();
   }
 }
 
@@ -413,8 +412,6 @@ uint64_t ActiveMessage::requestId() const {
 }
 
 uint64_t ActiveMessage::streamId() const { return stream_id_; }
-
-void ActiveMessage::continueDecoding() { parent_.continueDecoding(); }
 
 SerializationType ActiveMessage::serializationType() const {
   return parent_.downstreamSerializationType();

--- a/source/extensions/filters/network/dubbo_proxy/active_message.h
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.h
@@ -133,7 +133,6 @@ using ActiveMessageEncoderFilterPtr = std::unique_ptr<ActiveMessageEncoderFilter
 class ActiveMessage : public LinkedObject<ActiveMessage>,
                       public Event::DeferredDeletable,
                       public StreamHandler,
-                      public DubboFilters::DecoderFilterCallbacks,
                       public DubboFilters::FilterChainFactoryCallbacks,
                       Logger::Loggable<Logger::Id::dubbo> {
 public:
@@ -158,21 +157,19 @@ public:
   // StreamHandler
   void onStreamDecoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) override;
 
-  // DubboFilters::DecoderFilterCallbacks
-  uint64_t requestId() const override;
-  uint64_t streamId() const override;
-  const Network::Connection* connection() const override;
-  void continueDecoding() override;
-  SerializationType serializationType() const override;
-  ProtocolType protocolType() const override;
-  StreamInfo::StreamInfo& streamInfo() override;
-  Router::RouteConstSharedPtr route() override;
-  void sendLocalReply(const DubboFilters::DirectResponse& response, bool end_stream) override;
-  void startUpstreamResponse() override;
-  DubboFilters::UpstreamResponseStatus upstreamData(Buffer::Instance& buffer) override;
-  void resetDownstreamConnection() override;
-  Event::Dispatcher& dispatcher() override;
-  void resetStream() override;
+  uint64_t requestId() const;
+  uint64_t streamId() const;
+  const Network::Connection* connection() const;
+  SerializationType serializationType() const;
+  ProtocolType protocolType() const;
+  StreamInfo::StreamInfo& streamInfo();
+  Router::RouteConstSharedPtr route();
+  void sendLocalReply(const DubboFilters::DirectResponse& response, bool end_stream);
+  void startUpstreamResponse();
+  DubboFilters::UpstreamResponseStatus upstreamData(Buffer::Instance& buffer);
+  void resetDownstreamConnection();
+  Event::Dispatcher& dispatcher();
+  void resetStream();
 
   void createFilterChain();
   FilterStatus applyDecoderFilters(ActiveMessageDecoderFilter* filter,

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
@@ -97,11 +97,6 @@ void ConnectionManager::dispatch() {
     return;
   }
 
-  if (stopped_) {
-    ENVOY_CONN_LOG(debug, "dubbo: dubbo filter stopped", read_callbacks_->connection());
-    return;
-  }
-
   try {
     bool underflow = false;
     while (!underflow) {

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
@@ -29,20 +29,7 @@ Network::FilterStatus ConnectionManager::onData(Buffer::Instance& data, bool end
   dispatch();
 
   if (end_stream) {
-    ENVOY_CONN_LOG(trace, "downstream half-closed", read_callbacks_->connection());
-
-    // Downstream has closed. Unless we're waiting for an upstream connection to complete a oneway
-    // request, close. The special case for oneway requests allows them to complete before the
-    // ConnectionManager is destroyed.
-    if (stopped_) {
-      ASSERT(!active_message_list_.empty());
-      auto metadata = (*active_message_list_.begin())->metadata();
-      if (metadata && metadata->messageType() == MessageType::Oneway) {
-        ENVOY_CONN_LOG(trace, "waiting for one-way completion", read_callbacks_->connection());
-        half_closed_ = true;
-        return Network::FilterStatus::StopIteration;
-      }
-    }
+    ENVOY_CONN_LOG(trace, "downstream closed", read_callbacks_->connection());
 
     ENVOY_LOG(debug, "dubbo: end data processing");
     resetAllMessages(false);
@@ -163,19 +150,6 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata,
     break;
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
-  }
-}
-
-void ConnectionManager::continueDecoding() {
-  ENVOY_CONN_LOG(debug, "dubbo filter continued", read_callbacks_->connection());
-  stopped_ = false;
-  dispatch();
-
-  if (!stopped_ && half_closed_) {
-    // If we're half closed, but not stopped waiting for an upstream,
-    // reset any pending rpcs and close the connection.
-    resetAllMessages(false);
-    read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
   }
 }
 

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.h
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.h
@@ -72,7 +72,6 @@ public:
   SerializationType downstreamSerializationType() const { return protocol_->serializer()->type(); }
   ProtocolType downstreamProtocolType() const { return protocol_->type(); }
 
-  void continueDecoding();
   void deferredMessage(ActiveMessage& message);
   void sendLocalReply(MessageMetadata& metadata, const DubboFilters::DirectResponse& response,
                       bool end_stream);
@@ -86,9 +85,6 @@ private:
 
   Buffer::OwnedImpl request_buffer_;
   std::list<ActiveMessagePtr> active_message_list_;
-
-  bool stopped_{false};
-  bool half_closed_{false};
 
   Config& config_;
   TimeSource& time_system_;


### PR DESCRIPTION
Signed-off-by: wbpcode <wbphub@live.com>

Commit Message: dubbo: remove statuses and functions that should never be used
Additional Description:

Remove dubbo proxy statuses and functions that should never be used.

To close #17863. @FeiYing9

Risk Level: Low.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
