### PR TITLE
bazel: fix typo in external_deps.bzl

### DIFF
--- a/api/bazel/external_deps.bzl
+++ b/api/bazel/external_deps.bzl
@@ -71,7 +71,7 @@ USE_CATEGORIES = [
 USE_CATEGORIES_WITH_CPE_OPTIONAL = ["build", "other", "test_only", "api"]
 
 def _fail_missing_attribute(attr, key):
-    fail("The '%s' attribute must be defined for external dependecy " % attr + key)
+    fail("The '%s' attribute must be defined for external dependency " % attr + key)
 
 # Method for verifying content of the repository location specifications.
 #


### PR DESCRIPTION
Signed-off-by: James Heppenstall james.heppenstall@mongodb.com

**Commit Message:** bazel: fix typo in external_deps.bzl
**Additional Description:** N/A
**Risk Level:** Low
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A
**Platform Specific Features:** N/A

**Question:** I also see [here](https://github.com/envoyproxy/envoy/blob/main/bazel/EXTERNAL_DEPS.md#external-cmake-preferred) that the preferred way of adding external dependencies that use `CMake` is to add a `cmake_external` rule but there are no references to `cmake_external` in the codebase. Instead, there a various `envoy_cmake` references.  Should the documentation be updated?
