### PR TITLE
quic: use const reference for peer address in createConnectionSocket()

### DIFF
--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -136,12 +136,9 @@ void EnvoyQuicClientConnection::maybeMigratePort() {
         current_local_address->ip()->addressAsString());
   }
 
-  // TODO(renjietang): Make createConnectionSocket() take a const reference so that no casting is
-  // needed here.
-  auto remote_address = const_cast<Network::Address::InstanceConstSharedPtr&>(
-      connectionSocket()->connectionInfoProvider().remoteAddress());
   // The probing socket will have the same host but a different port.
-  auto probing_socket = createConnectionSocket(remote_address, new_local_address, nullptr);
+  auto probing_socket = createConnectionSocket(
+      connectionSocket()->connectionInfoProvider().remoteAddress(), new_local_address, nullptr);
   setUpConnectionSocket(*probing_socket, delegate_);
   auto writer = std::make_unique<EnvoyQuicPacketWriter>(
       std::make_unique<Network::UdpDefaultWriter>(probing_socket->ioHandle()));

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -127,7 +127,7 @@ Http::StreamResetReason quicErrorCodeToEnvoyRemoteResetReason(quic::QuicErrorCod
 }
 
 Network::ConnectionSocketPtr
-createConnectionSocket(Network::Address::InstanceConstSharedPtr& peer_addr,
+createConnectionSocket(const Network::Address::InstanceConstSharedPtr& peer_addr,
                        Network::Address::InstanceConstSharedPtr& local_addr,
                        const Network::ConnectionSocket::OptionsSharedPtr& options) {
   if (local_addr == nullptr) {

--- a/source/common/quic/envoy_quic_utils.h
+++ b/source/common/quic/envoy_quic_utils.h
@@ -157,7 +157,7 @@ Http::StreamResetReason quicErrorCodeToEnvoyRemoteResetReason(quic::QuicErrorCod
 // Create a connection socket instance and apply given socket options to the
 // socket. IP_PKTINFO and SO_RXQ_OVFL is always set if supported.
 Network::ConnectionSocketPtr
-createConnectionSocket(Network::Address::InstanceConstSharedPtr& peer_addr,
+createConnectionSocket(const Network::Address::InstanceConstSharedPtr& peer_addr,
                        Network::Address::InstanceConstSharedPtr& local_addr,
                        const Network::ConnectionSocket::OptionsSharedPtr& options);
 


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@google.com>

Modify createConnectionSocket() to take peer_address as const ref as the function won't modify this parameter.
Risk Level: Low
Testing: n/a. no behavior change.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
