### PR TITLE
Only track subscribed resources in Delta subscription state

### DIFF
--- a/source/common/config/delta_subscription_state.cc
+++ b/source/common/config/delta_subscription_state.cc
@@ -124,7 +124,9 @@ void DeltaSubscriptionState::handleGoodResponse(
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
     for (const auto& resource : message.resources()) {
-      addResourceState(resource);
+      if (wildcard_ || resource_state_.contains(resource.name())) {
+        addResourceState(resource);
+      }
     }
   }
 

--- a/source/common/config/delta_subscription_state.cc
+++ b/source/common/config/delta_subscription_state.cc
@@ -124,7 +124,7 @@ void DeltaSubscriptionState::handleGoodResponse(
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
     for (const auto& resource : message.resources()) {
-      if (!wildcard_ && !resource_state_.contains(resource.name())) {
+      if (wildcard_ || resource_state_.contains(resource.name())) {
         // Only consider tracked resources.
         // NOTE: This is not gonna work for xdstp resources with glob resource matching.
         addResourceState(resource);

--- a/source/common/config/delta_subscription_state.cc
+++ b/source/common/config/delta_subscription_state.cc
@@ -102,6 +102,10 @@ void DeltaSubscriptionState::handleGoodResponse(
     if (isHeartbeatResponse(resource)) {
       continue;
     }
+    if (!wildcard_ && !resource_state_.contains(resource.name())) {
+      // Only consider tracked resources.
+      continue;
+    }
     non_heartbeat_resources.Add()->CopyFrom(resource);
     // DeltaDiscoveryResponses for unresolved aliases don't contain an actual resource
     if (!resource.has_resource() && resource.aliases_size() > 0) {
@@ -123,10 +127,8 @@ void DeltaSubscriptionState::handleGoodResponse(
 
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
-    for (const auto& resource : message.resources()) {
-      if (wildcard_ || resource_state_.contains(resource.name())) {
-        addResourceState(resource);
-      }
+    for (const auto& resource : non_heartbeat_resources) {
+      addResourceState(resource);
     }
   }
 

--- a/source/common/config/xds_mux/delta_subscription_state.cc
+++ b/source/common/config/xds_mux/delta_subscription_state.cc
@@ -102,7 +102,7 @@ void DeltaSubscriptionState::handleGoodResponse(
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
     for (const auto& resource : message.resources()) {
-      if (!wildcard_ && !resource_state_.contains(resource.name())) {
+      if (wildcard_ || resource_state_.contains(resource.name())) {
         // Only consider tracked resources.
         // NOTE: This is not gonna work for xdstp resources with glob resource matching.
         addResourceState(resource);

--- a/source/common/config/xds_mux/delta_subscription_state.cc
+++ b/source/common/config/xds_mux/delta_subscription_state.cc
@@ -78,6 +78,10 @@ void DeltaSubscriptionState::handleGoodResponse(
     if (isHeartbeatResource(resource)) {
       continue;
     }
+    if (!wildcard_ && !resource_state_.contains(resource.name())) {
+      // Only consider tracked resources.
+      continue;
+    }
     // TODO (dmitri-d) consider changing onConfigUpdate callback interface to avoid copying of
     // resources
     non_heartbeat_resources.Add()->CopyFrom(resource);
@@ -101,10 +105,8 @@ void DeltaSubscriptionState::handleGoodResponse(
 
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
-    for (const auto& resource : message.resources()) {
-      if (wildcard_ || resource_state_.contains(resource.name())) {
-        addResourceState(resource);
-      }
+    for (const auto& resource : non_heartbeat_resources) {
+      addResourceState(resource);
     }
   }
 

--- a/source/common/config/xds_mux/delta_subscription_state.cc
+++ b/source/common/config/xds_mux/delta_subscription_state.cc
@@ -78,10 +78,6 @@ void DeltaSubscriptionState::handleGoodResponse(
     if (isHeartbeatResource(resource)) {
       continue;
     }
-    if (!wildcard_ && !resource_state_.contains(resource.name())) {
-      // Only consider tracked resources.
-      continue;
-    }
     // TODO (dmitri-d) consider changing onConfigUpdate callback interface to avoid copying of
     // resources
     non_heartbeat_resources.Add()->CopyFrom(resource);
@@ -105,8 +101,12 @@ void DeltaSubscriptionState::handleGoodResponse(
 
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
-    for (const auto& resource : non_heartbeat_resources) {
-      addResourceState(resource);
+    for (const auto& resource : message.resources()) {
+      if (!wildcard_ && !resource_state_.contains(resource.name())) {
+        // Only consider tracked resources.
+        // NOTE: This is not gonna work for xdstp resources with glob resource matching.
+        addResourceState(resource);
+      }
     }
   }
 

--- a/source/common/config/xds_mux/delta_subscription_state.cc
+++ b/source/common/config/xds_mux/delta_subscription_state.cc
@@ -105,7 +105,6 @@ void DeltaSubscriptionState::handleGoodResponse(
       if (wildcard_ || resource_state_.contains(resource.name())) {
         addResourceState(resource);
       }
-      addResourceState(resource);
     }
   }
 

--- a/source/common/config/xds_mux/delta_subscription_state.cc
+++ b/source/common/config/xds_mux/delta_subscription_state.cc
@@ -102,6 +102,9 @@ void DeltaSubscriptionState::handleGoodResponse(
   {
     const auto scoped_update = ttl_.scopedTtlUpdate();
     for (const auto& resource : message.resources()) {
+      if (wildcard_ || resource_state_.contains(resource.name())) {
+        addResourceState(resource);
+      }
       addResourceState(resource);
     }
   }


### PR DESCRIPTION
Signed-off-by: Xin Zhuang <stevenzzz@google.com>

Commit Message: Only track a resource in delta subscriptionState when there are subscriptions interested in it.
Additional Description:
Risk Level: LOW ( the extra tracked resources will be removed, but they are "invisible" to non-wildcard xDSes anyway.
Testing: unit tests added.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/18292
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
