### PR TITLE
admin: optimize prometheus format stat endopint.

### DIFF
--- a/source/server/admin/stats_handler.cc
+++ b/source/server/admin/stats_handler.cc
@@ -82,7 +82,7 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     return Http::Code::BadRequest;
   }
 
-  absl::optional<std::string> format_value = Utility::formatParam(params);
+  const absl::optional<std::string> format_value = Utility::formatParam(params);
   if (format_value.has_value() && format_value.value() == "prometheus") {
     return handlerPrometheusStats(url, response_headers, response, admin_stream);
   }

--- a/source/server/admin/stats_handler.cc
+++ b/source/server/admin/stats_handler.cc
@@ -82,6 +82,11 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     return Http::Code::BadRequest;
   }
 
+  absl::optional<std::string> format_value = Utility::formatParam(params);
+  if (format_value.has_value() && format_value.value() == "prometheus") {
+    return handlerPrometheusStats(url, response_headers, response, admin_stream);
+  }
+
   std::map<std::string, uint64_t> all_stats;
   for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     if (shouldShowMetric(*counter, used_only, regex)) {
@@ -103,7 +108,6 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     }
   }
 
-  absl::optional<std::string> format_value = Utility::formatParam(params);
   if (!format_value.has_value()) {
     // Display plain stats if format query param is not there.
     statsAsText(all_stats, text_readouts, server_.stats().histograms(), used_only, regex, response);
@@ -115,10 +119,6 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     response.add(
         statsAsJson(all_stats, text_readouts, server_.stats().histograms(), used_only, regex));
     return Http::Code::OK;
-  }
-
-  if (format_value.value() == "prometheus") {
-    return handlerPrometheusStats(url, response_headers, response, admin_stream);
   }
 
   response.add("usage: /stats?format=json  or /stats?format=prometheus \n");


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

Commit Message: This commit reduces the computational cost of /stats?format=prometheus endpoint by avoiding the construction of unused (name->stat value) map named "all_stats" only used by text and json formats in the /stats handler.
 
Additional Description: NA
Risk Level: low
Testing: unittest
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
[Optional Runtime guard:] NA
[Optional Fixes #Issue] NA
[Optional Deprecated:] NA
