### PR TITLE
[ci] disable multplexed integration test for coverage temporarily

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -368,6 +368,7 @@ envoy_cc_test(
         "multiplexed_integration_test.cc",
         "multiplexed_integration_test.h",
     ],
+    coverage = False,
     shard_count = 8,
     deps = [
         ":http_protocol_integration_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -368,7 +368,6 @@ envoy_cc_test(
         "multiplexed_integration_test.cc",
         "multiplexed_integration_test.h",
     ],
-    coverage = False,
     shard_count = 8,
     deps = [
         ":http_protocol_integration_lib",

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -1859,6 +1859,8 @@ TEST_P(Http2IntegrationTest, OnLocalReply) {
   }
 }
 
+// Disabled for coverge temporarily see #18881
+#if !defined(ENVOY_CONFIG_COVERAGE)
 TEST_P(Http2IntegrationTest, InvalidTrailers) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");
   autonomous_upstream_ = true;
@@ -1878,6 +1880,7 @@ TEST_P(Http2IntegrationTest, InvalidTrailers) {
   // http2.invalid.header.field or http3.invalid_header_field
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
 }
+#endif
 
 TEST_P(Http2IntegrationTest, InconsistentContentLength) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -1859,7 +1859,7 @@ TEST_P(Http2IntegrationTest, OnLocalReply) {
   }
 }
 
-// Disabled for coverge temporarily see #18881
+// Disabled for coverage temporarily see #18881
 #if !defined(ENVOY_CONFIG_COVERAGE)
 TEST_P(Http2IntegrationTest, InvalidTrailers) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

See https://github.com/envoyproxy/envoy/issues/18881.
temporarily disable until i figure out a fix

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
