### PR TITLE
coverage: attempting to improve coverage builds

### DIFF
--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -87,7 +87,7 @@ TEST_P(Http2IntegrationTest, LargeFlowControlOnAndGiantBodyWithContentLength) {
   config_helper_.setBufferLimits(128 * 1024,
                                  128 * 1024); // Set buffer limits upstream and downstream.
   testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, true, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+                                       3 * TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
 }
 
 TEST_P(Http2IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
@@ -1863,6 +1863,7 @@ TEST_P(Http2IntegrationTest, OnLocalReply) {
 TEST_P(Http2IntegrationTest, InvalidTrailers) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");
   autonomous_upstream_ = true;
+  autonomous_allow_incomplete_streams_ = true;
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -64,7 +64,8 @@ else
 fi
 
 # Don't block coverage on flakes.
-BAZEL_BUILD_OPTIONS+=("--flaky_test_attempts=2")
+# Output unusually long logs due to tracel logging.
+BAZEL_BUILD_OPTIONS+=("--flaky_test_attempts=2 --experimental_ui_max_stdouterr_bytes=5000000")
 
 bazel coverage "${BAZEL_BUILD_OPTIONS[@]}" "${COVERAGE_TARGETS[@]}"
 


### PR DESCRIPTION
looks like multiplexed integration test is failing on converage but isn't logged

/build/tmp/_bazel_envoybuild/b570b5ccd0454dc9af9f65ab1833764d/execroot/envoy/bazel-out/_tmp/actions/stdout-19949) exceeds maximum size of --experimental_ui_max_stdouterr_bytes=1048576 bytes; skipping

trying to adjust flags to improve data on what's going south
Also fixing two flakes I can repro locally.