### PR TITLE
upstream: fix typo in comment

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -141,7 +141,7 @@ public:
   virtual HostConstSharedPtr peekAnotherHost(LoadBalancerContext* context) PURE;
 
   /**
-   * Returns connnection lifetime callbacks that may be used to inform the load balancer of
+   * Returns connection lifetime callbacks that may be used to inform the load balancer of
    * connection events. Load balancers which do not intend to track connection lifetime events
    * will return nullopt.
    * @return optional lifetime callbacks for this load balancer.


### PR DESCRIPTION
Fix typo in comment, causing git push spellcheck hook to complain.

Signed-off-by: Dan Rosen <mergeconflict@google.com>