### PR TITLE
Drop clang-cl compilation target for the time being

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -512,41 +512,6 @@ stages:
         artifactName: windows.release
       condition: always()
 
-  - job: clang_cl
-    timeoutInMinutes: 120
-    pool:
-      vmImage: "windows-latest"
-    steps:
-    - task: Cache@2
-      inputs:
-        key: '"windows.release" | ./WORKSPACE | **/*.bzl'
-        path: $(Build.StagingDirectory)/repository_cache
-      continueOnError: true
-    - bash: ci/run_envoy_docker.sh ci/windows_ci_steps.sh
-      displayName: "Run Windows clang-cl CI"
-      env:
-        CI_TARGET: "windows"
-        ENVOY_DOCKER_BUILD_DIR: "$(Build.StagingDirectory)"
-        SLACK_TOKEN: $(SLACK_TOKEN)
-        REPO_URI: $(Build.Repository.Uri)
-        BUILD_URI: $(Build.BuildUri)
-        ENVOY_RBE: "true"
-        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=remote-clang-cl --jobs=$(RbeJobs) --flaky_test_attempts=2"
-        BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-        BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
-        GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFiles: "**/bazel-out/**/testlogs/**/test.xml"
-        testRunTitle: "clang-cl"
-        searchFolder: $(Build.StagingDirectory)/tmp
-      condition: always()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        pathtoPublish: "$(Build.StagingDirectory)/envoy"
-        artifactName: windows.clang-cl
-      condition: always()
-
   - job: docker
     dependsOn: ["release"]
     timeoutInMinutes: 120


### PR DESCRIPTION
Unfortunately, a change in the flags or behavior of the bazel 4.2.1
release has caused a regression in the ability to compile grpc under clang-cl.

The primary output of envoy-static.exe is generated by MSVC, the clang-cl
alternative is an observation point to see what the MS compiler might be
doing wrong based on our general clang compiler development strategy.
At the moment, it is a blocker.

This patch should be reverted once we've uncovered what's changed with
bazel 4.2.1; this isn't entirely on the compiler, the same error occurs on 
clang-cl versions 11 and 12, not on msvc, and does not occur in clang for linux.

See issue https://github.com/envoyproxy/envoy/issues/18407

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
