### PR TITLE
tools: Fix dependency checker release dates bug

### DIFF
--- a/tools/dependency/release_dates.py
+++ b/tools/dependency/release_dates.py
@@ -211,7 +211,7 @@ def get_tagged_release_date(repo, metadata_version, github_release):
         latest = ''
         print(f'GithubException {repo.name}: {err.data} {err.status} while getting latest release.')
 
-    if latest and github_release.version <= latest.tag_name:
+    if latest:
         release = repo.get_release(github_release.version)
         return release.published_at
     else:


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

Recently the kafka upstream dep released a new version for an older minor release (1.6.2)

This has caused a few problems with the release dates checker

This PR should fix an issue where it was falling back to using the commit date  rather than the release date

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
