### PR TITLE
dns resolvers: add All lookup mode

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -129,6 +129,8 @@ message Cluster {
   // If V4_PREFERRED is specified, the DNS resolver will first perform a lookup for addresses in the
   // IPv4 family and fallback to a lookup for addresses in the IPv6 family. i.e., the callback
   // target will only get v6 addresses if there were NO v4 addresses to return.
+  // If ALL is specified, the DNS resolver will perform a lookup for both IPv4 and IPv6 families,
+  // and return all resolved addresses.
   // For cluster types other than
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>` and
   // :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`,
@@ -140,6 +142,7 @@ message Cluster {
     V4_ONLY = 1;
     V6_ONLY = 2;
     V4_PREFERRED = 3;
+    ALL = 4;
   }
 
   enum ClusterProtocolSelection {

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -117,6 +117,7 @@ New Features
 * bootstrap: added :ref:`inline_headers <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.inline_headers>` in the bootstrap to make custom inline headers bootstrap configurable.
 * contrib: added new :ref:`contrib images <install_contrib>` which contain contrib extensions.
 * dns: added :ref:`V4_PREFERRED <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.V4_PREFERRED>` option to return V6 addresses only if V4 addresses are not available.
+* dns: added :ref:`ALL <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` option to return both V4 and V6 addresses.
 * ext_authz: added :ref:`dynamic_metadata_from_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.dynamic_metadata_from_headers>` to support emitting dynamic metadata from headers returned by an external authorization service via HTTP.
 * grpc reverse bridge: added a new :ref:`option <envoy_v3_api_field_extensions.filters.http.grpc_http1_reverse_bridge.v3.FilterConfig.response_size_header>` to support streaming response bodies when withholding gRPC frames from the upstream.
 * grpc_json_transcoder: added support to unescape '+' in query parameters to space with a new config field :ref:`query_param_unescape_plus <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.query_param_unescape_plus>`.

--- a/envoy/network/dns.h
+++ b/envoy/network/dns.h
@@ -46,7 +46,7 @@ struct DnsResponse {
   const std::chrono::seconds ttl_;
 };
 
-enum class DnsLookupFamily { V4Only, V6Only, Auto, V4Preferred };
+enum class DnsLookupFamily { V4Only, V6Only, Auto, V4Preferred, All };
 
 /**
  * An asynchronous DNS resolver.

--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -139,7 +139,8 @@ AppleDnsResolverImpl::PendingResolution::PendingResolution(AppleDnsResolverImpl&
                                                            const std::string& dns_name,
                                                            DnsLookupFamily dns_lookup_family)
     : parent_(parent), callback_(callback), dispatcher_(dispatcher), dns_name_(dns_name),
-      pending_cb_({ResolutionStatus::Success, {}, {}}), dns_lookup_family_(dns_lookup_family) {}
+      pending_response_({ResolutionStatus::Success, {}, {}, {}}),
+      dns_lookup_family_(dns_lookup_family) {}
 
 AppleDnsResolverImpl::PendingResolution::~PendingResolution() {
   ENVOY_LOG(debug, "Destroying PendingResolution for {}", dns_name_);
@@ -181,7 +182,7 @@ void AppleDnsResolverImpl::PendingResolution::onEventCallback(uint32_t events) {
     // Similar to receiving an error in onDNSServiceGetAddrInfoReply, an error while processing fd
     // events indicates that the sd_ref state is broken.
     // Therefore, finish resolving with an error.
-    pending_cb_.status_ = ResolutionStatus::Failure;
+    pending_response_.status_ = ResolutionStatus::Failure;
     finishResolve();
   }
 }
@@ -189,29 +190,39 @@ void AppleDnsResolverImpl::PendingResolution::onEventCallback(uint32_t events) {
 std::list<DnsResponse>& AppleDnsResolverImpl::PendingResolution::finalAddressList() {
   switch (dns_lookup_family_) {
   case DnsLookupFamily::V4Only:
-    return pending_cb_.v4_responses_;
+    return pending_response_.v4_responses_;
   case DnsLookupFamily::V6Only:
-    return pending_cb_.v6_responses_;
+    return pending_response_.v6_responses_;
   case DnsLookupFamily::Auto:
     // Per API docs only give v4 if v6 is not available.
-    if (pending_cb_.v6_responses_.empty()) {
-      return pending_cb_.v4_responses_;
+    if (pending_response_.v6_responses_.empty()) {
+      return pending_response_.v4_responses_;
     }
-    return pending_cb_.v6_responses_;
+    return pending_response_.v6_responses_;
   case DnsLookupFamily::V4Preferred:
     // Per API docs only give v6 if v4 is not available.
-    if (pending_cb_.v4_responses_.empty()) {
-      return pending_cb_.v6_responses_;
+    if (pending_response_.v4_responses_.empty()) {
+      return pending_response_.v6_responses_;
     }
-    return pending_cb_.v4_responses_;
+    return pending_response_.v4_responses_;
+  case DnsLookupFamily::All:
+    ASSERT(pending_response_.all_responses_.empty());
+    pending_response_.all_responses_.insert(pending_response_.all_responses_.end(),
+                                            pending_response_.v4_responses_.begin(),
+                                            pending_response_.v4_responses_.end());
+    pending_response_.all_responses_.insert(pending_response_.all_responses_.end(),
+                                            pending_response_.v6_responses_.begin(),
+                                            pending_response_.v6_responses_.end());
+    return pending_response_.all_responses_;
   }
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void AppleDnsResolverImpl::PendingResolution::finishResolve() {
   ENVOY_LOG_EVENT(debug, "apple_dns_resolution_complete",
-                  "dns resolution for {} completed with status {}", dns_name_, pending_cb_.status_);
-  callback_(pending_cb_.status_, std::move(finalAddressList()));
+                  "dns resolution for {} completed with status {}", dns_name_,
+                  pending_response_.status_);
+  callback_(pending_response_.status_, std::move(finalAddressList()));
 
   if (owned_) {
     ENVOY_LOG(debug, "Resolution for {} completed (async)", dns_name_);
@@ -233,6 +244,7 @@ DNSServiceErrorType AppleDnsResolverImpl::PendingResolution::dnsServiceGetAddrIn
     break;
   case DnsLookupFamily::Auto:
   case DnsLookupFamily::V4Preferred:
+  case DnsLookupFamily::All:
     protocol = kDNSServiceProtocol_IPv4 | kDNSServiceProtocol_IPv6;
     break;
   }
@@ -277,9 +289,9 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
   if (error_code != kDNSServiceErr_NoError) {
     parent_.chargeGetAddrInfoErrorStats(error_code);
 
-    pending_cb_.status_ = ResolutionStatus::Failure;
-    pending_cb_.v4_responses_.clear();
-    pending_cb_.v6_responses_.clear();
+    pending_response_.status_ = ResolutionStatus::Failure;
+    pending_response_.v4_responses_.clear();
+    pending_response_.v6_responses_.clear();
 
     finishResolve();
     // Note: Nothing can follow this call to flushPendingQueries due to deletion of this
@@ -296,10 +308,10 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
     ENVOY_LOG(debug, "Address to add address={}, ttl={}",
               dns_response.address_->ip()->addressAsString(), ttl);
     if (dns_response.address_->ip()->ipv4()) {
-      pending_cb_.v4_responses_.push_back(dns_response);
+      pending_response_.v4_responses_.push_back(dns_response);
     } else {
       ASSERT(dns_response.address_->ip()->ipv6());
-      pending_cb_.v6_responses_.push_back(dns_response);
+      pending_response_.v6_responses_.push_back(dns_response);
     }
   }
 

--- a/source/common/network/apple_dns_impl.h
+++ b/source/common/network/apple_dns_impl.h
@@ -108,10 +108,11 @@ private:
 
     // Small wrapping struct to accumulate addresses from firings of the
     // onDNSServiceGetAddrInfoReply callback.
-    struct FinalResponse {
+    struct PendingResponse {
       ResolutionStatus status_;
       std::list<DnsResponse> v4_responses_;
       std::list<DnsResponse> v6_responses_;
+      std::list<DnsResponse> all_responses_;
     };
 
     AppleDnsResolverImpl& parent_;
@@ -127,7 +128,7 @@ private:
     // DNSServiceGetAddrInfo fires one callback DNSServiceGetAddrInfoReply callback per IP address,
     // and informs via flags if more IP addresses are incoming. Therefore, these addresses need to
     // be accumulated before firing callback_.
-    FinalResponse pending_cb_;
+    PendingResponse pending_response_;
     DnsLookupFamily dns_lookup_family_;
   };
 

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -111,16 +111,16 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
       ASSERT(dns_lookup_family_ == DnsLookupFamily::All && !dual_resolution_);
       // The only way the resolver would have addresses here is if it is configured to resolve All
       // families, and the first resolution was successful. In that case, we might as well return
-      // the addresses that resolved.
+      // the addresses that resolved as a success.
     } else {
       pending_response_.status_ = ResolutionStatus::Failure;
     }
     // Nothing can follow a call to finishResolve due to the deletion of this object upon
     // finishResolve().
     finishResolve();
-
     return;
   }
+
   if (!dual_resolution_) {
     completed_ = true;
 

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -104,16 +104,24 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
     // ARES_ECONNREFUSED. If the PendingResolution has not been cancelled that means that the
     // callback_ target _should_ still be around. In that case, raise the callback_ so the target
     // can be done with this query and initiate a new one.
-    if (!cancelled_) {
-      ENVOY_LOG_EVENT(debug, "cares_dns_resolution_destroyed", "dns resolution for {} destroyed",
-                      dns_name_);
+    ENVOY_LOG_EVENT(debug, "cares_dns_resolution_destroyed", "dns resolution for {} destroyed",
+                    dns_name_);
 
-      callback_(ResolutionStatus::Failure, {});
+    if (!pending_response_.address_list_.empty()) {
+      ASSERT(dns_lookup_family_ == DnsLookupFamily::All && !dual_resolution_);
+      // The only way the resolver would have addresses here is if it is configured to resolve All
+      // families, and the first resolution was successful. In that case, we might as well return
+      // the addresses that resolved.
+    } else {
+      pending_response_.status_ = ResolutionStatus::Failure;
     }
-    delete this;
+    // Nothing can follow a call to finishResolve due to the deletion of this object upon
+    // finishResolve().
+    finishResolve();
+
     return;
   }
-  if (!fallback_if_failed_) {
+  if (!dual_resolution_) {
     completed_ = true;
 
     // If c-ares returns ARES_ECONNREFUSED and there is no fallback we assume that the channel_ is
@@ -130,10 +138,8 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
     }
   }
 
-  std::list<DnsResponse> address_list;
-  ResolutionStatus resolution_status;
   if (status == ARES_SUCCESS) {
-    resolution_status = ResolutionStatus::Success;
+    pending_response_.status_ = ResolutionStatus::Success;
     if (addrinfo != nullptr && addrinfo->nodes != nullptr) {
       if (addrinfo->nodes->ai_family == AF_INET) {
         for (const ares_addrinfo_node* ai = addrinfo->nodes; ai != nullptr; ai = ai->ai_next) {
@@ -143,7 +149,7 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
           address.sin_port = 0;
           address.sin_addr = reinterpret_cast<sockaddr_in*>(ai->ai_addr)->sin_addr;
 
-          address_list.emplace_back(
+          pending_response_.address_list_.emplace_back(
               DnsResponse(std::make_shared<const Address::Ipv4Instance>(&address),
                           std::chrono::seconds(ai->ai_ttl)));
         }
@@ -154,21 +160,30 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
           address.sin6_family = AF_INET6;
           address.sin6_port = 0;
           address.sin6_addr = reinterpret_cast<sockaddr_in6*>(ai->ai_addr)->sin6_addr;
-          address_list.emplace_back(
+          pending_response_.address_list_.emplace_back(
               DnsResponse(std::make_shared<const Address::Ipv6Instance>(address),
                           std::chrono::seconds(ai->ai_ttl)));
         }
       }
     }
 
-    if (!address_list.empty()) {
+    if (!pending_response_.address_list_.empty() && dns_lookup_family_ != DnsLookupFamily::All) {
       completed_ = true;
     }
 
     ASSERT(addrinfo != nullptr);
     ares_freeaddrinfo(addrinfo);
   } else {
-    resolution_status = ResolutionStatus::Failure;
+    // FIXME: if the failure happens on the second resolution of DnsLookupFamily::All, should this
+    // return the v6 addresses that it has from the first resolution?
+    if (!pending_response_.address_list_.empty()) {
+      ASSERT(dns_lookup_family_ == DnsLookupFamily::All && !dual_resolution_);
+      // The only way the resolver would have addresses here is if it is configured to resolve All
+      // families, and the first resolution was successful. In that case, we might as well return
+      // the addresses that resolved.
+    } else {
+      pending_response_.status_ = ResolutionStatus::Failure;
+    }
   }
 
   if (timeouts > 0) {
@@ -176,41 +191,16 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
   }
 
   if (completed_) {
-    if (!cancelled_) {
-      // Use a raw try here because it is used in both main thread and filter.
-      // Can not convert to use status code as there may be unexpected exceptions in server fuzz
-      // tests, which must be handled. Potential exception may come from getAddressWithPort() or
-      // portFromTcpUrl().
-      // TODO(chaoqin-li1123): remove try catch pattern here once we figure how to handle unexpected
-      // exception in fuzz tests.
-      ENVOY_LOG_EVENT(debug, "cares_dns_resolution_complete",
-                      "dns resolution for {} completed with status {}", dns_name_,
-                      resolution_status);
-
-      TRY_NEEDS_AUDIT { callback_(resolution_status, std::move(address_list)); }
-      catch (const EnvoyException& e) {
-        ENVOY_LOG(critical, "EnvoyException in c-ares callback: {}", e.what());
-        dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
-      }
-      catch (const std::exception& e) {
-        ENVOY_LOG(critical, "std::exception in c-ares callback: {}", e.what());
-        dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
-      }
-      catch (...) {
-        ENVOY_LOG(critical, "Unknown exception in c-ares callback");
-        dispatcher_.post([] { throw EnvoyException("unknown"); });
-      }
-    }
-    if (owned_) {
-      delete this;
-      return;
-    }
+    finishResolve();
+    // Nothing can follow a call to finishResolve due to the deletion of this object upon
+    // finishResolve().
+    return;
   }
 
-  if (!completed_ && fallback_if_failed_) {
-    fallback_if_failed_ = false;
+  if (dual_resolution_) {
+    dual_resolution_ = false;
 
-    if (dns_lookup_family_ == DnsLookupFamily::Auto) {
+    if (dns_lookup_family_ == DnsLookupFamily::Auto || dns_lookup_family_ == DnsLookupFamily::All) {
       getAddrInfo(AF_INET);
     } else {
       ASSERT(dns_lookup_family_ == DnsLookupFamily::V4Preferred);
@@ -219,6 +209,40 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
 
     // Note: Nothing can follow this call to getAddrInfo due to deletion of this
     // object upon synchronous resolution.
+    return;
+  }
+}
+
+void DnsResolverImpl::PendingResolution::finishResolve() {
+  if (!cancelled_) {
+    // Use a raw try here because it is used in both main thread and filter.
+    // Can not convert to use status code as there may be unexpected exceptions in server fuzz
+    // tests, which must be handled. Potential exception may come from getAddressWithPort() or
+    // portFromTcpUrl().
+    // TODO(chaoqin-li1123): remove try catch pattern here once we figure how to handle unexpected
+    // exception in fuzz tests.
+    ENVOY_LOG_EVENT(debug, "cares_dns_resolution_complete",
+                    "dns resolution for {} completed with status {}", dns_name_,
+                    pending_response_.status_);
+
+    TRY_NEEDS_AUDIT {
+      callback_(pending_response_.status_, std::move(pending_response_.address_list_));
+    }
+    catch (const EnvoyException& e) {
+      ENVOY_LOG(critical, "EnvoyException in c-ares callback: {}", e.what());
+      dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
+    }
+    catch (const std::exception& e) {
+      ENVOY_LOG(critical, "std::exception in c-ares callback: {}", e.what());
+      dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
+    }
+    catch (...) {
+      ENVOY_LOG(critical, "Unknown exception in c-ares callback");
+      dispatcher_.post([] { throw EnvoyException("unknown"); });
+    }
+  }
+  if (owned_) {
+    delete this;
     return;
   }
 }
@@ -283,8 +307,9 @@ ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
   auto pending_resolution = std::make_unique<PendingResolution>(
       *this, callback, dispatcher_, channel_, dns_name, dns_lookup_family);
   if (dns_lookup_family == DnsLookupFamily::Auto ||
-      dns_lookup_family == DnsLookupFamily::V4Preferred) {
-    pending_resolution->fallback_if_failed_ = true;
+      dns_lookup_family == DnsLookupFamily::V4Preferred ||
+      dns_lookup_family == DnsLookupFamily::All) {
+    pending_resolution->dual_resolution_ = true;
   }
 
   if (dns_lookup_family == DnsLookupFamily::V4Only ||

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -43,7 +43,8 @@ private:
                       ares_channel channel, const std::string& dns_name,
                       DnsLookupFamily dns_lookup_family)
         : parent_(parent), callback_(callback), dispatcher_(dispatcher), channel_(channel),
-          dns_name_(dns_name), dns_lookup_family_(dns_lookup_family) {}
+          dns_name_(dns_name), dns_lookup_family_(dns_lookup_family),
+          pending_response_({ResolutionStatus::Success, {}}) {}
 
     void cancel(CancelReason) override {
       // c-ares only supports channel-wide cancellation, so we just allow the
@@ -86,14 +87,14 @@ private:
     bool completed_ = false;
     // Was the query cancelled via cancel()?
     bool cancelled_ = false;
-    // Perform a second resolution under certain conditions. If dns_lookup_family_ is V4Preferred or
-    // Auto, perform a second resolution if the first one fails. If dns_lookup_family_ is All
+    // Perform a second resolution under certain conditions. If dns_lookup_family_ is V4Preferred
+    // or Auto, perform a second resolution if the first one fails. If dns_lookup_family_ is All
     // perform the second resolution whether the first one fails or succeeds.
     bool dual_resolution_ = false;
-    PendingResponse pending_response_;
     const ares_channel channel_;
     const std::string dns_name_;
     const DnsLookupFamily dns_lookup_family_;
+    PendingResponse pending_response_;
   };
 
   struct AresOptions {

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -65,6 +65,15 @@ private:
      */
     void getAddrInfo(int family);
 
+    void finishResolve();
+
+    // Small wrapping struct to accumulate addresses from firings of the
+    // onAresGetAddrInfoCallback callback.
+    struct PendingResponse {
+      ResolutionStatus status_;
+      std::list<DnsResponse> address_list_;
+    };
+
     DnsResolverImpl& parent_;
     // Caller supplied callback to invoke on query completion or error.
     const ResolveCb callback_;
@@ -77,9 +86,11 @@ private:
     bool completed_ = false;
     // Was the query cancelled via cancel()?
     bool cancelled_ = false;
-    // If dns_lookup_family is "fallback", fallback to v4 address if v6
-    // resolution failed.
-    bool fallback_if_failed_ = false;
+    // Perform a second resolution under certain conditions. If dns_lookup_family_ is V4Preferred or
+    // Auto, perform a second resolution if the first one fails. If dns_lookup_family_ is All
+    // perform the second resolution whether the first one fails or succeeds.
+    bool dual_resolution_ = false;
+    PendingResponse pending_response_;
     const ares_channel channel_;
     const std::string dns_name_;
     const DnsLookupFamily dns_lookup_family_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1772,6 +1772,8 @@ getDnsLookupFamilyFromEnum(envoy::config::cluster::v3::Cluster::DnsLookupFamily 
     return Network::DnsLookupFamily::Auto;
   case envoy::config::cluster::v3::Cluster::V4_PREFERRED:
     return Network::DnsLookupFamily::V4Preferred;
+  case envoy::config::cluster::v3::Cluster::ALL:
+    return Network::DnsLookupFamily::All;
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -165,6 +165,10 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersion) {
   EXPECT_NE(nullptr, resolveWithExpectations("google.com", DnsLookupFamily::V6Only,
                                              DnsResolver::ResolutionStatus::Success, true));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  EXPECT_NE(nullptr, resolveWithExpectations("google.com", DnsLookupFamily::All,
+                                             DnsResolver::ResolutionStatus::Success, true));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
 // dns_sd is very opaque and does not explicitly call out the state that is kept across queries.
@@ -204,6 +208,10 @@ TEST_F(AppleDnsImplTest, DnsIpAddressVersionInvalid) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   EXPECT_NE(nullptr, resolveWithExpectations("invalidDnsName", DnsLookupFamily::V6Only,
+                                             DnsResolver::ResolutionStatus::Failure, false));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  EXPECT_NE(nullptr, resolveWithExpectations("invalidDnsName", DnsLookupFamily::All,
                                              DnsResolver::ResolutionStatus::Failure, false));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
@@ -332,7 +340,8 @@ public:
 
   enum AddressType { V4, V6, Both };
 
-  void fallbackWith(DnsLookupFamily dns_lookup_family, AddressType address_type) {
+  void fallbackWith(DnsLookupFamily dns_lookup_family, AddressType address_type,
+                    uint32_t expected_address_size = 1) {
     const std::string hostname = "foo.com";
     sockaddr_in addr4;
     addr4.sin_family = AF_INET;
@@ -361,10 +370,10 @@ public:
 
     auto query = resolver_->resolve(
         hostname, dns_lookup_family,
-        [&dns_callback_executed, dns_lookup_family, address_type](
+        [&dns_callback_executed, dns_lookup_family, address_type, expected_address_size](
             DnsResolver::ResolutionStatus status, std::list<DnsResponse>&& response) -> void {
           EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
-          EXPECT_EQ(1, response.size());
+          EXPECT_EQ(expected_address_size, response.size());
 
           if (dns_lookup_family == DnsLookupFamily::Auto) {
             if (address_type == AddressType::V4) {
@@ -379,6 +388,23 @@ public:
               EXPECT_NE(nullptr, response.front().address_->ip()->ipv6());
             } else {
               EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
+            }
+          }
+
+          if (dns_lookup_family == DnsLookupFamily::All) {
+            switch (address_type) {
+            case AddressType::V4:
+              EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
+              break;
+            case AddressType::V6:
+              EXPECT_NE(nullptr, response.front().address_->ip()->ipv6());
+              break;
+            case AddressType::Both:
+              EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.back().address_->ip()->ipv6());
+              break;
+            default:
+              NOT_REACHED_GCOVR_EXCL_LINE;
             }
           }
           dns_callback_executed.Notify();
@@ -649,6 +675,7 @@ TEST_F(AppleDnsImplFakeApiTest, MultipleAddresses) {
   dns_callback_executed.WaitForNotification();
 }
 
+// TODO: write a TEST_P harness to eliminate duplication.
 TEST_F(AppleDnsImplFakeApiTest, AutoOnlyV6IfBothV6andV4) {
   fallbackWith(DnsLookupFamily::Auto, AddressType::Both);
 }
@@ -671,6 +698,18 @@ TEST_F(AppleDnsImplFakeApiTest, V4PreferredV6IfOnlyV6) {
 
 TEST_F(AppleDnsImplFakeApiTest, V4PreferredV4IfOnlyV4) {
   fallbackWith(DnsLookupFamily::V4Preferred, AddressType::V4);
+}
+
+TEST_F(AppleDnsImplFakeApiTest, AllIfBothV6andV4) {
+  fallbackWith(DnsLookupFamily::All, AddressType::Both, 2 /* expected_address_size*/);
+}
+
+TEST_F(AppleDnsImplFakeApiTest, AllV6IfOnlyV6) {
+  fallbackWith(DnsLookupFamily::All, AddressType::V6);
+}
+
+TEST_F(AppleDnsImplFakeApiTest, AllV4IfOnlyV4) {
+  fallbackWith(DnsLookupFamily::All, AddressType::V4);
 }
 
 TEST_F(AppleDnsImplFakeApiTest, MultipleAddressesSecondOneFails) {

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -45,6 +45,7 @@ using testing::IsSupersetOf;
 using testing::NiceMock;
 using testing::Not;
 using testing::Return;
+using testing::UnorderedElementsAreArray;
 
 namespace Envoy {
 namespace Network {
@@ -502,7 +503,7 @@ public:
           if (address == "localhost" && lookup_family == DnsLookupFamily::V4Only) {
             EXPECT_THAT(address_as_string_list, IsSupersetOf(expected_results));
           } else {
-            EXPECT_EQ(expected_results, address_as_string_list);
+            EXPECT_THAT(address_as_string_list, UnorderedElementsAreArray(expected_results));
           }
 
           for (const auto& expected_absent_result : expected_absent_results) {
@@ -845,6 +846,33 @@ TEST_P(DnsImplTest, V4PreferredV6IfOnlyV6) {
 TEST_P(DnsImplTest, V4PreferredV4IfOnlyV4) {
   server_->addHosts("some.good.domain", {"201.134.56.7"}, RecordType::A);
   EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::V4Preferred,
+                                             DnsResolver::ResolutionStatus::Success,
+                                             {{"201.134.56.7"}}, {}, absl::nullopt));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+}
+
+TEST_P(DnsImplTest, AllIfBothV6andV4) {
+  server_->addHosts("some.good.domain", {"201.134.56.7"}, RecordType::A);
+  server_->addHosts("some.good.domain", {"1::2"}, RecordType::AAAA);
+
+  EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::All,
+                                             DnsResolver::ResolutionStatus::Success,
+                                             {{"201.134.56.7"}, {"1::2"}}, {}, absl::nullopt));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+}
+
+TEST_P(DnsImplTest, AllV6IfOnlyV6) {
+  server_->addHosts("some.good.domain", {"1::2"}, RecordType::AAAA);
+
+  EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::All,
+                                             DnsResolver::ResolutionStatus::Success, {{"1::2"}}, {},
+                                             absl::nullopt));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+}
+
+TEST_P(DnsImplTest, AllV4IfOnlyV4) {
+  server_->addHosts("some.good.domain", {"201.134.56.7"}, RecordType::A);
+  EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::All,
                                              DnsResolver::ResolutionStatus::Success,
                                              {{"201.134.56.7"}}, {}, absl::nullopt));
   dispatcher_->run(Event::Dispatcher::RunType::Block);


### PR DESCRIPTION
Commit Message: dns resolvers - add All lookup mode
Additional Description: this change will enable callback targets to access both address families for a given hostname.
Risk Level: low - new behavior guarded by config option
Testing: added UT
Docs Changes: updated
Release Notes: updated