### PR TITLE
dep: Remove dependency - six

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -115,10 +115,6 @@ def _python_deps():
         name = "com_github_twitter_common_finagle_thrift",
         build_file = "@envoy//bazel/external:twitter_common_finagle_thrift.BUILD",
     )
-    external_http_archive(
-        name = "six",
-        build_file = "@com_google_protobuf//third_party:six.BUILD",
-    )
 
 # Bazel native C++ dependencies. For the dependencies that doesn't provide autoconf/automake builds.
 def _cc_deps():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -705,16 +705,6 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["build"],
         release_date = "2021-10-22",
     ),
-    six = dict(
-        project_name = "Six",
-        project_desc = "Python 2 and 3 compatibility library",
-        project_url = "https://github.com/benjaminp/six",
-        version = "1.12.0",
-        sha256 = "0ce7aef70d066b8dda6425c670d00c25579c3daad8108b3e3d41bef26003c852",
-        urls = ["https://github.com/benjaminp/six/archive/{version}.tar.gz"],
-        release_date = "2018-12-10",
-        use_category = ["other"],
-    ),
     org_llvm_llvm = dict(
         # When changing this, you must re-generate the list of llvm libs
         # see `bazel/foreign_cc/BUILD` for further information.


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Commit Message: Remove dependency - six
Additional Description: An internal 3pp scan reports that six version is older and a newer version is available. However as six is no longer used, attempting to remove the same
Risk Level: low
Testing: local build and pre checks done
