### PR TITLE
add empty() to PriorityConnPoolMap

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1200,7 +1200,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
   pools->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
   container.do_not_delete_ = false;
 
-  if (container.pools_->size() == 0) {
+  if (container.pools_->empty()) {
     host_http_conn_pool_map_.erase(old_host);
   }
 }
@@ -1393,7 +1393,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainAllConnPoolsWorker(
           Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
       container->do_not_delete_ = false;
 
-      if (container->pools_->size() == 0) {
+      if (container->pools_->empty()) {
         host_http_conn_pool_map_.erase(host);
       }
     }
@@ -1539,7 +1539,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::httpConnPoolIsIdle(
     // Guard deletion of the container with `do_not_delete_` to avoid deletion while
     // iterating through the container in `container->pools_->startDrain()`. See
     // comment in `ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools`.
-    if (!container->do_not_delete_ && container->pools_->size() == 0) {
+    if (!container->do_not_delete_ && container->pools_->empty()) {
       ENVOY_LOG(trace, "Pool container empty for host {}, erasing host entry", host);
       host_http_conn_pool_map_.erase(
           host); // NOTE: `container` is erased after this point in the lambda.

--- a/source/common/upstream/conn_pool_map.h
+++ b/source/common/upstream/conn_pool_map.h
@@ -47,6 +47,11 @@ public:
   size_t size() const;
 
   /**
+   * @return true if the pools are empty.
+   */
+  size_t empty() const;
+
+  /**
    * Destroys all mapped pools.
    */
   void clear();

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -85,7 +85,6 @@ size_t ConnPoolMap<KEY_TYPE, POOL_TYPE>::empty() const {
   return active_pools_.empty();
 }
 
-
 template <typename KEY_TYPE, typename POOL_TYPE> void ConnPoolMap<KEY_TYPE, POOL_TYPE>::clear() {
   Common::AutoDebugRecursionChecker assert_not_in(recursion_checker_);
   for (auto& pool_pair : active_pools_) {

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -80,6 +80,12 @@ size_t ConnPoolMap<KEY_TYPE, POOL_TYPE>::size() const {
   return active_pools_.size();
 }
 
+template <typename KEY_TYPE, typename POOL_TYPE>
+size_t ConnPoolMap<KEY_TYPE, POOL_TYPE>::empty() const {
+  return active_pools_.empty();
+}
+
+
 template <typename KEY_TYPE, typename POOL_TYPE> void ConnPoolMap<KEY_TYPE, POOL_TYPE>::clear() {
   Common::AutoDebugRecursionChecker assert_not_in(recursion_checker_);
   for (auto& pool_pair : active_pools_) {

--- a/source/common/upstream/priority_conn_pool_map.h
+++ b/source/common/upstream/priority_conn_pool_map.h
@@ -39,6 +39,11 @@ public:
   size_t size() const;
 
   /**
+   * @return true if the pools across all priorities are empty.
+   */
+  bool empty() const;
+
+  /**
    * Destroys all mapped pools.
    */
   void clear();

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -41,6 +41,16 @@ size_t PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::size() const {
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
+bool PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::empty() const {
+  for (const auto& pool_map : conn_pool_maps_) {
+    if (!pool_map.empty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename KEY_TYPE, typename POOL_TYPE>
 void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::clear() {
   for (auto& pool_map : conn_pool_maps_) {
     pool_map->clear();

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -43,7 +43,7 @@ size_t PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::size() const {
 template <typename KEY_TYPE, typename POOL_TYPE>
 bool PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::empty() const {
   for (const auto& pool_map : conn_pool_maps_) {
-    if (!pool_map.empty()) {
+    if (!pool_map->empty()) {
       return false;
     }
   }

--- a/test/common/upstream/priority_conn_pool_map_impl_test.cc
+++ b/test/common/upstream/priority_conn_pool_map_impl_test.cc
@@ -108,7 +108,7 @@ TEST_F(PriorityConnPoolMapImplTest, TestClearEmptiesOut) {
   test_map->getPool(ResourcePriority::Default, 2, getBasicFactory());
   test_map->clear();
 
-  EXPECT_EQ(test_map->size(), 0);
+  EXPECT_TRUE(test_map->empty());
 }
 
 TEST_F(PriorityConnPoolMapImplTest, TestErase) {
@@ -124,7 +124,7 @@ TEST_F(PriorityConnPoolMapImplTest, TestErase) {
   EXPECT_EQ(2, test_map->size());
   EXPECT_TRUE(test_map->erasePool(ResourcePriority::Default, 1));
   EXPECT_TRUE(test_map->erasePool(ResourcePriority::High, 1));
-  EXPECT_EQ(0, test_map->size());
+  EXPECT_TRUE(test_map->empty());
   EXPECT_NE(pool_ptr,
             &test_map->getPool(ResourcePriority::High, 1, getBasicFactory()).value().get());
 }


### PR DESCRIPTION
Commit Message:
Speed up a little bit since pool is very unlikely empty().

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
