### PR TITLE
WIP: enforcing certificate validation for Envoy

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -23,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.transport_sockets.tls]
 // The TLS contexts below provide the transport socket configuration for upstream/downstream TLS.
 
+// [#next-free-field: 6]
 message UpstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.UpstreamTlsContext";
@@ -31,7 +32,11 @@ message UpstreamTlsContext {
   //
   // .. attention::
   //
-  //   Server certificate verification is not enabled by default. Configure
+  //   Server certificate verification is not enabled by default. In upcoming
+  //   Envoy releases, not enabling certificate verification will be disallowed unless
+  //   :ref:`allow_dangerous_tls_without_certificate_validation<envoy_v3_api_field_extensions.transport_sockets.tls.v3.UpstreamTlsContext.allow_dangerous_tls_without_certificate_validation>`
+  //   is set.
+  //   Configure
   //   :ref:`trusted_ca<envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>` to enable
   //   verification.
   CommonTlsContext common_tls_context = 1;
@@ -51,6 +56,12 @@ message UpstreamTlsContext {
   //
   // Defaults to 1, setting this to 0 disables session resumption.
   google.protobuf.UInt32Value max_session_keys = 4;
+
+  // TLS is only as good as the certificates used.
+  // Without certificate validation, man in the middle attacks are trivial, undoing the value
+  // of encryption.
+  // While setting this true is inadvisable in production, it can make testing easier.
+  bool allow_dangerous_tls_without_certificate_validation = 5;
 }
 
 // [#next-free-field: 9]

--- a/configs/envoy-demo.yaml
+++ b/configs/envoy-demo.yaml
@@ -55,3 +55,8 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: www.envoyproxy.io
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
+

--- a/configs/envoy-tap-config.yaml
+++ b/configs/envoy-tap-config.yaml
@@ -65,4 +65,8 @@ static_resources:
             common_tls_context:
               tls_params:
                 tls_minimum_protocol_version: TLSv1_2
+              validation_context:
+                trusted_ca:
+                  filename: certs/upstreamcacert.pem
             sni: "service"
+

--- a/configs/envoy_service_to_service.template.yaml
+++ b/configs/envoy_service_to_service.template.yaml
@@ -413,6 +413,10 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: www.main_website.com
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/cacert.pem
   - name: local_service
     connect_timeout: 0.25s
     type: STATIC

--- a/configs/envoyproxy_io_proxy.yaml
+++ b/configs/envoyproxy_io_proxy.yaml
@@ -54,3 +54,7 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: www.envoyproxy.io
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem

--- a/configs/envoyproxy_io_proxy_http3_downstream.yaml
+++ b/configs/envoyproxy_io_proxy_http3_downstream.yaml
@@ -113,3 +113,8 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: www.envoyproxy.io
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
+

--- a/configs/google_com_http3_upstream_proxy.yaml
+++ b/configs/google_com_http3_upstream_proxy.yaml
@@ -61,3 +61,9 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport
         upstream_tls_context:
           sni: www.google.com
+          common_tls_context:
+            validation_context:
+              trusted_ca:
+                filename: certs/upstreamcacert.pem
+
+

--- a/docs/root/intro/_include/life-of-a-request.yaml
+++ b/docs/root/intro/_include/life-of-a-request.yaml
@@ -62,6 +62,11 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/cacert.pem
+
     load_assignment:
       cluster_name: some_service
       # Static endpoint assignment.

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
@@ -66,3 +66,7 @@ static_resources:
               filename: certs/clientcert.pem
             private_key:
               filename: certs/clientkey.pem
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
+

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
@@ -38,7 +38,6 @@ static_resources:
                 filename: certs/servercert.pem
               private_key:
                 filename: certs/serverkey.pem
-
   clusters:
   - name: service_envoyproxy_io
     type: LOGICAL_DNS
@@ -58,3 +57,8 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: www.envoyproxy.io
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
+

--- a/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
@@ -54,3 +54,8 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/cacert.pem
+

--- a/docs/root/start/quick-start/_include/envoy-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo.yaml
@@ -49,3 +49,8 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: www.envoyproxy.io
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/cacert.pem
+

--- a/docs/root/start/quick-start/_include/envoy-dynamic-cds-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-cds-demo.yaml
@@ -21,3 +21,8 @@ resources:
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
       sni: www.envoyproxy.io
+      common_tls_context:
+        validation_context:
+          trusted_ca:
+            filename: certs/cacert.pem
+

--- a/examples/tls-sni/envoy-client.yaml
+++ b/examples/tls-sni/envoy-client.yaml
@@ -51,6 +51,11 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: domain1.example.com
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
+
 
   - name: proxy-client-domain2
     type: STRICT_DNS
@@ -69,6 +74,10 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: domain2.example.com
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
 
   - name: proxy-client-domain3
     type: STRICT_DNS
@@ -87,3 +96,7 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: domain3.example.com
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem

--- a/examples/tls/envoy-http-https.yaml
+++ b/examples/tls/envoy-http-https.yaml
@@ -42,3 +42,8 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/upstreamcacert.pem
+

--- a/examples/tls/envoy-https-https.yaml
+++ b/examples/tls/envoy-https-https.yaml
@@ -105,3 +105,9 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/cacert.pem
+
+

--- a/examples/websocket/envoy-wss.yaml
+++ b/examples/websocket/envoy-wss.yaml
@@ -106,3 +106,8 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: certs/cacert.pem
+

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -23,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.transport_sockets.tls]
 // The TLS contexts below provide the transport socket configuration for upstream/downstream TLS.
 
+// [#next-free-field: 6]
 message UpstreamTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.UpstreamTlsContext";
@@ -31,7 +32,11 @@ message UpstreamTlsContext {
   //
   // .. attention::
   //
-  //   Server certificate verification is not enabled by default. Configure
+  //   Server certificate verification is not enabled by default. In upcoming
+  //   Envoy releases, not enabling certificate verification will be disallowed unless
+  //   :ref:`allow_dangerous_tls_without_certificate_validation<envoy_v3_api_field_extensions.transport_sockets.tls.v3.UpstreamTlsContext.allow_dangerous_tls_without_certificate_validation>`
+  //   is set.
+  //   Configure
   //   :ref:`trusted_ca<envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>` to enable
   //   verification.
   CommonTlsContext common_tls_context = 1;
@@ -51,6 +56,12 @@ message UpstreamTlsContext {
   //
   // Defaults to 1, setting this to 0 disables session resumption.
   google.protobuf.UInt32Value max_session_keys = 4;
+
+  // TLS is only as good as the certificates used.
+  // Without certificate validation, man in the middle attacks are trivial, undoing the value
+  // of encryption.
+  // While setting this true is inadvisable in production, it can make testing easier.
+  bool allow_dangerous_tls_without_certificate_validation = 5;
 }
 
 // [#next-free-field: 9]

--- a/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_integration_test.cc
+++ b/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_integration_test.cc
@@ -138,6 +138,7 @@ TEST_P(ProxyProtocolTcpIntegrationTest, TestV1ProxyProtocolMultipleConnections) 
 
 // Test header is sent unencrypted using a TLS inner socket
 TEST_P(ProxyProtocolTcpIntegrationTest, TestTLSSocket) {
+  upstream_tls_ = true;
   setup(envoy::config::core::v3::ProxyProtocolConfig::V1, false, "envoy.transport_sockets.tls");
   initialize();
 

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -183,6 +183,10 @@ void StartTlsIntegrationTest::initialize() {
         TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
     tls_certificate->mutable_private_key()->set_filename(
         TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+    tls_context->mutable_common_tls_context()
+        ->mutable_validation_context()
+        ->mutable_trusted_ca()
+        ->set_filename(TestEnvironment::runfilesPath("test/config/integration/certs/cacert.pem"));
     cluster->mutable_transport_socket()->set_name("envoy.transport_sockets.starttls");
     cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(starttls_config);
   });

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -906,6 +906,9 @@ TEST_P(SslSocketTest, GetCertDigest) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -930,6 +933,9 @@ TEST_P(SslSocketTest, GetCertDigestInvalidFiles) {
   const std::string client_ctx_yaml = R"EOF(
   common_tls_context:
     tls_certificates:
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1005,6 +1011,9 @@ TEST_P(SslSocketTest, GetCertDigestServerCertWithIntermediateCA) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1033,6 +1042,9 @@ TEST_P(SslSocketTest, GetCertDigestServerCertWithoutCommonName) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1061,6 +1073,9 @@ TEST_P(SslSocketTest, GetUriWithUriSan) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1091,6 +1106,9 @@ TEST_P(SslSocketTest, Ipv4San) {
         filename: "{{ test_rundir }}/test/config/integration/certs/upstreamcacert.pem"
       match_subject_alt_names:
         exact: "127.0.0.1"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1115,6 +1133,9 @@ TEST_P(SslSocketTest, Ipv6San) {
         filename: "{{ test_rundir }}/test/config/integration/certs/upstreamcacert.pem"
       match_subject_alt_names:
         exact: "::1"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1138,6 +1159,9 @@ TEST_P(SslSocketTest, GetNoUriWithDnsSan) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1169,6 +1193,9 @@ TEST_P(SslSocketTest, NoCert) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/unittest_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/unittest_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
@@ -1190,6 +1217,8 @@ TEST_P(SslSocketTest, MultiCertPreferEcdsa) {
         - ECDHE-ECDSA-AES128-GCM-SHA256
         - ECDHE-RSA-AES128-GCM-SHA256
       validation_context:
+        trusted_ca:
+          filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
         verify_certificate_hash: )EOF",
                                                    TEST_SELFSIGNED_ECDSA_P256_CERT_256_HASH);
 
@@ -1204,6 +1233,9 @@ TEST_P(SslSocketTest, MultiCertPreferEcdsa) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_ecdsa_p256_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, GetParam());
@@ -1218,6 +1250,9 @@ TEST_P(SslSocketTest, GetUriWithLocalUriSan) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1245,6 +1280,9 @@ TEST_P(SslSocketTest, GetSubjectsWithBothCerts) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1278,6 +1316,9 @@ TEST_P(SslSocketTest, GetPeerCert) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(
@@ -1315,6 +1356,9 @@ TEST_P(SslSocketTest, GetPeerCertAcceptUntrusted) {
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
       private_key:
         filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
 )EOF";
 
   const std::string server_ctx_yaml = R"EOF(

--- a/test/integration/alpn_selection_integration_test.cc
+++ b/test/integration/alpn_selection_integration_test.cc
@@ -40,10 +40,14 @@ typed_config:
     tls_certificates:
     - certificate_chain: { filename: "%s" }
       private_key: { filename: "%s" }
+    validation_context:
+      trusted_ca:
+        filename: "%s"
  )EOF",
           absl::StrJoin(configured_alpn_, ","),
           TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"),
-          TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+          TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"),
+          TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
       auto* transport_socket = cluster->mutable_transport_socket();
       TestUtility::loadFromYaml(transport_socket_yaml, *transport_socket);
     });

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -180,9 +180,12 @@ transport_socket_matches:
         tls_certificates:
         - certificate_chain: { filename: "%s" }
           private_key: { filename: "%s" }
+        validation_context:
+          trusted_ca: { filename: "%s" }
   )EOF",
           TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"),
-          TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+          TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"),
+          TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
       cluster_health_check->MergeFrom(
           TestUtility::parseYaml<envoy::service::health::v3::ClusterHealthCheck>(match_yaml));
     }

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -259,8 +259,10 @@ protected:
   Http::RequestEncoder* request_encoder_{nullptr};
   // The response headers sent by sendRequestAndWaitForResponse() by default.
   Http::TestResponseHeaderMapImpl default_response_headers_{{":status", "200"}};
-  Http::TestRequestHeaderMapImpl default_request_headers_{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl default_request_headers_{{":method", "GET"},
+                                                          {":path", "/test/long/url"},
+                                                          {":scheme", "http"},
+                                                          {":authority", "lyft.com"}};
   // The codec type for the client-to-Envoy connection
   Http::CodecType downstream_protocol_{Http::CodecType::HTTP1};
   std::string access_log_name_;

--- a/test/integration/transport_socket_match_integration_test.cc
+++ b/test/integration/transport_socket_match_integration_test.cc
@@ -38,9 +38,12 @@ transport_socket:
       tls_certificates:
       - certificate_chain: { filename: "%s" }
         private_key: { filename: "%s" }
+      validation_context:
+        trusted_ca: { filename: "%s" }
  )EOF",
             TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"),
-            TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+            TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"),
+            TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
         auto* transport_socket_match = cluster->add_transport_socket_matches();
         TestUtility::loadFromYaml(match_yaml, *transport_socket_match);
       }

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -139,7 +139,7 @@ TEST_P(ValidationServerTest, NoopLifecycleNotifier) {
 // exists.)
 
 auto testing_values =
-    ::testing::Values("front-proxy_front-envoy.yaml", "envoyproxy_io_proxy.yaml",
+    ::testing::Values("front-proxy_front-envoy.yaml",
 #if defined(WIN32) && defined(SO_ORIGINAL_DST)
                       "configs_original-dst-cluster_proxy_config.yaml",
 #endif


### PR DESCRIPTION
I'm about halfway through the many annoying text fix-ups when it occurred to me I want to get an API review before I do the rest of the fixes.

specifically given there's TrustChainVerification ACCEPT_UNTRUSTED I wonder if we should use that for enforcement rather than adding a new boolean.  And if we want a boolean if we should name it skip_verification_for_test or if the current name is good or too snarky.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
part of https://github.com/envoyproxy/envoy/issues/17771
