### PR TITLE
Minor: adding copy assignment operator for AsyncStream

### DIFF
--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -36,6 +36,7 @@ public:
   AsyncStream() = default;
   AsyncStream(RawAsyncStream* stream) : stream_(stream) {}
   AsyncStream(const AsyncStream& other) = default;
+  AsyncStream& operator=(const AsyncStream&) = default;
   void sendMessage(const Protobuf::Message& request, bool end_stream) {
     Internal::sendMessageUntyped(stream_, std::move(request), end_stream);
   }


### PR DESCRIPTION
Commit Message: The copy assignment operator is being invoked for `AsyncStream` implicitly. Explicitly request it.
Additional Description:
Detected due to a fuzz build failure when using clang 14.
Risk Level: Low.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A. 

Signed-off-by: Adi Suissa-Peleg <adip@google.com>