### PR TITLE
common: add support for thread local sink overrides

### DIFF
--- a/source/common/common/fancy_logger.cc
+++ b/source/common/common/fancy_logger.cc
@@ -100,11 +100,12 @@ FancyLogLevelMap FancyContext::getAllFancyLogLevelsForTest() ABSL_LOCKS_EXCLUDED
 }
 
 void FancyContext::initSink() {
-  Logger::DelegatingLogSinkSharedPtr sink = Logger::Registry::getSink();
-  if (!sink->hasLock()) {
+  spdlog::sink_ptr sink = Logger::Registry::getSink();
+  Logger::DelegatingLogSinkSharedPtr sp = std::static_pointer_cast<Logger::DelegatingLogSink>(sink);
+  if (!sp->hasLock()) {
     static FancyBasicLockable tlock;
-    sink->setLock(tlock);
-    sink->setShouldEscape(false);
+    sp->setLock(tlock);
+    sp->setShouldEscape(false);
   }
 }
 

--- a/source/common/common/fancy_logger.cc
+++ b/source/common/common/fancy_logger.cc
@@ -100,12 +100,11 @@ FancyLogLevelMap FancyContext::getAllFancyLogLevelsForTest() ABSL_LOCKS_EXCLUDED
 }
 
 void FancyContext::initSink() {
-  spdlog::sink_ptr sink = Logger::Registry::getSink();
-  Logger::DelegatingLogSinkSharedPtr sp = std::static_pointer_cast<Logger::DelegatingLogSink>(sink);
-  if (!sp->hasLock()) {
+  Logger::DelegatingLogSinkSharedPtr sink = Logger::Registry::getSink();
+  if (!sink->hasLock()) {
     static FancyBasicLockable tlock;
-    sp->setLock(tlock);
-    sp->setShouldEscape(false);
+    sink->setLock(tlock);
+    sink->setShouldEscape(false);
   }
 }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -27,13 +27,14 @@ void SinkDelegate::logWithStableName(absl::string_view, absl::string_view, absl:
 
 SinkDelegate::~SinkDelegate() {
   // The previous delegate should have never been set or should have been reset by now via
-  // restoreDelegate();
+  // restoreDelegate()/restoreTlsDelegate();
   assert(previous_delegate_ == nullptr);
+  assert(previous_tls_delegate_ == nullptr);
 }
 
 void SinkDelegate::setTlsDelegate() {
-  assert(previous_delegate_ == nullptr);
-  previous_delegate_ = log_sink_->tlsDelegate();
+  assert(previous_tls_delegate_ == nullptr);
+  previous_tls_delegate_ = log_sink_->tlsDelegate();
   log_sink_->setTlsDelegate(this);
 }
 
@@ -47,8 +48,8 @@ void SinkDelegate::setDelegate() {
 void SinkDelegate::restoreTlsDelegate() {
   // Ensures stacked allocation of delegates.
   assert(log_sink_->tlsDelegate() == this);
-  log_sink_->setTlsDelegate(previous_delegate_);
-  previous_delegate_ = nullptr;
+  log_sink_->setTlsDelegate(previous_tls_delegate_);
+  previous_tls_delegate_ = nullptr;
 }
 
 void SinkDelegate::restoreDelegate() {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -226,6 +226,16 @@ public:
    */
   static std::string escapeLogLine(absl::string_view source);
 
+protected:
+  // This is virtual in order to allow for multiple DelegatingLogSinks to exist and use different
+  // thread local overrides. A base class defining a new thread_local would be necessary for each
+  // DelegatingLogSink that will coexist.
+  virtual SinkDelegate** tlsSink() {
+    static thread_local SinkDelegate* tls_sink = nullptr;
+
+    return &tls_sink;
+  }
+
 private:
   friend class SinkDelegate;
 
@@ -243,12 +253,6 @@ private:
   void setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; }
 
   SinkDelegate* tlsDelegate() { return *tlsSink(); }
-
-  SinkDelegate** tlsSink() {
-    static thread_local SinkDelegate* tls_sink = nullptr;
-
-    return &tls_sink;
-  }
 
   SinkDelegate* sink_ ABSL_GUARDED_BY(sink_mutex_){nullptr};
   absl::Mutex sink_mutex_;

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -184,15 +184,7 @@ public:
   }
   // spdlog::sinks::sink
   void log(const spdlog::details::log_msg& msg) override;
-  void flush() override {
-    auto* tls_sink = tlsDelegate();
-    if (tls_sink != nullptr) {
-      tls_sink->flush();
-      return;
-    }
-    absl::ReaderMutexLock lock(&sink_mutex_);
-    sink_->flush();
-  }
+  void flush() override;
   void set_pattern(const std::string& pattern) override {
     set_formatter(spdlog::details::make_unique<spdlog::pattern_formatter>(pattern));
   }
@@ -239,16 +231,9 @@ private:
     absl::ReaderMutexLock lock(&sink_mutex_);
     return sink_;
   }
-
-  SinkDelegate** tlsSink() {
-    static thread_local SinkDelegate* tls_sink = nullptr;
-
-    return &tls_sink;
-  }
-
-  void setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; }
-
-  SinkDelegate* tlsDelegate() { return *tlsSink(); }
+  SinkDelegate** tlsSink();
+  void setTlsDelegate(SinkDelegate* sink);
+  SinkDelegate* tlsDelegate();
 
   SinkDelegate* sink_ ABSL_GUARDED_BY(sink_mutex_){nullptr};
   absl::Mutex sink_mutex_;

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -138,7 +138,7 @@ protected:
 
 private:
   SinkDelegate* previous_delegate_{nullptr};
-  SinkDelegate* previous_tls_delegate_{nullptr}
+  SinkDelegate* previous_tls_delegate_{nullptr};
   DelegatingLogSinkSharedPtr log_sink_;
 };
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -2,7 +2,6 @@
 
 #include <bitset>
 #include <chrono>
-#include <iostream>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -138,6 +138,7 @@ protected:
 
 private:
   SinkDelegate* previous_delegate_{nullptr};
+  SinkDelegate* previous_tls_delegate_{nullptr}
   DelegatingLogSinkSharedPtr log_sink_;
 };
 
@@ -225,16 +226,6 @@ public:
    */
   static std::string escapeLogLine(absl::string_view source);
 
-protected:
-  // This is virtual in order to allow for multiple DelegatingLogSinks to exist and use different
-  // thread local overrides. A base class defining a new thread_local would be necessary for each
-  // DelegatingLogSink that will coexist.
-  virtual SinkDelegate** tlsSink() {
-    static thread_local SinkDelegate* tls_sink = nullptr;
-
-    return &tls_sink;
-  }
-
 private:
   friend class SinkDelegate;
 
@@ -247,6 +238,12 @@ private:
   SinkDelegate* delegate() {
     absl::ReaderMutexLock lock(&sink_mutex_);
     return sink_;
+  }
+
+  SinkDelegate** tlsSink() {
+    static thread_local SinkDelegate* tls_sink = nullptr;
+
+    return &tls_sink;
   }
 
   void setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; }

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -192,7 +192,7 @@ struct TlsLogSink : SinkDelegate {
   MOCK_METHOD(void, log, (absl::string_view));
   MOCK_METHOD(void, logWithStableName,
               (absl::string_view, absl::string_view, absl::string_view, absl::string_view));
-  void flush() override {}
+  MOCK_METHOD(void, flush, ());
 };
 
 TEST(NamedLogtest, OverrideSink) {
@@ -215,6 +215,13 @@ TEST(NamedLogtest, OverrideSink) {
     // Sanity checking that we're still using the TLS sink.
     EXPECT_CALL(tls_sink, log(_));
     ENVOY_LOG_MISC(info, "hello tls");
+
+    // All the logging functions should be delegated to the TLS override.
+    EXPECT_CALL(tls_sink, flush());
+    Registry::getSink()->flush();
+
+    EXPECT_CALL(tls_sink, logWithStableName(_, _, _, _));
+    Registry::getSink()->logWithStableName("foo", "level", "bar", "msg");
   }
 
   // Now that the TLS sink is out of scope, log calls on this thread should use the global sink


### PR DESCRIPTION
Commit Message: 
This adds support for specifying a SinkDelegate that should be active
only on the current thread. This allows for per thread overrides of the
logging context, which opens up for overriding the logger for the
duration of a dispatcher event as well as overriding the logger for
specific function calls.
Additional Description: n/a
Risk Level: Low
Testing: New UTs, benchmarks
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
