### PR TITLE
Remove useless comment for ConnectionInfoProvider

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -47,8 +47,6 @@ private:
  * Interfaces for providing a socket's various addresses. This is split into a getters interface
  * and a getters + setters interface. This is so that only the getters portion can be overridden
  * in certain cases.
- * TODO(soulxu): Since there are more than address information inside the provider, this will be
- * renamed as ConnectionInfoProvider. Ref https://github.com/envoyproxy/envoy/issues/17168
  */
 class ConnectionInfoProvider {
 public:


### PR DESCRIPTION
Commit Message: Remove useless comment for ConnectionInfoProvider
Additional Description:
Already finished the rename task, so remove that comment.
Risk Level: low
Testing: N/A

Signed-off-by: He Jie Xu <hejie.xu@intel.com>