### PR TITLE
Explicit flow control: bug fix for "cancel" occurring just after a terminal "resumeData"

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -227,6 +227,9 @@ void ConnectionManagerImpl::doEndStream(ActiveStream& stream) {
   }
 
   if (!reset_stream) {
+    if (stream.response_encoder_ != nullptr) {
+      stream.response_encoder_->getStream().removeCallbacks(stream);
+    }
     doDeferredStreamDestroy(stream);
   }
 

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -138,7 +138,6 @@ void HttpConnectionManagerImplTest::setupFilterChain(int num_decoder_filters,
 }
 
 void HttpConnectionManagerImplTest::setUpBufferLimits() {
-  ON_CALL(response_encoder_, getStream()).WillByDefault(ReturnRef(stream_));
   EXPECT_CALL(stream_, bufferLimit()).WillOnce(Return(initial_buffer_limit_));
   EXPECT_CALL(stream_, addCallbacks(_))
       .WillOnce(Invoke(
@@ -149,6 +148,7 @@ void HttpConnectionManagerImplTest::setUpBufferLimits() {
 void HttpConnectionManagerImplTest::setUpEncoderAndDecoder(bool request_with_data_and_trailers,
                                                            bool decode_headers_stop_all) {
   setUpBufferLimits();
+  ON_CALL(response_encoder_, getStream()).WillByDefault(ReturnRef(stream_));
   EXPECT_CALL(*codec_, dispatch(_))
       .WillOnce(Invoke([&, request_with_data_and_trailers](Buffer::Instance&) -> Http::Status {
         RequestDecoder* decoder = &conn_manager_->newStream(response_encoder_);


### PR DESCRIPTION
For the explicit flow control, when a [cancelStream](https://github.com/envoyproxy/envoy-mobile/blob/main/library/common/http/client.cc#L448) occurs after executing the [resumeData](https://github.com/envoyproxy/envoy-mobile/blob/main/library/common/http/client.cc#L160) callback, which incidentally closes the stream, then [runResetCallbacks](https://github.com/envoyproxy/envoy/blob/main/source/common/http/codec_helper.h#L51) crashes upon closing the stream. Here is the sequence of events:

First, internally, the response header and the response body have been received, so the stream is closed.
```
[2021-10-26 14:31:26.690][3611160][debug][http] [library/common/http/client.cc:73] [S0] response data for stream (length=12 end_stream=false)
[2021-10-26 14:31:26.690][3611160][debug][http] [library/common/http/client.cc:102] [S0] buffering 12 bytes due to explicit flow control. 12 total bytes buffered.
[2021-10-26 14:31:26.690][3611160][debug][client] [external/envoy/source/common/http/codec_client.cc:128] [C0] response complete
[2021-10-26 14:31:26.690][3611160][debug][http] [library/common/http/client.cc:73] [S0] response data for stream (length=0 end_stream=true)
[2021-10-26 14:31:26.690][3611160][debug][http] [library/common/http/client.cc:188] [S0] closeStream

```
Then the user calls "cancel". The [client logic](https://github.com/envoyproxy/envoy-mobile/blob/main/library/common/http/client.cc#L448) attempts to performs some stream cleanup operations, but fails:
```
Current thread (0x00007fcb1134f800):  JavaThread "EnvoyMain" [_thread_in_native, id=3612806, stack(0x00007fcb141b1000,0x00007fcb149b0000)]

Stack: [0x00007fcb141b1000,0x00007fcb149b0000],  sp=0x00007fcb149ae2e8,  free space=8180k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  0x00007fcb100004e0
C  [libndk_envoy_jni.so+0x4e87ded]  Envoy::Http::Client::cancelStream(long)+0xd23
C  [libndk_envoy_jni.so+0x483da5a]  reset_stream::{lambda()#1}::operator()() const+0x52
```
What went wrong?
A new [ActiveStream](https://github.com/envoyproxy/envoy/blob/main/source/common/http/conn_manager_impl.h#L157) gets registered as a [stream callback](https://github.com/envoyproxy/envoy/blob/main/source/common/http/conn_manager_impl.cc#L301). When the stream gets closed because the message has been fully received, __that callback does not get unregistered__ in this scenario: the [FilterManager::maybeEndEncode](https://github.com/envoyproxy/envoy/blob/main/source/common/http/filter_manager.cc#L1339) directly invokes [ConnectionManagerImpl::doEndStream](https://github.com/envoyproxy/envoy/blob/main/source/common/http/conn_manager_impl.cc#L188). Now, when "cancel" is invoked, the deallocated registered stream is still lingering in the list of [stream callbacks](https://github.com/envoyproxy/envoy/blob/main/source/common/http/codec_helper.h#L82). Invoking```callbacks->onResetStream``` naturally crashes when hitting that entry.

The hack:
If the ```response_encoder_``` is present when closing the stream, then unregister the stream. 

Commit Message: N/A
Additional Description: this PR is mostly illustrative, as the proposed solution is a hack.
Risk Level: Medium
Testing: envoy-proxy CI and enabling an [envoy-mobile test](https://github.com/envoyproxy/envoy-mobile/blob/main/test/java/integration/AndroidEnvoyExplicitFlowTest.java#L127).
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: envoy-mobile
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
