### PR TITLE
signal action: fully disable sigaltstack on Apple

### DIFF
--- a/source/common/signal/signal_action.cc
+++ b/source/common/signal/signal_action.cc
@@ -82,13 +82,11 @@ void SignalAction::installSigHandlers() {
 }
 
 void SignalAction::removeSigHandlers() {
-#if defined(__APPLE__)
-  // ss_flags contains SS_DISABLE, but Darwin still checks the size, contrary to the man page
-  if (previous_altstack_.ss_size < MINSIGSTKSZ) {
-    previous_altstack_.ss_size = MINSIGSTKSZ;
-  }
-#endif
+// sigaltstack and backtrace() are incompatible on Apple platforms
+// https://reviews.llvm.org/D28265
+#if !defined(__APPLE__)
   RELEASE_ASSERT(sigaltstack(&previous_altstack_, nullptr) == 0, "");
+#endif
 
   int hidx = 0;
   for (const auto& sig : FATAL_SIGS) {

--- a/source/common/signal/signal_action.h
+++ b/source/common/signal/signal_action.h
@@ -128,7 +128,11 @@ private:
   void unmapStackMemory();
   char* altstack_{};
   std::array<struct sigaction, sizeof(FATAL_SIGS) / sizeof(int)> previous_handlers_;
+// sigaltstack and backtrace() are incompatible on Apple platforms
+// https://reviews.llvm.org/D28265
+#if !defined(__APPLE__)
   stack_t previous_altstack_;
+#endif
 };
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: signal action - fully disable sigaltstack on Apple
Additional Description: follow up from #18251 
Risk Level: low - follow up on previous PR
Platform Specific Features: only affects apple platforms

Signed-off-by: Jose Nino <jnino@lyft.com>
