### PR TITLE
router: make StreamInfo non-const in a couple of cases

### DIFF
--- a/envoy/upstream/retry.h
+++ b/envoy/upstream/retry.h
@@ -101,7 +101,7 @@ class RetryOptionsPredicate {
 public:
   struct UpdateOptionsParameters {
     // Stream info for the previous request attempt that is about to be retried.
-    const StreamInfo::StreamInfo& retriable_request_stream_info_;
+    StreamInfo::StreamInfo& retriable_request_stream_info_;
     // The current upstream socket options that were used for connection pool selection on the
     // previous attempt, or the result of an updated set of options from a previously run
     // retry options predicate.

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -119,7 +119,7 @@ public:
   bool encodeComplete() const { return encode_complete_; }
   RouterFilterInterface& parent() { return parent_; }
   // Exposes streamInfo for the upstream stream.
-  const StreamInfo::StreamInfo& streamInfo() const { return stream_info_; }
+  StreamInfo::StreamInfo& streamInfo() { return stream_info_; }
 
 private:
   bool shouldSendEndStream() {


### PR DESCRIPTION
Commit Message: router: make StreamInfo non-const in a couple of cases
Additional Description: Envoy Mobile stashes additional request state in StreamInfo FilterState, and requires mutable access to it for the lifetime of the request, including across retries. Making StreamInfo non-const in UpstreamRequest and RetryOptionPredicate affords that access without const_cast hacks.
Risk Level: Low
Testing: Built locally & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>