### PR TITLE
runtime: disable deprecated extensions names by default

### DIFF
--- a/contrib/squash/filters/http/test/config_test.cc
+++ b/contrib/squash/filters/http/test/config_test.cc
@@ -36,11 +36,12 @@ TEST(SquashFilterConfigFactoryTest, SquashFilterCorrectYaml) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(SquashFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.squash";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -28,11 +28,8 @@ Incompatible Behavior Changes
   renumbered fields have the types expected by those releases.
 * ext_authz: fixed skipping authentication when returning either a direct response or a redirect. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.http_ext_authz_do_not_skip_direct_response_and_redirect`` runtime guard to false.
 * extensions: deprecated extension names now default to triggering a configuration error.
-  The previous warning-only behavior can be reverted by setting the runtime key
+  The previous warning-only behavior may be temporarily reverted by setting the runtime key
   ``envoy.deprecated_features.allow_deprecated_extension_names`` to true.
-* grpc_bridge_filter: the filter no longer collects grpc stats in favor of the existing grpc stats filter.
-  The behavior can be reverted by changing runtime key ``envoy.reloadable_features.grpc_bridge_stats_disabled``.
-* tracing: update Apache SkyWalking tracer version to be compatible with 8.4.0 data collect protocol. This change will introduce incompatibility with SkyWalking 8.3.0.
 
 Minor Behavior Changes
 ----------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -27,7 +27,7 @@ Incompatible Behavior Changes
   vendor the corresponding protobuf definitions to ensure that the
   renumbered fields have the types expected by those releases.
 * ext_authz: fixed skipping authentication when returning either a direct response or a redirect. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.http_ext_authz_do_not_skip_direct_response_and_redirect`` runtime guard to false.
-* extensions: Deprecated extension names now default to triggering a configuration error.
+* extensions: deprecated extension names now default to triggering a configuration error.
   The previous warning-only behavior can be reverted by setting the runtime key
   ``envoy.deprecated_features.allow_deprecated_extension_names`` to true.
 * grpc_bridge_filter: the filter no longer collects grpc stats in favor of the existing grpc stats filter.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -27,6 +27,12 @@ Incompatible Behavior Changes
   vendor the corresponding protobuf definitions to ensure that the
   renumbered fields have the types expected by those releases.
 * ext_authz: fixed skipping authentication when returning either a direct response or a redirect. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.http_ext_authz_do_not_skip_direct_response_and_redirect`` runtime guard to false.
+* extensions: Deprecated extension names now default to triggering a configuration error.
+  The previous warning-only behavior can be reverted by setting the runtime key
+  ``envoy.deprecated_features.allow_deprecated_extension_names`` to true.
+* grpc_bridge_filter: the filter no longer collects grpc stats in favor of the existing grpc stats filter.
+  The behavior can be reverted by changing runtime key ``envoy.reloadable_features.grpc_bridge_stats_disabled``.
+* tracing: update Apache SkyWalking tracer version to be compatible with 8.4.0 data collect protocol. This change will introduce incompatibility with SkyWalking 8.3.0.
 
 Minor Behavior Changes
 ----------------------

--- a/examples/dynamic-config-fs/configs/lds.yaml
+++ b/examples/dynamic-config-fs/configs/lds.yaml
@@ -7,12 +7,12 @@ resources:
       port_value: 10000
   filter_chains:
   - filters:
-      name: envoy.http_connection_manager
+      name: envoy.filters.network.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         stat_prefix: ingress_http
         http_filters:
-        - name: envoy.router
+        - name: envoy.filters.http.router
         route_config:
           name: local_route
           virtual_hosts:

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -300,7 +300,7 @@ public:
    * Get a Factory from the registry with error checking to ensure the name and the factory are
    * valid. And a flag to control return nullptr or throw an exception.
    * @param message proto that contains fields 'name' and 'typed_config'.
-   * @param is_optional an exception will be throw when the value is true and no factory found.
+   * @param is_optional an exception will be throw when the value is false and no factory found.
    * @return factory the factory requested or nullptr if it does not exist.
    */
   template <class Factory, class ProtoMessage>

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -55,7 +55,6 @@ constexpr const char* runtime_features[] = {
     // Enabled
     "envoy.reloadable_features.test_feature_true",
     // Begin alphabetically sorted section.
-    "envoy.deprecated_features.allow_deprecated_extension_names",
     "envoy.reloadable_features.add_and_validate_scheme_header",
     "envoy.reloadable_features.allow_response_for_timeout",
     "envoy.reloadable_features.check_unsupported_typed_per_filter_config",

--- a/source/extensions/common/utility.h
+++ b/source/extensions/common/utility.h
@@ -32,12 +32,9 @@ public:
     UNREFERENCED_PARAMETER(runtime);
     return Status::Block;
 #else
-    bool warn_only = true;
-
-    if (runtime && !runtime->snapshot().deprecatedFeatureEnabled(
-                       "envoy.deprecated_features.allow_deprecated_extension_names", true)) {
-      warn_only = false;
-    }
+    const bool warn_only =
+        runtime && runtime->snapshot().deprecatedFeatureEnabled(
+                       "envoy.deprecated_features.allow_deprecated_extension_names", false);
 
     return warn_only ? Status::Warn : Status::Block;
 #endif

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1592,42 +1592,37 @@ typed_config:
   }
 }
 
-// Test that the deprecated extension names still function.
+// Test that the deprecated extension names are disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST_F(AccessLogImplTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
-  {
-    envoy::config::accesslog::v3::AccessLog config;
-    config.set_name("envoy.access_loggers.file");
-
-    EXPECT_NO_THROW(
-        Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
-            config));
-  }
-
   {
     envoy::config::accesslog::v3::AccessLog config;
     config.set_name("envoy.file_access_log");
 
-    EXPECT_NO_THROW(
+    EXPECT_THROW(
         Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
-            config));
+            config),
+        EnvoyException);
   }
 
   {
     envoy::config::accesslog::v3::AccessLog config;
     config.set_name("envoy.http_grpc_access_log");
 
-    EXPECT_NO_THROW(
+    EXPECT_THROW(
         Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
-            config));
+            config),
+        EnvoyException);
   }
 
   {
     envoy::config::accesslog::v3::AccessLog config;
     config.set_name("envoy.tcp_grpc_access_log");
 
-    EXPECT_NO_THROW(
+    EXPECT_THROW(
         Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
-            config));
+            config),
+        EnvoyException);
   }
 }
 

--- a/test/common/config/registry_test.cc
+++ b/test/common/config/registry_test.cc
@@ -91,18 +91,10 @@ public:
 REGISTER_FACTORY(TestWithDeprecatedPublishedFactory,
                  PublishedFactory){"testing.published.deprecated_name"};
 
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(RegistryTest, DEPRECATED_FEATURE_TEST(WithDeprecatedFactoryPublished)) {
-  EXPECT_EQ("testing.published.instead_name",
-            Envoy::Registry::FactoryRegistry<PublishedFactory>::getFactory(
-                "testing.published.deprecated_name")
-                ->name());
-  EXPECT_LOG_CONTAINS("warn",
-                      fmt::format("Using deprecated extension name '{}' for '{}'.",
-                                  "testing.published.deprecated_name",
-                                  "testing.published.instead_name"),
-                      Envoy::Registry::FactoryRegistry<PublishedFactory>::getFactory(
-                          "testing.published.deprecated_name")
-                          ->name());
+  EXPECT_EQ(nullptr, Envoy::Registry::FactoryRegistry<PublishedFactory>::getFactory(
+                         "testing.published.deprecated_name"));
 }
 
 class NoNamePublishedFactory : public PublishedFactory {
@@ -161,17 +153,9 @@ REGISTER_FACTORY(TestVersionedWithDeprecatedNamesFactory,
 
 // Test registration of versioned factory that also uses deprecated names
 TEST(RegistryTest, DEPRECATED_FEATURE_TEST(VersionedWithDeprecatedNamesFactory)) {
-  EXPECT_EQ("testing.published.versioned.instead_name",
-            Envoy::Registry::FactoryRegistry<PublishedFactory>::getFactory(
-                "testing.published.versioned.deprecated_name")
-                ->name());
-  EXPECT_LOG_CONTAINS("warn",
-                      fmt::format("Using deprecated extension name '{}' for '{}'.",
-                                  "testing.published.versioned.deprecated_name",
-                                  "testing.published.versioned.instead_name"),
-                      Envoy::Registry::FactoryRegistry<PublishedFactory>::getFactory(
-                          "testing.published.versioned.deprecated_name")
-                          ->name());
+  EXPECT_EQ(nullptr, Envoy::Registry::FactoryRegistry<PublishedFactory>::getFactory(
+                         "testing.published.versioned.deprecated_name"));
+
   const auto& factories = Envoy::Registry::FactoryCategoryRegistry::registeredFactories();
   auto version = factories.find("testing.published")
                      ->second->getFactoryVersion("testing.published.versioned.instead_name");

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -5676,7 +5676,8 @@ virtual_hosts:
   EXPECT_EQ(opaque_config.find("name2")->second, "value2");
 }
 
-// Test that the deprecated name works for opaque configs.
+// Test that the deprecated name no longer works by default for opaque configs.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST_F(RouteMatcherTest, DEPRECATED_FEATURE_TEST(TestOpaqueConfigUsingDeprecatedName)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
@@ -5696,13 +5697,8 @@ virtual_hosts:
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"ats"}, {});
-  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true);
-
-  const std::multimap<std::string, std::string>& opaque_config =
-      config.route(genHeaders("api.lyft.com", "/api", "GET"), 0)->routeEntry()->opaqueConfig();
-
-  EXPECT_EQ(opaque_config.find("name1")->second, "value1");
-  EXPECT_EQ(opaque_config.find("name2")->second, "value2");
+  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
+               EnvoyException);
 }
 
 class RoutePropertyTest : public testing::Test, public ConfigImplTestBase {};

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -100,11 +100,12 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
   EXPECT_TRUE(inflated);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(BufferFilterFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.buffer";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -705,11 +705,12 @@ TEST_F(CorsFilterTest, OptionsRequestNotMatchingOriginByRegex) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers_));
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(CorsFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.cors";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -450,11 +450,12 @@ TEST_F(CsrfFilterTest, RequestFromInvalidAdditionalRegexOrigin) {
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(CsrfFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.csrf";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/dynamo/config_test.cc
+++ b/test/extensions/filters/http/dynamo/config_test.cc
@@ -26,11 +26,12 @@ TEST(DynamoFilterConfigTest, DynamoFilter) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(DynamoFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.http_dynamo_filter";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -150,11 +150,12 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(HttpExtAuthzConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.ext_authz";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/fault/config_test.cc
+++ b/test/extensions/filters/http/fault/config_test.cc
@@ -69,11 +69,12 @@ TEST(FaultFilterConfigTest, FaultFilterEmptyProto) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(FaultFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.fault";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
@@ -23,11 +23,12 @@ TEST(GrpcHttp1BridgeFilterConfigTest, GrpcHttp1BridgeFilter) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(GrpcHttp1BridgeFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.grpc_http1_bridge";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
@@ -22,11 +22,12 @@ TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
                ProtoValidationException);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(GrpcJsonTranscoderFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.grpc_json_transcoder";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/grpc_web/config_test.cc
+++ b/test/extensions/filters/http/grpc_web/config_test.cc
@@ -23,11 +23,12 @@ TEST(GrpcWebFilterConfigTest, GrpcWebFilter) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(GrpcWebFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.grpc_web";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -270,11 +270,12 @@ TEST(HealthCheckFilterConfig, HealthCheckFilterDuplicateNoMatch) {
   testHealthCheckHeaderMatch(config, headers, false);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(HealthCheckFilterConfig, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.health_check";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -286,11 +286,12 @@ TEST_F(IpTaggingFilterTest, ClearRouteCache) {
   EXPECT_FALSE(request_headers.has(Http::Headers::get().EnvoyIpTags));
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(IpTaggingFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.ip_tagging";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -41,11 +41,12 @@ TEST(LuaFilterConfigTest, LuaFilterInJson) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(LuaFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.lua";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1677,12 +1677,11 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-// Test that the deprecated filter name works for metadata.
+// Test that the deprecated filter is disabled by default for metadata.
 TEST_F(LuaHttpFilterTest, DEPRECATED_FEATURE_TEST(GetMetadataFromHandleUsingDeprecatedName)) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_request(request_handle)
       request_handle:logTrace(request_handle:metadata():get("foo.bar")["name"])
-      request_handle:logTrace(request_handle:metadata():get("foo.bar")["prop"])
     end
   )EOF"};
 
@@ -1691,7 +1690,6 @@ TEST_F(LuaHttpFilterTest, DEPRECATED_FEATURE_TEST(GetMetadataFromHandleUsingDepr
       envoy.lua:
         foo.bar:
           name: foo
-          prop: bar
   )EOF"};
 
   InSequence s;
@@ -1700,21 +1698,7 @@ TEST_F(LuaHttpFilterTest, DEPRECATED_FEATURE_TEST(GetMetadataFromHandleUsingDepr
 
   // Logs deprecation warning the first time.
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("foo")));
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
-  EXPECT_LOG_CONTAINS(
-      "warn",
-      "Using deprecated http filter extension name 'envoy.lua' for 'envoy.filters.http.lua'",
-      filter_->decodeHeaders(request_headers, true));
-
-  // Doesn't log deprecation warning the second time.
-  setupMetadata(METADATA);
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("foo")));
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
-  EXPECT_LOG_NOT_CONTAINS(
-      "warn",
-      "Using deprecated http filter extension name 'envoy.lua' for 'envoy.filters.http.lua'",
-      filter_->decodeHeaders(request_headers, true));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("foo"))).Times(0);
 }
 
 // No available metadata on route.

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1678,6 +1678,7 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
 }
 
 // Test that the deprecated filter is disabled by default for metadata.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST_F(LuaHttpFilterTest, DEPRECATED_FEATURE_TEST(GetMetadataFromHandleUsingDeprecatedName)) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_request(request_handle)

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -81,11 +81,12 @@ TEST(RateLimitFilterConfigTest, BadRateLimitFilterConfig) {
                           "route_key: Cannot find field");
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(RateLimitFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.rate_limit";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/http/router/config_test.cc
+++ b/test/extensions/filters/http/router/config_test.cc
@@ -86,11 +86,12 @@ TEST(RouterFilterConfigTest, RouterFilterWithEmptyProtoConfig) {
   cb(filter_callback);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(RouterFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.router";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
@@ -45,11 +45,12 @@ TEST(HttpInspectorConfigFactoryTest, TestCreateFactory) {
   EXPECT_NE(dynamic_cast<HttpInspector::Filter*>(added_filter.get()), nullptr);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(HttpInspectorConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.listener.http_inspector";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<
           Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(deprecated_name));

--- a/test/extensions/filters/listener/original_dst/config_test.cc
+++ b/test/extensions/filters/listener/original_dst/config_test.cc
@@ -11,11 +11,12 @@ namespace ListenerFilters {
 namespace OriginalDst {
 namespace {
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(OriginalDstConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.listener.original_dst";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<
           Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(deprecated_name));

--- a/test/extensions/filters/listener/original_src/original_src_config_factory_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_config_factory_test.cc
@@ -43,11 +43,12 @@ TEST(OriginalSrcConfigFactoryTest, TestCreateFactory) {
   EXPECT_NE(dynamic_cast<OriginalSrcFilter*>(added_filter.get()), nullptr);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(OriginalSrcConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.listener.original_src";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<
           Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(deprecated_name));

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1483,11 +1483,12 @@ TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
   EXPECT_NE(dynamic_cast<ProxyProtocol::Filter*>(added_filter.get()), nullptr);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(ProxyProtocolConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.listener.proxy_protocol";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<
           Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(deprecated_name));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -282,11 +282,12 @@ TEST_P(TlsInspectorTest, InlineReadSucceed) {
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onAccept(cb_));
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(TlsInspectorConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.listener.tls_inspector";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<
           Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(deprecated_name));

--- a/test/extensions/filters/network/client_ssl_auth/config_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/config_test.cc
@@ -101,11 +101,12 @@ TEST(ClientSslAuthConfigFactoryTest, ValidateFail) {
       ProtoValidationException);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(ClientSslAuthConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.client_ssl_auth";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -64,11 +64,12 @@ TEST(ExtAuthzFilterConfigTest, ValidateFail) {
 
 TEST(ExtAuthzFilterConfigTest, ExtAuthzCorrectProto) { expectCorrectProto(); }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(ExtAuthzConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.ext_authz";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1707,11 +1707,12 @@ http2_protocol_options:
       R"(inconsistent HTTP/2 custom SETTINGS parameter\(s\) detected; identifiers = \{0x0a\})");
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST_F(HttpConnectionManagerConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.http_connection_manager";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/network/mongo_proxy/config_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/config_test.cc
@@ -226,11 +226,12 @@ TEST(MongoFilterConfigTest, CorrectFaultConfigurationInProto) {
   cb(connection);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(MongoFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.mongo_proxy";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -88,11 +88,12 @@ ip_allowlist: '12'
                           "ip_allowlist: Cannot find field");
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(RateLimitFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.ratelimit";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/network/redis_proxy/config_test.cc
+++ b/test/extensions/filters/network/redis_proxy/config_test.cc
@@ -148,11 +148,12 @@ settings:
   cb(connection);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(RedisProxyFilterConfigFactoryTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.redis_proxy";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -72,11 +72,12 @@ TEST(ConfigTest, ConfigTest) {
   cb(connection);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(ConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.tcp_proxy";
 
-  ASSERT_NE(
+  ASSERT_EQ(
       nullptr,
       Registry::FactoryRegistry<Server::Configuration::NamedNetworkFilterConfigFactory>::getFactory(
           deprecated_name));

--- a/test/extensions/stats_sinks/dog_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/dog_statsd/config_test.cc
@@ -142,10 +142,11 @@ TEST_P(DogStatsdConfigLoopbackTest, WithCustomPrefix) {
   EXPECT_EQ(udp_sink->getPrefix(), customPrefix);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(DogStatsdConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
-  ASSERT_NE(nullptr, Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(
-                         DogStatsdName));
+  ASSERT_EQ(nullptr, Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(
+                         "envoy.dog_statsd"));
 }
 
 } // namespace

--- a/test/extensions/stats_sinks/metrics_service/config_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/config_test.cc
@@ -12,10 +12,11 @@ namespace StatSinks {
 namespace MetricsService {
 namespace {
 
-// Test that the deprecated extension name still functions.
+// Test that the extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(MetricsServiceConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
-  ASSERT_NE(nullptr, Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(
-                         MetricsServiceName));
+  ASSERT_EQ(nullptr, Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(
+                         "envoy.metrics_service"));
 }
 
 } // namespace

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -42,11 +42,12 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
   EXPECT_NE(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get()), nullptr);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(StatsConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.statsd";
 
-  ASSERT_NE(nullptr, Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(
+  ASSERT_EQ(nullptr, Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(
                          deprecated_name));
 }
 

--- a/test/extensions/tracers/dynamic_ot/config_test.cc
+++ b/test/extensions/tracers/dynamic_ot/config_test.cc
@@ -53,11 +53,12 @@ TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
   EXPECT_NE(nullptr, tracer);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(DynamicOtTracerConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.dynamic.ot";
 
-  ASSERT_NE(nullptr, Registry::FactoryRegistry<Server::Configuration::TracerFactory>::getFactory(
+  ASSERT_EQ(nullptr, Registry::FactoryRegistry<Server::Configuration::TracerFactory>::getFactory(
                          deprecated_name));
 }
 

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -70,11 +70,12 @@ TEST(LightstepTracerConfigTest, LightstepHttpTracerAccessToken) {
   EXPECT_NE(nullptr, lightstep_tracer);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(LightstepTracerConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.lightstep";
 
-  ASSERT_NE(nullptr, Registry::FactoryRegistry<Server::Configuration::TracerFactory>::getFactory(
+  ASSERT_EQ(nullptr, Registry::FactoryRegistry<Server::Configuration::TracerFactory>::getFactory(
                          deprecated_name));
 }
 

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -67,11 +67,12 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracerWithTypedConfig) {
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 
-// Test that the deprecated extension name still functions.
+// Test that the deprecated extension name is disabled by default.
+// TODO(zuercher): remove when envoy.deprecated_features.allow_deprecated_extension_names is removed
 TEST(ZipkinTracerConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.zipkin";
 
-  ASSERT_NE(nullptr, Registry::FactoryRegistry<Server::Configuration::TracerFactory>::getFactory(
+  ASSERT_EQ(nullptr, Registry::FactoryRegistry<Server::Configuration::TracerFactory>::getFactory(
                          deprecated_name));
 }
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -604,14 +604,14 @@ TEST(DisableExtensions, DEPRECATED_FEATURE_TEST(IsDisabled)) {
                       OptionsImpl::disableExtensions({"no/such.factory"}));
 
   EXPECT_NE(Registry::FactoryRegistry<TestFactory>::getFactory("test"), nullptr);
-  EXPECT_NE(Registry::FactoryRegistry<TestFactory>::getFactory("test-1"), nullptr);
-  EXPECT_NE(Registry::FactoryRegistry<TestFactory>::getFactory("test-2"), nullptr);
+  EXPECT_EQ(Registry::FactoryRegistry<TestFactory>::getFactory("test-1"), nullptr);
+  EXPECT_EQ(Registry::FactoryRegistry<TestFactory>::getFactory("test-2"), nullptr);
   EXPECT_NE(Registry::FactoryRegistry<TestFactory>::getFactoryByType("google.protobuf.StringValue"),
             nullptr);
 
   EXPECT_NE(Registry::FactoryRegistry<TestingFactory>::getFactory("test"), nullptr);
-  EXPECT_NE(Registry::FactoryRegistry<TestingFactory>::getFactory("test-1"), nullptr);
-  EXPECT_NE(Registry::FactoryRegistry<TestingFactory>::getFactory("test-2"), nullptr);
+  EXPECT_EQ(Registry::FactoryRegistry<TestingFactory>::getFactory("test-1"), nullptr);
+  EXPECT_EQ(Registry::FactoryRegistry<TestingFactory>::getFactory("test-2"), nullptr);
 
   OptionsImpl::disableExtensions({"test/test", "testing/test-2"});
 


### PR DESCRIPTION
Modifies the default value when looking up `envoy.deprecated_features.allow_deprecated_extension_names` such that deprecated extension names (e.g. `envoy.router` instead of `envoy.filters.http.router`) are no longer allowed. The deprecated names have been logged as such since Envoy 1.14.0. See #18238 which tracks removing this feature altogether.

Risk Level: low
Testing: updated unit tests
Docs Changes: n/a
Release Notes: updated
Platform Specific Features: n/a
Runtime guard: envoy.deprecated_features.allow_deprecated_extension_names
