### PR TITLE
async_client: add trace sampling preference

### DIFF
--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -294,15 +294,28 @@ public:
       child_span_name_ = child_span_name;
       return *this;
     }
-    RequestOptions& setSampled(bool sampled) {
-      sampled_ = sampled;
+
+    enum class SamplingPreference {
+      // Just default to the sampling status of the parent.
+      ParentDefault = 0,
+
+      // Always trace this request, even if the parent span is sampled.
+      Always = 1,
+
+      // Never trace this request, even if the parent span is sampled.
+      Never = 2
+    };
+
+    RequestOptions& setSamplingPreference(const SamplingPreference& preference) {
+      sampling_preference_ = preference;
       return *this;
     }
 
     // For gmock test
     bool operator==(const RequestOptions& src) const {
       return StreamOptions::operator==(src) && parent_span_ == src.parent_span_ &&
-             child_span_name_ == src.child_span_name_ && sampled_ == src.sampled_;
+             child_span_name_ == src.child_span_name_ &&
+             sampling_preference_ == src.sampling_preference_;
     }
 
     // The parent span that child spans are created under to trace egress requests/responses.
@@ -312,8 +325,9 @@ public:
     // If left empty and parent_span_ is set, then the default name will have the cluster name.
     // Only used if parent_span_ is set.
     std::string child_span_name_{""};
-    // Sampling decision for the tracing span. The span is sampled by default.
-    bool sampled_{true};
+    // Sampling preference for the tracing span. The span uses the parent sampling decision by
+    // default.
+    SamplingPreference sampling_preference_{SamplingPreference::ParentDefault};
   };
 
   /**

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -256,7 +256,17 @@ AsyncRequestImpl::AsyncRequestImpl(RequestMessagePtr&& request, AsyncClientImpl&
   } else {
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }
-  child_span_->setSampled(options.sampled_);
+  switch (options.sampling_preference_) {
+  case AsyncClient::RequestOptions::SamplingPreference::Always:
+    child_span_->setSampled(true);
+    break;
+  case AsyncClient::RequestOptions::SamplingPreference::Never:
+    child_span_->setSampled(false);
+    break;
+  default:
+    // Do nothing, keep the inherited sampling decision from the parent span.
+    break;
+  }
 }
 
 void AsyncRequestImpl::initialize() {


### PR DESCRIPTION
Commit Message: async_client: add trace sampling preference
Additional Description:
Risk Level: medium, fixes 
Testing: TODO
Docs Changes: TODO
Release Notes: TODO
[Optional Runtime guard:] TODO: Needs a runtime option to re-enable the old behavior
