### PR TITLE
fuzz: move the test-thread initialization to fuzz_runner.cc

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -31,6 +31,8 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
   // state.
   ProcessWide process_wide;
   TestEnvironment::initializeOptions(argc, argv);
+  static auto* test_thread = new Envoy::Thread::TestThread;
+  UNREFERENCED_PARAMETER(test_thread);
 
   const auto environment_log_level = TestEnvironment::getOptions().logLevel();
   // We only override the default log level if it looks like we're debugging;

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -56,7 +56,6 @@ INSTANTIATE_TEST_SUITE_P(CorpusExamples, FuzzerCorpusTest, testing::ValuesIn(tes
 
 int main(int argc, char** argv) {
   Envoy::TestEnvironment::initializeTestMain(argv[0]);
-  Envoy::Thread::TestThread test_thread;
 
   // Expected usage: <test path> <corpus paths..> [other gtest flags]
   RELEASE_ASSERT(argc >= 2, "");


### PR DESCRIPTION
Commit Message: declaring the TestThread in test/fuzz/main.cc made sense, but it has proved harder to integrate into environments with other custom stuff in main(). It's easier to lazy-static-init it in fuzz_runner.cc which has an integrated hook.
Additional Description:
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

