### PR TITLE
Fix wrong comment for closing brace

### DIFF
--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -275,7 +275,7 @@ private:
   Grpc::FrameInspector response_counter_;
   Upstream::ClusterInfoConstSharedPtr cluster_;
   absl::optional<Grpc::Context::RequestStatNames> request_names_;
-}; // namespace
+};
 
 } // namespace
 


### PR DESCRIPTION
This makes a tiny change by removing wrong comment for closing brace.
It is not namespace's closing brace but class's.

Risk Level: low
Testing: n/a
Docs Changes: no
Release Notes: n/a
Platform Specific Features: n/a
