### PR TITLE
tests: Disable `kill_request_filter_integration_test`

### DIFF
--- a/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
@@ -74,6 +74,8 @@ TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyOnResp
                "KillRequestFilter is crashing Envoy!!!");
 }
 
+// Disabled for coverage per #18569
+#if !defined(ENVOY_CONFIG_COVERAGE)
 TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyWithCustomKillHeader) {
   const std::string filter_config_with_custom_kill_header =
       R"EOF(
@@ -96,6 +98,7 @@ typed_config:
   EXPECT_DEATH(sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 1024),
                "KillRequestFilter is crashing Envoy!!!");
 }
+#endif
 
 TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestDisabledWhenHeaderIsMissing) {
   initializeFilter(filter_config_);


### PR DESCRIPTION
Disabling the tests as they reduce the CI reliability. Opened an issue
for tracking

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>