### PR TITLE
bazel: remove duplicate -gsplit-dwarf argument

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -51,9 +51,9 @@ def envoy_copts(repository, test = False):
                # debugging info detailing some 1600 test binaries would be wasteful.
                # targets listed in order from generic to increasing specificity.
                # Bazel adds an implicit -DNDEBUG for opt targets.
-               repository + "//bazel:opt_build": [] if test else ["-ggdb3", "-gsplit-dwarf"],
+               repository + "//bazel:opt_build": [] if test else ["-ggdb3"],
                repository + "//bazel:fastbuild_build": [],
-               repository + "//bazel:dbg_build": ["-ggdb3", "-gsplit-dwarf"],
+               repository + "//bazel:dbg_build": ["-ggdb3"],
                repository + "//bazel:windows_opt_build": [] if test else ["-Z7"],
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],


### PR DESCRIPTION
With `--config=linux` we enable `per_object_debug_info`, which passes
this flag, so we don't also need to pass it here, otherwise you cannot
build without split debug info.

I verified with aquery that this arg is still passed, just only once now

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
