### PR TITLE
grpc_json: use a mutex to protext JsonTranscoderConfig::type_helper_

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -12,6 +12,7 @@
 #include "source/common/protobuf/protobuf.h"
 #include "source/extensions/filters/http/grpc_json_transcoder/transcoder_input_stream_impl.h"
 
+#include "absl/synchronization/mutex.h"
 #include "google/api/http.pb.h"
 #include "grpc_transcoding/path_matcher.h"
 #include "grpc_transcoding/request_message_translator.h"
@@ -126,6 +127,7 @@ private:
 
   Protobuf::DescriptorPool descriptor_pool_;
   google::grpc::transcoding::PathMatcherPtr<MethodInfoSharedPtr> path_matcher_;
+  mutable absl::Mutex type_helper_mutex_;
   std::unique_ptr<google::grpc::transcoding::TypeHelper> type_helper_;
   Protobuf::util::JsonPrintOptions print_options_;
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix https://github.com/envoyproxy/envoy/issues/18849

`JsonTranscoderConfig::type_helper_` is not a thread safe object. Its used
 [TypeInfoForTypeResolver](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/util/internal/type_info.cc#L170)
 uses three mutable maps to cache used data. 

Most of places use `type_helper_` are in the `JsonTranscoderConfig` constructor which is only called at main thread.
But there is a place inside `JsonTranscoderConfig::createTranscoder` and this function is called per-request processing in the worker thread.  It may have race condition that multiple threads try to update the mutable maps.

Hence use a mutex to protect it.

Tried alternative approach:  creating `type_helper_` as thread local.  It did not work

grpc_json_transcoder_integration_test failed at this 
[GOOGLE_CHECK](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.cc#L7881) as
```
GOOGLE_CHECK(file()->finished_building_ == true);
```
Did not spend too much time to debug it.  Maybe descriptor should not be used in the worker threads.

As low risk,  just add a mutex to protect it.  This `ResolveFieldPath` should be fairly quick,  so the contention should be low,  it should not slow down much.

Risk Level:  None
Testing:  unit tests and integration tests
Docs Changes: None
Release Notes: None
