### PR TITLE
docs: add more description for max_connection_duration in timeout faqs

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -149,8 +149,9 @@ message HttpProtocolOptions {
 
   // The maximum duration of a connection. The duration is defined as a period since a connection
   // was established. If not set, there is no max duration. When max_connection_duration is reached
-  // the connection will be closed. Drain sequence will occur prior to closing the connection if
-  // if's applicable. See :ref:`drain_timeout
+  // the connection will be closed. Any inflight requests will still get processed correctly if this
+  // timeout fires during request processing. Drain sequence will occur prior to closing the connection
+  // if it's applicable. See :ref:`drain_timeout
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
   // Note: not implemented for upstream connections.
   google.protobuf.Duration max_connection_duration = 3;

--- a/docs/root/faq/configuration/timeouts.rst
+++ b/docs/root/faq/configuration/timeouts.rst
@@ -30,6 +30,21 @@ Connection timeouts apply to the entire HTTP connection and all streams the conn
   connections use the
   :ref:`common_http_protocol_options <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.common_http_protocol_options>` field in the Cluster's :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`, keyed by `envoy.extensions.upstreams.http.v3.HttpProtocolOptions`
 
+* The HTTP protocol :ref:`max_connection_duration <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>`
+  is defined in a generic message used by both the HTTP connection manager as well as upstream cluster
+  HTTP connections but is currently only implemented for the downstream connections. The maximum
+  connection duration is the time after which a downstream connection will be closed, starting from
+  when it first got established. If any inflight requests are being processed when this timeout fires,
+  then these will get processed correctly before the connection is closed. Drain sequence will occur
+  before closing the connection if it's applicable. The default value of max connection duration is *0*
+  or unlimited, which means that the connections will never be closed due to aging. It could be helpful
+  in scenarios when you are running a pool of Envoy edge-proxies and would want to close a downstream
+  connection after some time to prevent sticky-ness. It could also help to better load balance the overall
+  traffic among this pool, especially if the size of this pool is dynamically changing. To modify the max
+  connection duration for downstream connections use the
+  :ref:`common_http_protocol_options <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.common_http_protocol_options>`
+  field in the HTTP connection manager configuration.
+
 See :ref:`below <faq_configuration_timeouts_transport_socket>` for other connection timeouts.
 
 Stream timeouts


### PR DESCRIPTION
This PR adds some more description around `max_connection_duration` in the Timeout FAQs.

**Commit Message:** add more description for max_connection_duration in timeout faqs.
**Additional Description:** -
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** Added some more description around `max_connection_duration` in the Timeout FAQs.
**Release Notes:** N/A
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>