### PR TITLE
bazel: disable lld on macOS

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -100,6 +100,11 @@ WEE8_BUILD_ARGS+=" v8_use_external_startup_data=false"
 # TODO(PiotrSikora): remove when fixed upstream.
 WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
 
+# Disable lld on Darwin since it's not vendored with Xcode
+if [[ $${SYSTEM} == Darwin ]]; then
+  WEE8_BUILD_ARGS+=" use_lld=false"
+fi
+
 # Set target architecture.
 if [[ $${ARCH} == "x86_64" ]]; then
   WEE8_BUILD_ARGS+=" target_cpu=\"x64\""


### PR DESCRIPTION
I'm not sure what changed here but it seems chromium attempts to use lld
on macOS even though it doesn't ship with Xcode. This could be
intentional on their part if they require folks to use an llvm toolchain
instead, but this likely isn't the right move for envoy unless we vendor
that toolchain ourselves. For now we can safely disable this.

https://github.com/envoyproxy/envoy/issues/16482#issuecomment-962372629

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
