### PR TITLE
minor perf: no empty space chars' replace in the set response code details method

### DIFF
--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -192,7 +192,7 @@ struct ResponseCodeDetailValues {
   const std::string FilterRemovedRequiredResponseHeaders =
       "filter_removed_required_response_headers";
   // The request was rejected because the original IP couldn't be detected.
-  const std::string OriginalIPDetectionFailed = "rejecting because detection failed";
+  const std::string OriginalIPDetectionFailed = "rejecting_because_detection_failed";
   // Changes or additions to details should be reflected in
   // docs/root/configuration/http/http_conn_man/response_code_details.rst
 };

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -1,5 +1,6 @@
 #include "source/common/common/utility.h"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -21,6 +22,7 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"
 #include "spdlog/spdlog.h"
@@ -268,8 +270,6 @@ uint64_t DateUtil::nowToSeconds(TimeSource& time_source) {
       .count();
 }
 
-const char StringUtil::WhitespaceChars[] = " \t\f\v\n\r";
-
 const char* StringUtil::strtoull(const char* str, uint64_t& out, int base) {
   if (strlen(str) == 0) {
     return nullptr;
@@ -378,6 +378,7 @@ std::vector<absl::string_view> StringUtil::splitToken(absl::string_view source,
                                                       bool keep_empty_string,
                                                       bool trim_whitespace) {
   std::vector<absl::string_view> result;
+
   if (keep_empty_string) {
     result = absl::StrSplit(source, absl::ByAnyChar(delimiters));
   } else {
@@ -574,6 +575,26 @@ std::string StringUtil::removeCharacters(const absl::string_view& str,
     pieces.push_back(str.substr(pos));
   }
   return absl::StrJoin(pieces, "");
+}
+
+bool StringUtil::hasEmptySpace(absl::string_view view) {
+  return view.find_first_of(WhitespaceChars) != absl::string_view::npos;
+}
+
+namespace {
+
+using ReplacementMap = absl::flat_hash_map<std::string, std::string>;
+
+const ReplacementMap& emptySpaceReplacement() {
+  CONSTRUCT_ON_FIRST_USE(
+      ReplacementMap,
+      ReplacementMap{{" ", "_"}, {"\t", "_"}, {"\f", "_"}, {"\v", "_"}, {"\n", "_"}, {"\r", "_"}});
+}
+
+} // namespace
+
+std::string StringUtil::replaceAllEmptySpace(absl::string_view view) {
+  return absl::StrReplaceAll(view, emptySpaceReplacement());
 }
 
 bool Primes::isPrime(uint32_t x) {

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -237,7 +237,7 @@ public:
   using CaseUnorderedSet =
       absl::flat_hash_set<std::string, CaseInsensitiveHash, CaseInsensitiveCompare>;
 
-  static const char WhitespaceChars[];
+  static constexpr absl::string_view WhitespaceChars = " \t\f\v\n\r";
 
   /**
    * Convert a string to an unsigned long, checking for error.
@@ -440,6 +440,21 @@ public:
    */
   static std::string removeCharacters(const absl::string_view& str,
                                       const IntervalSet<size_t>& remove_characters);
+
+  /**
+   * Check whether a string contains empty characters or space (' ', '\t', '\f', '\v', '\n', '\r').
+   * @param view string.
+   * @return true if string contains ' ', '\t', '\f', '\v', '\n', '\r'.
+   */
+  static bool hasEmptySpace(absl::string_view view);
+
+  /**
+   * Replace all empty characters or space (' ', '\t', '\f', '\v', '\n', '\r') in the string with
+   * '_'.
+   * @param view string.
+   * @return std::string the string after replaced all empty characters or space.
+   */
+  static std::string replaceAllEmptySpace(absl::string_view view);
 };
 
 /**

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -318,7 +318,7 @@ void ConnectionManagerImpl::handleCodecError(absl::string_view error) {
   // GOAWAY.
   doConnectionClose(Network::ConnectionCloseType::FlushWriteAndDelay,
                     StreamInfo::ResponseFlag::DownstreamProtocolError,
-                    absl::StrCat("codec error:", error));
+                    absl::StrCat("codec_error:", StringUtil::replaceAllEmptySpace(error)));
 }
 
 void ConnectionManagerImpl::createCodec(Buffer::Instance& data) {

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1144,7 +1144,7 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
     sendLocalReply(
         Http::Code::BadGateway, status.message(), nullptr, absl::nullopt,
         absl::StrCat(StreamInfo::ResponseCodeDetails::get().FilterRemovedRequiredResponseHeaders,
-                     "{", status.message(), "}"));
+                     "{", StringUtil::replaceAllEmptySpace(status.message()), "}"));
     return;
   }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -467,7 +467,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
                                              std::string(res.entry_->value().getStringView()));
         const std::string details =
             absl::StrCat(StreamInfo::ResponseCodeDetails::get().InvalidEnvoyRequestHeaders, "{",
-                         res.entry_->key().getStringView(), "}");
+                         StringUtil::replaceAllEmptySpace(res.entry_->key().getStringView()), "}");
         callbacks_->sendLocalReply(Http::Code::BadRequest, body, nullptr, absl::nullopt, details);
         return Http::FilterHeadersStatus::StopIteration;
       }
@@ -1168,9 +1168,9 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason,
   const std::string& basic_details =
       downstream_response_started_ ? StreamInfo::ResponseCodeDetails::get().LateUpstreamReset
                                    : StreamInfo::ResponseCodeDetails::get().EarlyUpstreamReset;
-  const std::string details = absl::StrCat(
+  const std::string details = StringUtil::replaceAllEmptySpace(absl::StrCat(
       basic_details, "{", Http::Utility::resetReasonToString(reset_reason),
-      transport_failure_reason.empty() ? "" : absl::StrCat(",", transport_failure_reason), "}");
+      transport_failure_reason.empty() ? "" : absl::StrCat(",", transport_failure_reason), "}"));
   onUpstreamAbort(error_code, response_flags, body, dropped, details);
 }
 

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -511,7 +511,7 @@ void UpstreamRequest::onPoolReady(
     stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamProtocolError);
     const std::string details =
         absl::StrCat(StreamInfo::ResponseCodeDetails::get().FilterRemovedRequiredRequestHeaders,
-                     "{", status.message(), "}");
+                     "{", StringUtil::replaceAllEmptySpace(status.message()), "}");
     parent_.callbacks()->sendLocalReply(Http::Code::ServiceUnavailable, status.message(), nullptr,
                                         absl::nullopt, details);
     return;

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -13,8 +13,8 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/common/dump_state_utils.h"
-#include "source/common/common/utility.h"
 #include "source/common/common/macros.h"
+#include "source/common/common/utility.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -13,6 +13,7 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/common/dump_state_utils.h"
+#include "source/common/common/utility.h"
 #include "source/common/common/macros.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
@@ -21,18 +22,6 @@
 
 namespace Envoy {
 namespace StreamInfo {
-
-namespace {
-
-using ReplacementMap = absl::flat_hash_map<std::string, std::string>;
-
-const ReplacementMap& emptySpaceReplacement() {
-  CONSTRUCT_ON_FIRST_USE(
-      ReplacementMap,
-      ReplacementMap{{" ", "_"}, {"\t", "_"}, {"\f", "_"}, {"\v", "_"}, {"\n", "_"}, {"\r", "_"}});
-}
-
-} // namespace
 
 struct UpstreamInfoImpl : public UpstreamInfo {
   void setUpstreamConnectionId(uint64_t id) override { upstream_connection_id_ = id; }
@@ -247,7 +236,8 @@ struct StreamInfoImpl : public StreamInfo {
   void setResponseCode(uint32_t code) override { response_code_ = code; }
 
   void setResponseCodeDetails(absl::string_view rc_details) override {
-    response_code_details_.emplace(absl::StrReplaceAll(rc_details, emptySpaceReplacement()));
+    ASSERT(!StringUtil::hasEmptySpace(rc_details));
+    response_code_details_.emplace(rc_details);
   }
 
   const absl::optional<std::string>& connectionTerminationDetails() const override {

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1636,7 +1636,8 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, std::string_view b
     // sendLocalReply() will fail. Net net, this is safe.
     wasm()->addAfterVmCallAction([this, response_code, body_text = std::string(body_text),
                                   modify_headers = std::move(modify_headers), grpc_status,
-                                  details = std::string(details)] {
+                                  details = StringUtil::replaceAllEmptySpace(
+                                      absl::string_view(details.data(), details.size()))] {
       decoder_callbacks_->sendLocalReply(static_cast<Envoy::Http::Code>(response_code), body_text,
                                          modify_headers, grpc_status, details);
     });

--- a/source/extensions/filters/common/rbac/utility.cc
+++ b/source/extensions/filters/common/rbac/utility.cc
@@ -20,9 +20,7 @@ generateStats(const std::string& prefix, const std::string& shadow_prefix, Stats
 std::string responseDetail(const std::string& policy_id) {
   // Replace whitespaces in policy_id with '_' to avoid breaking the access log (inconsistent number
   // of segments between log entries when the separator is whitespace).
-  const absl::flat_hash_map<std::string, std::string> replacement{
-      {" ", "_"}, {"\t", "_"}, {"\f", "_"}, {"\v", "_"}, {"\n", "_"}, {"\r", "_"}};
-  std::string sanitized = absl::StrReplaceAll(policy_id, replacement);
+  std::string sanitized = StringUtil::replaceAllEmptySpace(policy_id);
   return fmt::format("rbac_access_denied_matched_policy[{}]", sanitized);
 }
 

--- a/source/extensions/filters/http/admission_control/admission_control.cc
+++ b/source/extensions/filters/http/admission_control/admission_control.cc
@@ -99,7 +99,7 @@ Http::FilterHeadersStatus AdmissionControlFilter::decodeHeaders(Http::RequestHea
 
     stats_.rq_rejected_.inc();
     decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "", nullptr, absl::nullopt,
-                                       "denied by admission control");
+                                       "denied_by_admission_control");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -26,9 +26,15 @@ struct ResponseStringValues {
   const std::string PendingRequestOverflow = "Dynamic forward proxy pending request overflow";
 };
 
+struct RcDetailsValues {
+  const std::string DnsCacheOverflow = "dns_cache_overflow";
+  const std::string PendingRequestOverflow = "dynamic_forward_proxy_pending_request_overflow";
+};
+
 using CustomClusterType = envoy::config::cluster::v3::Cluster::CustomClusterType;
 
 using ResponseStrings = ConstSingleton<ResponseStringValues>;
+using RcDetails = ConstSingleton<RcDetailsValues>;
 
 using LoadDnsCacheEntryStatus = Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus;
 
@@ -85,7 +91,7 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
     ENVOY_STREAM_LOG(debug, "pending request overflow", *this->decoder_callbacks_);
     this->decoder_callbacks_->sendLocalReply(
         Http::Code::ServiceUnavailable, ResponseStrings::get().PendingRequestOverflow, nullptr,
-        absl::nullopt, ResponseStrings::get().PendingRequestOverflow);
+        absl::nullopt, RcDetails::get().PendingRequestOverflow);
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -153,7 +159,7 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
     ENVOY_STREAM_LOG(debug, "DNS cache overflow", *decoder_callbacks_);
     decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable,
                                        ResponseStrings::get().DnsCacheOverflow, nullptr,
-                                       absl::nullopt, ResponseStrings::get().DnsCacheOverflow);
+                                       absl::nullopt, RcDetails::get().DnsCacheOverflow);
     return Http::FilterHeadersStatus::StopIteration;
   }
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -25,7 +25,7 @@ using Http::RequestTrailerMap;
 using Http::ResponseHeaderMap;
 using Http::ResponseTrailerMap;
 
-static const std::string ErrorPrefix = "ext_proc error";
+static const std::string ErrorPrefix = "ext_proc_error";
 static const int DefaultImmediateStatus = 200;
 static const std::string FilterName = "envoy.filters.http.ext_proc";
 
@@ -536,7 +536,7 @@ void Filter::onGrpcError(Grpc::Status::GrpcStatus status) {
     cleanUpTimers();
     ImmediateResponse errorResponse;
     errorResponse.mutable_status()->set_code(envoy::type::v3::StatusCode::InternalServerError);
-    errorResponse.set_details(absl::StrFormat("%s: gRPC error %i", ErrorPrefix, status));
+    errorResponse.set_details(absl::StrFormat("%s_gRPC_error_%i", ErrorPrefix, status));
     sendImmediateResponse(errorResponse);
   }
 }
@@ -572,7 +572,7 @@ void Filter::onMessageTimeout() {
     encoding_state_.setCallbackState(ProcessorState::CallbackState::Idle);
     ImmediateResponse errorResponse;
     errorResponse.mutable_status()->set_code(envoy::type::v3::StatusCode::InternalServerError);
-    errorResponse.set_details(absl::StrFormat("%s: per-message timeout exceeded", ErrorPrefix));
+    errorResponse.set_details(absl::StrFormat("%s_per-message_timeout_exceeded", ErrorPrefix));
     sendImmediateResponse(errorResponse);
   }
 }

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -609,8 +609,9 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
 
   sent_immediate_response_ = true;
   ENVOY_LOG(debug, "Sending local reply with status code {}", status_code);
+  const auto details = StringUtil::replaceAllEmptySpace(response.details());
   encoder_callbacks_->sendLocalReply(static_cast<Http::Code>(status_code), response.body(),
-                                     mutate_headers, grpc_status, response.details());
+                                     mutate_headers, grpc_status, details);
 }
 
 static ProcessingMode allDisabledMode() {

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -463,7 +463,8 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
     decoder_callbacks_->sendLocalReply(
         static_cast<Http::Code>(http_code), status.message().ToString(), nullptr, absl::nullopt,
         absl::StrCat(RcDetails::get().GrpcTranscodeFailedEarly, "{",
-                     MessageUtil::codeEnumToString(status.code()), "}"));
+                     StringUtil::replaceAllEmptySpace(MessageUtil::codeEnumToString(status.code())),
+                     "}"));
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -743,7 +744,10 @@ bool JsonTranscoderFilter::checkIfTranscoderFailed(const std::string& details) {
         Http::Code::BadRequest,
         absl::string_view(request_status.message().data(), request_status.message().size()),
         nullptr, absl::nullopt,
-        absl::StrCat(details, "{", MessageUtil::codeEnumToString(request_status.code()), "}"));
+        absl::StrCat(
+            details, "{",
+            StringUtil::replaceAllEmptySpace(MessageUtil::codeEnumToString(request_status.code())),
+            "}"));
 
     return true;
   }

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -33,8 +33,8 @@ constexpr absl::string_view kRcDetailJwtAuthnPrefix = "jwt_authn_access_denied";
 std::string generateRcDetails(absl::string_view error_msg) {
   // Replace space with underscore since RCDetails may be written to access log.
   // Some log processors assume each log segment is separated by whitespace.
-  return absl::StrCat(kRcDetailJwtAuthnPrefix, "{",
-                      absl::StrJoin(absl::StrSplit(error_msg, ' '), "_"), "}");
+  return absl::StrCat(kRcDetailJwtAuthnPrefix, "{", StringUtil::replaceAllEmptySpace(error_msg),
+                      "}");
 }
 
 } // namespace

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -127,6 +127,35 @@ TEST(StringUtil, atoull) {
   EXPECT_EQ(18446744073709551615U, out);
 }
 
+TEST(StringUtil, hasEmptySpace) {
+  EXPECT_FALSE(StringUtil::hasEmptySpace("1234567890_-+=][|\"&*^%$#@!"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233 789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\t789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\f789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\v789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\n789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\r789"));
+
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233 \t\f789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\v\n\r789"));
+  EXPECT_TRUE(StringUtil::hasEmptySpace("1233\f\v\n789"));
+}
+
+TEST(StringUtil, replaceAllEmptySpace) {
+  EXPECT_EQ("1234567890_-+=][|\"&*^%$#@!",
+            StringUtil::replaceAllEmptySpace("1234567890_-+=][|\"&*^%$#@!"));
+  EXPECT_EQ("1233_789", StringUtil::replaceAllEmptySpace("1233 789"));
+  EXPECT_EQ("1233_789", StringUtil::replaceAllEmptySpace("1233\t789"));
+  EXPECT_EQ("1233_789", StringUtil::replaceAllEmptySpace("1233\f789"));
+  EXPECT_EQ("1233_789", StringUtil::replaceAllEmptySpace("1233\v789"));
+  EXPECT_EQ("1233_789", StringUtil::replaceAllEmptySpace("1233\n789"));
+  EXPECT_EQ("1233_789", StringUtil::replaceAllEmptySpace("1233\r789"));
+
+  EXPECT_EQ("1233___789", StringUtil::replaceAllEmptySpace("1233 \t\f789"));
+  EXPECT_EQ("1233___789", StringUtil::replaceAllEmptySpace("1233\v\n\r789"));
+  EXPECT_EQ("1233___789", StringUtil::replaceAllEmptySpace("1233\f\v\n789"));
+}
+
 TEST(DateUtil, All) {
   EXPECT_FALSE(DateUtil::timePointValid(SystemTime()));
   DangerousDeprecatedTestTime test_time;

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -243,12 +243,12 @@ TEST(InputConstMemoryStream, All) {
 }
 
 TEST(StringUtil, WhitespaceChars) {
-  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, ' '));
-  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\t'));
-  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\f'));
-  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\v'));
-  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\n'));
-  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\r'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars.data(), ' '));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars.data(), '\t'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars.data(), '\f'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars.data(), '\v'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars.data(), '\n'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars.data(), '\r'));
 }
 
 TEST(StringUtil, itoa) {

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -301,7 +301,7 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
-  EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{remote reset}");
+  EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{remote_reset}");
 }
 
 class RouterTestChildSpan : public RouterTestBase {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -374,7 +374,7 @@ TEST_F(RouterTest, PoolFailureWithPriority) {
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
   EXPECT_EQ(callbacks_.details(),
-            "upstream_reset_before_response_started{connection failure,tls version mismatch}");
+            "upstream_reset_before_response_started{connection_failure,tls_version_mismatch}");
 }
 
 TEST_F(RouterTest, PoolFailureDueToConnectTimeout) {
@@ -409,7 +409,7 @@ TEST_F(RouterTest, PoolFailureDueToConnectTimeout) {
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
   EXPECT_EQ(callbacks_.details(),
-            "upstream_reset_before_response_started{connection failure,connect_timeout}");
+            "upstream_reset_before_response_started{connection_failure,connect_timeout}");
 }
 
 TEST_F(RouterTest, Http1Upstream) {
@@ -1018,7 +1018,7 @@ TEST_F(RouterTest, EnvoyAttemptCountInResponsePresentWithLocalReply) {
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
-  EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{connection failure}");
+  EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{connection_failure}");
   EXPECT_EQ(1U, callbacks_.stream_info_.attemptCount().value());
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -322,7 +322,7 @@ TEST_F(RouterTest, MissingRequiredHeaders) {
       callbacks_,
       sendLocalReply(Http::Code::ServiceUnavailable,
                      testing::Eq("missing required header: :method"), _, _,
-                     "filter_removed_required_request_headers{missing required header: :method}"))
+                     "filter_removed_required_request_headers{missing_required_header:_:method}"))
       .WillOnce(testing::InvokeWithoutArgs([] {}));
   router_.decodeHeaders(headers, true);
   router_.onDestroy();

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -274,7 +274,7 @@ TEST_F(StreamInfoImplTest, DefaultRequestIDExtensionTest) {
 TEST_F(StreamInfoImplTest, Details) {
   StreamInfoImpl stream_info(test_time_.timeSystem(), nullptr);
   EXPECT_FALSE(stream_info.responseCodeDetails().has_value());
-  stream_info.setResponseCodeDetails("two words");
+  stream_info.setResponseCodeDetails("two_words");
   ASSERT_TRUE(stream_info.responseCodeDetails().has_value());
   EXPECT_EQ(stream_info.responseCodeDetails().value(), "two_words");
 }

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -162,7 +162,7 @@ TEST_F(ProxyFilterTest, CacheOverflow) {
       .WillOnce(Return(
           MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Overflow, nullptr, absl::nullopt}));
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable, Eq("DNS cache overflow"),
-                                         _, _, Eq("DNS cache overflow")));
+                                         _, _, Eq("dns_cache_overflow")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -200,7 +200,7 @@ TEST_F(ProxyFilterTest, CircuitBreakerOverflow) {
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_());
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable,
                                          Eq("Dynamic forward proxy pending request overflow"), _, _,
-                                         Eq("Dynamic forward proxy pending request overflow")));
+                                         Eq("dynamic_forward_proxy_pending_request_overflow")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -240,7 +240,7 @@ TEST_F(ProxyFilterTest, CircuitBreakerOverflowWithDnsCacheResourceManager) {
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_());
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable,
                                          Eq("Dynamic forward proxy pending request overflow"), _, _,
-                                         Eq("Dynamic forward proxy pending request overflow")));
+                                         Eq("dynamic_forward_proxy_pending_request_overflow")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -414,7 +414,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
 
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadRequest, "Bad request", _,
-                                                 Eq(absl::nullopt), "Got a bad request"))
+                                                 Eq(absl::nullopt), "Got_a_bad_request"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -486,7 +486,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyOnResponse) {
 
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadRequest, "Bad request", _,
-                                                 Eq(absl::nullopt), "Got a bad request"))
+                                                 Eq(absl::nullopt), "Got_a_bad_request"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -1540,9 +1540,8 @@ TEST_F(HttpFilterTest, PostAndFail) {
 
   // Oh no! The remote server had a failure!
   Http::TestResponseHeaderMapImpl immediate_response_headers;
-  EXPECT_CALL(encoder_callbacks_,
-              sendLocalReply(Http::Code::InternalServerError, "", _, Eq(absl::nullopt),
-                             "ext_proc error: gRPC error 13"))
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, "", _,
+                                                 Eq(absl::nullopt), "ext_proc_error_gRPC_error_13"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -1598,9 +1597,8 @@ TEST_F(HttpFilterTest, PostAndFailOnResponse) {
 
   // Oh no! The remote server had a failure!
   Http::TestResponseHeaderMapImpl immediate_response_headers;
-  EXPECT_CALL(encoder_callbacks_,
-              sendLocalReply(Http::Code::InternalServerError, "", _, Eq(absl::nullopt),
-                             "ext_proc error: gRPC error 13"))
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, "", _,
+                                                 Eq(absl::nullopt), "ext_proc_error_gRPC_error_13"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,

--- a/test/integration/filters/invalid_header_filter.cc
+++ b/test/integration/filters/invalid_header_filter.cc
@@ -30,7 +30,7 @@ public:
     }
     if (!headers.get(Http::LowerCaseString("send-reply")).empty()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt,
-                                         "InvalidHeaderFilter ready");
+                                         "invalid_header_filter_ready");
       return Http::FilterHeadersStatus::StopIteration;
     }
     return Http::FilterHeadersStatus::Continue;

--- a/test/integration/filters/listener_typed_metadata_filter.cc
+++ b/test/integration/filters/listener_typed_metadata_filter.cc
@@ -47,7 +47,7 @@ public:
 
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt,
-                                       "Successfully handled request.");
+                                       "successfully_handled_request");
     return Http::FilterHeadersStatus::Continue;
   }
 };

--- a/test/integration/filters/local_reply_with_metadata_filter.cc
+++ b/test/integration/filters/local_reply_with_metadata_filter.cc
@@ -20,7 +20,7 @@ public:
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     decoder_callbacks_->addDecodedMetadata().emplace_back(std::move(metadata_map_ptr));
     decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt,
-                                       "LocalReplyWithMetadataFilter is ready");
+                                       "local_reply_with_metadata_filter_is_ready");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -612,7 +612,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReply) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("InvalidHeaderFilter_ready\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready\n"));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyDownstreamBytesCount) {

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -680,7 +680,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyWithBody) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("InvalidHeaderFilter_ready\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready\n"));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyWithBodyBytesCount) {


### PR DESCRIPTION

Commit Message: minor perf: no empty space chars' replace in the set response code details method

Additional Description:

To prevent the response code details from breaking the access log format, we replace all whitespace chars of detail string in the `setResponseCodeDetails` method. Related issue: #13423.

However, **most code details do not contain whitespace chars, and it is unnecessary to make every setResponseCodeDetails call perform an additional absl::StrReplaceAll.**

We just need to require that the caller of `setResponseCodeDetails` must ensure that the detail string does not contain whitespace chars.

Risk Level: Low.
Testing: Partial
Docs Changes: N/A.
Release Notes: N/A.