### PR TITLE
doc: fix link formatting for TLS session_timeout

### DIFF
--- a/api/envoy/api/v2/auth/tls.proto
+++ b/api/envoy/api/v2/auth/tls.proto
@@ -81,7 +81,7 @@ message DownstreamTlsContext {
     bool disable_stateless_session_resumption = 7;
   }
 
-  // If specified, session_timeout will change the maximum lifetime (in seconds) of the TLS session.
+  // If specified, ``session_timeout`` will change the maximum lifetime (in seconds) of the TLS session.
   // Currently this value is used as a hint for the `TLS session ticket lifetime (for TLSv1.2) <https://tools.ietf.org/html/rfc5077#section-5.6>`_.
   // Only seconds can be specified (fractional seconds are ignored).
   google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -109,7 +109,7 @@ message DownstreamTlsContext {
     bool disable_stateless_session_resumption = 7;
   }
 
-  // If specified, session_timeout will change the maximum lifetime (in seconds) of the TLS session.
+  // If specified, ``session_timeout`` will change the maximum lifetime (in seconds) of the TLS session.
   // Currently this value is used as a hint for the `TLS session ticket lifetime (for TLSv1.2) <https://tools.ietf.org/html/rfc5077#section-5.6>`_.
   // Only seconds can be specified (fractional seconds are ignored).
   google.protobuf.Duration session_timeout = 6 [(validate.rules).duration = {


### PR DESCRIPTION
*Commit Message:*

Fix the session_timeout formatting so that it links to the RFC
reference correctly. Make some minor grammar improvements.

*Additional Description:* None
*Risk Level:* Low
*Testing:* Manually verified 
*Docs Changes:* Included
*Release Notes:* None
*Platform Specific Features:* None