### PR TITLE
dns cache: allow lookup of an extant dns cache by name

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -221,6 +221,13 @@ public:
    */
   virtual DnsCacheSharedPtr
   getCache(const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config) PURE;
+
+  /**
+   * Look up an existing DNS cache by name.
+   * @param name supplies the cache name to look up. If a cache exists with the same name it
+   *             will be returned.
+   */
+  virtual absl::optional<DnsCacheSharedPtr> lookUpCacheByName(absl::string_view cache_name) PURE;
 };
 
 using DnsCacheManagerSharedPtr = std::shared_ptr<DnsCacheManager>;

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -31,6 +31,16 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
   return new_cache;
 }
 
+absl::optional<DnsCacheSharedPtr> DnsCacheManagerImpl::lookUpCacheByName(
+    absl::string_view cache_name) {
+  const auto& existing_cache = caches_.find(cache_name);
+  if (existing_cache != caches_.end()) {
+    return existing_cache->second.cache_;
+  }
+
+  return absl::nullopt;
+}
+
 DnsCacheManagerSharedPtr DnsCacheManagerFactoryImpl::get() {
   return context_.singletonManager().getTyped<DnsCacheManager>(
       SINGLETON_MANAGER_REGISTERED_NAME(dns_cache_manager),

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
@@ -19,6 +19,8 @@ public:
   // DnsCacheManager
   DnsCacheSharedPtr getCache(
       const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config) override;
+  absl::optional<DnsCacheSharedPtr> lookUpCacheByName(
+      absl::string_view cache_name) override;
 
 private:
   struct ActiveCache {


### PR DESCRIPTION
Commit Message: dns cache: allow lookup of an extant dns cache by name
Additional Description: The current mechanism to find an existing DNS cache requires one to provide identical proto config to do the lookup. Depending on the context, locating or recreating the full proto may be complicated. This change allows existing DNS caches to be retrieved solely via their name.
Risk Level: Low
Testing:

Signed-off-by: Mike Schore <mike.schore@gmail.com>