### PR TITLE
thread: Assert thread quiescence between tests

### DIFF
--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -31,7 +31,7 @@ struct ThreadIds {
     return main_thread_id_ == id || test_thread_id_ == id;
   }
 
-  bool hasMainThread() const {
+  bool isMainThreadActive() const {
     absl::MutexLock lock(&mutex_);
     return main_thread_use_count_ != 0;
   }
@@ -106,7 +106,7 @@ private:
 
 bool MainThread::isMainOrTestThread() { return ThreadIds::get().inMainOrTestThread(); }
 
-bool MainThread::hasMainThread() { return ThreadIds::get().hasMainThread(); }
+bool MainThread::isMainThreadActive() { return ThreadIds::get().isMainThreadActive(); }
 
 TestThread::TestThread() { ThreadIds::get().registerTestThread(); }
 

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -204,7 +204,7 @@ public:
   /**
    * @return whether a MainThread has been instantiated.
    */
-  static bool hasMainThread();
+  static bool isMainThreadActive();
 };
 
 // To improve exception safety in data plane, we plan to forbid the use of raw try in the core code

--- a/test/test_listener.cc
+++ b/test/test_listener.cc
@@ -14,7 +14,7 @@ void TestListener::OnTestEnd(const ::testing::TestInfo& test_info) {
                               "]: Active singletons exist. Something is leaking. Consider "
                               "commenting out this assert and letting the heap checker run:\n",
                               active_singletons));
-  RELEASE_ASSERT(!Thread::MainThread::hasMainThread(),
+  RELEASE_ASSERT(!Thread::MainThread::isMainThreadActive(),
                  absl::StrCat("MainThreadLeak: [", test_info.test_suite_name(), ".",
                               test_info.name(), "] test exited before main thread shut down"));
 }


### PR DESCRIPTION
Commit Message: Adds assertions that any 'main threads' have completely quiesced between test methods. I am not certain this can be an issue given the rest of Envoy test infrastructure (e.g. memory leaks from unjoined threads), but testing this is essentially free, and it's hard to be certain.

This doesn't happen normally when I test on my machine, but maybe such a delayed closing out of a MainThread might be responsible for rare flakes.
Additional Description:
Risk Level: low (test changes only)
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
