### PR TITLE
vcl: remove extraneous cb call in event activate

### DIFF
--- a/contrib/vcl/source/vcl_event.cc
+++ b/contrib/vcl/source/vcl_event.cc
@@ -33,8 +33,6 @@ void VclEvent::activate(uint32_t events) {
   ASSERT((events & (Event::FileReadyType::Read | Event::FileReadyType::Write |
                     Event::FileReadyType::Closed)) == events);
 
-  cb_(events);
-
   // Schedule the activation callback so it runs as part of the next loop iteration if it is not
   // already scheduled.
   if (injected_activation_events_ == 0) {


### PR DESCRIPTION
Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: low
Testing: n/a
