### PR TITLE
test: fixing a reverse bridge teardown flake

### DIFF
--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -56,8 +56,6 @@ typed_config:
     HttpIntegrationTest::initialize();
   }
 
-  void TearDown() override { fake_upstream_connection_.reset(); }
-
 protected:
   Http::CodecType upstream_protocol_;
 };


### PR DESCRIPTION
the base class teardown has the order of destruction set up correctly to avoid crashes. Fixes a 6/5000 flake I'm seeing way more often on CI.

Risk Level: n/a
Testing: many runs