### PR TITLE
Fix test-only Http2Frame: host -> :authority.

### DIFF
--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -316,7 +316,7 @@ Http2Frame Http2Frame::makeMalformedRequestWithZerolenHeader(uint32_t stream_ind
   frame.appendStaticHeader(StaticHeaderIndex::MethodGet);
   frame.appendStaticHeader(StaticHeaderIndex::SchemeHttps);
   frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Path, path);
-  frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Host, host);
+  frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Authority, host);
   frame.appendEmptyHeader();
   frame.adjustPayloadSize();
   return frame;
@@ -340,7 +340,7 @@ Http2Frame Http2Frame::makeRequest(uint32_t stream_index, absl::string_view host
   frame.appendStaticHeader(StaticHeaderIndex::MethodGet);
   frame.appendStaticHeader(StaticHeaderIndex::SchemeHttps);
   frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Path, path);
-  frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Host, host);
+  frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Authority, host);
   frame.adjustPayloadSize();
   return frame;
 }
@@ -364,7 +364,7 @@ Http2Frame Http2Frame::makePostRequest(uint32_t stream_index, absl::string_view 
   frame.appendStaticHeader(StaticHeaderIndex::MethodPost);
   frame.appendStaticHeader(StaticHeaderIndex::SchemeHttps);
   frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Path, path);
-  frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Host, host);
+  frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Authority, host);
   frame.adjustPayloadSize();
   return frame;
 }

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -78,6 +78,7 @@ public:
   // See https://tools.ietf.org/html/rfc7541#appendix-A for static header indexes
   enum class StaticHeaderIndex : uint8_t {
     Unknown,
+    Authority = 1,
     MethodGet = 2,
     MethodPost = 3,
     Path = 4,
@@ -89,7 +90,6 @@ public:
     Status404 = 13,
     Status500 = 14,
     SchemeHttps = 7,
-    Host = 38,
   };
 
   enum class ErrorCode : uint8_t {


### PR DESCRIPTION
Signed-off-by: Dianna Hu <diannahu@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix test-only Http2Frame to send the ":authority" pseudoheader instead of "host" for requests.
Additional Description: This change enables tests using Http2Frame to comply with the "SHOULD" suggestion of the HTTP/2 specification: https://httpwg.org/specs/rfc7540.html#HttpRequest.
Risk Level: Low
Testing: //test/integration:http2_flood_integration_test //test/integration:h2_capture_fuzz_test //test/integration:h2_capture_persistent_fuzz_test //test/integration:h2_capture_direct_response_fuzz_test //test/integration:h2_capture_direct_response_persistent_fuzz_test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
