### PR TITLE
clang-tidy: Return from diff fun if empty diff

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -89,7 +89,13 @@ function run_clang_tidy() {
 }
 
 function run_clang_tidy_diff() {
-  git diff "$1" | filter_excludes | \
+  local diff
+  diff="$(git diff "${1}")"
+  if [[ -z "$diff" ]]; then
+    echo "No changes detected, skipping clang_tidy_diff"
+    return 0
+  fi
+  echo "$diff" | filter_excludes | \
     python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary="${CLANG_TIDY}" \
       -export-fixes="${FIX_YAML}" -j "${NUM_CPUS:-0}" -p 1 -quiet


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

Currently, all dependabot PRs fail due to a bug in the algorithm used for generating a clang-tidy diff

Altho dependabot PRs are mostly aggregated, sometimes it would be helpful to just approve them, and its not helpful that the PRs always shows fail

Afaict tell the problem is caused by an empty diff being sent to `grep -v` - if that is the case then this should resolve the problem

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
