### PR TITLE
coverage: Drop requirement in `source/common/upstream`

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -27,7 +27,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/tcp:94.6"
 "source/common/thread:0.0" # Death tests don't report LCOV
 "source/common/tracing:96.1"
-"source/common/upstream:96.2"
+"source/common/upstream:96.1"
 "source/common/watchdog:58.6" # Death tests don't report LCOV
 "source/exe:92.6"
 "source/extensions/common:95.8"


### PR DESCRIPTION
Deflake `source/common/upstream` by reducing the coverage
requirement.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>