### PR TITLE
stats(prometheus): escape problematic chars in text serialization

### DIFF
--- a/source/server/admin/prometheus_stats.cc
+++ b/source/server/admin/prometheus_stats.cc
@@ -16,6 +16,18 @@ const Regex::CompiledGoogleReMatcher& promRegex() {
   CONSTRUCT_ON_FIRST_USE(Regex::CompiledGoogleReMatcher, "[^a-zA-Z0-9_]", false);
 }
 
+const Regex::CompiledGoogleReMatcher& backslashRegex() {
+  CONSTRUCT_ON_FIRST_USE(Regex::CompiledGoogleReMatcher, R"(\\)", false);
+}
+
+const Regex::CompiledGoogleReMatcher& newlineRegex() {
+  CONSTRUCT_ON_FIRST_USE(Regex::CompiledGoogleReMatcher, "\n", false);
+}
+
+const Regex::CompiledGoogleReMatcher& quoteRegex() {
+  CONSTRUCT_ON_FIRST_USE(Regex::CompiledGoogleReMatcher, R"(")", false);
+}
+
 /**
  * Take a string and sanitize it according to Prometheus conventions.
  */
@@ -24,6 +36,20 @@ std::string sanitizeName(const absl::string_view name) {
   // prometheus. Refer to https://prometheus.io/docs/concepts/data_model/.
   // The initial [a-zA-Z_] constraint is always satisfied by the namespace prefix.
   return promRegex().replaceAll(name, "_");
+}
+
+/**
+ * Take tag values and sanitize it for text serialization, according to
+ * Prometheus conventions.
+ */
+std::string sanitizeValue(const absl::string_view value) {
+  // Removes problematic characters from Prometheus tag values to prevent
+  // text serialization issues. This matches the prometheus text formatting code:
+  // https://github.com/prometheus/common/blob/88f1636b699ae4fb949d292ffb904c205bf542c9/expfmt/text_create.go#L419-L420.
+  // The goal is to replace '\' with "\\", newline with "\n", and '"' with "\"".
+  auto tmp = backslashRegex().replaceAll(value, R"(\\\\)");
+  tmp = newlineRegex().replaceAll(tmp, R"(\\n)");
+  return quoteRegex().replaceAll(tmp, R"(\\")");
 }
 
 /*
@@ -188,7 +214,7 @@ std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag
   std::vector<std::string> buf;
   buf.reserve(tags.size());
   for (const Stats::Tag& tag : tags) {
-    buf.push_back(fmt::format("{}=\"{}\"", sanitizeName(tag.name_), tag.value_));
+    buf.push_back(fmt::format("{}=\"{}\"", sanitizeName(tag.name_), sanitizeValue(tag.value_)));
   }
   return absl::StrJoin(buf, ",");
 }

--- a/source/server/admin/prometheus_stats.cc
+++ b/source/server/admin/prometheus_stats.cc
@@ -47,7 +47,7 @@ std::string sanitizeValue(const absl::string_view value) {
   // text serialization issues. This matches the prometheus text formatting code:
   // https://github.com/prometheus/common/blob/88f1636b699ae4fb949d292ffb904c205bf542c9/expfmt/text_create.go#L419-L420.
   // The goal is to replace '\' with "\\", newline with "\n", and '"' with "\"".
-  auto tmp = backslashRegex().replaceAll(value, R"(\\\\)");
+  std::string tmp = backslashRegex().replaceAll(value, R"(\\\\)");
   tmp = newlineRegex().replaceAll(tmp, R"(\\n)");
   return quoteRegex().replaceAll(tmp, R"(\\")");
 }

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -148,9 +148,13 @@ TEST_F(PrometheusStatsFormatterTest, FormattedTags) {
   std::vector<Stats::Tag> tags;
   Stats::Tag tag1 = {"a.tag-name", "a.tag-value"};
   Stats::Tag tag2 = {"another_tag_name", "another_tag-value"};
+  Stats::Tag tag3 = {"replace_problematic", R"(val"ue with\ some
+ issues)"};
   tags.push_back(tag1);
   tags.push_back(tag2);
-  std::string expected = "a_tag_name=\"a.tag-value\",another_tag_name=\"another_tag-value\"";
+  tags.push_back(tag3);
+  std::string expected = "a_tag_name=\"a.tag-value\",another_tag_name=\"another_tag-value\","
+                         "replace_problematic=\"val\\\"ue with\\\\ some\\n issues\"";
   auto actual = PrometheusStatsFormatter::formattedTags(tags);
   EXPECT_EQ(expected, actual);
 }


### PR DESCRIPTION
Commit Message: stats(prometheus): escape problematic chars in text serialization
Additional Description:

This PR attempts to address https://github.com/envoyproxy/envoy/issues/18589 and https://github.com/istio/istio/issues/35575 by adding escaping logic to the prometheus stats code. An attempt was made to mirror the logic in the prometheus common golang code for text serialization.

Risk Level: Low
Testing: Unit
Fixes #18589

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>



