### PR TITLE
stream_info: cleaning up setters

### DIFF
--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -358,13 +358,6 @@ public:
    */
   virtual Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const PURE;
 
-  /**
-   * Sets the upstream timing information for this stream. This is useful for
-   * when multiple upstream requests are issued and we want to save timing
-   * information for the one that "wins".
-   */
-  virtual void setUpstreamTiming(const UpstreamTiming& upstream_timing) PURE;
-
   /*
    * @return the upstream timing for this stream
    * */
@@ -452,11 +445,6 @@ public:
   virtual bool intersectResponseFlags(uint64_t response_flags) const PURE;
 
   /**
-   * @param host the selected upstream host for the request.
-   */
-  virtual void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) PURE;
-
-  /**
    * @param std::string name denotes the name of the route.
    */
   virtual void setRouteName(absl::string_view name) PURE;
@@ -517,13 +505,6 @@ public:
    * request.
    */
   virtual absl::optional<std::chrono::nanoseconds> lastDownstreamRxByteReceived() const PURE;
-
-  /**
-   * Sets the upstream timing information for this stream. This is useful for
-   * when multiple upstream requests are issued and we want to save timing
-   * information for the one that "wins".
-   */
-  virtual void setUpstreamTiming(const UpstreamTiming& upstream_timing) PURE;
 
   /**
    * Sets the upstream information for this stream.
@@ -628,13 +609,6 @@ public:
   virtual Upstream::HostDescriptionConstSharedPtr upstreamHost() const PURE;
 
   /**
-   * @param upstream_local_address sets the local address of the upstream connection. Note that it
-   * can be different than the local address of the downstream connection.
-   */
-  virtual void setUpstreamLocalAddress(
-      const Network::Address::InstanceConstSharedPtr& upstream_local_address) PURE;
-
-  /**
    * @return the upstream local address.
    */
   virtual const Network::Address::InstanceConstSharedPtr& upstreamLocalAddress() const PURE;
@@ -653,12 +627,6 @@ public:
    * @return the downstream connection info provider.
    */
   virtual const Network::ConnectionInfoProvider& downstreamAddressProvider() const PURE;
-
-  /**
-   * @param connection_info sets the upstream ssl connection.
-   */
-  virtual void
-  setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
 
   /**
    * @return the upstream SSL connection. This will be nullptr if the upstream
@@ -701,12 +669,6 @@ public:
    * @return pointer to filter state to be used by upstream connections.
    */
   virtual const FilterStateSharedPtr& upstreamFilterState() const PURE;
-  virtual void setUpstreamFilterState(const FilterStateSharedPtr& filter_state) PURE;
-
-  /**
-   * @param failure_reason the upstream transport failure reason.
-   */
-  virtual void setUpstreamTransportFailureReason(absl::string_view failure_reason) PURE;
 
   /**
    * @return const std::string& the upstream transport failure reason, e.g. certificate validation
@@ -767,11 +729,6 @@ public:
    * @return Network filter chain name of the downstream connection.
    */
   virtual const std::string& filterChainName() const PURE;
-
-  /**
-   * @param connection ID of the upstream connection.
-   */
-  virtual void setUpstreamConnectionId(uint64_t id) PURE;
 
   /**
    * @return the ID of the upstream connection, or absl::nullopt if not available.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -895,12 +895,6 @@ void Filter::onDestroy() {
 void Filter::onResponseTimeout() {
   ENVOY_STREAM_LOG(debug, "upstream timeout", *callbacks_);
 
-  // If we had an upstream request that got a "good" response, save its
-  // upstream timing information into the downstream stream info.
-  if (final_upstream_request_) {
-    callbacks_->streamInfo().setUpstreamTiming(final_upstream_request_->upstreamTiming());
-  }
-
   // Reset any upstream requests that are still in flight.
   while (!upstream_requests_.empty()) {
     UpstreamRequestPtr upstream_request =
@@ -1164,7 +1158,6 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason,
                        ? ", transport failure reason: "
                        : "",
                    transport_failure_reason);
-  callbacks_->streamInfo().setUpstreamTransportFailureReason(transport_failure_reason);
   const std::string& basic_details =
       downstream_response_started_ ? StreamInfo::ResponseCodeDetails::get().LateUpstreamReset
                                    : StreamInfo::ResponseCodeDetails::get().EarlyUpstreamReset;
@@ -1407,14 +1400,8 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
 
   downstream_response_started_ = true;
   final_upstream_request_ = &upstream_request;
-  // In upstream request hedging scenarios the upstream connection ID set in onPoolReady might not
-  // be the connection ID of the upstream connection that ended up receiving upstream headers. Thus
-  // reset the upstream connection ID here with the ID of the connection that ultimately was the
-  // transport for the final upstream request.
-  if (final_upstream_request_->streamInfo().upstreamConnectionId().has_value()) {
-    callbacks_->streamInfo().setUpstreamConnectionId(
-        final_upstream_request_->streamInfo().upstreamConnectionId().value());
-  }
+  // Make sure that for request hedging, we end up with the correct final upstream info.
+  callbacks_->streamInfo().setUpstreamInfo(final_upstream_request_->streamInfo().upstreamInfo());
   resetOtherUpstreams(upstream_request);
   if (end_stream) {
     onUpstreamComplete(upstream_request);
@@ -1471,8 +1458,6 @@ void Filter::onUpstreamComplete(UpstreamRequest& upstream_request) {
   if (!downstream_end_stream_) {
     upstream_request.resetStream();
   }
-  callbacks_->streamInfo().setUpstreamTiming(final_upstream_request_->upstreamTiming());
-
   Event::Dispatcher& dispatcher = callbacks_->dispatcher();
   std::chrono::milliseconds response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
       dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -60,6 +60,8 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
       span_->setTag(Tracing::Tags::get().RetryCount, std::to_string(parent.attemptCount() - 1));
     }
   }
+  stream_info_.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
+  parent_.callbacks()->streamInfo().setUpstreamInfo(stream_info_.upstreamInfo());
 
   stream_info_.healthCheck(parent_.callbacks()->streamInfo().healthCheck());
   absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info =
@@ -115,7 +117,6 @@ UpstreamRequest::~UpstreamRequest() {
     }
   }
 
-  stream_info_.setUpstreamTiming(upstream_timing_);
   stream_info_.onRequestComplete();
   for (const auto& upstream_log : parent_.config().upstream_logs_) {
     upstream_log->log(parent_.downstreamHeaders(), upstream_headers_.get(),
@@ -162,7 +163,7 @@ void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool e
 
   // TODO(rodaine): This is actually measuring after the headers are parsed and not the first
   // byte.
-  upstream_timing_.onFirstUpstreamRxByteReceived(parent_.callbacks()->dispatcher().timeSource());
+  upstreamTiming().onFirstUpstreamRxByteReceived(parent_.callbacks()->dispatcher().timeSource());
   maybeEndDecode(end_stream);
 
   awaiting_headers_ = false;
@@ -219,15 +220,15 @@ void UpstreamRequest::decodeMetadata(Http::MetadataMapPtr&& metadata_map) {
 
 void UpstreamRequest::maybeEndDecode(bool end_stream) {
   if (end_stream) {
-    upstream_timing_.onLastUpstreamRxByteReceived(parent_.callbacks()->dispatcher().timeSource());
+    upstreamTiming().onLastUpstreamRxByteReceived(parent_.callbacks()->dispatcher().timeSource());
     decode_complete_ = true;
   }
 }
 
 void UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {
-  stream_info_.onUpstreamHostSelected(host);
+  StreamInfo::UpstreamInfo& upstream_info = *streamInfo().upstreamInfo();
+  upstream_info.setUpstreamHost(host);
   upstream_host_ = host;
-  parent_.callbacks()->streamInfo().onUpstreamHostSelected(host);
   parent_.onUpstreamHostSelected(host);
 }
 
@@ -260,7 +261,7 @@ void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
     stream_info_.addBytesSent(data.length());
     upstream_->encodeData(data, end_stream);
     if (end_stream) {
-      upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
+      upstreamTiming().onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
     }
   }
 }
@@ -277,7 +278,7 @@ void UpstreamRequest::encodeTrailers(const Http::RequestTrailerMap& trailers) {
 
     ENVOY_STREAM_LOG(trace, "proxying trailers", *parent_.callbacks());
     upstream_->encodeTrailers(trailers);
-    upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
+    upstreamTiming().onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
   }
 }
 
@@ -427,29 +428,22 @@ void UpstreamRequest::onPoolReady(
     stream_info_.protocol(protocol.value());
   }
 
+  parent_.callbacks()->streamInfo().setUpstreamInfo(stream_info_.upstreamInfo());
   if (info.upstreamInfo().has_value()) {
     auto& upstream_timing = info.upstreamInfo().value().get().upstreamTiming();
-    upstream_timing_.upstream_connect_start_ = upstream_timing.upstream_connect_start_;
-    upstream_timing_.upstream_connect_complete_ = upstream_timing.upstream_connect_complete_;
-    upstream_timing_.upstream_handshake_complete_ = upstream_timing.upstream_handshake_complete_;
+    upstreamTiming().upstream_connect_start_ = upstream_timing.upstream_connect_start_;
+    upstreamTiming().upstream_connect_complete_ = upstream_timing.upstream_connect_complete_;
+    upstreamTiming().upstream_handshake_complete_ = upstream_timing.upstream_handshake_complete_;
   }
 
-  stream_info_.setUpstreamFilterState(std::make_shared<StreamInfo::FilterStateImpl>(
+  StreamInfo::UpstreamInfo& upstream_info = *stream_info_.upstreamInfo();
+  upstream_info.setUpstreamFilterState(std::make_shared<StreamInfo::FilterStateImpl>(
       info.filterState().parent()->parent(), StreamInfo::FilterState::LifeSpan::Request));
-  parent_.callbacks()->streamInfo().setUpstreamFilterState(
-      std::make_shared<StreamInfo::FilterStateImpl>(info.filterState().parent()->parent(),
-                                                    StreamInfo::FilterState::LifeSpan::Request));
-  stream_info_.setUpstreamLocalAddress(upstream_local_address);
-  parent_.callbacks()->streamInfo().setUpstreamLocalAddress(upstream_local_address);
-
-  stream_info_.setUpstreamSslConnection(info.downstreamAddressProvider().sslConnection());
-  parent_.callbacks()->streamInfo().setUpstreamSslConnection(
-      info.downstreamAddressProvider().sslConnection());
+  upstream_info.setUpstreamLocalAddress(upstream_local_address);
+  upstream_info.setUpstreamSslConnection(info.downstreamAddressProvider().sslConnection());
 
   if (info.downstreamAddressProvider().connectionID().has_value()) {
-    stream_info_.setUpstreamConnectionId(info.downstreamAddressProvider().connectionID().value());
-    parent_.callbacks()->streamInfo().setUpstreamConnectionId(
-        info.downstreamAddressProvider().connectionID().value());
+    upstream_info.setUpstreamConnectionId(info.downstreamAddressProvider().connectionID().value());
   }
 
   stream_info_.setUpstreamBytesMeter(upstream_->bytesMeter());
@@ -478,7 +472,7 @@ void UpstreamRequest::onPoolReady(
     span_->injectContext(*parent_.downstreamHeaders());
   }
 
-  upstream_timing_.onFirstUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
+  upstreamTiming().onFirstUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
 
   // Make sure that when we are forwarding CONNECT payload we do not do so until
   // the upstream has accepted the CONNECT request.
@@ -549,7 +543,7 @@ void UpstreamRequest::encodeBodyAndTrailers() {
     }
 
     if (encode_complete_) {
-      upstream_timing_.onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
+      upstreamTiming().onLastUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
     }
   }
 }

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -104,7 +104,6 @@ public:
     outlier_detection_timeout_recorded_ = recorded;
   }
   bool outlierDetectionTimeoutRecorded() { return outlier_detection_timeout_recorded_; }
-  const StreamInfo::UpstreamTiming& upstreamTiming() { return upstream_timing_; }
   void retried(bool value) { retried_ = value; }
   bool retried() { return retried_; }
   bool grpcRqSuccessDeferred() { return grpc_rq_success_deferred_; }
@@ -122,6 +121,9 @@ public:
   StreamInfo::StreamInfo& streamInfo() { return stream_info_; }
 
 private:
+  StreamInfo::UpstreamTiming& upstreamTiming() {
+    return stream_info_.upstreamInfo()->upstreamTiming();
+  }
   bool shouldSendEndStream() {
     // Only encode end stream if the full request has been received, the body
     // has been sent, and any trailers or metadata have also been sent.
@@ -147,7 +149,6 @@ private:
   DownstreamWatermarkManager downstream_watermark_manager_{*this};
   Tracing::SpanPtr span_;
   StreamInfo::StreamInfoImpl stream_info_;
-  StreamInfo::UpstreamTiming upstream_timing_;
   const MonotonicTime start_time_;
   // This is wrapped in an optional, since we want to avoid computing zero size headers when in
   // reality we just didn't get a response back.

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -47,9 +47,6 @@ struct UpstreamInfoImpl : public UpstreamInfo {
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
     return upstream_ssl_info_;
   }
-  void setUpstreamTiming(const UpstreamTiming& upstream_timing) override {
-    upstream_timing_ = upstream_timing;
-  }
   UpstreamTiming& upstreamTiming() override { return upstream_timing_; }
   const UpstreamTiming& upstreamTiming() const override { return upstream_timing_; }
   const Network::Address::InstanceConstSharedPtr& upstreamLocalAddress() const override {
@@ -135,11 +132,6 @@ struct StreamInfoImpl : public StreamInfo {
     }
   }
 
-  void setUpstreamConnectionId(uint64_t id) override {
-    maybeCreateUpstreamInfo();
-    upstream_info_->setUpstreamConnectionId(id);
-  }
-
   absl::optional<uint64_t> upstreamConnectionId() const override {
     if (!upstream_info_) {
       return absl::nullopt;
@@ -154,13 +146,10 @@ struct StreamInfoImpl : public StreamInfo {
     return duration(downstream_timing_.value().lastDownstreamRxByteReceived());
   }
 
-  void setUpstreamTiming(const UpstreamTiming& upstream_timing) override {
-    maybeCreateUpstreamInfo();
-    upstream_info_->setUpstreamTiming(upstream_timing);
-  }
-
   void setUpstreamInfo(std::shared_ptr<UpstreamInfo> info) override { upstream_info_ = info; }
+
   std::shared_ptr<UpstreamInfo> upstreamInfo() override { return upstream_info_; }
+
   OptRef<const UpstreamInfo> upstreamInfo() const override {
     if (!upstream_info_) {
       return {};
@@ -274,11 +263,6 @@ struct StreamInfoImpl : public StreamInfo {
 
   uint64_t responseFlags() const override { return response_flags_; }
 
-  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) override {
-    maybeCreateUpstreamInfo();
-    upstream_info_->setUpstreamHost(host);
-  }
-
   Upstream::HostDescriptionConstSharedPtr upstreamHost() const override {
     if (!upstream_info_) {
       return nullptr;
@@ -291,12 +275,6 @@ struct StreamInfoImpl : public StreamInfo {
   }
 
   const std::string& getRouteName() const override { return route_name_; }
-
-  void setUpstreamLocalAddress(
-      const Network::Address::InstanceConstSharedPtr& upstream_local_address) override {
-    maybeCreateUpstreamInfo();
-    upstream_info_->setUpstreamLocalAddress(upstream_local_address);
-  }
 
   const Network::Address::InstanceConstSharedPtr& upstreamLocalAddress() const override {
     if (!upstream_info_) {
@@ -311,11 +289,6 @@ struct StreamInfoImpl : public StreamInfo {
 
   const Network::ConnectionInfoProvider& downstreamAddressProvider() const override {
     return *downstream_connection_info_provider_;
-  }
-
-  void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    maybeCreateUpstreamInfo();
-    upstream_info_->setUpstreamSslConnection(connection_info);
   }
 
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
@@ -339,15 +312,6 @@ struct StreamInfoImpl : public StreamInfo {
       return legacy_upstream_filter_state_;
     }
     return upstream_info_->upstreamFilterState();
-  }
-  void setUpstreamFilterState(const FilterStateSharedPtr& filter_state) override {
-    maybeCreateUpstreamInfo();
-    return upstream_info_->setUpstreamFilterState(filter_state);
-  }
-
-  void setUpstreamTransportFailureReason(absl::string_view failure_reason) override {
-    maybeCreateUpstreamInfo();
-    upstream_info_->setUpstreamTransportFailureReason(failure_reason);
   }
 
   const std::string& upstreamTransportFailureReason() const override {

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -298,7 +298,8 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
       host_->transportSocketFactory().implementsSecureTransport());
   StreamInfo::StreamInfoImpl stream_info(protocol_, parent_.dispatcher_.timeSource(),
                                          local_connection_info_provider_);
-  stream_info.onUpstreamHostSelected(host_);
+  stream_info.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
+  stream_info.upstreamInfo()->setUpstreamHost(host_);
   parent_.request_headers_parser_->evaluateHeaders(*request_headers, stream_info);
   auto status = request_encoder->encodeHeaders(*request_headers, true);
   // Encoding will only fail if required request headers are missing.

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -106,7 +106,7 @@ typed_config:
   EXPECT_CALL(*file_, write(_));
 
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
-  stream_info_.onUpstreamHostSelected(
+  stream_info_.upstreamInfo()->setUpstreamHost(
       Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime()));
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamConnectionTermination);
 
@@ -217,7 +217,7 @@ typed_config:
 
 TEST_F(AccessLogImplTest, UpstreamHost) {
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
-  stream_info_.onUpstreamHostSelected(
+  stream_info_.upstreamInfo()->setUpstreamHost(
       Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime()));
 
   const std::string yaml = R"EOF(

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -106,7 +106,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestformatWithUpstreamRemoteAddressVariabl
   testFormatting("UPSTREAM_REMOTE_ADDRESS", "10.0.0.1:443");
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  stream_info.host_.reset();
+  stream_info.upstreamInfo()->setUpstreamHost(nullptr);
   testFormatting(stream_info, "UPSTREAM_REMOTE_ADDRESS", "");
 }
 

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -280,10 +280,6 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
           }));
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRemoteReset));
-  EXPECT_CALL(callbacks_.stream_info_, onUpstreamHostSelected(_))
-      .WillRepeatedly(Invoke([&](const Upstream::HostDescriptionConstSharedPtr& host) -> void {
-        EXPECT_EQ(host_address_, host->address());
-      }));
 
   Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
@@ -728,10 +724,6 @@ TEST_F(RouterTestSupressGRPCStatsEnabled, ExcludeTimeoutHttpStats) {
                                   upstream_stream_info_, Http::Protocol::Http10);
             return nullptr;
           }));
-  EXPECT_CALL(callbacks_.stream_info_, onUpstreamHostSelected(_))
-      .WillOnce(Invoke([&](const Upstream::HostDescriptionConstSharedPtr host) -> void {
-        EXPECT_EQ(host_address_, host->address());
-      }));
 
   expectResponseTimerCreate();
 
@@ -793,10 +785,6 @@ TEST_F(RouterTestSupressGRPCStatsDisabled, IncludeHttpTimeoutStats) {
                                   upstream_stream_info_, Http::Protocol::Http10);
             return nullptr;
           }));
-  EXPECT_CALL(callbacks_.stream_info_, onUpstreamHostSelected(_))
-      .WillOnce(Invoke([&](const Upstream::HostDescriptionConstSharedPtr host) -> void {
-        EXPECT_EQ(host_address_, host->address());
-      }));
 
   expectResponseTimerCreate();
 

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -25,6 +25,7 @@ public:
     MonotonicTime now = timeSystem().monotonicTime();
     start_time_monotonic_ = now;
     end_time_ = now + std::chrono::milliseconds(3);
+    setUpstreamInfo(std::make_shared<Envoy::StreamInfo::UpstreamInfoImpl>());
   }
 
   SystemTime startTime() const override { return start_time_; }

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1093,8 +1093,9 @@ TEST_F(TcpProxyTest, AccessDownstreamAndUpstreamProperties) {
   raiseEventUpstreamConnected(0);
   EXPECT_EQ(filter_callbacks_.connection().streamInfo().downstreamAddressProvider().sslConnection(),
             filter_callbacks_.connection().ssl());
-  EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamLocalAddress(),
-            upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().localAddress());
+  EXPECT_EQ(
+      filter_callbacks_.connection().streamInfo().upstreamLocalAddress().get(),
+      upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().localAddress().get());
   EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamSslConnection(),
             upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().sslConnection());
 }

--- a/test/common/tcp_proxy/tcp_proxy_test_base.h
+++ b/test/common/tcp_proxy/tcp_proxy_test_base.h
@@ -62,11 +62,6 @@ public:
   TcpProxyTestBase() {
     ON_CALL(*factory_context_.access_log_manager_.file_, write(_))
         .WillByDefault(SaveArg<0>(&access_log_data_));
-    ON_CALL(filter_callbacks_.connection_.stream_info_, onUpstreamHostSelected(_))
-        .WillByDefault(Invoke(
-            [this](Upstream::HostDescriptionConstSharedPtr host) { upstream_host_ = host; }));
-    ON_CALL(filter_callbacks_.connection_.stream_info_, upstreamHost())
-        .WillByDefault(ReturnPointee(&upstream_host_));
     ON_CALL(filter_callbacks_.connection_.stream_info_, setUpstreamClusterInfo(_))
         .WillByDefault(Invoke([this](const Upstream::ClusterInfoConstSharedPtr& cluster_info) {
           upstream_cluster_ = cluster_info;

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -95,6 +95,10 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
 class HttpConnManFinalizerImplTest : public testing::Test {
 protected:
+  HttpConnManFinalizerImplTest() {
+    Upstream::HostDescriptionConstSharedPtr shared_host(host_);
+    stream_info.upstreamInfo()->setUpstreamHost(shared_host);
+  }
   struct CustomTagCase {
     std::string custom_tag;
     bool set;
@@ -117,6 +121,7 @@ protected:
   NiceMock<MockSpan> span;
   NiceMock<MockConfig> config;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Upstream::MockHostDescription* host_{new NiceMock<Upstream::MockHostDescription>()};
 };
 
 TEST_F(HttpConnManFinalizerImplTest, OriginalAndLongPath) {
@@ -257,7 +262,7 @@ metadata:
 }
 
 TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
-  stream_info.host_->cluster_.name_ = "my_upstream_cluster";
+  host_->hostname_ = "my_upstream_cluster";
 
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
@@ -292,8 +297,8 @@ TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
 }
 
 TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
-  stream_info.host_->cluster_.name_ = "my_upstream_cluster";
-  stream_info.host_->cluster_.observability_name_ = "my_upstream_cluster_observable";
+  host_->cluster_.name_ = "my_upstream_cluster";
+  host_->cluster_.observability_name_ = "my_upstream_cluster_observable";
 
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
@@ -402,8 +407,7 @@ ree:
   std::shared_ptr<envoy::config::core::v3::Metadata> host_metadata =
       std::make_shared<envoy::config::core::v3::Metadata>();
   (*host_metadata->mutable_filter_metadata())["m.host"].MergeFrom(fake_struct);
-  (*stream_info.host_->cluster_.metadata_.mutable_filter_metadata())["m.cluster"].MergeFrom(
-      fake_struct);
+  (*host_->cluster_.metadata_.mutable_filter_metadata())["m.cluster"].MergeFrom(fake_struct);
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
@@ -411,7 +415,7 @@ ree:
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(100));
-  EXPECT_CALL(*stream_info.host_, metadata()).WillRepeatedly(Return(host_metadata));
+  EXPECT_CALL(*host_, metadata()).WillRepeatedly(Return(host_metadata));
 
   EXPECT_CALL(config, customTags());
   EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
@@ -728,6 +732,8 @@ public:
     driver_ = new NiceMock<MockDriver>();
     DriverPtr driver_ptr(driver_);
     tracer_ = std::make_shared<HttpTracerImpl>(std::move(driver_ptr), local_info_);
+    Upstream::HostDescriptionConstSharedPtr shared_host(host_);
+    stream_info_.upstreamInfo()->setUpstreamHost(shared_host);
   }
 
   Http::TestRequestHeaderMapImpl request_headers_{
@@ -742,6 +748,7 @@ public:
   NiceMock<MockConfig> config_;
   NiceMock<MockDriver>* driver_;
   HttpTracerSharedPtr tracer_;
+  Upstream::MockHostDescription* host_{new NiceMock<Upstream::MockHostDescription>()};
 };
 
 TEST_F(HttpTracerImplTest, BasicFunctionalityNullSpan) {
@@ -799,10 +806,9 @@ TEST_F(HttpTracerImplTest, ChildUpstreamSpanTest) {
   const std::string ob_cluster_name = "ob fake cluster";
   EXPECT_CALL(stream_info_, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info_, protocol()).WillRepeatedly(ReturnPointee(&protocol));
-  EXPECT_CALL(*(stream_info_.host_), address()).WillOnce(Return(remote_address));
-  EXPECT_CALL(stream_info_.host_->cluster_, name()).WillOnce(ReturnRef(cluster_name));
-  EXPECT_CALL(stream_info_.host_->cluster_, observabilityName())
-      .WillOnce(ReturnRef(ob_cluster_name));
+  EXPECT_CALL(*host_, address()).WillOnce(Return(remote_address));
+  EXPECT_CALL(host_->cluster_, name()).WillOnce(ReturnRef(cluster_name));
+  EXPECT_CALL(host_->cluster_, observabilityName()).WillOnce(ReturnRef(ob_cluster_name));
 
   EXPECT_CALL(*second_span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -117,7 +117,6 @@ public:
 
   void expectLogRequestMethod(const std::string& request_method) {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
     stream_info.start_time_ = SystemTime(1h);
 
     Http::TestRequestHeaderMapImpl request_headers{
@@ -175,7 +174,7 @@ TEST_F(HttpGrpcAccessLogTest, Marshalling) {
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
     stream_info.start_time_monotonic_ = MonotonicTime(1h);
     stream_info.last_downstream_tx_byte_sent_ = 2ms;
@@ -231,7 +230,7 @@ response: {}
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
     stream_info.last_downstream_tx_byte_sent_ = std::chrono::nanoseconds(2000000);
 
@@ -264,14 +263,14 @@ response: {}
     stream_info.start_time_ = SystemTime(1h);
 
     stream_info.last_downstream_rx_byte_received_ = 2ms;
-    stream_info.first_upstream_tx_byte_sent_ = 4ms;
-    stream_info.last_upstream_tx_byte_sent_ = 6ms;
-    stream_info.first_upstream_rx_byte_received_ = 8ms;
-    stream_info.last_upstream_rx_byte_received_ = 10ms;
+    EXPECT_CALL(stream_info, firstUpstreamTxByteSent()).WillOnce(Return(4ms));
+    EXPECT_CALL(stream_info, lastUpstreamTxByteSent()).WillOnce(Return(6ms));
+    EXPECT_CALL(stream_info, firstUpstreamRxByteReceived()).WillOnce(Return(8ms));
+    EXPECT_CALL(stream_info, lastUpstreamRxByteReceived()).WillOnce(Return(10ms));
     stream_info.first_downstream_tx_byte_sent_ = 12ms;
     stream_info.last_downstream_tx_byte_sent_ = 14ms;
 
-    stream_info.setUpstreamLocalAddress(
+    stream_info.upstream_info_->setUpstreamLocalAddress(
         std::make_shared<Network::Address::Ipv4Instance>("10.0.0.2"));
     stream_info.protocol_ = Http::Protocol::Http10;
     stream_info.addBytesReceived(10);
@@ -363,9 +362,9 @@ response:
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
-    stream_info.upstream_transport_failure_reason_ = "TLS error";
+    stream_info.upstream_info_->setUpstreamTransportFailureReason("TLS error");
 
     Http::TestRequestHeaderMapImpl request_headers{
         {":method", "WHACKADOO"},
@@ -398,7 +397,7 @@ response: {}
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
 
     auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -465,7 +464,7 @@ response: {}
   // TLSv1.2
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
 
     auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -515,7 +514,7 @@ response: {}
   // TLSv1.1
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
 
     auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -565,7 +564,7 @@ response: {}
   // TLSv1
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
 
     auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -615,7 +614,7 @@ response: {}
   // Unknown TLS version (TLSv1.4)
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
 
     auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -685,7 +684,7 @@ TEST_F(HttpGrpcAccessLogTest, MarshallingAdditionalHeaders) {
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
-    stream_info.host_ = nullptr;
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
     stream_info.start_time_ = SystemTime(1h);
 
     Http::TestRequestHeaderMapImpl request_headers{

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -118,6 +118,7 @@ public:
   void expectLogRequestMethod(const std::string& request_method) {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
     stream_info.start_time_ = SystemTime(1h);
+    stream_info.upstreamInfo()->setUpstreamHost(nullptr);
 
     Http::TestRequestHeaderMapImpl request_headers{
         {":method", request_method},

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -157,7 +157,8 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
   auto upstream_metadata = std::make_shared<envoy::config::core::v3::Metadata>(
       replaceInvalidStringValues(stream_info.upstream_metadata()));
   ON_CALL(*upstream_host, metadata()).WillByDefault(testing::Return(upstream_metadata));
-  test_stream_info->onUpstreamHostSelected(upstream_host);
+  test_stream_info->setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
+  test_stream_info->upstreamInfo()->setUpstreamHost(upstream_host);
   auto address = stream_info.has_address()
                      ? Envoy::Network::Address::resolveProtoAddress(stream_info.address())
                      : Network::Utility::resolveUrl("tcp://10.0.0.1:443");
@@ -165,7 +166,7 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
       stream_info.has_upstream_local_address()
           ? Envoy::Network::Address::resolveProtoAddress(stream_info.upstream_local_address())
           : Network::Utility::resolveUrl("tcp://10.0.0.1:10000");
-  test_stream_info->setUpstreamLocalAddress(upstream_local_address);
+  test_stream_info->upstreamInfo()->setUpstreamLocalAddress(upstream_local_address);
   test_stream_info->downstream_connection_info_provider_ =
       std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
   test_stream_info->downstream_connection_info_provider_->setRequestedServerName(

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -14,6 +14,16 @@ using testing::ReturnRef;
 
 namespace Envoy {
 namespace StreamInfo {
+namespace {
+absl::optional<std::chrono::nanoseconds> duration(absl::optional<MonotonicTime> time,
+                                                  MonotonicTime start_time_monotonic) {
+  if (!time) {
+    return {};
+  }
+
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(time.value() - start_time_monotonic);
+}
+} // namespace
 
 MockStreamInfo::MockStreamInfo()
     : start_time_(ts_.systemTime()),
@@ -21,6 +31,10 @@ MockStreamInfo::MockStreamInfo()
       downstream_connection_info_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
           std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2"),
           std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"))) {
+  upstream_info_ = std::make_unique<UpstreamInfoImpl>();
+  Upstream::HostDescriptionConstSharedPtr host{
+      new testing::NiceMock<Upstream::MockHostDescription>()};
+  upstream_info_->setUpstreamHost(host);
   ON_CALL(*this, setResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag response_flag) {
     response_flags_ |= response_flag;
   }));
@@ -38,14 +52,22 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, startTimeMonotonic()).WillByDefault(ReturnPointee(&start_time_monotonic_));
   ON_CALL(*this, lastDownstreamRxByteReceived())
       .WillByDefault(ReturnPointee(&last_downstream_rx_byte_received_));
-  ON_CALL(*this, firstUpstreamTxByteSent())
-      .WillByDefault(ReturnPointee(&first_upstream_tx_byte_sent_));
-  ON_CALL(*this, lastUpstreamTxByteSent())
-      .WillByDefault(ReturnPointee(&last_upstream_tx_byte_sent_));
-  ON_CALL(*this, firstUpstreamRxByteReceived())
-      .WillByDefault(ReturnPointee(&first_upstream_rx_byte_received_));
-  ON_CALL(*this, lastUpstreamRxByteReceived())
-      .WillByDefault(ReturnPointee(&last_upstream_rx_byte_received_));
+  ON_CALL(*this, firstUpstreamTxByteSent()).WillByDefault(Invoke([this]() {
+    return duration(upstream_info_->upstreamTiming().first_upstream_tx_byte_sent_,
+                    start_time_monotonic_);
+  }));
+  ON_CALL(*this, lastUpstreamTxByteSent()).WillByDefault(Invoke([this]() {
+    return duration(upstream_info_->upstreamTiming().last_upstream_tx_byte_sent_,
+                    start_time_monotonic_);
+  }));
+  ON_CALL(*this, firstUpstreamRxByteReceived()).WillByDefault(Invoke([this]() {
+    return duration(upstream_info_->upstreamTiming().first_upstream_rx_byte_received_,
+                    start_time_monotonic_);
+  }));
+  ON_CALL(*this, lastUpstreamRxByteReceived()).WillByDefault(Invoke([this]() {
+    return duration(upstream_info_->upstreamTiming().last_upstream_rx_byte_received_,
+                    start_time_monotonic_);
+  }));
   ON_CALL(*this, firstDownstreamTxByteSent())
       .WillByDefault(ReturnPointee(&first_downstream_tx_byte_sent_));
   ON_CALL(*this, lastDownstreamTxByteSent())
@@ -57,19 +79,17 @@ MockStreamInfo::MockStreamInfo()
             .count());
   }));
   ON_CALL(*this, downstreamTiming()).WillByDefault(ReturnRef(downstream_timing_));
-  ON_CALL(*this, setUpstreamLocalAddress(_))
-      .WillByDefault(
-          Invoke([this](const Network::Address::InstanceConstSharedPtr& upstream_local_address) {
-            upstream_local_address_ = upstream_local_address;
-          }));
-  ON_CALL(*this, upstreamLocalAddress()).WillByDefault(ReturnRef(upstream_local_address_));
+  ON_CALL(*this, upstreamInfo()).WillByDefault(Invoke([this]() { return upstream_info_; }));
+  ON_CALL(testing::Const(*this), upstreamInfo()).WillByDefault(Invoke([this]() {
+    return OptRef<const UpstreamInfo>(*upstream_info_);
+  }));
+  ON_CALL(*this, upstreamLocalAddress()).WillByDefault(Invoke([this]() {
+    return upstream_info_->upstreamLocalAddress();
+  }));
   ON_CALL(*this, downstreamAddressProvider())
       .WillByDefault(ReturnPointee(downstream_connection_info_provider_));
-  ON_CALL(*this, setUpstreamSslConnection(_))
-      .WillByDefault(Invoke(
-          [this](const auto& connection_info) { upstream_connection_info_ = connection_info; }));
   ON_CALL(*this, upstreamSslConnection()).WillByDefault(Invoke([this]() {
-    return upstream_connection_info_;
+    return upstream_info_->upstreamSslConnection();
   }));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));
   ON_CALL(*this, responseCode()).WillByDefault(ReturnPointee(&response_code_));
@@ -94,38 +114,33 @@ MockStreamInfo::MockStreamInfo()
     return response_flags_ != 0;
   }));
   ON_CALL(*this, responseFlags()).WillByDefault(Return(response_flags_));
-  ON_CALL(*this, upstreamHost()).WillByDefault(ReturnPointee(&host_));
-
+  ON_CALL(*this, upstreamHost()).WillByDefault(Invoke([this]() {
+    return upstream_info_->upstreamHost();
+  }));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(Const(*this), filterState()).WillByDefault(Invoke([this]() -> const FilterState& {
     return *filter_state_;
   }));
-  ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(upstream_filter_state_));
-  ON_CALL(*this, setUpstreamFilterState(_))
-      .WillByDefault(Invoke([this](const FilterStateSharedPtr& filter_state) {
-        upstream_filter_state_ = filter_state;
-      }));
+  ON_CALL(*this, upstreamFilterState()).WillByDefault(Invoke([this]() {
+    return upstream_info_->upstreamFilterState();
+  }));
   ON_CALL(*this, setRouteName(_)).WillByDefault(Invoke([this](const absl::string_view route_name) {
     route_name_ = std::string(route_name);
   }));
   ON_CALL(*this, getRouteName()).WillByDefault(ReturnRef(route_name_));
   ON_CALL(*this, upstreamTransportFailureReason())
-      .WillByDefault(ReturnRef(upstream_transport_failure_reason_));
-  ON_CALL(*this, setConnectionID(_)).WillByDefault(Invoke([this](uint64_t id) {
-    connection_id_ = id;
-  }));
+      .WillByDefault(ReturnRef(upstream_info_->upstreamTransportFailureReason()));
+  ON_CALL(*this, setUpstreamInfo(_))
+      .WillByDefault(Invoke([this](std::shared_ptr<UpstreamInfo> info) { upstream_info_ = info; }));
   ON_CALL(*this, setFilterChainName(_))
       .WillByDefault(Invoke([this](const absl::string_view filter_chain_name) {
         filter_chain_name_ = std::string(filter_chain_name);
       }));
   ON_CALL(*this, filterChainName()).WillByDefault(ReturnRef(filter_chain_name_));
-  ON_CALL(*this, setUpstreamConnectionId(_)).WillByDefault(Invoke([this](uint64_t id) {
-    upstream_connection_id_ = id;
-  }));
   ON_CALL(*this, upstreamConnectionId()).WillByDefault(Invoke([this]() {
-    return upstream_connection_id_;
+    return upstream_info_->upstreamConnectionId();
   }));
   ON_CALL(*this, setAttemptCount(_)).WillByDefault(Invoke([this](uint32_t attempt_count) {
     attempt_count_ = attempt_count;
@@ -141,8 +156,8 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(Invoke([this](const BytesMeterSharedPtr& downstream_bytes_meter) {
         downstream_bytes_meter_ = downstream_bytes_meter;
       }));
-  ON_CALL(*this, upstreamTiming()).WillByDefault(ReturnRef(upstream_timing_));
-  ON_CALL(Const(*this), upstreamTiming()).WillByDefault(Return(upstream_timing_));
+  ON_CALL(*this, upstreamTiming()).WillByDefault(ReturnRef(upstream_info_->upstreamTiming()));
+  ON_CALL(Const(*this), upstreamTiming()).WillByDefault(Return(upstream_info_->upstreamTiming()));
 }
 
 MockStreamInfo::~MockStreamInfo() = default;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -6,6 +6,7 @@
 
 #include "source/common/network/socket_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
+#include "source/common/stream_info/stream_info_impl.h"
 
 #include "test/mocks/upstream/host.h"
 #include "test/test_common/simulated_time_system.h"
@@ -30,7 +31,6 @@ public:
   MOCK_METHOD(SystemTime, startTime, (), (const));
   MOCK_METHOD(MonotonicTime, startTimeMonotonic, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::nanoseconds>, lastDownstreamRxByteReceived, (), (const));
-  MOCK_METHOD(void, setUpstreamTiming, (const UpstreamTiming&));
   MOCK_METHOD(void, setUpstreamInfo, (std::shared_ptr<UpstreamInfo>));
   MOCK_METHOD(std::shared_ptr<UpstreamInfo>, upstreamInfo, ());
   MOCK_METHOD(OptRef<const UpstreamInfo>, upstreamInfo, (), (const));
@@ -68,12 +68,10 @@ public:
   MOCK_METHOD(bool, hasAnyResponseFlag, (), (const));
   MOCK_METHOD(uint64_t, responseFlags, (), (const));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, upstreamHost, (), (const));
-  MOCK_METHOD(void, setUpstreamLocalAddress, (const Network::Address::InstanceConstSharedPtr&));
   MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, upstreamLocalAddress, (), (const));
   MOCK_METHOD(bool, healthCheck, (), (const));
   MOCK_METHOD(void, healthCheck, (bool is_health_check));
   MOCK_METHOD(const Network::ConnectionInfoProvider&, downstreamAddressProvider, (), (const));
-  MOCK_METHOD(void, setUpstreamSslConnection, (const Ssl::ConnectionInfoConstSharedPtr&));
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, upstreamSslConnection, (), (const));
   MOCK_METHOD(Router::RouteConstSharedPtr, route, (), (const));
   MOCK_METHOD(envoy::config::core::v3::Metadata&, dynamicMetadata, ());
@@ -84,8 +82,6 @@ public:
   MOCK_METHOD(const FilterStateSharedPtr&, filterState, ());
   MOCK_METHOD(const FilterState&, filterState, (), (const));
   MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, (), (const));
-  MOCK_METHOD(void, setUpstreamFilterState, (const FilterStateSharedPtr&));
-  MOCK_METHOD(void, setUpstreamTransportFailureReason, (absl::string_view));
   MOCK_METHOD(const std::string&, upstreamTransportFailureReason, (), (const));
   MOCK_METHOD(void, setRequestHeaders, (const Http::RequestHeaderMap&));
   MOCK_METHOD(const Http::RequestHeaderMap*, getRequestHeaders, (), (const));
@@ -101,7 +97,6 @@ public:
   MOCK_METHOD(void, setConnectionID, (uint64_t));
   MOCK_METHOD(void, setFilterChainName, (const absl::string_view));
   MOCK_METHOD(const std::string&, filterChainName, (), (const));
-  MOCK_METHOD(void, setUpstreamConnectionId, (uint64_t));
   MOCK_METHOD(absl::optional<uint64_t>, upstreamConnectionId, (), (const));
   MOCK_METHOD(void, setAttemptCount, (uint32_t), ());
   MOCK_METHOD(absl::optional<uint32_t>, attemptCount, (), (const));
@@ -109,17 +104,10 @@ public:
   MOCK_METHOD(const BytesMeterSharedPtr&, getDownstreamBytesMeter, (), (const));
   MOCK_METHOD(void, setUpstreamBytesMeter, (const BytesMeterSharedPtr&));
   MOCK_METHOD(void, setDownstreamBytesMeter, (const BytesMeterSharedPtr&));
-  std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
-      new testing::NiceMock<Upstream::MockHostDescription>()};
   Envoy::Event::SimulatedTimeSystem ts_;
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;
   absl::optional<std::chrono::nanoseconds> last_downstream_rx_byte_received_;
-  absl::optional<std::chrono::nanoseconds> first_upstream_tx_byte_sent_;
-  absl::optional<std::chrono::nanoseconds> last_upstream_tx_byte_sent_;
-  absl::optional<std::chrono::nanoseconds> first_upstream_rx_byte_received_;
-  absl::optional<uint64_t> connection_id_;
-  absl::optional<std::chrono::nanoseconds> last_upstream_rx_byte_received_;
   absl::optional<std::chrono::nanoseconds> first_downstream_tx_byte_sent_;
   absl::optional<std::chrono::nanoseconds> last_downstream_tx_byte_sent_;
   absl::optional<std::chrono::nanoseconds> end_time_;
@@ -127,23 +115,18 @@ public:
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   absl::optional<std::string> connection_termination_details_;
-  UpstreamTiming upstream_timing_;
+  std::shared_ptr<UpstreamInfo> upstream_info_;
   uint64_t response_flags_{};
   envoy::config::core::v3::Metadata metadata_;
-  FilterStateSharedPtr upstream_filter_state_;
   FilterStateSharedPtr filter_state_;
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
-  Network::Address::InstanceConstSharedPtr upstream_local_address_;
   std::shared_ptr<Network::ConnectionInfoSetterImpl> downstream_connection_info_provider_;
   BytesMeterSharedPtr upstream_bytes_meter_;
   BytesMeterSharedPtr downstream_bytes_meter_;
   Ssl::ConnectionInfoConstSharedPtr downstream_connection_info_;
-  Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   std::string route_name_;
-  std::string upstream_transport_failure_reason_;
   std::string filter_chain_name_;
-  absl::optional<uint64_t> upstream_connection_id_;
   absl::optional<uint32_t> attempt_count_;
   DownstreamTiming downstream_timing_;
 };


### PR DESCRIPTION
Follow up to https://github.com/envoyproxy/envoy/pull/19020, cleaning up the stream info setters and using upstream timing directly.
This fixes a handful of bugs for hedging, where not all stream info members were updated when the final connection was selected.

Risk Level: High (major refactor to stream info use)
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a