### PR TITLE
Dns: respecting DNS TTL

### DIFF
--- a/api/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
+++ b/api/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
@@ -55,14 +55,7 @@ message DnsCacheConfig {
   config.cluster.v3.Cluster.DnsLookupFamily dns_lookup_family = 2
       [(validate.rules).enum = {defined_only: true}];
 
-  // The DNS refresh rate for currently cached DNS hosts. If not specified defaults to 60s.
-  //
-  // .. note:
-  //
-  //  The returned DNS TTL is not currently used to alter the refresh rate. This feature will be
-  //  added in a future change.
-  //
-  // .. note:
+  // The DNS refresh rate for unresolved DNS hosts. If not specified defaults to 60s.
   //
   // The refresh rate is rounded to the closest millisecond, and must be at least 1ms.
   google.protobuf.Duration dns_refresh_rate = 3

--- a/api/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
+++ b/api/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
@@ -58,6 +58,9 @@ message DnsCacheConfig {
   // The DNS refresh rate for unresolved DNS hosts. If not specified defaults to 60s.
   //
   // The refresh rate is rounded to the closest millisecond, and must be at least 1ms.
+  //
+  // Once a host has been resolved, the refresh rate will be the DNS TTL, capped
+  // at a minimum of 5s.
   google.protobuf.Duration dns_refresh_rate = 3
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,6 +38,7 @@ Minor Behavior Changes
   for "gRPC config stream closed" is now reduced to debug when the status is ``Ok`` or has been
   retriable (``DeadlineExceeded``, ``ResourceExhausted``, or ``Unavailable``) for less than 30
   seconds.
+* dns: now respecting the returned DNS TTL for resolved  hosts, rather than always relying on the hard-coded ref:`dns_refresh_rate. <envoy_v3_api_field_config.cluster.v3.Cluster.dns_refresh_rate>` This behavior can be temporarily reverted by setting the runtime guard ``envoy.reloadable_features.use_dns_ttl`` to false.
 * grpc: gRPC async client can be cached and shared across filter instances in the same thread, this feature is turned off by default, can be turned on by setting runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to true.
 * http: correct the use of the ``x-forwarded-proto`` header and the ``:scheme`` header. Where they differ
   (which is rare) ``:scheme`` will now be used for serving redirect URIs and cached content. This behavior

--- a/envoy/common/backoff_strategy.h
+++ b/envoy/common/backoff_strategy.h
@@ -22,6 +22,12 @@ public:
    * Resets the intervals so that the back off intervals can start again.
    */
   virtual void reset() PURE;
+
+  /**
+   * Resets the interval with a (potentially) new starting point.
+   */
+  virtual void reset(uint64_t base) PURE;
+
 };
 
 using BackOffStrategyPtr = std::unique_ptr<BackOffStrategy>;

--- a/source/common/common/backoff_strategy.h
+++ b/source/common/common/backoff_strategy.h
@@ -29,9 +29,13 @@ public:
   // BackOffStrategy methods
   uint64_t nextBackOffMs() override;
   void reset() override;
+  void reset(uint64_t base_interval) override {
+    base_interval_ = base_interval;
+    reset();
+  }
 
 private:
-  const uint64_t base_interval_;
+  uint64_t base_interval_;
   const uint64_t max_interval_{};
   uint64_t next_interval_;
   Random::RandomGenerator& random_;
@@ -53,9 +57,10 @@ public:
   // BackOffStrategy methods
   uint64_t nextBackOffMs() override;
   void reset() override {}
+  void reset(uint64_t min_interval) override { min_interval_ = min_interval; }
 
 private:
-  const uint64_t min_interval_;
+  uint64_t min_interval_;
   Random::RandomGenerator& random_;
 };
 
@@ -74,9 +79,10 @@ public:
   // BackOffStrategy methods.
   uint64_t nextBackOffMs() override;
   void reset() override {}
+  void reset(uint64_t interval_ms) override { interval_ms_ = interval_ms; }
 
 private:
-  const uint64_t interval_ms_;
+  uint64_t interval_ms_;
 };
 
 } // namespace Envoy

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -94,6 +94,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.udp_per_event_loop_read_limit",
     "envoy.reloadable_features.unquote_log_string_values",
     "envoy.reloadable_features.upstream_host_weight_change_causes_rebuild",
+    "envoy.reloadable_features.use_dns_ttl",
     "envoy.reloadable_features.use_observable_cluster_name",
     "envoy.reloadable_features.validate_connect",
     "envoy.reloadable_features.vhds_heartbeats",

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -357,8 +357,10 @@ void DnsCacheImpl::finishResolve(const std::string& host,
     if (!from_cache) {
       addCacheEntry(host, new_address, response.front().ttl_);
     }
-    // Arbitrarily cap DNS re-resolution at 5s to avoid constant DNS queries.
-    dns_ttl = std::max<std::chrono::seconds>(std::chrono::seconds(5), response.front().ttl_);
+    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_dns_ttl")) {
+      // Arbitrarily cap DNS re-resolution at 5s to avoid constant DNS queries.
+      dns_ttl = std::max<std::chrono::seconds>(std::chrono::seconds(5), response.front().ttl_);
+    }
     primary_host_info->host_info_->updateStale(resolution_time.value(), dns_ttl);
   }
 

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -20,6 +20,8 @@ DnsCacheImpl::DnsCacheImpl(
     Server::Configuration::FactoryContextBase& context,
     const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config)
     : main_thread_dispatcher_(context.mainThreadDispatcher()),
+      config_(config),
+      random_generator_(context.api().randomGenerator()),
       dns_lookup_family_(Upstream::getDnsLookupFamilyFromEnum(config.dns_lookup_family())),
       resolver_(selectDnsResolver(config, main_thread_dispatcher_)),
       tls_slot_(context.threadLocal()),
@@ -29,10 +31,6 @@ DnsCacheImpl::DnsCacheImpl(
                         config.dns_cache_circuit_breaker()),
       refresh_interval_(PROTOBUF_GET_MS_OR_DEFAULT(config, dns_refresh_rate, 60000)),
       timeout_interval_(PROTOBUF_GET_MS_OR_DEFAULT(config, dns_query_timeout, 5000)),
-      failure_backoff_strategy_(
-          Config::Utility::prepareDnsRefreshStrategy<
-              envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig>(
-              config, refresh_interval_.count(), context.api().randomGenerator())),
       file_system_(context.api().fileSystem()),
       validation_visitor_(context.messageValidationVisitor()),
       host_ttl_(PROTOBUF_GET_MS_OR_DEFAULT(config, host_ttl, 300000)),
@@ -250,8 +248,8 @@ void DnsCacheImpl::onReResolve(const std::string& host) {
   const std::chrono::steady_clock::duration now_duration =
       main_thread_dispatcher_.timeSource().monotonicTime().time_since_epoch();
   auto last_used_time = primary_host.host_info_->lastUsedTime();
-  ENVOY_LOG(debug, "host='{}' TTL check: now={} last_used={}", host, now_duration.count(),
-            last_used_time.count());
+  ENVOY_LOG(debug, "host='{}' TTL check: now={} last_used={} TTL {}", host, now_duration.count(),
+            last_used_time.count(), host_ttl_.count());
   if ((now_duration - last_used_time) > host_ttl_) {
     ENVOY_LOG(debug, "host='{}' TTL expired, removing", host);
     // If the host has no address then that means that the DnsCacheImpl has never
@@ -353,34 +351,32 @@ void DnsCacheImpl::finishResolve(const std::string& host,
   if (!resolution_time.has_value()) {
     resolution_time = main_thread_dispatcher_.timeSource().monotonicTime();
   }
+  std::chrono::seconds dns_ttl = std::chrono::duration_cast<std::chrono::seconds>(refresh_interval_);
   if (new_address) {
     // Update the cache entry and staleness any time the ttl changes.
     if (!from_cache) {
       addCacheEntry(host, new_address, response.front().ttl_);
     }
-    primary_host_info->host_info_->updateStale(resolution_time.value(), response.front().ttl_);
+    // Arbitrarily cap DNS re-resolution at 5s to avoid constant DNS queries.
+    dns_ttl = std::max<std::chrono::seconds>(std::chrono::seconds(5), response.front().ttl_);
+    primary_host_info->host_info_->updateStale(resolution_time.value(), dns_ttl);
   }
 
   if (first_resolve) {
     primary_host_info->host_info_->setFirstResolveComplete();
   }
-  if (first_resolve || address_changed) {
-    // TODO(alyssawilk) only notify threads of stale results after a resolution
-    // timeout.
+  if (first_resolve || (address_changed && !primary_host_info->host_info_->isStale())) {
     notifyThreads(host, primary_host_info->host_info_);
   }
 
   // Kick off the refresh timer.
-  // TODO(mattklein123): Consider jitter here. It may not be necessary since the initial host
-  // is populated dynamically.
-  // TODO(alyssawilk) also consider TTL here.
   if (status == Network::DnsResolver::ResolutionStatus::Success) {
-    failure_backoff_strategy_->reset();
-    primary_host_info->refresh_timer_->enableTimer(refresh_interval_);
+    primary_host_info->failure_backoff_strategy_->reset(std::chrono::duration_cast<std::chrono::milliseconds>(dns_ttl).count());
+    primary_host_info->refresh_timer_->enableTimer(dns_ttl);
     ENVOY_LOG(debug, "DNS refresh rate reset for host '{}', refresh rate {} ms", host,
               refresh_interval_.count());
   } else {
-    const uint64_t refresh_interval = failure_backoff_strategy_->nextBackOffMs();
+    const uint64_t refresh_interval = primary_host_info->failure_backoff_strategy_->nextBackOffMs();
     primary_host_info->refresh_timer_->enableTimer(std::chrono::milliseconds(refresh_interval));
     ENVOY_LOG(debug, "DNS refresh rate reset for host '{}', (failure) refresh rate {} ms", host,
               refresh_interval);
@@ -439,7 +435,11 @@ DnsCacheImpl::PrimaryHostInfo::PrimaryHostInfo(DnsCacheImpl& parent,
       refresh_timer_(parent.main_thread_dispatcher_.createTimer(refresh_timer_cb)),
       timeout_timer_(parent.main_thread_dispatcher_.createTimer(timeout_timer_cb)),
       host_info_(std::make_shared<DnsHostInfoImpl>(parent.main_thread_dispatcher_.timeSource(),
-                                                   host_to_resolve, is_ip_address)) {
+                                                     host_to_resolve, is_ip_address)),
+      failure_backoff_strategy_(
+          Config::Utility::prepareDnsRefreshStrategy<
+              envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig>(
+              parent_.config_, parent_.refresh_interval_.count(), parent_.random_generator_)) {
   parent_.stats_.host_added_.inc();
   parent_.stats_.num_hosts_.inc();
 }

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
@@ -114,6 +114,10 @@ private:
     void updateStale(MonotonicTime resolution_time, std::chrono::seconds ttl) {
       stale_at_time_ = resolution_time + ttl;
     }
+    bool isStale() {
+      const MonotonicTime stale_time = stale_at_time_;
+      return time_source_.monotonicTime() > stale_time;
+    }
 
     void setAddress(Network::Address::InstanceConstSharedPtr address) {
       absl::WriterMutexLock lock{&resolve_lock_};
@@ -159,6 +163,7 @@ private:
     const Event::TimerPtr refresh_timer_;
     const Event::TimerPtr timeout_timer_;
     const DnsHostInfoImplSharedPtr host_info_;
+    const BackOffStrategyPtr failure_backoff_strategy_;
     Network::ActiveDnsQuery* active_query_{};
   };
 
@@ -198,6 +203,8 @@ private:
   PrimaryHostInfo* createHost(const std::string& host, uint16_t default_port);
 
   Event::Dispatcher& main_thread_dispatcher_;
+  const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig config_;
+  Random::RandomGenerator& random_generator_;
   const Network::DnsLookupFamily dns_lookup_family_;
   const Network::DnsResolverSharedPtr resolver_;
   ThreadLocal::TypedSlot<ThreadLocalHostInfo> tls_slot_;
@@ -211,7 +218,6 @@ private:
   DnsCacheResourceManagerImpl resource_manager_;
   const std::chrono::milliseconds refresh_interval_;
   const std::chrono::milliseconds timeout_interval_;
-  const BackOffStrategyPtr failure_backoff_strategy_;
   Filesystem::Instance& file_system_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
   const std::chrono::milliseconds host_ttl_;

--- a/test/common/common/backoff_strategy_test.cc
+++ b/test/common/common/backoff_strategy_test.cc
@@ -23,11 +23,15 @@ TEST(ExponentialBackOffStrategyTest, JitteredBackOffBasicReset) {
   ON_CALL(random, random()).WillByDefault(Return(27));
 
   JitteredExponentialBackOffStrategy jittered_back_off(25, 30, random);
-  EXPECT_EQ(2, jittered_back_off.nextBackOffMs());
+  EXPECT_EQ(2, jittered_back_off.nextBackOffMs());  // 25 % 27
   EXPECT_EQ(27, jittered_back_off.nextBackOffMs());
 
   jittered_back_off.reset();
   EXPECT_EQ(2, jittered_back_off.nextBackOffMs()); // Should start from start
+  EXPECT_EQ(27, jittered_back_off.nextBackOffMs());
+
+  jittered_back_off.reset(26);
+  EXPECT_EQ(1, jittered_back_off.nextBackOffMs()); // 26 % 27
 }
 
 TEST(ExponentialBackOffStrategyTest, JitteredBackOffDoesntOverflow) {
@@ -77,6 +81,9 @@ TEST(ExponentialBackOffStrategyTest, JitteredBackOffWithMaxIntervalReset) {
   EXPECT_EQ(79, jittered_back_off.nextBackOffMs());
   EXPECT_EQ(99, jittered_back_off.nextBackOffMs()); // Should return Max here
   EXPECT_EQ(99, jittered_back_off.nextBackOffMs());
+
+  jittered_back_off.reset(4);
+  EXPECT_EQ(3, jittered_back_off.nextBackOffMs());
 }
 
 TEST(LowerBoundBackOffStrategyTest, JitteredBackOffWithLowRandomValue) {
@@ -102,6 +109,9 @@ TEST(FixedBackOffStrategyTest, FixedBackOffBasicReset) {
 
   fixed_back_off.reset();
   EXPECT_EQ(30, fixed_back_off.nextBackOffMs());
+
+  fixed_back_off.reset(20);
+  EXPECT_EQ(20, fixed_back_off.nextBackOffMs());
 }
 
 } // namespace Envoy

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -79,6 +79,8 @@ public:
   std::unique_ptr<DnsCache> dns_cache_;
   MockUpdateCallbacks update_callbacks_;
   DnsCache::AddUpdateCallbacksHandlePtr update_callbacks_handle_;
+  std::chrono::milliseconds configured_ttl_ = std::chrono::milliseconds(60000);
+  std::chrono::milliseconds dns_ttl_= std::chrono::milliseconds(6000);
 };
 
 MATCHER_P3(DnsHostInfoEquals, address, resolved_host, is_ip_address, "") {
@@ -161,7 +163,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccess) {
               onDnsHostAddOrUpdate("foo.com", DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.1"}));
 
@@ -179,7 +181,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccess) {
 
   // Address does not change.
   EXPECT_CALL(*timeout_timer, disableTimer());
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.1"}));
 
@@ -199,7 +201,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccess) {
   EXPECT_CALL(*timeout_timer, disableTimer());
   EXPECT_CALL(update_callbacks_,
               onDnsHostAddOrUpdate("foo.com", DnsHostInfoEquals("10.0.0.2:80", "foo.com", false)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.2"}));
 
@@ -230,7 +232,7 @@ TEST_F(DnsCacheImplTest, Ipv4Address) {
       onDnsHostAddOrUpdate("127.0.0.1", DnsHostInfoEquals("127.0.0.1:80", "127.0.0.1", true)));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("127.0.0.1:80", "127.0.0.1", true)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"127.0.0.1"}));
 }
@@ -258,7 +260,7 @@ TEST_F(DnsCacheImplTest, Ipv4AddressWithPort) {
                                    DnsHostInfoEquals("127.0.0.1:10000", "127.0.0.1", true)));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("127.0.0.1:10000", "127.0.0.1", true)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"127.0.0.1"}));
 }
@@ -284,7 +286,7 @@ TEST_F(DnsCacheImplTest, Ipv6Address) {
   EXPECT_CALL(update_callbacks_,
               onDnsHostAddOrUpdate("[::1]", DnsHostInfoEquals("[::1]:80", "::1", true)));
   EXPECT_CALL(callbacks, onLoadDnsCacheComplete(DnsHostInfoEquals("[::1]:80", "::1", true)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"::1"}));
 }
@@ -310,7 +312,7 @@ TEST_F(DnsCacheImplTest, Ipv6AddressWithPort) {
   EXPECT_CALL(update_callbacks_,
               onDnsHostAddOrUpdate("[::1]:10000", DnsHostInfoEquals("[::1]:10000", "::1", true)));
   EXPECT_CALL(callbacks, onLoadDnsCacheComplete(DnsHostInfoEquals("[::1]:10000", "::1", true)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"::1"}));
 }
@@ -340,15 +342,15 @@ TEST_F(DnsCacheImplTest, TTL) {
               onDnsHostAddOrUpdate("foo.com", DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(6000), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
-             TestUtility::makeDnsResponse({"10.0.0.1"}, std::chrono::seconds(0)));
+             TestUtility::makeDnsResponse({"10.0.0.1"}));
 
   checkStats(1 /* attempt */, 1 /* success */, 0 /* failure */, 1 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
 
-  // Re-resolve with ~60s passed. TTL should still be OK at default of 5 minutes.
-  simTime().advanceTimeWait(std::chrono::milliseconds(60001));
+  // Re-resolve with ~6s passed. The resolved entry TTL is 6s.
+  simTime().advanceTimeWait(std::chrono::milliseconds(6001));
   EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
   EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
@@ -357,15 +359,15 @@ TEST_F(DnsCacheImplTest, TTL) {
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
 
   EXPECT_CALL(*timeout_timer, disableTimer());
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(6000), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.1"}));
   checkStats(2 /* attempt */, 2 /* success */, 0 /* failure */, 1 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
 
-  // Re-resolve with ~5m passed. This is not realistic as we would have re-resolved many times
+  // Re-resolve with ~1m passed. This is not realistic as we would have re-resolved many times
   // during this period but it's good enough for the test.
-  simTime().advanceTimeWait(std::chrono::milliseconds(300000));
+  simTime().advanceTimeWait(std::chrono::seconds(60000));
   EXPECT_CALL(update_callbacks_, onDnsHostRemove("foo.com"));
   resolve_timer->invokeCallback();
   checkStats(2 /* attempt */, 2 /* success */, 0 /* failure */, 1 /* address changed */,
@@ -410,9 +412,9 @@ TEST_F(DnsCacheImplTest, TTLWithCustomParameters) {
               onDnsHostAddOrUpdate("foo.com", DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(30000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
-             TestUtility::makeDnsResponse({"10.0.0.1"}, std::chrono::seconds(0)));
+             TestUtility::makeDnsResponse({"10.0.0.1"}));
 
   // Re-resolve with ~30s passed. TTL should still be OK at 60s.
   simTime().advanceTimeWait(std::chrono::milliseconds(30001));
@@ -421,7 +423,7 @@ TEST_F(DnsCacheImplTest, TTLWithCustomParameters) {
       .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
   resolve_timer->invokeCallback();
   EXPECT_CALL(*timeout_timer, disableTimer());
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(30000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.1"}));
 
@@ -460,7 +462,7 @@ TEST_F(DnsCacheImplTest, InlineResolve) {
       onDnsHostAddOrUpdate("localhost", DnsHostInfoEquals("127.0.0.1:80", "localhost", false)));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("127.0.0.1:80", "localhost", false)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   post_cb();
 }
 
@@ -487,7 +489,9 @@ TEST_F(DnsCacheImplTest, ResolveTimeout) {
   EXPECT_CALL(*timeout_timer, disableTimer());
   EXPECT_CALL(update_callbacks_, onDnsHostAddOrUpdate(_, _)).Times(0);
   EXPECT_CALL(callbacks, onLoadDnsCacheComplete(DnsHostInfoAddressIsNull()));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  // The resolve timeout will be the default TTL as there was no specific TTL
+  // overriding.
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(configured_ttl_), _));
   timeout_timer->invokeCallback();
   checkStats(1 /* attempt */, 0 /* success */, 1 /* failure */, 0 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
@@ -517,7 +521,7 @@ TEST_F(DnsCacheImplTest, ResolveFailure) {
   EXPECT_CALL(*timeout_timer, disableTimer());
   EXPECT_CALL(update_callbacks_, onDnsHostAddOrUpdate(_, _)).Times(0);
   EXPECT_CALL(callbacks, onLoadDnsCacheComplete(DnsHostInfoAddressIsNull()));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(configured_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Failure, TestUtility::makeDnsResponse({}));
   checkStats(1 /* attempt */, 0 /* success */, 1 /* failure */, 0 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
@@ -531,7 +535,7 @@ TEST_F(DnsCacheImplTest, ResolveFailure) {
 
   // Re-resolve with ~5m passed. This is not realistic as we would have re-resolved many times
   // during this period but it's good enough for the test.
-  simTime().advanceTimeWait(std::chrono::milliseconds(300001));
+  simTime().advanceTimeWait(std::chrono::milliseconds(600001));
   // Because resolution failed for the host, onDnsHostAddOrUpdate was not called.
   // Therefore, onDnsHostRemove should not be called either.
   EXPECT_CALL(update_callbacks_, onDnsHostRemove(_)).Times(0);
@@ -581,7 +585,7 @@ TEST_F(DnsCacheImplTest, ResolveFailureWithFailureRefreshRate) {
 
   // Re-resolve with ~5m passed. This is not realistic as we would have re-resolved many times
   // during this period but it's good enough for the test.
-  simTime().advanceTimeWait(std::chrono::milliseconds(300001));
+  simTime().advanceTimeWait(std::chrono::milliseconds(600001));
   // Because resolution failed for the host, onDnsHostAddOrUpdate was not called.
   // Therefore, onDnsHostRemove should not be called either.
   EXPECT_CALL(update_callbacks_, onDnsHostRemove(_)).Times(0);
@@ -613,7 +617,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithEmptyResult) {
   EXPECT_CALL(*timeout_timer, disableTimer());
   EXPECT_CALL(update_callbacks_, onDnsHostAddOrUpdate(_, _)).Times(0);
   EXPECT_CALL(callbacks, onLoadDnsCacheComplete(DnsHostInfoAddressIsNull()));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(configured_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success, TestUtility::makeDnsResponse({}));
   checkStats(1 /* attempt */, 1 /* success */, 0 /* failure */, 0 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
@@ -627,7 +631,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithEmptyResult) {
 
   // Re-resolve with ~5m passed. This is not realistic as we would have re-resolved many times
   // during this period but it's good enough for the test.
-  simTime().advanceTimeWait(std::chrono::milliseconds(300001));
+  simTime().advanceTimeWait(std::chrono::milliseconds(600001));
   // Because resolution failed for the host, onDnsHostAddOrUpdate was not called.
   // Therefore, onDnsHostRemove should not be called either.
   EXPECT_CALL(update_callbacks_, onDnsHostRemove(_)).Times(0);
@@ -1010,11 +1014,13 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
         envoy::extensions::key_value::file_based::v3::FileBasedKeyValueStoreConfig>();
   }));
   MockKeyValueStore* store{};
-  EXPECT_CALL(factory, createStore(_, _, _, _)).WillOnce(Invoke([&store]() {
+  EXPECT_CALL(factory, createStore(_, _, _, _)).WillOnce(Invoke([this, &store]() {
     auto ret = std::make_unique<NiceMock<MockKeyValueStore>>();
     store = ret.get();
     // Make sure there's an attempt to load from the key value store.
-    EXPECT_CALL(*store, iterate);
+    EXPECT_CALL(*store, iterate(_));
+    // Make sure the result is sent to the worker threads.
+    EXPECT_CALL(context_.thread_local_, runOnAllThreads(_)).Times(2);
     return ret;
   }));
 
@@ -1044,12 +1050,12 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
   // Make sure the store gets the first insert.
   EXPECT_CALL(update_callbacks_,
               onDnsHostAddOrUpdate("foo.com", DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
-  EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.1:80|30|0"));
+  EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.1:80|6|0"));
   EXPECT_CALL(callbacks,
               onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(6000), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
-             TestUtility::makeDnsResponse({"10.0.0.1"}, std::chrono::seconds(30)));
+             TestUtility::makeDnsResponse({"10.0.0.1"}));
 
   checkStats(1 /* attempt */, 1 /* success */, 0 /* failure */, 1 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
@@ -1065,10 +1071,10 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
 
   // Address does not change.
   EXPECT_CALL(*timeout_timer, disableTimer());
-  EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.1:80|30|0"));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.1:80|6|0"));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
-             TestUtility::makeDnsResponse({"10.0.0.1"}, std::chrono::seconds(30)));
+             TestUtility::makeDnsResponse({"10.0.0.1"}));
 
   checkStats(2 /* attempt */, 2 /* success */, 0 /* failure */, 1 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
@@ -1086,10 +1092,10 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
   // Make sure the store gets the updated address.
   EXPECT_CALL(update_callbacks_,
               onDnsHostAddOrUpdate("foo.com", DnsHostInfoEquals("10.0.0.2:80", "foo.com", false)));
-  EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.2:80|30|0"));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.2:80|6|0"));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
-             TestUtility::makeDnsResponse({"10.0.0.2"}, std::chrono::seconds(30)));
+             TestUtility::makeDnsResponse({"10.0.0.2"}));
 
   checkStats(3 /* attempt */, 3 /* success */, 0 /* failure */, 2 /* address changed */,
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
@@ -1106,7 +1112,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
   // Address does not change.
   EXPECT_CALL(*timeout_timer, disableTimer());
   EXPECT_CALL(*store, addOrUpdate("foo.com", "10.0.0.2:80|40|0"));
-  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(60000), _));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(40000), _));
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
              TestUtility::makeDnsResponse({"10.0.0.2"}, std::chrono::seconds(40)));
 }

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -314,7 +314,7 @@ public:
    */
   static std::list<Network::DnsResponse>
   makeDnsResponse(const std::list<std::string>& addresses,
-                  std::chrono::seconds = std::chrono::seconds(0));
+                  std::chrono::seconds = std::chrono::seconds(6));
 
   /**
    * List files in a given directory path


### PR DESCRIPTION
Changes the DNS cache to respect the advertised TTL, modulo a floor of 5s.
That part of the change is runtime guard.  The part which is not, is that the backoff is done on a per-host basis not a global basis, so if one endpoint fails to resolve, it won't result in others backing off, and if one succeeds it won't result in changing backoff for failed hosts.

Risk Level: Medium
Testing: new unit tests
Docs Changes: inline
Release Notes: inline
Optional Runtime guard: envoy.reloadable_features.use_dns_ttl
