### PR TITLE
alternate_protocols_cache: Impose a max size limit on the alternate protocols cache

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -165,11 +165,11 @@ envoy_cc_library(
         "alternate_protocols_cache_impl.cc",
         "alternate_protocols_cache_manager_impl.cc",
     ],
-    external_deps = ["quiche_quic_platform"],
     hdrs = [
         "alternate_protocols_cache_impl.h",
         "alternate_protocols_cache_manager_impl.h",
     ],
+    external_deps = ["quiche_quic_platform"],
     deps = [
         "//envoy/common:time_interface",
         "//envoy/event:dispatcher_interface",

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -165,6 +165,7 @@ envoy_cc_library(
         "alternate_protocols_cache_impl.cc",
         "alternate_protocols_cache_manager_impl.cc",
     ],
+    external_deps = ["quiche_quic_platform"],
     hdrs = [
         "alternate_protocols_cache_impl.h",
         "alternate_protocols_cache_manager_impl.h",

--- a/source/common/http/alternate_protocols_cache_impl.cc
+++ b/source/common/http/alternate_protocols_cache_impl.cc
@@ -115,8 +115,8 @@ AlternateProtocolsCacheImpl::findAlternatives(const Origin& origin) {
                   protocols.end());
 
   if (protocols.empty()) {
-    protocols_map_.erase(entry_it);
     protocols_list_.erase(entry_it->second);
+    protocols_map_.erase(entry_it);
     if (key_value_store_) {
       key_value_store_->remove(originToString(origin));
     }

--- a/source/common/http/alternate_protocols_cache_impl.cc
+++ b/source/common/http/alternate_protocols_cache_impl.cc
@@ -77,20 +77,12 @@ void AlternateProtocolsCacheImpl::setAlternatives(const Origin& origin,
     ENVOY_LOG_MISC(trace, "Too many alternate protocols: {}, truncating", protocols.size());
     protocols.erase(protocols.begin() + max_protocols, protocols.end());
   }
-  while (protocols_list_.size() >= max_entries_) {
-    auto iter = protocols_list_.rbegin();
-    key_value_store_->remove(originToString(iter->origin_));
-    protocols_map_.erase(protocols_map_.find(iter->origin_));
-    protocols_list_.erase((++iter).base());
+  while (protocols_.size() >= max_entries_) {
+    auto iter = protocols_.begin();
+    key_value_store_->remove(originToString(iter->first));
+    protocols_.erase(iter);
   }
-  auto iter = protocols_map_.find(origin);
-  if (iter != protocols_map_.end()) {
-    protocols_list_.erase(iter->second);
-    protocols_map_.erase(iter);
-  }
-  std::pair<Origin, std::vector<AlternateProtocol>> value = {origin, protocols};
-  protocols_list_.emplace_front(origin, protocols);
-  protocols_map_[origin] = protocols_list_.begin();
+  protocols_[origin] = protocols;
   if (key_value_store_) {
     key_value_store_->addOrUpdate(originToString(origin),
                                   protocolsToStringForCache(protocols, time_source_));
@@ -99,12 +91,12 @@ void AlternateProtocolsCacheImpl::setAlternatives(const Origin& origin,
 
 OptRef<const std::vector<AlternateProtocolsCache::AlternateProtocol>>
 AlternateProtocolsCacheImpl::findAlternatives(const Origin& origin) {
-  auto entry_it = protocols_map_.find(origin);
-  if (entry_it == protocols_map_.end()) {
+  auto entry_it = protocols_.find(origin);
+  if (entry_it == protocols_.end()) {
     return makeOptRefFromPtr<const std::vector<AlternateProtocol>>(nullptr);
   }
 
-  std::vector<AlternateProtocol>& protocols = entry_it->second->protocols_;
+  std::vector<AlternateProtocol>& protocols = entry_it->second;
 
   auto original_size = protocols.size();
   const MonotonicTime now = time_source_.monotonicTime();
@@ -115,8 +107,7 @@ AlternateProtocolsCacheImpl::findAlternatives(const Origin& origin) {
                   protocols.end());
 
   if (protocols.empty()) {
-    protocols_list_.erase(entry_it->second);
-    protocols_map_.erase(entry_it);
+    protocols_.erase(entry_it);
     if (key_value_store_) {
       key_value_store_->remove(originToString(origin));
     }
@@ -130,7 +121,7 @@ AlternateProtocolsCacheImpl::findAlternatives(const Origin& origin) {
   return makeOptRef(const_cast<const std::vector<AlternateProtocol>&>(protocols));
 }
 
-size_t AlternateProtocolsCacheImpl::size() const { return protocols_list_.size(); }
+size_t AlternateProtocolsCacheImpl::size() const { return protocols_.size(); }
 
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/alternate_protocols_cache_impl.cc
+++ b/source/common/http/alternate_protocols_cache_impl.cc
@@ -66,8 +66,7 @@ AlternateProtocolsCacheImpl::protocolsFromString(absl::string_view alt_svc_strin
 AlternateProtocolsCacheImpl::AlternateProtocolsCacheImpl(
     TimeSource& time_source, std::unique_ptr<KeyValueStore>&& key_value_store, size_t max_entries)
     : time_source_(time_source), key_value_store_(std::move(key_value_store)),
-      max_entries_(max_entries > 0 ? max_entries : 1024) {
-}
+      max_entries_(max_entries > 0 ? max_entries : 1024) {}
 
 AlternateProtocolsCacheImpl::~AlternateProtocolsCacheImpl() = default;
 

--- a/source/common/http/alternate_protocols_cache_impl.h
+++ b/source/common/http/alternate_protocols_cache_impl.h
@@ -52,6 +52,7 @@ private:
 
   struct OriginHash {
     size_t operator()(const Origin& origin) const {
+      // Mutiply the hashes by the magic number 37 to spread the bits around.
       size_t hash = std::hash<std::string>()(origin.scheme_) +
                     37 * (std::hash<std::string>()(origin.hostname_) +
                           37 * std::hash<uint32_t>()(origin.port_));

--- a/source/common/http/alternate_protocols_cache_impl.h
+++ b/source/common/http/alternate_protocols_cache_impl.h
@@ -49,11 +49,18 @@ private:
   // Time source used to check expiration of entries.
   TimeSource& time_source_;
 
-  using ListType = std::list<std::pair<Origin, std::vector<AlternateProtocol>>>;
+  struct OriginProtocols {
+    OriginProtocols(const Origin& origin, const std::vector<AlternateProtocol>& protocols)
+    //OriginProtocols(Origin origin, std::vector<AlternateProtocol> protocols)
+        : origin_(origin), protocols_(protocols) {}
+
+    Origin origin_;
+    std::vector<AlternateProtocol> protocols_;
+  };
   // List of origin, alternate protocol pairs, in insertion order.
-  ListType protocols_list_;
+  std::list<OriginProtocols> protocols_list_;
   // Map from hostname to iterator into protocols_list_.
-  std::map<Origin, ListType::iterator> protocols_map_;
+  std::map<Origin, std::list<OriginProtocols>::iterator> protocols_map_;
 
   // The key value store, if flushing to persistent storage.
   std::unique_ptr<KeyValueStore> key_value_store_;

--- a/source/common/http/alternate_protocols_cache_impl.h
+++ b/source/common/http/alternate_protocols_cache_impl.h
@@ -52,7 +52,7 @@ private:
 
   struct OriginHash {
     size_t operator()(const Origin& origin) const {
-      // Mutiply the hashes by the magic number 37 to spread the bits around.
+      // Multiply the hashes by the magic number 37 to spread the bits around.
       size_t hash = std::hash<std::string>()(origin.scheme_) +
                     37 * (std::hash<std::string>()(origin.hostname_) +
                           37 * std::hash<uint32_t>()(origin.port_));

--- a/source/common/http/alternate_protocols_cache_impl.h
+++ b/source/common/http/alternate_protocols_cache_impl.h
@@ -51,7 +51,6 @@ private:
 
   struct OriginProtocols {
     OriginProtocols(const Origin& origin, const std::vector<AlternateProtocol>& protocols)
-    //OriginProtocols(Origin origin, std::vector<AlternateProtocol> protocols)
         : origin_(origin), protocols_(protocols) {}
 
     Origin origin_;

--- a/source/common/http/alternate_protocols_cache_manager_impl.cc
+++ b/source/common/http/alternate_protocols_cache_manager_impl.cc
@@ -51,7 +51,7 @@ AlternateProtocolsCacheSharedPtr AlternateProtocolsCacheManagerImpl::getCache(
   }
 
   AlternateProtocolsCacheSharedPtr new_cache = std::make_shared<AlternateProtocolsCacheImpl>(
-      data_.dispatcher_.timeSource(), std::move(store));
+      data_.dispatcher_.timeSource(), std::move(store), options.max_entries().value());
   (*slot_).caches_.emplace(options.name(), CacheWithOptions{options, new_cache});
   return new_cache;
 }

--- a/test/common/http/alternate_protocols_cache_impl_test.cc
+++ b/test/common/http/alternate_protocols_cache_impl_test.cc
@@ -15,10 +15,13 @@ class AlternateProtocolsCacheImplTest : public testing::Test, public Event::Test
 public:
   AlternateProtocolsCacheImplTest()
       : store_(new NiceMock<MockKeyValueStore>()),
-        protocols_(simTime(), std::unique_ptr<KeyValueStore>(store_)) {}
+        protocols_(simTime(), std::unique_ptr<KeyValueStore>(store_), max_entries_) {}
+
+  const size_t max_entries_ = 10;
 
   MockKeyValueStore* store_;
   AlternateProtocolsCacheImpl protocols_;
+
   const std::string hostname1_ = "hostname1";
   const std::string hostname2_ = "hostname2";
   const uint32_t port1_ = 1;
@@ -130,6 +133,22 @@ TEST_F(AlternateProtocolsCacheImplTest, FindAlternativesAfterTruncation) {
   ASSERT_TRUE(protocols.has_value());
   EXPECT_EQ(10, protocols->size());
   EXPECT_EQ(expected_protocols, protocols.ref());
+}
+
+TEST_F(AlternateProtocolsCacheImplTest, MaxEntries) {
+  EXPECT_EQ(0, protocols_.size());
+  const std::string hostname = "hostname";
+  for (uint32_t i = 0; i <= max_entries_; ++i) {
+    const AlternateProtocolsCache::Origin origin = {https_, hostname, i};
+    AlternateProtocolsCache::AlternateProtocol protocol = {alpn1_, hostname, i, expiration1_};
+    std::vector<AlternateProtocolsCache::AlternateProtocol> protocols = {protocol};
+    EXPECT_CALL(*store_, addOrUpdate(absl::StrCat("https://hostname:", i),
+                                     absl::StrCat("alpn1=\"hostname:", i, "\"; ma=5")));
+    if (i == max_entries_) {
+      EXPECT_CALL(*store_, remove("https://hostname:0"));
+    }
+    protocols_.setAlternatives(origin, protocols);
+  }
 }
 
 TEST_F(AlternateProtocolsCacheImplTest, ToAndFromString) {

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -102,7 +102,7 @@ class ConnectivityGridTest : public Event::TestUsingSimulatedTime, public testin
 public:
   ConnectivityGridTest()
       : options_({Http::Protocol::Http11, Http::Protocol::Http2, Http::Protocol::Http3}),
-        alternate_protocols_(std::make_shared<AlternateProtocolsCacheImpl>(simTime(), nullptr)),
+        alternate_protocols_(std::make_shared<AlternateProtocolsCacheImpl>(simTime(), nullptr, 10)),
         quic_stat_names_(store_.symbolTable()),
         grid_(dispatcher_, random_,
               Upstream::makeTestHost(cluster_, "hostname", "tcp://127.0.0.1:9000", simTime()),
@@ -120,7 +120,7 @@ public:
     if (!use_alternate_protocols) {
       return nullptr;
     }
-    return std::make_shared<AlternateProtocolsCacheImpl>(simTime(), nullptr);
+    return std::make_shared<AlternateProtocolsCacheImpl>(simTime(), nullptr, 10);
   }
 
   void addHttp3AlternateProtocol() {


### PR DESCRIPTION
alternate_protocols_cache: Impose a max size limit on the alternate protocols cache

Implement a very basic MRU map in AlternateProtocolsCacheImpl.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A