### PR TITLE
oauth2: Allow to customize cookie names

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
@@ -37,6 +37,24 @@ message OAuth2Credentials {
     transport_sockets.tls.v3.SdsSecretConfig hmac_secret = 3
         [(validate.rules).message = {required: true}];
   }
+
+  message CookieNames {
+    // Cookie name to hold OAuth bearer token value. When the authentication server validates the
+    // client and returns an authorization token back to the OAuth filter, no matter what format
+    // that token is, if :ref:`forward_bearer_token <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.forward_bearer_token>`
+    // is set to true the filter will send over the bearer token as a cookie with this name to the
+    // upstream. Defaults to ``BearerToken``.
+    string bearer_token = 1;
+
+    // Cookie name to hold OAuth HMAC value. Defaults to ``OauthHMAC``.
+    string oauth_hmac = 2;
+
+    // Cookie name to hold OAuth expiry value. Defaults to ``OauthExpires``.
+    string oauth_expires = 3;
+  }
+
+  // The cookie names used in OAuth filters flow.
+  CookieNames cookie_names = 4;
 }
 
 // OAuth config

--- a/docs/root/configuration/http/http_filters/oauth2_filter.rst
+++ b/docs/root/configuration/http/http_filters/oauth2_filter.rst
@@ -36,6 +36,12 @@ is set to true the filter will send over a
 cookie named ``BearerToken`` to the upstream. Additionally, the ``Authorization`` header will be populated
 with the same value.
 
+.. note::
+  By default, OAuth2 filter sets some cookies with the following names:
+  ``BearerToken``, ``OauthHMAC``, and ``OauthExpires``. These cookie names can be customized by
+  setting
+  :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Credentials.cookie_names>`.
+
 .. attention::
 
   The OAuth2 filter is currently under active development.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -114,6 +114,7 @@ New Features
 * jwt_authn: added support for extracting JWTs from request cookies using :ref:`from_cookies <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.from_cookies>`.
 * listener: new listener metric ``downstream_cx_transport_socket_connect_timeout`` to track transport socket timeouts.
 * matcher: added :ref:`invert <envoy_v3_api_field_type.matcher.v3.MetadataMatcher.invert>` for inverting the match result in the metadata matcher.
+* oauth filter: added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.
 * overload: add a new overload action that resets streams using a lot of memory. To enable the tracking of allocated bytes in buffers that a stream is using we need to configure the minimum threshold for tracking via:ref:`buffer_factory_config <envoy_v3_api_field_config.overload.v3.OverloadManager.buffer_factory_config>`. We have an overload action ``Envoy::Server::OverloadActionNameValues::ResetStreams`` that takes advantage of the tracking to reset the most expensive stream first.
 * rbac: added :ref:`destination_port_range <envoy_v3_api_field_config.rbac.v3.Permission.destination_port_range>` for matching range of destination ports.
 * route config: added :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RouteMatch.dynamic_metadata>` for routing based on dynamic metadata.

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -36,11 +36,13 @@ namespace {
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
     authorization_handle(Http::CustomHeaders::get().Authorization);
 
-constexpr absl::string_view SignoutCookieValue =
-    "OauthHMAC=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+// Deleted OauthHMAC cookie.
+constexpr const char* SignoutCookieValue =
+    "{}=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 
-constexpr absl::string_view SignoutBearerTokenValue =
-    "BearerToken=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+// Deleted BearerToken cookie.
+constexpr const char* SignoutBearerTokenValue =
+    "{}=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 
 constexpr const char* CookieTailFormatString = ";version=1;path=/;Max-Age={};secure";
 
@@ -130,7 +132,8 @@ FilterConfig::FilterConfig(
           absl::StrJoin(authScopesList(proto_config.auth_scopes()), " "), ":/=&? ")),
       encoded_resource_query_params_(encodeResourceList(proto_config.resources())),
       forward_bearer_token_(proto_config.forward_bearer_token()),
-      pass_through_header_matchers_(headerMatchers(proto_config.pass_through_matcher())) {
+      pass_through_header_matchers_(headerMatchers(proto_config.pass_through_matcher())),
+      cookie_names_(proto_config.credentials().cookie_names()) {
   if (!cluster_manager.clusters().hasCluster(oauth_token_endpoint_.cluster())) {
     throw EnvoyException(fmt::format("OAuth2 filter: unknown cluster '{}' in config. Please "
                                      "specify which cluster to direct OAuth requests to.",
@@ -144,13 +147,14 @@ FilterStats FilterConfig::generateStats(const std::string& prefix, Stats::Scope&
 
 void OAuth2CookieValidator::setParams(const Http::RequestHeaderMap& headers,
                                       const std::string& secret) {
-  const auto& cookies = Http::Utility::parseCookies(headers, [](absl::string_view key) -> bool {
-    return key == "OauthExpires" || key == "BearerToken" || key == "OauthHMAC";
+  const auto& cookies = Http::Utility::parseCookies(headers, [this](absl::string_view key) -> bool {
+    return key == cookie_names_.oauth_expires_ || key == cookie_names_.bearer_token_ ||
+           key == cookie_names_.oauth_hmac_;
   });
 
-  expires_ = findValue(cookies, "OauthExpires");
-  token_ = findValue(cookies, "BearerToken");
-  hmac_ = findValue(cookies, "OauthHMAC");
+  expires_ = findValue(cookies, cookie_names_.oauth_expires_);
+  token_ = findValue(cookies, cookie_names_.bearer_token_);
+  hmac_ = findValue(cookies, cookie_names_.oauth_hmac_);
   host_ = headers.Host()->value().getStringView();
 
   secret_.assign(secret.begin(), secret.end());
@@ -180,7 +184,7 @@ bool OAuth2CookieValidator::isValid() const { return hmacIsValid() && timestampI
 
 OAuth2Filter::OAuth2Filter(FilterConfigSharedPtr config,
                            std::unique_ptr<OAuth2Client>&& oauth_client, TimeSource& time_source)
-    : validator_(std::make_shared<OAuth2CookieValidator>(time_source)),
+    : validator_(std::make_shared<OAuth2CookieValidator>(time_source, config->cookieNames())),
       oauth_client_(std::move(oauth_client)), config_(std::move(config)),
       time_source_(time_source) {
 
@@ -397,8 +401,12 @@ Http::FilterHeadersStatus OAuth2Filter::signOutUser(const Http::RequestHeaderMap
       {{Http::Headers::get().Status, std::to_string(enumToInt(Http::Code::Found))}})};
 
   const std::string new_path = absl::StrCat(Http::Utility::getScheme(headers), "://", host_, "/");
-  response_headers->addReference(Http::Headers::get().SetCookie, SignoutCookieValue);
-  response_headers->addReference(Http::Headers::get().SetCookie, SignoutBearerTokenValue);
+  response_headers->addReferenceKey(
+      Http::Headers::get().SetCookie,
+      fmt::format(SignoutCookieValue, config_->cookieNames().oauth_hmac_));
+  response_headers->addReferenceKey(
+      Http::Headers::get().SetCookie,
+      fmt::format(SignoutBearerTokenValue, config_->cookieNames().bearer_token_));
   response_headers->setLocation(new_path);
   decoder_callbacks_->encodeHeaders(std::move(response_headers), true, SIGN_OUT);
 
@@ -457,18 +465,21 @@ void OAuth2Filter::finishFlow() {
   Http::ResponseHeaderMapPtr response_headers{Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
       {{Http::Headers::get().Status, std::to_string(enumToInt(Http::Code::Found))}})};
 
+  const CookieNames& cookie_names = config_->cookieNames();
+
   response_headers->addReferenceKey(
       Http::Headers::get().SetCookie,
-      absl::StrCat("OauthHMAC=", encoded_token, cookie_tail_http_only));
+      absl::StrCat(cookie_names.oauth_hmac_, "=", encoded_token, cookie_tail_http_only));
   response_headers->addReferenceKey(
       Http::Headers::get().SetCookie,
-      absl::StrCat("OauthExpires=", new_expires_, cookie_tail_http_only));
+      absl::StrCat(cookie_names.oauth_expires_, "=", new_expires_, cookie_tail_http_only));
 
   // If opted-in, we also create a new Bearer cookie for the authorization token provided by the
   // auth server.
   if (config_->forwardBearerToken()) {
-    response_headers->addReferenceKey(Http::Headers::get().SetCookie,
-                                      absl::StrCat("BearerToken=", access_token_, cookie_tail));
+    response_headers->addReferenceKey(
+        Http::Headers::get().SetCookie,
+        absl::StrCat(cookie_names.bearer_token_, "=", access_token_, cookie_tail));
   }
 
   response_headers->setLocation(state_);

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -95,6 +95,27 @@ struct FilterStats {
 };
 
 /**
+ * Helper structure to hold custom cookie names.
+ */
+struct CookieNames {
+  CookieNames(
+      const envoy::extensions::filters::http::oauth2::v3alpha::OAuth2Credentials::CookieNames&
+          cookie_names)
+      : CookieNames(cookie_names.bearer_token(), cookie_names.oauth_hmac(),
+                    cookie_names.oauth_expires()) {}
+
+  CookieNames(const std::string& bearer_token, const std::string& oauth_hmac,
+              const std::string& oauth_expires)
+      : bearer_token_(bearer_token.empty() ? "BearerToken" : bearer_token),
+        oauth_hmac_(oauth_hmac.empty() ? "OauthHMAC" : oauth_hmac),
+        oauth_expires_(oauth_expires.empty() ? "OauthExpires" : oauth_expires) {}
+
+  std::string bearer_token_;
+  std::string oauth_hmac_;
+  std::string oauth_expires_;
+};
+
+/**
  * This class encapsulates all data needed for the filter to operate so that we don't pass around
  * raw protobufs and other arbitrary data.
  */
@@ -123,6 +144,7 @@ public:
   FilterStats& stats() { return stats_; }
   const std::string& encodedAuthScopes() const { return encoded_auth_scopes_; }
   const std::string& encodedResourceQueryParams() const { return encoded_resource_query_params_; }
+  const CookieNames& cookieNames() const { return cookie_names_; }
 
 private:
   static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -139,6 +161,7 @@ private:
   const std::string encoded_resource_query_params_;
   const bool forward_bearer_token_ : 1;
   const std::vector<Http::HeaderUtility::HeaderData> pass_through_header_matchers_;
+  const CookieNames cookie_names_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
@@ -164,7 +187,8 @@ public:
 
 class OAuth2CookieValidator : public CookieValidator {
 public:
-  explicit OAuth2CookieValidator(TimeSource& time_source) : time_source_(time_source) {}
+  explicit OAuth2CookieValidator(TimeSource& time_source, const CookieNames& cookie_names)
+      : time_source_(time_source), cookie_names_(cookie_names) {}
 
   const std::string& token() const override { return token_; }
   void setParams(const Http::RequestHeaderMap& headers, const std::string& secret) override;
@@ -179,6 +203,7 @@ private:
   std::vector<uint8_t> secret_;
   absl::string_view host_;
   TimeSource& time_source_;
+  const CookieNames cookie_names_;
 };
 
 /**

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -86,6 +86,10 @@ config:
       name: token
     hmac_secret:
       name: hmac
+    cookie_names:
+      bearer_token: BearerToken
+      oauth_hmac: OauthHMAC
+      oauth_expires: OauthExpires
   authorization_endpoint: https://oauth.com/oauth/authorize/
   redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
   redirect_path_matcher:

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -119,6 +119,8 @@ public:
     credentials->set_client_id(TEST_CLIENT_ID);
     credentials->mutable_token_secret()->set_name("secret");
     credentials->mutable_hmac_secret()->set_name("hmac");
+    // Skipping setting credentials.cookie_names field should give default cookie names:
+    // BearerToken, OauthHMAC, and OauthExpires.
 
     MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
 
@@ -139,6 +141,43 @@ public:
     auto callbacks = callbacks_.front();
     callbacks_.pop_front();
     return callbacks;
+  }
+
+  // Validates the behavior of the cookie validator.
+  void expectValidCookies(const CookieNames& cookie_names) {
+    // Set SystemTime to a fixed point so we get consistent HMAC encodings between test runs.
+    test_time_.setSystemTime(SystemTime(std::chrono::seconds(0)));
+
+    const auto expires_at_s = DateUtil::nowToSeconds(test_time_.timeSystem()) + 10;
+
+    Http::TestRequestHeaderMapImpl request_headers{
+        {Http::Headers::get().Host.get(), "traffic.example.com"},
+        {Http::Headers::get().Path.get(), "/anypath"},
+        {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+        {Http::Headers::get().Cookie.get(),
+         fmt::format("{}={};version=test", cookie_names.oauth_expires_, expires_at_s)},
+        {Http::Headers::get().Cookie.get(),
+         absl::StrCat(cookie_names.bearer_token_, "=xyztoken;version=test")},
+        {Http::Headers::get().Cookie.get(),
+         absl::StrCat(cookie_names.oauth_hmac_, "="
+                                                "NGQ3MzVjZGExNGM5NTFiZGJjODBkMjBmYjAyYjNiOTFjMmNjYj"
+                                                "IxMTUzNmNiNWU0NjQzMmMxMWUzZmE2ZWJjYg=="
+                                                ";version=test")},
+    };
+
+    auto cookie_validator = std::make_shared<OAuth2CookieValidator>(test_time_, cookie_names);
+    EXPECT_EQ(cookie_validator->token(), "");
+    cookie_validator->setParams(request_headers, "mock-secret");
+
+    EXPECT_TRUE(cookie_validator->hmacIsValid());
+    EXPECT_TRUE(cookie_validator->timestampIsValid());
+    EXPECT_TRUE(cookie_validator->isValid());
+
+    // If we advance time beyond 10s the timestamp should no longer be valid.
+    test_time_.advanceTimeWait(std::chrono::seconds(11));
+
+    EXPECT_FALSE(cookie_validator->timestampIsValid());
+    EXPECT_FALSE(cookie_validator->isValid());
   }
 
   NiceMock<Event::MockTimer>* attachmentTimeout_timer_{};
@@ -493,37 +532,12 @@ TEST_F(OAuth2Test, OAuthOptionsRequestAndContinue) {
 
 // Validates the behavior of the cookie validator.
 TEST_F(OAuth2Test, CookieValidator) {
-  // Set SystemTime to a fixed point so we get consistent HMAC encodings between test runs.
-  test_time_.setSystemTime(SystemTime(std::chrono::seconds(0)));
+  expectValidCookies(CookieNames{"BearerToken", "OauthHMAC", "OauthExpires"});
+}
 
-  const auto expires_at_s = DateUtil::nowToSeconds(test_time_.timeSystem()) + 10;
-
-  Http::TestRequestHeaderMapImpl request_headers{
-      {Http::Headers::get().Host.get(), "traffic.example.com"},
-      {Http::Headers::get().Path.get(), "/anypath"},
-      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-      {Http::Headers::get().Cookie.get(),
-       fmt::format("OauthExpires={};version=test", expires_at_s)},
-      {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken;version=test"},
-      {Http::Headers::get().Cookie.get(),
-       "OauthHMAC="
-       "NGQ3MzVjZGExNGM5NTFiZGJjODBkMjBmYjAyYjNiOTFjMmNjYjIxMTUzNmNiNWU0NjQzMmMxMWUzZmE2ZWJjYg=="
-       ";version=test"},
-  };
-
-  auto cookie_validator = std::make_shared<OAuth2CookieValidator>(test_time_);
-  EXPECT_EQ(cookie_validator->token(), "");
-  cookie_validator->setParams(request_headers, "mock-secret");
-
-  EXPECT_TRUE(cookie_validator->hmacIsValid());
-  EXPECT_TRUE(cookie_validator->timestampIsValid());
-  EXPECT_TRUE(cookie_validator->isValid());
-
-  // If we advance time beyond 10s the timestamp should no longer be valid.
-  test_time_.advanceTimeWait(std::chrono::seconds(11));
-
-  EXPECT_FALSE(cookie_validator->timestampIsValid());
-  EXPECT_FALSE(cookie_validator->isValid());
+// Validates the behavior of the cookie validator with custom cookie names.
+TEST_F(OAuth2Test, CookieValidatorWithCustomNames) {
+  expectValidCookies(CookieNames{"CustomBearerToken", "CustomOauthHMAC", "CustomOauthExpires"});
 }
 
 // Validates the behavior of the cookie validator when the expires_at value is not a valid integer.
@@ -540,7 +554,8 @@ TEST_F(OAuth2Test, CookieValidatorInvalidExpiresAt) {
        ";version=test"},
   };
 
-  auto cookie_validator = std::make_shared<OAuth2CookieValidator>(test_time_);
+  auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
+      test_time_, CookieNames{"BearerToken", "OauthHMAC", "OauthExpires"});
   cookie_validator->setParams(request_headers, "mock-secret");
 
   EXPECT_TRUE(cookie_validator->hmacIsValid());


### PR DESCRIPTION
Commit Message: This patch adds `cookie_names` to the credentials config to allow overriding the default cookie names: `BearerToken`, `OauthHMAC`, and `OauthExpires`.

Additional Description:
Risk Level: Low, added knobs to override the current defaults
Testing: Added.
Docs Changes: Updated
Release Notes: Added
Platform-Specific Features: N/A
Fixes #18164

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>

