### PR TITLE
bazel: Add build options for su-exec

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -135,7 +135,7 @@ function bazel_binary_build() {
   fi
 
   # Build su-exec utility
-  bazel build external:su-exec
+  bazel build "${BAZEL_BUILD_OPTIONS[@]}" external:su-exec
   cp_binary_for_image_build "${BINARY_TYPE}" "${COMPILE_TYPE}" "${EXE_NAME}"
 }
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: bazel: Add build options for su-exec
Additional Description:

When checking that bazel commands had been added correctly in ci, i noticed that this build command is missing build options

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
