### PR TITLE
test: adding HTTP/3 fail socket write test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -515,6 +515,7 @@ envoy_cc_test_library(
         "//test/integration/filters:random_pause_filter_lib",
         "//test/integration/filters:remove_response_headers_lib",
         "//test/test_common:logging_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",

--- a/test/integration/filters/test_socket_interface.h
+++ b/test/integration/filters/test_socket_interface.h
@@ -21,15 +21,15 @@ namespace Network {
 
 class TestIoSocketHandle : public Test::IoSocketHandlePlatformImpl {
 public:
-  using WritevOverrideType = absl::optional<Api::IoCallUint64Result>(TestIoSocketHandle* io_handle,
-                                                                     const Buffer::RawSlice* slices,
-                                                                     uint64_t num_slice);
-  using WritevOverrideProc = std::function<WritevOverrideType>;
+  using WriteOverrideType = absl::optional<Api::IoCallUint64Result>(TestIoSocketHandle* io_handle,
+                                                                    const Buffer::RawSlice* slices,
+                                                                    uint64_t num_slice);
+  using WriteOverrideProc = std::function<WriteOverrideType>;
 
-  TestIoSocketHandle(WritevOverrideProc writev_override_proc, os_fd_t fd = INVALID_SOCKET,
+  TestIoSocketHandle(WriteOverrideProc write_override_proc, os_fd_t fd = INVALID_SOCKET,
                      bool socket_v6only = false, absl::optional<int> domain = absl::nullopt)
       : Test::IoSocketHandlePlatformImpl(fd, socket_v6only, domain),
-        writev_override_(writev_override_proc) {}
+        write_override_(write_override_proc) {}
 
   void initializeFileEvent(Event::Dispatcher& dispatcher, Event::FileReadyCb cb,
                            Event::FileTriggerType trigger, uint32_t events) override {
@@ -50,9 +50,13 @@ public:
 private:
   IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen) override;
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
+  Api::IoCallUint64Result sendmsg(const Buffer::RawSlice* slices, uint64_t num_slice, int flags,
+                                  const Address::Ip* self_ip,
+                                  const Address::Instance& peer_address) override;
+
   IoHandlePtr duplicate() override;
 
-  const WritevOverrideProc writev_override_;
+  const WriteOverrideProc write_override_;
   absl::Mutex mutex_;
   Event::Dispatcher* dispatcher_ ABSL_GUARDED_BY(mutex_) = nullptr;
 };
@@ -68,22 +72,22 @@ private:
 class TestSocketInterface : public SocketInterfaceImpl {
 public:
   /**
-   * Override the behavior of the IoSocketHandleImpl::writev() method.
-   * The supplied callback is invoked with the arguments of the writev method and the index
+   * Override the behavior of the IoSocketHandleImpl::writev() and
+   * IoSocketHandleImpl::sendmsg() methods.
+   * The supplied callback is invoked with the slices arguments of the write method and the index
    * of the accepted socket.
    * Returning absl::nullopt from the callback continues normal execution of the
-   * IoSocketHandleImpl::writev() method. Returning a Api::IoCallUint64Result from callback skips
-   * the IoSocketHandleImpl::writev() with the returned result value.
+   * write methods. Returning a Api::IoCallUint64Result from callback skips
+   * the write methods with the returned result value.
    */
-  TestSocketInterface(TestIoSocketHandle::WritevOverrideProc writev)
-      : writev_override_proc_(writev) {}
+  TestSocketInterface(TestIoSocketHandle::WriteOverrideProc write) : write_override_proc_(write) {}
 
 private:
   // SocketInterfaceImpl
   IoHandlePtr makeSocket(int socket_fd, bool socket_v6only,
                          absl::optional<int> domain) const override;
 
-  const TestIoSocketHandle::WritevOverrideProc writev_override_proc_;
+  const TestIoSocketHandle::WriteOverrideProc write_override_proc_;
 };
 
 } // namespace Network

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3541,7 +3541,7 @@ public:
 };
 
 TEST_P(DownstreamProtocolIntegrationTest, HandleSocketFail) {
-  // Make sure for HTTP/3 Enovy will use sendmsg, so the write_matcher will work.
+  // Make sure for HTTP/3 Envoy will use sendmsg, so the write_matcher will work.
   NoUdpGso reject_gso_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&reject_gso_};
 
@@ -3556,7 +3556,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HandleSocketFail) {
   Network::IoSocketError* ebadf = Network::IoSocketError::getIoSocketEbadfInstance();
   socket_swap.write_matcher_->setSourcePort(lookupPort("http"));
   socket_swap.write_matcher_->setWriteOverride(ebadf);
-  // TODO(danzh) set to true to repro.
+  // TODO(danzh) set to true.
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 
   if (downstreamProtocol() == Http::CodecType::HTTP3) {

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1343,6 +1343,14 @@ TEST_P(ProtocolIntegrationTest, EnvoyProxyingLateMultiple1xx) {
   testEnvoyProxying1xx(false, false, true);
 }
 
+TEST_P(ProtocolIntegrationTest, EnvoyProxying102) {
+  testEnvoyProxying1xx(false, false, false, "102");
+}
+
+TEST_P(ProtocolIntegrationTest, EnvoyProxying103) {
+  testEnvoyProxying1xx(false, false, false, "103");
+}
+
 TEST_P(ProtocolIntegrationTest, TwoRequests) { testTwoRequests(); }
 
 TEST_P(ProtocolIntegrationTest, TwoRequestsWithForcedBackup) { testTwoRequests(true); }

--- a/test/integration/socket_interface_swap.cc
+++ b/test/integration/socket_interface_swap.cc
@@ -2,17 +2,18 @@
 
 namespace Envoy {
 
+void preserveIoError(Api::IoError*) {}
+
 SocketInterfaceSwap::SocketInterfaceSwap() {
   Envoy::Network::SocketInterfaceSingleton::clear();
   test_socket_interface_loader_ = std::make_unique<Envoy::Network::SocketInterfaceLoader>(
       std::make_unique<Envoy::Network::TestSocketInterface>(
-          [writev_matcher = writev_matcher_](Envoy::Network::TestIoSocketHandle* io_handle,
-                                             const Buffer::RawSlice*,
-                                             uint64_t) -> absl::optional<Api::IoCallUint64Result> {
-            Network::IoSocketError* error_override = writev_matcher->returnOverride(io_handle);
+          [write_matcher = write_matcher_](Envoy::Network::TestIoSocketHandle* io_handle,
+                                           const Buffer::RawSlice*,
+                                           uint64_t) -> absl::optional<Api::IoCallUint64Result> {
+            Network::IoSocketError* error_override = write_matcher->returnOverride(io_handle);
             if (error_override) {
-              return Api::IoCallUint64Result(
-                  0, Api::IoErrorPtr(error_override, Network::IoSocketError::deleteIoError));
+              return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
             }
             return absl::nullopt;
           }));


### PR DESCRIPTION
Extending the socket override framework to work for HTTP/3 and using it in the failed write test.

Risk Level: n/a (test only)
Testing: yep
Docs Changes: n/a
Release Notes: n/a