### PR TITLE
ecds: make onConfigUpdate generic over filter type

### DIFF
--- a/envoy/config/extension_config_provider.h
+++ b/envoy/config/extension_config_provider.h
@@ -35,17 +35,17 @@ public:
   virtual absl::optional<FactoryCallback> config() PURE;
 };
 
-template <class FactoryCallback> class DynamicExtensionConfigProviderBase {
+class DynamicExtensionConfigProviderBase {
 public:
   virtual ~DynamicExtensionConfigProviderBase() = default;
 
   /**
    * Update the provider with a new configuration.
-   * @param config is an extension factory callback to replace the existing configuration.
+   * @param proto_config is a candidate configuration update.
    * @param version_info is the version of the new extension configuration.
    * @param cb the continuation callback for a completed configuration application on all threads.
    */
-  virtual void onConfigUpdate(FactoryCallback config, const std::string& version_info,
+  virtual void onConfigUpdate(const ProtobufWkt::Any& proto_config, const std::string& version_info,
                               ConfigAppliedCb applied_on_all_threads) PURE;
 
   /**
@@ -61,7 +61,7 @@ public:
 };
 
 template <class Factory, class FactoryCallback>
-class DynamicExtensionConfigProvider : public DynamicExtensionConfigProviderBase<FactoryCallback>,
+class DynamicExtensionConfigProvider : public DynamicExtensionConfigProviderBase,
                                        public ExtensionConfigProvider<Factory, FactoryCallback> {};
 
 } // namespace Config

--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -132,19 +132,17 @@ void FilterConfigSubscription::onConfigUpdate(
   for (auto* provider : filter_config_providers_) {
     provider->validateTerminalFilter(filter_config_name_, factory.name(), is_terminal_filter);
   }
-  Envoy::Http::FilterFactoryCb factory_callback =
-      factory.createFilterFactoryFromProto(*message, stat_prefix_, factory_context_);
   ENVOY_LOG(debug, "Updating filter config {}", filter_config_name_);
 
   Common::applyToAllWithCleanup<DynamicFilterConfigProviderImplBase*>(
       filter_config_providers_,
-      [&factory_callback, &version_info](DynamicFilterConfigProviderImplBase* provider,
-                                         std::shared_ptr<Cleanup> cleanup) {
-        provider->onConfigUpdate(factory_callback, version_info, [cleanup] {});
+      [&filter_config, &version_info](DynamicFilterConfigProviderImplBase* provider,
+                                      std::shared_ptr<Cleanup> cleanup) {
+        provider->onConfigUpdate(filter_config.typed_config(), version_info, [cleanup] {});
       },
       [this]() { stats_.config_reload_.inc(); });
   last_config_hash_ = new_hash;
-  last_config_ = factory_callback;
+  last_config_ = filter_config.typed_config();
   last_type_url_ = type_url;
   last_version_info_ = version_info;
   last_filter_name_ = factory.name();
@@ -265,16 +263,20 @@ DynamicFilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFil
     require_type_urls.emplace(factory_type_url);
   }
 
-  Envoy::Http::FilterFactoryCb default_config = nullptr;
+  absl::optional<ProtobufWkt::Any> default_config;
   if (config_source.has_default_config()) {
-    default_config = getDefaultConfig(config_source.default_config(), filter_config_name,
-                                      factory_context, stat_prefix, last_filter_in_filter_chain,
-                                      filter_chain_type, require_type_urls);
+    validateDefaultConfig(config_source.default_config(), filter_config_name, factory_context,
+                          last_filter_in_filter_chain, filter_chain_type, require_type_urls);
+    default_config = config_source.default_config();
   }
 
   auto provider = std::make_unique<DynamicFilterConfigProviderImpl>(
       subscription, require_type_urls, factory_context, default_config, last_filter_in_filter_chain,
-      filter_chain_type);
+      filter_chain_type,
+      [this, &stat_prefix,
+       &factory_context](const ProtobufWkt::Any& proto_config) -> Envoy::Http::FilterFactoryCb {
+        return instantiateFilterFactory(proto_config, stat_prefix, factory_context);
+      });
 
   // Ensure the subscription starts if it has not already.
   if (config_source.apply_default_config_without_warming()) {
@@ -284,10 +286,10 @@ DynamicFilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFil
   return provider;
 }
 
-Http::FilterFactoryCb HttpFilterConfigProviderManagerImpl::getDefaultConfig(
+void HttpFilterConfigProviderManagerImpl::validateDefaultConfig(
     const ProtobufWkt::Any& proto_config, const std::string& filter_config_name,
-    Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
-    bool last_filter_in_filter_chain, const std::string& filter_chain_type,
+    Server::Configuration::FactoryContext& factory_context, bool last_filter_in_filter_chain,
+    const std::string& filter_chain_type,
     const absl::flat_hash_set<std::string> require_type_urls) const {
   auto* default_factory =
       Config::Utility::getFactoryByType<Server::Configuration::NamedHttpFilterConfigFactory>(
@@ -304,7 +306,17 @@ Http::FilterFactoryCb HttpFilterConfigProviderManagerImpl::getDefaultConfig(
       filter_config_name, default_factory->name(), filter_chain_type,
       default_factory->isTerminalFilterByProto(*message, factory_context),
       last_filter_in_filter_chain);
-  return default_factory->createFilterFactoryFromProto(*message, stat_prefix, factory_context);
+}
+
+Http::FilterFactoryCb HttpFilterConfigProviderManagerImpl::instantiateFilterFactory(
+    const ProtobufWkt::Any& proto_config, const std::string& stat_prefix,
+    Server::Configuration::FactoryContext& factory_context) const {
+  auto* factory =
+      Config::Utility::getFactoryByType<Server::Configuration::NamedHttpFilterConfigFactory>(
+          proto_config);
+  ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
+      proto_config, factory_context.messageValidationVisitor(), *factory);
+  return factory->createFilterFactoryFromProto(*message, stat_prefix, factory_context);
 }
 
 } // namespace Filter


### PR DESCRIPTION
cc @kyessenov @lambdai 

Commit Message:
ecds: make onConfigUpdate generic over filter type

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description: Part of https://github.com/envoyproxy/envoy/issues/14696#issuecomment-897855672. The goal is to templatize `DynamicFilterConfigProviderImpl` while having `DynamicFilterConfigProviderImplBase`, `FilterConfigProviderManagerImplBase`, and `FilterConfigSubscription` agnostic to HTTP vs. network filters. This is a step in that direction, following the approach of #14717. Because extra validation was added since that PR, the filter factory object must be created before `onConfigUpdate` in addition to during

Risk Level: Low
Testing: Existing (refactoring)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
#14696