### PR TITLE
tools: remove gogo/protobuf from buf dependencies

### DIFF
--- a/api/buf.lock
+++ b/api/buf.lock
@@ -37,13 +37,6 @@ deps:
     digest: b1-QZUL5DC6-nVgMMlajH_hlImwghg5HjRsqlEAOl0dZgI=
     create_time: 2021-08-09T14:37:06.872899Z
   - remote: buf.build
-    owner: gogo
-    repository: protobuf
-    branch: main
-    commit: 4df00b267f944190a229ce3695781e99
-    digest: b1-sjLgsg7CzrkOrIjBDh3s-l0aMjE6oqTj85-OsoopKAw=
-    create_time: 2021-08-10T00:14:28.345069Z
-  - remote: buf.build
     owner: googleapis
     repository: googleapis
     branch: main

--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -4,7 +4,6 @@ deps:
     - buf.build/beta/opencensus
     - buf.build/beta/prometheus
     - buf.build/beta/opentelemetry
-    - buf.build/gogo/protobuf
     - buf.build/beta/xds
 breaking:
   ignore_unstable_packages: true

--- a/tools/api_proto_breaking_change_detector/detector.py
+++ b/tools/api_proto_breaking_change_detector/detector.py
@@ -120,7 +120,9 @@ class BufWrapper(ProtoBreakingChangeDetector):
         final_out, final_err = '\n'.join(final_out), '\n'.join(final_err)
 
         if final_err != "":
-            raise ChangeDetectorError(f"Error from buf: {final_err}")
+            # TODO(adisuissa): remove the final_out print before making the PR
+            # non-draft
+            raise ChangeDetectorError(f"Error from buf: {final_err} \n final_out: {final_out}")
 
         if final_code != 0:
             return True


### PR DESCRIPTION
Commit Message: tools: remove gogo/protobuf from buf dependencies
Additional Description:
Following discussion starting at [comment](https://github.com/envoyproxy/envoy/pull/18019#issuecomment-915508375), this is the first step of removing gogo/protobuf from the buf dependencies.
It seems that it was previously added to test breaking changes against old PRs that used gogo/protobuf.

Risk Level: Low - impacts CI only
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
