### PR TITLE
Minor: Request copy assignment operator.

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -24,6 +24,7 @@ namespace Network {
 struct SocketOptionName {
   SocketOptionName() = default;
   SocketOptionName(const SocketOptionName&) = default;
+  SocketOptionName& operator=(const SocketOptionName&) = default;
   SocketOptionName(int level, int option, const std::string& name)
       : value_(std::make_tuple(level, option, name)) {}
 


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: The copy assignment operator is being invoked for `SocketOptionName` implicitly. Explicitly request it.
Additional Description:
Risk Level: N/A
Testing: NA
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

It seems to be breaking for Clang 14. See:
```
Step #3 - "compile-afl-address-x86_64": [1m./envoy/network/socket.h:26:3: [0m[0;1;31merror: [0m[1mdefinition of implicit copy assignment operator for 'SocketOptionName' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy][0m
Step #3 - "compile-afl-address-x86_64":   SocketOptionName(const SocketOptionName&) = default;
Step #3 - "compile-afl-address-x86_64": [0;1;32m  ^
Step #3 - "compile-afl-address-x86_64": [0m[1msource/common/network/socket_option_impl.cc:52:14: [0m[0;1;30mnote: [0min implicit copy assignment operator for 'Envoy::Network::SocketOptionName' first required here[0m
```