### PR TITLE
[poc] socket: mimic MSG_PEEK by read for windows

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -235,6 +235,7 @@ envoy_cc_library(
         "//envoy/event:dispatcher_interface",
         "//envoy/network:io_handle_interface",
         "//source/common/api:os_sys_calls_lib",
+        "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_includes",
         "@envoy_api//envoy/extensions/network/socket_interface/v3:pkg_cc_proto",
     ],

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -114,6 +114,13 @@ Api::IoCallUint64Result IoSocketHandleImpl::read(Buffer::Instance& buffer,
   if (max_length == 0) {
     return Api::ioCallUint64ResultNoError();
   }
+  if constexpr (Event::PlatformDefaultTriggerType == Event::FileTriggerType::EmulatedEdge) {
+    if (buffer_->length() > 0) {
+      auto move_length = std::min(buffer_->length(), max_length);
+      buffer_->move(buffer);
+      return Api::IoCallUint64Result(move_length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
+    }
+  }
   Buffer::Reservation reservation = buffer.reserveForRead();
   Api::IoCallUint64Result result = readv(std::min(reservation.length(), max_length),
                                          reservation.slices(), reservation.numSlices());
@@ -502,6 +509,35 @@ Api::IoCallUint64Result IoSocketHandleImpl::recvmmsg(RawSliceArrays& slices, uin
 }
 
 Api::IoCallUint64Result IoSocketHandleImpl::recv(void* buffer, size_t length, int flags) {
+  if constexpr (Event::PlatformDefaultTriggerType == Event::FileTriggerType::EmulatedEdge) {
+    if (flags & MSG_PEEK) {
+      Buffer::Reservation reservation = buffer_->reserveForRead();
+      Api::IoCallUint64Result result = readv(std::min(reservation.length(), length),
+                                             reservation.slices(), reservation.numSlices());
+      uint64_t bytes_to_commit = result.ok() ? result.return_value_ : 0;
+      reservation.commit(bytes_to_commit);
+      // Emulated edge events need to registered if the socket operation did not complete
+      // because the socket would block.
+      if constexpr (Event::PlatformDefaultTriggerType == Event::FileTriggerType::EmulatedEdge) {
+        if (result.wouldBlock() && file_event_) {
+          file_event_->registerEventIfEmulatedEdge(Event::FileReadyType::Read);
+        }
+      }
+      buffer_->copyOut(0, bytes_to_commit, buffer);
+      return result;
+    } else {
+      if (buffer_->length() > 0) {
+        auto copy_size = std::min(buffer_->length(), length);
+        buffer_->copyOut(0, copy_size, buffer);
+        buffer_->drain(copy_size);
+        if (copy_size < length) {
+          length = length - copy_size;
+        } else {
+          return Api::IoCallUint64Result(copy_size, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
+        }
+      }
+    }
+  }
   const Api::SysCallSizeResult result =
       Api::OsSysCallsSingleton::get().recv(fd_, buffer, length, flags);
   auto io_result = sysCallResultToIoCallResult(result);

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -6,6 +6,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/io_handle.h"
 
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 #include "source/common/network/io_socket_error_impl.h"
 
@@ -19,7 +20,8 @@ class IoSocketHandleImpl : public IoHandle, protected Logger::Loggable<Logger::I
 public:
   explicit IoSocketHandleImpl(os_fd_t fd = INVALID_SOCKET, bool socket_v6only = false,
                               absl::optional<int> domain = absl::nullopt)
-      : fd_(fd), socket_v6only_(socket_v6only), domain_(domain) {}
+      : fd_(fd), socket_v6only_(socket_v6only), domain_(domain),
+        buffer_(std::make_unique<Buffer::OwnedImpl>()) {}
 
   // Close underlying socket if close() hasn't been call yet.
   ~IoSocketHandleImpl() override;
@@ -104,6 +106,7 @@ protected:
   int socket_v6only_{false};
   const absl::optional<int> domain_;
   Event::FileEventPtr file_event_{nullptr};
+  std::unique_ptr<Buffer::Instance> buffer_;
 
   // The minimum cmsg buffer size to filled in destination address, packets dropped and gso
   // size when receiving a packet. It is possible for a received packet to contain both IPv4

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -6,7 +6,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/io_handle.h"
 
-#include "source/common/buffer/watermark_buffer.h"
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 #include "source/common/network/io_socket_error_impl.h"
 
@@ -21,15 +21,11 @@ public:
   explicit IoSocketHandleImpl(os_fd_t fd = INVALID_SOCKET, bool socket_v6only = false,
                               absl::optional<int> domain = absl::nullopt)
       : fd_(fd), socket_v6only_(socket_v6only), domain_(domain),
-        buffer_(dispatcher.getWatermarkFactory().createBuffer(
-            [this]() -> void { this->onReadBufferLowWatermark(); },
-            [this]() -> void { this->onReadBufferHighWatermark(); }, []() -> void {})) {}
+        buffer_(std::make_unique<Buffer::OwnedImpl>()) {}
 
   // Close underlying socket if close() hasn't been call yet.
   ~IoSocketHandleImpl() override;
 
-  void onReadBufferLowWatermark();
-  void onReadBufferHighWatermark();
   // TODO(sbelair2)  To be removed when the fd is fully abstracted from clients.
   os_fd_t fdDoNotUse() const override { return fd_; }
 


### PR DESCRIPTION
Commit Message: socket: mimic MSG_PEEK by read for windows
Additional Description:
Windows only support level triggered event. The edge triggered event was emulated by the Envoy. But it depends on the envoy code read all the data out of socket buffer, then the `Read` event won't be triggered again. But for listener filter, we need to peek the data, the peek won't consume the data from the socket buffer, the `Read` event will be triggered again, and becomes a busy loop. 
This was found in the PR below:

https://github.com/envoyproxy/envoy/pull/17395#issuecomment-927788120

This PR is trying to mimic the MSG_PEEK by a normal read.

Risk Level: high
Testing:
Docs Changes:
Release Notes:
