### PR TITLE
access_log: added new access_log command operator %UPSTREAM_REQUEST_ATTEMPT_COUNT% to retrieve the number of times given request got attempted upstream

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -241,6 +241,16 @@ The following command operators are supported:
   TCP
     Downstream bytes sent on connection.
 
+%UPSTREAM_REQUEST_ATTEMPT_COUNT%
+  HTTP
+    Number of times the request is attempted upstream. Note that an attempt count of '0' means that
+    the request was never attempted upstream.
+
+  TCP
+    Not implemented ("-").
+
+  Renders a numeric value in typed JSON logs.
+
 %UPSTREAM_WIRE_BYTES_SENT%
   HTTP
     Total number of bytes sent to the upstream by the http stream.

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -247,7 +247,8 @@ The following command operators are supported:
     the request was never attempted upstream.
 
   TCP
-    Not implemented ("-").
+    Number of times the connection request is attempted upstream. Note that an attempt count of '0'
+    means that the connection request was never attempted upstream.
 
   Renders a numeric value in typed JSON logs.
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -56,6 +56,7 @@ Removed Config or Runtime
 New Features
 ------------
 * access log: added :ref:`grpc_stream_retry_policy <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.grpc_stream_retry_policy>` to the gRPC logger to reconnect when a connection fails to be established.
+* access_log: added new access_log command operator ``%UPSTREAM_REQUEST_ATTEMPT_COUNT%`` to retrieve the number of times given request got attempted upstream.
 * access_log: added new access_log command operator ``%VIRTUAL_CLUSTER_NAME%`` to retrieve the matched Virtual Cluster name.
 * api: added support for *xds.type.v3.TypedStruct* in addition to the now-deprecated *udpa.type.v1.TypedStruct* proto message, which is a wrapper proto used to encode typed JSON data in a *google.protobuf.Any* field.
 * aws_request_signing_filter: added :ref:`match_excluded_headers <envoy_v3_api_field_extensions.filters.http.aws_request_signing.v3.AwsRequestSigning.match_excluded_headers>` to the signing filter to optionally exclude request headers from signing.

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -818,6 +818,11 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
         StreamInfoAddressFieldExtractor::withPort([](const StreamInfo::StreamInfo& stream_info) {
           return stream_info.upstreamLocalAddress();
         });
+  } else if (field_name == "UPSTREAM_REQUEST_ATTEMPT_COUNT") {
+    field_extractor_ = std::make_unique<StreamInfoUInt64FieldExtractor>(
+        [](const StreamInfo::StreamInfo& stream_info) {
+          return stream_info.attemptCount().value_or(0);
+        });
   } else if (field_name == "DOWNSTREAM_LOCAL_ADDRESS") {
     field_extractor_ =
         StreamInfoAddressFieldExtractor::withPort([](const StreamInfo::StreamInfo& stream_info) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -362,6 +362,28 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
   }
 
   {
+    StreamInfoFormatter attempt_count_format("UPSTREAM_REQUEST_ATTEMPT_COUNT");
+    absl::optional<uint32_t> attempt_count{3};
+    EXPECT_CALL(stream_info, attemptCount()).WillRepeatedly(Return(attempt_count));
+    EXPECT_EQ("3", attempt_count_format.format(request_headers, response_headers, response_trailers,
+                                               stream_info, body));
+    EXPECT_THAT(attempt_count_format.formatValue(request_headers, response_headers,
+                                                 response_trailers, stream_info, body),
+                ProtoEq(ValueUtil::numberValue(3.0)));
+  }
+
+  {
+    StreamInfoFormatter attempt_count_format("UPSTREAM_REQUEST_ATTEMPT_COUNT");
+    absl::optional<uint32_t> attempt_count;
+    EXPECT_CALL(stream_info, attemptCount()).WillRepeatedly(Return(attempt_count));
+    EXPECT_EQ("0", attempt_count_format.format(request_headers, response_headers, response_trailers,
+                                               stream_info, body));
+    EXPECT_THAT(attempt_count_format.formatValue(request_headers, response_headers,
+                                                 response_trailers, stream_info, body),
+                ProtoEq(ValueUtil::numberValue(0.0)));
+  }
+
+  {
     StreamInfo::BytesMeterSharedPtr upstream_bytes_meter{
         std::make_shared<StreamInfo::BytesMeter>()};
     upstream_bytes_meter->addWireBytesReceived(1);


### PR DESCRIPTION
This PR adds a new command operator in the access logs called `%UPSTREAM_REQUEST_ATTEMPT_COUNT%` which can be used to retrieve the number of times given request got attempted upstream.

This could be very helpful to triage the slow requests due to the retry. [[See]](https://github.com/envoyproxy/envoy/issues/18870)

**Commit Message:** Added new access_log command operator %UPSTREAM_REQUEST_ATTEMPT_COUNT% to retrieve the number of times given request got attempted upstream
**Additional Description:** Adds a new command operator called `%UPSTREAM_REQUEST_ATTEMPT_COUNT%` in the access logs which can be used to retrieve the number of times given request got attempted upstream. (Fixes #18870)
**Risk Level:** Low
**Testing:** Unit Tests
**Docs Changes:** Added description on `%UPSTREAM_REQUEST_ATTEMPT_COUNT%` in the Docs.
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>