### PR TITLE
Fix typo (remove extra word)

### DIFF
--- a/api/envoy/extensions/formatter/metadata/v3/metadata.proto
+++ b/api/envoy/extensions/formatter/metadata/v3/metadata.proto
@@ -26,7 +26,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //    :ref:`Metadata <envoy_v3_api_msg_config.core.v3.Metadata>` info,
 //    where TYPE is type of metadata (see above for supported types),
 //    NAMESPACE is the filter namespace used when setting the metadata, KEY is an optional
-//    lookup up key in the namespace with the option of specifying nested keys separated by ':',
+//    lookup key in the namespace with the option of specifying nested keys separated by ':',
 //    and Z is an optional parameter denoting string truncation up to Z characters long.
 //    The data will be logged as a JSON string. For example, for the following ROUTE metadata:
 //

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -506,7 +506,7 @@ The following command operators are supported:
   HTTP
     :ref:`Dynamic Metadata <envoy_v3_api_msg_config.core.v3.Metadata>` info,
     where NAMESPACE is the filter namespace used when setting the metadata, KEY is an optional
-    lookup up key in the namespace with the option of specifying nested keys separated by ':',
+    lookup key in the namespace with the option of specifying nested keys separated by ':',
     and Z is an optional parameter denoting string truncation up to Z characters long. Dynamic Metadata
     can be set by filters using the :repo:`StreamInfo <envoy/stream_info/stream_info.h>` API:
     *setDynamicMetadata*. The data will be logged as a JSON string. For example, for the following dynamic metadata:
@@ -541,7 +541,7 @@ The following command operators are supported:
   HTTP
     :ref:`Upstream cluster Metadata <envoy_v3_api_msg_config.core.v3.Metadata>` info,
     where NAMESPACE is the filter namespace used when setting the metadata, KEY is an optional
-    lookup up key in the namespace with the option of specifying nested keys separated by ':',
+    lookup key in the namespace with the option of specifying nested keys separated by ':',
     and Z is an optional parameter denoting string truncation up to Z characters long. The data
     will be logged as a JSON string. For example, for the following dynamic metadata:
 


### PR DESCRIPTION
Signed-off-by: Peter Jausovec <peter.jausovec@gmail.com>

Commit Message: Fix typo (remove extra word)
Additional Description: Removes an extra word in the docs
Docs Changes: Removes an extra word
