### PR TITLE
lua: support body setBytes with header content length set automatically

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -248,8 +248,7 @@ There are two ways of doing this, the first one is via the ``body()`` API.
 .. code-block:: lua
 
     function envoy_on_response(response_handle)
-      local content_length = response_handle:body():setBytes("<html><b>Not Found<b></html>")
-      response_handle:headers():replace("content-length", content_length)
+      response_handle:body():setBytes("<html><b>Not Found<b></html>")
       response_handle:headers():replace("content-type", "text/html")
     end
 
@@ -260,8 +259,7 @@ Or, through ``bodyChunks()`` API, which let Envoy to skip buffering the upstream
 
     function envoy_on_response(response_handle)
 
-      -- Sets the content-length.
-      response_handle:headers():replace("content-length", 28)
+      -- Sets the content-type.
       response_handle:headers():replace("content-type", "text/html")
 
       local last

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -68,6 +68,7 @@ int BufferWrapper::luaSetBytes(lua_State* state) {
   data_.drain(data_.length());
   absl::string_view bytes = getStringViewFromLuaString(state, 2);
   data_.add(bytes);
+  headers_.setContentLength(data_.length());
   lua_pushnumber(state, data_.length());
   return 1;
 }

--- a/source/extensions/filters/common/lua/wrappers.h
+++ b/source/extensions/filters/common/lua/wrappers.h
@@ -16,7 +16,8 @@ namespace Lua {
  */
 class BufferWrapper : public BaseLuaObject<BufferWrapper> {
 public:
-  BufferWrapper(Buffer::Instance& data) : data_(data) {}
+  BufferWrapper(Http::RequestOrResponseHeaderMap& headers, Buffer::Instance& data)
+      : data_(data), headers_(headers) {}
 
   static ExportedFunctions exportedFunctions() {
     return {{"length", static_luaLength},
@@ -46,6 +47,7 @@ private:
   DECLARE_LUA_FUNCTION(BufferWrapper, luaSetBytes);
 
   Buffer::Instance& data_;
+  Http::RequestOrResponseHeaderMap& headers_;
 };
 
 class MetadataMapWrapper;

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -133,9 +133,9 @@ public:
     Responded
   };
 
-  StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine, Http::HeaderMap& headers,
-                      bool end_stream, Filter& filter, FilterCallbacks& callbacks,
-                      TimeSource& time_source);
+  StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
+                      Http::RequestOrResponseHeaderMap& headers, bool end_stream, Filter& filter,
+                      FilterCallbacks& callbacks, TimeSource& time_source);
 
   Http::FilterHeadersStatus start(int function_ref);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream);
@@ -309,7 +309,7 @@ private:
   void onBeforeFinalizeUpstreamSpan(Tracing::Span&, const Http::ResponseHeaderMap*) override {}
 
   Filters::Common::Lua::Coroutine& coroutine_;
-  Http::HeaderMap& headers_;
+  Http::RequestOrResponseHeaderMap& headers_;
   bool end_stream_;
   bool headers_continued_{};
   bool buffered_body_{};
@@ -538,8 +538,8 @@ private:
   Http::FilterHeadersStatus doHeaders(StreamHandleRef& handle,
                                       Filters::Common::Lua::CoroutinePtr& coroutine,
                                       FilterCallbacks& callbacks, int function_ref,
-                                      PerLuaCodeSetup* setup, Http::HeaderMap& headers,
-                                      bool end_stream);
+                                      PerLuaCodeSetup* setup,
+                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream);
   Http::FilterDataStatus doData(StreamHandleRef& handle, Buffer::Instance& data, bool end_stream);
   Http::FilterTrailersStatus doTrailers(StreamHandleRef& handle, Http::HeaderMap& trailers);
 

--- a/test/extensions/filters/common/lua/wrappers_test.cc
+++ b/test/extensions/filters/common/lua/wrappers_test.cc
@@ -82,7 +82,8 @@ TEST_F(LuaBufferWrapperTest, Methods) {
 
   setup(SCRIPT);
   Buffer::OwnedImpl data("hello world");
-  BufferWrapper::create(coroutine_->luaState(), data);
+  Http::RequestOrResponseHeaderMap headers;
+  BufferWrapper::create(coroutine_->luaState(), heders, data);
   EXPECT_CALL(printer_, testPrint("11"));
   EXPECT_CALL(printer_, testPrint("he"));
   EXPECT_CALL(printer_, testPrint("world"));
@@ -101,7 +102,8 @@ TEST_F(LuaBufferWrapperTest, GetBytesInvalidParams) {
 
   setup(SCRIPT);
   Buffer::OwnedImpl data("hello world");
-  BufferWrapper::create(coroutine_->luaState(), data);
+  Http::RequestOrResponseHeaderMap headers;
+  BufferWrapper::create(coroutine_->luaState(), headers, data);
   EXPECT_THROW_WITH_MESSAGE(
       start("callMe"), LuaException,
       "[string \"...\"]:3: index/length must be >= 0 and (index + length) must be <= buffer size");

--- a/test/extensions/filters/common/lua/wrappers_test.cc
+++ b/test/extensions/filters/common/lua/wrappers_test.cc
@@ -82,7 +82,7 @@ TEST_F(LuaBufferWrapperTest, Methods) {
 
   setup(SCRIPT);
   Buffer::OwnedImpl data("hello world");
-  Http::RequestOrResponseHeaderMap headers;
+  Http::TestRequestHeaderMapImpl headers;
   BufferWrapper::create(coroutine_->luaState(), headers, data);
   EXPECT_CALL(printer_, testPrint("11"));
   EXPECT_CALL(printer_, testPrint("he"));
@@ -102,7 +102,7 @@ TEST_F(LuaBufferWrapperTest, GetBytesInvalidParams) {
 
   setup(SCRIPT);
   Buffer::OwnedImpl data("hello world");
-  Http::RequestOrResponseHeaderMap headers;
+  Http::TestRequestHeaderMapImpl headers;
   BufferWrapper::create(coroutine_->luaState(), headers, data);
   EXPECT_THROW_WITH_MESSAGE(
       start("callMe"), LuaException,

--- a/test/extensions/filters/common/lua/wrappers_test.cc
+++ b/test/extensions/filters/common/lua/wrappers_test.cc
@@ -83,7 +83,7 @@ TEST_F(LuaBufferWrapperTest, Methods) {
   setup(SCRIPT);
   Buffer::OwnedImpl data("hello world");
   Http::RequestOrResponseHeaderMap headers;
-  BufferWrapper::create(coroutine_->luaState(), heders, data);
+  BufferWrapper::create(coroutine_->luaState(), headers, data);
   EXPECT_CALL(printer_, testPrint("11"));
   EXPECT_CALL(printer_, testPrint("he"));
   EXPECT_CALL(printer_, testPrint("world"));

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -1163,5 +1163,21 @@ typed_config:
   testRewriteResponse(FILTER_AND_CODE);
 }
 
+TEST_P(LuaIntegrationTest, RewriteResponseBufferWithoutHeaderReplaceContentLength) {
+  const std::string FILTER_AND_CODE =
+      R"EOF(
+name: lua
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+  inline_code: |
+    function envoy_on_response(response_handle)
+      local content_length = response_handle:body():setBytes("ok")
+      response_handle:logTrace(content_length)
+    end
+)EOF";
+
+  testRewriteResponse(FILTER_AND_CODE);
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: wangkai19 <wangkai19@corp.netease.com>

Commit Message: This patch modifies body setBytes API to make the header content length can be set automatically, which can avoid error when you forget set header content length in lua script and make the setBytes API more convenient for users.

Risk Level: Low
Testing: ut, integration
Docs Changes: N/A

