### PR TITLE
runtime: removed envoy.reloadable_features.return_502_for_upstream_protocol_errors

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -20,6 +20,7 @@ Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
+* http: removed ``envoy.reloadable_features.return_502_for_upstream_protocol_errors``. Envoy will always return 502 code upon encountering upstream protocol error.
 * http: removed ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` and legacy code paths.
 
 New Features

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -110,12 +110,8 @@ void CodecClient::onEvent(Network::ConnectionEvent event) {
     if (connected_) {
       reason = StreamResetReason::ConnectionTermination;
       if (protocol_error_) {
-        if (Runtime::runtimeFeatureEnabled(
-                "envoy.reloadable_features.return_502_for_upstream_protocol_errors")) {
-          reason = StreamResetReason::ProtocolError;
-          connection_->streamInfo().setResponseFlag(
-              StreamInfo::ResponseFlag::UpstreamProtocolError);
-        }
+        reason = StreamResetReason::ProtocolError;
+        connection_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
       }
     } else {
       ENVOY_CONN_LOG(warn, "Connection is closed by {} during connecting.", *connection_,

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1728,14 +1728,9 @@ ClientConnectionImpl::trackOutboundFrames(bool is_outbound_flood_monitored_contr
 }
 
 StreamResetReason ClientConnectionImpl::getMessagingErrorResetReason() const {
-  StreamResetReason reason = StreamResetReason::LocalReset;
-  if (Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.return_502_for_upstream_protocol_errors")) {
-    reason = StreamResetReason::ProtocolError;
-    connection_.streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
-  }
+  connection_.streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
 
-  return reason;
+  return StreamResetReason::ProtocolError;
 }
 
 ServerConnectionImpl::ServerConnectionImpl(

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -85,7 +85,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.preserve_downstream_scheme",
     "envoy.reloadable_features.remove_forked_chromium_url",
     "envoy.reloadable_features.require_strict_1xx_and_204_response_headers",
-    "envoy.reloadable_features.return_502_for_upstream_protocol_errors",
     "envoy.reloadable_features.send_strict_1xx_and_204_response_headers",
     "envoy.reloadable_features.strip_port_from_connect",
     "envoy.reloadable_features.treat_host_like_authority",

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1275,17 +1275,8 @@ TEST_P(IntegrationTest, Connect) {
   EXPECT_EQ(normalizeDate(response1), normalizeDate(response2));
 }
 
-// Test that Envoy by default returns HTTP code 502 on upstream protocol error.
-TEST_P(IntegrationTest, UpstreamProtocolErrorDefault) {
-  testRouterUpstreamProtocolError("502", "UPE");
-}
-
-// Test runtime overwrite to return 503 on upstream protocol error.
-TEST_P(IntegrationTest, UpstreamProtocolErrorRuntimeOverwrite) {
-  config_helper_.addRuntimeOverride(
-      "envoy.reloadable_features.return_502_for_upstream_protocol_errors", "false");
-  testRouterUpstreamProtocolError("503", "UC");
-}
+// Test that Envoy returns HTTP code 502 on upstream protocol error.
+TEST_P(IntegrationTest, UpstreamProtocolError) { testRouterUpstreamProtocolError("502", "UPE"); }
 
 TEST_P(IntegrationTest, TestHead) {
   initialize();


### PR DESCRIPTION
Commit Message:
Removed envoy.reloadable_features.return_502_for_upstream_protocol_errors runtime guard.
Additional Description:
Risk Level: Low
Testing: Adjusted tests after runtime guard removal.
Docs Changes: No
Release Notes: Yes.
Platform Specific Features:
Fixes #18443 
