### PR TITLE
docs: Fix build rst/html script

### DIFF
--- a/ci/upload_gcs_artifact.sh
+++ b/ci/upload_gcs_artifact.sh
@@ -24,7 +24,7 @@ if [[ "$BUILD_REASON" == "PullRequest" ]] || [[ "$TARGET_SUFFIX" == "docs" ]]; t
     #      -> https://storage.googleapis.com/envoy-postsubmit/$UPLOAD_PATH/docs/envoy-docs-rst.tar.gz
     # - PR build (commit sha from the developers branch)
     #      -> https://storage.googleapis.com/envoy-pr/$UPLOAD_PATH/$TARGET_SUFFIX
-    UPLOAD_PATH="$(git log --pretty=%P -n 1 | cut -d' ' -f2 | head -c7)"
+    UPLOAD_PATH="$(git rev-parse HEAD | head -c7)"
 else
     UPLOAD_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
 fi

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -19,17 +19,18 @@ fi
 MAIN_BRANCH="refs/heads/main"
 RELEASE_TAG_REGEX="^refs/tags/v.*"
 
+# default is to build html only
+BUILD_TYPE=html
+
 if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
     DOCS_TAG="${AZP_BRANCH/refs\/tags\//}"
     export DOCS_TAG
-    # no need to build rst explicitly, just html
-    HTML_ONLY=true
 else
     BUILD_SHA=$(git rev-parse HEAD)
     export BUILD_SHA
     if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
         # no need to build html, just rst
-        RST_ONLY=true
+        BUILD_TYPE=rst
     fi
 fi
 
@@ -41,10 +42,10 @@ BAZEL_BUILD_OPTIONS+=(
     "--action_env=SPHINX_SKIP_CONFIG_VALIDATION")
 
 # Building html/rst is determined by then needs of CI but can be overridden in dev.
-if [[ -z "${RST_ONLY}" ]] || [[ -n "${DOCS_BUILD_HTML}" ]]; then
+if [[ "${BUILD_TYPE}" == "html" ]] || [[ -n "${DOCS_BUILD_HTML}" ]]; then
     BUILD_HTML=1
 fi
-if [[ -z "${HTML_ONLY}" ]] || [[ -n "${DOCS_BUILD_RST}" ]]; then
+if [[ "${BUILD_TYPE}" == "rst" ]] || [[ -n "${DOCS_BUILD_RST}" ]]; then
     BUILD_RST=1
 fi
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Fix build rst/html script
Additional Description:

fix the docs build script to only build html *or* rst, by default

also fixes the commit sha so that the docs are pushed with the correct tag

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
