### PR TITLE
dfp: adding failed resolution test

### DIFF
--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -173,18 +173,19 @@ TEST_P(ProxyFilterIntegrationTest, RequestWithBody) {
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.host_added")->value());
 }
 
+// Currenctly if the first DNS resolution fails, the filter will continue with
+// a null address. Make sure this mode fails gracefully.
 TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomain) {
   initializeWithArgs();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  const Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"},
-      {":path", "/test/long/url"},
-      {":scheme", "http"},
-      {":authority", "www.dsadlsajdkslajdks.com"}};
+  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                       {":path", "/test/long/url"},
+                                                       {":scheme", "http"},
+                                                       {":authority", "doesnotexist.example.com"}};
 
-  auto response =
-      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("503", response->headers().getStatusValue());
 }
 
 // Verify that after we populate the cache and reload the cluster we reattach to the cache with

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -173,6 +173,20 @@ TEST_P(ProxyFilterIntegrationTest, RequestWithBody) {
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.host_added")->value());
 }
 
+TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomain) {
+  initializeWithArgs();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  const Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"},
+      {":path", "/test/long/url"},
+      {":scheme", "http"},
+      {":authority", "www.dsadlsajdkslajdks.com"}};
+
+  auto response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+}
+
 // Verify that after we populate the cache and reload the cluster we reattach to the cache with
 // its existing hosts.
 TEST_P(ProxyFilterIntegrationTest, ReloadClusterAndAttachToCache) {

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -173,7 +173,7 @@ TEST_P(ProxyFilterIntegrationTest, RequestWithBody) {
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.host_added")->value());
 }
 
-// Currenctly if the first DNS resolution fails, the filter will continue with
+// Currently if the first DNS resolution fails, the filter will continue with
 // a null address. Make sure this mode fails gracefully.
 TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomain) {
   initializeWithArgs();


### PR DESCRIPTION
Testing the first-resolve-fail case to make sure it fails cleanly (until-if we clean up DFP cache)

Risk Level: n/a 
Testing: ues
Docs Changes: n/a
Release Notes: n/a
cc @mattklein123 @conqerAtapple 