### PR TITLE
quic: validating concurrent streams

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -32,7 +32,7 @@ message TcpProtocolOptions {
 message QuicProtocolOptions {
   // Maximum number of streams that the client can negotiate per connection. 100
   // if not specified.
-  google.protobuf.UInt32Value max_concurrent_streams = 1;
+  google.protobuf.UInt32Value max_concurrent_streams = 1 [(validate.rules).uint32 = {gte: 1}];
 
   // `Initial stream-level flow-control receive window
   // <https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-4.1>`_ size. Valid values range from


### PR DESCRIPTION
I believe this is legal because QUIC is still in alpha

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes:n/a