### PR TITLE
wasm: update V8 to 9.6.152

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -808,14 +808,14 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "V8",
         project_desc = "Google’s open source high-performance JavaScript and WebAssembly engine, written in C++",
         project_url = "https://v8.dev",
-        version = "9.2.230.13",
+        version = "9.6.152",
         # This archive was created using https://storage.googleapis.com/envoyproxy-wee8/wee8-archive.sh
         # and contains complete checkout of V8 with all dependencies necessary to build wee8.
-        sha256 = "77b4d6aaabe1dc60bf6bd2523a187d82292c27a2073ec48610dd098e3d4f80ce",
+        sha256 = "f61f27bd17de546264aa58f40f3aafaac7021e0ef69c17f6b1b4cd7664a037ec",
         urls = ["https://storage.googleapis.com/envoyproxy-wee8/wee8-{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.v8"],
-        release_date = "2021-06-25",
+        release_date = "2021-09-30",
         cpe = "cpe:2.3:a:google:v8:*",
     ),
     com_github_google_quiche = dict(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Before merging this PR, someone with proper access (@PiotrSikora maybe?) should deploy artifacts built by https://storage.googleapis.com/envoyproxy-wee8/wee8-archive.sh to https://storage.googleapis.com/envoyproxy-wee8/wee8-9.6.152.tar.gz

Commit Message: wasm: The current (v9.2.230.13) contain bug which doesn't let build
envoy on centos 7
Additional Description: none
Risk Level: it's hard to asses by me as I don't have a lot of experience with v8 and couldn't find a good amount of information of changes between these versions
Testing: CI build checks
Docs Changes: none
Release Notes: none
Platform Specific Features: none
Fixer #18365
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
