### PR TITLE
http: added support for %REQUESTED_SERVER_NAME% to extract SNI as a custom header (Fixes #19024)

### DIFF
--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -682,6 +682,12 @@ Supported variable names are:
     The original protocol which is already added by Envoy as a
     :ref:`x-forwarded-proto <config_http_conn_man_headers_x-forwarded-proto>` request header.
 
+%REQUESTED_SERVER_NAME%
+  HTTP
+    String value set on ssl connection socket for Server Name Indication (SNI)
+  TCP
+    String value set on ssl connection socket for Server Name Indication (SNI)
+
 %UPSTREAM_METADATA(["namespace", "key", ...])%
     Populates the header with :ref:`EDS endpoint metadata <envoy_v3_api_field_config.endpoint.v3.LbEndpoint.metadata>` from the
     upstream host selected by the router. Metadata may be selected from any namespace. In general,

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -63,7 +63,7 @@ New Features
 * dns_resolver: added :ref:`CaresDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>` to support c-ares DNS resolver as an extension.
 * dns_resolver: added :ref:`AppleDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>` to support apple DNS resolver as an extension.
 * ext_authz: added :ref:`query_parameters_to_set <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_set>` and :ref:`query_parameters_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_remove>` for adding and removing query string parameters when using a gRPC authorization server.
-* http: added support for `%REQUESTED_SERVER_NAME%` to extract SNI as a custom header.
+* http: added support for %REQUESTED_SERVER_NAME% to extract SNI as a custom header.
 * http: added support for :ref:`retriable health check status codes <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`.
 * http: added timing information about upstream connection and encryption establishment to stream info. These can currently be accessed via custom access loggers.
 * listener: added API for extensions to access :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` configured in the listener's :ref:`metadata <envoy_v3_api_field_config.listener.v3.Listener.metadata>` field.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -63,6 +63,7 @@ New Features
 * dns_resolver: added :ref:`CaresDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>` to support c-ares DNS resolver as an extension.
 * dns_resolver: added :ref:`AppleDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>` to support apple DNS resolver as an extension.
 * ext_authz: added :ref:`query_parameters_to_set <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_set>` and :ref:`query_parameters_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_remove>` for adding and removing query string parameters when using a gRPC authorization server.
+* http: added support for `%REQUESTED_SERVER_NAME%` to extract SNI as a custom header.
 * http: added support for :ref:`retriable health check status codes <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`.
 * http: added timing information about upstream connection and encryption establishment to stream info. These can currently be accessed via custom access loggers.
 * listener: added API for extensions to access :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` configured in the listener's :ref:`metadata <envoy_v3_api_field_config.listener.v3.Listener.metadata>` field.

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -241,6 +241,13 @@ StreamInfoHeaderFormatter::StreamInfoHeaderFormatter(absl::string_view field_nam
       return Envoy::Formatter::SubstitutionFormatUtils::protocolToStringOrDefault(
           stream_info.protocol());
     };
+  } else if (field_name == "REQUESTED_SERVER_NAME") {
+    field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) -> std::string {
+      if (!stream_info.downstreamAddressProvider().requestedServerName().empty()) {
+        return std::string(stream_info.downstreamAddressProvider().requestedServerName());
+      }
+      return "";
+    };
   } else if (field_name == "DOWNSTREAM_REMOTE_ADDRESS") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
       return stream_info.downstreamAddressProvider().remoteAddress()->asString();

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -243,10 +243,7 @@ StreamInfoHeaderFormatter::StreamInfoHeaderFormatter(absl::string_view field_nam
     };
   } else if (field_name == "REQUESTED_SERVER_NAME") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) -> std::string {
-      if (!stream_info.downstreamAddressProvider().requestedServerName().empty()) {
-        return std::string(stream_info.downstreamAddressProvider().requestedServerName());
-      }
-      return "";
+      return std::string(stream_info.downstreamAddressProvider().requestedServerName());
     };
   } else if (field_name == "DOWNSTREAM_REMOTE_ADDRESS") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -141,6 +141,17 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithProtocolVariable) {
   testFormatting(stream_info, "PROTOCOL", "HTTP/1.1");
 }
 
+TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithRequestedServerNameVariable) {
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  // Validate for empty Request Server Name
+  testFormatting(stream_info, "REQUESTED_SERVER_NAME", "");
+
+  // Validate for a valid Request Server Name
+  const std::string requested_server_name_ = "foo.bar";
+  stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name_);
+  testFormatting(stream_info, "REQUESTED_SERVER_NAME", requested_server_name_);
+}
+
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerUriSanVariableSingleSan) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -835,6 +846,7 @@ TEST(HeaderParserTest, TestParseInternal) {
       {"%UPSTREAM_METADATA( \t [ \t \"ns\" \t , \t \"key\" \t ] \t )%", {"value"}, {}},
       {R"EOF(%UPSTREAM_METADATA(["\"quoted\"", "\"key\""])%)EOF", {"value"}, {}},
       {"%UPSTREAM_REMOTE_ADDRESS%", {"10.0.0.1:443"}, {}},
+      {"%REQUESTED_SERVER_NAME%", {"foo.bar"}, {}},
       {"%PER_REQUEST_STATE(testing)%", {"test_value"}, {}},
       {"%REQ(x-request-id)%", {"123"}, {}},
       {"%START_TIME%", {"2018-04-03T23:06:09.123Z"}, {}},
@@ -932,6 +944,8 @@ TEST(HeaderParserTest, TestParseInternal) {
   };
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  const std::string requested_server_name_ = "foo.bar";
+  stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name_);
   absl::optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
   ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
 

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -147,9 +147,9 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithRequestedServerNameVariable)
   testFormatting(stream_info, "REQUESTED_SERVER_NAME", "");
 
   // Validate for a valid Request Server Name
-  const std::string requested_server_name_ = "foo.bar";
-  stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name_);
-  testFormatting(stream_info, "REQUESTED_SERVER_NAME", requested_server_name_);
+  const std::string requested_server_name = "foo.bar";
+  stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name);
+  testFormatting(stream_info, "REQUESTED_SERVER_NAME", requested_server_name);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerUriSanVariableSingleSan) {
@@ -944,8 +944,8 @@ TEST(HeaderParserTest, TestParseInternal) {
   };
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  const std::string requested_server_name_ = "foo.bar";
-  stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name_);
+  const std::string requested_server_name = "foo.bar";
+  stream_info.downstream_connection_info_provider_->setRequestedServerName(requested_server_name);
   absl::optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
   ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
 


### PR DESCRIPTION
This PR adds a new command operator in the header formatter called `%REQUESTED_SERVER_NAME%` which can be used to extract the SNI information from the stream and set it as a custom header. 

**Commit Message:** Added support for `%REQUESTED_SERVER_NAME%` to extract the SNI as a custom header.
**Additional Description:** Adds a new command operator called `%REQUESTED_SERVER_NAME%` in the http header formatter which can be used to extract the SNI information from the stream and set it as a custom header.
**Risk Level:** Low
**Testing:** Unit Tests
**Docs Changes:** Added description on `%REQUESTED_SERVER_NAME%` in the docs.
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>