### PR TITLE
Remove unused portion of log message with bad format string

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -160,8 +160,7 @@ Http::FilterHeadersStatus Filter::encode100ContinueHeaders(Http::ResponseHeaderM
 
 Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers, bool) {
   ENVOY_STREAM_LOG(trace,
-                   "ext_authz filter has {} response header(s) to add and {} response header(s) to "
-                   "set to the encoded response:",
+                   "ext_authz filter has {} response header(s) to add",
                    *encoder_callbacks_, response_headers_to_add_.size());
   if (!response_headers_to_add_.empty()) {
     ENVOY_STREAM_LOG(


### PR DESCRIPTION
Signed-off-by: Michael Leuchtenburg <mleuchtenburg@google.com>

Commit Message: Fixes a broken log line. This message currently doesn't appear because the format is wrong.
Additional Description: This is hard to detect because Envoy doesn't use FMT_STRING, which would do compile-time checking of formats. It should be logged to stderr by default by spdlog, but I'm not seeing those logs anywhere when running the ext_authz tests.
Risk Level: low
Testing: Ran the ext_authz tests, verified that the log message appears.