### PR TITLE
tcp_proxy: add support to evaluate downstream info at tunnel setting

### DIFF
--- a/configs/encapsulate_in_http2_connect.yaml
+++ b/configs/encapsulate_in_http2_connect.yaml
@@ -26,6 +26,10 @@ static_resources:
           cluster: "cluster_0"
           tunneling_config:
             hostname: host.com:443
+            headers_to_add:
+            - header:
+                key: original_dst_port
+                value: "%DOWNSTREAM_LOCAL_PORT%"
   clusters:
   - name: cluster_0
     connect_timeout: 5s

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -62,6 +62,7 @@ New Features
 * listener: added support for :ref:`MPTCP <envoy_v3_api_field_config.listener.v3.Listener.enable_mptcp>` (multipath TCP).
 * oauth filter: added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.
 * tcp: added a :ref:`FilterState <envoy_v3_api_msg_type.v3.HashPolicy.FilterState>` :ref:`hash policy <envoy_v3_api_msg_type.v3.HashPolicy>`, used by :ref:`TCP proxy <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.hash_policy>` to allow hashing load balancer algorithms to hash on objects in filter state.
+* tcp_proxy: added support to populate upstream http connect header value from stream info. 
 * thrift_proxy: add upstream response zone metrics in the form ``cluster.cluster_name.zone.local_zone.upstream_zone.thrift.upstream_resp_success``.
 * thrift_proxy: add upstream metrics to show decoding errors and whether exception is from local or remote, e.g. ``cluster.cluster_name.thrift.upstream_resp_exception_remote``.
 * thrift_proxy: add host level success/error metrics where success is a reply of type success and error is any other response to a call.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -62,7 +62,7 @@ New Features
 * listener: added support for :ref:`MPTCP <envoy_v3_api_field_config.listener.v3.Listener.enable_mptcp>` (multipath TCP).
 * oauth filter: added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.
 * tcp: added a :ref:`FilterState <envoy_v3_api_msg_type.v3.HashPolicy.FilterState>` :ref:`hash policy <envoy_v3_api_msg_type.v3.HashPolicy>`, used by :ref:`TCP proxy <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.hash_policy>` to allow hashing load balancer algorithms to hash on objects in filter state.
-* tcp_proxy: added support to populate upstream http connect header value from stream info.
+* tcp_proxy: added support to populate upstream http connect header values from stream info.
 * thrift_proxy: add upstream response zone metrics in the form ``cluster.cluster_name.zone.local_zone.upstream_zone.thrift.upstream_resp_success``.
 * thrift_proxy: add upstream metrics to show decoding errors and whether exception is from local or remote, e.g. ``cluster.cluster_name.thrift.upstream_resp_exception_remote``.
 * thrift_proxy: add host level success/error metrics where success is a reply of type success and error is any other response to a call.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -62,7 +62,7 @@ New Features
 * listener: added support for :ref:`MPTCP <envoy_v3_api_field_config.listener.v3.Listener.enable_mptcp>` (multipath TCP).
 * oauth filter: added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.
 * tcp: added a :ref:`FilterState <envoy_v3_api_msg_type.v3.HashPolicy.FilterState>` :ref:`hash policy <envoy_v3_api_msg_type.v3.HashPolicy>`, used by :ref:`TCP proxy <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.hash_policy>` to allow hashing load balancer algorithms to hash on objects in filter state.
-* tcp_proxy: added support to populate upstream http connect header value from stream info. 
+* tcp_proxy: added support to populate upstream http connect header value from stream info.
 * thrift_proxy: add upstream response zone metrics in the form ``cluster.cluster_name.zone.local_zone.upstream_zone.thrift.upstream_resp_success``.
 * thrift_proxy: add upstream metrics to show decoding errors and whether exception is from local or remote, e.g. ``cluster.cluster_name.thrift.upstream_resp_exception_remote``.
 * thrift_proxy: add host level success/error metrics where success is a reply of type success and error is any other response to a call.

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -103,6 +103,7 @@ private:
   GenericConnectionPoolCallbacks* callbacks_{};
   Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks_;
   std::unique_ptr<HttpUpstream> upstream_;
+  const StreamInfo::StreamInfo& downstream_info_;
 };
 
 class TcpUpstream : public GenericUpstream {
@@ -150,12 +151,14 @@ public:
   }
 
 protected:
-  HttpUpstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks, const TunnelingConfig& config);
+  HttpUpstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks, const TunnelingConfig& config,
+               const StreamInfo::StreamInfo& downstream_info);
   void resetEncoder(Network::ConnectionEvent event, bool inform_downstream = true);
 
   Http::RequestEncoder* request_encoder_{};
   const TunnelingConfig config_;
   std::unique_ptr<Envoy::Router::HeaderParser> header_parser_;
+  const StreamInfo::StreamInfo& downstream_info_;
 
 private:
   class DecoderShim : public Http::ResponseDecoder {
@@ -198,7 +201,8 @@ private:
 
 class Http1Upstream : public HttpUpstream {
 public:
-  Http1Upstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks, const TunnelingConfig& config);
+  Http1Upstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks, const TunnelingConfig& config,
+                const StreamInfo::StreamInfo& downstream_info);
 
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void setRequestEncoder(Http::RequestEncoder& request_encoder, bool is_ssl) override;
@@ -207,7 +211,8 @@ public:
 
 class Http2Upstream : public HttpUpstream {
 public:
-  Http2Upstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks, const TunnelingConfig& config);
+  Http2Upstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks, const TunnelingConfig& config,
+                const StreamInfo::StreamInfo& downstream_info);
 
   void setRequestEncoder(Http::RequestEncoder& request_encoder, bool is_ssl) override;
   bool isValidResponse(const Http::ResponseHeaderMap& headers) override;

--- a/test/extensions/upstreams/tcp/generic/config_test.cc
+++ b/test/extensions/upstreams/tcp/generic/config_test.cc
@@ -2,6 +2,7 @@
 
 #include "test/mocks/tcp/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
+#include "test/mocks/upstream/load_balancer_context.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -19,17 +20,24 @@ namespace Generic {
 
 class TcpConnPoolTest : public ::testing::Test {
 public:
+  TcpConnPoolTest() {
+    EXPECT_CALL(connection_, streamInfo()).WillRepeatedly(ReturnRef(downstream_stream_info_));
+    EXPECT_CALL(lb_context_, downstreamConnection()).WillRepeatedly(Return(&connection_));
+  }
   NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster_;
   GenericConnPoolFactory factory_;
   NiceMock<Envoy::Tcp::ConnectionPool::MockUpstreamCallbacks> callbacks_;
+  NiceMock<StreamInfo::MockStreamInfo> downstream_stream_info_;
+  NiceMock<Network::MockConnection> connection_;
+  Upstream::MockLoadBalancerContext lb_context_;
 };
 
 TEST_F(TcpConnPoolTest, TestNoConnPool) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_TunnelingConfig config;
   config.set_hostname("host");
   EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _)).WillOnce(Return(absl::nullopt));
-  EXPECT_EQ(nullptr,
-            factory_.createGenericConnPool(thread_local_cluster_, config, nullptr, callbacks_));
+  EXPECT_EQ(nullptr, factory_.createGenericConnPool(thread_local_cluster_, config, &lb_context_,
+                                                    callbacks_));
 }
 
 TEST_F(TcpConnPoolTest, Http2Config) {
@@ -39,8 +47,8 @@ TEST_F(TcpConnPoolTest, Http2Config) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_TunnelingConfig config;
   config.set_hostname("host");
   EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _)).WillOnce(Return(absl::nullopt));
-  EXPECT_EQ(nullptr,
-            factory_.createGenericConnPool(thread_local_cluster_, config, nullptr, callbacks_));
+  EXPECT_EQ(nullptr, factory_.createGenericConnPool(thread_local_cluster_, config, &lb_context_,
+                                                    callbacks_));
 }
 
 TEST_F(TcpConnPoolTest, Http3Config) {
@@ -52,8 +60,8 @@ TEST_F(TcpConnPoolTest, Http3Config) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_TunnelingConfig config;
   config.set_hostname("host");
   EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _)).WillOnce(Return(absl::nullopt));
-  EXPECT_EQ(nullptr,
-            factory_.createGenericConnPool(thread_local_cluster_, config, nullptr, callbacks_));
+  EXPECT_EQ(nullptr, factory_.createGenericConnPool(thread_local_cluster_, config, &lb_context_,
+                                                    callbacks_));
 }
 
 } // namespace Generic


### PR DESCRIPTION
Commit Message:
This allows to generate tcp proxy's upstream CONNECT header values using downstream info.
Examples include modifying the host/:authority headers
Or emulate the proxy protocol via CONNECT as in the test cases.

Use with caution: a RFC in-compliant upstream header can be introduced because stream info may carry arbitrary bytes. 

Additional Description:
Risk Level: LOW 
Testing:
Docs Changes:
Release Notes:
Fixes #18128