### PR TITLE
doc: fix curl command in http connect tunnel example

### DIFF
--- a/configs/encapsulate_in_http1_connect.yaml
+++ b/configs/encapsulate_in_http1_connect.yaml
@@ -1,7 +1,7 @@
 # This configuration takes incoming data on port 10000 and encapsulates it in a CONNECT
 # request which is sent upstream port 10001.
 # It can be used to test TCP tunneling as described in docs/root/intro/arch_overview/http/upgrades.rst
-# and running `curl --x 127.0.0.1:10000 https://www.google.com`
+# and running `curl -x 127.0.0.1:10000 https://www.google.com`
 
 admin:
   address:

--- a/configs/encapsulate_in_http2_connect.yaml
+++ b/configs/encapsulate_in_http2_connect.yaml
@@ -1,7 +1,7 @@
 # This configuration takes incoming data on port 10000 and encapsulates it in a CONNECT
 # request which is sent upstream port 10001.
 # It can be used to test TCP tunneling as described in docs/root/intro/arch_overview/http/upgrades.rst
-# and running `curl --x 127.0.0.1:10000 https://www.google.com`
+# and running `curl -x 127.0.0.1:10000 https://www.google.com`
 
 admin:
   address:

--- a/configs/encapsulate_in_http2_post.yaml
+++ b/configs/encapsulate_in_http2_post.yaml
@@ -1,7 +1,7 @@
 # This configuration takes incoming data on port 10000 and encapsulates it in a POST
 # request which is sent upstream port 10001.
 # It can be used to test TCP tunneling as described in docs/root/intro/arch_overview/http/upgrades.rst
-# and running `curl --x 127.0.0.1:10000 https://www.google.com`
+# and running `curl -x 127.0.0.1:10000 https://www.google.com`
 
 admin:
   address:


### PR DESCRIPTION
Commit Message:

curl somehow accepts `--x` while specifying proxy. 
It attempts to use proxy once and then not using proxy.

curl version: 7.74.0 (x86_64-pc-linux-gnu) libcurl/7.74.0

Additional Description:
tl;dr 2 request are initiated
* Rebuilt URL to: 127.0.0.1:10000/
* Rebuilt URL to: http://hey/

```
$ curl -vvv --x 127.0.0.1:10000  http://hey
* Rebuilt URL to: 127.0.0.1:10000/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 10000 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:10000
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-type: text/plan
< Date: Fri, 17 Sep 2021 04:54:08 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
Hello Node JS Server Response
* Connection #0 to host 127.0.0.1 left intact
* Rebuilt URL to: http://hey/
* Could not resolve host: hey
* Closing connection 1
curl: (6) Could not resolve host: hey

```
Risk Level: NONE
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
