### PR TITLE
Simple benchmark to compare OwnedImpl::add to WatermarkBuffer::add

### DIFF
--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -112,6 +112,8 @@ envoy_cc_benchmark_binary(
     ],
     deps = [
         "//source/common/buffer:buffer_lib",
+        "//source/common/buffer:watermark_buffer_lib",
+        "@envoy_api//envoy/config/overload/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/buffer/buffer_speed_test.cc
+++ b/test/common/buffer/buffer_speed_test.cc
@@ -1,4 +1,8 @@
+#include "envoy/config/overload/v3/overload.pb.h"
+#include "envoy/http/stream_reset_handler.h"
+
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/buffer/watermark_buffer.h"
 #include "source/common/common/assert.h"
 
 #include "absl/strings/string_view.h"
@@ -7,6 +11,11 @@
 namespace Envoy {
 
 static constexpr uint64_t MaxBufferLength = 1024 * 1024;
+
+class FakeStreamResetHandler : public Http::StreamResetHandler {
+public:
+  void resetStream(Http::StreamResetReason reason) override { UNREFERENCED_PARAMETER(reason); }
+};
 
 // The fragment needs to be heap allocated in order to survive past the processing done in the inner
 // loop in the benchmarks below. Do not attempt to release the actual contents of the buffer.
@@ -23,6 +32,76 @@ static void bufferCreateEmpty(benchmark::State& state) {
   benchmark::DoNotOptimize(length);
 }
 BENCHMARK(bufferCreateEmpty);
+
+// Test add performance of OwnedImpl vs WatermarkBuffer
+static void bufferVsWatermarkBuffer(benchmark::State& state) {
+  const uint64_t length = state.range(0);
+  const uint64_t high_watermark = state.range(1);
+  const bool use_watermark_buffer = (state.range(2) != 0);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    std::unique_ptr<Buffer::Instance> buffer;
+    if (use_watermark_buffer) {
+      buffer = std::make_unique<Buffer::WatermarkBuffer>([]() {}, []() {}, []() {});
+      buffer->setWatermarks(high_watermark);
+    } else {
+      buffer = std::make_unique<Buffer::OwnedImpl>();
+    }
+
+    for (uint64_t idx = 0; idx < length; ++idx) {
+      buffer->add("a", 1);
+    }
+  }
+  benchmark::DoNotOptimize(length);
+}
+BENCHMARK(bufferVsWatermarkBuffer)
+    ->Args({1024, 0, 0})
+    ->Args({1024, 0, 1})
+    ->Args({1024, 1, 1})
+    ->Args({1024, 1024, 1})
+    ->Args({64 * 1024, 0, 0})
+    ->Args({64 * 1024, 0, 1})
+    ->Args({64 * 1024, 1, 1})
+    ->Args({64 * 1024, 64 * 1024, 1})
+    ->Args({1024 * 1024, 0, 0})
+    ->Args({1024 * 1024, 0, 1})
+    ->Args({1024 * 1024, 1, 1})
+    ->Args({1024 * 1024, 1024 * 1024, 1});
+
+// Measure performance impact of enabling accounts.
+static void bufferAccountUse(benchmark::State& state) {
+  const std::string data(state.range(0), 'a');
+  uint64_t iters = state.range(1);
+  const bool enable_accounts = (state.range(2) != 0);
+
+  auto config = envoy::config::overload::v3::BufferFactoryConfig();
+  config.set_minimum_account_to_track_power_of_two(2);
+  Buffer::WatermarkBufferFactory buffer_factory(config);
+  FakeStreamResetHandler reset_handler;
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    Buffer::OwnedImpl buffer;
+    if (enable_accounts) {
+      auto account = buffer_factory.createAccount(reset_handler);
+      RELEASE_ASSERT(account != nullptr, "");
+      buffer.bindAccount(account);
+    }
+    for (uint64_t idx = 0; idx < iters; ++idx) {
+      buffer.add(data);
+    }
+  }
+}
+BENCHMARK(bufferAccountUse)
+    ->Args({1, 1024 * 1024, 0})
+    ->Args({1, 1024 * 1024, 1})
+    ->Args({1024, 1024, 0})
+    ->Args({1024, 1024, 1})
+    ->Args({4 * 1024, 1024, 0})
+    ->Args({4 * 1024, 1024, 1})
+    ->Args({16 * 1024, 1024, 0})
+    ->Args({16 * 1024, 1024, 1});
 
 // Test the creation of an OwnedImpl with varying amounts of content.
 static void bufferCreate(benchmark::State& state) {


### PR DESCRIPTION
Commit Message:
Simple benchmark to compare OwnedImpl::add to WatermarkBuffer::add

Also, benchmark to cover buffer account use.

Risk Level: n/a (benchmark, test-only changes)
Testing: test-only changes
Docs Changes: n/a
Release Notes: n/a
