### PR TITLE
deps: test macro removal

### DIFF
--- a/bazel/cel.patch
+++ b/bazel/cel.patch
@@ -7,7 +7,7 @@ index 7bca2ca..3bed9d3 100644
    }
  
 -#if defined(__clang_major_version__) && __clang_major_version__ >= 8 && !defined(__APPLE__)
-+#if 1
++#if !defined(__GNUC__) || defined(__clang__)
    template <int arg_index>
    inline absl::Status RunWrap(absl::Span<const CelValue> arguments,
                                std::tuple<::google::protobuf::Arena*, Arguments...> input,
@@ -16,7 +16,7 @@ index 7bca2ca..3bed9d3 100644
      }
  
 -#if defined(__clang_major_version__) && __clang_major_version__ >= 8 && !defined(__APPLE__)
-+#if 1
++#if !defined(__GNUC__) || defined(__clang__)
      std::tuple<::google::protobuf::Arena*, Arguments...> input;
      std::get<0>(input) = arena;
      return RunWrap<0>(arguments, input, result, arena);

--- a/bazel/cel.patch
+++ b/bazel/cel.patch
@@ -1,0 +1,22 @@
+diff --git a/eval/public/cel_function_adapter.h b/eval/public/cel_function_adapter.h
+index 7bca2ca..3bed9d3 100644
+--- a/eval/public/cel_function_adapter.h
++++ b/eval/public/cel_function_adapter.h
+@@ -121,7 +121,7 @@ class FunctionAdapter : public CelFunction {
+     return registry->Register(std::move(status).value());
+   }
+ 
+-#if defined(__clang_major_version__) && __clang_major_version__ >= 8 && !defined(__APPLE__)
++#if 1
+   template <int arg_index>
+   inline absl::Status RunWrap(absl::Span<const CelValue> arguments,
+                               std::tuple<::google::protobuf::Arena*, Arguments...> input,
+@@ -177,7 +177,7 @@ class FunctionAdapter : public CelFunction {
+                           "Argument number mismatch");
+     }
+ 
+-#if defined(__clang_major_version__) && __clang_major_version__ >= 8 && !defined(__APPLE__)
++#if 1
+     std::tuple<::google::protobuf::Arena*, Arguments...> input;
+     std::get<0>(input) = arena;
+     return RunWrap<0>(arguments, input, result, arena);

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -454,7 +454,11 @@ def _org_brotli():
     )
 
 def _com_google_cel_cpp():
-    external_http_archive("com_google_cel_cpp")
+    external_http_archive(
+        name = "com_google_cel_cpp",
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:cel.patch"],
+    )
     external_http_archive("rules_antlr")
 
     # Parser dependencies


### PR DESCRIPTION
`__clang_major_version__` is suspiciously absent from clang docs. Let's see if CI can build without assuming clang.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
