### PR TITLE
config: update xDS V2 deprecation error

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -395,6 +395,7 @@ envoy_cc_library(
         "//source/common/stats:stats_lib",
         "//source/common/stats:stats_matcher_lib",
         "//source/common/stats:tag_producer_lib",
+        "//source/common/version:api_version_lib",
         "@com_github_cncf_udpa//udpa/type/v1:pkg_cc_proto",
         "@com_github_cncf_udpa//xds/type/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -29,8 +29,8 @@
 #include "source/common/protobuf/utility.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/singleton/const_singleton.h"
-#include "source/common/version/api_version_struct.h"
 #include "source/common/version/api_version.h"
+#include "source/common/version/api_version_struct.h"
 
 #include "udpa/type/v1/typed_struct.pb.h"
 #include "xds/type/v3/typed_struct.pb.h"

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -29,6 +29,8 @@
 #include "source/common/protobuf/utility.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/singleton/const_singleton.h"
+#include "source/common/version/api_version_struct.h"
+#include "source/common/version/api_version.h"
 
 #include "udpa/type/v1/typed_struct.pb.h"
 #include "xds/type/v3/typed_struct.pb.h"
@@ -198,12 +200,13 @@ public:
     if (transport_api_version == envoy::config::core::v3::ApiVersion::AUTO ||
         transport_api_version == envoy::config::core::v3::ApiVersion::V2) {
       Runtime::LoaderSingleton::getExisting()->countDeprecatedFeatureUse();
+      const ApiVersion version = ApiVersionInfo::apiVersion();
       const std::string& warning = fmt::format(
           "V2 (and AUTO) xDS transport protocol versions are deprecated in {}. "
           "The v2 xDS major version has been removed and is no longer supported. "
           "You may be missing explicit V3 configuration of the transport API version, "
-          "see the advice in https://www.envoyproxy.io/docs/envoy/v1.19.1/faq/api/envoy_v3.",
-          api_config_source.DebugString());
+          "see the advice in https://www.envoyproxy.io/docs/envoy/v{}.{}.{}/faq/api/envoy_v3.",
+          api_config_source.DebugString(), version.major, version.minor, version.patch);
       ENVOY_LOG_MISC(warn, warning);
       throw DeprecatedMajorVersionException(warning);
     }

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -200,9 +200,9 @@ public:
       Runtime::LoaderSingleton::getExisting()->countDeprecatedFeatureUse();
       const std::string& warning = fmt::format(
           "V2 (and AUTO) xDS transport protocol versions are deprecated in {}. "
-          "The v2 xDS major version is deprecated and disabled by default. Support for v2 will be "
-          "removed from Envoy at the start of Q1 2021. You may make use of v2 in Q4 2020 by "
-          "following the advice in https://www.envoyproxy.io/docs/envoy/latest/faq/api/transition.",
+          "The v2 xDS major version has been removed and is no longer supported. "
+          "You may be missing explicit V3 configuration of the transport API version, "
+          "see the advice in https://www.envoyproxy.io/docs/envoy/v1.19.1/faq/api/envoy_v3.",
           api_config_source.DebugString());
       ENVOY_LOG_MISC(warn, warning);
       throw DeprecatedMajorVersionException(warning);


### PR DESCRIPTION
<!--
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: config: update xDS V2 deprecation error
Additional Description: Fixes broken link and updates error message to note that xDS V2 support has been removed. The current link is [only applicable up through v1.17 docs](https://www.envoyproxy.io/docs/envoy/v1.17.4/faq/api/transition). A similar fix should likely be applied to the [`release/v1.18`](https://github.com/envoyproxy/envoy/tree/release/v1.18) branch too.
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

_Edit: rebased to add DCO sign-off, missed that the first time_