### PR TITLE
Refactor: Allow the H2 codec to have both header and trailers 

### DIFF
--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1149,14 +1149,14 @@ TEST_P(Http2CodecImplTest, ShouldDumpActiveStreamsWithoutAllocatingMemory) {
             "  stream: \n"
             "    ConnectionImpl::StreamImpl"));
     EXPECT_THAT(ostream.contents(), HasSubstr("local_end_stream_: 1"));
-    EXPECT_THAT(ostream.contents(),
-                HasSubstr("pending_trailers_to_encode_:     null\n"
-                          "    absl::get<RequestHeaderMapPtr>(headers_or_trailers_): \n"
-                          "      ':scheme', 'http'\n"
-                          "      ':method', 'GET'\n"
-                          "      ':authority', 'host'\n"
-                          "      ':path', '/'\n"
-                          "  current_slice_: null"));
+    EXPECT_THAT(ostream.contents(), HasSubstr("pending_trailers_to_encode_:     null\n"
+                                              "    headers_: \n"
+                                              "      ':scheme', 'http'\n"
+                                              "      ':method', 'GET'\n"
+                                              "      ':authority', 'host'\n"
+                                              "      ':path', '/'\n"
+                                              "    trailers_:     null\n"
+                                              "  current_slice_: null"));
   }
 
   // Dump client
@@ -1176,11 +1176,11 @@ TEST_P(Http2CodecImplTest, ShouldDumpActiveStreamsWithoutAllocatingMemory) {
             "  stream: \n"
             "    ConnectionImpl::StreamImpl"));
     EXPECT_THAT(ostream.contents(), HasSubstr("local_end_stream_: 0"));
-    EXPECT_THAT(ostream.contents(),
-                HasSubstr("pending_trailers_to_encode_:     null\n"
-                          "    absl::get<ResponseHeaderMapPtr>(headers_or_trailers_): \n"
-                          "      ':status', '200'\n"
-                          "  current_slice_: null"));
+    EXPECT_THAT(ostream.contents(), HasSubstr("pending_trailers_to_encode_:     null\n"
+                                              "    headers_: \n"
+                                              "      ':status', '200'\n"
+                                              "    trailers_:     null\n"
+                                              "  current_slice_: null"));
   }
 }
 


### PR DESCRIPTION
Currently we can only have either headers or trailers. With deferring processing, we could end up having both in the codec e.g. due to the stream being on a backed up connection.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Refactor to allow the H2 codec to have both header and trailers.
Additional Description:
Risk Level: low (refactor)
Testing: Ran tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Related Issue: #19127 

