### PR TITLE
dns cache: remove main thread assert in cache lookup

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -32,7 +32,6 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
 }
 
 DnsCacheSharedPtr DnsCacheManagerImpl::lookUpCacheByName(absl::string_view cache_name) {
-  ASSERT(context_.mainThreadDispatcher().isThreadSafe());
   const auto& existing_cache = caches_.find(cache_name);
   if (existing_cache != caches_.end()) {
     return existing_cache->second.cache_;


### PR DESCRIPTION
Commit Message: dns cache: remove assert at this layer
Additional Description: Envoy Mobile has logic that executes on the main thread but may not have the necessary state to pass this assertion. This change maintains the existing convention that callers of the DNS cache manager should validate their thread context independently.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>