### PR TITLE
router: update expected timeout header on retry

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,7 +19,7 @@ Minor Behavior Changes
 * json: switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.remove_legacy_json`` to false.
 * listener: destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 * quic: add back the support for IETF draft 29 which is guarded via ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_disable_version_draft_29``. It is off by default so Envoy only supports RFCv1 without flipping this runtime guard explicitly. Draft 29 is not recommended for use.
-* router: Take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
+* router: take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
 
 Bug Fixes
 ---------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,7 +19,7 @@ Minor Behavior Changes
 * json: switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.remove_legacy_json`` to false.
 * listener: destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 * quic: add back the support for IETF draft 29 which is guarded via ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_disable_version_draft_29``. It is off by default so Envoy only supports RFCv1 without flipping this runtime guard explicitly. Draft 29 is not recommended for use.
-* router: take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
+* router: take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries, and never send a value that's longer than the request timeout. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
 
 Bug Fixes
 ---------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,7 +19,7 @@ Minor Behavior Changes
 * json: switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.remove_legacy_json`` to false.
 * listener: destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 * quic: add back the support for IETF draft 29 which is guarded via ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_disable_version_draft_29``. It is off by default so Envoy only supports RFCv1 without flipping this runtime guard explicitly. Draft 29 is not recommended for use.
-* router: Take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries.
+* router: Take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
 
 Bug Fixes
 ---------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,6 +19,7 @@ Minor Behavior Changes
 * json: switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.remove_legacy_json`` to false.
 * listener: destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 * quic: add back the support for IETF draft 29 which is guarded via ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_disable_version_draft_29``. It is off by default so Envoy only supports RFCv1 without flipping this runtime guard explicitly. Draft 29 is not recommended for use.
+* router: Take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries.
 
 Bug Fixes
 ---------

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -205,29 +205,55 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::RequestHeaderMap& req
     timeout.per_try_timeout_ = std::chrono::milliseconds(0);
   }
 
+  setTimeoutHeaders(0, timeout, route, request_headers, insert_envoy_expected_request_timeout_ms,
+                    grpc_request, per_try_timeout_hedging_enabled);
+
+  return timeout;
+}
+
+void FilterUtility::setTimeoutHeaders(uint64_t elapsed_time,
+                                      const FilterUtility::TimeoutData& timeout,
+                                      const RouteEntry& route,
+                                      Http::RequestHeaderMap& request_headers,
+                                      bool insert_envoy_expected_request_timeout_ms,
+                                      bool grpc_request, bool per_try_timeout_hedging_enabled) {
+
+  const uint64_t global_timeout = timeout.global_timeout_.count();
+
   // See if there is any timeout to write in the expected timeout header.
   uint64_t expected_timeout = timeout.per_try_timeout_.count();
+
   // Use the global timeout if no per try timeout was specified or if we're
   // doing hedging when there are per try timeouts. Either of these scenarios
   // mean that the upstream server can use the full global timeout.
   if (per_try_timeout_hedging_enabled || expected_timeout == 0) {
-    expected_timeout = timeout.global_timeout_.count();
+    expected_timeout = global_timeout;
   }
 
-  if (insert_envoy_expected_request_timeout_ms && expected_timeout > 0) {
-    request_headers.setEnvoyExpectedRequestTimeoutMs(expected_timeout);
-  }
-
-  // If we've configured max_grpc_timeout, override the grpc-timeout header with
-  // the expected timeout. This ensures that the optional per try timeout is reflected
-  // in grpc-timeout, ensuring that the upstream gRPC server is aware of the actual timeout.
   // If the expected timeout is 0 set no timeout, as Envoy treats 0 as infinite timeout.
-  if (grpc_request && !route.usingNewTimeouts() && route.maxGrpcTimeout() &&
-      expected_timeout != 0) {
-    Grpc::Common::toGrpcTimeout(std::chrono::milliseconds(expected_timeout), request_headers);
-  }
+  if (expected_timeout > 0) {
 
-  return timeout;
+    if (global_timeout > 0) {
+      if (elapsed_time >= global_timeout) {
+        // We are out of time, but 0 would be an infinite timeout. So instead we send a 1ms timeout
+        // and assume the timer will fire to end the request soon.
+        expected_timeout = 1;
+      } else {
+        expected_timeout = std::min(expected_timeout, global_timeout - elapsed_time);
+      }
+    }
+
+    if (insert_envoy_expected_request_timeout_ms) {
+      request_headers.setEnvoyExpectedRequestTimeoutMs(expected_timeout);
+    }
+
+    // If we've configured max_grpc_timeout, override the grpc-timeout header with
+    // the expected timeout. This ensures that the optional per try timeout is reflected
+    // in grpc-timeout, ensuring that the upstream gRPC server is aware of the actual timeout.
+    if (grpc_request && !route.usingNewTimeouts() && route.maxGrpcTimeout()) {
+      Grpc::Common::toGrpcTimeout(std::chrono::milliseconds(expected_timeout), request_headers);
+    }
+  }
 }
 
 absl::optional<std::chrono::milliseconds>
@@ -1693,6 +1719,14 @@ void Filter::doRetry() {
   if (include_attempt_count_in_request_) {
     downstream_headers_->setEnvoyAttemptCount(attempt_count_);
   }
+
+  Event::Dispatcher& dispatcher = callbacks_->dispatcher();
+  std::chrono::milliseconds elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+      dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
+
+  FilterUtility::setTimeoutHeaders(elapsed_time.count(), timeout_, *route_entry_,
+                                   *downstream_headers_, !config_.suppress_envoy_headers_,
+                                   grpc_request_, hedging_params_.hedge_on_per_try_timeout_);
 
   UpstreamRequest* upstream_request_tmp = upstream_request.get();
   LinkedList::moveIntoList(std::move(upstream_request), upstream_requests_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1720,13 +1720,18 @@ void Filter::doRetry() {
     downstream_headers_->setEnvoyAttemptCount(attempt_count_);
   }
 
-  Event::Dispatcher& dispatcher = callbacks_->dispatcher();
-  std::chrono::milliseconds elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-      dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.update_expected_rq_timeout_on_retry")) {
+    // If not enabled, then it will re-use the previous headers (if any.)
 
-  FilterUtility::setTimeoutHeaders(elapsed_time.count(), timeout_, *route_entry_,
-                                   *downstream_headers_, !config_.suppress_envoy_headers_,
-                                   grpc_request_, hedging_params_.hedge_on_per_try_timeout_);
+    Event::Dispatcher& dispatcher = callbacks_->dispatcher();
+    std::chrono::milliseconds elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
+
+    FilterUtility::setTimeoutHeaders(elapsed_time.count(), timeout_, *route_entry_,
+                                     *downstream_headers_, !config_.suppress_envoy_headers_,
+                                     grpc_request_, hedging_params_.hedge_on_per_try_timeout_);
+  }
 
   UpstreamRequest* upstream_request_tmp = upstream_request.get();
   LinkedList::moveIntoList(std::move(upstream_request), upstream_requests_);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -148,6 +148,21 @@ public:
                                   bool respect_expected_rq_timeout);
 
   /**
+   * Set the x-envoy-expected-request-timeout-ms and grpc-timeout headers if needed.
+   * @param elapsed_time time elapsed since completion of the downstream request
+   * @param timeout final TimeoutData to use for the request
+   * @param request_headers the request headers to modify
+   * @param insert_envoy_expected_request_timeout_ms insert
+   *        x-envoy-expected-request-timeout-ms?
+   * @param grpc_request tells if the request is a gRPC request.
+   * @param per_try_timeout_headging_enabled is request hedging enabled?
+   */
+  static void setTimeoutHeaders(uint64_t elapsed_time, const FilterUtility::TimeoutData& timeout,
+                                const RouteEntry& route, Http::RequestHeaderMap& request_headers,
+                                bool insert_envoy_expected_request_timeout_ms, bool grpc_request,
+                                bool per_try_timeout_hedging_enabled);
+
+  /**
    * Try to parse a header entry that may have a timeout field
    *
    * @param header_timeout_entry header entry which may contain a timeout value.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -82,6 +82,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.udp_listener_updates_filter_chain_in_place",
     "envoy.reloadable_features.udp_per_event_loop_read_limit",
     "envoy.reloadable_features.unquote_log_string_values",
+    "envoy.reloadable_features.update_expected_rq_timeout_on_retry",
     "envoy.reloadable_features.use_dns_ttl",
     "envoy.reloadable_features.use_observable_cluster_name",
     "envoy.reloadable_features.validate_connect",

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6366,5 +6366,187 @@ TEST_F(RouterTest, RequestResponseSize) { testRequestResponseSize(false); }
 // when there are trailers in both the request/response.
 TEST_F(RouterTest, RequestResponseSizeWithTrailers) { testRequestResponseSize(true); }
 
+TEST_F(RouterTest, ExpectedUpstreamTimeoutUpdatedDuringRetries) {
+  auto retry_options_predicate = std::make_shared<MockRetryOptionsPredicate>();
+  callbacks_.route_->route_entry_.retry_policy_.retry_options_predicates_.emplace_back(
+      retry_options_predicate);
+
+  setIncludeAttemptCountInRequest(true);
+
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke(
+          [&](Http::ResponseDecoder& decoder,
+              Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+            response_decoder = &decoder;
+            callbacks.onPoolReady(encoder1, cm_.thread_local_cluster_.conn_pool_.host_,
+                                  upstream_stream_info_, Http::Protocol::Http10);
+            return nullptr;
+          }));
+  expectResponseTimerCreate();
+
+  Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"},
+                                         {"x-envoy-internal", "true"},
+                                         {"x-envoy-upstream-rq-timeout-ms", "200"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, true);
+  EXPECT_EQ(1U,
+            callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
+
+  test_time_.advanceTimeWait(std::chrono::milliseconds(50));
+
+  // Initial request has 1 attempt.
+  EXPECT_EQ(1, atoi(std::string(headers.getEnvoyAttemptCountValue()).c_str()));
+  EXPECT_EQ(200, atoi(std::string(headers.getEnvoyExpectedRequestTimeoutMsValue()).c_str()));
+
+  // 5xx response.
+  router_.retry_state_->expectHeadersRetry();
+  Upstream::RetryOptionsPredicate::UpdateOptionsReturn update_options_return{
+      std::make_shared<Network::Socket::Options>()};
+  EXPECT_CALL(*retry_options_predicate, updateOptions(_)).WillOnce(Return(update_options_return));
+  Http::ResponseHeaderMapPtr response_headers1(
+      new Http::TestResponseHeaderMapImpl{{":status", "503"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putHttpResponseCode(503));
+  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+  response_decoder->decodeHeaders(std::move(response_headers1), true);
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
+
+  // Verify retry options predicate return values have been updated.
+  EXPECT_EQ(update_options_return.new_upstream_socket_options_.value(),
+            router_.upstreamSocketOptions());
+
+  // We expect the 5xx response to kick off a new request.
+  EXPECT_CALL(encoder1.stream_, resetStream(_)).Times(0);
+  NiceMock<Http::MockRequestEncoder> encoder2;
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke(
+          [&](Http::ResponseDecoder& decoder,
+              Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+            response_decoder = &decoder;
+            callbacks.onPoolReady(encoder2, cm_.thread_local_cluster_.conn_pool_.host_,
+                                  upstream_stream_info_, Http::Protocol::Http10);
+            return nullptr;
+          }));
+  router_.retry_state_->callback_();
+  EXPECT_EQ(2U,
+            callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
+
+  // The retry should cause the header to increase to 2.
+  EXPECT_EQ(2, atoi(std::string(headers.getEnvoyAttemptCountValue()).c_str()));
+  // We already used 50ms of our 200ms timeout before the retry was triggered
+  EXPECT_EQ(150, atoi(std::string(headers.getEnvoyExpectedRequestTimeoutMsValue()).c_str()));
+
+  // Normal response.
+  EXPECT_CALL(*router_.retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->health_checker_, setUnhealthy(_))
+      .Times(0);
+  Http::ResponseHeaderMapPtr response_headers2(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putHttpResponseCode(200));
+  response_decoder->decodeHeaders(std::move(response_headers2), true);
+  EXPECT_TRUE(verifyHostUpstreamStats(1, 1));
+  EXPECT_EQ(2, callbacks_.stream_info_.attemptCount().value());
+}
+
+TEST(RouterFilterUtilityTest, SetTimeoutHeaders) {
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(0);
+
+    FilterUtility::setTimeoutHeaders(0, timeout, route, headers, true, false, false);
+    EXPECT_EQ("200",
+              headers.get_(
+                  "x-envoy-expected-rq-timeout-ms")); // No per try configured, use global timeout
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(0);
+
+    FilterUtility::setTimeoutHeaders(150, timeout, route, headers, true, false, false);
+    EXPECT_EQ("50", headers.get_("x-envoy-expected-rq-timeout-ms")); // Remains of global timeout
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(150);
+
+    FilterUtility::setTimeoutHeaders(0, timeout, route, headers, true, false, false);
+    EXPECT_EQ("150", headers.get_("x-envoy-expected-rq-timeout-ms")); // Per try timeout
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(150);
+
+    FilterUtility::setTimeoutHeaders(25, timeout, route, headers, true, false, false);
+    EXPECT_EQ("150", headers.get_("x-envoy-expected-rq-timeout-ms")); // Per try timeout
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(150);
+
+    FilterUtility::setTimeoutHeaders(150, timeout, route, headers, true, false, false);
+    EXPECT_EQ("50", headers.get_("x-envoy-expected-rq-timeout-ms")); // Remains of global timeout
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(0);
+
+    FilterUtility::setTimeoutHeaders(300, timeout, route, headers, true, false, false);
+    EXPECT_EQ("1", headers.get_("x-envoy-expected-rq-timeout-ms")); // Over time
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(150);
+
+    FilterUtility::setTimeoutHeaders(0, timeout, route, headers, true, false, true);
+    EXPECT_EQ("200", headers.get_("x-envoy-expected-rq-timeout-ms")); // Global timeout as hedged
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(150);
+
+    FilterUtility::setTimeoutHeaders(25, timeout, route, headers, true, false, true);
+    EXPECT_EQ("175", headers.get_(
+                         "x-envoy-expected-rq-timeout-ms")); // Remains of global timeout as hedged
+  }
+  {
+    NiceMock<MockRouteEntry> route;
+    Http::TestRequestHeaderMapImpl headers;
+    FilterUtility::TimeoutData timeout;
+    timeout.global_timeout_ = std::chrono::milliseconds(200);
+    timeout.per_try_timeout_ = std::chrono::milliseconds(150);
+
+    FilterUtility::setTimeoutHeaders(150, timeout, route, headers, true, false, true);
+    EXPECT_EQ("50", headers.get_(
+                        "x-envoy-expected-rq-timeout-ms")); // Remains of global timeout as hedged
+  }
+}
+
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6451,6 +6451,96 @@ TEST_F(RouterTest, ExpectedUpstreamTimeoutUpdatedDuringRetries) {
   EXPECT_EQ(2, callbacks_.stream_info_.attemptCount().value());
 }
 
+TEST_F(RouterTest, ExpectedUpstreamTimeoutNotUpdatedDuringRetriesWhenRuntimeGuardDisabled) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.update_expected_rq_timeout_on_retry", "false"}});
+
+  auto retry_options_predicate = std::make_shared<MockRetryOptionsPredicate>();
+  callbacks_.route_->route_entry_.retry_policy_.retry_options_predicates_.emplace_back(
+      retry_options_predicate);
+
+  setIncludeAttemptCountInRequest(true);
+
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke(
+          [&](Http::ResponseDecoder& decoder,
+              Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+            response_decoder = &decoder;
+            callbacks.onPoolReady(encoder1, cm_.thread_local_cluster_.conn_pool_.host_,
+                                  upstream_stream_info_, Http::Protocol::Http10);
+            return nullptr;
+          }));
+  expectResponseTimerCreate();
+
+  Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"},
+                                         {"x-envoy-internal", "true"},
+                                         {"x-envoy-upstream-rq-timeout-ms", "200"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, true);
+  EXPECT_EQ(1U,
+            callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
+
+  test_time_.advanceTimeWait(std::chrono::milliseconds(50));
+
+  // Initial request has 1 attempt.
+  EXPECT_EQ(1, atoi(std::string(headers.getEnvoyAttemptCountValue()).c_str()));
+  EXPECT_EQ(200, atoi(std::string(headers.getEnvoyExpectedRequestTimeoutMsValue()).c_str()));
+
+  // 5xx response.
+  router_.retry_state_->expectHeadersRetry();
+  Upstream::RetryOptionsPredicate::UpdateOptionsReturn update_options_return{
+      std::make_shared<Network::Socket::Options>()};
+  EXPECT_CALL(*retry_options_predicate, updateOptions(_)).WillOnce(Return(update_options_return));
+  Http::ResponseHeaderMapPtr response_headers1(
+      new Http::TestResponseHeaderMapImpl{{":status", "503"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putHttpResponseCode(503));
+  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+  response_decoder->decodeHeaders(std::move(response_headers1), true);
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
+
+  // Verify retry options predicate return values have been updated.
+  EXPECT_EQ(update_options_return.new_upstream_socket_options_.value(),
+            router_.upstreamSocketOptions());
+
+  // We expect the 5xx response to kick off a new request.
+  EXPECT_CALL(encoder1.stream_, resetStream(_)).Times(0);
+  NiceMock<Http::MockRequestEncoder> encoder2;
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke(
+          [&](Http::ResponseDecoder& decoder,
+              Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+            response_decoder = &decoder;
+            callbacks.onPoolReady(encoder2, cm_.thread_local_cluster_.conn_pool_.host_,
+                                  upstream_stream_info_, Http::Protocol::Http10);
+            return nullptr;
+          }));
+  router_.retry_state_->callback_();
+  EXPECT_EQ(2U,
+            callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
+
+  // The retry should cause the header to increase to 2.
+  EXPECT_EQ(2, atoi(std::string(headers.getEnvoyAttemptCountValue()).c_str()));
+  // We already used 50ms of our 200ms timeout before the retry was triggered,
+  // but with the guard disabled this should not change the header.
+  EXPECT_EQ(200, atoi(std::string(headers.getEnvoyExpectedRequestTimeoutMsValue()).c_str()));
+
+  // Normal response.
+  EXPECT_CALL(*router_.retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->health_checker_, setUnhealthy(_))
+      .Times(0);
+  Http::ResponseHeaderMapPtr response_headers2(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putHttpResponseCode(200));
+  response_decoder->decodeHeaders(std::move(response_headers2), true);
+  EXPECT_TRUE(verifyHostUpstreamStats(1, 1));
+  EXPECT_EQ(2, callbacks_.stream_info_.attemptCount().value());
+}
+
 TEST(RouterFilterUtilityTest, SetTimeoutHeaders) {
   {
     NiceMock<MockRouteEntry> route;


### PR DESCRIPTION
Commit Message:
Take the time elapsed since the downstream request was completed into account when setting the ``x-envoy-expected-rq-timeout-ms`` header on retries.
Previously the header value from the first request would be used for retries, but this meant expected timeouts could be sent that were longer than the remaining time until the global timeout expired.

Additional Description:
Risk Level: Low
Testing: unit tests
Docs Changes: No
Release Notes: Yes
Runtime Guard: ``envoy.reloadable_features.update_expected_rq_timeout_on_retry``
Fixes: #13196
