### PR TITLE
Disable sigaltstack on Apple platforms

### DIFF
--- a/source/common/signal/signal_action.cc
+++ b/source/common/signal/signal_action.cc
@@ -54,12 +54,16 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
 }
 
 void SignalAction::installSigHandlers() {
+  // sigaltstack and backtrace() are incompatible on Apple platforms
+  // https://reviews.llvm.org/D28265
+#if !defined(__APPLE__)
   stack_t stack;
   stack.ss_sp = altstack_ + guard_size_; // Guard page at one end ...
   stack.ss_size = altstack_size_;        // ... guard page at the other
   stack.ss_flags = 0;
 
   RELEASE_ASSERT(sigaltstack(&stack, &previous_altstack_) == 0, "");
+#endif
 
   // Make sure VersionInfo::version() is initialized so we don't allocate std::string in signal
   // handlers.

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1088,6 +1088,7 @@ setsockopt
 sig
 sigaction
 sigactions
+sigaltstack
 siginfo
 signalstack
 siloed


### PR DESCRIPTION
According to https://reviews.llvm.org/D28265 using `sigaltstack` with
`backtrace()` (which absiel uses internally to get stack trace info) is
not compatible. Using them together results in crashes in tests not
printing backtraces only on macOS

https://github.com/envoyproxy/envoy-mobile/issues/1827