### PR TITLE
Fix crash-on-startup on macOS 12

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -79,11 +79,13 @@ build:clang-asan --linkopt -fuse-ld=lld
 build:clang-asan --linkopt --rtlib=compiler-rt
 build:clang-asan --linkopt --unwindlib=libgcc
 
-# macOS ASAN/UBSAN
+# macOS
 build:macos --cxxopt=-std=c++17
 build:macos --action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
 build:macos --host_action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
+build:macos --define tcmalloc=disabled
 
+# macOS ASAN/UBSAN
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932
 build:macos-asan --copt -Wno-macro-redefined


### PR DESCRIPTION

Fixes #17535

Signed-off-by: Greg Greenway <ggreenway@apple.com>


Commit Message: gperftools_tcmalloc is not compatible with macOS 12, resulting in a
crash on startup. The crash happens very early, before CLI args are
parsed.
Additional Description:
Risk Level: Low
Testing: Manually built and verified it launches
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: macOS only fix
[Optional Runtime guard:]
Fixes #17535
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
