### PR TITLE
docs: updating backports docs to reflect recent process and new setec folks

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -67,6 +67,8 @@ without further review.
 * Tony Allen ([tonya11en](https://github.com/tonya11en)) (tony@allen.gg)
 * Yan Avlasov ([yanavlasov](https://github.com/yanavlasov)) (yavlasov@google.com)
 * William A Rowe Jr ([wrowe](https://github.com/wrowe)) (wrowe@vmware.com)
+* Otto van der Schaaf ([oschaaf](https://github.com/oschaaf)) (oschaaf@redhat.com)
+* Tim Walsh ([twghu](https://github.com/twghu)) (walsh@redhat.com)
 
 # Emeritus maintainers
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,7 +26,7 @@ to execute tests on it.
 ### Security releases
 
 Critical security fixes are owned by the Envoy security team, which provides fixes for the
-`main` branch, and the latest release branch. Once those fixes are ready, the maintainers
+`main` branch. Once those fixes are ready, the maintainers
 of stable releases backport them to the remaining supported stable releases.
 
 ### Backports

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -55,6 +55,7 @@ stable releases and sending announcements about them. This role is rotating on a
 | 2021 Q1 | Rei Shimizu ([Shikugawa](https://github.com/Shikugawa))        |
 | 2021 Q2 | Dmitri Dolguikh ([dmitri-d](https://github.com/dmitri-d))      |
 | 2021 Q3 | Takeshi Yoneda ([mathetake](https://github.com/mathetake))     |
+| 2021 Q4 | Otto van der Schaaf ([oschaaf](https://github.com/oschaaf))    |
 
 ## Release schedule
 


### PR DESCRIPTION
Risk Level: n/a
Testing: n/a
Docs Changes: yes
Release Notes: n/a