### PR TITLE
router/common: add log events for retries and dfp queuing

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -447,6 +447,14 @@ public:
                       (STREAM).connection() ? (STREAM).connection()->id() : 0,                     \
                       (STREAM).streamId(), ##__VA_ARGS__)
 
+/**
+ * Convenience macros for logging events with a stream ID and a connection ID.
+ */
+#define ENVOY_STREAM_LOG_EVENT_TO_LOGGER(LOGGER, LEVEL, EVENT_NAME, FORMAT, STREAM, ...)           \
+  ENVOY_LOG_EVENT_TO_LOGGER(LOGGER, LEVEL, EVENT_NAME, "[C{}][S{}] " FORMAT,                       \
+                            (STREAM).connection() ? (STREAM).connection()->id() : 0,               \
+                            (STREAM).streamId(), ##__VA_ARGS__)
+
 // TODO(danielhochman): macros(s)/function(s) for logging structures that support iteration.
 
 /**
@@ -586,4 +594,9 @@ using t_logclock = std::chrono::steady_clock; // NOLINT
     }                                                                                              \
   } while (0)
 
+#define ENVOY_STREAM_LOG_EVENT(LEVEL, EVENT_NAME, FORMAT, STREAM, ...)                             \
+  do {                                                                                             \
+    ENVOY_STREAM_LOG_EVENT_TO_LOGGER(ENVOY_LOGGER(), LEVEL, EVENT_NAME, FORMAT, STREAM,            \
+                                     ##__VA_ARGS__);                                               \
+  } while (0)
 } // namespace Envoy

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1620,7 +1620,8 @@ bool Filter::convertRequestHeadersForInternalRedirect(Http::RequestHeaderMap& do
 }
 
 void Filter::doRetry() {
-  ENVOY_STREAM_LOG(debug, "performing retry", *callbacks_);
+  ENVOY_STREAM_LOG_EVENT(debug, "http_router_retry", "performing retry to cluster {}", *callbacks_,
+                         route_entry_->clusterName());
 
   is_retry_ = true;
   attempt_count_++;


### PR DESCRIPTION
Converts existing log lines into ENVOY_LOG_EVENT in order to provide more insight during envoy-mobile debugging.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Commit Message:
Additional Description:
Risk Level: Low, small changes to existing logs
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
