### PR TITLE
[Backport v1.17] udp: Fixes segfault for packets > 24000 bytes. Partial backport of 73eec645.

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,6 +13,8 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* udp: fixed issue in which receiving UDP datagrams larger than 24000 bytes would cause Envoy to crash.
+
 Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -591,7 +591,7 @@ Api::IoCallUint64Result Utility::readFromSocket(IoHandle& handle,
     Api::IoCallUint64Result result =
         receiveMessage(max_packet_size_with_gro, buffer, output, handle, local_address);
 
-    if (!result.ok()) {
+    if (!result.ok() || output.msg_[0].truncated_and_dropped_) {
       return result;
     }
 


### PR DESCRIPTION
Commit Message:
```
Fixes segfault in !18553. Partial backport of 73eec64.
Current behaviour: segfaults when receiving UDP packets larger than 24000 bytes.
New behaviour: drops packets larger than 24000.
```
Additional Description: Due to GRO the segfaults also occur when MTU is much smaller than 24000 as packets get reassembled.
Risk Level: Low
Testing: todo
Docs Changes: none
Release Notes: udp: fix segfault for packets larger than 24000 bytes.
Platform Specific Features:
[Optional Runtime guard:]
Fixes #18553
Backports fix from 73eec645
