### PR TITLE
docs: Small optimization for protodoc

### DIFF
--- a/tools/protodoc/protodoc.bzl
+++ b/tools/protodoc/protodoc.bzl
@@ -17,10 +17,15 @@ protodoc_aspect = api_proto_plugin_aspect("//tools/protodoc", _protodoc_impl)
 def _protodoc_rule_impl(ctx):
     return [
         DefaultInfo(
-            files = depset(transitive = [
-                d[OutputGroupInfo].rst
-                for d in ctx.attr.deps
-            ]),
+            files = depset(
+                transitive = [
+                    depset([
+                        x
+                        for x in ctx.attr.deps[0][OutputGroupInfo].rst.to_list()
+                        if x.short_path.startswith("../envoy_api")
+                    ]),
+                ],
+            ),
         ),
     ]
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Small optimization for protodoc
Additional Description:

this is a small optimization that removes non-envoy rst files from the output depset of protodoc

this makes the api tarball smaller and allows the downstream code to not have to filter these out

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
