### PR TITLE
aws_request_signing: Don't sign x-envoy headers

### DIFF
--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -38,7 +38,8 @@ Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers) {
     // Skip headers that are likely to mutate, when crossing proxies
     const auto key = entry.key().getStringView();
     if (key == Http::Headers::get().ForwardedFor.get() ||
-        key == Http::Headers::get().ForwardedProto.get() || key == "x-amzn-trace-id") {
+        key == Http::Headers::get().ForwardedProto.get() || key == "x-amzn-trace-id" ||
+        absl::StartsWith(key, "x-envoy")) {
       return Http::HeaderMap::Iterate::Continue;
     }
 

--- a/test/extensions/common/aws/utility_test.cc
+++ b/test/extensions/common/aws/utility_test.cc
@@ -87,9 +87,17 @@ TEST(UtilityTest, CanonicalizeHeadersTrimmingWhitespace) {
 // Headers that are likely to mutate are not considered canonical
 TEST(UtilityTest, CanonicalizeHeadersDropMutatingHeaders) {
   Http::TestRequestHeaderMapImpl headers{
-      {":authority", "example.com"},          {"x-forwarded-for", "1.2.3.4"},
-      {"x-forwarded-proto", "https"},         {"x-amz-date", "20130708T220855Z"},
+      {":authority", "example.com"},
+      {"x-forwarded-for", "1.2.3.4"},
+      {"x-forwarded-proto", "https"},
+      {"x-amz-date", "20130708T220855Z"},
       {"x-amz-content-sha256", "e3b0c44..."},
+      {"x-envoy-retry-on", "5xx"},
+      {"x-envoy-retry-grpc-on", "cancelled"},
+      {"x-envoy-max-retries", "2"},
+      {"x-envoy-hedge-on-per-try-timeout", "true"},
+      {"x-envoy-retriable-header-names", "X-Upstream-Retry,X-Try-Again"},
+      {"x-envoy-upstream-rq-per-try-timeout-ms", "100"},
   };
   const auto map = Utility::canonicalizeHeaders(headers);
   EXPECT_THAT(map,


### PR DESCRIPTION
Commit Message:
Envoy often modifies x-envoy headers ie in https://github.com/envoyproxy/envoy/blob/0fae697/source/common/router/retry_state_impl.cc#L35.
This change also makes them non-canonical and excludes them from request signing.

This is an initial fix for https://github.com/envoyproxy/envoy/issues/18695

Signed-off-by: Will Bertelsen <wbertel@amazon.com>

Additional Description: N/A
Risk Level: Low
Testing: Tested manually against repo case. Also built and deployed it to own infra. 
Docs Changes: None
Release Notes: None
Platform Specific Features: None
Fixes: #18695 

