### PR TITLE
bazel: use mac ninja on arm64

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -131,7 +131,7 @@ else
 fi
 
 # Select ninja tool for the current platform.
-if [[ $${PLATFORM} == "Darwin-x86_64" ]]; then
+if [[ $${SYSTEM} == "Darwin" ]]; then
   ninja=third_party/depot_tools/ninja-mac
 elif [[ $${PLATFORM} == "Linux-x86_64" ]]; then
   ninja=third_party/depot_tools/ninja-linux64


### PR DESCRIPTION
I don't know gn well enough to know how this is used, but it seems like
both macOS architectures should point to this.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>