### PR TITLE
docker: Add distroless image as an artefact

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -147,7 +147,7 @@ for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
     build_images "${BUILD_TYPE}" "$image_tag"
 
     if ! is_windows; then
-        if [[ "$BUILD_TYPE" == "" || "$BUILD_TYPE" == "-contrib" || "$BUILD_TYPE" == "-alpine" ]]; then
+        if [[ "$BUILD_TYPE" == "" || "$BUILD_TYPE" == "-contrib" || "$BUILD_TYPE" == "-alpine" || "$BUILD_TYPE" == "-distroless" ]]; then
             # verify_examples expects the base and alpine images, and for them to be named `-dev`
             dev_image="envoyproxy/envoy${BUILD_TYPE}-dev:latest"
             docker tag "$image_tag" "$dev_image"


### PR DESCRIPTION
Commit Message: docker: Add distroless image as an artefact
Additional Description:

the distroless image is pretty small, and as there is not anything testing it in ci, its useful to be able to fish it out and test it


Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
