### PR TITLE
tls: decouple dnsNameMatch from default cert validator.

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/BUILD
+++ b/contrib/cryptomb/private_key_providers/source/BUILD
@@ -2,7 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_contrib_extension",
     "envoy_cc_library",
-    "envoy_cmake_external",
+    "envoy_cmake",
     "envoy_contrib_package",
 )
 load(
@@ -14,7 +14,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
 
-envoy_cmake_external(
+envoy_cmake(
     name = "ipp-crypto",
     cache_entries = {
         "BORINGSSL": "on",
@@ -23,7 +23,7 @@ envoy_cmake_external(
         "OPENSSL_USE_STATIC_LIBS=TRUE",
     ],
     lib_source = "@com_github_intel_ipp_crypto_crypto_mb//:all",
-    static_libraries = ["libcrypto_mb.a"],
+    out_static_libs = ["libcrypto_mb.a"],
     tags = ["skip_on_windows"],
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:private"],

--- a/source/common/quic/envoy_quic_proof_verifier.cc
+++ b/source/common/quic/envoy_quic_proof_verifier.cc
@@ -1,7 +1,7 @@
 #include "source/common/quic/envoy_quic_proof_verifier.h"
 
 #include "source/common/quic/envoy_quic_utils.h"
-#include "source/extensions/transport_sockets/tls/cert_validator/default_validator.h"
+#include "source/extensions/transport_sockets/tls/utility.h"
 
 #include "quiche/quic/core/crypto/certificate_view.h"
 
@@ -45,8 +45,7 @@ quic::QuicAsyncStatus EnvoyQuicProofVerifier::VerifyCertChain(
   }
 
   for (const absl::string_view& config_san : cert_view->subject_alt_name_domains()) {
-    if (Extensions::TransportSockets::Tls::DefaultCertValidator::dnsNameMatch(hostname,
-                                                                              config_san)) {
+    if (Extensions::TransportSockets::Tls::Utility::dnsNameMatch(hostname, config_san)) {
       return quic::QUIC_SUCCESS;
     }
   }

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -277,33 +277,12 @@ bool DefaultCertValidator::verifySubjectAltName(X509* cert,
   for (const GENERAL_NAME* general_name : san_names.get()) {
     const std::string san = Utility::generalNameAsString(general_name);
     for (auto& config_san : subject_alt_names) {
-      if (general_name->type == GEN_DNS ? dnsNameMatch(config_san, san.c_str())
+      if (general_name->type == GEN_DNS ? Utility::dnsNameMatch(config_san, san.c_str())
                                         : config_san == san) {
         return true;
       }
     }
   }
-  return false;
-}
-
-bool DefaultCertValidator::dnsNameMatch(const absl::string_view dns_name,
-                                        const absl::string_view pattern) {
-  const std::string lower_case_dns_name = absl::AsciiStrToLower(dns_name);
-  const std::string lower_case_pattern = absl::AsciiStrToLower(pattern);
-  if (lower_case_dns_name == lower_case_pattern) {
-    return true;
-  }
-
-  size_t pattern_len = lower_case_pattern.length();
-  if (pattern_len > 1 && lower_case_pattern[0] == '*' && lower_case_pattern[1] == '.') {
-    if (lower_case_dns_name.length() > pattern_len - 1) {
-      const size_t off = lower_case_dns_name.length() - pattern_len + 1;
-      return lower_case_dns_name.substr(0, off).find('.') == std::string::npos &&
-             lower_case_dns_name.substr(off, pattern_len - 1) ==
-                 lower_case_pattern.substr(1, pattern_len - 1);
-    }
-  }
-
   return false;
 }
 
@@ -323,7 +302,7 @@ bool DefaultCertValidator::matchSubjectAltName(
       if (general_name->type == GEN_DNS &&
                   config_san_matcher.matcher().match_pattern_case() ==
                       envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact
-              ? dnsNameMatch(config_san_matcher.matcher().exact(), absl::string_view(san))
+              ? Utility::dnsNameMatch(config_san_matcher.matcher().exact(), absl::string_view(san))
               : config_san_matcher.match(san)) {
         return true;
       }

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
@@ -88,15 +88,6 @@ public:
   static bool verifySubjectAltName(X509* cert, const std::vector<std::string>& subject_alt_names);
 
   /**
-   * Determines whether the given name matches 'pattern' which may optionally begin with a wildcard.
-   * NOTE:  public for testing
-   * @param dns_name the DNS name to match
-   * @param pattern the pattern to match against (*.example.com)
-   * @return true if the san matches pattern
-   */
-  static bool dnsNameMatch(const absl::string_view dns_name, const absl::string_view pattern);
-
-  /**
    * Performs subjectAltName matching with the provided matchers.
    * @param ssl the certificate to verify
    * @param subject_alt_name_matchers the configured matchers to match

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -71,6 +71,26 @@ Envoy::Ssl::CertificateDetailsPtr Utility::certificateDetails(X509* cert, const 
   return certificate_details;
 }
 
+bool Utility::dnsNameMatch(const absl::string_view dns_name, const absl::string_view pattern) {
+  const std::string lower_case_dns_name = absl::AsciiStrToLower(dns_name);
+  const std::string lower_case_pattern = absl::AsciiStrToLower(pattern);
+  if (lower_case_dns_name == lower_case_pattern) {
+    return true;
+  }
+
+  size_t pattern_len = lower_case_pattern.length();
+  if (pattern_len > 1 && lower_case_pattern[0] == '*' && lower_case_pattern[1] == '.') {
+    if (lower_case_dns_name.length() > pattern_len - 1) {
+      const size_t off = lower_case_dns_name.length() - pattern_len + 1;
+      return lower_case_dns_name.substr(0, off).find('.') == std::string::npos &&
+             lower_case_dns_name.substr(off, pattern_len - 1) ==
+                 lower_case_pattern.substr(1, pattern_len - 1);
+    }
+  }
+
+  return false;
+}
+
 namespace {
 
 enum class CertName { Issuer, Subject };

--- a/source/extensions/transport_sockets/tls/utility.h
+++ b/source/extensions/transport_sockets/tls/utility.h
@@ -21,6 +21,14 @@ Envoy::Ssl::CertificateDetailsPtr certificateDetails(X509* cert, const std::stri
                                                      TimeSource& time_source);
 
 /**
+ * Determines whether the given name matches 'pattern' which may optionally begin with a wildcard.
+ * @param dns_name the DNS name to match
+ * @param pattern the pattern to match against (*.example.com)
+ * @return true if the san matches pattern
+ */
+bool dnsNameMatch(const absl::string_view dns_name, const absl::string_view pattern);
+
+/**
  * Retrieves the serial number of a certificate.
  * @param cert the certificate
  * @return std::string the serial number field of the certificate. Returns "" if

--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -16,20 +16,6 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
-TEST(DefaultCertValidatorTest, TestDnsNameMatching) {
-  EXPECT_TRUE(DefaultCertValidator::dnsNameMatch("lyft.com", "lyft.com"));
-  EXPECT_TRUE(DefaultCertValidator::dnsNameMatch("a.lyft.com", "*.lyft.com"));
-  EXPECT_TRUE(DefaultCertValidator::dnsNameMatch("a.LYFT.com", "*.lyft.COM"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("a.b.lyft.com", "*.lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("foo.test.com", "*.lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("lyft.com", "*.lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("alyft.com", "*.lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("alyft.com", "*lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("lyft.com", "*lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("", "*lyft.com"));
-  EXPECT_FALSE(DefaultCertValidator::dnsNameMatch("lyft.com", ""));
-}
-
 TEST(DefaultCertValidatorTest, TestVerifySubjectAltNameDNSMatched) {
   bssl::UniquePtr<X509> cert = readCertFromFile(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem"));

--- a/test/extensions/transport_sockets/tls/utility_test.cc
+++ b/test/extensions/transport_sockets/tls/utility_test.cc
@@ -21,6 +21,20 @@ namespace TransportSockets {
 namespace Tls {
 namespace {
 
+TEST(UtilityTest, TestDnsNameMatching) {
+  EXPECT_TRUE(Utility::dnsNameMatch("lyft.com", "lyft.com"));
+  EXPECT_TRUE(Utility::dnsNameMatch("a.lyft.com", "*.lyft.com"));
+  EXPECT_TRUE(Utility::dnsNameMatch("a.LYFT.com", "*.lyft.COM"));
+  EXPECT_FALSE(Utility::dnsNameMatch("a.b.lyft.com", "*.lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("foo.test.com", "*.lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("lyft.com", "*.lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("alyft.com", "*.lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("alyft.com", "*lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("lyft.com", "*lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("", "*lyft.com"));
+  EXPECT_FALSE(Utility::dnsNameMatch("lyft.com", ""));
+}
+
 TEST(UtilityTest, TestGetSubjectAlternateNamesWithDNS) {
   bssl::UniquePtr<X509> cert = readCertFromFile(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem"));


### PR DESCRIPTION
This PR decouple static DefaultCertValidator::dnsNameMatch method from cert validator and move it to Tls::Utility namespace for clarity since it is also used in QUIC and there's no certificate verification specific logic there. 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
