### PR TITLE
ci: disable multplexed integration test for coverage temporarily

### DIFF
--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -412,6 +412,8 @@ TEST_P(Http2MetadataIntegrationTest, ProxyMultipleMetadata) {
   EXPECT_EQ(response->metadataMap().size(), multiple_vecs.size());
 }
 
+// Disabled temporarily see #19040
+#if 0
 TEST_P(Http2MetadataIntegrationTest, ProxyInvalidMetadata) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -440,6 +442,7 @@ TEST_P(Http2MetadataIntegrationTest, ProxyInvalidMetadata) {
   EXPECT_EQ(0, response->metadataMapsDecodedCount());
   EXPECT_EQ(response->metadataMap().size(), 0);
 }
+#endif
 
 void verifyExpectedMetadata(Http::MetadataMap metadata_map, std::set<std::string> keys) {
   for (const auto& key : keys) {


### PR DESCRIPTION
Commit Message: ci: disable multplexed integration test for coverage temporarily
Additional Description:
IpVersions/Http2MetadataIntegrationTest.ProxyInvalidMetadata/IPv4_Http2Downstream_Http2UpstreamWrappedHttp2 test fails often in coverage and compile_time_options builds.
Disable it for now.

Risk Level: low
Testing: run the failing test manually
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Details in #19040 
