### PR TITLE
Fix Label() usage in genrule_repository

### DIFF
--- a/bazel/genrule_repository.bzl
+++ b/bazel/genrule_repository.bzl
@@ -13,16 +13,7 @@ def _genrule_repository(ctx):
         if patch_result.return_code != 0:
             fail("Failed to apply patch %r: %s" % (patch, patch_result.stderr))
 
-    # https://github.com/bazelbuild/bazel/issues/3766
-    genrule_cmd_file = Label("@envoy//bazel").relative(str(ctx.attr.genrule_cmd_file))
-    ctx.symlink(genrule_cmd_file, "_envoy_genrule_cmd.genrule_cmd")
-    cat_genrule_cmd = ctx.execute(["cat", "_envoy_genrule_cmd.genrule_cmd"])
-    if cat_genrule_cmd.return_code != 0:
-        fail("Failed to read genrule command %r: %s" % (
-            genrule_cmd_file,
-            cat_genrule_cmd.stderr,
-        ))
-
+    genrule_cmd = ctx.read(ctx.attr.genrule_cmd_file)
     ctx.file("WORKSPACE", "workspace(name=%r)" % (ctx.name,))
     ctx.symlink(ctx.attr.build_file, "BUILD.bazel")
 
@@ -32,8 +23,8 @@ def _genrule_repository(ctx):
     ctx.file("genrule_cmd.bzl", """
 _GENRULE_CMD = {%r: %r}
 def genrule_cmd(label):
-    return _GENRULE_CMD[label]
-""" % (str(genrule_cmd_file), cat_genrule_cmd.stdout))
+    return _GENRULE_CMD[Label(label)]
+""" % (ctx.attr.genrule_cmd_file, genrule_cmd))
 
 genrule_repository = repository_rule(
     attrs = {


### PR DESCRIPTION
Bazel pre-5.0 had a bug where the Label() function, when called from
a WORKSPACE-loaded .bzl file, used no repo mapping. This meant that
the previous logic here calling `Label("@envoy//bazel")` did not
actually recognize that `@envoy` referred to the main repo; it just
considered it "some repo called 'envoy'".

Bazel 5.0 fixes the bug so that this call will recognize that fact,
and hence turn the label into just `//bazel` since `@envoy` is the
main repo. This, however, causes the lookup in `genrule_cmd(label)`
to fail. This commit fixes that by using the Label object itself as
the key in the dict, instead of a string representation, so that
it's always comparing the resolved target label.

I also took this opportunity to fix the weird `ctx.execute("cat")`
workaround, now that we have `ctx.read`.


Commit Message: See above
Additional Description: Just a build system change, nothing user-visible.
Risk Level: Low
Testing: Tested that `//test/common/...` builds on both Bazel HEAD and 4.2.1 (current LTS release).
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/a
