### PR TITLE
Update ipp-crypto to 2021.4 release.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -264,14 +264,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "libipp-crypto",
         project_desc = "Intel® Integrated Performance Primitives Cryptography",
         project_url = "https://github.com/intel/ipp-crypto",
-        # The required BoringSSL compatibility patches are present in the
-        # "development" branch, but not yet in the release branch. The target
-        # release for the patches is 2021.4.
-        version = "4048dac1617bf33ff85d37a4b8f68f21342263b7",
-        sha256 = "4316589a7c0afa5788b84b04510283dab0979bf6d3b0aa0e4ef0fe540675af5e",
-        strip_prefix = "ipp-crypto-{version}",
-        urls = ["https://github.com/intel/ipp-crypto/archive/{version}.tar.gz"],
-        release_date = "2021-07-07",
+        version = "2021.4",
+        sha256 = "23e250dcf281aa00d186be8dc4e34fa8fc5c95a0895694cd00b33f18af5d60c7",
+        strip_prefix = "ipp-crypto-ippcp_{version}",
+        urls = ["https://github.com/intel/ipp-crypto/archive/ippcp_{version}.tar.gz"],
+        release_date = "2021-10-01",
         use_category = ["dataplane_ext"],
         extensions = ["envoy.tls.key_providers.cryptomb"],
         cpe = "N/A",


### PR DESCRIPTION
Commit Message:

Update ipp-crypto to 2021.4 release.

Risk Level: Low
Testing: Ran the code + basic perf tests on Xeon Scalable Gen 3.
Fixes #18384
