### PR TITLE
tests: Reduce the coverage requirement in `source/common`

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -3,7 +3,7 @@
 # directory:coverage_percent
 # for existing directories with low coverage.
 declare -a KNOWN_LOW_COVERAGE=(
-"source/common:96.0" # Raise when QUIC coverage goes up
+"source/common:95.9" # Raise when QUIC coverage goes up
 "source/common/api:79.8"
 "source/common/api/posix:78.5"
 "source/common/common/posix:92.7"


### PR DESCRIPTION
Reduce the coverage requirement slightly to avoid flakes.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>