### PR TITLE
[API] Add stream RPC for `RateLimitService` and add the flag to let controller specifies whether unary or stream RPC will be used

### DIFF
--- a/api/envoy/config/ratelimit/v3/rls.proto
+++ b/api/envoy/config/ratelimit/v3/rls.proto
@@ -17,6 +17,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Rate limit service]
 
 // Rate limit :ref:`configuration overview <config_rate_limit_service>`.
+// [#next-free-field: 6]
 message RateLimitServiceConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.ratelimit.v2.RateLimitServiceConfig";
@@ -31,4 +32,8 @@ message RateLimitServiceConfig {
   // API version for rate limit transport protocol. This describes the rate limit gRPC endpoint and
   // version of messages used on the wire.
   core.v3.ApiVersion transport_api_version = 4 [(validate.rules).enum = {defined_only: true}];
+
+  // Specifies whether the RPC communication with RLS server should be unary or streaming RPC.
+  // [#not-implemented-hide:]
+  bool use_stream_api = 5;
 }

--- a/api/envoy/config/ratelimit/v3/rls.proto
+++ b/api/envoy/config/ratelimit/v3/rls.proto
@@ -33,7 +33,7 @@ message RateLimitServiceConfig {
   // version of messages used on the wire.
   core.v3.ApiVersion transport_api_version = 4 [(validate.rules).enum = {defined_only: true}];
 
-  // Specifies whether the RPC communication with RLS server should be unary or streaming RPC.
+  // Specifies whether the RPC communication with RLS server should be unary or streaming RPC. The default value is false.
   // [#not-implemented-hide:]
   bool use_stream_api = 5;
 }

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -25,6 +25,11 @@ service RateLimitService {
   // Determine whether rate limiting should take place.
   rpc ShouldRateLimit(RateLimitRequest) returns (RateLimitResponse) {
   }
+
+  // Determine whether rate limiting should take place (Stream RPC version).
+  // [#not-implemented-hide:]
+  rpc ShouldRateLimitStream(stream RateLimitRequest) returns (stream RateLimitResponse) {
+  }
 }
 
 // Main message for a rate limit request. The rate limit service is designed to be fully generic

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -26,7 +26,7 @@ service RateLimitService {
   rpc ShouldRateLimit(RateLimitRequest) returns (RateLimitResponse) {
   }
 
-  // Determine whether rate limiting should take place (Stream RPC version).
+  // Determine whether rate limiting should take place (Bidi-Stream RPC version).
   // [#not-implemented-hide:]
   rpc ShouldRateLimitStream(stream RateLimitRequest) returns (stream RateLimitResponse) {
   }


### PR DESCRIPTION
- Introduce bi-direction stream gRPC communication to RLS sever
- Add the flag to make the stream vs unary communication configurable 

Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: LOW
Testing: CI
Release Notes: Not implemented
