### PR TITLE
Fixing test failure issue in IPv6 only system

### DIFF
--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -1116,6 +1116,9 @@ TEST_P(DnsImplTest, PendingTimerEnable) {
   Event::MockDispatcher dispatcher;
   Event::MockTimer* timer = new NiceMock<Event::MockTimer>();
   EXPECT_CALL(dispatcher, createTimer_(_)).WillOnce(Return(timer));
+  if (GetParam() == Network::Address::IpVersion::v6) {
+    vec = {socket_->connectionInfoProvider().localAddress()};
+  }
   resolver_ = std::make_shared<DnsResolverImpl>(dispatcher, vec, dns_resolver_options_);
   Event::FileEvent* file_event = new NiceMock<Event::MockFileEvent>();
   EXPECT_CALL(dispatcher, createFileEvent_(_, _, _, _)).WillOnce(Return(file_event));


### PR DESCRIPTION
Fixing test failure issue in IPv6 only system due to empty resolver address list  causing c-ares library setup channel with IPv4 only parameters. This leads to socket() system call failure.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
