### PR TITLE
coverage: exclude a guarddog test from coverage

### DIFF
--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -820,6 +820,8 @@ TEST_P(GuardDogActionsTest, KillShouldTriggerGuardDogActions) {
   EXPECT_DEATH(die_function(), "ASSERT_GUARDDOG_ACTION");
 }
 
+// Disabled for coverage per #18229
+#if !defined(ENVOY_CONFIG_COVERAGE)
 TEST_P(GuardDogActionsTest, MultikillShouldTriggerGuardDogActions) {
   auto die_function = [&]() -> void {
     const NiceMock<Configuration::MockWatchdog> config(DISABLE_MISS, DISABLE_MEGAMISS, DISABLE_KILL,
@@ -833,6 +835,7 @@ TEST_P(GuardDogActionsTest, MultikillShouldTriggerGuardDogActions) {
 
   EXPECT_DEATH(die_function(), "ASSERT_GUARDDOG_ACTION");
 }
+#endif
 
 } // namespace
 } // namespace Server


### PR DESCRIPTION
This is a clone of https://github.com/envoyproxy/envoy/pull/18252 but with the formatting fixed.

Risk Level: None - test only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A