### PR TITLE
cluster: correct ipv6 url for strict dns cluster and logical dns cluster

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -86,8 +86,11 @@ std::string hostFromUrl(const std::string& url, absl::string_view scheme,
       throw EnvoyException(absl::StrCat("malformed url: ", url));
     }
 
+    // Find the colon which splits the address and port. The colon should be
+    // after ':'.
     const size_t colon_index = url.find(':', bracket_end_index);
 
+    // Ensure there is colon for split the address and port.
     if (colon_index == std::string::npos) {
       throw EnvoyException(absl::StrCat("malformed url: ", url));
     }
@@ -113,13 +116,17 @@ uint32_t portFromUrl(const std::string& url, absl::string_view scheme,
     if ((bracket_end_index == std::string::npos) || (bracket_begin_index != scheme.size())) {
       throw EnvoyException(absl::StrCat("malformed url: ", url));
     }
+    // Find the colon which splits the address and port. The colon should be
+    // after ':'.
     colon_index = url.find(':', bracket_end_index);
   }
 
+  // Ensure there is colon for split the address and port.
   if (colon_index == std::string::npos) {
     throw EnvoyException(absl::StrCat("malformed url: ", url));
   }
 
+  // There should be only one colon after address
   const size_t rcolon_index = url.rfind(':');
   if (colon_index != rcolon_index) {
     throw EnvoyException(absl::StrCat("malformed url: ", url));

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -163,9 +163,9 @@ std::string Utility::formatTcpUrl(const std::string& address, uint16_t port) {
   // If the address is hostname, then address_instance could be `nullptr`.
   if ((address_instance != nullptr) &&
       (address_instance->ip()->version() == Address::IpVersion::v6)) {
-    return fmt::format("tcp://[{}]:{}", ip_address, port);
+    return fmt::format("tcp://[{}]:{}", address, port);
   } else {
-    return fmt::format("tcp://{}:{}", ip_address, port);
+    return fmt::format("tcp://{}:{}", address, port);
   }
 }
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -68,9 +68,12 @@ std::string hostFromUrl(const std::string& url, absl::string_view scheme,
 
   const size_t bracket_begin_index = url.find('[', scheme.size());
 
+  // If there is no '[', it means it is ipv4 address, otherwise it is ipv6 address.
   if (bracket_begin_index == std::string::npos) {
     const size_t colon_index = url.find(':', scheme.size());
 
+    // Ensure there is a colon between address and port. If colon is right behind
+    // scheme, it means there is no address.
     if ((colon_index == std::string::npos) || (colon_index == scheme.size())) {
       throw EnvoyException(absl::StrCat("malformed url: ", url));
     }
@@ -78,6 +81,7 @@ std::string hostFromUrl(const std::string& url, absl::string_view scheme,
     return url.substr(scheme.size(), colon_index - scheme.size());
   } else {
     const size_t bracket_end_index = url.find(']', scheme.size() + 1);
+    // Ensure there is ']', and '[' is right behind the scheme.
     if ((bracket_end_index == std::string::npos) || (bracket_begin_index != scheme.size())) {
       throw EnvoyException(absl::StrCat("malformed url: ", url));
     }
@@ -100,10 +104,12 @@ uint32_t portFromUrl(const std::string& url, absl::string_view scheme,
 
   const size_t bracket_begin_index = url.find('[', scheme.size());
   size_t colon_index = 0;
+  // If there is no '[', it means it is ipv4 address, otherwise it is ipv6 address.
   if (bracket_begin_index == std::string::npos) {
     colon_index = url.find(':', scheme.size());
   } else {
     const size_t bracket_end_index = url.find(']', scheme.size() + 1);
+    // Ensure there is ']', and '[' is right behind the scheme.
     if ((bracket_end_index == std::string::npos) || (bracket_begin_index != scheme.size())) {
       throw EnvoyException(absl::StrCat("malformed url: ", url));
     }
@@ -145,7 +151,7 @@ Api::IoCallUint64Result receiveMessage(uint64_t max_rx_datagram_size, Buffer::In
 
 } // namespace
 
-std::string Utility::getTcpUrl(const std::string& ip_address, uint16_t port) {
+std::string Utility::formatTcpUrl(const std::string& ip_address, uint16_t port) {
   auto address_instance = parseInternetAddressNoThrow(ip_address, port, false);
   if ((address_instance != nullptr) &&
       (address_instance->ip()->version() == Address::IpVersion::v6)) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -158,8 +158,9 @@ Api::IoCallUint64Result receiveMessage(uint64_t max_rx_datagram_size, Buffer::In
 
 } // namespace
 
-std::string Utility::formatTcpUrl(const std::string& ip_address, uint16_t port) {
-  auto address_instance = parseInternetAddressNoThrow(ip_address, port, false);
+std::string Utility::formatTcpUrl(const std::string& address, uint16_t port) {
+  auto address_instance = parseInternetAddressNoThrow(address, port, false);
+  // If the address is hostname, then address_instance could be `nullptr`.
   if ((address_instance != nullptr) &&
       (address_instance->ip()->version() == Address::IpVersion::v6)) {
     return fmt::format("tcp://[{}]:{}", ip_address, port);

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -122,6 +122,14 @@ public:
   static bool urlIsUnixScheme(absl::string_view url);
 
   /**
+   * Build a TCP URL
+   * @param ip_address as ip address include in URL
+   * @param port to included in URL.
+   * @return std::string the tcp URL
+   */
+  static std::string getTcpUrl(const std::string& ip_address, uint16_t port);
+
+  /**
    * Parses the host from a TCP URL
    * @param the URL to parse host from
    * @return std::string the parsed host

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -122,12 +122,12 @@ public:
   static bool urlIsUnixScheme(absl::string_view url);
 
   /**
-   * Build a TCP URL
+   * Format a TCP URL for IPv4 or IPv6
    * @param ip_address as ip address include in URL
    * @param port to included in URL.
    * @return std::string the tcp URL
    */
-  static std::string getTcpUrl(const std::string& ip_address, uint16_t port);
+  static std::string formatTcpUrl(const std::string& ip_address, uint16_t port);
 
   /**
    * Parses the host from a TCP URL

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -122,12 +122,12 @@ public:
   static bool urlIsUnixScheme(absl::string_view url);
 
   /**
-   * Format a TCP URL for IPv4 or IPv6
-   * @param ip_address as ip address include in URL
+   * Format a TCP URL for IPv4, IPv6 or hostname
+   * @param address as the address include in URL
    * @param port to included in URL.
    * @return std::string the tcp URL
    */
-  static std::string formatTcpUrl(const std::string& ip_address, uint16_t port);
+  static std::string formatTcpUrl(const std::string& address, uint16_t port);
 
   /**
    * Parses the host from a TCP URL

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -80,7 +80,7 @@ LogicalDnsCluster::LogicalDnsCluster(
     throw EnvoyException("LOGICAL_DNS clusters must NOT have a custom resolver name set");
   }
 
-  dns_url_ = Network::Utility::getTcpUrl(socket_address.address(), socket_address.port_value());
+  dns_url_ = Network::Utility::formatTcpUrl(socket_address.address(), socket_address.port_value());
   if (lbEndpoint().endpoint().hostname().empty()) {
     hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
   } else {

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -80,7 +80,7 @@ LogicalDnsCluster::LogicalDnsCluster(
     throw EnvoyException("LOGICAL_DNS clusters must NOT have a custom resolver name set");
   }
 
-  dns_url_ = fmt::format("tcp://{}:{}", socket_address.address(), socket_address.port_value());
+  dns_url_ = Network::Utility::getTcpUrl(socket_address.address(), socket_address.port_value());
   if (lbEndpoint().endpoint().hostname().empty()) {
     hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
   } else {

--- a/source/common/upstream/strict_dns_cluster.cc
+++ b/source/common/upstream/strict_dns_cluster.cc
@@ -5,6 +5,8 @@
 #include "envoy/config/endpoint/v3/endpoint.pb.h"
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
 
+#include "source/common/network/utility.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -36,7 +38,7 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(
       }
 
       const std::string& url =
-          fmt::format("tcp://{}:{}", socket_address.address(), socket_address.port_value());
+          Network::Utility::getTcpUrl(socket_address.address(), socket_address.port_value());
       resolve_targets.emplace_back(new ResolveTarget(*this, factory_context.mainThreadDispatcher(),
                                                      url, locality_lb_endpoint, lb_endpoint));
     }

--- a/source/common/upstream/strict_dns_cluster.cc
+++ b/source/common/upstream/strict_dns_cluster.cc
@@ -38,7 +38,7 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(
       }
 
       const std::string& url =
-          Network::Utility::getTcpUrl(socket_address.address(), socket_address.port_value());
+          Network::Utility::formatTcpUrl(socket_address.address(), socket_address.port_value());
       resolve_targets.emplace_back(new ResolveTarget(*this, factory_context.mainThreadDispatcher(),
                                                      url, locality_lb_endpoint, lb_endpoint));
     }

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -26,7 +26,13 @@ namespace Envoy {
 namespace Network {
 namespace {
 
-TEST(NetworkUtility, Url) {
+TEST(NetworkUtility, GetTcpUrl) {
+  EXPECT_EQ("tcp://foo:1234", Utility::getTcpUrl("foo", 1234));
+  EXPECT_EQ("tcp://1.2.3.4:1234", Utility::getTcpUrl("1.2.3.4", 1234));
+  EXPECT_EQ("tcp://[::1]:1234", Utility::getTcpUrl("::1", 1234));
+}
+
+TEST(NetworkUtility, UrlWithIpv4) {
   EXPECT_EQ("foo", Utility::hostFromTcpUrl("tcp://foo:1234"));
   EXPECT_EQ(1234U, Utility::portFromTcpUrl("tcp://foo:1234"));
   EXPECT_THROW(Utility::hostFromTcpUrl("bogus://foo:1234"), EnvoyException);
@@ -39,6 +45,25 @@ TEST(NetworkUtility, Url) {
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://https://foo:1234"), EnvoyException);
   EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:999999999999"), EnvoyException);
+}
+
+TEST(NetworkUtility, UrlWithIpv6) {
+  EXPECT_EQ("::1", Utility::hostFromTcpUrl("tcp://[::1]:1234"));
+  EXPECT_EQ(1234U, Utility::portFromTcpUrl("tcp://[::1]:1234"));
+  EXPECT_THROW(Utility::hostFromTcpUrl("bogus://[::1]:1234"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("bogus://[::1]:1234"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl("abc://[::1]"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("abc://[::1]"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl("tcp://[::1]"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://[::1]"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://[::1]:bar"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://https://[::1]:1234"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://[::1]:999999999999"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl("tcp://[::1:999999999999"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromTcpUrl("tcp://::1]:999999999999"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://[::1:999999999999"), EnvoyException);
+  EXPECT_THROW(Utility::portFromTcpUrl("tcp://::1]:999999999999"), EnvoyException);
 }
 
 TEST(NetworkUtility, udpUrl) {

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -26,10 +26,10 @@ namespace Envoy {
 namespace Network {
 namespace {
 
-TEST(NetworkUtility, GetTcpUrl) {
-  EXPECT_EQ("tcp://foo:1234", Utility::getTcpUrl("foo", 1234));
-  EXPECT_EQ("tcp://1.2.3.4:1234", Utility::getTcpUrl("1.2.3.4", 1234));
-  EXPECT_EQ("tcp://[::1]:1234", Utility::getTcpUrl("::1", 1234));
+TEST(NetworkUtility, FormatTcpUrl) {
+  EXPECT_EQ("tcp://foo:1234", Utility::formatTcpUrl("foo", 1234));
+  EXPECT_EQ("tcp://1.2.3.4:1234", Utility::formatTcpUrl("1.2.3.4", 1234));
+  EXPECT_EQ("tcp://[::1]:1234", Utility::formatTcpUrl("::1", 1234));
 }
 
 TEST(NetworkUtility, UrlWithIpv4) {


### PR DESCRIPTION
Commit Message: correct ipv6 url for strict dns cluster and logical dns cluster
Additional Description:
Strict DNS cluster and logical DNS cluster building a wrong URL with ipv6 address as `tcp://::1:5000`, it leads an exception raised from the cluster config parsing. The correct URL should be `tcp://[::1]:5000`.

Risk Level: low
Testing: unittest added
Docs Changes: n/a
Release Notes: n/a
Fixes #18606

Signed-off-by: He Jie Xu <hejie.xu@intel.com>