### PR TITLE
tools: fix protoprint to respect CLANG_FORMAT env var

### DIFF
--- a/tools/protoxform/protoprint.py
+++ b/tools/protoxform/protoprint.py
@@ -82,8 +82,9 @@ def clang_format(contents):
     Returns:
         clang-formatted string
     """
+    clang_format_path = os.getenv("CLANG_FORMAT", "clang-format-11")
     return subprocess.run(
-        ['clang-format',
+        [clang_format_path,
          '--style=%s' % CLANG_FORMAT_STYLE, '--assume-filename=.proto'],
         input=contents.encode('utf-8'),
         stdout=subprocess.PIPE).stdout


### PR DESCRIPTION
On OSX with `clang-format` 12.0.1 and `clang-format-11` installed elsewhere with `CLANG_FORMAT=/usr/local/opt/llvm@11/bin/clang-format`, I noticed that `tools/proto_format/proto_format.sh fix` produced an odd diff on `api/envoy/extensions/filters/http/jwt_authn/v3/config.proto`.

After some digging, I found that protoprint.py was invoking clang-format directly instead of consulting `CLANG_FORMAT`. This PR fixes that behavior, taking precedent from `tools/code_format/check_format.py`

Commit Message: tools: fix protoprint to respect CLANG_FORMAT env var
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
