### PR TITLE
ci: preserve PATH in run_envoy_docker.sh

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -44,7 +44,7 @@ else
     && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /build envoybuild \
     && usermod -a -G pcap envoybuild \
     && chown envoybuild:envoygroup /build \
-    && sudo -EHs -u envoybuild bash -c 'cd /source && $*'")
+    && sudo -EHs -u envoybuild PATH=\$PATH bash -c 'cd /source && $*'")
 fi
 
 # The IMAGE_ID defaults to the CI hash but can be set to an arbitrary image ID (found with 'docker


### PR DESCRIPTION
**Commit Message**:
By using `-E` flag with sudo we so far were preserving env vars
in start command. The problem is it's not preserving PATH var,
which is fine for ubuntu based images as it looks like all tools
are available within default PATH (/sbin:/bin:/usr/sbin:/usr/bin).
The problem starts when we need to modify this PATH, (like in
[centos image](https://github.com/envoyproxy/envoy-build-tools/blob/55a7bbe700586729bd38231a9a6f3dcd1ff85e7d/build_container/Dockerfile-centos#L21))

This change is explicitly passing the PATH variable from
the container the start command is being called

**Additional Description**:
none

**Risk Level**:
I don't see any potential risks

**Testing**:
I have built envoy using both, **centos** and **ubuntu** images

**Docs Changes**:
no changes

**Release Notes**:
no release notes

**Platform Specific Features**:
it let's envoy-build-centos image to work again