### PR TITLE
Fix a broken example in Lua filter docs

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -769,8 +769,8 @@ its keys can only be *string* or *numeric*.
   function envoy_on_request(request_handle)
     local headers = request_handle:headers()
     request_handle:streamInfo():dynamicMetadata():set("envoy.filters.http.lua", "request.info", {
-      auth: headers:get("authorization"),
-      token: headers:get("x-request-token"),
+      auth = headers:get("authorization"),
+      token = headers:get("x-request-token"),
     })
   end
 


### PR DESCRIPTION
Signed-off-by: Peter Jausovec <peter.jausovec@gmail.com>

Commit Message: Fix a broken example in Lua filter docs
Additional Description: Setting values in Lua is done using `=`, not `:`
Docs Changes: Fix the broken example