### PR TITLE
Remove wrong ASSERT from MockOsSysCalls::setsockopt().

### DIFF
--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -60,8 +60,6 @@ MockOsSysCalls::~MockOsSysCalls() = default;
 
 SysCallIntResult MockOsSysCalls::setsockopt(os_fd_t sockfd, int level, int optname,
                                             const void* optval, socklen_t optlen) {
-  ASSERT(optlen == sizeof(int));
-
   // Allow mocking system call failure.
   if (setsockopt_(sockfd, level, optname, optval, optlen) != 0) {
     return SysCallIntResult{-1, 0};


### PR DESCRIPTION
Signed-off-by: Misha Efimov <mef@google.com>

Commit Message: Remove wrong ASSERT from MockOsSysCalls::setsockopt().
Additional Description: setsockopt should accept options of any length.
Risk Level: Low
Testing: Existing tests
Docs Changes: n/a
Release Notes: Remove wrong ASSERT from MockOsSysCalls::setsockopt().
