### PR TITLE
stream_info: removing redundant test code.

### DIFF
--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -47,13 +47,17 @@ envoy::config::accesslog::v3::AccessLog parseAccessLogFromV3Yaml(const std::stri
 
 class AccessLogImplTest : public Event::TestUsingSimulatedTime, public testing::Test {
 public:
-  AccessLogImplTest() : file_(new MockAccessLogFile()) {
+  AccessLogImplTest() : stream_info_(time_source_), file_(new MockAccessLogFile()) {
     ON_CALL(context_, runtime()).WillByDefault(ReturnRef(runtime_));
     ON_CALL(context_, accessLogManager()).WillByDefault(ReturnRef(log_manager_));
     ON_CALL(log_manager_, createAccessLog(_)).WillByDefault(Return(file_));
     ON_CALL(*file_, write(_)).WillByDefault(SaveArg<0>(&output_));
+    stream_info_.addBytesReceived(1);
+    stream_info_.addBytesSent(2);
+    stream_info_.protocol(Http::Protocol::Http11);
   }
 
+  NiceMock<MockTimeSystem> time_source_;
   Http::TestRequestHeaderMapImpl request_headers_{{":method", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers_;
   Http::TestResponseTrailerMapImpl response_trailers_;
@@ -77,7 +81,7 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  stream_info_.response_flags_ = StreamInfo::ResponseFlag::UpstreamConnectionFailure;
+  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
   request_headers_.addCopy(Http::Headers::get().UserAgent, "user-agent-set");
   request_headers_.addCopy(Http::Headers::get().RequestId, "id");
   request_headers_.addCopy(Http::Headers::get().Host, "host");
@@ -104,7 +108,7 @@ typed_config:
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
   stream_info_.upstream_host_ =
       Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime());
-  stream_info_.response_flags_ = StreamInfo::ResponseFlag::DownstreamConnectionTermination;
+  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamConnectionTermination);
 
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 DC 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
@@ -126,8 +130,8 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  stream_info_.route_name_ = "route-test-name";
-  stream_info_.response_flags_ = StreamInfo::ResponseFlag::UpstreamConnectionFailure;
+  stream_info_.setRouteName("route-test-name");
+  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
   request_headers_.addCopy(Http::Headers::get().UserAgent, "user-agent-set");
   request_headers_.addCopy(Http::Headers::get().RequestId, "id");
   request_headers_.addCopy(Http::Headers::get().Host, "host");
@@ -598,7 +602,7 @@ typed_config:
   )EOF";
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
-  stream_info_.response_code_ = 500;
+  stream_info_.setResponseCode(500);
 
   {
     EXPECT_CALL(*file_, write(_));
@@ -677,7 +681,8 @@ duration_filter:
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers;
   Http::TestResponseTrailerMapImpl response_trailers;
-  TestStreamInfo stream_info;
+  NiceMock<MockTimeSystem> time_source;
+  TestStreamInfo stream_info(time_source);
 
   stream_info.end_time_ = stream_info.startTimeMonotonic() + std::chrono::microseconds(100000);
   EXPECT_CALL(runtime.snapshot_, getInteger("key", 1000000)).WillOnce(Return(1));
@@ -712,10 +717,11 @@ status_code_filter:
   TestUtility::loadFromYaml(filter_yaml, config);
   StatusCodeFilter filter(config.status_code_filter(), runtime);
 
+  NiceMock<MockTimeSystem> time_source;
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers;
   Http::TestResponseTrailerMapImpl response_trailers;
-  TestStreamInfo info;
+  TestStreamInfo info(time_source);
 
   info.response_code_ = 400;
   EXPECT_CALL(runtime.snapshot_, getInteger("key", 300)).WillOnce(Return(350));
@@ -1002,7 +1008,7 @@ typed_config:
        StreamInfo::ResponseFlagUtils::ALL_RESPONSE_STRING_FLAGS) {
     UNREFERENCED_PARAMETER(flag_string);
 
-    TestStreamInfo stream_info;
+    TestStreamInfo stream_info(time_source_);
     stream_info.setResponseFlag(response_flag);
     EXPECT_CALL(*file_, write(_));
     log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
@@ -1323,7 +1329,7 @@ typed_config:
   path: /dev/null
   )EOF";
 
-  TestStreamInfo stream_info;
+  TestStreamInfo stream_info(time_source_);
   ProtobufWkt::Struct metadata_val;
   auto& fields_a = *metadata_val.mutable_fields();
   auto& struct_b = *fields_a["a"].mutable_struct_value();
@@ -1359,7 +1365,7 @@ typed_config:
   path: /dev/null
   )EOF";
 
-  TestStreamInfo stream_info;
+  TestStreamInfo stream_info(time_source_);
   ProtobufWkt::Struct metadata_val;
   stream_info.setDynamicMetadata("some.namespace", metadata_val);
 
@@ -1406,7 +1412,7 @@ typed_config:
   path: /dev/null
   )EOF";
 
-  TestStreamInfo stream_info;
+  TestStreamInfo stream_info(time_source_);
   ProtobufWkt::Struct metadata_val;
   auto& fields_a = *metadata_val.mutable_fields();
   auto& struct_b = *fields_a["a"].mutable_struct_value();

--- a/test/common/formatter/substitution_formatter_fuzz_test.cc
+++ b/test/common/formatter/substitution_formatter_fuzz_test.cc
@@ -19,7 +19,9 @@ DEFINE_PROTO_FUZZER(const test::common::substitution::TestCase& input) {
         Fuzz::fromHeaders<Http::TestResponseHeaderMapImpl>(input.response_headers());
     const auto& response_trailers =
         Fuzz::fromHeaders<Http::TestResponseTrailerMapImpl>(input.response_trailers());
-    const std::unique_ptr<TestStreamInfo> stream_info = Fuzz::fromStreamInfo(input.stream_info());
+    MockTimeSystem time_system;
+    const std::unique_ptr<TestStreamInfo> stream_info =
+        Fuzz::fromStreamInfo(input.stream_info(), time_system);
     for (const auto& it : formatters) {
       it->format(request_headers, response_headers, response_trailers, *stream_info,
                  absl::string_view());

--- a/test/common/formatter/substitution_formatter_speed_test.cc
+++ b/test/common/formatter/substitution_formatter_speed_test.cc
@@ -46,8 +46,8 @@ std::unique_ptr<Envoy::Formatter::StructFormatter> makeStructFormatter(bool type
   return std::make_unique<Envoy::Formatter::StructFormatter>(StructLogFormat, typed, false);
 }
 
-std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
-  auto stream_info = std::make_unique<Envoy::TestStreamInfo>();
+std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo(TimeSource& time_source) {
+  auto stream_info = std::make_unique<Envoy::TestStreamInfo>(time_source);
   stream_info->downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
   return stream_info;
@@ -57,7 +57,8 @@ std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_AccessLogFormatter(benchmark::State& state) {
-  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  MockTimeSystem time_system;
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo(time_system);
   static const char* LogFormat =
       "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
       "%REQ(:METHOD)% "
@@ -83,7 +84,8 @@ BENCHMARK(BM_AccessLogFormatter);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_StructAccessLogFormatter(benchmark::State& state) {
-  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  MockTimeSystem time_system;
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo(time_system);
   std::unique_ptr<Envoy::Formatter::StructFormatter> struct_formatter = makeStructFormatter(false);
 
   size_t output_bytes = 0;
@@ -103,7 +105,8 @@ BENCHMARK(BM_StructAccessLogFormatter);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_TypedStructAccessLogFormatter(benchmark::State& state) {
-  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  MockTimeSystem time_system;
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo(time_system);
   std::unique_ptr<Envoy::Formatter::StructFormatter> typed_struct_formatter =
       makeStructFormatter(true);
 
@@ -124,7 +127,8 @@ BENCHMARK(BM_TypedStructAccessLogFormatter);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_JsonAccessLogFormatter(benchmark::State& state) {
-  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  MockTimeSystem time_system;
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo(time_system);
   std::unique_ptr<Envoy::Formatter::JsonFormatterImpl> json_formatter = makeJsonFormatter(false);
 
   size_t output_bytes = 0;
@@ -144,7 +148,8 @@ BENCHMARK(BM_JsonAccessLogFormatter);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
-  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
+  MockTimeSystem time_system;
+  std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo(time_system);
   std::unique_ptr<Envoy::Formatter::JsonFormatterImpl> typed_json_formatter =
       makeJsonFormatter(true);
 

--- a/test/common/router/header_parser_fuzz_test.cc
+++ b/test/common/router/header_parser_fuzz_test.cc
@@ -15,7 +15,9 @@ DEFINE_PROTO_FUZZER(const test::common::router::TestCase& input) {
     Router::HeaderParserPtr parser =
         Router::HeaderParser::configure(input.headers_to_add(), input.headers_to_remove());
     Http::TestRequestHeaderMapImpl header_map;
-    std::unique_ptr<TestStreamInfo> test_stream_info = fromStreamInfo(input.stream_info());
+    MockTimeSystem time_system_;
+    std::unique_ptr<TestStreamInfo> test_stream_info =
+        fromStreamInfo(input.stream_info(), time_system_);
     parser->evaluateHeaders(header_map, *test_stream_info);
     ENVOY_LOG_MISC(trace, "Success");
   } catch (const EnvoyException& e) {

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -7,22 +7,21 @@
 #include "source/common/common/random_generator.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
+#include "source/common/stream_info/stream_info_impl.h"
 #include "source/extensions/request_id/uuid/config.h"
 
+#include "test/mocks/common.h"
 #include "test/test_common/simulated_time_system.h"
 
 namespace Envoy {
 
-class TestStreamInfo : public StreamInfo::StreamInfo {
+class TestStreamInfo : public StreamInfo::StreamInfoImpl {
 public:
-  TestStreamInfo()
-      : filter_state_(std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
-            Envoy::StreamInfo::FilterState::LifeSpan::FilterChain)) {
+  TestStreamInfo(TimeSource& time_source) : StreamInfoImpl(time_source, nullptr) {
     // Use 1999-01-01 00:00:00 +0
     time_t fake_time = 915148800;
     start_time_ = std::chrono::system_clock::from_time_t(fake_time);
     request_id_provider_ = Extensions::RequestId::UUIDRequestIDExtension::defaultInstance(random_);
-
     MonotonicTime now = timeSystem().monotonicTime();
     start_time_monotonic_ = now;
     end_time_ = now + std::chrono::milliseconds(3);
@@ -31,148 +30,15 @@ public:
   SystemTime startTime() const override { return start_time_; }
   MonotonicTime startTimeMonotonic() const override { return start_time_monotonic_; }
 
-  void addBytesReceived(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  uint64_t bytesReceived() const override { return 1; }
-  absl::optional<Http::Protocol> protocol() const override { return protocol_; }
-  void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
-  absl::optional<uint32_t> responseCode() const override { return response_code_; }
-  const absl::optional<std::string>& responseCodeDetails() const override {
-    return response_code_details_;
-  }
-  void setResponseCode(uint32_t code) override { response_code_ = code; }
-  void setResponseCodeDetails(absl::string_view rc_details) override {
-    response_code_details_.emplace(rc_details);
-  }
-  const absl::optional<std::string>& connectionTerminationDetails() const override {
-    return connection_termination_details_;
-  }
-  void setConnectionTerminationDetails(absl::string_view details) override {
-    connection_termination_details_.emplace(details);
-  }
-  void addBytesSent(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  uint64_t bytesSent() const override { return 2; }
-  bool intersectResponseFlags(uint64_t response_flags) const override {
-    return (response_flags_ & response_flags) != 0;
-  }
-  bool hasResponseFlag(Envoy::StreamInfo::ResponseFlag response_flag) const override {
-    return response_flags_ & response_flag;
-  }
-  bool hasAnyResponseFlag() const override { return response_flags_ != 0; }
-  void setResponseFlag(Envoy::StreamInfo::ResponseFlag response_flag) override {
-    response_flags_ |= response_flag;
-  }
-  uint64_t responseFlags() const override { return response_flags_; }
-  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) override {
-    upstream_host_ = host;
-  }
-  Upstream::HostDescriptionConstSharedPtr upstreamHost() const override { return upstream_host_; }
-  void setUpstreamLocalAddress(
-      const Network::Address::InstanceConstSharedPtr& upstream_local_address) override {
-    upstream_local_address_ = upstream_local_address;
-  }
-  const Network::Address::InstanceConstSharedPtr& upstreamLocalAddress() const override {
-    return upstream_local_address_;
-  }
-  bool healthCheck() const override { return health_check_request_; }
-  void healthCheck(bool is_health_check) override { health_check_request_ = is_health_check; }
   const Network::ConnectionInfoSetter& downstreamAddressProvider() const override {
     return *downstream_connection_info_provider_;
   }
 
-  void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    upstream_connection_info_ = connection_info;
-  }
-
-  Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
-    return upstream_connection_info_;
-  }
-  void setRouteName(absl::string_view route_name) override {
-    route_name_ = std::string(route_name);
-  }
-  const std::string& getRouteName() const override { return route_name_; }
-
-  Router::RouteConstSharedPtr route() const override { return route_; }
-
-  absl::optional<std::chrono::nanoseconds>
-  duration(const absl::optional<MonotonicTime>& time) const {
-    if (!time) {
-      return {};
-    }
-
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(time.value() -
-                                                                start_time_monotonic_);
-  }
-
-  absl::optional<std::chrono::nanoseconds> lastDownstreamRxByteReceived() const override {
-    return duration(last_rx_byte_received_);
-  }
-
-  absl::optional<std::chrono::nanoseconds> firstUpstreamTxByteSent() const override {
-    return duration(upstream_timing_.first_upstream_tx_byte_sent_);
-  }
-
-  absl::optional<std::chrono::nanoseconds> lastUpstreamTxByteSent() const override {
-    return duration(upstream_timing_.last_upstream_tx_byte_sent_);
-  }
-  absl::optional<std::chrono::nanoseconds> firstUpstreamRxByteReceived() const override {
-    return duration(upstream_timing_.first_upstream_rx_byte_received_);
-  }
-
-  absl::optional<std::chrono::nanoseconds> lastUpstreamRxByteReceived() const override {
-    return duration(upstream_timing_.last_upstream_rx_byte_received_);
-  }
-
-  absl::optional<std::chrono::nanoseconds> firstDownstreamTxByteSent() const override {
-    return duration(downstream_timing_.firstDownstreamTxByteSent());
-  }
-
-  absl::optional<std::chrono::nanoseconds> lastDownstreamTxByteSent() const override {
-    return duration(downstream_timing_.lastDownstreamTxByteSent());
-  }
-
   void onRequestComplete() override { end_time_ = timeSystem().monotonicTime(); }
-
-  Envoy::StreamInfo::DownstreamTiming& downstreamTiming() override { return downstream_timing_; }
-
-  void setUpstreamTiming(const Envoy::StreamInfo::UpstreamTiming& upstream_timing) override {
-    upstream_timing_ = upstream_timing;
-  }
 
   absl::optional<std::chrono::nanoseconds> requestComplete() const override {
     return duration(end_time_);
   }
-
-  envoy::config::core::v3::Metadata& dynamicMetadata() override { return metadata_; };
-  const envoy::config::core::v3::Metadata& dynamicMetadata() const override { return metadata_; };
-
-  void setDynamicMetadata(const std::string& name, const ProtobufWkt::Struct& value) override {
-    (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
-  };
-
-  const Envoy::StreamInfo::FilterStateSharedPtr& filterState() override { return filter_state_; }
-  const Envoy::StreamInfo::FilterState& filterState() const override { return *filter_state_; }
-
-  const Envoy::StreamInfo::FilterStateSharedPtr& upstreamFilterState() const override {
-    return upstream_filter_state_;
-  }
-  void
-  setUpstreamFilterState(const Envoy::StreamInfo::FilterStateSharedPtr& filter_state) override {
-    upstream_filter_state_ = filter_state;
-  }
-
-  void setUpstreamTransportFailureReason(absl::string_view failure_reason) override {
-    upstream_transport_failure_reason_ = std::string(failure_reason);
-  }
-
-  const std::string& upstreamTransportFailureReason() const override {
-    return upstream_transport_failure_reason_;
-  }
-
-  void setRequestHeaders(const Http::RequestHeaderMap& headers) override {
-    request_headers_ = &headers;
-  }
-
-  const Http::RequestHeaderMap* getRequestHeaders() const override { return request_headers_; }
 
   void setRequestIDProvider(const Http::RequestIdStreamInfoProviderSharedPtr& provider) override {
     ASSERT(provider != nullptr);
@@ -182,93 +48,16 @@ public:
     return request_id_provider_.get();
   }
 
-  void setTraceReason(Tracing::Reason reason) override { trace_reason_ = reason; }
-  Tracing::Reason traceReason() const override { return trace_reason_; }
-
   Event::TimeSystem& timeSystem() { return test_time_.timeSystem(); }
-
-  void setUpstreamClusterInfo(
-      const Upstream::ClusterInfoConstSharedPtr& upstream_cluster_info) override {
-    upstream_cluster_info_ = upstream_cluster_info;
-  }
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> upstreamClusterInfo() const override {
-    return upstream_cluster_info_;
-  }
-
-  void setFilterChainName(absl::string_view filter_chain_name) override {
-    filter_chain_name_ = std::string(filter_chain_name);
-  }
-
-  const std::string& filterChainName() const override { return filter_chain_name_; }
-
-  void setUpstreamConnectionId(uint64_t id) override { upstream_connection_id_ = id; }
-
-  absl::optional<uint64_t> upstreamConnectionId() const override { return upstream_connection_id_; }
-
-  void setAttemptCount(uint32_t attempt_count) override { attempt_count_ = attempt_count; }
-
-  absl::optional<uint32_t> attemptCount() const override { return attempt_count_; }
-
-  const Envoy::StreamInfo::BytesMeterSharedPtr& getUpstreamBytesMeter() const override {
-    return upstream_bytes_meter_;
-  }
-
-  const Envoy::StreamInfo::BytesMeterSharedPtr& getDownstreamBytesMeter() const override {
-    return downstream_bytes_meter_;
-  }
-
-  void setUpstreamBytesMeter(
-      const Envoy::StreamInfo::BytesMeterSharedPtr& upstream_bytes_meter) override {
-    upstream_bytes_meter_ = upstream_bytes_meter;
-  }
-
-  void setDownstreamBytesMeter(
-      const Envoy::StreamInfo::BytesMeterSharedPtr& downstream_bytes_meter) override {
-    downstream_bytes_meter_ = downstream_bytes_meter;
-  }
 
   Random::RandomGeneratorImpl random_;
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;
-
-  Envoy::StreamInfo::DownstreamTiming downstream_timing_;
-  absl::optional<MonotonicTime> last_rx_byte_received_;
   absl::optional<MonotonicTime> end_time_;
-
-  absl::optional<Http::Protocol> protocol_{Http::Protocol::Http11};
-  absl::optional<uint32_t> response_code_;
-  absl::optional<std::string> response_code_details_;
-  absl::optional<std::string> connection_termination_details_;
-  uint64_t response_flags_{};
-  Upstream::HostDescriptionConstSharedPtr upstream_host_{};
-  bool health_check_request_{};
-  std::string route_name_;
-  Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::ConnectionInfoSetterSharedPtr downstream_connection_info_provider_{
       std::make_shared<Network::ConnectionInfoSetterImpl>(nullptr, nullptr)};
-  Ssl::ConnectionInfoConstSharedPtr downstream_connection_info_;
-  Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
-  Router::RouteConstSharedPtr route_;
-  envoy::config::core::v3::Metadata metadata_{};
-  Envoy::StreamInfo::FilterStateSharedPtr filter_state_{
-      std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
-          Envoy::StreamInfo::FilterState::LifeSpan::FilterChain)};
-  Envoy::StreamInfo::FilterStateSharedPtr upstream_filter_state_;
-  Envoy::StreamInfo::UpstreamTiming upstream_timing_;
-  std::string requested_server_name_;
-  std::string upstream_transport_failure_reason_;
-  const Http::RequestHeaderMap* request_headers_{};
   Envoy::Event::SimulatedTimeSystem test_time_;
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_{};
   Http::RequestIdStreamInfoProviderSharedPtr request_id_provider_;
-  std::string filter_chain_name_;
-  Tracing::Reason trace_reason_{Tracing::Reason::NotTraceable};
-  absl::optional<uint64_t> upstream_connection_id_;
-  absl::optional<uint32_t> attempt_count_;
-  Envoy::StreamInfo::BytesMeterSharedPtr upstream_bytes_meter_{
-      std::make_shared<Envoy::StreamInfo::BytesMeter>()};
-  Envoy::StreamInfo::BytesMeterSharedPtr downstream_bytes_meter_{
-      std::make_shared<Envoy::StreamInfo::BytesMeter>()};
 };
 
 } // namespace Envoy

--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_speed_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_speed_test.cc
@@ -7,6 +7,8 @@
 #include "benchmark/benchmark.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 
+using testing::NiceMock;
+
 namespace Envoy {
 namespace Extensions {
 namespace AccessLoggers {
@@ -54,7 +56,8 @@ std::unique_ptr<OpenTelemetryFormatter> makeOpenTelemetryFormatter() {
 }
 
 std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
-  auto stream_info = std::make_unique<Envoy::TestStreamInfo>();
+  NiceMock<MockTimeSystem> time_source;
+  auto stream_info = std::make_unique<Envoy::TestStreamInfo>(time_source);
   stream_info->downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Envoy::Network::Address::Ipv4Instance>("203.0.113.1"));
   return stream_info;

--- a/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
@@ -20,13 +20,14 @@ namespace {
 DEFINE_PROTO_FUZZER(const test::extensions::filters::common::expr::EvaluatorTestCase& input) {
   // Create builder without constant folding.
   static Expr::BuilderPtr builder = Expr::createBuilder(nullptr);
+  MockTimeSystem time_source;
   std::unique_ptr<TestStreamInfo> stream_info;
 
   try {
     // Validate that the input has an expression.
     TestUtility::validate(input);
     // Create stream_info to test against, this may catch exceptions from invalid addresses.
-    stream_info = Fuzz::fromStreamInfo(input.stream_info());
+    stream_info = Fuzz::fromStreamInfo(input.stream_info(), time_source);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
     return;

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -61,7 +61,8 @@ class MongoProxyFilterTest : public testing::Test {
 public:
   MongoProxyFilterTest()
       : mongo_stats_(std::make_shared<MongoStats>(store_, "test",
-                                                  std::vector<std::string>{"insert", "count"})) {
+                                                  std::vector<std::string>{"insert", "count"})),
+        stream_info_(time_source_) {
     setup();
   }
 
@@ -127,6 +128,7 @@ public:
   NiceMock<Network::MockReadFilterCallbacks> read_filter_callbacks_;
   Envoy::AccessLog::MockAccessLogManager log_manager_;
   NiceMock<Network::MockDrainDecision> drain_decision_;
+  MockTimeSystem time_source_;
   TestStreamInfo stream_info_;
 };
 

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -128,7 +128,7 @@ public:
   NiceMock<Network::MockReadFilterCallbacks> read_filter_callbacks_;
   Envoy::AccessLog::MockAccessLogManager log_manager_;
   NiceMock<Network::MockDrainDecision> drain_decision_;
-  MockTimeSystem time_source_;
+  NiceMock<MockTimeSystem> time_source_;
   TestStreamInfo stream_info_;
 };
 

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -129,11 +129,12 @@ inline test::fuzz::Headers toHeaders(const Http::HeaderMap& headers) {
 const std::string TestSubjectPeer =
     "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
 
-inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamInfo& stream_info) {
+inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamInfo& stream_info,
+                                                      TimeSource& time_source) {
   // Set mocks' default string return value to be an empty string.
   // TODO(asraa): Speed up this function, which is slowed because of the use of mocks.
   testing::DefaultValue<const std::string&>::Set(EMPTY_STRING);
-  auto test_stream_info = std::make_unique<TestStreamInfo>();
+  auto test_stream_info = std::make_unique<TestStreamInfo>(time_source);
   test_stream_info->metadata_ = stream_info.dynamic_metadata();
   // Truncate recursive filter metadata fields.
   // TODO(asraa): Resolve MessageToJsonString failure on recursive filter metadata.
@@ -164,7 +165,7 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
       stream_info.has_upstream_local_address()
           ? Envoy::Network::Address::resolveProtoAddress(stream_info.upstream_local_address())
           : Network::Utility::resolveUrl("tcp://10.0.0.1:10000");
-  test_stream_info->upstream_local_address_ = upstream_local_address;
+  test_stream_info->setUpstreamLocalAddress(upstream_local_address);
   test_stream_info->downstream_connection_info_provider_ =
       std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
   test_stream_info->downstream_connection_info_provider_->setRequestedServerName(


### PR DESCRIPTION
Every update to the stream into interface requires updates to the impl, the mocks, and the test class. Making the test class inherit from the impl to reduce churn.

Risk Level: n/a  (test only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Clean up for https://github.com/envoyproxy/envoy-mobile/issues/1520