### PR TITLE
Migrate the wasm filter to use grpc client cache.

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -994,7 +994,7 @@ WasmResult Context::grpcCall(std::string_view grpc_service, std::string_view ser
   handler.token_ = token;
   auto grpc_client = clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
       service_proto, *wasm()->scope_, true /* skip_cluster_check */,
-      Grpc::CacheOption::CacheWhenRuntimeEnabled);
+      Grpc::CacheOption::AlwaysCache);
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
   // set default hash policy to be based on :authority to enable consistent hash
@@ -1043,7 +1043,7 @@ WasmResult Context::grpcStream(std::string_view grpc_service, std::string_view s
   handler.token_ = token;
   auto grpc_client = clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
       service_proto, *wasm()->scope_, true /* skip_cluster_check */,
-      Grpc::CacheOption::CacheWhenRuntimeEnabled);
+      Grpc::CacheOption::AlwaysCache);
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
   // set default hash policy to be based on :authority to enable consistent hash

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -126,7 +126,7 @@ ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
   // requests.
   return std::make_unique<Filters::Common::RateLimit::GrpcClientImpl>(
       context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
-          grpc_service, context.scope(), true, Grpc::CacheOption::CacheWhenRuntimeEnabled),
+          grpc_service, context.scope(), true, Grpc::CacheOption::AlwaysCache),
       timeout);
 }
 

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -126,7 +126,7 @@ ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
   // requests.
   return std::make_unique<Filters::Common::RateLimit::GrpcClientImpl>(
       context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
-          grpc_service, context.scope(), true, Grpc::CacheOption::AlwaysCache),
+          grpc_service, context.scope(), true, Grpc::CacheOption::CacheWhenRuntimeEnabled),
       timeout);
 }
 


### PR DESCRIPTION
Signed-off-by: chaoqin-li1123 <chaoqinli@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Use AlwaysCache option for grpc client in ratelimit filter and wasm filter
Additional Description: NA
Risk Level: Medium, may have lifetime issue.
Testing: NA
