### PR TITLE
test: fix headerMapEqualIgnoreOrder utility missing a check

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -447,11 +447,9 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
       [](Http::HeaderMap& headers) { headers.addCopy(LowerCaseString("x-remove-this"), "yes"); });
 
   processRequestHeadersMessage(true, [](const HttpHeaders& headers, HeadersResponse& headers_resp) {
-    Http::TestRequestHeaderMapImpl expected_request_headers{{":scheme", "http"},
-                                                            {":method", "GET"},
-                                                            {"host", "host"},
-                                                            {":path", "/"},
-                                                            {"x-remove-this", "yes"}};
+    Http::TestRequestHeaderMapImpl expected_request_headers{
+        {":scheme", "http"}, {":method", "GET"},       {"host", "host"},
+        {":path", "/"},      {"x-remove-this", "yes"}, {"x-forwarded-proto", "http"}};
     EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_request_headers));
 
     auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();

--- a/test/extensions/filters/http/ext_proc/utils.cc
+++ b/test/extensions/filters/http/ext_proc/utils.cc
@@ -8,7 +8,7 @@ namespace HttpFilters {
 namespace ExternalProcessing {
 
 const absl::flat_hash_set<std::string> ExtProcTestUtility::ignoredHeaders() {
-  CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "x-forwarded-proto", "x-request-id",
+  CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "x-request-id",
                          "x-envoy-upstream-service-time");
 }
 

--- a/test/extensions/filters/http/ext_proc/utils.cc
+++ b/test/extensions/filters/http/ext_proc/utils.cc
@@ -7,13 +7,20 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
+const absl::flat_hash_set<std::string> ExtProcTestUtility::ignoredHeaders() {
+  CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "x-forwarded-proto", "x-request-id",
+                         "x-envoy-upstream-service-time");
+}
+
 bool ExtProcTestUtility::headerProtosEqualIgnoreOrder(
     const Http::HeaderMap& expected, const envoy::config::core::v3::HeaderMap& actual) {
   // Comparing header maps is hard because they have duplicates in them.
   // So we're going to turn them into a HeaderMap and let Envoy do the work.
   Http::TestRequestHeaderMapImpl actual_headers;
   for (const auto& header : actual.headers()) {
-    actual_headers.addCopy(header.key(), header.value());
+    if (!ignoredHeaders().contains(header.key())) {
+      actual_headers.addCopy(header.key(), header.value());
+    }
   }
   return TestUtility::headerMapEqualIgnoreOrder(expected, actual_headers);
 }

--- a/test/extensions/filters/http/ext_proc/utils.h
+++ b/test/extensions/filters/http/ext_proc/utils.h
@@ -18,7 +18,7 @@ public:
                                            const envoy::config::core::v3::HeaderMap& actual);
 };
 
-MATCHER_P(HeaderProtosEqual, expected, "HTTP header protos match") {
+MATCHER_P(HeaderProtosEqual, expected, absl::StrFormat("HTTP header has \"%s\"", expected)) {
   return ExtProcTestUtility::headerProtosEqualIgnoreOrder(expected, arg);
 }
 

--- a/test/extensions/filters/http/ext_proc/utils.h
+++ b/test/extensions/filters/http/ext_proc/utils.h
@@ -16,9 +16,14 @@ public:
   // Compare a reference header map to a proto
   static bool headerProtosEqualIgnoreOrder(const Http::HeaderMap& expected,
                                            const envoy::config::core::v3::HeaderMap& actual);
+
+private:
+  // These headers are present in the actual, but cannot be specified in the expected
+  // ignoredHeaders should not be used for equal comparison
+  static const absl::flat_hash_set<std::string> ignoredHeaders();
 };
 
-MATCHER_P(HeaderProtosEqual, expected, absl::StrFormat("HTTP header has \"%s\"", expected)) {
+MATCHER_P(HeaderProtosEqual, expected, "HTTP header protos match") {
   return ExtProcTestUtility::headerProtosEqualIgnoreOrder(expected, arg);
 }
 

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -74,7 +74,9 @@ bool TestUtility::headerMapEqualIgnoreOrder(const Http::HeaderMap& lhs,
     lhs_keys.insert(key);
     return Http::HeaderMap::Iterate::Continue;
   });
-  rhs.iterate([&lhs, &rhs, &rhs_keys](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+  bool values_match = true;
+  rhs.iterate([&values_match, &lhs, &rhs, &rhs_keys]
+              (const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
     const std::string key{header.key().getStringView()};
     // Compare with canonicalized multi-value headers. This ensures we respect order within
     // a header.
@@ -84,12 +86,13 @@ bool TestUtility::headerMapEqualIgnoreOrder(const Http::HeaderMap& lhs,
         Http::HeaderUtility::getAllOfHeaderAsString(rhs, Http::LowerCaseString(key));
     ASSERT(rhs_entry.result());
     if (lhs_entry.result() != rhs_entry.result()) {
+      values_match = false;
       return Http::HeaderMap::Iterate::Break;
     }
     rhs_keys.insert(key);
     return Http::HeaderMap::Iterate::Continue;
   });
-  return lhs_keys.size() == rhs_keys.size();
+  return values_match && lhs_keys.size() == rhs_keys.size();
 }
 
 bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instance& rhs) {

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -75,8 +75,8 @@ bool TestUtility::headerMapEqualIgnoreOrder(const Http::HeaderMap& lhs,
     return Http::HeaderMap::Iterate::Continue;
   });
   bool values_match = true;
-  rhs.iterate([&values_match, &lhs, &rhs, &rhs_keys]
-              (const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+  rhs.iterate([&values_match, &lhs, &rhs,
+               &rhs_keys](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
     const std::string key{header.key().getStringView()};
     // Compare with canonicalized multi-value headers. This ensures we respect order within
     // a header.


### PR DESCRIPTION
Signed-off-by: Saidi Tang tangsaidi@google.com

Description: The `headerMapEqualIgnoreOrder` function didn't check the outcome of the `iterate` method. We are passing a few tests in `cache` and `ext_proc` with incorrect expected values. I fixed the comparison utility and updated the tests accordingly.

Commit Message: Added a flag variable to check whether the iterate function returned after a value mismatch for a key
Risk Level: Low, it's part of the test utility
Testing: Does not apply

