### PR TITLE
leds: lowering EDS memory usage when LEDS is not used

### DIFF
--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -46,7 +46,7 @@ void EdsClusterImpl::startPreInit() { subscription_->start({cluster_name_}); }
 void EdsClusterImpl::BatchUpdateHelper::batchUpdate(PrioritySet::HostUpdateCb& host_update_cb) {
   absl::flat_hash_set<std::string> all_new_hosts;
   PriorityStateManager priority_state_manager(parent_, parent_.local_info_, &host_update_cb);
-  for (const auto& locality_lb_endpoint : parent_.cluster_load_assignment_.endpoints()) {
+  for (const auto& locality_lb_endpoint : cluster_load_assignment_.endpoints()) {
     parent_.validateEndpointsForZoneAwareRouting(locality_lb_endpoint);
 
     priority_state_manager.initializePriorityFor(locality_lb_endpoint);
@@ -81,9 +81,8 @@ void EdsClusterImpl::BatchUpdateHelper::batchUpdate(PrioritySet::HostUpdateCb& h
   HostMapConstSharedPtr all_hosts = parent_.prioritySet().crossPriorityHostMap();
   ASSERT(all_hosts != nullptr);
 
-  const uint32_t overprovisioning_factor =
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(parent_.cluster_load_assignment_.policy(),
-                                      overprovisioning_factor, kDefaultOverProvisioningFactor);
+  const uint32_t overprovisioning_factor = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+      cluster_load_assignment_.policy(), overprovisioning_factor, kDefaultOverProvisioningFactor);
 
   LocalityWeightsMap empty_locality_map;
 
@@ -206,6 +205,13 @@ void EdsClusterImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef
     return cla_leds_configs.find(leds_config) == cla_leds_configs.end();
   });
 
+  // Optimize for no-copy, if possible.
+  if (cla_leds_configs.empty()) {
+    cluster_load_assignment_ = absl::nullopt;
+  } else {
+    cluster_load_assignment_ = std::move(cluster_load_assignment);
+  }
+
   // Add all the LEDS localities that are new.
   for (const auto& leds_config : cla_leds_configs) {
     if (leds_localities_.find(leds_config) == leds_localities_.end()) {
@@ -217,7 +223,7 @@ void EdsClusterImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef
           leds_config, cluster_name_, factory_context_, info_->statsScope(), [&]() {
             // Called upon an update to the locality.
             if (validateAllLedsUpdated()) {
-              BatchUpdateHelper helper(*this);
+              BatchUpdateHelper helper(*this, cluster_load_assignment_.value());
               priority_set_.batchHostUpdate(helper);
             }
           });
@@ -225,16 +231,15 @@ void EdsClusterImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef
     }
   }
 
-  // TODO(adisuissa): optimize for no-copy, if possible.
-  cluster_load_assignment_ = cluster_load_assignment;
-
   // If all the LEDS localities are updated, the EDS update can occur. If not, then when the last
   // LEDS locality will be updated, it will trigger the EDS update helper.
   if (!validateAllLedsUpdated()) {
     return;
   }
 
-  BatchUpdateHelper helper(*this);
+  BatchUpdateHelper helper(*this, cluster_load_assignment_.has_value()
+                                      ? cluster_load_assignment_.value()
+                                      : cluster_load_assignment);
   priority_set_.batchHostUpdate(helper);
 }
 

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -66,7 +66,10 @@ private:
 
   class BatchUpdateHelper : public PrioritySet::BatchUpdateCb {
   public:
-    BatchUpdateHelper(EdsClusterImpl& parent) : parent_(parent) {}
+    BatchUpdateHelper(
+        EdsClusterImpl& parent,
+        const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment)
+        : parent_(parent), cluster_load_assignment_(cluster_load_assignment) {}
 
     // Upstream::PrioritySet::BatchUpdateCb
     void batchUpdate(PrioritySet::HostUpdateCb& host_update_cb) override;
@@ -79,6 +82,7 @@ private:
         absl::flat_hash_set<std::string>& all_new_hosts);
 
     EdsClusterImpl& parent_;
+    const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment_;
   };
 
   Config::SubscriptionPtr subscription_;
@@ -96,8 +100,9 @@ private:
   // data.
   LedsConfigMap leds_localities_;
   // TODO(adisuissa): Avoid saving the entire cluster load assignment, only the
-  // relevant parts of the config for each locality.
-  envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment_;
+  // relevant parts of the config for each locality. Note that this field must
+  // be set when LEDS is used.
+  absl::optional<envoy::config::endpoint::v3::ClusterLoadAssignment> cluster_load_assignment_;
 };
 
 using EdsClusterImplSharedPtr = std::shared_ptr<EdsClusterImpl>;

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -2016,4 +2016,129 @@ TEST_P(XdsTpAdsIntegrationTest, LedsTimeout) {
                               {}));
 }
 
+// Modifying a cluster to alternate use of EDS with and without LEDS.
+TEST_P(XdsTpAdsIntegrationTest, EdsAlternatingLedsUsage) {
+  initialize();
+  const auto cds_type_url = Config::getTypeUrl<envoy::config::cluster::v3::Cluster>();
+  const auto eds_type_url =
+      Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>();
+  const auto leds_type_url = Config::getTypeUrl<envoy::config::endpoint::v3::LbEndpoint>();
+
+  // Receive CDS request, and send a cluster with EDS.
+  EXPECT_TRUE(compareDiscoveryRequest(cds_type_url, "", {},
+                                      {"xdstp://test/envoy.config.cluster.v3.Cluster/foo-cluster/"
+                                       "*?xds.node.cluster=cluster_name&xds.node.id=node_name"},
+                                      {}, true));
+  const std::string cluster_name = "xdstp://test/envoy.config.cluster.v3.Cluster/foo-cluster/"
+                                   "baz?xds.node.cluster=cluster_name&xds.node.id=node_name";
+  auto cluster_resource = buildCluster(cluster_name);
+  const std::string endpoints_name =
+      "xdstp://test/envoy.config.endpoint.v3.ClusterLoadAssignment/foo-cluster/baz";
+  cluster_resource.mutable_eds_cluster_config()->set_service_name(endpoints_name);
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(cds_type_url, {}, {cluster_resource},
+                                                             {}, "1");
+
+  // Receive EDS request, and send ClusterLoadAssignment with one locality,
+  // that doesn't use LEDS.
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment, "", {},
+                                      {endpoints_name}, {}));
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      Config::TypeUrl::get().ClusterLoadAssignment, {},
+      {buildClusterLoadAssignment(endpoints_name)}, {}, "1");
+
+  EXPECT_TRUE(compareDiscoveryRequest(cds_type_url, "1", {}, {}, {}));
+
+  // LDS/RDS xDS initialization (LDS via xdstp:// glob collection)
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TypeUrl::get().Listener, "", {},
+                              {"xdstp://test/envoy.config.listener.v3.Listener/foo-listener/"
+                               "*?xds.node.cluster=cluster_name&xds.node.id=node_name"},
+                              {}));
+  const std::string route_name_0 =
+      "xdstp://test/envoy.config.route.v3.RouteConfiguration/route_config_0";
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(
+      Config::TypeUrl::get().Listener, {},
+      {buildListener("xdstp://test/envoy.config.listener.v3.Listener/foo-listener/"
+                     "bar?xds.node.cluster=cluster_name&xds.node.id=node_name",
+                     route_name_0)},
+      {}, "1");
+
+  EXPECT_TRUE(
+      compareDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment, "1", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "", {},
+                                      {route_name_0}, {}));
+  sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TypeUrl::get().RouteConfiguration, {}, {buildRouteConfig(route_name_0, cluster_name)},
+      {}, "1");
+
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Listener, "1", {}, {}, {}));
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "1", {}, {}, {}));
+
+  test_server_->waitForCounterEq("listener_manager.listener_create_success", 1);
+  makeSingleRequest();
+
+  // Send a new EDS update that uses LEDS.
+  const auto leds_resource_prefix =
+      "xdstp://test/envoy.config.endpoint.v3.LbEndpoint/foo-endpoints/";
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      eds_type_url, {},
+      {buildClusterLoadAssignmentWithLeds(endpoints_name, absl::StrCat(leds_resource_prefix, "*"))},
+      {}, "2");
+
+  // Receive LEDS request.
+  EXPECT_TRUE(compareDiscoveryRequest(
+      leds_type_url, "", {},
+      {absl::StrCat(leds_resource_prefix, "*?xds.node.cluster=cluster_name&xds.node.id=node_name")},
+      {}));
+
+  // Make sure that traffic can still be sent to the endpoint (still using the
+  // EDS without LEDS).
+  makeSingleRequest();
+
+  // Receive the EDS ack.
+  EXPECT_TRUE(compareDiscoveryRequest(eds_type_url, "2", {}, {}, {}));
+
+  // Send LEDS response with 2 endpoints.
+  const auto endpoint1_name = absl::StrCat(leds_resource_prefix, "endpoint_0",
+                                           "?xds.node.cluster=cluster_name&xds.node.id=node_name");
+  const auto endpoint2_name = absl::StrCat(leds_resource_prefix, "endpoint_1",
+                                           "?xds.node.cluster=cluster_name&xds.node.id=node_name");
+  sendExplicitResourcesDeltaDiscoveryResponse(
+      Config::TypeUrl::get().LbEndpoint,
+      {buildLbEndpointResource(endpoint1_name, "1"), buildLbEndpointResource(endpoint2_name, "1")},
+      {});
+
+  // Receive the LEDS ack.
+  EXPECT_TRUE(compareDiscoveryRequest(leds_type_url, "1", {}, {}, {}));
+
+  // Make sure that traffic can still be sent to the endpoint (now using the
+  // EDS with LEDS).
+  makeSingleRequest();
+
+  // Send a new EDS update that doesn't use LEDS.
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      Config::TypeUrl::get().ClusterLoadAssignment, {},
+      {buildClusterLoadAssignment(endpoints_name)}, {}, "3");
+
+  // The server should remove interest in the old LEDS.
+  EXPECT_TRUE(compareDiscoveryRequest(
+      leds_type_url, "", {}, {},
+      {absl::StrCat(leds_resource_prefix,
+                    "*?xds.node.cluster=cluster_name&xds.node.id=node_name")}));
+
+  // Receive the EDS ack.
+  EXPECT_TRUE(compareDiscoveryRequest(eds_type_url, "3", {}, {}, {}));
+
+  // Remove the LEDS endpoints.
+  sendExplicitResourcesDeltaDiscoveryResponse(Config::TypeUrl::get().LbEndpoint, {},
+                                              {endpoint1_name, endpoint2_name});
+
+  // Receive the LEDS ack.
+  EXPECT_TRUE(compareDiscoveryRequest(leds_type_url, "3", {}, {}, {}));
+
+  // Make sure that traffic can still be sent to the endpoint (now using the
+  // EDS without LEDS).
+  makeSingleRequest();
+}
+
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: LEDS: lowering EDS memory usage when LEDS is not used
Additional Description:
Prior work on LEDS saved the `ClusterLoadAssignment` for future use (needed when LEDS updates arrive).
This PR makes the field optional, and it will only be used when LEDS is configured.
Risk Level: low - only impacts deployments using LEDS.
Testing: Added an integration test.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
