### PR TITLE
http3: sending goaways

### DIFF
--- a/source/common/quic/codec_impl.cc
+++ b/source/common/quic/codec_impl.cc
@@ -55,11 +55,7 @@ void QuicHttpServerConnectionImpl::shutdownNotice() {
 }
 
 void QuicHttpServerConnectionImpl::goAway() {
-// TODO(alyssawilk) remove these guards once QUICHE has been updated to remove
-// the perspective check.
-#if defined(NDEBUG)
-  quic_server_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "client goaway");
-#endif
+  quic_server_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "server shutdown imminent");
 }
 
 QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
@@ -76,7 +72,11 @@ QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
 }
 
 void QuicHttpClientConnectionImpl::goAway() {
-  quic_client_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "server shutdown imminent");
+// TODO(alyssawilk) remove these guards once QUICHE has been updated to remove
+// the perspective check.
+#if defined(NDEBUG)
+  quic_client_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "client goaway");
+#endif
 }
 
 Http::RequestEncoder&

--- a/source/common/quic/codec_impl.cc
+++ b/source/common/quic/codec_impl.cc
@@ -55,7 +55,11 @@ void QuicHttpServerConnectionImpl::shutdownNotice() {
 }
 
 void QuicHttpServerConnectionImpl::goAway() {
-  quic_server_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "server shutdown imminent");
+// TODO(alyssawilk) remove these guards once QUICHE has been updated to remove
+// the perspective check.
+#if defined(NDEBUG)
+  quic_server_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "client goaway");
+#endif
 }
 
 QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
@@ -69,6 +73,10 @@ QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
   session.setHttpConnectionCallbacks(callbacks);
   session.setMaxIncomingHeadersCount(max_response_headers_count);
   session.set_max_inbound_header_list_size(max_request_headers_kb * 1024);
+}
+
+void QuicHttpClientConnectionImpl::goAway() {
+  quic_client_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "server shutdown imminent");
 }
 
 Http::RequestEncoder&

--- a/source/common/quic/codec_impl.h
+++ b/source/common/quic/codec_impl.h
@@ -70,8 +70,8 @@ public:
   Http::RequestEncoder& newStream(Http::ResponseDecoder& response_decoder) override;
 
   // Http::Connection
-  void goAway() override { NOT_REACHED_GCOVR_EXCL_LINE; }
-  void shutdownNotice() override { NOT_REACHED_GCOVR_EXCL_LINE; }
+  void goAway() override;
+  void shutdownNotice() override {}
   void onUnderlyingConnectionAboveWriteBufferHighWatermark() override;
   void onUnderlyingConnectionBelowWriteBufferLowWatermark() override;
 

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -29,7 +29,6 @@ using ::testing::MatchesRegex;
 
 namespace Envoy {
 
-// TODO(#2557) fix all the failures.
 #define EXCLUDE_DOWNSTREAM_HTTP3                                                                   \
   if (downstreamProtocol() == Http::CodecType::HTTP3) {                                            \
     return;                                                                                        \
@@ -906,8 +905,7 @@ TEST_P(Http2IntegrationTest, GrpcRetry) { testGrpcRetry(); }
 
 // Verify the case where there is an HTTP/2 codec/protocol error with an active stream.
 TEST_P(Http2IntegrationTest, CodecErrorAfterStreamStart) {
-  // TODO(#16757) Needs HTTP/3 "bad frame" equivalent.
-  EXCLUDE_DOWNSTREAM_HTTP3;
+  EXCLUDE_DOWNSTREAM_HTTP3; // The HTTP/3 client has no "bad frame" equivalent.
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -940,7 +938,7 @@ TEST_P(Http2IntegrationTest, Http2BadMagic) {
 }
 
 TEST_P(Http2IntegrationTest, BadFrame) {
-  EXCLUDE_DOWNSTREAM_HTTP3; // Needs HTTP/3 "bad frame" equivalent.
+  EXCLUDE_DOWNSTREAM_HTTP3; // The HTTP/3 client has no "bad frame" equivalent.
 
   initialize();
   std::string response;
@@ -956,7 +954,6 @@ TEST_P(Http2IntegrationTest, BadFrame) {
 // Send client headers, a GoAway and then a body and ensure the full request and
 // response are received.
 TEST_P(Http2IntegrationTest, GoAway) {
-  EXCLUDE_DOWNSTREAM_HTTP3; // QuicHttpClientConnectionImpl::goAway NOT_REACHED_GCOVR_EXCL_LINE
   config_helper_.prependFilter(ConfigHelper::defaultHealthCheckFilter());
   initialize();
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -53,12 +53,6 @@ void setDoNotValidateRouteConfig(
   route_config->mutable_validate_clusters()->set_value(false);
 };
 
-// TODO(#2557) fix all the failures.
-#define EXCLUDE_DOWNSTREAM_HTTP3                                                                   \
-  if (downstreamProtocol() == Http::CodecType::HTTP3) {                                            \
-    return;                                                                                        \
-  }
-
 TEST_P(ProtocolIntegrationTest, TrailerSupportHttp1) {
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());


### PR DESCRIPTION
Fixing client side goaways to send (in opt mode) rather than crash.
In debug mode, this unfortunately still crashes due to an upstream quiche perspective check, so commenting that out and adding a TODO.

Risk Level: low
Testing: updated
Docs Changes: n/a
Release Notes: n/a
Fixes https://github.com/envoyproxy/envoy/issues/12930
