### PR TITLE
test: fix corner-case for waiting stats change utility on integration test

### DIFF
--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -173,8 +173,11 @@ AssertionResult TestUtility::waitForCounterEq(Stats::Store& store, const std::st
                                               std::chrono::milliseconds timeout,
                                               Event::Dispatcher* dispatcher) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
-  while (findCounter(store, name) == nullptr || findCounter(store, name)->value() != value) {
+  while (true) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
+    if (findCounter(store, name) != nullptr && findCounter(store, name)->value() == value) {
+      break;
+    }
     if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
       std::string current_value;
       if (findCounter(store, name)) {
@@ -196,8 +199,11 @@ AssertionResult TestUtility::waitForCounterGe(Stats::Store& store, const std::st
                                               uint64_t value, Event::TestTimeSystem& time_system,
                                               std::chrono::milliseconds timeout) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
-  while (findCounter(store, name) == nullptr || findCounter(store, name)->value() < value) {
+  while (true) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
+    if (findCounter(store, name) != nullptr && findCounter(store, name)->value() >= value) {
+      break;
+    }
     if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
       return AssertionFailure() << fmt::format("timed out waiting for {} to be {}", name, value);
     }
@@ -209,8 +215,11 @@ AssertionResult TestUtility::waitForGaugeGe(Stats::Store& store, const std::stri
                                             uint64_t value, Event::TestTimeSystem& time_system,
                                             std::chrono::milliseconds timeout) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
-  while (findGauge(store, name) == nullptr || findGauge(store, name)->value() < value) {
+  while (true) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
+    if (findGauge(store, name) != nullptr && findGauge(store, name)->value() >= value) {
+      break;
+    }
     if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
       return AssertionFailure() << fmt::format("timed out waiting for {} to be {}", name, value);
     }
@@ -222,8 +231,11 @@ AssertionResult TestUtility::waitForGaugeEq(Stats::Store& store, const std::stri
                                             uint64_t value, Event::TestTimeSystem& time_system,
                                             std::chrono::milliseconds timeout) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
-  while (findGauge(store, name) == nullptr || findGauge(store, name)->value() != value) {
+  while (true) {
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
+    if (findGauge(store, name) != nullptr && findGauge(store, name)->value() == value) {
+      break;
+    }
     if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
       std::string current_value;
       if (findGauge(store, name)) {


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: In previous implementation, we have incorrect logic for waiting stats update on integration test. It will potentially break logical consistency after waiting and may cause flaky tests, such as that worker thread updated stats while `time_system.advanceTimeWait(std::chrono::milliseconds(10))`. 
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
