### PR TITLE
filter: exposed setSni() function to Lua for setting SNI value for upstream connections

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -713,6 +713,15 @@ requestedServerName()
 Returns the string representation of :repo:`requested server name <envoy/stream_info/stream_info.h>`
 (e.g. SNI in TLS) for the current request if present.
 
+setSni()
+^^^^^^^^
+
+.. code-block:: lua
+
+  streamInfo:setSni(serverName)
+
+Sets transport socket `SNI <https://en.wikipedia.org/wiki/Server_Name_Indication>`_ for upstream connections from the given *serverName* string.
+
 Dynamic metadata object API
 ---------------------------
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -99,6 +99,7 @@ New Features
 * jwt_authn: added support for :ref:`Jwt Cache <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.jwt_cache_config>` and its size can be specified by :ref:`jwt_cache_size <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtCacheConfig.jwt_cache_size>`.
 * jwt_authn: added support for extracting JWTs from request cookies using :ref:`from_cookies <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.from_cookies>`.
 * listener: new listener metric ``downstream_cx_transport_socket_connect_timeout`` to track transport socket timeouts.
+* lua: added a new function ``setSni()`` to dynamically set the SNI value.
 * matcher: added :ref:`invert <envoy_v3_api_field_type.matcher.v3.MetadataMatcher.invert>` for inverting the match result in the metadata matcher.
 * overload: add a new overload action that resets streams using a lot of memory. To enable the tracking of allocated bytes in buffers that a stream is using  we need to configure the minimum threshold for tracking via:ref:`buffer_factory_config <envoy_v3_api_field_config.overload.v3.OverloadManager.buffer_factory_config>`. We have an overload action ``Envoy::Server::OverloadActionNameValues::ResetStreams`` that takes advantage of the tracking to  reset the most expensive stream first.
 * rbac: added :ref:`destination_port_range <envoy_v3_api_field_config.rbac.v3.Permission.destination_port_range>` for matching range of destination ports.

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -44,6 +44,7 @@ envoy_cc_library(
         "//source/common/crypto:utility_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http:utility_lib",
+        "//source/common/network:upstream_server_name_lib",
         "//source/extensions/common/crypto:utility_lib",
         "//source/extensions/filters/common/lua:lua_lib",
         "//source/extensions/filters/common/lua:wrappers_lib",

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -2,6 +2,7 @@
 
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
+#include "source/common/network/upstream_server_name.h"
 #include "source/extensions/filters/common/lua/wrappers.h"
 
 namespace Envoy {
@@ -125,6 +126,16 @@ int StreamInfoWrapper::luaDownstreamSslConnection(lua_State* state) {
   } else {
     lua_pushnil(state);
   }
+  return 1;
+}
+
+int StreamInfoWrapper::luaSetSni(lua_State* state) {
+  // Step 1: Get server name.
+  absl::string_view server_name = luaL_checkstring(state, 2);
+  // Step 2: Set SNI value.
+  stream_info_.filterState()->setData(Network::UpstreamServerName::key(),
+                                      std::make_unique<Network::UpstreamServerName>(server_name),
+                                      StreamInfo::FilterState::StateType::Mutable);
   return 1;
 }
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -186,7 +186,8 @@ public:
             {"downstreamLocalAddress", static_luaDownstreamLocalAddress},
             {"downstreamDirectRemoteAddress", static_luaDownstreamDirectRemoteAddress},
             {"downstreamSslConnection", static_luaDownstreamSslConnection},
-            {"requestedServerName", static_luaRequestedServerName}};
+            {"requestedServerName", static_luaRequestedServerName},
+            {"setSni", static_luaSetSni}};
   }
 
 private:
@@ -226,6 +227,12 @@ private:
    * @return requested server name (e.g. SNI in TLS), if any.
    */
   DECLARE_LUA_FUNCTION(StreamInfoWrapper, luaRequestedServerName);
+
+  /**
+   * Sets transport socket SNI for the upstream connections.
+   * @return nothing.
+   */
+  DECLARE_LUA_FUNCTION(StreamInfoWrapper, luaSetSni);
 
   // Envoy::Lua::BaseLuaObject
   void onMarkDead() override {

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -16,6 +16,7 @@ envoy_extension_cc_test(
     srcs = ["lua_filter_test.cc"],
     extension_names = ["envoy.filters.http.lua"],
     deps = [
+        "//source/common/network:upstream_server_name_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/http/lua:lua_filter_lib",
         "//test/mocks/api:api_mocks",


### PR DESCRIPTION
This PR exposes a new method called `setSni()` in the LUA filter to dynamically set the SNI value from the LUA block. Currently, the `auto_sni()` only looks at the Host/Authority header to set this value and in our use-case we want to use a different header for setting the SNI while sending requests to the upstream clusters. 

**Commit Message:** exposed a new `setSni()` function to Lua for setting SNI value for upstream connections.
**Additional Description:** Added a new function so that SNI value can be set dynamically from the LUA's `envoy_on_request()` block as `auto_sni()` only supports setting the Host/Authority header value as SNI currently.
**Risk Level:** Low
**Testing:** Unit Tests, Integration Tests
**Docs Changes:** Added `setSni()` method description in LUA docs.
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>