### PR TITLE
tcp_proxy: better handling flow control given the upstream can be multiplexed

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -305,7 +305,7 @@ public:
     Filter* parent_{};
     Drainer* drainer_{};
 
-    bool on_high_watermark_called_{false};
+    uint32_t above_high_watermark_counter_{0};
   };
 
   StreamInfo::StreamInfo& getStreamInfo();

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -305,6 +305,11 @@ public:
     Filter* parent_{};
     Drainer* drainer_{};
 
+    // above high watermark maybe called from different sources. In the case that upstream is h2 or
+    // h3 tunnel where streams can be multiplexed in an upstream connection, the upstream http
+    // stream buffer can be over high watermark. The upstream http connection can be over high
+    // watermark independently. In either case, the downstream read should be disabled. This counter
+    // is used so that least read disable is propagated to downstream.
     uint32_t above_high_watermark_counter_{0};
   };
 


### PR DESCRIPTION
Commit Message:
Tcp_proxy can use upstream h2/h3 as upstream. Since h2 and h3 streams can be multiplexed in the upstream connection,
there are more than 1 sources of upstream write throttling control. One from upstream connection stream buffer and one from
upstream h2/h3 stream buffer.

Additional Description:

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
