### PR TITLE
quic: test fast-fail if secrets not loaded when create quic connection

### DIFF
--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -106,6 +106,9 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
             Quic::createQuicNetworkConnection(h3_pool->quicInfo(), pool->dispatcher(), host_address,
                                               source_address, quic_stat_names, scope);
         if (data.connection_ == nullptr) {
+          ENVOY_LOG_TO_LOGGER(
+              Envoy::Logger::Registry::getLog(Envoy::Logger::Id::pool), warn,
+              "Failed to create Http/3 client. Failed to create quic network connection.");
           return nullptr;
         }
         // Store a handle to connection as it will be moved during client construction.

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -89,9 +89,10 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
         auto factory = &pool->host()->transportSocketFactory();
         ASSERT(dynamic_cast<Quic::QuicClientTransportSocketFactory*>(factory) != nullptr);
         if (static_cast<Quic::QuicClientTransportSocketFactory*>(factory)->sslCtx() == nullptr) {
-          ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::pool), warn,
-                              "Failed to create Http/3 client. Transport socket "
-                              "factory is not configured correctly.");
+          ENVOY_LOG_EVERY_POW_2_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::pool),
+                                          warn,
+                                          "Failed to create Http/3 client. Transport socket "
+                                          "factory is not configured correctly.");
           return nullptr;
         }
         Http3ConnPoolImpl* h3_pool = reinterpret_cast<Http3ConnPoolImpl*>(pool);
@@ -106,7 +107,7 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
             Quic::createQuicNetworkConnection(h3_pool->quicInfo(), pool->dispatcher(), host_address,
                                               source_address, quic_stat_names, scope);
         if (data.connection_ == nullptr) {
-          ENVOY_LOG_TO_LOGGER(
+          ENVOY_LOG_EVERY_POW_2_TO_LOGGER(
               Envoy::Logger::Registry::getLog(Envoy::Logger::Id::pool), warn,
               "Failed to create Http/3 client. Failed to create quic network connection.");
           return nullptr;

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -105,6 +105,9 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
         data.connection_ =
             Quic::createQuicNetworkConnection(h3_pool->quicInfo(), pool->dispatcher(), host_address,
                                               source_address, quic_stat_names, scope);
+        if (data.connection_ == nullptr) {
+          return nullptr;
+        }
         // Store a handle to connection as it will be moved during client construction.
         Network::Connection& connection = *data.connection_;
         auto client = std::make_unique<ActiveClient>(*pool, data);

--- a/source/common/quic/quic_transport_socket_factory.h
+++ b/source/common/quic/quic_transport_socket_factory.h
@@ -108,7 +108,7 @@ public:
     return fallback_factory_->createTransportSocket(options);
   }
 
-  Envoy::Ssl::ClientContextSharedPtr sslCtx() { return fallback_factory_->sslCtx(); }
+  virtual Envoy::Ssl::ClientContextSharedPtr sslCtx() { return fallback_factory_->sslCtx(); }
 
   const Ssl::ClientContextConfig& clientContextConfig() const {
     return fallback_factory_->config();

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -68,15 +68,50 @@ public:
   ConnectionPool::InstancePtr pool_;
 };
 
-TEST_F(Http3ConnPoolImplTest, CreationWithoutSecretsLoaded) {
-  std::unique_ptr<Ssl::MockClientContextConfig> config(new NiceMock<Ssl::MockClientContextConfig>);
-  EXPECT_CALL(*config, isReady()).WillRepeatedly(Return(false));
-  auto factory = Quic::QuicClientTransportSocketFactory(move(config), context_);
+class MockQuicClientTransportSocketFactory : public Quic::QuicClientTransportSocketFactory {
+public:
+  MockQuicClientTransportSocketFactory(
+      Ssl::ClientContextConfigPtr config,
+      Server::Configuration::TransportSocketFactoryContext& factory_context)
+      : Quic::QuicClientTransportSocketFactory(move(config), factory_context) {}
+
+  MOCK_METHOD(Envoy::Ssl::ClientContextSharedPtr, sslCtx, ());
+};
+
+TEST_F(Http3ConnPoolImplTest, FastFailWithoutSecretsLoaded) {
+  MockQuicClientTransportSocketFactory factory{
+      std::unique_ptr<Envoy::Ssl::ClientContextConfig>(new NiceMock<Ssl::MockClientContextConfig>),
+      context_};
+
+  EXPECT_CALL(factory, sslCtx()).WillRepeatedly(Return(nullptr));
 
   EXPECT_CALL(mockHost(), address()).WillRepeatedly(Return(test_address_));
-  EXPECT_CALL(mockHost(), transportSocketFactory()).WillRepeatedly(testing::ReturnRef(factory_));
+  EXPECT_CALL(mockHost(), transportSocketFactory()).WillRepeatedly(testing::ReturnRef(factory));
   // The unique pointer of this object will be returned in createSchedulableCallback_ of
   // dispatcher_, so there is no risk of object leak.
+  new Event::MockSchedulableCallback(&dispatcher_);
+  Network::ConnectionSocket::OptionsSharedPtr options;
+  Network::TransportSocketOptionsConstSharedPtr transport_options;
+  ConnectionPool::InstancePtr pool =
+      allocateConnPool(dispatcher_, random_, host_, Upstream::ResourcePriority::Default, options,
+                       transport_options, state_, simTime(), quic_stat_names_, store_);
+
+  EXPECT_EQ(static_cast<Http3ConnPoolImpl*>(pool.get())->instantiateActiveClient(), nullptr);
+}
+
+TEST_F(Http3ConnPoolImplTest, FailWithSecretsBecomeEmpty) {
+  MockQuicClientTransportSocketFactory factory{
+      std::unique_ptr<Envoy::Ssl::ClientContextConfig>(new NiceMock<Ssl::MockClientContextConfig>),
+      context_};
+
+  Ssl::ClientContextSharedPtr ssl_context(new Ssl::MockClientContext());
+  EXPECT_CALL(factory, sslCtx())
+      .WillOnce(Return(ssl_context))
+      .WillOnce(Return(nullptr))
+      .WillRepeatedly(Return(ssl_context));
+
+  EXPECT_CALL(mockHost(), address()).WillRepeatedly(Return(test_address_));
+  EXPECT_CALL(mockHost(), transportSocketFactory()).WillRepeatedly(testing::ReturnRef(factory));
   new Event::MockSchedulableCallback(&dispatcher_);
   Network::ConnectionSocket::OptionsSharedPtr options;
   Network::TransportSocketOptionsConstSharedPtr transport_options;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: quic: test fast-fail if secrets not loaded when create quic connection  
Additional Description: N/A
Risk Level: Low
Testing:  N/A
Docs Changes: N/A