### PR TITLE
network: remove an assert

### DIFF
--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -13,16 +13,6 @@ bool MainThread::isMainThread() {
   return main_thread_singleton->inMainThread() || main_thread_singleton->inTestThread();
 }
 
-bool MainThread::isWorkerThread() {
-  auto main_thread_singleton = MainThreadSingleton::getExisting();
-  // Allow worker thread code to be executed in test thread.
-  if (main_thread_singleton == nullptr) {
-    return true;
-  }
-  // When threading is on, compare thread id with main thread id.
-  return !main_thread_singleton->inMainThread();
-}
-
 void MainThread::clear() {
   delete MainThreadSingleton::getExisting();
   MainThreadSingleton::clear();

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -194,7 +194,6 @@ struct MainThread {
    */
   static void clear();
   static bool isMainThread();
-  static bool isWorkerThread();
 
 private:
   std::thread::id main_thread_id_;

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -110,7 +110,6 @@ addressFromSockAddrOrDie(const sockaddr_storage& ss, socklen_t ss_len, os_fd_t f
   // address and the socket is actually v6 only, the returned address will be
   // regarded as a v6 address from dual stack socket. However, this address is not going to be
   // used to create socket. Wrong knowledge of dual stack support won't hurt.
-  ASSERT(Thread::MainThread::isWorkerThread());
   StatusOr<Address::InstanceConstSharedPtr> address =
       Address::addressFromSockAddr(ss, ss_len, v6only);
   if (!address.ok()) {

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -18,13 +18,11 @@ namespace ThreadLocal {
 TEST(MainThreadVerificationTest, All) {
   // Before threading is on, assertion on main thread should be true.
   EXPECT_TRUE(Thread::MainThread::isMainThread());
-  EXPECT_TRUE(Thread::MainThread::isWorkerThread());
   {
     InstanceImpl tls;
     // Tls instance has been initialized.
     // Call to main thread verification should succeed in main thread.
     EXPECT_TRUE(Thread::MainThread::isMainThread());
-    EXPECT_FALSE(Thread::MainThread::isWorkerThread());
     tls.shutdownGlobalThreading();
     tls.shutdownThread();
   }


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/16122 added asserts to utilities to make sure they were called from the correct thread.
Over on the Envoy mobile side when we do QUIC we're doing it from the main thread, and failing some of the assert checks.
I think the right thing to do here is just remove the assert

This is the only use of isWorkerThread()  so I'm inclined to just remove it.
cc @goaway 

Risk Level: n/a
Testing: n/a
Docs Changes:  n/a
Release Notes: n/a