### PR TITLE
test: Stabilize ext_proc:streaming_integration_test

### DIFF
--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -472,6 +472,7 @@ TEST_P(StreamingIntegrationTest, GetAndProcessStreamedResponseBody) {
   EXPECT_TRUE(client_response_->complete());
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
   EXPECT_EQ(client_response_->body().size(), response_size);
+  test_processor_.shutdown();
   EXPECT_EQ(processor_response_hash_, HashUtil::xxHash64(client_response_->body()));
 }
 


### PR DESCRIPTION
Commit Message:
Stabilize ext_proc:streaming_integration_test

Additional Description:
`StreamingIntegrationTest.GetAndProcessStreamedResponseBody` of
`//test/extensions/filters/http/ext_proc:streaming_integration_test` 
sporadically fails with error like following:
```
[ RUN      ] StreamingProtocols/StreamingIntegrationTest.GetAndProcessStreamedResponseBody/0
test/extensions/filters/http/ext_proc/streaming_integration_test.cc:475: Failure
Expected equality of these values:
  processor_response_hash_
    Which is: 0
  HashUtil::xxHash64(client_response_->body())
    Which is: 3015323255580051823 
```
The `processor_response_hash_` is set by `test_processor_` after the stream is ended.
However there is wait for end of stream before the test of hash, but
with unlucky thread scheduling the hash set still can happen later than the test of it.
Adding a short sleep directly before 
`processor_response_hash_ = HashUtil::xxHash64(allData.toString());`
can make the fail permanent.
As fix need to shutdown the `test_processor_` explicitly before hash test.

Risk Level:
None

Testing:
Existing UT

