### PR TITLE
correcting urls in deployment types docs

### DIFF
--- a/docs/root/intro/deployment_types/double_proxy.rst
+++ b/docs/root/intro/deployment_types/double_proxy.rst
@@ -22,4 +22,4 @@ Configuration template
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The source distribution includes an example double proxy configuration. See
-:ref:`here <intro_deployment_types>` for more information.
+:ref:`here <install_sandboxes_double_proxy>` for more information.

--- a/docs/root/intro/deployment_types/front_proxy.rst
+++ b/docs/root/intro/deployment_types/front_proxy.rst
@@ -22,4 +22,4 @@ Configuration template
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The source distribution includes an example front proxy configuration. See
-:ref:`here <intro_deployment_types>` for more information.
+:ref:`here <install_sandboxes_front_proxy>` for more information.


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: in docs urls are pointing back to originals page for below mentioned deployments.(for text "**See **here** for more information.**")
Front_Proxy - https://www.envoyproxy.io/docs/envoy/latest/intro/deployment_types/front_proxy#configuration-template and
Double_Proxy - https://www.envoyproxy.io/docs/envoy/latest/intro/deployment_types/double_proxy#configuration-template
Additional Description: the changes done after release v1.16.0
Risk Level: LOW
Testing: Local
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
