### PR TITLE
Fix Apple & c-ares DNS Resolver Factories

### DIFF
--- a/source/extensions/network/dns_resolver/apple/apple_dns_impl.cc
+++ b/source/extensions/network/dns_resolver/apple/apple_dns_impl.cc
@@ -370,7 +370,7 @@ AppleDnsResolverImpl::PendingResolution::buildDnsResponse(const struct sockaddr*
 }
 
 // apple DNS resolver factory
-class AppleDnsResolverFactoryImpl : public DnsResolverFactory {
+class AppleDnsResolverFactory : public DnsResolverFactory {
 public:
   std::string name() const override { return std::string(AppleDnsResolver); }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -386,7 +386,7 @@ public:
 };
 
 // Register the AppleDnsResolverFactory
-REGISTER_FACTORY(AppleDnsResolverFactoryImpl, DnsResolverFactory);
+REGISTER_FACTORY(AppleDnsResolverFactory, DnsResolverFactory);
 
 } // namespace Network
 } // namespace Envoy

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -332,7 +332,7 @@ void DnsResolverImpl::PendingResolution::getAddrInfo(int family) {
 }
 
 // c-ares DNS resolver factory
-class CaresDnsResolverFactoryImpl : public DnsResolverFactory {
+class CaresDnsResolverFactory : public DnsResolverFactory {
 public:
   std::string name() const override { return std::string(CaresDnsResolver); }
 
@@ -365,7 +365,7 @@ public:
 };
 
 // Register the CaresDnsResolverFactory
-REGISTER_FACTORY(CaresDnsResolverFactoryImpl, DnsResolverFactory);
+REGISTER_FACTORY(CaresDnsResolverFactory, DnsResolverFactory);
 
 } // namespace Network
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Fix Apple & c-ares DNS Resolver Factories
Additional Description: By convention these don't have an "Impl" suffix
Risk Level: Low. Since the factory registration wasn't correct, no downstream consumers have already integrated this successfully.
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]