### PR TITLE
tools: improve support for using compdb script from subrepos 

### DIFF
--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -73,7 +73,8 @@ def modify_compile_command(target, args):
         options += " -Wno-unused-function"
         # By treating external/envoy* as C++ files we are able to use this script from subrepos that
         # depend on Envoy targets.
-        if not target["file"].startswith("external/") or target["file"].startswith("external/envoy"):
+        if not target["file"].startswith("external/") or target["file"].startswith(
+                "external/envoy"):
             # *.h file is treated as C header by default while our headers files are all C++17.
             options = "-x c++ -std=c++17 -fexceptions " + options
 

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -71,7 +71,9 @@ def modify_compile_command(target, args):
     if is_header(target["file"]):
         options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
         options += " -Wno-unused-function"
-        if not target["file"].startswith("external/"):
+        # By treating external/envoy* as C++ files we are able to use this script from subrepos that
+        # depend on Envoy targets.
+        if not target["file"].startswith("external/") or target["file"].startswith("external/envoy"):
             # *.h file is treated as C header by default while our headers files are all C++17.
             options = "-x c++ -std=c++17 -fexceptions " + options
 


### PR DESCRIPTION
This ensures that the compdb treats Envoy source code as C++ in case it is pulled in as an external repo, allowing this code
to be reused by repos that depend on Envoy. This also conveniently match envoy-mobile. 

Risk Level: Low
Testing: Manual testing
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
