### PR TITLE
quic: Disable QuicHttpIntegrationTest.AdminDrainDrainsListeners

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -613,7 +613,8 @@ TEST_P(QuicHttpIntegrationTest, PortMigrationFailureOnPathDegrading) {
   EXPECT_EQ(1024u * 2, upstream_request_->bodyLength());
 }
 
-TEST_P(QuicHttpIntegrationTest, AdminDrainDrainsListeners) {
+// TODO(#19006): Track down the flakiness and re-enable.
+TEST_P(QuicHttpIntegrationTest, DISABLED_AdminDrainDrainsListeners) {
   testAdminDrain(Http::CodecType::HTTP1);
 }
 


### PR DESCRIPTION
quic: Disable flaky test QuicHttpIntegrationTest.AdminDrainDrainsListeners while we work on a fix to the underlying issue.

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A