### PR TITLE
remove unnecessary file level not unimplemented hide annotation

### DIFF
--- a/api/envoy/service/discovery/v2/ads.proto
+++ b/api/envoy/service/discovery/v2/ads.proto
@@ -14,7 +14,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Aggregated Discovery Service (ADS)]
 
-// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// Discovery services for endpoints, clusters, routes,
 // and listeners are retained in the package `envoy.api.v2` for backwards
 // compatibility with existing management servers. New development in discovery
 // services should proceed in the package `envoy.service.discovery.v2`.

--- a/api/envoy/service/discovery/v3/ads.proto
+++ b/api/envoy/service/discovery/v3/ads.proto
@@ -15,7 +15,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Aggregated Discovery Service (ADS)]
 
-// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// Discovery services for endpoints, clusters, routes,
 // and listeners are retained in the package `envoy.api.v2` for backwards
 // compatibility with existing management servers. New development in discovery
 // services should proceed in the package `envoy.service.discovery.v2`.

--- a/api/envoy/service/endpoint/v3/leds.proto
+++ b/api/envoy/service/endpoint/v3/leds.proto
@@ -13,6 +13,7 @@ option java_multiple_files = true;
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
+// [#not-implemented-hide:]
 // [#protodoc-title: LEDS]
 // Locality-Endpoint discovery
 // [#comment:TODO(adisuissa): Link to unified matching docs:

--- a/api/envoy/service/endpoint/v3/leds.proto
+++ b/api/envoy/service/endpoint/v3/leds.proto
@@ -13,7 +13,6 @@ option java_multiple_files = true;
 option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
-// [#not-implemented-hide:]
 // [#protodoc-title: LEDS]
 // Locality-Endpoint discovery
 // [#comment:TODO(adisuissa): Link to unified matching docs:


### PR DESCRIPTION
Commit Message: remove unnecessary file level 'not unimplemented hide' annotation
Additional Description:

Remove the unnecessary file level 'not-implemented-hide' annotation. I found these annotations during the development of PR #18923 . But it seems that they should not have this annotation.

If this is a misunderstanding on my part, please close this PR.

Risk Level: Doc Only.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
