### PR TITLE
test: Remove exceptions from the H/2 codec test

### DIFF
--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1945,7 +1945,7 @@ TEST_P(Http2CodecImplStreamLimitTest, LazyDecreaseMaxConcurrentStreamsIgnoreErro
   EXPECT_EQ(0, server_stats_store_.counter("http2.tx_reset").value());
 
   // Not verifying the http2.streams_active server/client gauges here as the
-  // EXPECT_THROW_WITH_MESSAGE above doesn't let us fully capture the behavior of the real system.
+  // test dispatch function doesn't let us fully capture the behavior of the real system.
   // In the real world, the status returned from dispatch would trigger a connection close which
   // would result in the active stream gauges to go down to 0.
 }


### PR DESCRIPTION
Additional Description:
Remove the stop gap solution we had in the H/2 codec test. The codecs can now correctly unwind in error conditions and using exceptions to propagate test error is no longer required.

Risk Level: Low, Test Only
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
