### PR TITLE
[BLOCKED] build(deps): bump protobuf in /examples/grpc-bridge/client

### DIFF
--- a/examples/grpc-bridge/client/requirements.txt
+++ b/examples/grpc-bridge/client/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.22.0
 grpcio
 grpcio-tools
-protobuf==3.17.3
+protobuf==3.18.0


### PR DESCRIPTION
This currently breaks the example as the newer lib expects python3

checking how we run it and its with a very out of date docker image that should not be used, so this will need addressing before we can update

---


Bumps [protobuf](https://github.com/protocolbuffers/protobuf) from 3.17.3 to 3.18.0.
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Changelog](https://github.com/protocolbuffers/protobuf/blob/master/generate_changelog.py)
- [Commits](https://github.com/protocolbuffers/protobuf/compare/v3.17.3...v3.18.0)

---
updated-dependencies:
- dependency-name: protobuf
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
