### PR TITLE
unnecessary use of url for localhost in doc for service_to_service.rst file

### DIFF
--- a/docs/root/intro/deployment_types/service_to_service.rst
+++ b/docs/root/intro/deployment_types/service_to_service.rst
@@ -14,7 +14,7 @@ Service to service egress listener
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is the port used by applications to talk to other services in the infrastructure. For example,
-http://localhost:9001. HTTP and gRPC requests use the HTTP/1.1 *host* header or the HTTP/2 or HTTP/3
+*http://localhost:9001*. HTTP and gRPC requests use the HTTP/1.1 *host* header or the HTTP/2 or HTTP/3
 *:authority* header to indicate which remote cluster the request is destined for. Envoy handles
 service discovery, load balancing, rate limiting, etc. depending on the details in the
 configuration. Services only need to know about the local Envoy and do not need to concern


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: Unnecessary use of url in doc
Additional Description: NA
Risk Level: LOW
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
