### PR TITLE
dns cache: log event with addresses on resolution

### DIFF
--- a/source/common/common/stl_helpers.h
+++ b/source/common/common/stl_helpers.h
@@ -28,7 +28,7 @@ std::string accumulateToString(const ContainerT& source,
   if (source.empty()) {
     return "[]";
   }
-  return std::accumulate(std::next(source.begin()), source.end(), "[" + string_func(source[0]),
+  return std::accumulate(std::next(source.begin()), source.end(), "[" + string_func(source.front()),
                          [string_func](std::string acc, const T& element) {
                            return acc + ", " + string_func(element);
                          }) +

--- a/source/common/common/stl_helpers.h
+++ b/source/common/common/stl_helpers.h
@@ -28,7 +28,8 @@ std::string accumulateToString(const ContainerT& source,
   if (source.empty()) {
     return "[]";
   }
-  return std::accumulate(std::next(source.begin()), source.end(), "[" + string_func(source.front()),
+  return std::accumulate(std::next(source.begin()), source.end(),
+                         "[" + string_func(*source.begin()),
                          [string_func](std::string acc, const T& element) {
                            return acc + ", " + string_func(element);
                          }) +

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -290,7 +290,8 @@ void DnsCacheImpl::finishResolve(const std::string& host,
                                  Network::DnsResolver::ResolutionStatus status,
                                  std::list<Network::DnsResponse>&& response, bool from_cache) {
   ASSERT(main_thread_dispatcher_.isThreadSafe());
-  ENVOY_LOG_EVENT(debug, "main thread resolve complete for host '{}': {}", host,
+  ENVOY_LOG_EVENT(debug, "dns_cache_finish_resolve",
+                  "main thread resolve complete for host '{}': {}", host,
                   accumulateToString<Network::DnsResponse>(response, [](const auto& dns_response) {
                     return dns_response.address_->asString();
                   }));

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.pb.h"
 
+#include "source/common/common/stl_helpers.h"
 #include "source/common/config/utility.h"
 #include "source/common/http/utility.h"
 #include "source/common/network/resolver_impl.h"
@@ -289,7 +290,10 @@ void DnsCacheImpl::finishResolve(const std::string& host,
                                  Network::DnsResolver::ResolutionStatus status,
                                  std::list<Network::DnsResponse>&& response, bool from_cache) {
   ASSERT(main_thread_dispatcher_.isThreadSafe());
-  ENVOY_LOG(debug, "main thread resolve complete for host '{}'. {} results", host, response.size());
+  ENVOY_LOG_EVENT(debug, "main thread resolve complete for host '{}': {}", host,
+                  accumulateToString<Network::DnsResponse>(response, [](const auto& dns_response) {
+                    return dns_response.address_->asString();
+                  }));
 
   // Functions like this one that modify primary_hosts_ are only called in the main thread so we
   // know it is safe to use the PrimaryHostInfo pointers outside of the lock.


### PR DESCRIPTION
Commit Message: adds addresses to finish resolution log. Moves to ENVOY_LOG_EVENT macro.
Risk Level: low

Signed-off-by: Jose Nino <jnino@lyft.com>