### PR TITLE
Fix invalid link in CDN-loop

### DIFF
--- a/docs/root/configuration/http/http_filters/cdn_loop_filter.rst
+++ b/docs/root/configuration/http/http_filters/cdn_loop_filter.rst
@@ -26,7 +26,7 @@ Configuration
 
 The filter is configured with the name *envoy.filters.http.cdn_loop*.
 
-The `filter config <config_http_filters_cdn_loop>`_ has two fields.
+The :ref:`filter config <envoy_v3_api_msg_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig>` has two fields.
 
 * The *cdn_id* field sets the identifier that the filter will look for within and append to the
   CDN-Loop header. RFC 8586 calls this field the "cdn-id"; "cdn-id" can either be a pseudonym or a


### PR DESCRIPTION
This docs https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cdn_loop_filter#configuration has an 404 link.

It seems to need `:ref:` tag but also the link should point to [`extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto.html#extensions-filters-http-cdn-loop-v3alpha-cdnloopconfig).

This patch fixes it.

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
