### PR TITLE
quic: turn off GRO in client connection

### DIFF
--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -200,7 +200,7 @@ void EnvoyQuicClientConnection::onFileEvent(uint32_t events,
   if (connected() && (events & Event::FileReadyType::Read)) {
     Api::IoErrorPtr err = Network::Utility::readPacketsFromSocket(
         connection_socket.ioHandle(), *connection_socket.connectionInfoProvider().localAddress(),
-        *this, dispatcher_.timeSource(), true, packets_dropped_);
+        *this, dispatcher_.timeSource(), /*prefer_gro=*/false, packets_dropped_);
     if (err == nullptr) {
       // In the case where the path validation fails, the probing socket will be closed and its IO
       // events are no longer interesting.


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: hard code prefer_gro to false. The performance of GRO hasn't been evaluated yet, so it shouldn't be default on.

Risk Level: low
Testing: existing tests pass
