### PR TITLE
[config] support an inline RouteConfiguration in ScopedRouteConfiguration

### DIFF
--- a/api/envoy/config/route/v3/scoped_route.proto
+++ b/api/envoy/config/route/v3/scoped_route.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.route.v3;
 
+import "envoy/config/route/v3/route.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -16,7 +17,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Specifies a routing scope, which associates a
 // :ref:`Key<envoy_v3_api_msg_config.route.v3.ScopedRouteConfiguration.Key>` to a
-// :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` (identified by its resource name).
+// :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration`.
+// The :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` can be obtained dynamically
+// via RDS (:ref:`route_configuration_name<envoy_v3_api_field_config.route.v3.ScopedRouteConfiguration.route_configuration_name>`)
+// or specified inline (:ref:`route_configuration<envoy_v3_api_field_config.route.v3.ScopedRouteConfiguration.route_configuration>`).
 //
 // The HTTP connection manager builds up a table consisting of these Key to
 // RouteConfiguration mappings, and looks up the RouteConfiguration to use per
@@ -110,10 +114,17 @@ message ScopedRouteConfiguration {
   // The name assigned to the routing scope.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // The resource name to use for a :ref:`envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest` to an
-  // RDS server to fetch the :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` associated
-  // with this scope.
-  string route_configuration_name = 2 [(validate.rules).string = {min_len: 1}];
+  oneof route_config {
+    option (validate.required) = true;
+
+    // The resource name to use for a :ref:`envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest` to an
+    // RDS server to fetch the :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` associated
+    // with this scope.
+    string route_configuration_name = 2 [(validate.rules).string = {min_len: 1}];
+
+    // The :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration` associated with the scope.
+    RouteConfiguration route_configuration = 5;
+  }
 
   // The key to match against.
   Key key = 3 [(validate.rules).message = {required: true}];

--- a/api/envoy/config/route/v3/scoped_route.proto
+++ b/api/envoy/config/route/v3/scoped_route.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.route.v3;
 
 import "envoy/config/route/v3/route.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -77,6 +78,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // would result in the routing table defined by the `route-config1`
 // RouteConfiguration being assigned to the HTTP request/stream.
 //
+// [#next-free-field: 6]
 message ScopedRouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.ScopedRouteConfiguration";

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -582,8 +582,7 @@ message FilterStateRule {
 
   // A map of string keys to requirements. The string key is the string value
   // in the FilterState with the name specified in the *name* field above.
-  map<string, JwtRequirement>
-  requires = 3;
+  map<string, JwtRequirement> requires = 3;
 }
 
 // This is the Envoy HTTP filter config for JWT authentication.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -911,7 +911,7 @@ message ScopedRoutes {
   // Configuration source specifier for RDS.
   // This config source is used to subscribe to RouteConfiguration resources specified in
   // ScopedRouteConfiguration messages.
-  config.core.v3.ConfigSource rds_config_source = 3 [(validate.rules).message = {required: true}];
+  config.core.v3.ConfigSource rds_config_source = 3;
 
   oneof config_specifier {
     option (validate.required) = true;

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -233,6 +233,7 @@ envoy_cc_library(
         "//source/common/config:xds_resource_lib",
         "//source/common/init:manager_lib",
         "//source/common/init:watcher_lib",
+        "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",

--- a/source/common/router/scoped_config_impl.cc
+++ b/source/common/router/scoped_config_impl.cc
@@ -75,9 +75,9 @@ HeaderValueExtractorImpl::computeFragment(const Http::HeaderMap& headers) const 
   return nullptr;
 }
 
-ScopedRouteInfo::ScopedRouteInfo(envoy::config::route::v3::ScopedRouteConfiguration&& config_proto,
-                                 ConfigConstSharedPtr&& route_config)
-    : config_proto_(std::move(config_proto)), route_config_(std::move(route_config)) {
+ScopedRouteInfo::ScopedRouteInfo(envoy::config::route::v3::ScopedRouteConfiguration config_proto,
+                                 ConfigConstSharedPtr route_config)
+    : config_proto_(config_proto), route_config_(route_config) {
   // TODO(stevenzzzz): Maybe worth a KeyBuilder abstraction when there are more than one type of
   // Fragment.
   for (const auto& fragment : config_proto_.key().fragments()) {

--- a/source/common/router/scoped_config_impl.h
+++ b/source/common/router/scoped_config_impl.h
@@ -81,8 +81,8 @@ private:
 // ScopedRouteConfiguration and corresponding RouteConfigProvider.
 class ScopedRouteInfo {
 public:
-  ScopedRouteInfo(envoy::config::route::v3::ScopedRouteConfiguration&& config_proto,
-                  ConfigConstSharedPtr&& route_config);
+  ScopedRouteInfo(envoy::config::route::v3::ScopedRouteConfiguration config_proto,
+                  ConfigConstSharedPtr route_config);
 
   const ConfigConstSharedPtr& routeConfig() const { return route_config_; }
   const ScopeKey& scopeKey() const { return scope_key_; }

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -9,7 +9,6 @@
 #include "envoy/service/discovery/v3/discovery.pb.h"
 
 #include "source/common/common/assert.h"
-#include "envoy/config/core/v3/config_source.pb.h"
 #include "source/common/common/cleanup.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/utility.h"

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -52,7 +52,8 @@ public:
                                    ScopedRoutesConfigProviderManager& config_provider_manager,
                                    envoy::config::core::v3::ConfigSource rds_config_source,
                                    envoy::extensions::filters::network::http_connection_manager::
-                                       v3::ScopedRoutes::ScopeKeyBuilder scope_key_builder);
+                                       v3::ScopedRoutes::ScopeKeyBuilder scope_key_builder,
+                                   const OptionalHttpFilters& optional_http_filters);
 
   ~InlineScopedRoutesConfigProvider() override = default;
 
@@ -61,9 +62,9 @@ public:
   // Envoy::Config::ConfigProvider
   Envoy::Config::ConfigProvider::ConfigProtoVector getConfigProtos() const override {
     Envoy::Config::ConfigProvider::ConfigProtoVector out_protos;
-    std::for_each(config_protos_.begin(), config_protos_.end(),
-                  [&out_protos](const std::unique_ptr<const Protobuf::Message>& message) {
-                    out_protos.push_back(message.get());
+    std::for_each(scopes_.begin(), scopes_.end(),
+                  [&out_protos](const ScopedRouteInfoConstSharedPtr& scope) {
+                    out_protos.push_back(&scope->configProto());
                   });
     return out_protos;
   }
@@ -74,8 +75,8 @@ public:
 private:
   const std::string name_;
   ConfigConstSharedPtr config_;
-  const std::vector<std::unique_ptr<const Protobuf::Message>> config_protos_;
   const envoy::config::core::v3::ConfigSource rds_config_source_;
+  std::vector<ScopedRouteInfoConstSharedPtr> scopes_;
 };
 
 /**
@@ -295,7 +296,7 @@ public:
       Server::Configuration::ServerFactoryContext& factory_context,
       const Envoy::Config::ConfigProviderManager::OptionalArg& optarg) override;
 
-  RouteConfigProviderManager& routeConfigProviderPanager() {
+  RouteConfigProviderManager& routeConfigProviderManager() {
     return route_config_provider_manager_;
   }
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -433,11 +433,15 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
 void HttpIntegrationTest::sendRequestAndVerifyResponse(
     const Http::TestRequestHeaderMapImpl& request_headers, const int request_size,
     const Http::TestResponseHeaderMapImpl& response_headers, const int response_size,
-    const int backend_idx) {
+    const int backend_idx,
+    absl::optional<const Http::TestResponseHeaderMapImpl> expected_response_headers) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
                                                 response_size, backend_idx);
-  verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
+  verifyResponse(std::move(response), "200",
+                 (expected_response_headers.has_value()) ? *expected_response_headers
+                                                         : response_headers,
+                 std::string(response_size, 'a'));
 
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ(request_size, upstream_request_->bodyLength());

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -186,7 +186,9 @@ protected:
   void sendRequestAndVerifyResponse(const Http::TestRequestHeaderMapImpl& request_headers,
                                     const int request_size,
                                     const Http::TestResponseHeaderMapImpl& response_headers,
-                                    const int response_size, const int backend_idx);
+                                    const int response_size, const int backend_idx,
+                                    absl::optional<const Http::TestResponseHeaderMapImpl>
+                                        expected_response_headers = absl::nullopt);
 
   // Check for completion of upstream_request_, and a simple "200" response.
   void checkSimpleRequestSuccess(uint64_t expected_request_size, uint64_t expected_response_size,

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -15,7 +15,6 @@
 #include "test/test_common/resources.h"
 
 #include "absl/strings/str_cat.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -14,11 +14,160 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/resources.h"
 
+#include "absl/strings/str_cat.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
 namespace {
+
+class InlineScopedRoutesIntegrationTest : public HttpIntegrationTest, public testing::Test {
+protected:
+  InlineScopedRoutesIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4) {}
+
+  void setScopedRoutesConfig(absl::string_view config_yaml) {
+    config_helper_.addConfigModifier(
+        [config_yaml](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
+          envoy::extensions::filters::network::http_connection_manager::v3::ScopedRoutes*
+              scoped_routes = hcm.mutable_scoped_routes();
+          const std::string scoped_routes_yaml = absl::StrCat(R"EOF(
+name: foo-scoped-routes
+scope_key_builder:
+  fragments:
+    - header_value_extractor:
+        name: Addr
+        element_separator: ;
+        element:
+          key: x-foo-key
+          separator: =
+)EOF",
+                                                              config_yaml);
+          TestUtility::loadFromYaml(scoped_routes_yaml, *scoped_routes);
+        });
+  }
+};
+
+TEST_F(InlineScopedRoutesIntegrationTest, NoScopeFound) {
+  absl::string_view config_yaml = R"EOF(
+scoped_route_configurations_list:
+  scoped_route_configurations:
+    - name: foo-scope
+      route_configuration:
+        name: foo
+        virtual_hosts:
+          - name: bar
+            domains: ["*"]
+            routes:
+              - match: { prefix: "/" }
+                route: { cluster: cluster_0 }
+      key:
+        fragments: { string_key: foo }
+)EOF";
+  setScopedRoutesConfig(config_yaml);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     // "xyz-route" is not a configured scope key.
+                                     {"Addr", "x-foo-key=xyz-route"}});
+  ASSERT_TRUE(response->waitForEndStream());
+  verifyResponse(std::move(response), "404", Http::TestResponseHeaderMapImpl{}, "");
+  cleanupUpstreamAndDownstream();
+}
+
+TEST_F(InlineScopedRoutesIntegrationTest, ScopeWithSingleRouteConfiguration) {
+  absl::string_view config_yaml = R"EOF(
+scoped_route_configurations_list:
+  scoped_route_configurations:
+    - name: foo-scope
+      route_configuration:
+        name: foo
+        virtual_hosts:
+          - name: bar
+            domains: ["*"]
+            routes:
+              - match: { prefix: "/" }
+                route: { cluster: cluster_0 }
+      key:
+        fragments: { string_key: foo }
+)EOF";
+  setScopedRoutesConfig(config_yaml);
+  initialize();
+
+  sendRequestAndVerifyResponse(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=foo"}},
+      /*request_size=*/0, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", "foo"}},
+      /*response_size=*/0,
+      /*backend_idx=*/0);
+}
+
+TEST_F(InlineScopedRoutesIntegrationTest, ScopeWithMultipleRouteConfigurations) {
+  absl::string_view config_yaml = R"EOF(
+scoped_route_configurations_list:
+  scoped_route_configurations:
+    - name: foo-scope
+      route_configuration:
+        name: foo
+        virtual_hosts:
+          - name: bar
+            domains: ["*"]
+            routes:
+              - match: { prefix: "/" }
+                route: { cluster: cluster_0 }
+            response_headers_to_add:
+              header: { key: route-name, value: foo }
+      key:
+        fragments: { string_key: foo }
+    - name: baz-scope
+      route_configuration:
+        name: baz
+        virtual_hosts:
+          - name: bar
+            domains: ["*"]
+            routes:
+              - match: { prefix: "/" }
+                route: { cluster: cluster_0 }
+            response_headers_to_add:
+              header: { key: route-name, value: baz }
+      key:
+        fragments: { string_key: baz }
+
+)EOF";
+  setScopedRoutesConfig(config_yaml);
+  initialize();
+
+  sendRequestAndVerifyResponse(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=baz"}},
+      /*request_size=*/0, Http::TestResponseHeaderMapImpl{{":status", "200"}},
+      /*response_size=*/0,
+      /*backend_idx=*/0, Http::TestResponseHeaderMapImpl{{"route-name", "baz"}});
+  sendRequestAndVerifyResponse(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=foo"}},
+      /*request_size=*/0, Http::TestResponseHeaderMapImpl{{":status", "200"}},
+      /*response_size=*/0,
+      /*backend_idx=*/0, Http::TestResponseHeaderMapImpl{{"route-name", "foo"}});
+  ;
+}
 
 class ScopedRdsIntegrationTest : public HttpIntegrationTest,
                                  public Grpc::DeltaSotwIntegrationParamTest {


### PR DESCRIPTION
Support an inline `RouteConfiguration` in `ScopedRouteConfiguration`.

This change enables fully inlined scoped route configuration by allowing users to specify an inline `RouteConfiguration` in the scope's config, as opposed to requiring a `route_configuration_name` to use for an RDS subscription.

Risk Level: Low
Testing: Unit and integration tests added.
Docs Changes: Proto comments modified and generated docs verified for correctness.
Release Notes: n/a