### PR TITLE
Fix oss-fuzz build compilation errors

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -23,7 +23,6 @@ namespace Network {
 // avoid #ifdef proliferation.
 struct SocketOptionName {
   SocketOptionName() = default;
-  SocketOptionName(const SocketOptionName&) = default;
   SocketOptionName& operator=(const SocketOptionName&) = default;
   SocketOptionName(int level, int option, const std::string& name)
       : value_(std::make_tuple(level, option, name)) {}

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -23,7 +23,6 @@ namespace Network {
 // avoid #ifdef proliferation.
 struct SocketOptionName {
   SocketOptionName() = default;
-  SocketOptionName& operator=(const SocketOptionName&) = default;
   SocketOptionName(int level, int option, const std::string& name)
       : value_(std::make_tuple(level, option, name)) {}
 

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -35,7 +35,6 @@ template <typename Request> class AsyncStream /* : public RawAsyncStream */ {
 public:
   AsyncStream() = default;
   AsyncStream(RawAsyncStream* stream) : stream_(stream) {}
-  AsyncStream(const AsyncStream& other) = default;
   AsyncStream& operator=(const AsyncStream&) = default;
   void sendMessage(const Protobuf::Message& request, bool end_stream) {
     Internal::sendMessageUntyped(stream_, std::move(request), end_stream);

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -35,7 +35,6 @@ template <typename Request> class AsyncStream /* : public RawAsyncStream */ {
 public:
   AsyncStream() = default;
   AsyncStream(RawAsyncStream* stream) : stream_(stream) {}
-  AsyncStream& operator=(const AsyncStream&) = default;
   void sendMessage(const Protobuf::Message& request, bool end_stream) {
     Internal::sendMessageUntyped(stream_, std::move(request), end_stream);
   }


### PR DESCRIPTION
This PR fixes two compilation error that are happening in the oss-fuzz build of Envoy. Note that the latest oss-fuzz build errors out with only the [ error related to `AsyncStream`](https://oss-fuzz-build-logs.storage.googleapis.com/log-917e4a97-e528-4cce-b749-9187973dd9ed.txt) but AFAIR when it is fixed, a different compilation error has to be fixed which I fixed in the first commit that changes the socket.h file.
