### PR TITLE
boringssl/fips: allow fips builds for CentOS

### DIFF
--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -28,6 +28,11 @@ VERSION=7.0.1
 SHA256=02ad925add5b2b934d64c3dd5cbd1b2002258059f7d962993ba7f16524c3089c
 PLATFORM="x86_64-linux-gnu-ubuntu-16.04"
 
+if [[ -f /etc/centos-release ]] && [[ $$(cat /etc/centos-release) =~ "CentOS Linux release 7" ]]; then
+  SHA256=609190391ea7be5a0e0b267f1657228ca728c545d6e27a2d8e0b65080eec3001
+  PLATFORM="x86_64-linux-sles11.3"
+fi
+
 curl -sLO https://releases.llvm.org/"$$VERSION"/clang+llvm-"$$VERSION"-"$$PLATFORM".tar.xz \
   && echo "$$SHA256" clang+llvm-"$$VERSION"-"$$PLATFORM".tar.xz | sha256sum --check
 tar xf clang+llvm-"$$VERSION"-"$$PLATFORM".tar.xz
@@ -61,14 +66,24 @@ fi
 
 # Ninja 1.9.0
 VERSION=1.9.0
-SHA256=1b1235f2b0b4df55ac6d80bbe681ea3639c9d2c505c7ff2159a3daf63d196305
-PLATFORM="linux"
 
-curl -sLO https://github.com/ninja-build/ninja/releases/download/v"$$VERSION"/ninja-"$$PLATFORM".zip \
-  && echo "$$SHA256" ninja-"$$PLATFORM".zip | sha256sum --check
-unzip -o ninja-"$$PLATFORM".zip
-
-export PATH="$$PWD:$$PATH"
+if [[ -f /etc/centos-release ]] && [[ $$(cat /etc/centos-release) =~ "CentOS Linux release 7" ]]; then
+  SHA256=5d7ec75828f8d3fd1a0c2f31b5b0cea780cdfe1031359228c428c1a48bfcd5b9
+  curl -sLo ninja-"$$VERSION".tar.gz https://github.com/ninja-build/ninja/archive/refs/tags/v"$$VERSION".tar.gz \
+    && echo "$$SHA256" ninja-"$$VERSION".tar.gz | sha256sum --check
+  tar xf ninja-"$$VERSION".tar.gz
+  pushd ninja-"$$VERSION"
+  ./configure.py --bootstrap
+  export PATH="$$PWD:$$PATH"
+  popd
+else
+  SHA256=1b1235f2b0b4df55ac6d80bbe681ea3639c9d2c505c7ff2159a3daf63d196305
+  PLATFORM="linux"
+  curl -sLO https://github.com/ninja-build/ninja/releases/download/v"$$VERSION"/ninja-"$$PLATFORM".zip \
+    && echo "$$SHA256" ninja-"$$PLATFORM".zip | sha256sum --check
+  unzip -o ninja-"$$PLATFORM".zip
+  export PATH="$$PWD:$$PATH"
+fi
 
 if [[ `ninja --version` != "$$VERSION" ]]; then
   echo "ERROR: Ninja version doesn't match."

--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -2,8 +2,8 @@
 
 set -e
 
-# BoringSSL build as described in the Security Policy for BoringCrypto module (2020-07-02):
-# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3678.pdf
+# BoringSSL build as described in the Security Policy for BoringCrypto module (2021-05-03):
+# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4028.pdf
 
 # This works only on Linux-x86_64.
 if [[ `uname` != "Linux" || `uname -m` != "x86_64" ]]; then


### PR DESCRIPTION
**Commit Message**: boringssl/fips: allow fips builds for CentOS
**Additional Description**: By introducing conditional logic for downloading appropriate version of llvm+clang which would run on CentOS 7 and compiling ninja-build we are allowing FIPS builds of BoringSSL included with envoy to work on CentOS 7/8
**Risk Level**: Shouldn't be any risk as the logic I added is conditional for CentOS, which so far was ignored
**Testing**: manually on CentOS 7 VM and docker image
**Docs Changes**: no changes
**Release Notes**: no release notes
**Platform Specific Features**: FIPS build of BoringSSL for CentOS 7/8
**Fixes**: https://github.com/envoyproxy/envoy/issues/18425 
