### PR TITLE
Revert "deps: Bump com_github_nlohmann_json -> 3.10.4 (#18744)" 

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -548,14 +548,14 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "nlohmann JSON",
         project_desc = "Fast JSON parser/generator for C++",
         project_url = "https://nlohmann.github.io/json",
-        version = "3.10.4",
-        sha256 = "1155fd1a83049767360e9a120c43c578145db3204d2b309eba49fbbedd0f4ed3",
+        version = "3.10.2",
+        sha256 = "081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c",
         strip_prefix = "json-{version}",
         urls = ["https://github.com/nlohmann/json/archive/v{version}.tar.gz"],
         # This will be a replacement for rapidJSON used in extensions and may also be a fast
         # replacement for protobuf JSON.
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2021-10-16",
+        release_date = "2021-08-26",
         cpe = "cpe:2.3:a:json-for-modern-cpp_project:json-for-modern-cpp:*",
     ),
     # This is an external dependency needed while running the

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -548,6 +548,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "nlohmann JSON",
         project_desc = "Fast JSON parser/generator for C++",
         project_url = "https://nlohmann.github.io/json",
+        # 3.10.4 introduced incompatible changes with Envoy Mobile. Until Envoy Mobile updates it's
+        # minimum iOS version to 13+ this dependency cannot be updated.
         version = "3.10.2",
         sha256 = "081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c",
         strip_prefix = "json-{version}",


### PR DESCRIPTION
3.10.4 introduced [CPP 17 specific functionality](https://github.com/nlohmann/json/compare/v3.10.2..v3.10.4#diff-8477168a53cf806fd7b9fba0ee3b7f4e28e378a5b0b2737cdddd8cf49f99b318R396). Envoy Mobile itself is compatible with CPP 17. However, there is specific functionality not available on iOS <13. This means that this dependency cannot be updated until Envoy Mobile moves the [minimum iOS version to 13](https://github.com/envoyproxy/envoy-mobile/blob/69a697d9052d8f6842e147d5e8b9d7a34e8fdf64/.bazelrc#L12).
Risk Level: low. The bump was a regular bump AFAICT.

This reverts commit 6e7243f6459ee059ef7fa7274760df9e542d3494.

Signed-off-by: Jose Nino <jnino@lyft.com>