### PR TITLE
grpc: implement TTL manager to re-buffer pending messages for bidirectional gRPC

### DIFF
--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -211,6 +211,7 @@ envoy_cc_library(
     name = "buffered_async_client_lib",
     hdrs = ["buffered_async_client.h"],
     deps = [
+        ":buffered_message_ttl_manager_lib",
         ":typed_async_client_lib",
         "//source/common/protobuf:utility_lib",
         "@com_google_absl//absl/container:btree",
@@ -221,7 +222,6 @@ envoy_cc_library(
     name = "buffered_message_ttl_manager_lib",
     hdrs = ["buffered_message_ttl_manager.h"],
     deps = [
-        ":buffered_async_client_lib",
         "//envoy/event:dispatcher_interface",
     ],
 )

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -213,6 +213,7 @@ envoy_cc_library(
     deps = [
         ":typed_async_client_lib",
         "//source/common/protobuf:utility_lib",
+        "@com_google_absl//absl/container:btree",
     ],
 )
 

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -215,3 +215,12 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
     ],
 )
+
+envoy_cc_library(
+    name = "buffered_message_ttl_manager_lib",
+    hdrs = ["buffered_message_ttl_manager.h"],
+    deps = [
+        ":buffered_async_client_lib",
+        "//envoy/event:dispatcher_interface",
+    ],
+)

--- a/source/common/grpc/buffered_async_client.h
+++ b/source/common/grpc/buffered_async_client.h
@@ -27,7 +27,7 @@ public:
       : max_buffer_bytes_(max_buffer_bytes), service_method_(service_method), callbacks_(callbacks),
         client_(client),
         ttl_manager_(
-            dispatcher, [this](uint64_t id) { this->onError(id); }, message_timeout_msec) {}
+            dispatcher, [this](uint64_t id) { onError(id); }, message_timeout_msec) {}
 
   ~BufferedAsyncClient() {
     if (active_stream_ != nullptr) {

--- a/source/common/grpc/buffered_message_ttl_manager.h
+++ b/source/common/grpc/buffered_message_ttl_manager.h
@@ -9,17 +9,15 @@ namespace Grpc {
 
 using BufferedMessageExpirationCallback = std::function<void(uint64_t)>;
 
-// This class is used to manage the lifetime of messages stored in BufferedAsyncClient. Messages
-// whose survival period has expired will be deleted from the Buffer.
-// We can set the ID you want to monitor TTL in the TTL Manager,
-// which will set up a callback to check for expiration.
-// You can set the ID even after the callback has been invoked.
-// When the callback is invoked, the callback given to the constructor will be
-// executed with the TTL-elapsed ID as an argument.
-// After that, if the ID to be monitored is not empty, the callback for expiration check will be set
-// again. The TTL Manager can be given a set of IDs that are expected to expire at the same time.
-// When checking for ID expiration, an expiration callback will be called for each ID
-// belonging to this set of IDs.
+// The TTL Manager can be given a set of IDs that are expected to expire at the same time.
+// When checking for ID expiration, an expiration callback will be called for each ID belonging to
+// this set of IDs. This class is used to manage the lifetime of messages stored in
+// BufferedAsyncClient. Messages whose survival period has expired will be deleted from the Buffer.
+// It allows monitoring a set of IDs for expiration, triggering a callback upon expiration.
+// This class is able to monitor multiple sets of IDs at the same time, even after some of them have
+// expired. When the callback is invoked, the callback given to the constructor will be will be
+// executed for each of the TTL-elapsed IDs. After that, if the IDs to be monitored is not empty,
+// the manager will continue to monitor for expiration again.
 class BufferedMessageTtlManager {
 public:
   BufferedMessageTtlManager(Event::Dispatcher& dispatcher,

--- a/source/common/grpc/buffered_message_ttl_manager.h
+++ b/source/common/grpc/buffered_message_ttl_manager.h
@@ -11,6 +11,15 @@ using BufferedMessageExpirationCallback = std::function<void(uint64_t)>;
 
 // This class is used to manage the lifetime of messages stored in BufferedAsyncClient. Messages
 // whose survival period has expired will be deleted from the Buffer.
+// We can set the ID you want to monitor TTL in the TTL Manager,
+// which will set up a callback to check for expiration.
+// You can set the ID even after the callback has been invoked.
+// When the callback is invoked, the callback given to the constructor will be
+// executed with the TTL-elapsed ID as an argument.
+// After that, if the ID to be monitored is not empty, the callback for expiration check will be set
+// again. The TTL Manager can be given a set of IDs that are expected to expire at the same time.
+// When checking for ID expiration, an expiration callback will be called for each ID
+// belonging to this set of IDs.
 class BufferedMessageTtlManager {
 public:
   BufferedMessageTtlManager(Event::Dispatcher& dispatcher,

--- a/source/common/grpc/buffered_message_ttl_manager.h
+++ b/source/common/grpc/buffered_message_ttl_manager.h
@@ -25,6 +25,10 @@ public:
     }
   }
 
+  const std::map<MonotonicTime, absl::flat_hash_set<uint64_t>, std::greater<>>& deadline() {
+    return deadline_;
+  }
+
 private:
   void checkMessages() {
     const auto now = dispatcher_.timeSource().monotonicTime();

--- a/source/common/grpc/buffered_message_ttl_manager.h
+++ b/source/common/grpc/buffered_message_ttl_manager.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+
+#include "source/common/grpc/buffered_async_client.h"
+
+namespace Envoy {
+namespace Grpc {
+
+class BufferedMessageTtlManager {
+public:
+  BufferedMessageTtlManager(Event::Dispatcher& dispatcher, BufferedAsyncClientCallbacks& callbacks,
+                            std::chrono::milliseconds message_ack_timeout)
+      : dispatcher_(dispatcher), message_ack_timeout_(message_ack_timeout), callbacks_(callbacks),
+        timer_(dispatcher_.createTimer([this] { checkMessages(); })) {}
+
+  ~BufferedMessageTtlManager() { timer_->disableTimer(); }
+
+  void setDeadline(absl::flat_hash_set<uint64_t>&& ids) {
+    const auto expires_at = dispatcher_.timeSource().monotonicTime() + message_ack_timeout_;
+    deadline_.emplace(expires_at, std::move(ids));
+
+    if (!timer_->enabled()) {
+      timer_->enableTimer(message_ack_timeout_);
+    }
+  }
+
+private:
+  void checkMessages() {
+    const auto now = dispatcher_.timeSource().monotonicTime();
+
+    auto begin_it = deadline_.lower_bound(now);
+
+    for (auto it = begin_it; it != deadline_.end(); ++it) {
+      for (auto&& id : it->second) {
+        // If the retrieved message is a PendingFlush, it means that the message
+        // has timed out. A timeout is treated as an error, and the callback will
+        // re-buffer the message.
+        callbacks_.onError(id);
+      }
+    }
+
+    deadline_.erase(begin_it, deadline_.end());
+
+    if (!deadline_.empty()) {
+      const auto earliest_timepoint = deadline_.rbegin()->first;
+      timer_->enableTimer(
+          std::chrono::duration_cast<std::chrono::milliseconds>(earliest_timepoint - now));
+    }
+  }
+
+  Event::Dispatcher& dispatcher_;
+  std::chrono::milliseconds message_ack_timeout_;
+  BufferedAsyncClientCallbacks& callbacks_;
+  Event::TimerPtr timer_;
+  std::map<MonotonicTime, absl::flat_hash_set<uint64_t>, std::greater<>> deadline_;
+};
+} // namespace Grpc
+} // namespace Envoy

--- a/source/common/grpc/buffered_message_ttl_manager.h
+++ b/source/common/grpc/buffered_message_ttl_manager.h
@@ -14,7 +14,7 @@ public:
   BufferedMessageTtlManager(Event::Dispatcher& dispatcher, BufferedAsyncClientCallbacks& callbacks,
                             std::chrono::milliseconds message_ack_timeout)
       : dispatcher_(dispatcher), message_ack_timeout_(message_ack_timeout), callbacks_(callbacks),
-        timer_(dispatcher_.createTimer([this] { checkMessages(); })) {}
+        timer_(dispatcher_.createTimer([this] { checkExpiredMessages(); })) {}
 
   ~BufferedMessageTtlManager() { timer_->disableTimer(); }
 
@@ -32,7 +32,7 @@ public:
   }
 
 private:
-  void checkMessages() {
+  void checkExpiredMessages() {
     const auto now = dispatcher_.timeSource().monotonicTime();
 
     while (!deadline_.empty()) {

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -207,7 +207,8 @@ envoy_cc_test(
     name = "buffered_message_ttl_manager_test",
     srcs = ["buffered_message_ttl_manager_test.cc"],
     deps = [
+        "//source/common/event:dispatcher_lib",
         "//source/common/grpc:buffered_message_ttl_manager_lib",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -202,3 +202,12 @@ envoy_cc_test(
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
+
+envoy_cc_test(
+    name = "buffered_message_ttl_manager_test",
+    srcs = ["buffered_message_ttl_manager_test.cc"],
+    deps = [
+        "//source/common/grpc:buffered_message_ttl_manager_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)

--- a/test/common/grpc/buffered_async_client_test.cc
+++ b/test/common/grpc/buffered_async_client_test.cc
@@ -1,3 +1,7 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
 #include "envoy/config/core/v3/grpc_service.pb.h"
 
 #include "source/common/grpc/async_client_impl.h"
@@ -23,117 +27,145 @@ namespace Envoy {
 namespace Grpc {
 namespace {
 
+constexpr uint32_t kPendingBufferSizeLimit = 1 << 16;
+
 class BufferedAsyncClientTest : public testing::Test {
 public:
   BufferedAsyncClientTest()
-      : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")) {
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")),
+        method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")) {
     config_.mutable_envoy_grpc()->set_cluster_name("test_cluster");
 
     cm_.initializeThreadLocalClusters({"test_cluster"});
     ON_CALL(cm_.thread_local_cluster_, httpAsyncClient()).WillByDefault(ReturnRef(http_client_));
   }
 
+  void SetUp() override {
+    EXPECT_CALL(http_client_, start(_, _)).WillOnce(Return(&http_stream_));
+    EXPECT_CALL(http_stream_, sendHeaders(_, _));
+    EXPECT_CALL(http_stream_, reset());
+
+    raw_client_ = std::make_shared<AsyncClientImpl>(cm_, config_, test_time_.timeSystem());
+    client_ = std::make_unique<AsyncClient<helloworld::HelloRequest, helloworld::HelloReply>>(
+        raw_client_);
+  }
+
+  void prepareBufferedClient(uint32_t buffer_size, std::chrono::milliseconds ttl) {
+    buffered_client_ =
+        std::make_unique<BufferedAsyncClient<helloworld::HelloRequest, helloworld::HelloReply>>(
+            buffer_size, *method_descriptor_, callback_, *client_, *dispatcher_, ttl);
+  }
+
+  void bufferNewMessage(absl::optional<uint32_t> expected_message_id) {
+    helloworld::HelloRequest request;
+    request.set_name("Alice");
+    EXPECT_EQ(expected_message_id, buffered_client_->bufferMessage(request));
+  }
+
+  void validateBuffer(uint32_t expected_buffered_count, uint32_t expected_pending_count) {
+    const auto buffer = buffered_client_->messageBuffer();
+    uint32_t buffered_count = 0;
+    uint32_t pending_count = 0;
+
+    for (const auto& message : buffer) {
+      switch (message.second.first) {
+      case BufferState::Buffered:
+        ++buffered_count;
+        break;
+      case BufferState::PendingFlush:
+        ++pending_count;
+        break;
+      default:
+        break;
+      }
+    }
+
+    EXPECT_EQ(buffered_count, expected_buffered_count);
+    EXPECT_EQ(pending_count, expected_pending_count);
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
   const Protobuf::MethodDescriptor* method_descriptor_;
   envoy::config::core::v3::GrpcService config_;
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<Http::MockAsyncClient> http_client_;
+  Http::MockAsyncClientStream http_stream_;
+  DangerousDeprecatedTestTime test_time_;
+  std::shared_ptr<AsyncClientImpl> raw_client_;
+  std::unique_ptr<AsyncClient<helloworld::HelloRequest, helloworld::HelloReply>> client_;
+  NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> callback_;
+  std::unique_ptr<BufferedAsyncClient<helloworld::HelloRequest, helloworld::HelloReply>>
+      buffered_client_;
 };
 
 TEST_F(BufferedAsyncClientTest, BasicSendFlow) {
-  Http::MockAsyncClientStream http_stream;
-  EXPECT_CALL(http_client_, start(_, _)).WillOnce(Return(&http_stream));
-  EXPECT_CALL(http_stream, sendHeaders(_, _));
-  EXPECT_CALL(http_stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-  EXPECT_CALL(http_stream, sendData(_, _));
-  EXPECT_CALL(http_stream, reset());
+  EXPECT_CALL(http_stream_, sendData(_, _));
+  EXPECT_CALL(http_stream_, isAboveWriteBufferHighWatermark()).WillRepeatedly(Return(false));
 
-  DangerousDeprecatedTestTime test_time_;
-  auto raw_client = std::make_shared<AsyncClientImpl>(cm_, config_, test_time_.timeSystem());
-  AsyncClient<helloworld::HelloRequest, helloworld::HelloReply> client(raw_client);
+  prepareBufferedClient(kPendingBufferSizeLimit, std::chrono::milliseconds(1000));
+  bufferNewMessage(0);
+  validateBuffer(1, 0);
 
-  NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> callback;
-  BufferedAsyncClient<helloworld::HelloRequest, helloworld::HelloReply> buffered_client(
-      100000, *method_descriptor_, callback, client);
-
-  helloworld::HelloRequest request;
-  request.set_name("Alice");
-  EXPECT_EQ(0, buffered_client.bufferMessage(request).value());
-  const auto inflight_message_ids = buffered_client.sendBufferedMessages();
-  EXPECT_TRUE(buffered_client.hasActiveStream());
-  EXPECT_EQ(1, inflight_message_ids.size());
+  EXPECT_EQ(1, buffered_client_->sendBufferedMessages().size());
+  EXPECT_TRUE(buffered_client_->hasActiveStream());
+  validateBuffer(0, 1);
 
   // Pending messages should not be re-sent.
-  EXPECT_CALL(http_stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-  const auto inflight_message_ids2 = buffered_client.sendBufferedMessages();
-  EXPECT_EQ(0, inflight_message_ids2.size());
+  EXPECT_EQ(0, buffered_client_->sendBufferedMessages().size());
+  validateBuffer(0, 1);
 
-  // Re-buffer, and transport.
-  buffered_client.onError(*inflight_message_ids.begin());
+  // It will call onError().
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+  validateBuffer(1, 0);
 
-  EXPECT_CALL(http_stream, sendData(_, _)).Times(2);
-  EXPECT_CALL(http_stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
+  // If we call onSuccess(), after onError() called,
+  // onSuccess() do not affect to the buffer.
+  buffered_client_->onSuccess(0);
+  validateBuffer(1, 0);
 
-  helloworld::HelloRequest request2;
-  request2.set_name("Bob");
-  EXPECT_EQ(1, buffered_client.bufferMessage(request2).value());
-  auto ids2 = buffered_client.sendBufferedMessages();
-  EXPECT_EQ(2, ids2.size());
+  EXPECT_CALL(http_stream_, sendData(_, _)).Times(2);
+  bufferNewMessage(1);
+  validateBuffer(2, 0);
+
+  const auto inflight_message_ids = buffered_client_->sendBufferedMessages();
+  EXPECT_EQ(2, inflight_message_ids.size());
+  validateBuffer(0, 2);
 
   // Clear existing messages.
-  for (auto&& id : ids2) {
-    buffered_client.onSuccess(id);
+  for (auto&& id : inflight_message_ids) {
+    buffered_client_->onSuccess(id);
   }
+  validateBuffer(0, 0);
+
+  // It will call onError().
+  // But messages have been already cleared.
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+  validateBuffer(0, 0);
 
   // Successfully cleared pending messages.
-  EXPECT_CALL(http_stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-  auto ids3 = buffered_client.sendBufferedMessages();
-  EXPECT_EQ(0, ids3.size());
+  EXPECT_EQ(0, buffered_client_->sendBufferedMessages().size());
+  validateBuffer(0, 0);
 }
 
 TEST_F(BufferedAsyncClientTest, BufferLimitExceeded) {
-  Http::MockAsyncClientStream http_stream;
-  EXPECT_CALL(http_client_, start(_, _)).WillOnce(Return(&http_stream));
-  EXPECT_CALL(http_stream, sendHeaders(_, _));
-  EXPECT_CALL(http_stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-  EXPECT_CALL(http_stream, reset());
+  EXPECT_CALL(http_stream_, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
 
-  DangerousDeprecatedTestTime test_time_;
-  auto raw_client = std::make_shared<AsyncClientImpl>(cm_, config_, test_time_.timeSystem());
-  AsyncClient<helloworld::HelloRequest, helloworld::HelloReply> client(raw_client);
+  prepareBufferedClient(0, std::chrono::milliseconds(1000));
+  bufferNewMessage(absl::nullopt);
 
-  NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> callback;
-  BufferedAsyncClient<helloworld::HelloRequest, helloworld::HelloReply> buffered_client(
-      0, *method_descriptor_, callback, client);
-
-  helloworld::HelloRequest request;
-  request.set_name("Alice");
-  EXPECT_EQ(absl::nullopt, buffered_client.bufferMessage(request));
-
-  EXPECT_EQ(0, buffered_client.sendBufferedMessages().size());
-  EXPECT_TRUE(buffered_client.hasActiveStream());
+  EXPECT_EQ(0, buffered_client_->sendBufferedMessages().size());
+  EXPECT_TRUE(buffered_client_->hasActiveStream());
 }
 
 TEST_F(BufferedAsyncClientTest, BufferHighWatermarkTest) {
-  Http::MockAsyncClientStream http_stream;
-  EXPECT_CALL(http_client_, start(_, _)).WillOnce(Return(&http_stream));
-  EXPECT_CALL(http_stream, sendHeaders(_, _));
-  EXPECT_CALL(http_stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(true));
-  EXPECT_CALL(http_stream, reset());
+  EXPECT_CALL(http_stream_, isAboveWriteBufferHighWatermark()).WillOnce(Return(true));
 
-  DangerousDeprecatedTestTime test_time_;
-  auto raw_client = std::make_shared<AsyncClientImpl>(cm_, config_, test_time_.timeSystem());
-  AsyncClient<helloworld::HelloRequest, helloworld::HelloReply> client(raw_client);
+  prepareBufferedClient(kPendingBufferSizeLimit, std::chrono::milliseconds(1000));
+  bufferNewMessage(0);
 
-  NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> callback;
-  BufferedAsyncClient<helloworld::HelloRequest, helloworld::HelloReply> buffered_client(
-      100000, *method_descriptor_, callback, client);
-
-  helloworld::HelloRequest request;
-  request.set_name("Alice");
-  EXPECT_EQ(0, buffered_client.bufferMessage(request).value());
-
-  EXPECT_EQ(0, buffered_client.sendBufferedMessages().size());
-  EXPECT_TRUE(buffered_client.hasActiveStream());
+  EXPECT_EQ(0, buffered_client_->sendBufferedMessages().size());
+  EXPECT_TRUE(buffered_client_->hasActiveStream());
 }
 
 } // namespace

--- a/test/common/grpc/buffered_async_client_test.cc
+++ b/test/common/grpc/buffered_async_client_test.cc
@@ -45,7 +45,7 @@ public:
     EXPECT_CALL(http_stream_, sendHeaders(_, _));
     EXPECT_CALL(http_stream_, reset());
 
-    raw_client_ = std::make_shared<AsyncClientImpl>(cm_, config_, test_time_.timeSystem());
+    raw_client_ = std::make_shared<AsyncClientImpl>(cm_, config_, dispatcher_->timeSource());
     client_ = std::make_unique<AsyncClient<helloworld::HelloRequest, helloworld::HelloReply>>(
         raw_client_);
   }
@@ -91,7 +91,6 @@ public:
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<Http::MockAsyncClient> http_client_;
   Http::MockAsyncClientStream http_stream_;
-  DangerousDeprecatedTestTime test_time_;
   std::shared_ptr<AsyncClientImpl> raw_client_;
   std::unique_ptr<AsyncClient<helloworld::HelloRequest, helloworld::HelloReply>> client_;
   NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> callback_;

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -26,7 +26,9 @@ public:
   uint32_t callback_called_counter_ = 0;
 };
 
-TEST_F(BufferedMessageTtlManagerTest, Basic) {
+// In this test, we will test the basic TTL Manager behavior,
+// making sure that the buffers for identity management are in the proper state after deadline.
+TEST_F(BufferedMessageTtlManagerTest, BasicFlow) {
   absl::flat_hash_set<uint64_t> ids{0};
   ttl_manager_ = std::make_shared<BufferedMessageTtlManager>(
       *dispatcher_,
@@ -51,9 +53,10 @@ TEST_F(BufferedMessageTtlManagerTest, Basic) {
   ttl_manager_->addDeadlineEntry(std::move(ids));
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_EQ(ttl_manager_->deadlineForTest().size(), 0);
 
   // Test if deadline queue is empty after queue cleared once.
+  EXPECT_EQ(ttl_manager_->deadlineForTest().size(), 0);
+
   absl::flat_hash_set<uint64_t> ids2{3};
   ttl_manager_->addDeadlineEntry(std::move(ids2));
   dispatcher_->run(Event::Dispatcher::RunType::Block);

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -14,9 +14,6 @@ namespace Envoy {
 namespace Grpc {
 namespace {
 
-using testing::Invoke;
-using testing::NiceMock;
-
 class BufferedMessageTtlManagerTest : public testing::Test {
 public:
   BufferedMessageTtlManagerTest()

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -41,25 +41,25 @@ public:
 TEST_F(BufferedMessageTtlManagerTest, Basic) {
   absl::flat_hash_set<uint64_t> ids{0};
   EXPECT_CALL(callbacks_, onError(_)).WillOnce(Invoke([this] {
-    EXPECT_EQ(ttl_manager_->deadline().size(), 1);
+    EXPECT_EQ(ttl_manager_->deadlineForTest().size(), 1);
     absl::flat_hash_set<uint64_t> ids{1, 2};
     EXPECT_CALL(callbacks_, onError(_)).Times(2);
-    ttl_manager_->setDeadline(std::move(ids));
+    ttl_manager_->addDeadlineEntry(std::move(ids));
   }));
-  ttl_manager_->setDeadline(std::move(ids));
+  ttl_manager_->addDeadlineEntry(std::move(ids));
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_EQ(ttl_manager_->deadline().size(), 0);
+  EXPECT_EQ(ttl_manager_->deadlineForTest().size(), 0);
 
   // Test if deadline queue is empty after queue cleared once.
   absl::flat_hash_set<uint64_t> ids2{3};
   EXPECT_CALL(callbacks_, onError(_)).WillOnce(Invoke([this] {
-    EXPECT_EQ(ttl_manager_->deadline().size(), 1);
+    EXPECT_EQ(ttl_manager_->deadlineForTest().size(), 1);
   }));
-  ttl_manager_->setDeadline(std::move(ids2));
+  ttl_manager_->addDeadlineEntry(std::move(ids2));
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  EXPECT_EQ(ttl_manager_->deadline().size(), 0);
+  EXPECT_EQ(ttl_manager_->deadlineForTest().size(), 0);
 }
 
 } // namespace

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -19,6 +19,7 @@ public:
   MOCK_METHOD(void, onError, (uint64_t), ());
 };
 
+using testing::Invoke;
 using testing::NiceMock;
 
 class BufferedMessageTtlManagerTest : public testing::Test {
@@ -27,21 +28,28 @@ public:
       : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   void SetUp() override {
-    ttl_manager_ = std::make_shared<BufferedMessageTtlManager>(*dispatcher_, callbacks_,
-                                                               std::chrono::milliseconds(1000));
+    ttl_manager_ = std::make_shared<BufferedMessageTtlManager>(*dispatcher_, callbacks_, msec_);
   }
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
   std::shared_ptr<BufferedMessageTtlManager> ttl_manager_;
   NiceMock<MockBufferedAsyncClientCallbacks> callbacks_;
+  std::chrono::milliseconds msec_{1000};
 };
 
 TEST_F(BufferedMessageTtlManagerTest, Basic) {
-  absl::flat_hash_set<uint64_t> ids{0, 1, 2};
-  EXPECT_CALL(callbacks_, onError(_)).Times(3);
+  absl::flat_hash_set<uint64_t> ids{0};
+  EXPECT_CALL(callbacks_, onError(_)).WillOnce(Invoke([this] {
+    EXPECT_EQ(ttl_manager_->deadline().size(), 1);
+    absl::flat_hash_set<uint64_t> ids{1, 2};
+    EXPECT_CALL(callbacks_, onError(_)).Times(2);
+    ttl_manager_->setDeadline(std::move(ids));
+  }));
   ttl_manager_->setDeadline(std::move(ids));
+
   dispatcher_->run(Event::Dispatcher::RunType::Block);
+  EXPECT_EQ(ttl_manager_->deadline().size(), 0);
 }
 
 } // namespace

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -1,0 +1,12 @@
+#include "envoy/config/core/v3/grpc_service.pb.h"
+
+#include "source/common/grpc/buffered_message_ttl_manager.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Grpc {
+namespace {}
+} // namespace Grpc
+} // namespace Envoy

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -1,12 +1,49 @@
-#include "envoy/config/core/v3/grpc_service.pb.h"
+#include <chrono>
+#include <memory>
 
+#include "source/common/event/dispatcher_impl.h"
 #include "source/common/grpc/buffered_message_ttl_manager.h"
+
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
 namespace Grpc {
-namespace {}
+namespace {
+
+class MockBufferedAsyncClientCallbacks : public BufferedAsyncClientCallbacks {
+public:
+  MOCK_METHOD(void, onSuccess, (uint64_t), ());
+  MOCK_METHOD(void, onError, (uint64_t), ());
+};
+
+using testing::NiceMock;
+
+class BufferedMessageTtlManagerTest : public testing::Test {
+public:
+  BufferedMessageTtlManagerTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
+
+  void SetUp() override {
+    ttl_manager_ = std::make_shared<BufferedMessageTtlManager>(*dispatcher_, callbacks_,
+                                                               std::chrono::milliseconds(1000));
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  std::shared_ptr<BufferedMessageTtlManager> ttl_manager_;
+  NiceMock<MockBufferedAsyncClientCallbacks> callbacks_;
+};
+
+TEST_F(BufferedMessageTtlManagerTest, Basic) {
+  absl::flat_hash_set<uint64_t> ids{0, 1, 2};
+  EXPECT_CALL(callbacks_, onError(_)).Times(3);
+  ttl_manager_->setDeadline(std::move(ids));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+}
+
+} // namespace
 } // namespace Grpc
 } // namespace Envoy

--- a/test/common/grpc/buffered_message_ttl_manager_test.cc
+++ b/test/common/grpc/buffered_message_ttl_manager_test.cc
@@ -50,6 +50,16 @@ TEST_F(BufferedMessageTtlManagerTest, Basic) {
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   EXPECT_EQ(ttl_manager_->deadline().size(), 0);
+
+  // Test if deadline queue is empty after queue cleared once.
+  absl::flat_hash_set<uint64_t> ids2{3};
+  EXPECT_CALL(callbacks_, onError(_)).WillOnce(Invoke([this] {
+    EXPECT_EQ(ttl_manager_->deadline().size(), 1);
+  }));
+  ttl_manager_->setDeadline(std::move(ids2));
+
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+  EXPECT_EQ(ttl_manager_->deadline().size(), 0);
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: grpc: implement TTL manager to re-buffer pending messages for bidirectional gRPC 
Additional Description: Related with #17486. This PR provides the TTL manager for buffered bidirectional gRPC messages.
Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
