### PR TITLE
filter: set additional termination details and response flag for auth_digest_no_match in client_ssl_auth

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,7 +38,7 @@ Minor Behavior Changes
   for "gRPC config stream closed" is now reduced to debug when the status is ``Ok`` or has been
   retriable (``DeadlineExceeded``, ``ResourceExhausted``, or ``Unavailable``) for less than 30
   seconds.
-* client_ssl_auth filter: now sets additional termination details and ``UAEX`` response flag when the client certificate is not in the allowed-list.
+* client_ssl_auth filter: now sets additional termination details and **UAEX** response flag when the client certificate is not in the allowed-list.
 * grpc: gRPC async client can be cached and shared across filter instances in the same thread, this feature is turned off by default, can be turned on by setting runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to true.
 * http: correct the use of the ``x-forwarded-proto`` header and the ``:scheme`` header. Where they differ
   (which is rare) ``:scheme`` will now be used for serving redirect URIs and cached content. This behavior

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -32,13 +32,13 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* client_ssl_auth filter: now sets additional termination details and **UAEX** response flag when the client certificate is not in the allowed-list.
 * config: configuration files ending in .yml now load as YAML.
 * config: configuration file extensions now ignore case when deciding the file type. E.g., .JSON file load as JSON.
 * config: reduced log level for "Unable to establish new stream" xDS logs to debug. The log level
   for "gRPC config stream closed" is now reduced to debug when the status is ``Ok`` or has been
   retriable (``DeadlineExceeded``, ``ResourceExhausted``, or ``Unavailable``) for less than 30
   seconds.
-* client_ssl_auth filter: now sets additional termination details and **UAEX** response flag when the client certificate is not in the allowed-list.
 * grpc: gRPC async client can be cached and shared across filter instances in the same thread, this feature is turned off by default, can be turned on by setting runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to true.
 * http: correct the use of the ``x-forwarded-proto`` header and the ``:scheme`` header. Where they differ
   (which is rare) ``:scheme`` will now be used for serving redirect URIs and cached content. This behavior

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,6 +38,7 @@ Minor Behavior Changes
   for "gRPC config stream closed" is now reduced to debug when the status is ``Ok`` or has been
   retriable (``DeadlineExceeded``, ``ResourceExhausted``, or ``Unavailable``) for less than 30
   seconds.
+* client_ssl_auth filter: now sets additional termination details and ``UAEX`` response flag when the client certificate is not in the allowed-list.
 * grpc: gRPC async client can be cached and shared across filter instances in the same thread, this feature is turned off by default, can be turned on by setting runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to true.
 * http: correct the use of the ``x-forwarded-proto`` header and the ``:scheme`` header. Where they differ
   (which is rare) ``:scheme`` will now be used for serving redirect URIs and cached content. This behavior

--- a/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
+++ b/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
@@ -22,11 +22,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ClientSslAuth {
 
-struct RcDetailsValues {
-  // SSL certificate is not in the allowed principals list.
-  const std::string AuthDigestNoMatch = "auth_digest_no_match";
-};
-using RcDetails = ConstSingleton<RcDetailsValues>;
+constexpr absl::string_view AuthDigestNoMatch = "auth_digest_no_match";
 
 ClientSslAuthConfig::ClientSslAuthConfig(
     const envoy::extensions::filters::network::client_ssl_auth::v3::ClientSSLAuth& config,
@@ -129,8 +125,7 @@ void ClientSslAuthFilter::onEvent(Network::ConnectionEvent event) {
           read_callbacks_->connection().ssl()->sha256PeerCertificateDigest())) {
     read_callbacks_->connection().streamInfo().setResponseFlag(
         StreamInfo::ResponseFlag::UpstreamProtocolError);
-    read_callbacks_->connection().streamInfo().setResponseCodeDetails(
-        RcDetails::get().AuthDigestNoMatch);
+    read_callbacks_->connection().streamInfo().setResponseCodeDetails(AuthDigestNoMatch);
     config_->stats().auth_digest_no_match_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     return;

--- a/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
+++ b/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
@@ -22,6 +22,12 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ClientSslAuth {
 
+struct RcDetailsValues {
+  // SSL certificate is not in the allowed principals list.
+  const std::string AuthDigestNoMatch = "auth_digest_no_match";
+};
+using RcDetails = ConstSingleton<RcDetailsValues>;
+
 ClientSslAuthConfig::ClientSslAuthConfig(
     const envoy::extensions::filters::network::client_ssl_auth::v3::ClientSSLAuth& config,
     ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
@@ -121,6 +127,10 @@ void ClientSslAuthFilter::onEvent(Network::ConnectionEvent event) {
 
   if (!config_->allowedPrincipals().allowed(
           read_callbacks_->connection().ssl()->sha256PeerCertificateDigest())) {
+    read_callbacks_->connection().streamInfo().setResponseFlag(
+        StreamInfo::ResponseFlag::UpstreamProtocolError);
+    read_callbacks_->connection().streamInfo().setResponseCodeDetails(
+        RcDetails::get().AuthDigestNoMatch);
     config_->stats().auth_digest_no_match_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     return;

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -163,6 +163,10 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
       std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1"));
   std::string expected_sha_1("digest");
   EXPECT_CALL(*ssl_, sha256PeerCertificateDigest()).WillOnce(ReturnRef(expected_sha_1));
+  EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError));
+  EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
+              setResponseCodeDetails("auth_digest_no_match"));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);


### PR DESCRIPTION
### Background

Currently, `client_ssl_auth` does not set any response flags or any other additional details while terminating the condition due to `auth_digest_no_match` error which occurs when the SSL certificate coming from the client is not in the allowed-list of principals.

**Motivation:** [See This](https://github.com/envoyproxy/envoy/issues/17847)

### Changes

This PR adds the response flag of `UAEX` and also sets `auth_digest_no_match` in the additional response details when the above mentioned conditions occur. 

---
**Commit Message:** set additional termination details and response flag for auth_digest_no_match in client_ssl_auth
**Additional Description:** See Background Section.
**Risk Level:** Low
**Testing:** Unit Tests
**Docs Changes:** N/A
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>