### PR TITLE
Revert "syscall: add getifaddrs to os syscalls (#18513)"

### DIFF
--- a/envoy/api/os_sys_calls.h
+++ b/envoy/api/os_sys_calls.h
@@ -190,21 +190,6 @@ public:
    * @see man TCP_INFO. Get the tcp info for the socket.
    */
   virtual SysCallBoolResult socketTcpInfo(os_fd_t sockfd, EnvoyTcpInfo* tcp_info) PURE;
-
-  /**
-   * return true if the OS supports getifaddrs.
-   */
-  virtual bool supportsGetifaddrs() const PURE;
-
-  /**
-   * @see man getifaddrs
-   */
-  virtual SysCallIntResult getifaddrs(ifaddrs** ifap) PURE;
-
-  /**
-   * @see man getifaddrs
-   */
-  virtual void freeifaddrs(ifaddrs* ifp) PURE;
 };
 
 using OsSysCallsPtr = std::unique_ptr<OsSysCalls>;

--- a/envoy/common/platform.h
+++ b/envoy/common/platform.h
@@ -293,19 +293,17 @@ struct mmsghdr {
 };
 #endif
 
-// https://android.googlesource.com/platform/prebuilts/ndk/+/dev/platform/sysroot/usr/include/ifaddrs.h
-#if defined(WIN32) || (defined(__ANDROID_API__) && __ANDROID_API__ < 24)
-// Posix structure necessary for getifaddrs definition.
-struct ifaddrs {
-  struct ifaddrs* ifa_next;
-  char* ifa_name;
-  unsigned int ifa_flags;
-  struct sockaddr* ifa_addr;
-  struct sockaddr* ifa_netmask;
-  struct sockaddr* ifa_dstaddr;
-  void* ifa_data;
-};
+#define SUPPORTS_GETIFADDRS
+#ifdef WIN32
+#undef SUPPORTS_GETIFADDRS
 #endif
+
+// https://android.googlesource.com/platform/prebuilts/ndk/+/dev/platform/sysroot/usr/include/ifaddrs.h
+#ifdef __ANDROID_API__
+#if __ANDROID_API__ < 24
+#undef SUPPORTS_GETIFADDRS
+#endif // __ANDROID_API__ < 24
+#endif // ifdef __ANDROID_API__
 
 // TODO: Remove once bazel supports NDKs > 21
 #define SUPPORTS_CPP_17_CONTIGUOUS_ITERATOR

--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -282,20 +282,5 @@ SysCallBoolResult OsSysCallsImpl::socketTcpInfo([[maybe_unused]] os_fd_t sockfd,
   return {false, EOPNOTSUPP};
 }
 
-bool OsSysCallsImpl::supportsGetifaddrs() const {
-// https://android.googlesource.com/platform/prebuilts/ndk/+/dev/platform/sysroot/usr/include/ifaddrs.h
-#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
-  return false;
-#endif
-  return true;
-}
-
-SysCallIntResult OsSysCallsImpl::getifaddrs(struct ifaddrs** ifap) {
-  const int rc = ::getifaddrs(ifap);
-  return {rc, rc != -1 ? 0 : errno};
-}
-
-void OsSysCallsImpl::freeifaddrs(struct ifaddrs* ifp) { ::freeifaddrs(ifp); }
-
 } // namespace Api
 } // namespace Envoy

--- a/source/common/api/posix/os_sys_calls_impl.h
+++ b/source/common/api/posix/os_sys_calls_impl.h
@@ -49,9 +49,6 @@ public:
   SysCallSocketResult duplicate(os_fd_t oldfd) override;
   SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen) override;
   SysCallBoolResult socketTcpInfo(os_fd_t sockfd, EnvoyTcpInfo* tcp_info) override;
-  bool supportsGetifaddrs() const override;
-  SysCallIntResult getifaddrs(struct ifaddrs** ifap) override;
-  void freeifaddrs(struct ifaddrs* ifp) override;
 };
 
 using OsSysCallsSingleton = ThreadSafeSingleton<OsSysCallsImpl>;

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -404,9 +404,5 @@ SysCallBoolResult OsSysCallsImpl::socketTcpInfo([[maybe_unused]] os_fd_t sockfd,
   return {false, WSAEOPNOTSUPP};
 }
 
-SysCallIntResult OsSysCallsImpl::getifaddrs(struct ifaddrs**) { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-
-void OsSysCallsImpl::freeifaddrs(struct ifaddrs*) { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-
 } // namespace Api
 } // namespace Envoy

--- a/source/common/api/win32/os_sys_calls_impl.h
+++ b/source/common/api/win32/os_sys_calls_impl.h
@@ -51,9 +51,6 @@ public:
   SysCallSocketResult duplicate(os_fd_t oldfd) override;
   SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen) override;
   SysCallBoolResult socketTcpInfo(os_fd_t sockfd, EnvoyTcpInfo* tcp_info) override;
-  bool supportsGetifaddrs() const override { return false; }
-  SysCallIntResult getifaddrs(struct ifaddrs** ifap) override;
-  void freeifaddrs(struct ifaddrs* ifp) override;
 };
 
 using OsSysCallsSingleton = ThreadSafeSingleton<OsSysCallsImpl>;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -239,36 +239,35 @@ void Utility::throwWithMalformedIp(absl::string_view ip_address) {
 // need to be updated in the future. Discussion can be found at Github issue #939.
 Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersion version) {
   Address::InstanceConstSharedPtr ret;
-  if (Api::OsSysCallsSingleton::get().supportsGetifaddrs()) {
-    struct ifaddrs* ifaddr;
-    struct ifaddrs* ifa;
+#ifdef SUPPORTS_GETIFADDRS
+  struct ifaddrs* ifaddr;
+  struct ifaddrs* ifa;
 
-    const Api::SysCallIntResult rc = Api::OsSysCallsSingleton::get().getifaddrs(&ifaddr);
-    RELEASE_ASSERT(!rc.return_value_, fmt::format("getiffaddrs error: {}", rc.errno_));
+  const int rc = getifaddrs(&ifaddr);
+  RELEASE_ASSERT(!rc, "");
 
-    // man getifaddrs(3)
-    for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
-      if (ifa->ifa_addr == nullptr) {
-        continue;
-      }
-
-      if ((ifa->ifa_addr->sa_family == AF_INET && version == Address::IpVersion::v4) ||
-          (ifa->ifa_addr->sa_family == AF_INET6 && version == Address::IpVersion::v6)) {
-        const struct sockaddr_storage* addr =
-            reinterpret_cast<const struct sockaddr_storage*>(ifa->ifa_addr);
-        ret = Address::addressFromSockAddrOrThrow(*addr, (version == Address::IpVersion::v4)
-                                                             ? sizeof(sockaddr_in)
-                                                             : sizeof(sockaddr_in6));
-        if (!isLoopbackAddress(*ret)) {
-          break;
-        }
-      }
+  // man getifaddrs(3)
+  for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr) {
+      continue;
     }
 
-    if (ifaddr) {
-      Api::OsSysCallsSingleton::get().freeifaddrs(ifaddr);
+    if ((ifa->ifa_addr->sa_family == AF_INET && version == Address::IpVersion::v4) ||
+        (ifa->ifa_addr->sa_family == AF_INET6 && version == Address::IpVersion::v6)) {
+      const struct sockaddr_storage* addr =
+          reinterpret_cast<const struct sockaddr_storage*>(ifa->ifa_addr);
+      ret = Address::addressFromSockAddrOrThrow(
+          *addr, (version == Address::IpVersion::v4) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
+      if (!isLoopbackAddress(*ret)) {
+        break;
+      }
     }
   }
+
+  if (ifaddr) {
+    freeifaddrs(ifaddr);
+  }
+#endif
 
   // If the local address is not found above, then return the loopback address by default.
   if (ret == nullptr) {

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -11,7 +11,6 @@ ALS
 AMZ
 APC
 API
-ARRAYSIZE
 ARN
 ASAN
 ASCII
@@ -815,7 +814,6 @@ megamiss
 mem
 memcmp
 memcpy
-memset
 memoize
 mergeable
 messagename


### PR DESCRIPTION
Commit Message: Revert "syscall: add getifaddrs to os syscalls (#18513)"
Additional Description: This reverts commit fc0438294d088bc55ccd4d9f7e5dbaf23662b1fb. This change broke Envoy Mobile, which contains its own ifaddrs implementation for Android. Ultimately, it could make sense to move this implementation to upstream Envoy, but for now it's useful to keep it in Envoy Mobile where we can iterate with lower friction if needed.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>