### PR TITLE
udp_proxy: added per packet load balancing possibility

### DIFF
--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -20,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.udp_listener.udp_proxy]
 
 // Configuration for the UDP proxy filter.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message UdpProxyConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.udp.udp_proxy.v2alpha.UdpProxyConfig";
@@ -82,4 +82,9 @@ message UdpProxyConfig {
   // :ref:`prefer_gro <envoy_v3_api_field_config.core.v3.UdpSocketConfig.prefer_gro>` is true for upstream
   // sockets as the assumption is datagrams will be received from a single source.
   config.core.v3.UdpSocketConfig upstream_socket_config = 6;
+
+  // Perform per packet load balancing (upstream host selection) on each received data chunk.
+  // The default if not specified is false, that means each data chunk is forwarded
+  // to upstream host selected on first chunk receival for that "session" (identified by source IP/port and local IP/port).
+  bool use_per_packet_load_balancing = 7;
 }

--- a/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
+++ b/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
@@ -35,7 +35,8 @@ Load balancing and unhealthy host handling
 Envoy will fully utilize the configured load balancer for the configured upstream cluster when
 load balancing UDP datagrams. By default, when a new session is created, Envoy will associate the session
 with an upstream host selected using the configured load balancer. All future datagrams that
-belong to the session will be routed to the same upstream host. However, if :ref:`use_original_src_ip <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>`
+belong to the session will be routed to the same upstream host. However, if :ref:`use_per_packet_load_balancing
+<envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>`
 field is set to true, Envoy selects another upstream host on next datagram using the configured load balancer
 and creates a new session if such does not exist. So in case of several upstream hosts available for the load balancer
 each data chunk is forwarded to a different host.

--- a/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
+++ b/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
@@ -20,17 +20,25 @@ Each session is index by the 4-tuple consisting of source IP/port and local IP/p
 datagram is received on. Sessions last until the :ref:`idle timeout
 <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.idle_timeout>` is reached.
 
+Above *session stickness* could be disabled by setting :ref:`use_per_packet_load_balancing
+<envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>` to true.
+In that case, *per packet load balancing* is enabled. It means that upstream host is selected on every single data chunk
+received by udp proxy using currently used load balancing policy.
+
 The UDP proxy listener filter also can operate as a *transparent* proxy if the
 :ref:`use_original_src_ip <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>`
-field is set. But please keep in mind that it does not forward the port to upstreams. It forwards only the IP address to upstreams.
+field is set to true. But please keep in mind that it does not forward the port to upstreams. It forwards only the IP address to upstreams.
 
 Load balancing and unhealthy host handling
 ------------------------------------------
 
 Envoy will fully utilize the configured load balancer for the configured upstream cluster when
-load balancing UDP datagrams. When a new session is created, Envoy will associate the session
+load balancing UDP datagrams. By default, when a new session is created, Envoy will associate the session
 with an upstream host selected using the configured load balancer. All future datagrams that
-belong to the session will be routed to the same upstream host.
+belong to the session will be routed to the same upstream host. However, if :ref:`use_original_src_ip <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>`
+field is set to true, Envoy selects another upstream host on next datagram using the configured load balancer
+and creates a new session if such does not exist. So in case of several upstream hosts available for the load balancer
+each data chunk is forwarded to a different host.
 
 When an upstream host becomes unhealthy (due to :ref:`active health checking
 <arch_overview_health_checking>`), Envoy will attempt to create a new session to a healthy host

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -76,10 +76,10 @@ New Features
 * tls: added support for only verifying the leaf CRL in the certificate chain with :ref:`only_verify_leaf_cert_crl <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.only_verify_leaf_cert_crl>`.
 * transport_socket: added :ref:`envoy.transport_sockets.tcp_stats <envoy_v3_api_msg_extensions.transport_sockets.tcp_stats.v3.Config>` which generates additional statistics gathered from the OS TCP stack.
 * udp: add support for multiple listener filters.
+* udp_proxy: added :ref:`use_per_packet_load_balancing <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>` option to enable per packet load balancing (selection of upstream host on each data chunk).
 * upstream: added the ability to :ref:`configure max connection duration <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>` for upstream clusters.
 * vcl_socket_interface: added VCL socket interface extension for fd.io VPP integration to :ref:`contrib images <install_contrib>`. This can be enabled via :ref:`VCL <envoy_v3_api_msg_extensions.vcl.v3alpha.VclSocketInterface>` configuration.
 * xds: re-introduced unified delta and sotw xDS multiplexers that share most of the implementation. Added a new runtime config ``envoy.reloadable_features.unified_mux`` (disabled by default) that when enabled, switches xDS to use unified multiplexers.
-* udp_proxy: added :ref:`use_per_packet_load_balancing <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>` option to enable per packet load balancing (selection of upstream host on each data chunk).
 
 Deprecated
 ----------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -79,6 +79,7 @@ New Features
 * upstream: added the ability to :ref:`configure max connection duration <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>` for upstream clusters.
 * vcl_socket_interface: added VCL socket interface extension for fd.io VPP integration to :ref:`contrib images <install_contrib>`. This can be enabled via :ref:`VCL <envoy_v3_api_msg_extensions.vcl.v3alpha.VclSocketInterface>` configuration.
 * xds: re-introduced unified delta and sotw xDS multiplexers that share most of the implementation. Added a new runtime config ``envoy.reloadable_features.unified_mux`` (disabled by default) that when enabled, switches xDS to use unified multiplexers.
+* udp_proxy: added :ref:`use_per_packet_load_balancing <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>` option to enable per packet load balancing (selection of upstream host on each data chunk).
 
 Deprecated
 ----------

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -27,8 +27,13 @@ void UdpProxyFilter::onClusterAddOrUpdate(Upstream::ThreadLocalCluster& cluster)
   }
 
   ENVOY_LOG(debug, "udp proxy: attaching to cluster {}", cluster.info()->name());
-  ASSERT(cluster_info_ == absl::nullopt || &cluster_info_.value().cluster_ != &cluster);
-  cluster_info_.emplace(*this, cluster);
+  ASSERT(cluster_info_ == absl::nullopt || &cluster_info_.value()->cluster_ != &cluster);
+
+  if (config_->usingPerPacketLoadBalancing()) {
+    cluster_info_.emplace(std::make_unique<PerPacketLoadBalancingClusterInfo>(*this, cluster));
+  } else {
+    cluster_info_.emplace(std::make_unique<StickySessionClusterInfo>(*this, cluster));
+  }
 }
 
 void UdpProxyFilter::onClusterRemoval(const std::string& cluster) {
@@ -46,7 +51,7 @@ Network::FilterStatus UdpProxyFilter::onData(Network::UdpRecvData& data) {
     return Network::FilterStatus::StopIteration;
   }
 
-  return cluster_info_.value().onData(data);
+  return cluster_info_.value()->onData(data);
 }
 
 Network::FilterStatus UdpProxyFilter::onReceiveError(Api::IoError::IoErrorCode) {
@@ -58,7 +63,11 @@ Network::FilterStatus UdpProxyFilter::onReceiveError(Api::IoError::IoErrorCode) 
 UdpProxyFilter::ClusterInfo::ClusterInfo(UdpProxyFilter& filter,
                                          Upstream::ThreadLocalCluster& cluster)
     : filter_(filter), cluster_(cluster),
-      cluster_stats_(generateStats(cluster.info()->statsScope())),
+      cluster_stats_(generateStats(cluster.info()->statsScope())) {}
+
+UdpProxyFilter::StickySessionClusterInfo::StickySessionClusterInfo(
+    UdpProxyFilter& filter, Upstream::ThreadLocalCluster& cluster)
+    : ClusterInfo(filter, cluster),
       member_update_cb_handle_(cluster.prioritySet().addMemberUpdateCb(
           [this](const Upstream::HostVector&, const Upstream::HostVector& hosts_removed) {
             for (const auto& host : hosts_removed) {
@@ -76,7 +85,7 @@ UdpProxyFilter::ClusterInfo::ClusterInfo(UdpProxyFilter& filter,
             }
           })) {}
 
-UdpProxyFilter::ClusterInfo::~ClusterInfo() {
+UdpProxyFilter::StickySessionClusterInfo::~StickySessionClusterInfo() {
   // Sanity check the session accounting. This is not as fast as a straight teardown, but this is
   // not a performance critical path.
   while (!sessions_.empty()) {
@@ -85,7 +94,7 @@ UdpProxyFilter::ClusterInfo::~ClusterInfo() {
   ASSERT(host_to_sessions_.empty());
 }
 
-Network::FilterStatus UdpProxyFilter::ClusterInfo::onData(Network::UdpRecvData& data) {
+Network::FilterStatus UdpProxyFilter::StickySessionClusterInfo::onData(Network::UdpRecvData& data) {
   const auto active_session_it = sessions_.find(data.addresses_);
   ActiveSession* active_session;
   if (active_session_it == sessions_.end()) {
@@ -132,9 +141,9 @@ Network::FilterStatus UdpProxyFilter::ClusterInfo::onData(Network::UdpRecvData& 
   return Network::FilterStatus::StopIteration;
 }
 
-UdpProxyFilter::ActiveSession*
-UdpProxyFilter::ClusterInfo::createSession(Network::UdpRecvData::LocalPeerAddresses&& addresses,
-                                           const Upstream::HostConstSharedPtr& host) {
+UdpProxyFilter::ActiveSession* UdpProxyFilter::StickySessionClusterInfo::createSession(
+    Network::UdpRecvData::LocalPeerAddresses&& addresses,
+    const Upstream::HostConstSharedPtr& host) {
   auto new_session = std::make_unique<ActiveSession>(*this, std::move(addresses), host);
   auto new_session_ptr = new_session.get();
   sessions_.emplace(std::move(new_session));
@@ -142,7 +151,7 @@ UdpProxyFilter::ClusterInfo::createSession(Network::UdpRecvData::LocalPeerAddres
   return new_session_ptr;
 }
 
-void UdpProxyFilter::ClusterInfo::removeSession(const ActiveSession* session) {
+void UdpProxyFilter::StickySessionClusterInfo::removeSession(const ActiveSession* session) {
   // First remove from the host to sessions map.
   ASSERT(host_to_sessions_[&session->host()].count(session) == 1);
   auto host_sessions_it = host_to_sessions_.find(&session->host());
@@ -154,6 +163,134 @@ void UdpProxyFilter::ClusterInfo::removeSession(const ActiveSession* session) {
   // Now remove it from the primary map.
   ASSERT(sessions_.count(session) == 1);
   sessions_.erase(session);
+}
+
+UdpProxyFilter::PerPacketLoadBalancingClusterInfo::PerPacketLoadBalancingClusterInfo(
+    UdpProxyFilter& filter, Upstream::ThreadLocalCluster& cluster)
+    : ClusterInfo(filter, cluster),
+      member_update_cb_handle_(cluster.prioritySet().addMemberUpdateCb(
+          [this](const Upstream::HostVector&, const Upstream::HostVector& hosts_removed) {
+            for (const auto& host : hosts_removed) {
+              auto host_sessions_it = host_to_sessions_.find(host.get());
+              if (host_sessions_it != host_to_sessions_.end()) {
+                host_to_sessions_.erase(host_sessions_it);
+              }
+            }
+          })) {}
+
+UdpProxyFilter::PerPacketLoadBalancingClusterInfo::~PerPacketLoadBalancingClusterInfo() {
+  while (!host_to_sessions_.empty()) {
+    const auto& sessions = host_to_sessions_.begin()->second;
+    while (!sessions.empty()) {
+      removeSession(sessions.begin()->get());
+    }
+  }
+  ASSERT(host_to_sessions_.empty());
+}
+
+void UdpProxyFilter::PerPacketLoadBalancingClusterInfo::onData(Network::UdpRecvData& data) {
+  UdpLoadBalancerContext context(filter_.config_->hashPolicy(), data.addresses_.peer_);
+  Upstream::HostConstSharedPtr host = cluster_.loadBalancer().chooseHost(&context);
+  if (host == nullptr) {
+    ENVOY_LOG(debug, "cannot find any valid host. failed to create a session.");
+    cluster_.info()->stats().upstream_cx_none_healthy_.inc();
+    return;
+  }
+
+  ENVOY_LOG(debug, "selected {} host as upstream.", host->address()->asStringView());
+
+  auto active_session = findSession(*host, data.addresses_);
+  if (active_session == nullptr) {
+    if (!cluster_.info()
+             ->resourceManager(Upstream::ResourcePriority::Default)
+             .connections()
+             .canCreate()) {
+      cluster_.info()->stats().upstream_cx_overflow_.inc();
+      return;
+    }
+
+    active_session = createSession(std::move(data.addresses_), host);
+  } else {
+    if (active_session->host().health() == Upstream::Host::Health::Unhealthy) {
+      // If a host becomes unhealthy, we optimally would like to replace it with a new session
+      // to a healthy host. We may eventually want to make this behavior configurable, but for now
+      // this will be the universal behavior.
+
+      auto another_host = getAnotherHealthyHost(context, *host);
+      if (another_host != nullptr) {
+        removeSession(active_session);
+        auto another_host_session = findSession(*another_host, data.addresses_);
+        if (another_host_session == nullptr) {
+          ENVOY_LOG(debug, "upstream session unhealthy, recreating the session");
+          active_session = createSession(std::move(data.addresses_), another_host);
+        } else {
+          ENVOY_LOG(debug, "upstream session unhealthy, reusing already existing session for other "
+                           "healthy host");
+          active_session = another_host_session;
+        }
+      } else {
+        // In this case we could not get a better host, so just keep using the current session.
+        ENVOY_LOG(trace, "upstream session unhealthy, but unable to get a better host");
+      }
+    } else {
+      ENVOY_LOG(debug, "Found already existing session on host {}.",
+                active_session->host().address()->asStringView());
+    }
+  }
+
+  active_session->write(*data.buffer_);
+}
+
+UdpProxyFilter::ActiveSession* UdpProxyFilter::PerPacketLoadBalancingClusterInfo::createSession(
+    Network::UdpRecvData::LocalPeerAddresses&& addresses,
+    const Upstream::HostConstSharedPtr& host) {
+  auto new_session = std::make_unique<ActiveSession>(*this, std::move(addresses), host);
+  auto new_session_ptr = new_session.get();
+  host_to_sessions_[host.get()].emplace(std::move(new_session));
+  return new_session_ptr;
+}
+
+void UdpProxyFilter::PerPacketLoadBalancingClusterInfo::removeSession(
+    const ActiveSession* session) {
+  ASSERT(host_to_sessions_[&session->host()].count(session) == 1);
+  auto host_sessions_it = host_to_sessions_.find(&session->host());
+  host_sessions_it->second.erase(session);
+  if (host_sessions_it->second.empty()) {
+    host_to_sessions_.erase(host_sessions_it);
+  }
+}
+
+Upstream::HostConstSharedPtr
+UdpProxyFilter::PerPacketLoadBalancingClusterInfo::getAnotherHealthyHost(
+    UdpLoadBalancerContext& context, const Upstream::Host& current_host) {
+  Upstream::HostConstSharedPtr another_host;
+  // Safety mechanism for detecting if chosen host was already checked
+  // It can happen when current_host is already deleted from available hosts and all other hosts are
+  // unhealthy
+  absl::flat_hash_set<const Upstream::Host*> visited_hosts;
+  do {
+    another_host = cluster_.loadBalancer().chooseHost(&context);
+    if (another_host == nullptr || another_host.get() == &current_host ||
+        visited_hosts.contains(another_host.get())) {
+      return nullptr;
+    }
+    visited_hosts.emplace(another_host.get());
+  } while (another_host->health() == Upstream::Host::Health::Unhealthy);
+
+  return another_host;
+}
+
+UdpProxyFilter::ActiveSession* UdpProxyFilter::PerPacketLoadBalancingClusterInfo::findSession(
+    const Upstream::Host& host, const Network::UdpRecvData::LocalPeerAddresses& addresses) const {
+  const auto host_to_sessions_it = host_to_sessions_.find(&host);
+  if (host_to_sessions_it == host_to_sessions_.end()) {
+    return nullptr;
+  }
+  const auto active_session_it = host_to_sessions_it->second.find(addresses);
+  if (active_session_it == host_to_sessions_it->second.end()) {
+    return nullptr;
+  }
+  return active_session_it->get();
 }
 
 UdpProxyFilter::ActiveSession::ActiveSession(ClusterInfo& cluster,

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -107,7 +107,7 @@ void UdpProxyFilter::ClusterInfo::removeSession(const ActiveSession* session) {
 
 UdpProxyFilter::ActiveSession*
 UdpProxyFilter::ClusterInfo::createSession(Network::UdpRecvData::LocalPeerAddresses&& addresses,
-                                           const HostConstSharedPtrOptConstRef& optional_host) {
+                                           const Upstream::HostConstSharedPtr& optional_host) {
   if (!cluster_.info()
            ->resourceManager(Upstream::ResourcePriority::Default)
            .connections()
@@ -118,7 +118,7 @@ UdpProxyFilter::ClusterInfo::createSession(Network::UdpRecvData::LocalPeerAddres
   }
 
   if (optional_host) {
-    return createSessionWithHost(std::move(addresses), *optional_host);
+    return createSessionWithHost(std::move(addresses), optional_host);
   }
 
   auto host = chooseHost(addresses.peer_);

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -327,7 +327,7 @@ private:
   class StickySessionClusterInfo : public ClusterInfo {
   public:
     StickySessionClusterInfo(UdpProxyFilter& filter, Upstream::ThreadLocalCluster& cluster);
-    ~StickySessionClusterInfo();
+    ~StickySessionClusterInfo() override;
     Network::FilterStatus onData(Network::UdpRecvData& data) override;
     ActiveSession* getSession(const Network::UdpRecvData::LocalPeerAddresses& addresses,
                               const Upstream::HostConstSharedPtr& host) const override;
@@ -349,7 +349,7 @@ private:
   public:
     PerPacketLoadBalancingClusterInfo(UdpProxyFilter& filter,
                                       Upstream::ThreadLocalCluster& cluster);
-    ~PerPacketLoadBalancingClusterInfo();
+    ~PerPacketLoadBalancingClusterInfo() override;
     Network::FilterStatus onData(Network::UdpRecvData& data) override;
     ActiveSession* getSession(const Network::UdpRecvData::LocalPeerAddresses& addresses,
                               const Upstream::HostConstSharedPtr& host) const override;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -287,12 +287,8 @@ private:
     UdpProxyUpstreamStats cluster_stats_;
 
   protected:
-    using HostConstSharedPtrOptConstRef =
-        absl::optional<std::reference_wrapper<const Upstream::HostConstSharedPtr>>;
-
-    ActiveSession*
-    createSession(Network::UdpRecvData::LocalPeerAddresses&& addresses,
-                  const HostConstSharedPtrOptConstRef& optional_host = absl::nullopt);
+    ActiveSession* createSession(Network::UdpRecvData::LocalPeerAddresses&& addresses,
+                                 const Upstream::HostConstSharedPtr& optional_host = nullptr);
     Upstream::HostConstSharedPtr
     chooseHost(const Network::Address::InstanceConstSharedPtr& peer_address) const;
 
@@ -325,7 +321,7 @@ private:
 
   /**
    * On each data chunk selects another host using underlying load balancing method and communicates
-   * with that host
+   * with that host.
    */
   class PerPacketLoadBalancingClusterInfo : public ClusterInfo {
   public:

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -303,15 +303,8 @@ private:
       const auto final_prefix = "udp";
       return {ALL_UDP_PROXY_UPSTREAM_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
     }
-    void removeHostSessions(const Upstream::HostConstSharedPtr& host);
     ActiveSession* createSessionWithHost(Network::UdpRecvData::LocalPeerAddresses&& addresses,
                                          const Upstream::HostConstSharedPtr& host);
-
-    void storeSession(ActiveSessionPtr session);
-    void removeSessionFromStorage(const ActiveSession* session);
-    virtual ActiveSession*
-    getSession(const Network::UdpRecvData::LocalPeerAddresses& addresses,
-               const HostConstSharedPtrOptConstRef& optional_host = absl::nullopt) const PURE;
 
     Envoy::Common::CallbackHandlePtr member_update_cb_handle_;
     absl::flat_hash_map<const Upstream::Host*, absl::flat_hash_set<const ActiveSession*>>
@@ -321,18 +314,13 @@ private:
   using ClusterInfoPtr = std::unique_ptr<ClusterInfo>;
 
   /**
-   * Performs forwarding and replying data to one upstream host, selected when the first datagram for a session is received.
-   * In the upstream host becomes unhealthy, a new one is selected.
+   * Performs forwarding and replying data to one upstream host, selected when the first datagram
+   * for a session is received. If the upstream host becomes unhealthy, a new one is selected.
    */
   class StickySessionClusterInfo : public ClusterInfo {
   public:
     StickySessionClusterInfo(UdpProxyFilter& filter, Upstream::ThreadLocalCluster& cluster);
     Network::FilterStatus onData(Network::UdpRecvData& data) override;
-
-  private:
-    ActiveSession*
-    getSession(const Network::UdpRecvData::LocalPeerAddresses& addresses,
-               const HostConstSharedPtrOptConstRef& optional_host = absl::nullopt) const override;
   };
 
   /**
@@ -344,10 +332,6 @@ private:
     PerPacketLoadBalancingClusterInfo(UdpProxyFilter& filter,
                                       Upstream::ThreadLocalCluster& cluster);
     Network::FilterStatus onData(Network::UdpRecvData& data) override;
-
-  private:
-    ActiveSession* getSession(const Network::UdpRecvData::LocalPeerAddresses& addresses,
-                              const HostConstSharedPtrOptConstRef& optional_host) const override;
   };
 
   virtual Network::SocketPtr createSocket(const Upstream::HostConstSharedPtr& host) {

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -321,8 +321,8 @@ private:
   using ClusterInfoPtr = std::unique_ptr<ClusterInfo>;
 
   /**
-   * Performs forwarding and replying data to one, selected at the beginning upstream host
-   * In case of not healthy upstream host, selects a new one
+   * Performs forwarding and replying data to one upstream host, selected when the first datagram for a session is received.
+   * In the upstream host becomes unhealthy, a new one is selected.
    */
   class StickySessionClusterInfo : public ClusterInfo {
   public:

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -21,6 +21,7 @@
 using testing::AtLeast;
 using testing::ByMove;
 using testing::DoAll;
+using testing::DoDefault;
 using testing::InSequence;
 using testing::InvokeWithoutArgs;
 using testing::Return;
@@ -637,6 +638,239 @@ TEST_F(UdpProxyFilterTest, SocketOptionForUseOriginalSrcIp) {
   InSequence s;
 
   ensureIpTransparentSocketOptions(upstream_address_, "10.0.0.2:80", 1, 0);
+}
+
+// Verify that on second data packet sent from the client, another upstream host is selected.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingBasicFlow) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  // Allow for two sessions.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->resetResourceManager(2, 0, 0, 0, 0);
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+  checkTransferStats(5 /*rx_bytes*/, 1 /*rx_datagrams*/, 0 /*tx_bytes*/, 0 /*tx_datagrams*/);
+  test_sessions_[0].recvDataFromUpstream("world");
+  checkTransferStats(5 /*rx_bytes*/, 1 /*rx_datagrams*/, 5 /*tx_bytes*/, 1 /*tx_datagrams*/);
+
+  auto new_host_address = Network::Utility::parseInternetAddressAndPort("20.0.0.2:443");
+  auto new_host = createHost(new_host_address);
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(new_host));
+  expectSessionCreate(new_host_address);
+  test_sessions_[1].expectWriteToUpstream("hello2");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(2, config_->stats().downstream_sess_active_.value());
+  checkTransferStats(11 /*rx_bytes*/, 2 /*rx_datagrams*/, 5 /*tx_bytes*/, 1 /*tx_datagrams*/);
+
+  // On next datagram, first session should be used
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillRepeatedly(DoDefault());
+  test_sessions_[0].expectWriteToUpstream("hello3");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello3");
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(2, config_->stats().downstream_sess_active_.value());
+  checkTransferStats(17 /*rx_bytes*/, 3 /*rx_datagrams*/, 5 /*tx_bytes*/, 1 /*tx_datagrams*/);
+}
+
+// Verify that when no host is available, message is dropped.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingFirstInvalidHost) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(nullptr));
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(0, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+  EXPECT_EQ(1, cluster_manager_.thread_local_cluster_.cluster_.info_->stats_
+                   .upstream_cx_none_healthy_.value());
+}
+
+// Verify that when on second packet no host is available, message is dropped.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingSecondInvalidHost) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+  EXPECT_EQ(0, cluster_manager_.thread_local_cluster_.cluster_.info_->stats_
+                   .upstream_cx_none_healthy_.value());
+
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(nullptr));
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+  EXPECT_EQ(1, cluster_manager_.thread_local_cluster_.cluster_.info_->stats_
+                   .upstream_cx_none_healthy_.value());
+}
+
+// Verify that all sessions for a host are removed when a host is removed.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingRemoveHostSessions) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+
+  cluster_manager_.thread_local_cluster_.cluster_.priority_set_.runUpdateCallbacks(
+      0, {}, {cluster_manager_.thread_local_cluster_.lb_.host_});
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[1].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+}
+
+// Verify that all sessions for hosts in cluster are removed when a cluster is removed.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingRemoveCluster) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  // Allow for two sessions.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->resetResourceManager(2, 0, 0, 0, 0);
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+
+  auto new_host_address = Network::Utility::parseInternetAddressAndPort("20.0.0.2:443");
+  auto new_host = createHost(new_host_address);
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(new_host));
+  expectSessionCreate(new_host_address);
+  test_sessions_[1].expectWriteToUpstream("hello2");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(2, config_->stats().downstream_sess_active_.value());
+
+  // Remove a cluster we don't care about.
+  cluster_update_callbacks_->onClusterRemoval("other_cluster");
+  EXPECT_EQ(2, config_->stats().downstream_sess_active_.value());
+
+  // Remove the cluster we do care about. This should purge all sessions.
+  cluster_update_callbacks_->onClusterRemoval("fake_cluster");
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+}
+
+// Verify that specific stat is included when connection limit is hit.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingCannotCreateConnection) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  // Don't allow for any session.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->resetResourceManager(0, 0, 0, 0, 0);
+
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(
+      1,
+      cluster_manager_.thread_local_cluster_.cluster_.info_->stats_.upstream_cx_overflow_.value());
+}
+
+// In this case the host becomes unhealthy, but we get the same host back, so just keep using the
+// current session.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingHostUnhealthyPickSameHost) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+
+  EXPECT_CALL(*cluster_manager_.thread_local_cluster_.lb_.host_, health())
+      .WillRepeatedly(Return(Upstream::Host::Health::Unhealthy));
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+}
+
+// Make sure that we are able to reuse already existing session if there is an available healthy
+// host, assigned to active session and our current host is unhealthy.
+TEST_F(UdpProxyFilterTest, PerPacketLoadBalancingHostUnhealthyPickDifferentHost) {
+  InSequence s;
+
+  setup(R"EOF(
+stat_prefix: foo
+cluster: fake_cluster
+use_per_packet_load_balancing: true
+  )EOF");
+
+  // Allow for two sessions.
+  cluster_manager_.thread_local_cluster_.cluster_.info_->resetResourceManager(2, 0, 0, 0, 0);
+
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectWriteToUpstream("hello");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+  EXPECT_EQ(1, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+
+  auto new_host_address = Network::Utility::parseInternetAddressAndPort("20.0.0.2:443");
+  auto new_host = createHost(new_host_address);
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(new_host));
+  expectSessionCreate(new_host_address);
+  test_sessions_[1].expectWriteToUpstream("hello2");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello2");
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(2, config_->stats().downstream_sess_active_.value());
+
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(DoDefault());
+  EXPECT_CALL(*cluster_manager_.thread_local_cluster_.lb_.host_, health())
+      .WillOnce(Return(Upstream::Host::Health::Unhealthy));
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.lb_, chooseHost(_)).WillOnce(Return(new_host));
+  // EXPECT_CALL(*new_host, health()); // This causes leakage of some mocks
+  test_sessions_[1].expectWriteToUpstream("hello3");
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello3");
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
 }
 
 // Make sure socket option is set correctly if use_original_src_ip is set in case of ipv6.

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1008,6 +1008,7 @@ rebalancer
 rebalancing
 rebuffer
 rebuilder
+receival
 reconnection
 recurse
 recv


### PR DESCRIPTION
Signed-off-by: Michał Mąka <m.maka@partner.samsung.com>

Commit Message: udp_proxy: added per packet load balancing possibility which can be enabled via specifying 'use_per_packet_load_balancing' field
Additional Description:
This feature adds possibility to have per packet load balancing in UDP proxy. Currently, there is kind of `sticky session`, which means that once data was forwarded to specific upstream host, the host is also used for subsequent messages if timeout does not occur.
By default, current behavior is used, but if `use_per_packet_load_balancing` configuration flag is set to true, on each data receival, new upstream host is selected and receives that data.
Risk Level: Medium
Testing: unit test, manual testing
Docs Changes: Introduced description of the feature and a way it can be enabled
Release Notes: Added to current.rst
Platform Specific Features: N/A
