### PR TITLE
test: deflaking starttls test

### DIFF
--- a/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
@@ -258,7 +258,6 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromClient) {
 
   FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
-  ASSERT_THAT(test_server_->server().listenerManager().numConnections(), 1);
 
   Buffer::OwnedImpl buffer;
   buffer.add("hello");
@@ -326,7 +325,6 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromUpstream) {
 
   FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
-  ASSERT_THAT(test_server_->server().listenerManager().numConnections(), 1);
 
   Buffer::OwnedImpl buffer;
   buffer.add("hello");


### PR DESCRIPTION
I don't _think_ this test server assert adds value, and it's flaking horribly on CI today.
changes from failing 16:200 to passing 100%

Risk Level: n/a (test only)
Testing: yep
Docs Changes: n/a
Release Notes: n/a