### PR TITLE
bazel: Add CC=clang to clang configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,6 +47,7 @@ build:sanitizer --test_tag_filters=-no_san
 
 # Common flags for Clang
 build:clang --action_env=BAZEL_COMPILER=clang
+build:clang --action_env=CC=clang --action_env=CXX=clang++
 build:clang --linkopt=-fuse-ld=lld
 
 # Flags for Clang + PCH


### PR DESCRIPTION
Just setting BAZEL_COMPILER=clang isn't enough to actually force clang.
When the crosstool setup happens it uses the CC variable for this

https://github.com/bazelbuild/bazel/blob/e1b842d755a01a693e79568ea11ca127b0e7bd21/tools/cpp/unix_cc_configure.bzl#L310

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>