### PR TITLE
tls: make server options available to the handshaker factory

### DIFF
--- a/envoy/ssl/handshaker.h
+++ b/envoy/ssl/handshaker.h
@@ -5,6 +5,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/network/post_io_action.h"
 #include "envoy/protobuf/message_validator.h"
+#include "envoy/server/options.h"
 
 #include "openssl/ssl.h"
 
@@ -62,6 +63,11 @@ using SslCtxCb = std::function<void(SSL_CTX*)>;
 class HandshakerFactoryContext {
 public:
   virtual ~HandshakerFactoryContext() = default;
+
+  /**
+   * @return reference to the server options
+   */
+  virtual const Server::Options& options() const PURE;
 
   /**
    * @return reference to the Api object

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -170,6 +170,7 @@ ContextConfigImpl::ContextConfigImpl(
     const std::string& default_cipher_suites, const std::string& default_curves,
     Server::Configuration::TransportSocketFactoryContext& factory_context)
     : api_(factory_context.api()),
+      options_(factory_context.options()),
       alpn_protocols_(RepeatedPtrUtil::join(config.alpn_protocols(), ",")),
       cipher_suites_(StringUtil::nonEmptyStringOrDefault(
           RepeatedPtrUtil::join(config.tls_params().cipher_suites(), ":"), default_cipher_suites)),
@@ -218,7 +219,7 @@ ContextConfigImpl::ContextConfigImpl(
     }
   }
 
-  HandshakerFactoryContextImpl handshaker_factory_context(api_, alpn_protocols_);
+  HandshakerFactoryContextImpl handshaker_factory_context(api_, options_, alpn_protocols_);
   Ssl::HandshakerFactory* handshaker_factory;
   if (config.has_custom_handshaker()) {
     // If a custom handshaker is configured, derive the factory from the config.

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -68,6 +68,7 @@ protected:
                     const std::string& default_cipher_suites, const std::string& default_curves,
                     Server::Configuration::TransportSocketFactoryContext& factory_context);
   Api::Api& api_;
+  const Server::Options& options_;
 
 private:
   static unsigned tlsVersionFromProto(

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.h
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.h
@@ -6,6 +6,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/network/transport_socket.h"
 #include "envoy/secret/secret_callbacks.h"
+#include "envoy/server/options.h"
 #include "envoy/ssl/handshaker.h"
 #include "envoy/ssl/private_key/private_key_callbacks.h"
 #include "envoy/ssl/ssl_socket_extended_info.h"
@@ -100,15 +101,18 @@ using SslHandshakerImplSharedPtr = std::shared_ptr<SslHandshakerImpl>;
 
 class HandshakerFactoryContextImpl : public Ssl::HandshakerFactoryContext {
 public:
-  HandshakerFactoryContextImpl(Api::Api& api, absl::string_view alpn_protocols)
-      : api_(api), alpn_protocols_(alpn_protocols) {}
+  HandshakerFactoryContextImpl(Api::Api& api, const Server::Options& options,
+                               absl::string_view alpn_protocols)
+      : api_(api), options_(options), alpn_protocols_(alpn_protocols) {}
 
   // HandshakerFactoryContext
   Api::Api& api() override { return api_; }
+  const Server::Options& options() const override { return options_; }
   absl::string_view alpnProtocols() const override { return alpn_protocols_; }
 
 private:
   Api::Api& api_;
+  const Server::Options& options_;
   const std::string alpn_protocols_;
 };
 

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -244,6 +244,7 @@ envoy_cc_mock(
         "//source/common/secret:secret_manager_impl_lib",
         "//test/mocks/api:api_mocks",
         "//test/mocks/server:config_tracker_mocks",
+        "//test/mocks/server:options_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
     ],

--- a/test/mocks/server/transport_socket_factory_context.cc
+++ b/test/mocks/server/transport_socket_factory_context.cc
@@ -19,6 +19,7 @@ MockTransportSocketFactoryContext::MockTransportSocketFactoryContext()
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
   ON_CALL(*this, sslContextManager()).WillByDefault(ReturnRef(context_manager_));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(store_));
+  ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
 }
 
 MockTransportSocketFactoryContext::~MockTransportSocketFactoryContext() = default;

--- a/test/mocks/server/transport_socket_factory_context.h
+++ b/test/mocks/server/transport_socket_factory_context.h
@@ -8,6 +8,7 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
+#include "test/mocks/server/options.h"
 
 #include "config_tracker.h"
 #include "gmock/gmock.h"
@@ -42,6 +43,7 @@ public:
   testing::NiceMock<MockConfigTracker> config_tracker_;
   testing::NiceMock<Ssl::MockContextManager> context_manager_;
   testing::NiceMock<Stats::MockStore> store_;
+  testing::NiceMock<Server::MockOptions> options_;
   std::unique_ptr<Secret::SecretManager> secret_manager_;
 };
 } // namespace Configuration


### PR DESCRIPTION
Commit Message: Make Server::Options available to the SSL handshaker factory
Additional Description:
This allows the handshaker to detect the run mode (`Server::Options::mode`) and use that
to bypass checks required for serving but not for validation.

Risk Level: low
Testing: added and ran unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a