### PR TITLE
fix possible use-after-free introduced by the cross-priority host map updates in the thread aware lb

### DIFF
--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -98,7 +98,7 @@ protected:
       Random::RandomGenerator& random,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
       : LoadBalancerBase(priority_set, stats, runtime, random, common_config),
-        factory_(new LoadBalancerFactoryImpl(stats, random, *this)) {}
+        factory_(new LoadBalancerFactoryImpl(stats, random)) {}
 
 private:
   struct PerPriorityState {
@@ -108,9 +108,8 @@ private:
   using PerPriorityStatePtr = std::unique_ptr<PerPriorityState>;
 
   struct LoadBalancerImpl : public LoadBalancer {
-    LoadBalancerImpl(ClusterStats& stats, Random::RandomGenerator& random,
-                     HostMapConstSharedPtr host_map)
-        : stats_(stats), random_(random), cross_priority_host_map_(std::move(host_map)) {}
+    LoadBalancerImpl(ClusterStats& stats, Random::RandomGenerator& random)
+        : stats_(stats), random_(random) {}
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -128,14 +127,11 @@ private:
   };
 
   struct LoadBalancerFactoryImpl : public LoadBalancerFactory {
-    LoadBalancerFactoryImpl(ClusterStats& stats, Random::RandomGenerator& random,
-                            ThreadAwareLoadBalancerBase& thread_aware_lb)
-        : thread_aware_lb_(thread_aware_lb), stats_(stats), random_(random) {}
+    LoadBalancerFactoryImpl(ClusterStats& stats, Random::RandomGenerator& random)
+        : stats_(stats), random_(random) {}
 
     // Upstream::LoadBalancerFactory
     LoadBalancerPtr create() override;
-
-    ThreadAwareLoadBalancerBase& thread_aware_lb_;
 
     ClusterStats& stats_;
     Random::RandomGenerator& random_;
@@ -144,6 +140,16 @@ private:
     // This is split out of PerPriorityState so LoadBalancerBase::ChoosePriority can be reused.
     std::shared_ptr<HealthyLoad> healthy_per_priority_load_ ABSL_GUARDED_BY(mutex_);
     std::shared_ptr<DegradedLoad> degraded_per_priority_load_ ABSL_GUARDED_BY(mutex_);
+
+    // Whenever the membership changes, the cross_priority_host_map_ will be updated automatically.
+    // And all workers will create a new worker local load balancer and copy the
+    // cross_priority_host_map_.
+    // This leads to the possibility of simultaneous reading and writing of cross_priority_host_map_
+    // in different threads. For this reason, mutex is necessary to guard cross_priority_host_map_.
+    //
+    // Cross priority host map for fast cross priority host searching. When the priority update
+    // callback is executed, the host map will also be updated.
+    HostMapConstSharedPtr cross_priority_host_map_ ABSL_GUARDED_BY(mutex_);
   };
 
   virtual HashingLoadBalancerSharedPtr
@@ -151,29 +157,8 @@ private:
                      double min_normalized_weight, double max_normalized_weight) PURE;
   void refresh();
 
-  void threadSafeSetCrossPriorityHostMap(HostMapConstSharedPtr host_map) {
-    absl::MutexLock ml(&cross_priority_host_map_mutex_);
-    cross_priority_host_map_ = std::move(host_map);
-  }
-  HostMapConstSharedPtr threadSafeGetCrossPriorityHostMap() {
-    absl::MutexLock ml(&cross_priority_host_map_mutex_);
-    return cross_priority_host_map_;
-  }
-
   std::shared_ptr<LoadBalancerFactoryImpl> factory_;
   Common::CallbackHandlePtr priority_update_cb_;
-
-  // Whenever the membership changes, the cross_priority_host_map_ will be updated automatically.
-  // And all workers will create a new worker local load balancer and copy the
-  // cross_priority_host_map_.
-  //
-  // This leads to the possibility of simultaneous reading and writing of cross_priority_host_map_
-  // in different threads. For this reason, an additional mutex is necessary to guard
-  // cross_priority_host_map_.
-  absl::Mutex cross_priority_host_map_mutex_;
-  // Cross priority host map for fast cross priority host searching. When the priority update
-  // callback is executed, the host map will also be updated.
-  HostMapConstSharedPtr cross_priority_host_map_ ABSL_GUARDED_BY(cross_priority_host_map_mutex_);
 };
 
 } // namespace Upstream

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -105,7 +105,7 @@ TEST_F(MaglevLoadBalancerTest, SelectOverrideHost) {
 
 // Test for thread aware load balancer destructed before load balancer factory. After CDS removes a
 // cluster, the operation does not immediately reach the worker thread. There may be cases where the
-// thread aware load balancer is destructured, but the load balancer factory is still used in the
+// thread aware load balancer is destructed, but the load balancer factory is still used in the
 // worker thread.
 TEST_F(MaglevLoadBalancerTest, LbDestructedBeforeFactory) {
   init(7);

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -103,6 +103,19 @@ TEST_F(MaglevLoadBalancerTest, SelectOverrideHost) {
   EXPECT_EQ(mock_host, lb_->factory()->create()->chooseHost(&context));
 }
 
+// Test for thread aware load balancer destructed before load balancer factory. After CDS removes a
+// cluster, the operation does not immediately reach the worker thread. There may be cases where the
+// thread aware load balancer is destructured, but the load balancer factory is still used in the
+// worker thread.
+TEST_F(MaglevLoadBalancerTest, LbDestructedBeforeFactory) {
+  init(7);
+
+  auto factory = lb_->factory();
+  lb_.reset();
+
+  EXPECT_NE(nullptr, factory->create());
+}
+
 // Throws an exception if table size is not a prime number.
 TEST_F(MaglevLoadBalancerTest, NoPrimeNumber) {
   EXPECT_THROW_WITH_MESSAGE(init(8), EnvoyException,

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -122,7 +122,7 @@ TEST_P(RingHashLoadBalancerTest, SelectOverrideHost) {
 
 // Test for thread aware load balancer destructed before load balancer factory. After CDS removes a
 // cluster, the operation does not immediately reach the worker thread. There may be cases where the
-// thread aware load balancer is destructured, but the load balancer factory is still used in the
+// thread aware load balancer is destructed, but the load balancer factory is still used in the
 // worker thread.
 TEST_P(RingHashLoadBalancerTest, LbDestructedBeforeFactory) {
   init();

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -120,6 +120,19 @@ TEST_P(RingHashLoadBalancerTest, SelectOverrideHost) {
   EXPECT_EQ(mock_host, lb_->factory()->create()->chooseHost(&context));
 }
 
+// Test for thread aware load balancer destructed before load balancer factory. After CDS removes a
+// cluster, the operation does not immediately reach the worker thread. There may be cases where the
+// thread aware load balancer is destructured, but the load balancer factory is still used in the
+// worker thread.
+TEST_P(RingHashLoadBalancerTest, LbDestructedBeforeFactory) {
+  init();
+
+  auto factory = lb_->factory();
+  lb_.reset();
+
+  EXPECT_NE(nullptr, factory->create());
+}
+
 // Given minimum_ring_size > maximum_ring_size, expect an exception.
 TEST_P(RingHashLoadBalancerTest, BadRingSizeBounds) {
   config_ = envoy::config::cluster::v3::Cluster::RingHashLbConfig();

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -404,9 +404,12 @@ admin:
 }
 
 // TODO(samflattery): bundle this up with buildCluster
-envoy::config::cluster::v3::Cluster
-ConfigHelper::buildStaticCluster(const std::string& name, int port, const std::string& address) {
-  return TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(
+envoy::config::cluster::v3::Cluster ConfigHelper::buildStaticCluster(const std::string& name,
+                                                                     int port,
+                                                                     const std::string& address,
+                                                                     const std::string& lb_policy) {
+  return TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(
+      fmt::format(R"EOF(
       name: {}
       connect_timeout: 5s
       type: STATIC
@@ -419,15 +422,14 @@ ConfigHelper::buildStaticCluster(const std::string& name, int port, const std::s
                 socket_address:
                   address: {}
                   port_value: {}
-      lb_policy: ROUND_ROBIN
+      lb_policy: {}
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           explicit_http_config:
             http2_protocol_options: {{}}
     )EOF",
-                                                                                 name, name,
-                                                                                 address, port));
+                  name, name, address, port, lb_policy));
 }
 
 envoy::config::cluster::v3::Cluster ConfigHelper::buildCluster(const std::string& name,

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -146,8 +146,9 @@ public:
   static std::string discoveredClustersBootstrap(const std::string& api_type);
   static std::string adsBootstrap(const std::string& api_type);
   // Builds a standard Cluster config fragment, with a single endpoint (at address:port).
-  static envoy::config::cluster::v3::Cluster buildStaticCluster(const std::string& name, int port,
-                                                                const std::string& address);
+  static envoy::config::cluster::v3::Cluster
+  buildStaticCluster(const std::string& name, int port, const std::string& address,
+                     const std::string& lb_policy = "ROUND_ROBIN");
 
   // ADS configurations
   static envoy::config::cluster::v3::Cluster

--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -194,7 +194,7 @@ TEST_P(CdsIntegrationTest, CdsClusterWithThreadAwareLbCycleUpDownUp) {
       ClusterName1, fake_upstreams_[UpstreamIndex1]->localAddress()->ip()->port(),
       Network::Test::getLoopbackAddressString(ipVersion()), "MAGLEV");
 
-  // Cyclically add and remove cluster withs ThreadAwareLb.
+  // Cyclically add and remove cluster with ThreadAwareLb.
   for (int i = 42; i < 142; i += 2) {
     EXPECT_TRUE(
         compareDiscoveryRequest(Config::TypeUrl::get().Cluster, absl::StrCat(i), {}, {}, {}));

--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -175,6 +175,40 @@ TEST_P(CdsIntegrationTest, CdsClusterUpDownUp) {
   cleanupUpstreamAndDownstream();
 }
 
+// Test the fast addition and removal of clusters when they use ThreadAwareLb.
+TEST_P(CdsIntegrationTest, CdsClusterWithThreadAwareLbCycleUpDownUp) {
+  // Calls our initialize(), which includes establishing a listener, route, and cluster.
+  testRouterHeaderOnlyRequestAndResponse(nullptr, UpstreamIndex1, "/cluster1");
+  test_server_->waitForCounterGe("cluster_manager.cluster_added", 1);
+
+  // Tell Envoy that cluster_1 is gone.
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "55", {}, {}, {}));
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster, {}, {},
+                                                             {ClusterName1}, "42");
+  // Make sure that Envoy's ClusterManager has made use of the DiscoveryResponse that says cluster_1
+  // is gone.
+  test_server_->waitForCounterGe("cluster_manager.cluster_removed", 1);
+
+  // Update cluster1_ to use MAGLEV load balancer policy.
+  cluster1_ = ConfigHelper::buildStaticCluster(
+      ClusterName1, fake_upstreams_[UpstreamIndex1]->localAddress()->ip()->port(),
+      Network::Test::getLoopbackAddressString(ipVersion()), "MAGLEV");
+
+  // Cyclically add and remove cluster withs ThreadAwareLb.
+  for (int i = 42; i < 142; i += 2) {
+    EXPECT_TRUE(
+        compareDiscoveryRequest(Config::TypeUrl::get().Cluster, absl::StrCat(i), {}, {}, {}));
+    sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
+        Config::TypeUrl::get().Cluster, {cluster1_}, {cluster1_}, {}, absl::StrCat(i + 1));
+    EXPECT_TRUE(
+        compareDiscoveryRequest(Config::TypeUrl::get().Cluster, absl::StrCat(i + 1), {}, {}, {}));
+    sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
+        Config::TypeUrl::get().Cluster, {}, {}, {ClusterName1}, absl::StrCat(i + 2));
+  }
+
+  cleanupUpstreamAndDownstream();
+}
+
 // Tests adding a cluster, adding another, then removing the first.
 TEST_P(CdsIntegrationTest, TwoClusters) {
   // Calls our initialize(), which includes establishing a listener, route, and cluster.


### PR DESCRIPTION
Commit Message: fix possible use-after-free introduced by the cross-priority host map updates in the thread aware lb
Additional Description:

Fixes commit #17848
Fix #18250.

Risk Level: Low.
Testing: Added.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.