### PR TITLE
dns cache manager: lookup cache by name

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -221,6 +221,14 @@ public:
    */
   virtual DnsCacheSharedPtr
   getCache(const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config) PURE;
+
+  /**
+   * Look up an existing DNS cache by name.
+   * @param name supplies the cache name to look up. If a cache exists with the same name it
+   *             will be returned.
+   * @return pointer to the cache if it exists, nullptr otherwise.
+   */
+  virtual DnsCacheSharedPtr lookUpCacheByName(absl::string_view cache_name) PURE;
 };
 
 using DnsCacheManagerSharedPtr = std::shared_ptr<DnsCacheManager>;

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -32,6 +32,7 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
 }
 
 DnsCacheSharedPtr DnsCacheManagerImpl::lookUpCacheByName(absl::string_view cache_name) {
+  ASSERT(context_.mainThreadDispatcher().isThreadSafe());
   const auto& existing_cache = caches_.find(cache_name);
   if (existing_cache != caches_.end()) {
     return existing_cache->second.cache_;

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -31,6 +31,15 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
   return new_cache;
 }
 
+DnsCacheSharedPtr DnsCacheManagerImpl::lookUpCacheByName(absl::string_view cache_name) {
+  const auto& existing_cache = caches_.find(cache_name);
+  if (existing_cache != caches_.end()) {
+    return existing_cache->second.cache_;
+  }
+
+  return nullptr;
+}
+
 DnsCacheManagerSharedPtr DnsCacheManagerFactoryImpl::get() {
   return context_.singletonManager().getTyped<DnsCacheManager>(
       SINGLETON_MANAGER_REGISTERED_NAME(dns_cache_manager),

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
@@ -19,6 +19,7 @@ public:
   // DnsCacheManager
   DnsCacheSharedPtr getCache(
       const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config) override;
+  DnsCacheSharedPtr lookUpCacheByName(absl::string_view cache_name) override;
 
 private:
   struct ActiveCache {

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -975,6 +975,23 @@ TEST(DnsCacheManagerImplTest, LoadViaConfig) {
                             "config specified DNS cache 'foo' with different settings");
 }
 
+TEST(DnsCacheManagerImplTest, LookupByName) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  DnsCacheManagerImpl cache_manager(context);
+
+  EXPECT_EQ(cache_manager.lookUpCacheByName("foo"), nullptr);
+
+  envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig config1;
+  config1.set_name("foo");
+
+  auto cache1 = cache_manager.getCache(config1);
+  EXPECT_NE(cache1, nullptr);
+
+  auto cache2 = cache_manager.lookUpCacheByName("foo");
+  EXPECT_NE(cache2, nullptr);
+  EXPECT_EQ(cache1, cache2);
+}
+
 TEST(DnsCacheConfigOptionsTest, EmtpyDnsResolutionConfig) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig config;

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -77,6 +77,7 @@ public:
 
   MOCK_METHOD(DnsCacheSharedPtr, getCache,
               (const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config));
+  MOCK_METHOD(DnsCacheSharedPtr, lookUpCacheByName, (absl::string_view cache_name));
 
   std::shared_ptr<NiceMock<MockDnsCache>> dns_cache_{new NiceMock<MockDnsCache>()};
 };


### PR DESCRIPTION
Commit Message: dns cache manager - lookup cache by name
Additional Description: the existing lookup function, which requires a config object, is not ergonomic in places where synthesizing such a config is convoluted.
Risk Level: low - new API
Testing: new unit tests

Signed-off-by: Jose Nino <jnino@lyft.com>
Co-Authored-By: Mike Schore <mike.schore@gmail.com>