### PR TITLE
tooling: Fix sync_assignable

### DIFF
--- a/tools/github/BUILD
+++ b/tools/github/BUILD
@@ -1,1 +1,10 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@base_pip3//:requirements.bzl", "requirement")
+
 licenses(["notice"])  # Apache 2
+
+py_binary(
+    name = "sync_assignable",
+    srcs = ["sync_assignable.py"],
+    deps = [requirement("pygithub")],
+)

--- a/tools/github/sync_assignable.sh
+++ b/tools/github/sync_assignable.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-. tools/shell_utils.sh
-
-set -e
-
-python_venv sync_assignable


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: tooling: Fix sync_assignable
Additional Description:

This lib lost its github dependency mostly as it uses a venv.

This shifts it to bazel and fixes the required dependencies

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
