### PR TITLE
docs: Add remote_refuse and remote_reset in response code details

### DIFF
--- a/docs/root/configuration/http/http_conn_man/response_code_details.rst
+++ b/docs/root/configuration/http/http_conn_man/response_code_details.rst
@@ -101,6 +101,8 @@ All http2 details are rooted at *http2.*
     http2.unexpected_underscore, Envoy was configured to drop requests with header keys beginning with underscores.
     http2.unknown.nghttp2.error, An unknown error was encountered by nghttp2
     http2.violation.of.messaging.rule, The stream was in violation of a HTTP/2 messaging rule.
+    http2.remote_refuse, The peer refused the stream.
+    http2.remote_reset, The peer reset the stream.
 
 Http3 details
 ~~~~~~~~~~~~~
@@ -116,4 +118,6 @@ All http3 details are rooted at *http3.*
     http3.unexpected_underscore, Envoy was configured to drop or reject requests with header keys beginning with underscores.
     http3.too_many_headers, Either incoming request or response headers contained too many headers.
     http3.too_many_trailers, Either incoming request or response trailers contained too many entries.
+    http3.remote_refuse, The peer refused the stream.
+    http3.remote_reset, The peer reset the stream.
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -33,7 +33,7 @@ namespace Http1 {
 namespace {
 
 // Changes or additions to details should be reflected in
-// docs/root/configuration/http/http_conn_man/response_code_details_details.rst
+// docs/root/configuration/http/http_conn_man/response_code_details.rst
 struct Http1ResponseCodeDetailValues {
   const absl::string_view TooManyHeaders = "http1.too_many_headers";
   const absl::string_view HeadersTooLarge = "http1.headers_too_large";

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -34,7 +34,7 @@ namespace Http {
 namespace Http2 {
 
 // Changes or additions to details should be reflected in
-// docs/root/configuration/http/http_conn_man/response_code_details_details.rst
+// docs/root/configuration/http/http_conn_man/response_code_details.rst
 class Http2ResponseCodeDetailValues {
 public:
   // Invalid HTTP header field was received and stream is going to be


### PR DESCRIPTION
These two are missed in the [doc](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/response_code_details#per-codec-details).

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
