### PR TITLE
singleton manager: overload getTyped with non-constructing version

### DIFF
--- a/envoy/singleton/manager.h
+++ b/envoy/singleton/manager.h
@@ -74,8 +74,8 @@ public:
   }
 
   /**
-   * This is a non-constructing getter only for use on instances when the caller can deal with
-   * circumstances where the singleton being access has not being constructed yet.
+   * This is a non-constructing getter. Use when the caller can deal with
+   * the singleton may not have been constructed yet.
    */
   template <class T> std::shared_ptr<T> getTyped(const std::string& name) {
     return std::dynamic_pointer_cast<T>(get(name, [] { return nullptr; }));

--- a/envoy/singleton/manager.h
+++ b/envoy/singleton/manager.h
@@ -74,6 +74,14 @@ public:
   }
 
   /**
+   * This is a non-constructing getter only for use on instances when the caller can deal with
+   * circumstances where the singleton being access has not being constructed yet.
+   */
+  template <class T> std::shared_ptr<T> getTyped(const std::string& name) {
+    return std::dynamic_pointer_cast<T>(get(name, [] { return nullptr; }));
+  }
+
+  /**
    * Get a singleton and create it if it does not exist.
    * @param name supplies the singleton name. Must be registered via RegistrationImpl.
    * @param singleton supplies the singleton creation callback. This will only be called if the

--- a/envoy/singleton/manager.h
+++ b/envoy/singleton/manager.h
@@ -75,7 +75,8 @@ public:
 
   /**
    * This is a non-constructing getter. Use when the caller can deal with instances where
-   * the singleton being accessed may not have been constructed yet.
+   * the singleton being accessed may not have been constructed previously.
+   * @return InstancePtr the singleton. nullptr if the singleton does not exist.
    */
   template <class T> std::shared_ptr<T> getTyped(const std::string& name) {
     return std::dynamic_pointer_cast<T>(get(name, [] { return nullptr; }));

--- a/envoy/singleton/manager.h
+++ b/envoy/singleton/manager.h
@@ -74,8 +74,8 @@ public:
   }
 
   /**
-   * This is a non-constructing getter. Use when the caller can deal with
-   * the singleton may not have been constructed yet.
+   * This is a non-constructing getter. Use when the caller can deal with instances where
+   * the singleton being accessed may not have been constructed yet.
    */
   template <class T> std::shared_ptr<T> getTyped(const std::string& name) {
     return std::dynamic_pointer_cast<T>(get(name, [] { return nullptr; }));

--- a/test/common/singleton/manager_impl_test.cc
+++ b/test/common/singleton/manager_impl_test.cc
@@ -42,6 +42,23 @@ TEST(SingletonManagerImplTest, Basic) {
   singleton.reset();
 }
 
+TEST(SingletonManagerImplTest, NonConstructingGetTyped) {
+  ManagerImpl manager(Thread::threadFactoryForTest());
+
+  // Access without first constructing should be null.
+  EXPECT_EQ(nullptr, manager.getTyped<TestSingleton>("test_singleton"));
+
+  std::shared_ptr<TestSingleton> singleton = std::make_shared<TestSingleton>();
+  // Use a construct on first use getter.
+  EXPECT_EQ(singleton, manager.get("test_singleton", [singleton] { return singleton; }));
+  // Now access should return the constructed singleton.
+  EXPECT_EQ(singleton, manager.getTyped<TestSingleton>("test_singleton"));
+  EXPECT_EQ(1UL, singleton.use_count());
+
+  EXPECT_CALL(*singleton, onDestroy());
+  singleton.reset();
+}
+
 } // namespace
 } // namespace Singleton
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: singleton manager - overload getTyped with non-constructing version
Additional Description: allows uses of the singleton manager where constructing is not viable, but using an existing singleton is
Risk Level: low. new api
Testing: unit tests

Signed-off-by: Jose Nino <jnino@lyft.com>