### PR TITLE
tools: Restrict check-deps workflow to run only on the main repo

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -9,6 +9,8 @@ on :
 jobs :
   build :
     runs-on : ubuntu-latest
+    if: github.repository_owner == 'envoyproxy'
+
     steps :
       - name : checkout
         uses : actions/checkout/@v2


### PR DESCRIPTION
Signed-off-by: Ryan Hamilton <rch@google.com>

tools: Restrict check-deps workflow to run only on the main repo

Commit Message: N/A
Additional Description: N/A
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A