### PR TITLE
Fix issue where EnvoyUsers password expires

### DIFF
--- a/ci/Dockerfile-envoy-windows
+++ b/ci/Dockerfile-envoy-windows
@@ -4,7 +4,8 @@ ARG BUILD_TAG=ltsc2019
 FROM $BUILD_OS:$BUILD_TAG
 
 USER ContainerAdministrator
-RUN net user /add "EnvoyUser"
+RUN net accounts /MaxPWAge:unlimited
+RUN net user /add "EnvoyUser" /expires:never
 RUN net localgroup "Network Configuration Operators" "EnvoyUser" /add
 
 RUN mkdir "C:\\Program\ Files\\envoy"


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Windows sets an expiration date on password of users even
when the password is empty. This prevents running the container
as EnvoyUser after the expiration.
Additional Description: N/A
Risk Level: Low, this only affects unpublished images
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
