### PR TITLE
docs: fix bazelisk installation command for linux/arm64

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -7,7 +7,7 @@ It is recommended to use [Bazelisk](https://github.com/bazelbuild/bazelisk) inst
 On Linux, run the following commands:
 
 ```console
-sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-$([ $(uname -m) = "aarch64" ] && echo "arm64" || echo "amd64")
 sudo chmod +x /usr/local/bin/bazel
 ```
 


### PR DESCRIPTION
In aarch64 machines, the bazelisk installation command in the docs fails due to binary format mismatch.
This change is not critical for users because they can notice it before or after invoking it, but for convenience, this PR fixes the command to take care of the machine architecture running on.

Since the bazelisk is written in Go and anyway the Go is needed to build BoringSSL, it might be better to use `go install` or `go get -u` command to install bazelisk to avoid tricky oneliner install command. Please take a look and give some comments about it.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: Low
Testing: N/A
Docs Changes: fix the bazelisk installation command for Linux in `bazel/README.md` to take care of its running arch.
Release Notes: N/A
