### PR TITLE
WIP: For #18979 connection: client connection set connected as immediate error

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -604,14 +604,7 @@ void ConnectionImpl::onReadReady() {
   const bool latched_dispatch_buffered_data = dispatch_buffered_data_;
   dispatch_buffered_data_ = false;
 
-  if (connecting_) {
-    // Client connection read event can be activated if the underlying io handle is user space.
-    // Note that read event can be activated when an OS io handle before connect attempt. However,
-    // it occurs only when the socket is closed and writeReady() early returns. See
-    // ConnectionImpl::onFileEvent().
-    ASSERT(ioHandle().localAddress()->envoyInternalAddress() != nullptr);
-    return;
-  }
+  ASSERT(!connecting_);
 
   // We get here while read disabled in two ways.
   // 1) There was a call to setTransportSocketIsReadable(), for example if a raw buffer socket ceded

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -166,7 +166,7 @@ protected:
   Buffer::InstancePtr read_buffer_;
   uint32_t read_buffer_limit_ = 0;
   bool connecting_{false};
-  ConnectionEvent immediate_error_event_{ConnectionEvent::Connected};
+  absl::optional<ConnectionEvent> immediate_error_event_;
   bool bind_error_{false};
   std::string failure_reason_;
 

--- a/test/integration/socket_interface_integration_test.cc
+++ b/test/integration/socket_interface_integration_test.cc
@@ -104,9 +104,7 @@ TEST_P(SocketInterfaceIntegrationTest, InternalAddressWithSocketInterface) {
   ASSERT_DEATH(client_ = dispatcher_->createClientConnection(
                    address, Network::Address::InstanceConstSharedPtr(),
                    Network::Test::createRawBufferSocket(), nullptr),
-               // Attempted to dereference a nullptr client connection factory because the internal
-               // connection factory is not linked.
-               ".*");
+               "panic: not implemented");
 }
 
 // Test that recv from internal address will crash.

--- a/test/integration/socket_interface_integration_test.cc
+++ b/test/integration/socket_interface_integration_test.cc
@@ -104,7 +104,9 @@ TEST_P(SocketInterfaceIntegrationTest, InternalAddressWithSocketInterface) {
   ASSERT_DEATH(client_ = dispatcher_->createClientConnection(
                    address, Network::Address::InstanceConstSharedPtr(),
                    Network::Test::createRawBufferSocket(), nullptr),
-               "panic: not implemented");
+               // Attempted to dereference a nullptr client connection factory because the internal
+               // connection factory is not linked.
+               ".*");
 }
 
 // Test that recv from internal address will crash.


### PR DESCRIPTION
only after connect() is called.

This allow Write/Read event activated at no harm.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
