### PR TITLE
Add postOnAllThreads on ThreadLocal::Instance.

### DIFF
--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -96,10 +96,10 @@ public:
   virtual Stats::Scope& serverScope() PURE;
 
   /**
-   * @return ThreadLocal::SlotAllocator& the thread local storage engine for the server. This is
+   * @return ThreadLocal::Instance& the thread local instance engine for the server. This is
    *         used to allow runtime lockless updates to configuration, etc. across multiple threads.
    */
-  virtual ThreadLocal::SlotAllocator& threadLocal() PURE;
+  virtual ThreadLocal::Instance& threadLocal() PURE;
 };
 
 /**

--- a/envoy/server/transport_socket_config.h
+++ b/envoy/server/transport_socket_config.h
@@ -87,7 +87,7 @@ public:
   /**
    * @return the server's TLS slot allocator.
    */
-  virtual ThreadLocal::SlotAllocator& threadLocal() PURE;
+  virtual ThreadLocal::Instance& threadLocal() PURE;
 
   /**
    * @return ProtobufMessage::ValidationVisitor& validation visitor for filter configuration

--- a/envoy/thread_local/thread_local.h
+++ b/envoy/thread_local/thread_local.h
@@ -195,7 +195,8 @@ private:
 template <class T = ThreadLocalObject> using TypedSlotPtr = std::unique_ptr<TypedSlot<T>>;
 
 /**
- * Interface for getting and setting thread local data as well as registering a thread
+ * Interface for getting and setting thread local data as well as registering a thread and
+ * posting callbacks into registered threads.
  */
 class Instance : public SlotAllocator {
 public:
@@ -233,6 +234,12 @@ public:
    * @return true if global threading has been shutdown or false if not.
    */
   virtual bool isShutdown() const PURE;
+
+  /**
+   * Schedule a given callback into all threads registered by registerThread.
+   * @param cb is the callback that will be scheduled *on each thread*.
+   */
+  virtual void postOnAllThreads(Event::PostCb cb) const PURE;
 };
 
 } // namespace ThreadLocal

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -441,7 +441,7 @@ public:
     const LocalInfo::LocalInfo& local_info_;
     Event::Dispatcher& dispatcher_;
     Singleton::Manager& singleton_manager_;
-    ThreadLocal::SlotAllocator& tls_;
+    ThreadLocal::Instance& tls_;
     ProtobufMessage::ValidationVisitor& validation_visitor_;
     Api::Api& api_;
     const Server::Options& options_;

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -145,6 +145,14 @@ void InstanceImpl::removeSlot(uint32_t slot) {
   });
 }
 
+void InstanceImpl::postOnAllThreads(Event::PostCb cb) const {
+  ASSERT(!shutdown_);
+  for (Event::Dispatcher& dispatcher : registered_threads_) {
+    dispatcher.post(cb);
+  }
+  main_thread_dispatcher_->post(cb);
+}
+
 void InstanceImpl::runOnAllThreads(Event::PostCb cb) {
   ASSERT(Thread::MainThread::isMainOrTestThread());
   ASSERT(!shutdown_);

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -28,6 +28,7 @@ public:
   void shutdownThread() override;
   Event::Dispatcher& dispatcher() override;
   bool isShutdown() const override { return shutdown_; }
+  void postOnAllThreads(Event::PostCb cb) const override;
 
 private:
   // On destruction returns the slot index to the deferred delete queue (detaches it). This allows

--- a/source/common/upstream/cluster_factory_impl.h
+++ b/source/common/upstream/cluster_factory_impl.h
@@ -52,8 +52,7 @@ class ClusterFactoryContextImpl : public ClusterFactoryContext {
 
 public:
   ClusterFactoryContextImpl(ClusterManager& cluster_manager, Stats::Store& stats,
-                            ThreadLocal::SlotAllocator& tls,
-                            Network::DnsResolverSharedPtr dns_resolver,
+                            ThreadLocal::Instance& tls, Network::DnsResolverSharedPtr dns_resolver,
                             Ssl::ContextManager& ssl_context_manager, Runtime::Loader& runtime,
                             Event::Dispatcher& dispatcher, AccessLog::AccessLogManager& log_manager,
                             const LocalInfo::LocalInfo& local_info, Server::Admin& admin,
@@ -70,7 +69,7 @@ public:
 
   ClusterManager& clusterManager() override { return cluster_manager_; }
   Stats::Store& stats() override { return stats_; }
-  ThreadLocal::SlotAllocator& threadLocal() override { return tls_; }
+  ThreadLocal::Instance& threadLocal() override { return tls_; }
   Network::DnsResolverSharedPtr dnsResolver() override { return dns_resolver_; }
   Ssl::ContextManager& sslContextManager() override { return ssl_context_manager_; }
   Runtime::Loader& runtime() override { return runtime_; }
@@ -90,7 +89,7 @@ public:
 private:
   ClusterManager& cluster_manager_;
   Stats::Store& stats_;
-  ThreadLocal::SlotAllocator& tls_;
+  ThreadLocal::Instance& tls_;
   Network::DnsResolverSharedPtr dns_resolver_;
   Ssl::ContextManager& ssl_context_manager_;
   Runtime::Loader& runtime_;

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -33,7 +33,7 @@ HdsDelegate::HdsDelegate(Stats::Scope& scope, Grpc::RawAsyncClientPtr async_clie
                          ClusterInfoFactory& info_factory,
                          AccessLog::AccessLogManager& access_log_manager, ClusterManager& cm,
                          const LocalInfo::LocalInfo& local_info, Server::Admin& admin,
-                         Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
+                         Singleton::Manager& singleton_manager, ThreadLocal::Instance& tls,
                          ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
                          const Server::Options& options)
     : stats_{ALL_HDS_STATS(POOL_COUNTER_PREFIX(scope, "hds_delegate."))},
@@ -333,7 +333,7 @@ HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
                        Ssl::ContextManager& ssl_context_manager, bool added_via_api,
                        ClusterInfoFactory& info_factory, ClusterManager& cm,
                        const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher,
-                       Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
+                       Singleton::Manager& singleton_manager, ThreadLocal::Instance& tls,
                        ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
                        const Server::Options& options)
     : runtime_(runtime), cluster_(std::move(cluster)), bind_config_(bind_config), stats_(stats),
@@ -385,7 +385,7 @@ HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
 void HdsCluster::update(Server::Admin& admin, envoy::config::cluster::v3::Cluster cluster,
                         ClusterInfoFactory& info_factory, ClusterManager& cm,
                         const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher,
-                        Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
+                        Singleton::Manager& singleton_manager, ThreadLocal::Instance& tls,
                         ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
                         AccessLog::AccessLogManager& access_log_manager, Runtime::Loader& runtime) {
 

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -53,7 +53,7 @@ public:
              Ssl::ContextManager& ssl_context_manager, bool added_via_api,
              ClusterInfoFactory& info_factory, ClusterManager& cm,
              const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher,
-             Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
+             Singleton::Manager& singleton_manager, ThreadLocal::Instance& tls,
              ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
              const Server::Options& options);
 
@@ -71,7 +71,7 @@ public:
   void update(Server::Admin& admin, envoy::config::cluster::v3::Cluster cluster,
               ClusterInfoFactory& info_factory, ClusterManager& cm,
               const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher,
-              Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
+              Singleton::Manager& singleton_manager, ThreadLocal::Instance& tls,
               ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
               AccessLog::AccessLogManager& access_log_manager, Runtime::Loader& runtime);
   // Creates healthcheckers and adds them to the list, then does initial start.
@@ -152,7 +152,7 @@ public:
               Ssl::ContextManager& ssl_context_manager, ClusterInfoFactory& info_factory,
               AccessLog::AccessLogManager& access_log_manager, ClusterManager& cm,
               const LocalInfo::LocalInfo& local_info, Server::Admin& admin,
-              Singleton::Manager& singleton_manager, ThreadLocal::SlotAllocator& tls,
+              Singleton::Manager& singleton_manager, ThreadLocal::Instance& tls,
               ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
               const Server::Options& options);
 
@@ -199,7 +199,7 @@ private:
   const LocalInfo::LocalInfo& local_info_;
   Server::Admin& admin_;
   Singleton::Manager& singleton_manager_;
-  ThreadLocal::SlotAllocator& tls_;
+  ThreadLocal::Instance& tls_;
 
   envoy::service::health::v3::HealthCheckRequestOrEndpointHealthResponse health_check_request_;
   uint64_t specifier_hash_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -690,7 +690,7 @@ public:
   Stats::Scope& scope() override { return stats_scope_; }
   Stats::Scope& serverScope() override { return server_scope_; }
   Singleton::Manager& singletonManager() override { return singleton_manager_; }
-  ThreadLocal::SlotAllocator& threadLocal() override { return tls_; }
+  ThreadLocal::Instance& threadLocal() override { return tls_; }
   Server::Admin& admin() override { return admin_; }
   TimeSource& timeSource() override { return api().timeSource(); }
   ProtobufMessage::ValidationContext& messageValidationContext() override {
@@ -728,7 +728,7 @@ private:
   Event::Dispatcher& dispatcher_;
   Envoy::Runtime::Loader& runtime_;
   Singleton::Manager& singleton_manager_;
-  ThreadLocal::SlotAllocator& tls_;
+  ThreadLocal::Instance& tls_;
   Api::Api& api_;
   const Server::Options& options_;
   ProtobufMessage::ValidationVisitor& message_validation_visitor_;

--- a/source/server/factory_context_base_impl.h
+++ b/source/server/factory_context_base_impl.h
@@ -38,7 +38,7 @@ public:
   };
   Stats::Scope& scope() override { return scope_; };
   Stats::Scope& serverScope() override { return scope_; }
-  ThreadLocal::SlotAllocator& threadLocal() override { return thread_local_; };
+  ThreadLocal::Instance& threadLocal() override { return thread_local_; };
 
 private:
   const Server::Options& options_;
@@ -50,7 +50,7 @@ private:
   Singleton::Manager& singleton_manager_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
   Stats::Scope& scope_;
-  ThreadLocal::SlotAllocator& thread_local_;
+  ThreadLocal::Instance& thread_local_;
 };
 
 } // namespace Server

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -43,7 +43,7 @@ Network::DrainDecision& PerFilterChainFactoryContextImpl::drainDecision() { retu
 
 Init::Manager& PerFilterChainFactoryContextImpl::initManager() { return init_manager_; }
 
-ThreadLocal::SlotAllocator& PerFilterChainFactoryContextImpl::threadLocal() {
+ThreadLocal::Instance& PerFilterChainFactoryContextImpl::threadLocal() {
   return parent_context_.threadLocal();
 }
 
@@ -772,7 +772,7 @@ Envoy::Runtime::Loader& FactoryContextImpl::runtime() { return server_.runtime()
 Stats::Scope& FactoryContextImpl::scope() { return global_scope_; }
 Singleton::Manager& FactoryContextImpl::singletonManager() { return server_.singletonManager(); }
 OverloadManager& FactoryContextImpl::overloadManager() { return server_.overloadManager(); }
-ThreadLocal::SlotAllocator& FactoryContextImpl::threadLocal() { return server_.threadLocal(); }
+ThreadLocal::Instance& FactoryContextImpl::threadLocal() { return server_.threadLocal(); }
 Admin& FactoryContextImpl::admin() { return server_.admin(); }
 TimeSource& FactoryContextImpl::timeSource() { return server_.timeSource(); }
 ProtobufMessage::ValidationContext& FactoryContextImpl::messageValidationContext() {

--- a/source/server/filter_chain_manager_impl.h
+++ b/source/server/filter_chain_manager_impl.h
@@ -70,7 +70,7 @@ public:
   Stats::Scope& serverScope() override { return parent_context_.serverScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
-  ThreadLocal::SlotAllocator& threadLocal() override;
+  ThreadLocal::Instance& threadLocal() override;
   Admin& admin() override;
   const envoy::config::core::v3::Metadata& listenerMetadata() const override;
   const Envoy::Config::TypedMetadata& listenerTypedMetadata() const override;
@@ -161,7 +161,7 @@ public:
   Stats::Scope& serverScope() override { return server_.stats(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
-  ThreadLocal::SlotAllocator& threadLocal() override;
+  ThreadLocal::Instance& threadLocal() override;
   Admin& admin() override;
   TimeSource& timeSource() override;
   ProtobufMessage::ValidationContext& messageValidationContext() override;

--- a/source/server/transport_socket_config_impl.h
+++ b/source/server/transport_socket_config_impl.h
@@ -17,7 +17,7 @@ public:
                                     const LocalInfo::LocalInfo& local_info,
                                     Event::Dispatcher& dispatcher, Stats::Store& stats,
                                     Singleton::Manager& singleton_manager,
-                                    ThreadLocal::SlotAllocator& tls,
+                                    ThreadLocal::Instance& tls,
                                     ProtobufMessage::ValidationVisitor& validation_visitor,
                                     Api::Api& api, const Server::Options& options)
       : admin_(admin), context_manager_(context_manager), stats_scope_(stats_scope),
@@ -47,7 +47,7 @@ public:
     return *init_manager_;
   }
   Singleton::Manager& singletonManager() override { return singleton_manager_; }
-  ThreadLocal::SlotAllocator& threadLocal() override { return tls_; }
+  ThreadLocal::Instance& threadLocal() override { return tls_; }
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
     return validation_visitor_;
   }
@@ -63,7 +63,7 @@ private:
   Event::Dispatcher& dispatcher_;
   Stats::Store& stats_;
   Singleton::Manager& singleton_manager_;
-  ThreadLocal::SlotAllocator& tls_;
+  ThreadLocal::Instance& tls_;
   Init::Manager* init_manager_{};
   ProtobufMessage::ValidationVisitor& validation_visitor_;
   Api::Api& api_;

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -105,16 +105,9 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   tls_.shutdownThread();
 }
 
-TEST(ThreadLocalInstanceImpl, PostOnAllThreads) {
-  InstanceImpl tls_;
-  Event::MockDispatcher main_dispatcher_{"test_main_thread"};
-  Event::MockDispatcher thread_dispatcher_{"test_worker_thread"};
-  // Called only in postOnAllThreads.
+TEST_F(ThreadLocalInstanceImplTest, PostOnAllThreads) {
   EXPECT_CALL(main_dispatcher_, post(_));
-  // Called in registerThread and postOnAllThreads.
-  EXPECT_CALL(thread_dispatcher_, post(_)).Times(2);
-  tls_.registerThread(main_dispatcher_, true);
-  tls_.registerThread(thread_dispatcher_, false);
+  EXPECT_CALL(thread_dispatcher_, post(_));
   tls_.postOnAllThreads([] {});
   tls_.shutdownGlobalThreading();
 }

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -105,6 +105,20 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   tls_.shutdownThread();
 }
 
+TEST(ThreadLocalInstanceImpl, PostOnAllThreads) {
+  InstanceImpl tls_;
+  Event::MockDispatcher main_dispatcher_{"test_main_thread"};
+  Event::MockDispatcher thread_dispatcher_{"test_worker_thread"};
+  // Called only in postOnAllThreads.
+  EXPECT_CALL(main_dispatcher_, post(_));
+  // Called in registerThread and postOnAllThreads.
+  EXPECT_CALL(thread_dispatcher_, post(_)).Times(2);
+  tls_.registerThread(main_dispatcher_, true);
+  tls_.registerThread(thread_dispatcher_, false);
+  tls_.postOnAllThreads([] {});
+  tls_.shutdownGlobalThreading();
+}
+
 struct ThreadStatus {
   uint64_t thread_local_calls_{0};
   bool all_threads_complete_ = false;

--- a/test/mocks/server/transport_socket_factory_context.h
+++ b/test/mocks/server/transport_socket_factory_context.h
@@ -34,7 +34,7 @@ public:
   MOCK_METHOD(Stats::Store&, stats, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(Singleton::Manager&, singletonManager, ());
-  MOCK_METHOD(ThreadLocal::SlotAllocator&, threadLocal, ());
+  MOCK_METHOD(ThreadLocal::Instance&, threadLocal, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
 

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -16,6 +16,7 @@ public:
   MockInstance();
   ~MockInstance() override;
 
+  MOCK_METHOD(void, postOnAllThreads, (Event::PostCb cb), (const));
   MOCK_METHOD(void, runOnAllThreads, (Event::PostCb cb));
   MOCK_METHOD(void, runOnAllThreads, (Event::PostCb cb, Event::PostCb main_callback));
 


### PR DESCRIPTION
Signed-off-by: mathetake <takeshi@tetrate.io>

Commit Message: Add postOnAllThreads on ThreadLocal::Instance.
Additional Description: This commit adds postOnAllThreads method on ThreadLocal::Instance which allows callers to schedule callbacks into all registered threads. Also this commit makes the FactoryContext expose `ThreadLocal::Instance` instead of `ThreadLocal::SlotAllocator` so that FactoryContext users (e.g. Wasm extensions) can use this new method. `postOnAllThreads` will be used in Wasm extensions later in another PR. Reference: https://github.com/envoyproxy/envoy/issues/17576 


Risk Level: low
Testing: ut
Docs Changes: none
Release Notes: none
