### PR TITLE
cvescan: Exclude fails by version

### DIFF
--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -72,6 +72,7 @@ IGNORES_CVES = set([
     # See https://nvd.nist.gov/vuln/detail/CVE-2021-22940
     'CVE-2021-22918',
     'CVE-2021-22921',
+    'CVE-2021-22930',
     'CVE-2021-22931',
     'CVE-2021-22939',
     'CVE-2021-22940',


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

This doesnt fix the cve scanner,  but does exclude some errors/warnings that have already been updated

We still have this

```console
  CVE ID: CVE-2021-22930
  CVSS v3 score: 9.8
  Severity: CRITICAL
  Published date: 2021-10-07
  Last modified date: 2021-10-18
  Dependencies: com_github_nodejs_http_parser
  Description: Node.js before 16.6.0, 14.17.4, and 12.22.4 is vulnerable to a use
  after free attack where an attacker might be able to exploit the
  memory corruption, to change process behavior.
  Affected CPEs:
  - cpe:2.3:a:nodejs:node.js:*
```

here https://dev.azure.com/cncf/envoy/_build/results?buildId=92610&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=9c939e41-62c2-5605-5e05-fc3554afc9f5&l=116

iirc the proposed solution to that one is to replace the parser altogether

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
