### PR TITLE
Fix crash-on-startup on macOS 12 (#18779)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -79,11 +79,13 @@ build:clang-asan --linkopt -fuse-ld=lld
 build:clang-asan --linkopt --rtlib=compiler-rt
 build:clang-asan --linkopt --unwindlib=libgcc
 
-# macOS ASAN/UBSAN
+# macOS
 build:macos --cxxopt=-std=c++17
 build:macos --action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
 build:macos --host_action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
+build:macos --define tcmalloc=disabled
 
+# macOS ASAN/UBSAN
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932
 build:macos-asan --copt -Wno-macro-redefined

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -16,6 +16,7 @@ Bug Fixes
 * http: remove redundant Warn log in HTTP codec.
 * listener: fix a crash when updating any listener that does not bind to port.
 * listener: listener add can reuse the listener socket of a draining filter chain listener and fix the request lost.
+* macOS: fix crash on startup on macOS 12 by changing the default allocator.
 
 Removed Config or Runtime
 -------------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -16,7 +16,7 @@ Bug Fixes
 * http: remove redundant Warn log in HTTP codec.
 * listener: fix a crash when updating any listener that does not bind to port.
 * listener: listener add can reuse the listener socket of a draining filter chain listener and fix the request lost.
-* macOS: fix crash on startup on macOS 12 by changing the default allocator.
+* mac: fix crash on startup on macOS 12 by changing the default allocator.
 
 Removed Config or Runtime
 -------------------------


### PR DESCRIPTION
gperftools_tcmalloc is not compatible with macOS 12, resulting in a
crash on startup. The crash happens very early, before CLI args are
parsed.

Fixes #17535

Signed-off-by: Greg Greenway <ggreenway@apple.com>
(cherry picked from commit b9939c6f8045b12b98933ffdf3d9f2eacd9cf38e)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
