### PR TITLE
Cache: Added validation logic for `Vary` entries

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -113,6 +113,9 @@ public:
 
   struct {
     const std::string AcceptEncoding{"Accept-Encoding"};
+    const std::string Accept{"Accept"};
+    const std::string UserAgent{"User-Agent"};
+    const std::string ContentType{"Content-Type"};
     const std::string Wildcard{"*"};
   } VaryValues;
 };

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -398,12 +398,12 @@ bool CacheFilter::isSuccessfulValidation(const Http::ResponseHeaderMap& response
   ASSERT(filter_state_ == FilterState::ValidatingCachedResponse,
          "isSuccessfulValidation precondition unsatisfied: the "
          "CacheFilter is not validating a cache lookup result");
-  // Should only update for 304 responses
+  // If the response has changed then the cache entry is not valid
   if (!isResponseNotModified(response_headers)) {
     return false;
   }
 
-  // Delete the entry instead of updating if
+  // The cached entry is not valid if
   // (1) the vary header has changed
   // (2) the vary allow list changed to disallow the varied field. Note this is a rare case
   //     because the vary allow list change must happen between the initial look up and validation

--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -38,6 +38,8 @@ public:
   Http::FilterDataStatus encodeData(Buffer::Instance& buffer, bool end_stream) override;
 
 private:
+  friend class CacheFilterTestPeer;
+
   // Utility functions; make any necessary checks and call the corresponding lookup_ functions
   void getHeaders(Http::RequestHeaderMap& request_headers);
   void getBody();
@@ -55,8 +57,8 @@ private:
 
   // Precondition: lookup_result_ points to a cache lookup result that requires validation.
   //               filter_state_ is ValidatingCachedResponse.
-  // Checks if a cached entry should be updated with a 304 response.
-  bool shouldUpdateCachedEntry(const Http::ResponseHeaderMap& response_headers) const;
+  // Checks if a cached entry validation is successful, i.e whether certain fields matches
+  bool isSuccessfulValidation(const Http::ResponseHeaderMap& response_headers) const;
 
   // Precondition: lookup_result_ points to a cache lookup result that requires validation.
   // Should only be called during onHeaders as it modifies RequestHeaderMap.

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -345,6 +345,15 @@ VaryHeaderUtils::createVaryIdentifier(const VaryAllowList& allow_list,
   return vary_identifier;
 }
 
+bool VaryHeaderUtils::hasEqualVaryValues(const Envoy::Http::ResponseHeaderMap& existing_headers,
+                                         const Envoy::Http::ResponseHeaderMap& incoming_headers) {
+  absl::btree_set<absl::string_view> existing_vary_header_values =
+      VaryHeaderUtils::getVaryValues(existing_headers);
+  absl::btree_set<absl::string_view> response_vary_header_values =
+      VaryHeaderUtils::getVaryValues(incoming_headers);
+  return existing_vary_header_values == response_vary_header_values;
+}
+
 } // namespace Cache
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -153,6 +153,9 @@ absl::optional<std::string>
 createVaryIdentifier(const VaryAllowList& allow_list,
                      const absl::btree_set<absl::string_view>& vary_header_values,
                      const Envoy::Http::RequestHeaderMap& request_headers);
+
+bool hasEqualVaryValues(const Envoy::Http::ResponseHeaderMap& existing_headers,
+                        const Envoy::Http::ResponseHeaderMap& incoming_headers);
 } // namespace VaryHeaderUtils
 
 } // namespace Cache

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -161,7 +161,7 @@ void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
     ASSERT(iter->second.response_headers_ || !iter->second.response_headers_);
   }
 
-  // the iterator should point to the correct entry now
+  // the iterator now points to the correct entry
   Entry& entry = iter->second;
 
   // Assumptions:

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -423,7 +423,7 @@ TEST_P(CacheIntegrationTest, ServeGetFollowedByHead304WithValidation) {
   // Also to make sure response date header gets updated with the 304 date
   simTime().advanceTimeWait(Seconds(11));
 
-  // Send HEAD request, the cached response should be validate then served
+  // Send HEAD request, the cached response should be validated then served
   {
     // Include test name and params in URL to make each test's requests unique.
     const Http::TestRequestHeaderMapImpl request_headers =

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -32,10 +32,10 @@ public:
 namespace {
 
 envoy::extensions::filters::http::cache::v3alpha::CacheConfig
-getConfig(bool extraAllowedVaryHeaders) {
+getConfig(bool extra_allowed_vary_headers) {
   // Allows 'accept' to be varied in the tests.
   envoy::extensions::filters::http::cache::v3alpha::CacheConfig config;
-  if (extraAllowedVaryHeaders) {
+  if (extra_allowed_vary_headers) {
     const auto& add_accept = config.mutable_allowed_vary_headers()->Add();
     add_accept->set_exact("accept");
   }

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -46,9 +46,9 @@ class CacheFilterTest : public ::testing::Test {
 protected:
   // The filter has to be created as a shared_ptr to enable shared_from_this() which is used in the
   // cache callbacks.
-  CacheFilterSharedPtr makeFilter(HttpCache& cache, bool extraAllowedVaryHeaders = false) {
+  CacheFilterSharedPtr makeFilter(HttpCache& cache, bool extra_allowed_vary_headers = false) {
     auto filter =
-        std::make_shared<CacheFilter>(getConfig(extraAllowedVaryHeaders), /*stats_prefix=*/"",
+        std::make_shared<CacheFilter>(getConfig(extra_allowed_vary_headers), /*stats_prefix=*/"",
                                       context_.scope(), context_.timeSource(), cache);
     filter->setDecoderFilterCallbacks(decoder_callbacks_);
     filter->setEncoderFilterCallbacks(encoder_callbacks_);

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -872,6 +872,21 @@ TEST_F(VaryAllowListTest, NotAllowsHeadersMixed) {
   EXPECT_FALSE(vary_allow_list_.allowsHeaders(response_headers_));
 }
 
+TEST(HasEqualVaryValuesTest, NotEqualVary) {
+  Http::TestResponseHeaderMapImpl headers_1{{"accept", "image/*"}, {"vary", "content-type"}};
+  Http::TestResponseHeaderMapImpl headers_2{{"accept", "image/*"},
+                                            {"vary", "user-agent, content-type"}};
+  Http::TestResponseHeaderMapImpl headers_3{{"accept", "image/*"}, {"vary", "user-agent"}};
+  EXPECT_FALSE(VaryHeaderUtils::hasEqualVaryValues(headers_1, headers_2));
+  EXPECT_FALSE(VaryHeaderUtils::hasEqualVaryValues(headers_1, headers_3));
+}
+
+TEST(HasEqualVaryValuesTest, EqualVary) {
+  Http::TestResponseHeaderMapImpl headers_1{{"accept", "image/*"}, {"vary", "content-type"}};
+  Http::TestResponseHeaderMapImpl headers_2{{"accept", "application/*"}, {"vary", "content-type"}};
+  EXPECT_TRUE(VaryHeaderUtils::hasEqualVaryValues(headers_1, headers_2));
+}
+
 } // namespace
 } // namespace Cache
 } // namespace HttpFilters

--- a/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -365,7 +365,7 @@ TEST_F(SimpleHttpCacheTest, UpdateHeadersForMissingKey) {
   EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
 }
 
-TEST_F(SimpleHttpCacheTest, UpdateHeadersDisabledForVaryHeaders) {
+TEST_F(SimpleHttpCacheTest, UpdateHeadersForVaryHeaders) {
   const std::string request_path_1("/name");
   const std::string time_value_1 = formatter_.fromTime(time_source_.systemTime());
   Http::TestResponseHeaderMapImpl response_headers_1{{"date", time_value_1},
@@ -385,7 +385,7 @@ TEST_F(SimpleHttpCacheTest, UpdateHeadersDisabledForVaryHeaders) {
                                                      {"vary", "accept"}};
   updateHeaders(request_path_1, response_headers_2, {time_2});
 
-  EXPECT_TRUE(expectLookupSuccessWithHeaders(lookup(request_path_1).get(), response_headers_1));
+  EXPECT_TRUE(expectLookupSuccessWithHeaders(lookup(request_path_1).get(), response_headers_2));
 }
 
 TEST_F(SimpleHttpCacheTest, UpdateHeadersSkipEtagHeader) {


### PR DESCRIPTION
Commit Message: simple_http_cache vary validation logic impl
Additional Description: Vary entries use placeholders to store the varied fields. We need to be able to
1. If a matching vary entry is found, perform the regular header update procedure on the entry with `varied_key`
2. Otherwise, it's a failed validation. We will need a new GET request to insert the entry again.
Risk Level: Low
Testing: Unit
Fixes: a TODO item
Signed-off-by: tangsaidi@google.com
