### PR TITLE
Remove redundant Warn log in HTTP codec.

### DIFF
--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -113,9 +113,6 @@ void CodecClient::onEvent(Network::ConnectionEvent event) {
         reason = StreamResetReason::ProtocolError;
         connection_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
       }
-    } else {
-      ENVOY_CONN_LOG(warn, "Connection is closed by {} during connecting.", *connection_,
-                     (event == Network::ConnectionEvent::RemoteClose ? "peer" : "self"));
     }
     while (!active_requests_.empty()) {
       // Fake resetting all active streams so that reset() callbacks get invoked.


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

This line was introduced in https://github.com/envoyproxy/envoy/commit/efcf2e5c18214c95006df9e60919941f86b619ee, but it is flooding the log outputs of Envoy users, so this PR just deletes the line. For detail, please refer to https://github.com/envoyproxy/envoy/issues/18643.