### PR TITLE
[dns] Declare AppleDnsResolverFactory

### DIFF
--- a/source/extensions/network/dns_resolver/apple/apple_dns_impl.h
+++ b/source/extensions/network/dns_resolver/apple/apple_dns_impl.h
@@ -10,13 +10,13 @@
 #include "envoy/event/file_event.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/dns.h"
+#include "envoy/registry/registry.h"
 
 #include "source/common/common/backoff_strategy.h"
 #include "source/common/common/linked_object.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 #include "source/common/singleton/threadsafe_singleton.h"
-#include "envoy/registry/registry.h"
 
 #include "absl/container/node_hash_map.h"
 

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -7,6 +7,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/file_event.h"
 #include "envoy/network/dns.h"
+#include "envoy/registry/registry.h"
 
 #include "source/common/common/linked_object.h"
 #include "source/common/common/logger.h"
@@ -114,6 +115,8 @@ private:
   absl::node_hash_map<int, Event::FileEventPtr> events_;
   const absl::optional<std::string> resolvers_csv_;
 };
+
+DECLARE_FACTORY(CaresDnsResolverFactory);
 
 } // namespace Network
 } // namespace Envoy


### PR DESCRIPTION
Follow-up to https://github.com/envoyproxy/envoy/pull/17479

This is so platforms where Envoy is statically linked (e.g. iOS) can prevent the linker from stripping out extensions.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]