### PR TITLE
runtime: do not share runtime snapshot between worker threads

### DIFF
--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -64,7 +64,8 @@ struct RuntimeStats {
 class SnapshotImpl : public Snapshot, Logger::Loggable<Logger::Id::runtime> {
 public:
   SnapshotImpl(Random::RandomGenerator& generator, RuntimeStats& stats,
-               std::vector<OverrideLayerConstPtr>&& layers);
+               std::shared_ptr<std::vector<OverrideLayerConstPtr>> layers);
+  SnapshotImpl(SnapshotImpl* src) : SnapshotImpl(src->generator_, src->stats_, src->layers_){};
 
   // Runtime::Snapshot
   bool deprecatedFeatureEnabled(absl::string_view key, bool default_value) const override;
@@ -112,7 +113,7 @@ private:
   static bool parseEntryDoubleValue(Entry& entry);
   static void parseEntryFractionalPercentValue(Entry& entry);
 
-  const std::vector<OverrideLayerConstPtr> layers_;
+  const std::shared_ptr<std::vector<OverrideLayerConstPtr>> layers_;
   EntryMap values_;
   Random::RandomGenerator& generator_;
   RuntimeStats& stats_;


### PR DESCRIPTION
Commit Message:
Currently, every worker thread accesses the shared_ptr of the runtime snapshot. When the data plane frequently needs to do runtime feature checking under heavy load, the resource contention becomes a scaling bottleneck. The created snapshot does not need to be shared in that way. This patch eliminates the scaling bottleneck.

An alternative way to resolve the contention may be to change LoaderImpl::threadsafeSnapshot so that it never touch refcount of the original shared_ptr to a new snapshot, and returns a plain reference instead of SnapshotConstSharedPtr. (https://github.com/envoyproxy/envoy/pull/18485#discussion_r727690188 )

This is a fllow-up PR of https://github.com/envoyproxy/envoy/pull/18485.

Ref: #18600 
Additional Description: n/a
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
