### PR TITLE
Extend StatefulHeaderFormatter to allow forwarding HTTP1 reason phrase

### DIFF
--- a/api/envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.proto
+++ b/api/envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.proto
@@ -16,4 +16,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // See the :ref:`header casing <config_http_conn_man_header_casing>` configuration guide for more
 // information.
 message PreserveCaseFormatterConfig {
+  // Allows forwarding reason phrase text.
+  // This is off by default, and a standard reason phrase is used for a corresponding HTTP response code.
+  bool forward_reason_phrase = 1;
 }

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -67,6 +67,7 @@ New Features
 * http: added support for %REQUESTED_SERVER_NAME% to extract SNI as a custom header.
 * http: added support for :ref:`retriable health check status codes <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`.
 * http: added timing information about upstream connection and encryption establishment to stream info. These can currently be accessed via custom access loggers.
+* http: added support for :ref:`forwarding HTTP1 reason phrase <envoy_v3_api_field_extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig.forward_reason_phrase>`.
 * listener: added API for extensions to access :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` configured in the listener's :ref:`metadata <envoy_v3_api_field_config.listener.v3.Listener.metadata>` field.
 * listener: added support for :ref:`MPTCP <envoy_v3_api_field_config.listener.v3.Listener.enable_mptcp>` (multipath TCP).
 * oauth filter: added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.

--- a/envoy/http/header_formatter.h
+++ b/envoy/http/header_formatter.h
@@ -33,6 +33,16 @@ public:
    * Called for each header key received by the codec.
    */
   virtual void processKey(absl::string_view key) PURE;
+
+  /**
+   * Called to save received reason phrase
+   */
+  virtual void setReasonPhrase(absl::string_view reason_phrase) PURE;
+
+  /**
+   * Called to get saved reason phrase
+   */
+  virtual absl::string_view getReasonPhrase() const PURE;
 };
 
 using StatefulHeaderKeyFormatterPtr = std::unique_ptr<StatefulHeaderKeyFormatter>;

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -499,6 +499,7 @@ private:
 
   // ParserCallbacks.
   Status onUrl(const char* data, size_t length) override;
+  Status onStatus(const char*, size_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   // ConnectionImpl
   void onEncodeComplete() override;
   StreamInfo::BytesMeter& getBytesMeter() override {
@@ -593,6 +594,7 @@ private:
 
   // ParserCallbacks.
   Status onUrl(const char*, size_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  Status onStatus(const char* data, size_t length) override;
   // ConnectionImpl
   Http::Status dispatch(Buffer::Instance& data) override;
   void onEncodeComplete() override {}

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -51,7 +51,11 @@ public:
           auto status = conn_impl->onUrl(at, length);
           return conn_impl->setAndCheckCallbackStatus(std::move(status));
         },
-        nullptr, // on_status
+        [](http_parser* parser, const char* at, size_t length) -> int {
+          auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
+          auto status = conn_impl->onStatus(at, length);
+          return conn_impl->setAndCheckCallbackStatus(std::move(status));
+        },
         [](http_parser* parser, const char* at, size_t length) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onHeaderField(at, length);

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -73,6 +73,14 @@ public:
   virtual Status onHeaderValue(const char* data, size_t length) PURE;
 
   /**
+   * Called when response status data is received.
+   * @param data supplies the start address.
+   * @param length supplies the length.
+   * @return Status representing success or failure.
+   */
+  virtual Status onStatus(const char* data, size_t length) PURE;
+
+  /**
    * Called when headers are complete. A base routine happens first then a virtual dispatch is
    * invoked. Note that this only applies to headers and NOT trailers. End of
    * trailers are signaled via onMessageCompleteBase().

--- a/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h
+++ b/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
 #include "envoy/http/header_formatter.h"
 
 #include "source/common/common/utility.h"
@@ -13,11 +14,17 @@ namespace PreserveCase {
 class PreserveCaseHeaderFormatter : public Envoy::Http::StatefulHeaderKeyFormatter {
 public:
   // Envoy::Http::StatefulHeaderKeyFormatter
+  PreserveCaseHeaderFormatter(const bool forward_reason_phrase);
+
   std::string format(absl::string_view key) const override;
   void processKey(absl::string_view key) override;
+  void setReasonPhrase(absl::string_view reason_phrase) override;
+  absl::string_view getReasonPhrase() const override;
 
 private:
   StringUtil::CaseUnorderedSet original_header_keys_;
+  bool forward_reason_phrase_{false};
+  std::string reason_phrase_;
 };
 
 } // namespace PreserveCase

--- a/test/extensions/http/header_formatters/preserve_case/BUILD
+++ b/test/extensions/http/header_formatters/preserve_case/BUILD
@@ -35,3 +35,17 @@ envoy_extension_cc_test(
         "//test/integration:http_integration_lib",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "preserve_case_formatter_reason_phrase_integration_test",
+    srcs = [
+        "preserve_case_formatter_reason_phrase_integration_test.cc",
+    ],
+    extension_names = ["envoy.http.stateful_header_formatters.preserve_case"],
+    deps = [
+        "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
+        "//test/integration:http_integration_lib",
+        "//test/integration:http_protocol_integration_lib",
+        "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
@@ -13,8 +13,9 @@ struct TestParams {
 };
 
 std::string testParamsToString(const ::testing::TestParamInfo<TestParams>& p) {
-  return fmt::format("{}_{}", p.param.ip_version == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6",
-                              p.param.forward_reason_phrase ? "enabled" : "disabled");
+  return fmt::format("{}_{}",
+                     p.param.ip_version == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6",
+                     p.param.forward_reason_phrase ? "enabled" : "disabled");
 }
 
 std::vector<TestParams> getTestsParams() {
@@ -28,9 +29,8 @@ std::vector<TestParams> getTestsParams() {
   return ret;
 }
 
-class PreserveCaseFormatterReasonPhraseIntegrationTest
-    : public testing::TestWithParam<TestParams>,
-      public HttpIntegrationTest {
+class PreserveCaseFormatterReasonPhraseIntegrationTest : public testing::TestWithParam<TestParams>,
+                                                         public HttpIntegrationTest {
 public:
   PreserveCaseFormatterReasonPhraseIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam().ip_version) {}
@@ -52,8 +52,8 @@ public:
 
         auto config =
             TestUtility::parseYaml<envoy::extensions::http::header_formatters::preserve_case::v3::
-                                       PreserveCaseFormatterConfig>(fmt::format("forward_reason_phrase: {}",
-                                            GetParam().forward_reason_phrase ? "true": "false"));
+                                       PreserveCaseFormatterConfig>(fmt::format(
+                "forward_reason_phrase: {}", GetParam().forward_reason_phrase ? "true": "false"));
         typed_extension_config->mutable_typed_config()->PackFrom(config);
 
         ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
@@ -81,7 +81,8 @@ TEST_P(PreserveCaseFormatterReasonPhraseIntegrationTest, VerifyReasonPhraseEnabl
   auto response = "HTTP/1.1 503 Slow Down\r\ncontent-length: 0\r\n\r\n";
   ASSERT_TRUE(upstream_connection->write(response));
 
-  auto expected_reason_phrase = GetParam().forward_reason_phrase ? "Slow Down" : "Service Unavailable";
+  auto expected_reason_phrase =
+      GetParam().forward_reason_phrase ? "Slow Down" : "Service Unavailable";
   // Verify that the downstream response has proper reason phrase
   tcp_client->waitForData(fmt::format("HTTP/1.1 503 {}", expected_reason_phrase), false);
 

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
@@ -1,0 +1,70 @@
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
+
+#include "test/integration/filters/common.h"
+#include "test/integration/http_integration.h"
+#include "test/test_common/registry.h"
+
+namespace Envoy {
+namespace {
+
+class PreserveCaseFormatterReasonPhraseIntegrationTest
+    : public testing::TestWithParam<Network::Address::IpVersion>,
+      public HttpIntegrationTest {
+public:
+  PreserveCaseFormatterReasonPhraseIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void SetUp() override {
+    setDownstreamProtocol(Http::CodecType::HTTP1);
+    setUpstreamProtocol(Http::CodecType::HTTP1);
+  }
+
+  void initialize() override {
+    if (upstreamProtocol() == Http::CodecType::HTTP1) {
+      config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        ConfigHelper::HttpProtocolOptions protocol_options;
+        auto typed_extension_config = protocol_options.mutable_explicit_http_config()
+                                          ->mutable_http_protocol_options()
+                                          ->mutable_header_key_format()
+                                          ->mutable_stateful_formatter();
+        typed_extension_config->set_name("preserve_case");
+
+        auto config =
+            TestUtility::parseYaml<envoy::extensions::http::header_formatters::preserve_case::v3::
+                                       PreserveCaseFormatterConfig>("forward_reason_phrase: true");
+        typed_extension_config->mutable_typed_config()->PackFrom(config);
+
+        ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
+                                         protocol_options);
+      });
+    }
+
+    HttpIntegrationTest::initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, PreserveCaseFormatterReasonPhraseIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(PreserveCaseFormatterReasonPhraseIntegrationTest, VerifyReasonPhrase) {
+  initialize();
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("http"));
+  auto request = "GET / HTTP/1.1\r\nhost: host\r\n\r\n";
+  ASSERT_TRUE(tcp_client->write(request, false));
+
+  Envoy::FakeRawConnectionPtr upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream_connection));
+
+  auto response = "HTTP/1.1 503 Slow Down\r\ncontent-length: 0\r\n\r\n";
+  ASSERT_TRUE(upstream_connection->write(response));
+
+  // Verify that the downstream response has proper reason phrase
+  tcp_client->waitForData("HTTP/1.1 503 Slow Down", false);
+
+  tcp_client->close();
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
@@ -53,7 +53,7 @@ public:
         auto config =
             TestUtility::parseYaml<envoy::extensions::http::header_formatters::preserve_case::v3::
                                        PreserveCaseFormatterConfig>(fmt::format(
-                "forward_reason_phrase: {}", GetParam().forward_reason_phrase ? "true": "false"));
+                "forward_reason_phrase: {}", GetParam().forward_reason_phrase ? "true" : "false"));
         typed_extension_config->mutable_typed_config()->PackFrom(config);
 
         ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
@@ -22,12 +22,20 @@ TEST(PreserveCaseFormatterTest, All) {
   EXPECT_EQ("baz", formatter.format("baz"));
 }
 
-TEST(PreserveCaseFormatterTest, ReasonPhrase) {
+TEST(PreserveCaseFormatterTest, ReasonPhraseEnabled) {
   PreserveCaseHeaderFormatter formatter(true);
 
   formatter.setReasonPhrase(absl::string_view("Slow Down"));
 
   EXPECT_EQ("Slow Down", formatter.getReasonPhrase());
+}
+
+TEST(PreserveCaseFormatterTest, ReasonPhraseDisabled) {
+  PreserveCaseHeaderFormatter formatter(false);
+
+  formatter.setReasonPhrase(absl::string_view("Slow Down"));
+
+  EXPECT_TRUE(formatter.getReasonPhrase().empty());
 }
 
 } // namespace PreserveCase

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
@@ -9,7 +9,7 @@ namespace HeaderFormatters {
 namespace PreserveCase {
 
 TEST(PreserveCaseFormatterTest, All) {
-  PreserveCaseHeaderFormatter formatter;
+  PreserveCaseHeaderFormatter formatter(false);
   formatter.processKey("Foo");
   formatter.processKey("Bar");
   formatter.processKey("BAR");
@@ -20,6 +20,14 @@ TEST(PreserveCaseFormatterTest, All) {
   EXPECT_EQ("Bar", formatter.format("Bar"));
   EXPECT_EQ("Bar", formatter.format("BAR"));
   EXPECT_EQ("baz", formatter.format("baz"));
+}
+
+TEST(PreserveCaseFormatterTest, ReasonPhrase) {
+  PreserveCaseHeaderFormatter formatter(true);
+
+  formatter.setReasonPhrase(absl::string_view("Slow Down"));
+
+  EXPECT_EQ("Slow Down", formatter.getReasonPhrase());
 }
 
 } // namespace PreserveCase


### PR DESCRIPTION
Commit Message: http: extend StatefulHeaderFormatter to allow forwarding HTTP1 reason phrase
Additional Description: In some cases the upstream can produce a non-default reason phrase when using HTTP1. For example AWS S3 can return `503 Slow Down` in certain cases. StatefuleHeaderFormatter can now take an optional flag to enable forwarding non-default HTTP1 reason phrases.
Risk Level: Medium
Testing: unit testing, integration testing
Docs Changes: release notes
Release Notes: http: added support for forwarding HTTP1 reason phrase
Platform Specific Features: N/A