### PR TITLE
bazel: remove rules_cc

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@com_envoyproxy_protoc_gen_validate//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_google_protobuf//:protobuf.bzl", _py_proto_library = "py_proto_library")
@@ -143,7 +142,7 @@ def api_cc_py_proto_library(
         _api_cc_grpc_library(name = cc_grpc_name, proto = relative_name, deps = cc_proto_deps)
 
 def api_cc_test(name, **kwargs):
-    cc_test(
+    native.cc_test(
         name = name,
         **kwargs
     )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//bazel:envoy_internal.bzl", "envoy_select_force_libcpp")
 load("//bazel:utils.bzl", "json_data")

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -8,7 +8,6 @@ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
 
 # go version for rules_go
 GO_VERSION = "1.15.5"
@@ -28,8 +27,6 @@ def envoy_dependency_imports(go_version = GO_VERSION):
         oss_fuzz = True,
         honggfuzz = False,
     )
-    rules_cc_dependencies()
-    rules_cc_toolchains()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy binary targets
 load(
@@ -30,7 +28,7 @@ def envoy_cc_binary(
         linkopts = linkopts + _envoy_stamped_linkopts()
         deps = deps + _envoy_stamped_deps()
     deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + envoy_stdlib_deps()
-    cc_binary(
+    native.cc_binary(
         name = name,
         srcs = srcs,
         data = data,

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy library targets
 load(
@@ -40,7 +38,7 @@ def tcmalloc_external_deps(repository):
 # all envoy targets pass through an envoy-declared Starlark function where they can be modified
 # before being passed to a native bazel function.
 def envoy_basic_cc_library(name, deps = [], external_deps = [], **kargs):
-    cc_library(
+    native.cc_library(
         name = name,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps],
         **kargs
@@ -62,7 +60,7 @@ def envoy_cc_extension(
         visibility = visibility,
         **kwargs
     )
-    cc_library(
+    native.cc_library(
         name = ext_name,
         tags = tags,
         deps = select({
@@ -99,7 +97,7 @@ def envoy_cc_library(
     if tcmalloc_dep:
         deps += tcmalloc_external_deps(repository)
 
-    cc_library(
+    native.cc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs,
@@ -125,7 +123,7 @@ def envoy_cc_library(
 
     # Intended for usage by external consumers. This allows them to disambiguate
     # include paths via `external/envoy...`
-    cc_library(
+    native.cc_library(
         name = name + "_with_external_headers",
         hdrs = hdrs,
         copts = envoy_copts(repository) + copts,

--- a/bazel/envoy_pch.bzl
+++ b/bazel/envoy_pch.bzl
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy library targets
 load(
@@ -27,7 +25,7 @@ def envoy_pch_library(
         visibility,
         testonly = False,
         repository = ""):
-    cc_library(
+    native.cc_library(
         name = name + "_libs",
         visibility = ["//visibility:private"],
         copts = envoy_copts(repository),

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,7 +1,6 @@
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "fuzzing_decoration")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
@@ -42,7 +41,7 @@ def _envoy_cc_test_infrastructure_library(
         extra_deps = [repository + "//test:test_pch"]
         pch_copts = envoy_pch_copts(repository, "//test:test_pch")
 
-    cc_library(
+    native.cc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs,
@@ -103,7 +102,7 @@ def envoy_cc_fuzz_test(
         **kwargs
     )
 
-    cc_test(
+    native.cc_test(
         name = name,
         copts = envoy_copts("@envoy", test = True),
         linkopts = _envoy_test_linkopts() + select({
@@ -160,7 +159,7 @@ def envoy_cc_test(
         env = {}):
     coverage_tags = tags + ([] if coverage else ["nocoverage"])
 
-    cc_test(
+    native.cc_test(
         name = name,
         srcs = srcs,
         data = data,

--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 # Use a wrapper cc_library with an empty source source file to force

--- a/bazel/external/boringssl_fips.BUILD
+++ b/bazel/external/boringssl_fips.BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load(":genrule_cmd.bzl", "genrule_cmd")
 
 licenses(["notice"])  # Apache 2

--- a/bazel/external/compiler_rt.BUILD
+++ b/bazel/external/compiler_rt.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/fmtlib.BUILD
+++ b/bazel/external/fmtlib.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/http-parser.BUILD
+++ b/bazel/external/http-parser.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/json.BUILD
+++ b/bazel/external/json.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/libcircllhist.BUILD
+++ b/bazel/external/libcircllhist.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/libprotobuf_mutator.BUILD
+++ b/bazel/external/libprotobuf_mutator.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load(":genrule_cmd.bzl", "genrule_cmd")
 load(

--- a/bazel/external/rapidjson.BUILD
+++ b/bazel/external/rapidjson.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/spdlog.BUILD
+++ b/bazel/external/spdlog.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/sqlparser.BUILD
+++ b/bazel/external/sqlparser.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/su-exec.BUILD
+++ b/bazel/external/su-exec.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-
 licenses(["notice"])  # Apache 2
 
 cc_binary(

--- a/bazel/external/tclap.BUILD
+++ b/bazel/external/tclap.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/external/wasm-c-api.BUILD
+++ b/bazel/external/wasm-c-api.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 package(default_visibility = ["//visibility:public"])

--- a/bazel/external/wasmtime.BUILD
+++ b/bazel/external/wasmtime.BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//rust:rust.bzl", "rust_library")
 
 licenses(["notice"])  # Apache 2

--- a/bazel/external/wee8.BUILD
+++ b/bazel/external/wee8.BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@envoy_large_machine_exec_property//:constants.bzl", "LARGE_MACHINE")
 load(":genrule_cmd.bzl", "genrule_cmd")
 

--- a/bazel/external/xxhash.BUILD
+++ b/bazel/external/xxhash.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 licenses(["notice"])  # Apache 2
 
 cc_library(

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//bazel:envoy_build_system.bzl", "envoy_cmake", "envoy_package")
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -232,7 +232,6 @@ def envoy_dependencies(skip_targets = []):
         patch_args = ["-p1"],
         patches = ["@envoy//bazel/external:envoy_build_tools.patch"],
     )
-    external_http_archive("rules_cc")
     external_http_archive("rules_pkg")
     _com_github_fdio_vpp_vcl()
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -663,16 +663,6 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "org_golang_x_tools",
         ],
     ),
-    rules_cc = dict(
-        project_name = "C++ rules for Bazel",
-        project_desc = "Bazel rules for the C++ language",
-        project_url = "https://github.com/bazelbuild/rules_cc",
-        version = "0.0.1",
-        sha256 = "4dccbfd22c0def164c8f47458bd50e0c7148f3d92002cdb459c2a96a68498241",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/{version}/rules_cc-{version}.tar.gz"],
-        release_date = "2021-10-07",
-        use_category = ["build"],
-    ),
     rules_foreign_cc = dict(
         project_name = "Rules for using foreign build systems in Bazel",
         project_desc = "Rules for using foreign build systems in Bazel",

--- a/contrib/vcl/source/BUILD
+++ b/contrib/vcl/source/BUILD
@@ -4,7 +4,6 @@ load(
     "envoy_cc_library",
     "envoy_contrib_package",
 )
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@base_pip3//:requirements.bzl", "requirement")
 

--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:envoy_build_system.bzl",

--- a/source/extensions/common/wasm/ext/BUILD
+++ b/source/extensions/common/wasm/ext/BUILD
@@ -1,5 +1,4 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",

--- a/test/extensions/filters/http/wasm/test_data/BUILD
+++ b/test/extensions/filters/http/wasm/test_data/BUILD
@@ -1,5 +1,4 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
@@ -42,9 +41,9 @@ wasm_rust_binary(
     name = "grpc_call_rust.wasm",
     srcs = ["grpc_call_rust.rs"],
     deps = [
+        "//bazel/external/cargo:protobuf",
         "@proxy_wasm_rust_sdk//:proxy_wasm",
         "@proxy_wasm_rust_sdk//bazel/cargo:log",
-        "//bazel/external/cargo:protobuf",
     ],
 )
 
@@ -52,9 +51,9 @@ wasm_rust_binary(
     name = "grpc_stream_rust.wasm",
     srcs = ["grpc_stream_rust.rs"],
     deps = [
+        "//bazel/external/cargo:protobuf",
         "@proxy_wasm_rust_sdk//:proxy_wasm",
         "@proxy_wasm_rust_sdk//bazel/cargo:log",
-        "//bazel/external/cargo:protobuf",
     ],
 )
 

--- a/tools/clang_tools/support/clang_tools.bzl
+++ b/tools/clang_tools/support/clang_tools.bzl
@@ -1,12 +1,10 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-
 _clang_tools_copts = [
     "-fno-exceptions",
     "-fno-rtti",
 ]
 
 def clang_tools_cc_binary(name, copts = [], tags = [], deps = [], **kwargs):
-    cc_binary(
+    native.cc_binary(
         name = name,
         copts = copts + _clang_tools_copts,
         tags = tags + ["manual"],
@@ -15,14 +13,14 @@ def clang_tools_cc_binary(name, copts = [], tags = [], deps = [], **kwargs):
     )
 
 def clang_tools_cc_library(name, copts = [], **kwargs):
-    cc_library(
+    native.cc_library(
         name = name,
         copts = copts + _clang_tools_copts,
         **kwargs
     )
 
 def clang_tools_cc_test(name, copts = [], deps = [], **kwargs):
-    cc_test(
+    native.cc_test(
         name = name,
         copts = copts + _clang_tools_copts,
         deps = deps + ["@com_google_googletest//:gtest_main"],

--- a/tools/testdata/check_format/skip_envoy_package.BUILD
+++ b/tools/testdata/check_format/skip_envoy_package.BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-
 licenses(["notice"])  # Apache 2
 
 cc_binary(

--- a/tools/testdata/check_format/skip_envoy_package.BUILD.gold
+++ b/tools/testdata/check_format/skip_envoy_package.BUILD.gold
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-
 licenses(["notice"])  # Apache 2
 
 cc_binary(


### PR DESCRIPTION
The plans for bazel to move to rules_cc have been postponed without any
communication. There's no value to us in using this right now, but it
will be trivial to re-adopt in the future if needed. But it has the
downside of using a fork of bazel's crosstool, that has to be updated
independently of bazel, which doesn't always happen as improvements are
made.

More details: https://github.com/bazelbuild/rules_cc/issues/86 https://github.com/bazelbuild/bazel/issues/14150

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
