### PR TITLE
bazel: add root `envoy` alias

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,6 +8,11 @@ exports_files([
     ".coveragerc",
 ])
 
+alias(
+    name = "envoy",
+    actual = "//source/exe:envoy",
+)
+
 # These two definitions exist to help reduce Envoy upstream core code depending on extensions.
 # To avoid visibility problems, see notes in source/extensions/extensions_build_config.bzl
 #

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -30,7 +30,7 @@ dependencies](https://www.envoyproxy.io/docs/envoy/latest/start/building#require
 independently sourced, the following steps should be followed:
 
 1. Configure, build and/or install the [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/start/building#requirements).
-1. `bazel build -c opt //source/exe:envoy-static` from the repository root.
+1. `bazel build -c opt envoy` from the repository root.
 
 ## Quick start Bazel build for developers
 
@@ -236,7 +236,7 @@ for how to update or override dependencies.
    in your shell for buildifier to work.
 1. `go get -u github.com/bazelbuild/buildtools/buildozer` to install buildozer. You may need to set `BUILDOZER_BIN` to `$GOPATH/bin/buildozer`
    in your shell for buildozer to work.
-1. `bazel build //source/exe:envoy-static` from the Envoy source directory. Add `-c opt` for an optimized release build or
+1. `bazel build envoy` from the Envoy source directory. Add `-c opt` for an optimized release build or
    `-c dbg` for an unoptimized, fully instrumented debugging build.
 
 ## Building Envoy with the CI Docker image
@@ -270,7 +270,7 @@ To build Envoy with a remote build services, run Bazel with your remote build se
 For example the following command runs build with the GCP RBE service used in CI:
 
 ```
-bazel build //source/exe:envoy-static --config=remote-clang \
+bazel build envoy --config=remote-clang \
     --remote_cache=grpcs://remotebuildexecution.googleapis.com \
     --remote_executor=grpcs://remotebuildexecution.googleapis.com \
     --remote_instance_name=projects/envoy-ci/instances/default_instance
@@ -289,7 +289,7 @@ Building Envoy with Docker sandbox uses the same Docker image used in CI with fi
 output which is not depending on your local C++ toolchain. It can also help debugging issues with RBE. To build Envoy with Docker sandbox:
 
 ```
-bazel build //source/exe:envoy-static --config=docker-clang
+bazel build envoy --config=docker-clang
 ```
 
 Tests can be run in docker sandbox too. Note that the network environment, such as IPv6, may be different in the docker sandbox so you may want
@@ -299,7 +299,7 @@ set different options. See below to configure test IP versions.
 
 To link Envoy against libc++, follow the [quick start](#quick-start-bazel-build-for-developers) to setup Clang+LLVM and run:
 ```
-bazel build --config=libc++ //source/exe:envoy-static
+bazel build --config=libc++ envoy
 ```
 
 Or use our configuration with Remote Execution or Docker sandbox, pass `--config=remote-clang-libc++` or
@@ -522,14 +522,14 @@ that Bazel supports:
 You can use the `-c <compilation_mode>` flag to control this, e.g.
 
 ```
-bazel build -c opt //source/exe:envoy-static
+bazel build -c opt envoy
 ```
 
 To override the compilation mode and optimize the build for binary size, you can
 use the `sizeopt` configuration:
 
 ```
-bazel build //source/exe:envoy-static --config=sizeopt
+bazel build envoy --config=sizeopt
 ```
 
 ## Sanitizers
@@ -751,7 +751,7 @@ They should also ignore any local `.bazelrc` for reproducibility. This can be
 achieved with:
 
 ```
-bazel --bazelrc=/dev/null build -c opt //source/exe:envoy-static.stripped
+bazel --bazelrc=/dev/null build -c opt envoy.stripped
 ```
 
 One caveat to note is that the Git SHA1 is truncated to 16 bytes today as a
@@ -818,7 +818,7 @@ resources, you can override Bazel's default job parallelism determination with
 `--jobs=N` to restrict the build to at most `N` simultaneous jobs, e.g.:
 
 ```
-bazel build --jobs=2 //source/exe:envoy-static
+bazel build --jobs=2 envoy
 ```
 
 # Debugging the Bazel build
@@ -827,19 +827,19 @@ When trying to understand what Bazel is doing, the `-s` and `--explain` options
 are useful. To have Bazel provide verbose output on which commands it is executing:
 
 ```
-bazel build -s //source/exe:envoy-static
+bazel build -s envoy
 ```
 
 To have Bazel emit to a text file the rationale for rebuilding a target:
 
 ```
-bazel build --explain=file.txt //source/exe:envoy-static
+bazel build --explain=file.txt envoy
 ```
 
 To get more verbose explanations:
 
 ```
-bazel build --explain=file.txt --verbose_explanations //source/exe:envoy-static
+bazel build --explain=file.txt --verbose_explanations envoy
 ```
 
 # Resolving paths in bazel build output


### PR DESCRIPTION
This is a minor quality of life improvement to just be able to run
`bazel build envoy`

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>