### PR TITLE
Fix --log-format example to conform to glog format

### DIFF
--- a/docs/root/configuration/observability/application_logging.rst
+++ b/docs/root/configuration/observability/application_logging.rst
@@ -14,7 +14,7 @@ Stackdriver Logging with GKE
 `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`_. Envoy should be configured
 with the following :ref:`command line options <operations_cli>`:
 
-* ``--log-format '%L%m%d %T.%e %t envoy] [%t][%n]%v'``: Logs are formatted in `glog <https://github.com/google/glog>`_
+* ``--log-format '%L%m%d %T.%e %t envoy/%@] [%t][%n]%v'``: Logs are formatted in `glog <https://github.com/google/glog>`_
   format, allowing Stackdriver to parse the log severity and timestamp.
 * ``--log-format-escaped``: Each string that is logged will be printed in a single line.
   C-style escape sequences (such as ``\n``) will be escaped and prevent a single string


### PR DESCRIPTION
According to GKE's fluent-bit config, logs should be of the format `^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source_file>[^ \]]+)\:(?<source_line>\d+)\]\s(?<message>.*)$`. (I found it by running `kubectl describe cm fluentbit-gke-config-v1.0.6 -n kube-system` on my GKE cluster.)

The example in doc lacks `\:(?<source_line>\d+)` part, so I added it.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
