### PR TITLE
network: set failure reason for transport socket connect timeout

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -827,6 +827,7 @@ void ServerConnectionImpl::onTransportSocketConnectTimeout() {
   stream_info_.setConnectionTerminationDetails(kTransportSocketConnectTimeoutTerminationDetails);
   closeConnectionImmediately();
   transport_socket_timeout_stat_->inc();
+  failure_reason_ = "connect timeout";
 }
 
 ClientConnectionImpl::ClientConnectionImpl(

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -419,6 +419,7 @@ TEST_P(ConnectionImplTest, SetServerTransportSocketTimeout) {
   mock_timer->invokeCallback();
   EXPECT_THAT(stream_info_.connectionTerminationDetails(),
               Optional(HasSubstr("transport socket timeout")));
+  EXPECT_EQ(server_connection->transportFailureReason(), "connect timeout");
 }
 
 TEST_P(ConnectionImplTest, SetServerTransportSocketTimeoutAfterConnect) {


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: Updated UT
Docs Changes: n/a
Release Notes: n/a