### PR TITLE
Fixduplicate

### DIFF
--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -141,6 +141,8 @@ Network::SocketSharedPtr ListenSocketFactoryImpl::createListenSocketAndApplyOpti
       factory.createListenSocket(local_address_, socket_type, options_, bind_type_, worker_index);
 
   // Binding is done by now.
+  ENVOY_LOG(debug, "Create listen socket for listener {} on address {}", listener_name_,
+            local_address_->asString());
   if (socket != nullptr && options_ != nullptr) {
     const bool ok = Network::Socket::applyOptions(
         options_, *socket, envoy::config::core::v3::SocketOption::STATE_BOUND);

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -141,8 +141,6 @@ Network::SocketSharedPtr ListenSocketFactoryImpl::createListenSocketAndApplyOpti
       factory.createListenSocket(local_address_, socket_type, options_, bind_type_, worker_index);
 
   // Binding is done by now.
-  ENVOY_LOG(debug, "Create listen socket for listener {} on address {}", listener_name_,
-            local_address_->asString());
   if (socket != nullptr && options_ != nullptr) {
     const bool ok = Network::Socket::applyOptions(
         options_, *socket, envoy::config::core::v3::SocketOption::STATE_BOUND);

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -144,7 +144,8 @@ protected:
   void testNotBindToPort() {
     auto local_address = version_ == Address::IpVersion::v4 ? Utility::getIpv6AnyAddress()
                                                             : Utility::getIpv4AnyAddress();
-    UdpListenSocket socket(local_address, nullptr, /*bind_to_port=*/false);
+    auto socket = NetworkListenSocket<NetworkSocketTrait<Type>>(local_address, nullptr,
+                                                                /*bind_to_port=*/false);
     auto dup_socket = socket.duplicate();
     EXPECT_FALSE(socket.isOpen());
     EXPECT_FALSE(dup_socket->isOpen());

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -139,6 +139,18 @@ protected:
     EXPECT_GT(socket->connectionInfoProvider().localAddress()->ip()->port(), 0U);
     EXPECT_EQ(Type, socket->socketType());
   }
+
+  // Verify that a listen sockets that do not bind to port can be duplicated and closed.
+  void testNotBindToPort() {
+    auto local_address = version_ == Address::IpVersion::v4 ? Utility::getIpv6AnyAddress()
+                                                            : Utility::getIpv4AnyAddress();
+    UdpListenSocket socket(local_address, nullptr, /*bind_to_port=*/false);
+    auto dup_socket = socket.duplicate();
+    EXPECT_FALSE(socket.isOpen());
+    EXPECT_FALSE(dup_socket->isOpen());
+    socket.close();
+    dup_socket->close();
+  }
 };
 
 using ListenSocketImplTestTcp = ListenSocketImplTest<Network::Socket::Type::Stream>;
@@ -227,6 +239,10 @@ TEST_P(ListenSocketImplTestUdp, BindSpecificPort) { testBindSpecificPort(); }
 TEST_P(ListenSocketImplTestTcp, BindPortZero) { testBindPortZero(); }
 
 TEST_P(ListenSocketImplTestUdp, BindPortZero) { testBindPortZero(); }
+
+TEST_P(ListenSocketImplTestTcp, NotBindToPortAccess) { testNotBindToPort(); }
+
+TEST_P(ListenSocketImplTestUdp, NotBindToPortAccess) { testNotBindToPort(); }
 
 } // namespace
 } // namespace Network

--- a/test/integration/filters/address_restore_listener_filter.cc
+++ b/test/integration/filters/address_restore_listener_filter.cc
@@ -16,8 +16,16 @@ public:
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override {
     FANCY_LOG(debug, "in FakeOriginalDstListenerFilter::onAccept");
     Network::ConnectionSocket& socket = cb.socket();
-    socket.connectionInfoProvider().restoreLocalAddress(
-        std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2", 80));
+    auto local_address = socket.connectionInfoProvider().localAddress();
+    if (local_address != nullptr &&
+        local_address->ip()->version() == Network::Address::IpVersion::v6) {
+      socket.connectionInfoProvider().restoreLocalAddress(
+          std::make_shared<Network::Address::Ipv6Instance>("::1", 80));
+    } else {
+
+      socket.connectionInfoProvider().restoreLocalAddress(
+          std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 80));
+    }
     FANCY_LOG(debug, "current local socket address is {} restored = {}",
               socket.connectionInfoProvider().localAddress()->asString(),
               socket.connectionInfoProvider().localAddressRestored());

--- a/test/integration/filters/address_restore_listener_filter.cc
+++ b/test/integration/filters/address_restore_listener_filter.cc
@@ -10,6 +10,7 @@
 namespace Envoy {
 
 // The FakeOriginalDstListenerFilter restore desired local address without the dependency of OS.
+// Ipv6 and Ipv4 addresses are restored to the corresponding loopback ip address and port 80.
 class FakeOriginalDstListenerFilter : public Network::ListenerFilter {
 public:
   // Network::ListenerFilter
@@ -22,7 +23,6 @@ public:
       socket.connectionInfoProvider().restoreLocalAddress(
           std::make_shared<Network::Address::Ipv6Instance>("::1", 80));
     } else {
-
       socket.connectionInfoProvider().restoreLocalAddress(
           std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 80));
     }

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -636,7 +636,7 @@ public:
               repeats);
   }
 
-  // The stats
+  // The stats prefix that shared by ipv6 and ipv4 listener.
   std::string target_listener_prefix_{"balanced_listener"};
 };
 

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -554,6 +554,11 @@ TEST_P(ListenerIntegrationTest, ChangeListenerAddress) {
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
 }
 
+struct PerConnection {
+  std::string response_;
+  std::unique_ptr<RawConnectionDriver> client_conn_;
+  FakeRawConnectionPtr upstream_conn_;
+};
 class RebalancerTest : public testing::TestWithParam<Network::Address::IpVersion>,
                        public BaseIntegrationTest {
 public:
@@ -585,10 +590,7 @@ public:
           virtual_listener_config.mutable_bind_to_port()->set_value(false);
           virtual_listener_config.set_name("balanced_target_listener");
           virtual_listener_config.mutable_connection_balance_config()->mutable_exact_balance();
-
-          // TODO(lambdai): Replace by getLoopbackAddressUrlString to emulate the real world.
-          *virtual_listener_config.mutable_address()->mutable_socket_address()->mutable_address() =
-              "127.0.0.2";
+          *virtual_listener_config.mutable_stat_prefix() = target_listener_prefix_;
           virtual_listener_config.mutable_address()->mutable_socket_address()->set_port_value(80);
         });
     BaseIntegrationTest::initialize();
@@ -604,13 +606,65 @@ public:
         },
         version_, *dispatcher_);
   }
+
+  void verifyBalance(uint32_t repeats = 10) {
+    // The balancer is balanced as per active connection instead of total connection.
+    // The below vector maintains all the connections alive.
+    std::vector<PerConnection> connections;
+    for (uint32_t i = 0; i < repeats * concurrency_; ++i) {
+      connections.emplace_back();
+      connections.back().client_conn_ =
+          createConnectionAndWrite("dummy", connections.back().response_);
+      connections.back().client_conn_->waitForConnection();
+      ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(connections.back().upstream_conn_));
+    }
+    for (auto& conn : connections) {
+      conn.client_conn_->close();
+      while (!conn.client_conn_->closed()) {
+        dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+      }
+    }
+    ASSERT_EQ(TestUtility::findCounter(test_server_->statStore(),
+                                       absl::StrCat("listener.", target_listener_prefix_,
+                                                    ".worker_0.downstream_cx_total"))
+                  ->value(),
+              repeats);
+    ASSERT_EQ(TestUtility::findCounter(test_server_->statStore(),
+                                       absl::StrCat("listener.", target_listener_prefix_,
+                                                    ".worker_1.downstream_cx_total"))
+                  ->value(),
+              repeats);
+  }
+
+  // The stats
+  std::string target_listener_prefix_{"balanced_listener"};
 };
 
-struct PerConnection {
-  std::string response_;
-  std::unique_ptr<RawConnectionDriver> client_conn_;
-  FakeRawConnectionPtr upstream_conn_;
-};
+TEST_P(RebalancerTest, BindToPortUpdate) {
+  concurrency_ = 2;
+  initialize();
+
+  ConfigHelper new_config_helper(
+      version_, *api_, MessageUtil::getJsonStringFromMessageOrDie(config_helper_.bootstrap()));
+
+  new_config_helper.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap)
+                                          -> void {
+    // This virtual listener need updating.
+    auto& virtual_listener_config = *bootstrap.mutable_static_resources()->mutable_listeners(1);
+    *virtual_listener_config.mutable_address()->mutable_socket_address()->mutable_address() =
+        bootstrap.static_resources().listeners(0).address().socket_address().address();
+    (*(*virtual_listener_config.mutable_metadata()->mutable_filter_metadata())["random_filter_name"]
+          .mutable_fields())["random_key"]
+        .set_number_value(2);
+  });
+  // Create an LDS response with the new config, and reload config.
+  new_config_helper.setLds("1");
+
+  test_server_->waitForCounterEq("listener_manager.listener_modified", 1);
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_draining", 0);
+
+  verifyBalance();
+}
 
 // Verify the connections are distributed evenly on the 2 worker threads of the redirected
 // listener.
@@ -620,36 +674,8 @@ TEST_P(RebalancerTest, DISABLED_RedirectConnectionIsBalancedOnDestinationListene
   auto ip_address_str =
       Network::Test::getLoopbackAddressUrlString(TestEnvironment::getIpVersionsForTest().front());
   concurrency_ = 2;
-  int repeats = 10;
   initialize();
-
-  // The balancer is balanced as per active connection instead of total connection.
-  // The below vector maintains all the connections alive.
-  std::vector<PerConnection> connections;
-  for (uint32_t i = 0; i < repeats * concurrency_; ++i) {
-    connections.emplace_back();
-    connections.back().client_conn_ =
-        createConnectionAndWrite("dummy", connections.back().response_);
-    connections.back().client_conn_->waitForConnection();
-    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(connections.back().upstream_conn_));
-  }
-  for (auto& conn : connections) {
-    conn.client_conn_->close();
-    while (!conn.client_conn_->closed()) {
-      dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-    }
-  }
-
-  ASSERT_EQ(TestUtility::findCounter(
-                test_server_->statStore(),
-                absl::StrCat("listener.", ip_address_str, "_80.worker_0.downstream_cx_total"))
-                ->value(),
-            repeats);
-  ASSERT_EQ(TestUtility::findCounter(
-                test_server_->statStore(),
-                absl::StrCat("listener.", ip_address_str, "_80.worker_1.downstream_cx_total"))
-                ->value(),
-            repeats);
+  verifyBalance();
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, RebalancerTest,


### PR DESCRIPTION
Commit Message:
Fix the crash caused by listener update when the any listener set bind_to_port to false.
A listener does not bind to port has no io handle. close() already check it. 
Now add the check to isOpen().

Also the Tcp(or Udp)ListenSocket::duplicate() creates parent ListenSocketImpl 
Make it returning the derived ListenSocket, either TcpListenSocket or UdpListenSocket

Additional Description:
Risk Level: 
Testing: Unit test on duplicate. Integration test on bind_to_port.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
