### PR TITLE
dns: fix lifetime issue with local context

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -68,7 +68,7 @@ def envoy_copts(repository, test = False):
                    "-Wc++2a-extensions",
                    "-Wrange-loop-analysis",
                ],
-               repository + "//bazel:gcc_build": ["-Wno-uninitialized"],
+               repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
                # Allow 'nodiscard' function results values to be discarded for test code only
                # TODO(envoyproxy/windows-dev): Replace /Zc:preprocessor with /experimental:preprocessor
                # for msvc versions between 15.8 through 16.4.x. see

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -68,7 +68,7 @@ def envoy_copts(repository, test = False):
                    "-Wc++2a-extensions",
                    "-Wrange-loop-analysis",
                ],
-               repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
+               repository + "//bazel:gcc_build": ["-Wno-uninitialized"],
                # Allow 'nodiscard' function results values to be discarded for test code only
                # TODO(envoyproxy/windows-dev): Replace /Zc:preprocessor with /experimental:preprocessor
                # for msvc versions between 15.8 through 16.4.x. see

--- a/source/extensions/common/dynamic_forward_proxy/BUILD
+++ b/source/extensions/common/dynamic_forward_proxy/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
     deps = [
         ":dns_cache_impl",
         "//source/common/protobuf",
+        "//source/server:factory_context_base_impl_lib",
         "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -32,6 +32,7 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
 }
 
 DnsCacheSharedPtr DnsCacheManagerImpl::lookUpCacheByName(absl::string_view cache_name) {
+  ASSERT(context_.mainThreadDispatcher().isThreadSafe());
   const auto& existing_cache = caches_.find(cache_name);
   if (existing_cache != caches_.end()) {
     return existing_cache->second.cache_;

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
@@ -4,6 +4,7 @@
 #include "envoy/server/factory_context.h"
 
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache.h"
+#include "source/server/factory_context_base_impl.h"
 
 #include "absl/container/flat_hash_map.h"
 
@@ -44,7 +45,7 @@ public:
   DnsCacheManagerSharedPtr get() override;
 
 private:
-  Server::Configuration::FactoryContextBase& context_;
+  Server::FactoryContextBaseImpl context_;
 };
 
 } // namespace DynamicForwardProxy

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
@@ -32,8 +32,7 @@ private:
     DnsCacheSharedPtr cache_;
   };
 
-  Server::Configuration::FactoryContextBase& context_;
-
+  Server::FactoryContextBaseImpl context_;
   absl::flat_hash_map<std::string, ActiveCache> caches_;
 };
 

--- a/source/server/factory_context_base_impl.h
+++ b/source/server/factory_context_base_impl.h
@@ -18,6 +18,13 @@ public:
         singleton_manager_(singleton_manager), validation_visitor_(validation_visitor),
         scope_(scope), thread_local_(local) {}
 
+  FactoryContextBaseImpl(Configuration::FactoryContextBase& config)
+      : options_(config.options()), main_thread_dispatcher_(config.mainThreadDispatcher()),
+        api_(config.api()), local_info_(config.localInfo()), admin_(config.admin()),
+        runtime_(config.runtime()), singleton_manager_(config.singletonManager()),
+        validation_visitor_(config.messageValidationVisitor()), scope_(config.scope()),
+        thread_local_(config.threadLocal()) {}
+
   // FactoryContextBase
   const Options& options() override { return options_; };
   Event::Dispatcher& mainThreadDispatcher() override { return main_thread_dispatcher_; };
@@ -41,8 +48,8 @@ private:
   Runtime::Loader& runtime_;
   Singleton::Manager& singleton_manager_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
-  Stats::Store& scope_;
-  ThreadLocal::Instance& thread_local_;
+  Stats::Scope& scope_;
+  ThreadLocal::SlotAllocator& thread_local_;
 };
 
 } // namespace Server

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -7,6 +7,7 @@
 #include "source/common/network/resolver_impl.h"
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h"
+#include "source/server/factory_context_base_impl.h"
 
 #include "test/extensions/common/dynamic_forward_proxy/mocks.h"
 #include "test/mocks/filesystem/mocks.h"
@@ -19,6 +20,7 @@
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
+
 
 using testing::AtLeast;
 using testing::DoAll;
@@ -1175,6 +1177,21 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
   EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.2"}, std::chrono::seconds(40)));
+}
+
+// Make sure the cache manager can handle the context going out of scope.
+TEST(DnsCacheManagerImplTest, TestLifetime) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  std::unique_ptr<DnsCacheManagerImpl> cache_manager;
+
+  {
+    Server::FactoryContextBaseImpl scoped_context(context);
+    cache_manager = std::make_unique<DnsCacheManagerImpl>(scoped_context);
+  }
+  envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig config1;
+  config1.set_name("foo");
+
+  EXPECT_TRUE(cache_manager->getCache(config1) != nullptr);
 }
 
 } // namespace

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -21,7 +21,6 @@
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
-
 using testing::AtLeast;
 using testing::DoAll;
 using testing::InSequence;


### PR DESCRIPTION
Make sure the DNS code can handle the creating factory (and context) being destroyed before the DNS cache.

Risk Level: low
Testing: new unit tests
Docs Changes: n/a 
Release Notes: n/a