### PR TITLE
runtime: flipping envoy.reloadable_features.remove_legacy_json

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -16,6 +16,7 @@ Minor Behavior Changes
 * config: the log message for "gRPC config stream closed" now uses the most recent error message, and reports seconds instead of milliseconds for how long the most recent status has been received.
 * dns: now respecting the returned DNS TTL for resolved hosts, rather than always relying on the hard-coded :ref:`dns_refresh_rate. <envoy_v3_api_field_config.cluster.v3.Cluster.dns_refresh_rate>` This behavior can be temporarily reverted by setting the runtime guard ``envoy.reloadable_features.use_dns_ttl`` to false.
 * http: usage of the experimental matching API is no longer guarded behind a feature flag, as the corresponding protobuf fields have been marked as WIP.
+* json: switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.remove_legacy_json`` to false.
 * listener: destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 * quic: add back the support for IETF draft 29 which is guarded via ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_disable_version_draft_29``. It is off by default so Envoy only supports RFCv1 without flipping this runtime guard explicitly. Draft 29 is not recommended for use.
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -75,6 +75,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.new_tcp_connection_pool",
     "envoy.reloadable_features.no_chunked_encoding_header_for_304",
     "envoy.reloadable_features.preserve_downstream_scheme",
+    "envoy.reloadable_features.remove_legacy_json",
     "envoy.reloadable_features.require_strict_1xx_and_204_response_headers",
     "envoy.reloadable_features.send_strict_1xx_and_204_response_headers",
     "envoy.reloadable_features.strip_port_from_connect",
@@ -107,8 +108,6 @@ constexpr const char* runtime_features[] = {
 constexpr const char* disabled_runtime_features[] = {
     // TODO(alyssawilk, junr03) flip (and add release notes + docs) these after Lyft tests
     "envoy.reloadable_features.allow_multiple_dns_addresses",
-    // TODO(asraa) flip to true in a separate PR to enable the new JSON by default.
-    "envoy.reloadable_features.remove_legacy_json",
     // Sentinel and test flag.
     "envoy.reloadable_features.test_feature_false",
     // When the runtime is flipped to true, use shared cache in getOrCreateRawAsyncClient method if

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -37,6 +37,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "json_loader_legacy_test",
     srcs = ["json_loader_test.cc"],
-    deps = JSON_TEST_DEPS,
     args = ["--runtime-feature-disable-for-tests=envoy.reloadable_features.remove_legacy_json"],
+    deps = JSON_TEST_DEPS,
 )

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -38,4 +38,5 @@ envoy_cc_test(
     name = "json_loader_legacy_test",
     srcs = ["json_loader_test.cc"],
     deps = JSON_TEST_DEPS,
+    args = ["--runtime-feature-disable-for-tests=envoy.reloadable_features.remove_legacy_json"],
 )

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -17,7 +17,6 @@ envoy_cc_fuzz_test(
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
         "//test/fuzz:utility_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/json/json_fuzz_test.cc
+++ b/test/common/json/json_fuzz_test.cc
@@ -3,7 +3,6 @@
 
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
@@ -13,10 +12,6 @@ namespace Fuzz {
 // We fuzz nlohmann/JSON and protobuf and compare their results, since RapidJSON is deprecated and
 // has known limitations. See https://github.com/envoyproxy/envoy/issues/4705.
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
-  TestScopedRuntime runtime;
-  Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.reloadable_features.remove_legacy_json", "true"}});
-
   std::string json_string{reinterpret_cast<const char*>(buf), len};
 
   // Load via Protobuf JSON parsing, if we can.

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -733,11 +733,13 @@ TEST_F(StreamInfoHeaderFormatterTest, UnknownVariable) { testInvalidFormat("INVA
 
 TEST_F(StreamInfoHeaderFormatterTest, WrongFormatOnUpstreamMetadataVariable) {
   // Invalid JSON.
-  EXPECT_THROW_WITH_MESSAGE(
-      StreamInfoHeaderFormatter("UPSTREAM_METADATA(abcd)", false), EnvoyException,
-      "Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", \"k\", "
-      "...]), actual format UPSTREAM_METADATA(abcd), because JSON supplied is not valid. "
-      "Error(offset 0, line 1): Invalid value.\n");
+  EXPECT_THROW_WITH_MESSAGE(StreamInfoHeaderFormatter("UPSTREAM_METADATA(abcd)", false),
+                            EnvoyException,
+                            "Invalid header configuration. Expected format "
+                            "UPSTREAM_METADATA([\"namespace\", \"k\", ...]), actual format "
+                            "UPSTREAM_METADATA(abcd), because JSON supplied is not valid. "
+                            "Error(line 1, column 1, token a): syntax error while parsing value - "
+                            "invalid literal; last read: 'a'\n");
 
   // No parameters.
   EXPECT_THROW_WITH_MESSAGE(StreamInfoHeaderFormatter("UPSTREAM_METADATA", false), EnvoyException,
@@ -747,9 +749,10 @@ TEST_F(StreamInfoHeaderFormatterTest, WrongFormatOnUpstreamMetadataVariable) {
 
   EXPECT_THROW_WITH_MESSAGE(
       StreamInfoHeaderFormatter("UPSTREAM_METADATA()", false), EnvoyException,
-      "Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", \"k\", "
-      "...]), actual format UPSTREAM_METADATA(), because JSON supplied is not valid. Error(offset "
-      "0, line 1): The document is empty.\n");
+      "Invalid header configuration. Expected format "
+      "UPSTREAM_METADATA([\"namespace\", \"k\", ...]), actual format UPSTREAM_METADATA(), "
+      "because JSON supplied is not valid. Error(line 1, column 1, token ): syntax error while "
+      "parsing value - unexpected end of input; expected '[', '{', or a literal\n");
 
   // One parameter.
   EXPECT_THROW_WITH_MESSAGE(StreamInfoHeaderFormatter("UPSTREAM_METADATA([\"ns\"])", false),
@@ -787,9 +790,10 @@ TEST_F(StreamInfoHeaderFormatterTest, WrongFormatOnUpstreamMetadataVariable) {
   // Invalid string elements.
   EXPECT_THROW_WITH_MESSAGE(
       StreamInfoHeaderFormatter("UPSTREAM_METADATA([\"a\", \"\\unothex\"])", false), EnvoyException,
-      "Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", \"k\", "
-      "...]), actual format UPSTREAM_METADATA([\"a\", \"\\unothex\"]), because JSON supplied is "
-      "not valid. Error(offset 7, line 1): Incorrect hex digit after \\u escape in string.\n");
+      "Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", "
+      "\"k\", ...]), actual format UPSTREAM_METADATA([\"a\", \"\\unothex\"]), because JSON "
+      "supplied is not valid. Error(line 1, column 10, token \"\\un): syntax error while parsing "
+      "value - invalid string: '\\u' must be followed by 4 hex digits; last read: '\"\\un'\n");
 
   // Non-array parameters.
   EXPECT_THROW_WITH_MESSAGE(
@@ -868,14 +872,17 @@ TEST(HeaderParserTest, TestParseInternal) {
       // Parsing errors in variable expressions that take a JSON-array parameter.
       {"%UPSTREAM_METADATA(no array)%",
        {},
-       {"Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", \"k\", "
-        "...]), actual format UPSTREAM_METADATA(no array), because JSON supplied is not valid. "
-        "Error(offset 1, line 1): Invalid value.\n"}},
+       {"Invalid header configuration. Expected format "
+        "UPSTREAM_METADATA([\"namespace\", \"k\", ...]), actual format "
+        "UPSTREAM_METADATA(no array), because JSON supplied is not valid. Error(line 1, "
+        "column 2, token no): syntax error while parsing value - invalid literal; last read: "
+        "'no'\n"}},
       {"%UPSTREAM_METADATA( no array)%",
        {},
-       {"Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", \"k\", "
-        "...]), actual format UPSTREAM_METADATA( no array), because JSON supplied is not valid. "
-        "Error(offset 2, line 1): Invalid value.\n"}},
+       {"Invalid header configuration. Expected format "
+        "UPSTREAM_METADATA([\"namespace\", \"k\", ...]), actual format UPSTREAM_METADATA( "
+        "no array), because JSON supplied is not valid. Error(line 1, column 3, token  no): "
+        "syntax error while parsing value - invalid literal; last read: ' no'\n"}},
       {"%UPSTREAM_METADATA([\"unterminated array\")%",
        {},
        {"Invalid header configuration. Expecting ',', ']', or whitespace after "

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -13,7 +13,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/filesystem/posix:95.5"
 "source/common/http:96.3"
 "source/common/http/http2:96.4"
-"source/common/json:90.1"
+"source/common/json:89.8"
 "source/common/matcher:94.0"
 "source/common/network:94.4" # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
 "source/common/network/dns_resolver:90.7"  # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts


### PR DESCRIPTION
We added the code to switch json libraries over in https://github.com/envoyproxy/envoy/pull/14467
The removal is tracked by https://github.com/envoyproxy/envoy/issues/4705 and smoke tested (https://github.com/envoyproxy/envoy/issues/18451)

Risk Level: Medium for folks using json
Testing: n/a
Docs Changes: n/a
Release Notes: inline
Fixes https://github.com/envoyproxy/envoy/issues/18451