### PR TITLE
Install `cmake` for `Coverage` task on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,6 +16,7 @@ tasks:
     name: "Coverage"
     platform: ubuntu1804
     shell_commands:
+    - "apt update && apt install cmake"
     - "bazel/setup_clang.sh /usr/lib/llvm-10"
     test_targets:
     - "//test/common/common/..."


### PR DESCRIPTION
The `Coverage` task has been red for a long time on Bazel CI caused by `cmake: command not found`. It used to work fine since `cmake` was preinstalled on the containers.

However, instead of preinstalling a lot of dependencies, we want to only have minimal packages preinstalled and let projects can just install whatever they need in config files.

This PR adds the command to install `cmake` for `Coverage` task.