### PR TITLE
proxy_protocol: fix IOCallResult error checks

### DIFF
--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -456,7 +456,7 @@ ReadOrParseState Filter::readProxyHeader(Network::IoHandle& io_handle) {
       if (buf_off_ < PROXY_PROTO_V2_HEADER_LEN) {
         ssize_t exp = PROXY_PROTO_V2_HEADER_LEN - buf_off_;
         const auto read_result = io_handle.recv(buf_ + buf_off_, exp, 0);
-        if (!result.ok() || read_result.return_value_ != uint64_t(exp)) {
+        if (!read_result.ok() || read_result.return_value_ != uint64_t(exp)) {
           ENVOY_LOG(debug, "failed to read proxy protocol (remote closed)");
           return ReadOrParseState::Error;
         }
@@ -478,7 +478,7 @@ ReadOrParseState Filter::readProxyHeader(Network::IoHandle& io_handle) {
       if (ssize_t(buf_off_) + nread >= PROXY_PROTO_V2_HEADER_LEN + addr_len) {
         ssize_t missing = (PROXY_PROTO_V2_HEADER_LEN + addr_len) - buf_off_;
         const auto read_result = io_handle.recv(buf_ + buf_off_, missing, 0);
-        if (!result.ok() || read_result.return_value_ != uint64_t(missing)) {
+        if (!read_result.ok() || read_result.return_value_ != uint64_t(missing)) {
           ENVOY_LOG(debug, "failed to read proxy protocol (remote closed)");
           return ReadOrParseState::Error;
         }


### PR DESCRIPTION
Signed-off-by: James Heppenstall <james.heppenstall@mongodb.com>

**Commit Message:** proxy_protocol: fix IOCallResult error checks
**Additional Description:** There are two redundant `result.ok()` checks in `Envoy::Extensions::ListenerFilters::ProxyProtocol::readProxyHeader`. It appears that these are typos and the checks should instead be `read_result.ok()`.
**Risk Level:** Low
**Testing:** Manual
**Docs Changes:** N/A
**Release Notes:** N/A
**Platform Specific Features:** N/A
