### PR TITLE
dns: renumber dns filter fields for wire compatibility (#17943)

### DIFF
--- a/api/envoy/extensions/filters/udp/dns_filter/v3alpha/BUILD
+++ b/api/envoy/extensions/filters/udp/dns_filter/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/data/dns/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
@@ -2,12 +2,14 @@ syntax = "proto3";
 
 package envoy.extensions.filters.udp.dns_filter.v3alpha;
 
+import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/resolver.proto";
 import "envoy/data/dns/v3/dns_table.proto";
 
 import "google/protobuf/duration.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -44,6 +46,8 @@ message DnsFilterConfig {
   // in a client context. This message will contain the timeouts, retry,
   // and forwarding configuration for Envoy to make DNS requests to other
   // resolvers
+  //
+  // [#next-free-field: 6]
   message ClientContextConfig {
     // Sets the maximum time we will wait for the upstream query to complete
     // We allow 5s for the upstream resolution to complete, so the minimum
@@ -51,8 +55,20 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
+    // This field was used for `dns_resolution_config` in Envoy 1.19.0 and
+    // 1.19.1.
+    // Control planes that need to set this field for Envoy 1.19.0 and
+    // 1.19.1 clients should fork the protobufs and change the field type
+    // to `DnsResolutionConfig`.
+    // Control planes that need to simultaneously support Envoy 1.18.x and
+    // Envoy 1.19.x should avoid Envoy 1.19.0 and 1.19.1.
+    //
+    // [#not-implemented-hide:]
+    repeated config.core.v3.Address upstream_resolvers = 2
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
     // DNS resolution configuration which includes the underlying dns resolver addresses and options.
-    config.core.v3.DnsResolutionConfig dns_resolution_config = 2;
+    config.core.v3.DnsResolutionConfig dns_resolution_config = 5;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external

--- a/api/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
@@ -51,9 +51,15 @@ message DnsFilterConfig {
   // in a client context. This message will contain the timeouts, retry,
   // and forwarding configuration for Envoy to make DNS requests to other
   // resolvers
+  //
+  // [#next-free-field: 6]
   message ClientContextConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig";
+
+    reserved 2;
+
+    reserved "upstream_resolvers";
 
     // Sets the maximum time we will wait for the upstream query to complete
     // We allow 5s for the upstream resolution to complete, so the minimum
@@ -62,7 +68,7 @@ message DnsFilterConfig {
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
     // DNS resolution configuration which includes the underlying dns resolver addresses and options.
-    config.core.v4alpha.DnsResolutionConfig dns_resolution_config = 2;
+    config.core.v4alpha.DnsResolutionConfig dns_resolution_config = 5;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -3,6 +3,17 @@
 
 Incompatible Behavior Changes
 -----------------------------
+*Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+
+* dns_filter: :ref:`dns_filter <envoy_v3_api_msg_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig>`
+  protobuf fields have been renumbered to restore compatibility with Envoy
+  1.18, breaking compatibility with Envoy 1.19.0 and 1.19.1. The new field
+  numbering allows control planes supporting Envoy 1.18 to gracefully upgrade to
+  :ref:`dns_resolution_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig.dns_resolution_config>`,
+  provided they skip over Envoy 1.19.0 and 1.19.1.
+  Control planes upgrading from Envoy 1.19.0 and 1.19.1 will need to
+  vendor the corresponding protobuf definitions to ensure that the
+  renumbered fields have the types expected by those releases.
 
 Minor Behavior Changes
 ----------------------

--- a/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v3alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v3alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/data/dns/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
+++ b/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
@@ -2,12 +2,14 @@ syntax = "proto3";
 
 package envoy.extensions.filters.udp.dns_filter.v3alpha;
 
+import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/resolver.proto";
 import "envoy/data/dns/v3/dns_table.proto";
 
 import "google/protobuf/duration.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -44,6 +46,8 @@ message DnsFilterConfig {
   // in a client context. This message will contain the timeouts, retry,
   // and forwarding configuration for Envoy to make DNS requests to other
   // resolvers
+  //
+  // [#next-free-field: 6]
   message ClientContextConfig {
     // Sets the maximum time we will wait for the upstream query to complete
     // We allow 5s for the upstream resolution to complete, so the minimum
@@ -51,8 +55,20 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
+    // This field was used for `dns_resolution_config` in Envoy 1.19.0 and
+    // 1.19.1.
+    // Control planes that need to set this field for Envoy 1.19.0 and
+    // 1.19.1 clients should fork the protobufs and change the field type
+    // to `DnsResolutionConfig`.
+    // Control planes that need to simultaneously support Envoy 1.18.x and
+    // Envoy 1.19.x should avoid Envoy 1.19.0 and 1.19.1.
+    //
+    // [#not-implemented-hide:]
+    repeated config.core.v3.Address upstream_resolvers = 2
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
     // DNS resolution configuration which includes the underlying dns resolver addresses and options.
-    config.core.v3.DnsResolutionConfig dns_resolution_config = 2;
+    config.core.v3.DnsResolutionConfig dns_resolution_config = 5;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external

--- a/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v4alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/data/dns/v4alpha:pkg",
         "//envoy/extensions/filters/udp/dns_filter/v3alpha:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
+++ b/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
@@ -2,12 +2,14 @@ syntax = "proto3";
 
 package envoy.extensions.filters.udp.dns_filter.v4alpha;
 
+import "envoy/config/core/v4alpha/address.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/resolver.proto";
 import "envoy/data/dns/v4alpha/dns_table.proto";
 
 import "google/protobuf/duration.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -51,6 +53,8 @@ message DnsFilterConfig {
   // in a client context. This message will contain the timeouts, retry,
   // and forwarding configuration for Envoy to make DNS requests to other
   // resolvers
+  //
+  // [#next-free-field: 6]
   message ClientContextConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig";
@@ -61,8 +65,20 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
+    // This field was used for `dns_resolution_config` in Envoy 1.19.0 and
+    // 1.19.1.
+    // Control planes that need to set this field for Envoy 1.19.0 and
+    // 1.19.1 clients should fork the protobufs and change the field type
+    // to `DnsResolutionConfig`.
+    // Control planes that need to simultaneously support Envoy 1.18.x and
+    // Envoy 1.19.x should avoid Envoy 1.19.0 and 1.19.1.
+    //
+    // [#not-implemented-hide:]
+    repeated config.core.v4alpha.Address hidden_envoy_deprecated_upstream_resolvers = 2
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
     // DNS resolution configuration which includes the underlying dns resolver addresses and options.
-    config.core.v4alpha.DnsResolutionConfig dns_resolution_config = 2;
+    config.core.v4alpha.DnsResolutionConfig dns_resolution_config = 5;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external


### PR DESCRIPTION
Commit Message:

Field 2 in the `DnsFilterConfig` message was released in Envoy 1.18,
and repurposed in Envoy 1.19. Renumber the field, while leaving a
compatibility field so that control planes can gracefully migrate to a
subsequent 1.19 release.

Risk Level: Medium. Note that this breaks wire compatibility with 1.19.0 and 1.19.1 in order to fix wire compatibility with 1.18.
Testing: Unit tests.
Docs Changes: None.
Release Notes: Included.
Fixes #17921.

This is a backport of #17943 for the 1.19.2 release.