### PR TITLE
proto: Handle maps correctly in `redact`.

### DIFF
--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -459,18 +459,26 @@ insensitive_repeated_string:
 TEST_F(ProtobufUtilityTest, RedactMap) {
   envoy::test::Sensitive actual, expected;
   TestUtility::loadFromYaml(R"EOF(
-sensitive_map:
+sensitive_string_map:
   "a": "b"
-insensitive_map:
+sensitive_int_map:
+  "x": 12345
+insensitive_string_map:
   "c": "d"
+insensitive_int_map:
+  "y": 123456
 )EOF",
                             actual);
 
   TestUtility::loadFromYaml(R"EOF(
-sensitive_map:
+sensitive_string_map:
   "a": "[redacted]"
-insensitive_map:
+sensitive_int_map:
+  "x":
+insensitive_string_map:
   "c": "d"
+insensitive_int_map:
+  "y": 123456
 )EOF",
                             expected);
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -455,6 +455,29 @@ insensitive_repeated_string:
   EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
 }
 
+// Fields that are values in a sensitive map should be redacted.
+TEST_F(ProtobufUtilityTest, RedactMap) {
+  envoy::test::Sensitive actual, expected;
+  TestUtility::loadFromYaml(R"EOF(
+sensitive_map:
+  "a": "b"
+insensitive_map:
+  "c": "d"
+)EOF",
+                            actual);
+
+  TestUtility::loadFromYaml(R"EOF(
+sensitive_map:
+  "a": "[redacted]"
+insensitive_map:
+  "c": "d"
+)EOF",
+                            expected);
+
+  MessageUtil::redact(actual);
+  EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
+}
+
 // Bytes fields annotated as sensitive should be converted to the ASCII / UTF-8 encoding of the
 // string "[redacted]". Bytes fields that are neither annotated as sensitive nor contained in a
 // sensitive message should be left alone.

--- a/test/proto/sensitive.proto
+++ b/test/proto/sensitive.proto
@@ -26,7 +26,8 @@ message Sensitive {
   udpa.type.v1.TypedStruct sensitive_typed_struct = 11 [(udpa.annotations.sensitive) = true];
   repeated udpa.type.v1.TypedStruct sensitive_repeated_typed_struct = 12
       [(udpa.annotations.sensitive) = true];
-  map<string, string> sensitive_map = 13 [(udpa.annotations.sensitive) = true];
+  map<string, string> sensitive_string_map = 13 [(udpa.annotations.sensitive) = true];
+  map<string, int64> sensitive_int_map = 14 [(udpa.annotations.sensitive) = true];
 
   string insensitive_string = 101;
   repeated string insensitive_repeated_string = 102;
@@ -40,5 +41,6 @@ message Sensitive {
   repeated google.protobuf.Any insensitive_repeated_any = 110;
   udpa.type.v1.TypedStruct insensitive_typed_struct = 111;
   repeated udpa.type.v1.TypedStruct insensitive_repeated_typed_struct = 112;
-  map<string, string> insensitive_map = 113;
+  map<string, string> insensitive_string_map = 113;
+  map<string, int64> insensitive_int_map = 114;
 }

--- a/test/proto/sensitive.proto
+++ b/test/proto/sensitive.proto
@@ -26,6 +26,7 @@ message Sensitive {
   udpa.type.v1.TypedStruct sensitive_typed_struct = 11 [(udpa.annotations.sensitive) = true];
   repeated udpa.type.v1.TypedStruct sensitive_repeated_typed_struct = 12
       [(udpa.annotations.sensitive) = true];
+  map<string, string> sensitive_map = 13 [(udpa.annotations.sensitive) = true];
 
   string insensitive_string = 101;
   repeated string insensitive_repeated_string = 102;
@@ -39,4 +40,5 @@ message Sensitive {
   repeated google.protobuf.Any insensitive_repeated_any = 110;
   udpa.type.v1.TypedStruct insensitive_typed_struct = 111;
   repeated udpa.type.v1.TypedStruct insensitive_repeated_typed_struct = 112;
+  map<string, string> insensitive_map = 113;
 }


### PR DESCRIPTION
Signed-off-by: Paul Gallagher <pgal@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: proto: handle maps correctly in `redact`.
Additional Description: Currently, when a map is marked as sensitive, `redact` will turn every key into the string "[redacted]", thereby invalidating the map. This change causes the map to only have values converted to "[redacted]".
Risk Level: low
Testing: unit tested.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
