### PR TITLE
bazel: Remove CMAKE_TRY_COMPILE_TARGET_TYPE from libsxg

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -113,7 +113,6 @@ envoy_cmake(
         "SXG_WITH_CERT_CHAIN": "off",
         "RUN_TEST": "off",
         "CMAKE_INSTALL_LIBDIR": "lib",
-        "CMAKE_TRY_COMPILE_TARGET_TYPE": "STATIC_LIBRARY",
     },
     lib_source = "@com_github_google_libsxg//:all",
     out_static_libs = ["libsxg.a"],


### PR DESCRIPTION
On macOS the value of `CMAKE_AR` is actually `libtool` which has an
entirely different interface. This works with rules_foreign_cc because
it takes the correct flags from the cc toolchain for `libtool` and tells
cmake to use those.

When using `CMAKE_TRY_COMPILE_TARGET_TYPE` cmake does a test of
compiling a file where it respects `CMAKE_AR`, but doesn't respect
`CMAKE_C_ARCHIVE_CREATE` which is what rules_foreign_cc uses to override
the args. This resulted in a argument mismatch where `ar` args would be
passed to `libtool`, and if we set `CMAKE_AR` back to `/usr/bin/ar`,
when the actual build happened, not just this test, it would be passed
`libtool` args instead.

I don't think removing this should cause problems, since it's just an
early warning sign in the build.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>