### PR TITLE
tracing: dump tracing span into access log via metadata

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -127,7 +127,7 @@ message HttpConnectionManager {
     UNESCAPE_AND_FORWARD = 4;
   }
 
-  // [#next-free-field: 10]
+  // [#next-free-field: 11]
   message Tracing {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing";
@@ -192,6 +192,9 @@ message HttpConnectionManager {
     //   Such a constraint is inherent to OpenCensus itself. It cannot be overcome without changes
     //   on OpenCensus side.
     config.trace.v3.Tracing.Http provider = 9;
+
+    // It dumps information provided by tracing span on single HTTP request into access log through metadata.
+    bool dump_tracing_span_into_accesslog = 10;
   }
 
   message InternalAddressConfig {

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -45,6 +45,7 @@ Removed Config or Runtime
 
 New Features
 ------------
+* access log: add :ref:`dump_tracing_span_into_accesslog <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.dump_tracing_span_into_accesslog>` to dump trace context into access log.
 * api: added support for *xds.type.v3.TypedStruct* in addition to the now-deprecated *udpa.type.v1.TypedStruct* proto message, which is a wrapper proto used to encode typed JSON data in a *google.protobuf.Any* field.
 * bootstrap: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>` in the bootstrap to support DNS resolver as an extension.
 * cluster: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>` in the cluster to support DNS resolver as an extension.

--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -78,6 +78,12 @@ public:
    * for HTTP protocol tracing.
    */
   virtual uint32_t maxPathTagLength() const PURE;
+
+  /**
+   * @return whether or not dumping span info provided by tracing provider into access log through
+   * metadata.
+   */
+  virtual bool dumpTracingSpanIntoAccesslog() const PURE;
 };
 
 /**
@@ -160,6 +166,18 @@ public:
    * @return trace ID as a hex string
    */
   virtual std::string getTraceIdAsHex() const PURE;
+
+  /**
+   * Dump trace context as metadata which depends on tracing provider.
+   * @param protobuf struct which should have information related with this span.
+   */
+  virtual void dumpToStruct(ProtobufWkt::Struct& proto) const PURE;
+
+  /**
+   * Tracer name which created this span.
+   * @return tracer name
+   */
+  virtual absl::string_view tracerName() const PURE;
 };
 
 /**

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -133,6 +133,7 @@ struct TracingConnectionManagerConfig {
   envoy::type::v3::FractionalPercent overall_sampling_;
   bool verbose_;
   uint32_t max_path_tag_length_;
+  bool dump_tracing_span_into_accesslog_;
 };
 
 using TracingConnectionManagerConfigPtr = std::unique_ptr<TracingConnectionManagerConfig>;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1561,6 +1561,10 @@ uint32_t ConnectionManagerImpl::ActiveStream::maxPathTagLength() const {
   return connection_manager_.config_.tracingConfig()->max_path_tag_length_;
 }
 
+bool ConnectionManagerImpl::ActiveStream::dumpTracingSpanIntoAccesslog() const {
+  return connection_manager_.config_.tracingConfig()->dump_tracing_span_into_accesslog_;
+}
+
 const Router::RouteEntry::UpgradeMap* ConnectionManagerImpl::ActiveStream::upgradeMap() {
   // We must check if the 'cached_route_' optional is populated since this function can be called
   // early via sendLocalReply(), before the cached route is populated.

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -203,6 +203,7 @@ private:
     const Tracing::CustomTagMap* customTags() const override;
     bool verbose() const override;
     uint32_t maxPathTagLength() const override;
+    bool dumpTracingSpanIntoAccesslog() const override;
 
     // ScopeTrackedObject
     void dumpState(std::ostream& os, int indent_level = 0) const override {

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -46,7 +46,7 @@ public:
   static void finalizeDownstreamSpan(Span& span, const Http::RequestHeaderMap* request_headers,
                                      const Http::ResponseHeaderMap* response_headers,
                                      const Http::ResponseTrailerMap* response_trailers,
-                                     const StreamInfo::StreamInfo& stream_info,
+                                     StreamInfo::StreamInfo& stream_info,
                                      const Config& tracing_config);
 
   /**
@@ -55,7 +55,7 @@ public:
    */
   static void finalizeUpstreamSpan(Span& span, const Http::ResponseHeaderMap* response_headers,
                                    const Http::ResponseTrailerMap* response_trailers,
-                                   const StreamInfo::StreamInfo& stream_info,
+                                   StreamInfo::StreamInfo& stream_info,
                                    const Config& tracing_config);
 
   /**
@@ -81,6 +81,7 @@ public:
   const CustomTagMap* customTags() const override { return nullptr; }
   bool verbose() const override { return false; }
   uint32_t maxPathTagLength() const override { return Tracing::DefaultMaxPathTagLength; }
+  bool dumpTracingSpanIntoAccesslog() const override { return false; }
 };
 
 using EgressConfig = ConstSingleton<EgressConfigImpl>;

--- a/source/common/tracing/null_span_impl.h
+++ b/source/common/tracing/null_span_impl.h
@@ -7,6 +7,8 @@
 namespace Envoy {
 namespace Tracing {
 
+constexpr absl::string_view kNullTracerName = "envoy.tracers.null";
+
 /**
  * Null implementation of Span.
  */
@@ -26,6 +28,8 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  void dumpToStruct(ProtobufWkt::Struct&) const override {}
+  absl::string_view tracerName() const override { return kNullTracerName; }
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -520,7 +520,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     tracing_config_ =
         std::make_unique<Http::TracingConnectionManagerConfig>(Http::TracingConnectionManagerConfig{
             tracing_operation_name, custom_tags, client_sampling, random_sampling, overall_sampling,
-            tracing_config.verbose(), max_path_tag_length});
+            tracing_config.verbose(), max_path_tag_length,
+            tracing_config.dump_tracing_span_into_accesslog()});
   }
 
   for (const auto& access_log : config.access_log()) {

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -28,6 +28,8 @@ struct OpenTracingTracerStats {
 
 class OpenTracingDriver;
 
+constexpr absl::string_view kOpenTracingTracerName = "envoy.tracers.opentracing";
+
 class OpenTracingSpan : public Tracing::Span, Logger::Loggable<Logger::Id::tracing> {
 public:
   OpenTracingSpan(OpenTracingDriver& driver, std::unique_ptr<opentracing::Span>&& span);
@@ -46,6 +48,8 @@ public:
 
   // TODO: This method is unimplemented for OpenTracing.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  void dumpToStruct(ProtobufWkt::Struct&) const override {}
+  absl::string_view tracerName() const override { return kOpenTracingTracerName; }
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/opencensus/config.cc
+++ b/source/extensions/tracers/opencensus/config.cc
@@ -11,7 +11,7 @@ namespace Extensions {
 namespace Tracers {
 namespace OpenCensus {
 
-OpenCensusTracerFactory::OpenCensusTracerFactory() : FactoryBase("envoy.tracers.opencensus") {}
+OpenCensusTracerFactory::OpenCensusTracerFactory() : FactoryBase(kOpenCensusTracerName.data()) {}
 
 Tracing::DriverSharedPtr OpenCensusTracerFactory::createTracerDriverTyped(
     const envoy::config::trace::v3::OpenCensusConfig& proto_config,

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -79,6 +79,8 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; };
 
   std::string getTraceIdAsHex() const override;
+  void dumpToStruct(ProtobufWkt::Struct&) const override {}
+  absl::string_view tracerName() const override { return kOpenCensusTracerName; }
 
 private:
   ::opencensus::trace::Span span_;

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
@@ -12,6 +12,8 @@ namespace Extensions {
 namespace Tracers {
 namespace OpenCensus {
 
+constexpr absl::string_view kOpenCensusTracerName = "envoy.tracers.opencensus";
+
 /**
  * OpenCensus tracing driver.
  */

--- a/source/extensions/tracers/skywalking/config.cc
+++ b/source/extensions/tracers/skywalking/config.cc
@@ -12,7 +12,7 @@ namespace Extensions {
 namespace Tracers {
 namespace SkyWalking {
 
-SkyWalkingTracerFactory::SkyWalkingTracerFactory() : FactoryBase("envoy.tracers.skywalking") {}
+SkyWalkingTracerFactory::SkyWalkingTracerFactory() : FactoryBase(kSkywalkingTracerName.data()) {}
 
 Tracing::DriverSharedPtr SkyWalkingTracerFactory::createTracerDriverTyped(
     const envoy::config::trace::v3::SkyWalkingConfig& proto_config,

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/tracers/skywalking/tracer.h"
 
+#include <google/protobuf/struct.pb.h>
+
 #include <string>
 
 namespace Envoy {
@@ -60,6 +62,10 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& nam
   auto child_span = tracing_context_->createExitSpan(span_entity_);
   child_span->startSpan(name);
   return std::make_unique<Span>(child_span, tracing_context_, parent_tracer_);
+}
+
+void Span::dumpToStruct(ProtobufWkt::Struct& proto) const {
+  MessageUtil::jsonConvert(span_entity_->createSpanObject(), proto);
 }
 
 Tracer::Tracer(TraceSegmentReporterPtr reporter) : reporter_(std::move(reporter)) {}

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <google/protobuf/struct.pb.h>
+
 #include <memory>
 
 #include "envoy/tracing/trace_driver.h"
@@ -18,6 +20,8 @@ namespace SkyWalking {
 
 using cpp2sky::TracingContextPtr;
 using cpp2sky::TracingSpanPtr;
+
+constexpr absl::string_view kSkywalkingTracerName = "envoy.tracers.skywalking";
 
 const Http::LowerCaseString& skywalkingPropagationHeaderKey();
 
@@ -73,6 +77,8 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  void dumpToStruct(ProtobufWkt::Struct&) const override;
+  absl::string_view tracerName() const override { return kSkywalkingTracerName; }
 
   const TracingContextPtr tracingContext() { return tracing_context_; }
   const TracingSpanPtr spanEntity() { return span_entity_; }

--- a/source/extensions/tracers/xray/config.cc
+++ b/source/extensions/tracers/xray/config.cc
@@ -16,7 +16,7 @@ namespace Extensions {
 namespace Tracers {
 namespace XRay {
 
-XRayTracerFactory::XRayTracerFactory() : FactoryBase("envoy.tracers.xray") {}
+XRayTracerFactory::XRayTracerFactory() : FactoryBase(kXrayTracerName.data()) {}
 
 Tracing::DriverSharedPtr
 XRayTracerFactory::createTracerDriverTyped(const envoy::config::trace::v3::XRayConfig& proto_config,

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -25,6 +25,7 @@ namespace Extensions {
 namespace Tracers {
 namespace XRay {
 
+constexpr absl::string_view kXrayTracerName = "envoy.tracers.xray";
 constexpr auto XRayTraceHeader = "x-amzn-trace-id";
 
 class Span : public Tracing::Span, Logger::Loggable<Logger::Id::config> {
@@ -194,6 +195,10 @@ public:
 
   // TODO: This method is unimplemented for X-Ray.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+
+  void dumpToStruct(ProtobufWkt::Struct&) const override {}
+
+  absl::string_view tracerName() const override { return kXrayTracerName; }
 
   /**
    * Creates a child span.

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -12,7 +12,7 @@ namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
-ZipkinTracerFactory::ZipkinTracerFactory() : FactoryBase("envoy.tracers.zipkin") {}
+ZipkinTracerFactory::ZipkinTracerFactory() : FactoryBase(kZipkinTracerName.data()) {}
 
 Tracing::DriverSharedPtr ZipkinTracerFactory::createTracerDriverTyped(
     const envoy::config::trace::v3::ZipkinConfig& proto_config,

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -32,6 +32,8 @@ namespace Zipkin {
   COUNTER(reports_dropped)                                                                         \
   COUNTER(reports_failed)
 
+constexpr absl::string_view kZipkinTracerName = "envoy.tracers.zipkin";
+
 struct ZipkinTracerStats {
   ZIPKIN_TRACER_STATS(GENERATE_COUNTER_STRUCT)
 };
@@ -84,6 +86,10 @@ public:
 
   // TODO: This method is unimplemented for Zipkin.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+
+  void dumpToStruct(ProtobufWkt::Struct&) const override {}
+
+  absl::string_view tracerName() const override { return kZipkinTracerName; }
 
   /**
    * @return a reference to the Zipkin::Span object.

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1358,7 +1358,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   }
   tracing_config_ = std::make_unique<TracingConnectionManagerConfig>(
       TracingConnectionManagerConfig{Tracing::OperationName::Ingress, conn_tracing_tags, percent1,
-                                     percent2, percent1, false, 256});
+                                     percent2, percent1, false, 256, false});
   NiceMock<Router::MockRouteTracing> route_tracing;
   ON_CALL(route_tracing, getClientSampling()).WillByDefault(ReturnRef(percent1));
   ON_CALL(route_tracing, getRandomSampling()).WillByDefault(ReturnRef(percent2));
@@ -1640,7 +1640,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
                                      percent2,
                                      percent1,
                                      false,
-                                     256});
+                                     256,
+                                     false});
 
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
@@ -1722,7 +1723,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
                                      percent2,
                                      percent1,
                                      false,
-                                     256});
+                                     256,
+                                     false});
 
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
@@ -1806,7 +1808,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
                                      percent2,
                                      percent1,
                                      false,
-                                     256});
+                                     256,
+                                     false});
 
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
@@ -1882,7 +1885,8 @@ TEST_F(HttpConnectionManagerImplTest,
                                      percent2,
                                      percent1,
                                      false,
-                                     256});
+                                     256,
+                                     false});
 
   EXPECT_CALL(
       runtime_.snapshot_,

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -92,7 +92,8 @@ void HttpConnectionManagerImplTest::setup(bool ssl, const std::string& server_na
                                        percent2,
                                        percent1,
                                        false,
-                                       256});
+                                       256,
+                                       false});
   }
 }
 

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -697,6 +697,7 @@ TEST(EgressConfigImplTest, EgressConfigImplTest) {
   EXPECT_EQ(nullptr, config_impl.customTags());
   EXPECT_EQ(false, config_impl.verbose());
   EXPECT_EQ(Tracing::DefaultMaxPathTagLength, config_impl.maxPathTagLength());
+  EXPECT_FALSE(config_impl.dumpTracingSpanIntoAccesslog());
 }
 
 TEST(HttpNullTracerTest, BasicFunctionality) {

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -172,6 +172,15 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
 
     second_child_span->finishSpan();
     EXPECT_NE(0, second_child_span->spanEntity()->endTime());
+
+    ProtobufWkt::Struct dumped_struct;
+    org_second_child_span->dumpToStruct(dumped_struct);
+    EXPECT_EQ(dumped_struct.fields().at("componentId").number_value(), 9000);
+    EXPECT_EQ(dumped_struct.fields().at("operationName").string_value(), "TestChild");
+    EXPECT_TRUE(dumped_struct.fields().at("skipAnalysis").bool_value());
+    EXPECT_EQ(dumped_struct.fields().at("spanId").number_value(), 2);
+    EXPECT_EQ(dumped_struct.fields().at("spanLayer").string_value(), "Http");
+    EXPECT_EQ(dumped_struct.fields().at("spanType").string_value(), "Exit");
   }
 
   // When the child span ends, the data is not reported immediately, but the end time is set.

--- a/test/mocks/tracing/mocks.cc
+++ b/test/mocks/tracing/mocks.cc
@@ -16,6 +16,8 @@ MockConfig::MockConfig() {
   ON_CALL(*this, customTags()).WillByDefault(Return(&custom_tags_));
   ON_CALL(*this, verbose()).WillByDefault(Return(verbose_));
   ON_CALL(*this, maxPathTagLength()).WillByDefault(Return(uint32_t(256)));
+  ON_CALL(*this, dumpTracingSpanIntoAccesslog())
+      .WillByDefault(Return(dump_tracing_span_into_accesslog_));
 }
 MockConfig::~MockConfig() = default;
 

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <google/protobuf/struct.pb.h>
+
 #include <string>
 #include <vector>
 
@@ -21,10 +23,12 @@ public:
   MOCK_METHOD(const CustomTagMap*, customTags, (), (const));
   MOCK_METHOD(bool, verbose, (), (const));
   MOCK_METHOD(uint32_t, maxPathTagLength, (), (const));
+  MOCK_METHOD(bool, dumpTracingSpanIntoAccesslog, (), (const));
 
   OperationName operation_name_{OperationName::Ingress};
   CustomTagMap custom_tags_;
   bool verbose_{false};
+  bool dump_tracing_span_into_accesslog_{true};
 };
 
 class MockSpan : public Span {
@@ -41,6 +45,8 @@ public:
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
   MOCK_METHOD(std::string, getTraceIdAsHex, (), (const));
+  MOCK_METHOD(void, dumpToStruct, (ProtobufWkt::Struct&), (const));
+  MOCK_METHOD(absl::string_view, tracerName, (), (const));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: tracing: dump tracing span into access log via metadata
Additional Description: This feature enables to dump trace context into metadata to output them via access log.
Risk Level: Low
Testing: Unit
Docs Changes: Required
Release Notes: Required
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

cc @wu-sheng