### PR TITLE
tooling: auto-assign dependency shephards

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -34,6 +34,7 @@ use(
       "label": "deps",
       "allow_global_approval": False,
       "github_status_label": "any dependency change",
+      "auto_assign": True,
     },
   ],
 )


### PR DESCRIPTION
I noticed on https://github.com/envoyproxy/envoy/pull/18787 we only cc shephards.  I think we want to auto-assign?

Risk Level: n/a (tooling)
Testing: hoping for the best
Docs Changes: n/a
Release Notes: n/a