### PR TITLE
Wrong past participle words fixed in comments

### DIFF
--- a/envoy/server/overload/overload_manager.h
+++ b/envoy/server/overload/overload_manager.h
@@ -46,7 +46,7 @@ using OverloadActionNames = ConstSingleton<OverloadActionNameValues>;
  */
 class OverloadActionStatsNameValues {
 public:
-  // Count of ther number of streams the reset streams action has reset
+  // Count of the number of streams the reset streams action has reset
   const std::string ResetStreamsCount = "envoy.overload_actions.reset_high_memory_stream.count";
 };
 

--- a/envoy/stats/allocator.h
+++ b/envoy/stats/allocator.h
@@ -70,11 +70,12 @@ public:
   virtual void markTextReadoutForDeletion(const TextReadoutSharedPtr& text_readout) PURE;
 
   /**
-   * Iterate over all stats that need to be sunk. Note, that implementations can potentially hold
-   * on to a mutex that will deadlock if the passed in functors try to create or delete a stat.
-   * @param f_size functor that is provided the number of all sunk stats. Note this is called
-   *        only once, prior to any calls to f_stat.
-   * @param f_stat functor that is provided one sunk stat at a time.
+   * Iterate over all stats that need to be added to a sink. Note, that implementations can
+   * potentially hold on to a mutex that will deadlock if the passed in functors try to create
+   * or delete a stat.
+   * @param f_size functor that is provided the number of all stats in the sink. Note this is
+   *        called only once, prior to any calls to f_stat.
+   * @param f_stat functor that is provided one stat in the sink at a time.
    */
   virtual void forEachCounter(std::function<void(std::size_t)> f_size,
                               std::function<void(Stats::Counter&)> f_stat) const PURE;

--- a/envoy/stats/allocator.h
+++ b/envoy/stats/allocator.h
@@ -70,11 +70,11 @@ public:
   virtual void markTextReadoutForDeletion(const TextReadoutSharedPtr& text_readout) PURE;
 
   /**
-   * Iterate over all stats that need to be sinked. Note, that implementations can potentially hold
+   * Iterate over all stats that need to be sunk. Note, that implementations can potentially hold
    * on to a mutex that will deadlock if the passed in functors try to create or delete a stat.
-   * @param f_size functor that is provided the number of all sinked stats. Note this is called
+   * @param f_size functor that is provided the number of all sunk stats. Note this is called
    *        only once, prior to any calls to f_stat.
-   * @param f_stat functor that is provided one sinked stat at a time.
+   * @param f_stat functor that is provided one sunk stat at a time.
    */
   virtual void forEachCounter(std::function<void(std::size_t)> f_size,
                               std::function<void(Stats::Counter&)> f_stat) const PURE;

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -51,10 +51,11 @@ public:
   virtual std::vector<ParentHistogramSharedPtr> histograms() const PURE;
 
   /**
-   * Iterate over all stats that need to be sunk. Note, that implementations can potentially  hold
-   * on to a mutex that will deadlock if the passed in functors try to create or delete a stat.
-   * @param f_size functor that is provided the number of all sunk stats.
-   * @param f_stat functor that is provided one sunk stat at a time.
+   * Iterate over all stats that need to be added to a sink. Note, that implementations can
+   * potentially  hold on to a mutex that will deadlock if the passed in functors try to create
+   * or delete a stat.
+   * @param f_size functor that is provided the number of all stats in the sink.
+   * @param f_stat functor that is provided one stat in the sink at a time.
    */
   virtual void forEachCounter(std::function<void(std::size_t)> f_size,
                               std::function<void(Stats::Counter&)> f_stat) const PURE;

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -51,10 +51,10 @@ public:
   virtual std::vector<ParentHistogramSharedPtr> histograms() const PURE;
 
   /**
-   * Iterate over all stats that need to be sinked. Note, that implementations can potentially  hold
+   * Iterate over all stats that need to be sunk. Note, that implementations can potentially  hold
    * on to a mutex that will deadlock if the passed in functors try to create or delete a stat.
-   * @param f_size functor that is provided the number of all sinked stats.
-   * @param f_stat functor that is provided one sinked stat at a time.
+   * @param f_size functor that is provided the number of all sunk stats.
+   * @param f_stat functor that is provided one sunk stat at a time.
    */
   virtual void forEachCounter(std::function<void(std::size_t)> f_size,
                               std::function<void(Stats::Counter&)> f_stat) const PURE;


### PR DESCRIPTION
Signed-off-by: Le Yao <le.yao@intel.com>

Commit Message: Wrong past participle words fixed in comments
Additional Description: Sink past participle: sunk not sinked
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
