### PR TITLE
grpc: Use lru cache for grpc raw async client

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -50,6 +50,7 @@ envoy_cc_library(
         "//envoy/thread_local:thread_local_interface",
         "//envoy/upstream:cluster_manager_interface",
     ] + envoy_select_google_grpc([":google_async_client_lib"]),
+    external_deps = ["simple_lru_cache_lib"],
 )
 
 envoy_cc_library(

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -42,7 +42,6 @@ envoy_cc_library(
     name = "async_client_manager_lib",
     srcs = ["async_client_manager_impl.cc"],
     hdrs = ["async_client_manager_impl.h"],
-    external_deps = ["simple_lru_cache_lib"],
     deps = [
         ":async_client_lib",
         ":context_lib",

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
     name = "async_client_manager_lib",
     srcs = ["async_client_manager_impl.cc"],
     hdrs = ["async_client_manager_impl.h"],
+    external_deps = ["simple_lru_cache_lib"],
     deps = [
         ":async_client_lib",
         ":context_lib",
@@ -50,7 +51,6 @@ envoy_cc_library(
         "//envoy/thread_local:thread_local_interface",
         "//envoy/upstream:cluster_manager_interface",
     ] + envoy_select_google_grpc([":google_async_client_lib"]),
-    external_deps = ["simple_lru_cache_lib"],
 )
 
 envoy_cc_library(

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -156,8 +156,7 @@ RawAsyncClientSharedPtr AsyncClientManagerImpl::RawAsyncClientCache::getCache(
     return nullptr;
   }
   if (idle_keys_.find(config) != idle_keys_.end()) {
-    idle_keys_.erase(config);
-    active_keys_.insert(config);
+    active_keys_.insert(idle_keys_.extract(config));
   }
   return it->second;
 }
@@ -168,9 +167,9 @@ void AsyncClientManagerImpl::RawAsyncClientCache::setCache(
   active_keys_.insert(config);
 }
 
-void AsyncClientManagerImpl::RawAsyncClientCache::refresh() {
+void AsyncClientManagerImpl::RawAsyncClientCache::evictIdleEntries() {
   // Remove all the cache entries idle in the last interval.
-  for (auto const& config : idle_keys_) {
+  for (const auto& config : idle_keys_) {
     cache_.erase(config);
   }
   // Reset all the entries to be idle at the beginning of next interval.

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -149,32 +149,9 @@ RawAsyncClientSharedPtr AsyncClientManagerImpl::getOrCreateRawAsyncClient(
   return client;
 }
 
-RawAsyncClientSharedPtr AsyncClientManagerImpl::RawAsyncClientCache::getCache(
-    const envoy::config::core::v3::GrpcService& config) {
-  auto it = cache_.find(config);
-  if (it == cache_.end()) {
-    return nullptr;
-  }
-  if (idle_keys_.find(config) != idle_keys_.end()) {
-    active_keys_.insert(idle_keys_.extract(config));
-  }
-  return it->second;
-}
 
-void AsyncClientManagerImpl::RawAsyncClientCache::setCache(
-    const envoy::config::core::v3::GrpcService& config, const RawAsyncClientSharedPtr& client) {
-  cache_[config] = client;
-  active_keys_.insert(config);
-}
 
-void AsyncClientManagerImpl::RawAsyncClientCache::evictIdleEntries() {
-  // Remove all the cache entries idle in the last interval.
-  for (const auto& config : idle_keys_) {
-    cache_.erase(config);
-  }
-  // Reset all the entries to be idle at the beginning of next interval.
-  idle_keys_ = std::move(active_keys_);
-}
+
 
 } // namespace Grpc
 } // namespace Envoy

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -149,9 +149,5 @@ RawAsyncClientSharedPtr AsyncClientManagerImpl::getOrCreateRawAsyncClient(
   return client;
 }
 
-
-
-
-
 } // namespace Grpc
 } // namespace Envoy

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -149,17 +149,17 @@ RawAsyncClientSharedPtr AsyncClientManagerImpl::getOrCreateRawAsyncClient(
 }
 
 RawAsyncClientSharedPtr AsyncClientManagerImpl::RawAsyncClientCache::getCache(
-    const envoy::config::core::v3::GrpcService& config) const {
-  auto it = cache_.find(config);
-  if (it == cache_.end()) {
-    return nullptr;
+    const envoy::config::core::v3::GrpcService& config) {
+  RawAsyncClientLRUMap::ScopedLookup lookup(&lru_cache_, config);
+  if (lookup.found()) {
+    return *(lookup.value());
   }
-  return it->second;
+  return nullptr;
 }
 
 void AsyncClientManagerImpl::RawAsyncClientCache::setCache(
     const envoy::config::core::v3::GrpcService& config, const RawAsyncClientSharedPtr& client) {
-  cache_[config] = client;
+  lru_cache_.insert(config, new RawAsyncClientSharedPtr{client}, 1);
 }
 
 } // namespace Grpc

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -151,8 +151,8 @@ RawAsyncClientSharedPtr AsyncClientManagerImpl::getOrCreateRawAsyncClient(
 
 RawAsyncClientSharedPtr AsyncClientManagerImpl::RawAsyncClientCache::getCache(
     const envoy::config::core::v3::GrpcService& config) {
-  auto it = kvs_.find(config);
-  if (it == kvs_.end()) {
+  auto it = cache_.find(config);
+  if (it == cache_.end()) {
     return nullptr;
   }
   if (idle_keys_.find(config) != idle_keys_.end()) {

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -164,14 +164,14 @@ RawAsyncClientSharedPtr AsyncClientManagerImpl::RawAsyncClientCache::getCache(
 
 void AsyncClientManagerImpl::RawAsyncClientCache::setCache(
     const envoy::config::core::v3::GrpcService& config, const RawAsyncClientSharedPtr& client) {
-  kvs_[config] = client;
+  cache_[config] = client;
   active_keys_.insert(config);
 }
 
 void AsyncClientManagerImpl::RawAsyncClientCache::refresh() {
   // Remove all the cache entries idle in the last interval.
   for (auto const& config : idle_keys_) {
-    kvs_.erase(config);
+    cache_.erase(config);
   }
   // Reset all the entries to be idle at the beginning of next interval.
   idle_keys_ = std::move(active_keys_);

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -57,11 +57,11 @@ public:
   class RawAsyncClientCache : public ThreadLocal::ThreadLocalObject {
   public:
     explicit RawAsyncClientCache(Event::Dispatcher& dispatcher) {
-      timer_ = dispatcher.createTimer([this] {
+      evict_idle_entries_timer_ = dispatcher.createTimer([this] {
         evictIdleEntries();
-        timer_->enableTimer(RefreshInterval);
+        evict_idle_entries_timer_->enableTimer(RefreshInterval);
       });
-      timer_->enableTimer(RefreshInterval);
+      evict_idle_entries_timer_->enableTimer(RefreshInterval);
     }
     void setCache(const envoy::config::core::v3::GrpcService& config,
                   const RawAsyncClientSharedPtr& client);
@@ -76,7 +76,7 @@ public:
     absl::flat_hash_set<envoy::config::core::v3::GrpcService, MessageUtil, MessageUtil> idle_keys_;
     absl::flat_hash_set<envoy::config::core::v3::GrpcService, MessageUtil, MessageUtil>
         active_keys_;
-    Envoy::Event::TimerPtr timer_;
+    Envoy::Event::TimerPtr evict_idle_entries_timer_;
     static constexpr std::chrono::milliseconds RefreshInterval{50000};
   };
 

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -60,18 +60,20 @@ public:
                                               bool skip_cluster_check) override;
 
 private:
+  using RawAsyncClientLRUMap = SimpleLRUCache<envoy::config::core::v3::GrpcService,
+                                              RawAsyncClientSharedPtr, MessageUtil, MessageUtil>;
   class RawAsyncClientCache : public ThreadLocal::ThreadLocalObject {
   public:
+    ~RawAsyncClientCache() { lru_cache_.clear(); }
     void setCache(const envoy::config::core::v3::GrpcService& config,
                   const RawAsyncClientSharedPtr& client);
-    RawAsyncClientSharedPtr getCache(const envoy::config::core::v3::GrpcService& config) const;
+    RawAsyncClientSharedPtr getCache(const envoy::config::core::v3::GrpcService& config);
 
   private:
     absl::flat_hash_map<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
                         MessageUtil>
         cache_;
-      SimpleLRUCache<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
-                        MessageUtil> lru_cache_{500};  
+    RawAsyncClientLRUMap lru_cache_{500};
   };
   Upstream::ClusterManager& cm_;
   ThreadLocal::Instance& tls_;

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -54,8 +54,6 @@ public:
   AsyncClientFactoryPtr factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
                                               Stats::Scope& scope,
                                               bool skip_cluster_check) override;
-
-private:
   class RawAsyncClientCache : public ThreadLocal::ThreadLocalObject {
   public:
     RawAsyncClientCache(Event::Dispatcher& dispatcher) {
@@ -81,6 +79,8 @@ private:
     Envoy::Event::TimerPtr timer_;
     static constexpr std::chrono::milliseconds RefreshInterval{50000};
   };
+
+private:
   Upstream::ClusterManager& cm_;
   ThreadLocal::Instance& tls_;
   ThreadLocal::SlotPtr google_tls_slot_;

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -73,7 +73,9 @@ public:
     absl::flat_hash_map<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
                         MessageUtil>
         cache_;
+    // The keys of cache entries that haven't been accessed since last eviction.
     absl::flat_hash_set<envoy::config::core::v3::GrpcService, MessageUtil, MessageUtil> idle_keys_;
+    // The keys of cache entries that have been accessed since last eviction.
     absl::flat_hash_set<envoy::config::core::v3::GrpcService, MessageUtil, MessageUtil>
         active_keys_;
     Envoy::Event::TimerPtr evict_idle_entries_timer_;

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -10,6 +10,10 @@
 
 #include "source/common/grpc/stat_names.h"
 
+#include "simple_lru_cache/simple_lru_cache_inl.h"
+
+using ::google::simple_lru_cache::SimpleLRUCache;
+
 namespace Envoy {
 namespace Grpc {
 
@@ -66,6 +70,8 @@ private:
     absl::flat_hash_map<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
                         MessageUtil>
         cache_;
+      SimpleLRUCache<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
+                        MessageUtil> lru_cache_{500};  
   };
   Upstream::ClusterManager& cm_;
   ThreadLocal::Instance& tls_;

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -58,7 +58,7 @@ public:
   public:
     explicit RawAsyncClientCache(Event::Dispatcher& dispatcher) {
       timer_ = dispatcher.createTimer([this] {
-        refresh();
+        evictIdleEntries();
         timer_->enableTimer(RefreshInterval);
       });
       timer_->enableTimer(RefreshInterval);
@@ -67,7 +67,7 @@ public:
                   const RawAsyncClientSharedPtr& client);
     RawAsyncClientSharedPtr getCache(const envoy::config::core::v3::GrpcService& config);
 
-    void refresh();
+    void evictIdleEntries();
 
   private:
     absl::flat_hash_map<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -56,7 +56,7 @@ public:
                                               bool skip_cluster_check) override;
   class RawAsyncClientCache : public ThreadLocal::ThreadLocalObject {
   public:
-    RawAsyncClientCache(Event::Dispatcher& dispatcher) {
+    explicit RawAsyncClientCache(Event::Dispatcher& dispatcher) {
       timer_ = dispatcher.createTimer([this] {
         refresh();
         timer_->enableTimer(RefreshInterval);

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -64,7 +64,11 @@ private:
                                               RawAsyncClientSharedPtr, MessageUtil, MessageUtil>;
   class RawAsyncClientCache : public ThreadLocal::ThreadLocalObject {
   public:
-    ~RawAsyncClientCache() { lru_cache_.clear(); }
+    RawAsyncClientCache() {
+      double timeout = 0.2;
+      lru_cache_.setMaxIdleSeconds(timeout);
+    }
+    ~RawAsyncClientCache() override { lru_cache_.clear(); }
     void setCache(const envoy::config::core::v3::GrpcService& config,
                   const RawAsyncClientSharedPtr& client);
     RawAsyncClientSharedPtr getCache(const envoy::config::core::v3::GrpcService& config);

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -70,9 +70,6 @@ private:
     RawAsyncClientSharedPtr getCache(const envoy::config::core::v3::GrpcService& config);
 
   private:
-    absl::flat_hash_map<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
-                        MessageUtil>
-        cache_;
     RawAsyncClientLRUMap lru_cache_{500};
   };
   Upstream::ClusterManager& cm_;

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -72,7 +72,7 @@ public:
   private:
     absl::flat_hash_map<envoy::config::core::v3::GrpcService, RawAsyncClientSharedPtr, MessageUtil,
                         MessageUtil>
-        kvs_;
+        cache_;
     absl::flat_hash_set<envoy::config::core::v3::GrpcService, MessageUtil, MessageUtil> idle_keys_;
     absl::flat_hash_set<envoy::config::core::v3::GrpcService, MessageUtil, MessageUtil>
         active_keys_;

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
     name = "async_client_impl_test",
     srcs = ["async_client_impl_test.cc"],
     deps = [
+        "//source/common/event:dispatcher_lib",
         "//source/common/grpc:async_client_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/tracing:tracing_mocks",

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -27,17 +27,17 @@ namespace {
 class AsyncClientCacheTest : public testing::Test {
 public:
   AsyncClientCacheTest()
-      : api_(Api::createApiForTest(stats_, time_system_)),
-        dispatcher_("test_thread", *api_, time_system_), client_cache_(dispatcher_) {}
+      : api_(Api::createApiForTest(time_system_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")), client_cache_(*dispatcher_) {}
 
   void step() {
-    time_system_.advanceTimeAndRun(std::chrono::milliseconds(10000), dispatcher_,
+    time_system_.advanceTimeAndRun(std::chrono::milliseconds(10000), *dispatcher_,
                                    Event::Dispatcher::RunType::NonBlock);
   }
   Envoy::Stats::IsolatedStoreImpl stats_;
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
-  Event::DispatcherImpl dispatcher_;
+  Event::DispatcherPtr dispatcher_;
   AsyncClientManagerImpl::RawAsyncClientCache client_cache_;
 };
 

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -105,7 +105,7 @@ TEST_F(AsyncClientManagerImplTest, RawAsyncClientCacheEvictOldEntries) {
                                                     CacheOption::AlwaysCache);
   }
 
-  // Get a different raw async client bacause cache has been evicted.
+  // Get a different raw async client because cache has been evicted.
   grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
   RawAsyncClientSharedPtr client0c = async_client_manager_.getOrCreateRawAsyncClient(
       grpc_service, scope_, true, CacheOption::AlwaysCache);

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -53,7 +53,7 @@ TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   waitForSeconds(45);
   // Cache entry hasn't been evicted because it was accessed 45s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
-  waitForSeconds(80);
+  waitForSeconds(51);
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), nullptr);
 }
 
@@ -64,7 +64,7 @@ TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
     client_cache_.setCache(grpc_service, foo_client);
   }
-  waitForSeconds(80);
+  waitForSeconds(21);
   for (int i = 51; i <= 100; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
     client_cache_.setCache(grpc_service, foo_client);

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -47,10 +47,10 @@ TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   foo_service.mutable_envoy_grpc()->set_cluster_name("foo");
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   client_cache_.setCache(foo_service, foo_client);
-  waitForSeconds(45);
+  waitForSeconds(49);
   // Cache entry hasn't been evicted because it was created 45s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
-  waitForSeconds(45);
+  waitForSeconds(49);
   // Cache entry hasn't been evicted because it was accessed 45s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(51);
@@ -70,12 +70,12 @@ TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
     client_cache_.setCache(grpc_service, foo_client);
   }
   waitForSeconds(30);
-  // Cache entries that have expired.
+  // Cache entries created 51s before have expired.
   for (int i = 1; i <= 50; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
     EXPECT_EQ(client_cache_.getCache(grpc_service).get(), nullptr);
   }
-  // Cache entries that haven't expired.
+  // Cache entries 30s before haven't expired.
   for (int i = 51; i <= 100; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
     EXPECT_EQ(client_cache_.getCache(grpc_service).get(), foo_client.get());

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -110,6 +110,28 @@ TEST_F(AsyncClientManagerImplTest, RawAsyncClientCacheEvictOldEntries) {
   RawAsyncClientSharedPtr client0c = async_client_manager_.getOrCreateRawAsyncClient(
       grpc_service, scope_, true, CacheOption::AlwaysCache);
   EXPECT_NE(client0b.get(), client0c.get());
+
+  for (int i = 1; i <= 499; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    async_client_manager_.getOrCreateRawAsyncClient(grpc_service, scope_, true,
+                                                    CacheOption::AlwaysCache);
+  }
+
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
+  RawAsyncClientSharedPtr client0d = async_client_manager_.getOrCreateRawAsyncClient(
+      grpc_service, scope_, true, CacheOption::AlwaysCache);
+  EXPECT_EQ(client0c.get(), client0d.get());
+
+  for (int i = 1; i <= 500; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    async_client_manager_.getOrCreateRawAsyncClient(grpc_service, scope_, true,
+                                                    CacheOption::AlwaysCache);
+  }
+
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
+  RawAsyncClientSharedPtr client0e = async_client_manager_.getOrCreateRawAsyncClient(
+      grpc_service, scope_, true, CacheOption::AlwaysCache);
+  EXPECT_NE(client0d.get(), client0e.get());
 }
 
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcInvalid) {

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -82,58 +82,6 @@ TEST_F(AsyncClientManagerImplTest, EnableRawAsyncClientCache) {
   EXPECT_NE(foo_client1.get(), bar_client.get());
 }
 
-TEST_F(AsyncClientManagerImplTest, RawAsyncClientCacheEvictOldEntries) {
-  envoy::config::core::v3::GrpcService grpc_service;
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
-  RawAsyncClientSharedPtr client0a = async_client_manager_.getOrCreateRawAsyncClient(
-      grpc_service, scope_, true, CacheOption::AlwaysCache);
-
-  for (int i = 1; i < 100; i++) {
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    async_client_manager_.getOrCreateRawAsyncClient(grpc_service, scope_, true,
-                                                    CacheOption::AlwaysCache);
-  }
-
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
-  RawAsyncClientSharedPtr client0b = async_client_manager_.getOrCreateRawAsyncClient(
-      grpc_service, scope_, true, CacheOption::AlwaysCache);
-  EXPECT_EQ(client0a.get(), client0b.get());
-
-  for (int i = 1000; i < 3000; i++) {
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    async_client_manager_.getOrCreateRawAsyncClient(grpc_service, scope_, true,
-                                                    CacheOption::AlwaysCache);
-  }
-
-  // Get a different raw async client because cache has been evicted.
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
-  RawAsyncClientSharedPtr client0c = async_client_manager_.getOrCreateRawAsyncClient(
-      grpc_service, scope_, true, CacheOption::AlwaysCache);
-  EXPECT_NE(client0b.get(), client0c.get());
-
-  for (int i = 1; i <= 499; i++) {
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    async_client_manager_.getOrCreateRawAsyncClient(grpc_service, scope_, true,
-                                                    CacheOption::AlwaysCache);
-  }
-
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
-  RawAsyncClientSharedPtr client0d = async_client_manager_.getOrCreateRawAsyncClient(
-      grpc_service, scope_, true, CacheOption::AlwaysCache);
-  EXPECT_EQ(client0c.get(), client0d.get());
-
-  for (int i = 1; i <= 500; i++) {
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    async_client_manager_.getOrCreateRawAsyncClient(grpc_service, scope_, true,
-                                                    CacheOption::AlwaysCache);
-  }
-
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("0");
-  RawAsyncClientSharedPtr client0e = async_client_manager_.getOrCreateRawAsyncClient(
-      grpc_service, scope_, true, CacheOption::AlwaysCache);
-  EXPECT_NE(client0d.get(), client0e.get());
-}
-
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcInvalid) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -55,10 +55,10 @@ TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   client_cache_.setCache(foo_service, foo_client);
   waitForSeconds(49);
-  // Cache entry hasn't been evicted because it was created 45s ago.
+  // Cache entry hasn't been evicted because it was created 49s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(49);
-  // Cache entry hasn't been evicted because it was accessed 45s ago.
+  // Cache entry hasn't been evicted because it was accessed 49s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(51);
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), nullptr);
@@ -89,13 +89,15 @@ TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
   }
 }
 
-TEST_F(RawAsyncClientCacheTest, GetTimeoutButNotEvictedCacheEntry) {
+// Test the case when the eviction timer doesn't fire on time, getting the oldest entry that has
+// already expired but hasn't been evicted should succeed.
+TEST_F(RawAsyncClientCacheTest, GetExpiredButNotEvictedCacheEntry) {
   envoy::config::core::v3::GrpcService foo_service;
   foo_service.mutable_envoy_grpc()->set_cluster_name("foo");
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   client_cache_.setCache(foo_service, foo_client);
   time_system_.advanceTimeAsyncImpl(std::chrono::seconds(50));
-  // Cache entry doesn't get evicted because it is accessed before timer fire.
+  // Cache entry hasn't been evicted because it is accessed before timer fire.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   time_system_.advanceTimeAndRun(std::chrono::seconds(50), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -30,9 +30,11 @@ public:
       : api_(Api::createApiForTest(time_system_)),
         dispatcher_(api_->allocateDispatcher("test_thread")), client_cache_(*dispatcher_) {}
 
-  // Because advanceTimeAndRun simply increase the time system timestamp without interuption and
-  // then run the event loop, advance time in small steps so that the cache eviction timer can fire
-  // in correct timestamps.
+  // Because advanceTimeAndRun moves the current time as requested, and then executes
+  // all runnable timers in a non-deterministic order. This mimics real-time behavior in
+  // libevent if there is a long delay between libevent regaining control. Here we want to
+  // test behavior with a specific sequence of events, where each timer fires within a
+  // simulated second of what was programmed.
   void waitForSeconds(int seconds) {
     for (int i = 0; i < seconds; i++) {
       time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -48,10 +48,10 @@ TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   client_cache_.setCache(foo_service, foo_client);
   waitForSeconds(45);
-  // Cache entry hasn't been evicted because it was created 10s ago.
+  // Cache entry hasn't been evicted because it was created 45s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(45);
-  // Cache entry hasn't been evicted because it was accessed 10s ago.
+  // Cache entry hasn't been evicted because it was accessed 45s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(80);
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), nullptr);

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -30,7 +30,7 @@ public:
       : api_(Api::createApiForTest(time_system_)),
         dispatcher_(api_->allocateDispatcher("test_thread")), client_cache_(*dispatcher_) {}
 
-  // Because advanceTimeAndRun moves the current time as requested, and then executes
+  // advanceTimeAndRun moves the current time as requested, and then executes
   // all runnable timers in a non-deterministic order. This mimics real-time behavior in
   // libevent if there is a long delay between libevent regaining control. Here we want to
   // test behavior with a specific sequence of events, where each timer fires within a

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -32,11 +32,10 @@ public:
 
   void waitForSeconds(size_t seconds) {
     for (size_t i = 0; i < seconds; i++) {
-      time_system_.advanceTimeAndRun(std::chrono::milliseconds(1000), *dispatcher_,
+      time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
                                      Event::Dispatcher::RunType::NonBlock);
     }
   }
-  Envoy::Stats::IsolatedStoreImpl stats_;
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -31,7 +31,7 @@ public:
         dispatcher_(api_->allocateDispatcher("test_thread")), client_cache_(*dispatcher_) {}
 
   // advanceTimeAndRun moves the current time as requested, and then executes
-  // all runnable timers in a non-deterministic order. This mimics real-time behavior in
+  // all executable timers in a non-deterministic order. This mimics real-time behavior in
   // libevent if there is a long delay between libevent regaining control. Here we want to
   // test behavior with a specific sequence of events, where each timer fires within a
   // simulated second of what was programmed.

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -47,10 +47,10 @@ TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   foo_service.mutable_envoy_grpc()->set_cluster_name("foo");
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   client_cache_.setCache(foo_service, foo_client);
-  waitForSeconds(10);
+  waitForSeconds(45);
   // Cache entry hasn't been evicted because it was created 10s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
-  waitForSeconds(10);
+  waitForSeconds(45);
   // Cache entry hasn't been evicted because it was accessed 10s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(80);

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -24,9 +24,9 @@ namespace Envoy {
 namespace Grpc {
 namespace {
 
-class AsyncClientCacheTest : public testing::Test {
+class RawAsyncClientCacheTest : public testing::Test {
 public:
-  AsyncClientCacheTest()
+  RawAsyncClientCacheTest()
       : api_(Api::createApiForTest(time_system_)),
         dispatcher_(api_->allocateDispatcher("test_thread")), client_cache_(*dispatcher_) {}
 
@@ -42,17 +42,44 @@ public:
   AsyncClientManagerImpl::RawAsyncClientCache client_cache_;
 };
 
-TEST_F(AsyncClientCacheTest, CacheEviction) {
+TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   envoy::config::core::v3::GrpcService foo_service;
   foo_service.mutable_envoy_grpc()->set_cluster_name("foo");
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   client_cache_.setCache(foo_service, foo_client);
   waitForSeconds(10);
+  // Cache entry hasn't been evicted because it was created 10s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(10);
+  // Cache entry hasn't been evicted because it was accessed 10s ago.
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
   waitForSeconds(80);
   EXPECT_EQ(client_cache_.getCache(foo_service).get(), nullptr);
+}
+
+TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
+  envoy::config::core::v3::GrpcService grpc_service;
+  RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
+  for (int i = 1; i <= 50; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    client_cache_.setCache(grpc_service, foo_client);
+  }
+  waitForSeconds(80);
+  for (int i = 51; i <= 100; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    client_cache_.setCache(grpc_service, foo_client);
+  }
+  waitForSeconds(30);
+  // Cache entries that have expired.
+  for (int i = 1; i <= 50; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    EXPECT_EQ(client_cache_.getCache(grpc_service).get(), nullptr);
+  }
+  // Cache entries that haven't expired.
+  for (int i = 51; i <= 100; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    EXPECT_EQ(client_cache_.getCache(grpc_service).get(), foo_client.get());
+  }
 }
 
 class AsyncClientManagerImplTest : public testing::Test {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: As we are migrating to cache raw async grpc client, it is necessary to evict unused client to prevent the size of the cache to grow infinitely.
Additional Description:
Risk Level: low
Testing: Some test to verify the behavior.
Docs Changes:NA
Release Notes:NA
Platform Specific Features:NA
