### PR TITLE
[v1.20 backport] config: adjust "gRPC config stream closed" log message

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,6 +9,8 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* config: the log message for "gRPC config stream closed" now uses the most recent error message, and reports seconds instead of milliseconds for how long the most recent status has been received.
+
 Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*


### PR DESCRIPTION
Commit Message:
config: adjust "gRPC config stream closed" log message (#18533)

backport of c35ff419e3b4fe3f7e6deae08e6e329cf91ba5b5

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description:
Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A