### PR TITLE
dns: abstraction c-ares pending resolution

### DIFF
--- a/envoy/network/dns.h
+++ b/envoy/network/dns.h
@@ -9,6 +9,8 @@
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 
+#include "absl/types/variant.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -36,17 +38,41 @@ public:
 };
 
 /**
- * DNS response.
+ * DNS A/AAAA record response.
  */
-struct DnsResponse {
-  DnsResponse(const Address::InstanceConstSharedPtr& address, const std::chrono::seconds ttl)
-      : address_(address), ttl_(ttl) {}
-
+struct AddrInfoResponse {
   const Address::InstanceConstSharedPtr address_;
   const std::chrono::seconds ttl_;
 };
 
+/**
+ * DNS SRV record response.
+ */
+struct SrvResponse {
+  const std::string host_;
+  const uint16_t port_;
+  const uint16_t priority_;
+  const uint16_t weight_;
+};
+
+enum class RecordType { A, AAAA, SRV };
+
 enum class DnsLookupFamily { V4Only, V6Only, Auto, V4Preferred, All };
+
+class DnsResponse {
+public:
+  DnsResponse(const Address::InstanceConstSharedPtr& address, const std::chrono::seconds ttl)
+      : response_(AddrInfoResponse{address, ttl}) {}
+  DnsResponse(const std::string& host, uint16_t port, uint16_t priority, uint16_t weight)
+      : response_(SrvResponse{host, port, priority, weight}) {}
+
+  const AddrInfoResponse& addrInfo() const { return absl::get<AddrInfoResponse>(response_); }
+
+  const SrvResponse& srv() const { return absl::get<SrvResponse>(response_); }
+
+private:
+  absl::variant<AddrInfoResponse, SrvResponse> response_;
+};
 
 /**
  * An asynchronous DNS resolver.
@@ -65,7 +91,8 @@ public:
    * @param status supplies the final status of the resolution.
    * @param response supplies the list of resolved IP addresses and TTLs.
    */
-  using ResolveCb = std::function<void(ResolutionStatus status, std::list<DnsResponse>&& response)>;
+  using ResolveCb =
+      std::function<void(ResolutionStatus status, const std::list<DnsResponse>&& response)>;
 
   /**
    * Initiate an async DNS resolution.

--- a/envoy/network/dns.h
+++ b/envoy/network/dns.h
@@ -91,8 +91,7 @@ public:
    * @param status supplies the final status of the resolution.
    * @param response supplies the list of resolved IP addresses and TTLs.
    */
-  using ResolveCb =
-      std::function<void(ResolutionStatus status, const std::list<DnsResponse>&& response)>;
+  using ResolveCb = std::function<void(ResolutionStatus status, std::list<DnsResponse>&& response)>;
 
   /**
    * Initiate an async DNS resolution.

--- a/source/common/common/dns_utils.cc
+++ b/source/common/common/dns_utils.cc
@@ -35,7 +35,7 @@ generateAddressList(const std::list<Network::DnsResponse>& responses, uint32_t p
     return addresses;
   }
   for (const auto& response : responses) {
-    auto address = Network::Utility::getAddressWithPort(*(response.address_), port);
+    auto address = Network::Utility::getAddressWithPort(*(response.addrInfo().address_), port);
     if (address) {
       addresses.push_back(address);
     }

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -111,7 +111,7 @@ void LogicalDnsCluster::startResolve() {
   active_dns_query_ = dns_resolver_->resolve(
       dns_address, dns_lookup_family_,
       [this, dns_address](Network::DnsResolver::ResolutionStatus status,
-                          std::list<Network::DnsResponse>&& response) -> void {
+                          const std::list<Network::DnsResponse>&& response) -> void {
         active_dns_query_ = nullptr;
         ENVOY_LOG(debug, "async DNS resolution complete for {}", dns_address);
 
@@ -122,11 +122,12 @@ void LogicalDnsCluster::startResolve() {
         // not stabilize back to 0 hosts.
         if (status == Network::DnsResolver::ResolutionStatus::Success && !response.empty()) {
           info_->stats().update_success_.inc();
+          const auto addrinfo = response.front().addrInfo();
           // TODO(mattklein123): Move port handling into the DNS interface.
           uint32_t port = Network::Utility::portFromTcpUrl(dns_url_);
-          ASSERT(response.front().address_ != nullptr);
+          ASSERT(addrinfo.address_ != nullptr);
           Network::Address::InstanceConstSharedPtr new_address =
-              Network::Utility::getAddressWithPort(*(response.front().address_), port);
+              Network::Utility::getAddressWithPort(*(response.front().addrInfo().address_), port);
           auto address_list = DnsUtils::generateAddressList(response, port);
 
           if (!logical_host_) {
@@ -159,8 +160,8 @@ void LogicalDnsCluster::startResolve() {
           // reset failure backoff strategy because there was a success.
           failure_backoff_strategy_->reset();
 
-          if (respect_dns_ttl_ && response.front().ttl_ != std::chrono::seconds(0)) {
-            final_refresh_rate = response.front().ttl_;
+          if (respect_dns_ttl_ && addrinfo.ttl_ != std::chrono::seconds(0)) {
+            final_refresh_rate = addrinfo.ttl_;
           }
           ENVOY_LOG(debug, "DNS refresh rate reset for {}, refresh rate {} ms", dns_address,
                     final_refresh_rate.count());

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -111,7 +111,7 @@ void LogicalDnsCluster::startResolve() {
   active_dns_query_ = dns_resolver_->resolve(
       dns_address, dns_lookup_family_,
       [this, dns_address](Network::DnsResolver::ResolutionStatus status,
-                          const std::list<Network::DnsResponse>&& response) -> void {
+                          std::list<Network::DnsResponse>&& response) -> void {
         active_dns_query_ = nullptr;
         ENVOY_LOG(debug, "async DNS resolution complete for {}", dns_address);
 

--- a/source/common/upstream/strict_dns_cluster.cc
+++ b/source/common/upstream/strict_dns_cluster.cc
@@ -108,7 +108,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
   active_query_ = parent_.dns_resolver_->resolve(
       dns_address_, parent_.dns_lookup_family_,
       [this](Network::DnsResolver::ResolutionStatus status,
-             const std::list<Network::DnsResponse>&& response) -> void {
+             std::list<Network::DnsResponse>&& response) -> void {
         active_query_ = nullptr;
         ENVOY_LOG(trace, "async DNS resolution complete for {}", dns_address_);
 

--- a/source/common/upstream/strict_dns_cluster.cc
+++ b/source/common/upstream/strict_dns_cluster.cc
@@ -108,7 +108,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
   active_query_ = parent_.dns_resolver_->resolve(
       dns_address_, parent_.dns_lookup_family_,
       [this](Network::DnsResolver::ResolutionStatus status,
-             std::list<Network::DnsResponse>&& response) -> void {
+             const std::list<Network::DnsResponse>&& response) -> void {
         active_query_ = nullptr;
         ENVOY_LOG(trace, "async DNS resolution complete for {}", dns_address_);
 
@@ -121,12 +121,13 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           std::chrono::seconds ttl_refresh_rate = std::chrono::seconds::max();
           absl::flat_hash_set<std::string> all_new_hosts;
           for (const auto& resp : response) {
+            const auto& addrinfo = resp.addrInfo();
             // TODO(mattklein123): Currently the DNS interface does not consider port. We need to
             // make a new address that has port in it. We need to both support IPv6 as well as
             // potentially move port handling into the DNS interface itself, which would work better
             // for SRV.
-            ASSERT(resp.address_ != nullptr);
-            auto address = Network::Utility::getAddressWithPort(*(resp.address_), port_);
+            ASSERT(addrinfo.address_ != nullptr);
+            auto address = Network::Utility::getAddressWithPort(*(addrinfo.address_), port_);
             if (all_new_hosts.count(address->asString()) > 0) {
               continue;
             }
@@ -139,7 +140,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
                 lb_endpoint_.endpoint().health_check_config(), locality_lb_endpoints_.priority(),
                 lb_endpoint_.health_status(), parent_.time_source_));
             all_new_hosts.emplace(address->asString());
-            ttl_refresh_rate = min(ttl_refresh_rate, resp.ttl_);
+            ttl_refresh_rate = min(ttl_refresh_rate, addrinfo.ttl_);
           }
 
           HostVector hosts_added;

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -275,8 +275,10 @@ void RedisCluster::RedisDiscoverySession::registerDiscoveryAddress(
   // Since the address from DNS does not have port, we need to make a new address that has
   // port in it.
   for (const Network::DnsResponse& res : response) {
-    ASSERT(res.address_ != nullptr);
-    discovery_address_list_.push_back(Network::Utility::getAddressWithPort(*(res.address_), port));
+    const auto& addrinfo = res.addrInfo();
+    ASSERT(addrinfo.address_ != nullptr);
+    discovery_address_list_.push_back(
+        Network::Utility::getAddressWithPort(*(addrinfo.address_), port));
   }
 }
 

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -194,8 +194,8 @@ void Context::onResolveDns(uint32_t token, Envoy::Network::DnsResolver::Resoluti
   //    N * null-terminated addresses
   uint32_t s = 4; // length
   for (auto& e : response) {
-    s += 4;                                     // for TTL
-    s += e.address_->asStringView().size() + 1; // null terminated.
+    s += 4;                                                // for TTL
+    s += e.addrInfo().address_->asStringView().size() + 1; // null terminated.
   }
   auto buffer = std::unique_ptr<char[]>(new char[s]);
   char* b = buffer.get();
@@ -203,14 +203,14 @@ void Context::onResolveDns(uint32_t token, Envoy::Network::DnsResolver::Resoluti
   safeMemcpyUnsafeDst(b, &n);
   b += sizeof(uint32_t);
   for (auto& e : response) {
-    uint32_t ttl = e.ttl_.count();
+    uint32_t ttl = e.addrInfo().ttl_.count();
     safeMemcpyUnsafeDst(b, &ttl);
     b += sizeof(uint32_t);
   };
   for (auto& e : response) {
-    memcpy(b, e.address_->asStringView().data(), // NOLINT(safe-memcpy)
-           e.address_->asStringView().size());
-    b += e.address_->asStringView().size();
+    memcpy(b, e.addrInfo().address_->asStringView().data(), // NOLINT(safe-memcpy)
+           e.addrInfo().address_->asStringView().size());
+    b += e.addrInfo().address_->asStringView().size();
     *b++ = 0;
   };
   buffer_.set(std::move(buffer), s);

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.cc
@@ -90,10 +90,12 @@ void DnsFilterResolver::resolveExternalQuery(DnsQueryContextPtr context,
                        if (status == Network::DnsResolver::ResolutionStatus::Success) {
                          ctx.resolved_hosts.reserve(response.size());
                          for (const auto& resp : response) {
-                           ASSERT(resp.address_ != nullptr);
+                           const auto& addrinfo = resp.addrInfo();
+                           ASSERT(addrinfo.address_ != nullptr);
                            ENVOY_LOG(trace, "Resolved address: {} for {}",
-                                     resp.address_->ip()->addressAsString(), ctx.query_rec->name_);
-                           ctx.resolved_hosts.emplace_back(std::move(resp.address_));
+                                     addrinfo.address_->ip()->addressAsString(),
+                                     ctx.query_rec->name_);
+                           ctx.resolved_hosts.emplace_back(std::move(addrinfo.address_));
                          }
                        }
                        // Invoke the filter callback notifying it of resolved addresses

--- a/source/extensions/network/dns_resolver/apple/apple_dns_impl.cc
+++ b/source/extensions/network/dns_resolver/apple/apple_dns_impl.cc
@@ -318,13 +318,13 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
   // Therefore, only add this address to the list if kDNSServiceFlagsAdd is set.
   if (flags & kDNSServiceFlagsAdd) {
     ASSERT(address, "invalid to add null address");
-    auto dns_response = buildDnsResponse(address, ttl).addrInfo();
+    auto dns_response = buildDnsResponse(address, ttl);
     ENVOY_LOG(debug, "Address to add address={}, ttl={}",
-              dns_response.address_->ip()->addressAsString(), ttl);
-    if (dns_response.address_->ip()->ipv4()) {
+              dns_response.addrInfo().address_->ip()->addressAsString(), ttl);
+    if (dns_response.addrInfo().address_->ip()->ipv4()) {
       pending_response_.v4_responses_.push_back(dns_response);
     } else {
-      ASSERT(dns_response.address_->ip()->ipv6());
+      ASSERT(dns_response.addrInfo().address_->ip()->ipv6());
       pending_response_.v6_responses_.push_back(dns_response);
     }
   }

--- a/source/extensions/network/dns_resolver/apple/apple_dns_impl.cc
+++ b/source/extensions/network/dns_resolver/apple/apple_dns_impl.cc
@@ -318,7 +318,7 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
   // Therefore, only add this address to the list if kDNSServiceFlagsAdd is set.
   if (flags & kDNSServiceFlagsAdd) {
     ASSERT(address, "invalid to add null address");
-    auto dns_response = buildDnsResponse(address, ttl);
+    auto dns_response = buildDnsResponse(address, ttl).addrInfo();
     ENVOY_LOG(debug, "Address to add address={}, ttl={}",
               dns_response.address_->ip()->addressAsString(), ttl);
     if (dns_response.address_->ip()->ipv4()) {

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -111,13 +111,10 @@ private:
     // or Auto: perform a second resolution if the first one fails. If dns_lookup_family_ is All:
     // perform resolutions on both families concurrently.
     bool dual_resolution_ = false;
-
-    int family_ = AF_INET;
-
-    const DnsLookupFamily dns_lookup_family_;
-
     // Whether or not to lookup both V4 and V6 address.
     bool lookup_all_ = false;
+    int family_ = AF_INET;
+    const DnsLookupFamily dns_lookup_family_;
   };
 
   struct AresOptions {

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -38,35 +38,38 @@ public:
 
 private:
   friend class DnsResolverImplPeer;
-  struct PendingResolution : public ActiveDnsQuery {
-    // Network::ActiveDnsQuery
-    PendingResolution(DnsResolverImpl& parent, ResolveCb callback, Event::Dispatcher& dispatcher,
-                      ares_channel channel, const std::string& dns_name,
-                      DnsLookupFamily dns_lookup_family)
-        : parent_(parent), callback_(callback), dispatcher_(dispatcher), channel_(channel),
-          dns_name_(dns_name), dns_lookup_family_(dns_lookup_family) {}
-
+  class PendingResolution : public ActiveDnsQuery {
+  public:
     void cancel(CancelReason) override {
       // c-ares only supports channel-wide cancellation, so we just allow the
       // network events to continue but don't invoke the callback on completion.
       // TODO(mattklein123): Potentially use timeout to destroy and recreate the channel.
       cancelled_ = true;
     }
+    // Does the object own itself? Resource reclamation occurs via self-deleting
+    // on query completion or error.
+    bool owned_ = false;
+    // Has the query completed? Only meaningful if !owned_;
+    bool completed_ = false;
 
-    /**
-     * ares_getaddrinfo query callback.
-     * @param status return status of call to ares_getaddrinfo.
-     * @param timeouts the number of times the request timed out.
-     * @param addrinfo structure to store address info.
-     */
-    void onAresGetAddrInfoCallback(int status, int timeouts, ares_addrinfo* addrinfo);
-    /**
-     * wrapper function of call to ares_getaddrinfo.
-     * @param family currently AF_INET and AF_INET6 are supported.
-     */
-    void getAddrInfo(int family);
+  protected:
+    // Network::ActiveDnsQuery
+    PendingResolution(DnsResolverImpl& parent, ResolveCb callback, Event::Dispatcher& dispatcher,
+                      ares_channel channel, const std::string& dns_name)
+        : parent_(parent), callback_(callback), dispatcher_(dispatcher), channel_(channel),
+          dns_name_(dns_name) {}
 
     void finishResolve();
+
+    DnsResolverImpl& parent_;
+    // Caller supplied callback to invoke on query completion or error.
+    const ResolveCb callback_;
+    // Dispatcher to post any callback_ exceptions to.
+    Event::Dispatcher& dispatcher_;
+    // Was the query cancelled via cancel()?
+    bool cancelled_ = false;
+    const ares_channel channel_;
+    const std::string dns_name_;
 
     // Small wrapping struct to accumulate addresses from firings of the
     // onAresGetAddrInfoCallback callback.
@@ -75,30 +78,46 @@ private:
       std::list<DnsResponse> address_list_;
     };
 
-    DnsResolverImpl& parent_;
-    // Caller supplied callback to invoke on query completion or error.
-    const ResolveCb callback_;
-    // Dispatcher to post any callback_ exceptions to.
-    Event::Dispatcher& dispatcher_;
-    // Does the object own itself? Resource reclamation occurs via self-deleting
-    // on query completion or error.
-    bool owned_ = false;
-    // Has the query completed? Only meaningful if !owned_;
-    bool completed_ = false;
-    // Was the query cancelled via cancel()?
-    bool cancelled_ = false;
-    // Perform a second resolution under certain conditions. If dns_lookup_family_ is V4Preferred
-    // or Auto: perform a second resolution if the first one fails. If dns_lookup_family_ is All:
-    // perform resolutions on both families concurrently.
-    bool dual_resolution_ = false;
-    const ares_channel channel_;
-    const std::string dns_name_;
-    const DnsLookupFamily dns_lookup_family_;
     // Note: pending_response_ is constructed with ResolutionStatus::Failure by default and
     // __only__ changed to ResolutionStatus::Success if there is an ARES_SUCCESS reply.
     // In the dual_resolution case __any__ ARES_SUCCESS reply will result in a
     // ResolutionStatus::Success callback.
     PendingResponse pending_response_{ResolutionStatus::Failure, {}};
+  };
+
+  class AddrInfoPendingResolution final : public PendingResolution {
+  public:
+    AddrInfoPendingResolution(DnsResolverImpl& parent, ResolveCb callback,
+                              Event::Dispatcher& dispatcher, ares_channel channel,
+                              const std::string& dns_name, DnsLookupFamily dns_lookup_family);
+
+    /**
+     * ares_getaddrinfo query callback.
+     * @param status return status of call to ares_getaddrinfo.
+     * @param timeouts the number of times the request timed out.
+     * @param addrinfo structure to store address info.
+     */
+    void onAresGetAddrInfoCallback(int status, int timeouts, ares_addrinfo* addrinfo);
+
+    /**
+     * wrapper function of call to ares_getaddrinfo.
+     */
+    void startResolution();
+
+  private:
+    void startResolutionImpl(int family);
+
+    // Perform a second resolution under certain conditions. If dns_lookup_family_ is V4Preferred
+    // or Auto: perform a second resolution if the first one fails. If dns_lookup_family_ is All:
+    // perform resolutions on both families concurrently.
+    bool dual_resolution_ = false;
+
+    int family_ = AF_INET;
+
+    const DnsLookupFamily dns_lookup_family_;
+
+    // Whether or not to lookup both V4 and V6 address.
+    bool lookup_all_ = false;
   };
 
   struct AresOptions {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -423,7 +423,7 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-      // No request trailer O(1) headers.
+    // No request trailer O(1) headers.
   }
   {
     auto header_map = ResponseHeaderMapImpl::create();

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -423,7 +423,7 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-    // No request trailer O(1) headers.
+      // No request trailer O(1) headers.
   }
   {
     auto header_map = ResponseHeaderMapImpl::create();

--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -90,12 +90,13 @@ public:
             EXPECT_FALSE(results.empty());
             absl::optional<bool> is_v4{};
             for (const auto& result : results) {
+              const auto& addrinfo = result.addrInfo();
               switch (lookup_family) {
               case DnsLookupFamily::V4Only:
-                EXPECT_NE(nullptr, result.address_->ip()->ipv4());
+                EXPECT_NE(nullptr, addrinfo.address_->ip()->ipv4());
                 break;
               case DnsLookupFamily::V6Only:
-                EXPECT_NE(nullptr, result.address_->ip()->ipv6());
+                EXPECT_NE(nullptr, addrinfo.address_->ip()->ipv6());
                 break;
               // In CI these modes could return either IPv4 or IPv6 with the non-mocked API calls.
               // But regardless of the family all returned addresses need to be one _or_ the other.
@@ -103,7 +104,7 @@ public:
               case DnsLookupFamily::Auto:
                 // Set the expectation for subsequent responses based on the first one.
                 if (!is_v4.has_value()) {
-                  if (result.address_->ip()->ipv4()) {
+                  if (addrinfo.address_->ip()->ipv4()) {
                     is_v4 = true;
                   } else {
                     is_v4 = false;
@@ -111,17 +112,17 @@ public:
                 }
 
                 if (is_v4.value()) {
-                  EXPECT_NE(nullptr, result.address_->ip()->ipv4());
+                  EXPECT_NE(nullptr, addrinfo.address_->ip()->ipv4());
                 } else {
-                  EXPECT_NE(nullptr, result.address_->ip()->ipv6());
+                  EXPECT_NE(nullptr, addrinfo.address_->ip()->ipv6());
                 }
                 break;
               // All could be either IPv4 or IPv6.
               case DnsLookupFamily::All:
-                if (result.address_->ip()->ipv4()) {
-                  EXPECT_NE(nullptr, result.address_->ip()->ipv4());
+                if (addrinfo.address_->ip()->ipv4()) {
+                  EXPECT_NE(nullptr, addrinfo.address_->ip()->ipv4());
                 } else {
-                  EXPECT_NE(nullptr, result.address_->ip()->ipv6());
+                  EXPECT_NE(nullptr, addrinfo.address_->ip()->ipv6());
                 }
                 break;
               default:
@@ -372,8 +373,8 @@ TEST_F(AppleDnsImplTest, LocalResolution) {
       [](DnsResolver::ResolutionStatus status, std::list<DnsResponse>&& results) -> void {
         EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
         EXPECT_EQ(1, results.size());
-        EXPECT_EQ("0.0.0.0:0", results.front().address_->asString());
-        EXPECT_EQ(std::chrono::seconds(60), results.front().ttl_);
+        EXPECT_EQ("0.0.0.0:0", results.front().addrInfo().address_->asString());
+        EXPECT_EQ(std::chrono::seconds(60), results.front().addrInfo().ttl_);
       });
   EXPECT_EQ(nullptr, pending_resolution);
   // Note that the dispatcher does NOT have to run because resolution is synchronous.
@@ -492,31 +493,31 @@ public:
 
           if (dns_lookup_family == DnsLookupFamily::Auto) {
             if (address_type == AddressType::V4) {
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
             } else {
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv6());
             }
           }
 
           if (dns_lookup_family == DnsLookupFamily::V4Preferred) {
             if (address_type == AddressType::V6) {
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv6());
             } else {
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
             }
           }
 
           if (dns_lookup_family == DnsLookupFamily::All) {
             switch (address_type) {
             case AddressType::V4:
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
               break;
             case AddressType::V6:
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv6());
               break;
             case AddressType::Both:
-              EXPECT_NE(nullptr, response.front().address_->ip()->ipv4());
-              EXPECT_NE(nullptr, response.back().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.addrInfo().back().address_->ip()->ipv6());
               break;
             default:
               NOT_REACHED_GCOVR_EXCL_LINE;
@@ -705,16 +706,16 @@ TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {
 
   // The returned value is nullptr because the query has already been fulfilled. Verify that the
   // callback ran via notification.
-  EXPECT_EQ(nullptr,
-            resolver_->resolve(hostname, Network::DnsLookupFamily::Auto,
-                               [&dns_callback_executed](DnsResolver::ResolutionStatus status,
-                                                        std::list<DnsResponse>&& response) -> void {
-                                 EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
-                                 EXPECT_EQ(1, response.size());
-                                 EXPECT_EQ("1.2.3.4:0", response.front().address_->asString());
-                                 EXPECT_EQ(std::chrono::seconds(30), response.front().ttl_);
-                                 dns_callback_executed.Notify();
-                               }));
+  EXPECT_EQ(nullptr, resolver_->resolve(
+                         hostname, Network::DnsLookupFamily::Auto,
+                         [&dns_callback_executed](DnsResolver::ResolutionStatus status,
+                                                  std::list<DnsResponse>&& response) -> void {
+                           EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
+                           EXPECT_EQ(1, response.size());
+                           EXPECT_EQ("1.2.3.4:0", response.front().addrInfo().address_->asString());
+                           EXPECT_EQ(std::chrono::seconds(30), response.addrInfo().front().ttl_);
+                           dns_callback_executed.Notify();
+                         }));
   dns_callback_executed.WaitForNotification();
 }
 
@@ -890,8 +891,8 @@ TEST_F(AppleDnsImplFakeApiTest, MultipleQueries) {
                                                   std::list<DnsResponse>&& response) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
                            EXPECT_EQ(1, response.size());
-                           EXPECT_EQ("1.2.3.4:0", response.front().address_->asString());
-                           EXPECT_EQ(std::chrono::seconds(30), response.front().ttl_);
+                           EXPECT_EQ("1.2.3.4:0", response.front().addrInfo().address_->asString());
+                           EXPECT_EQ(std::chrono::seconds(30), response.addrInfo().front().ttl_);
                            dns_callback_executed.Notify();
                          });
   ASSERT_NE(nullptr, query);
@@ -912,8 +913,8 @@ TEST_F(AppleDnsImplFakeApiTest, MultipleQueries) {
                                                    std::list<DnsResponse>&& response) -> void {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
                            EXPECT_EQ(1, response.size());
-                           EXPECT_EQ("5.6.7.8:0", response.front().address_->asString());
-                           EXPECT_EQ(std::chrono::seconds(30), response.front().ttl_);
+                           EXPECT_EQ("5.6.7.8:0", response.front().addrInfo().address_->asString());
+                           EXPECT_EQ(std::chrono::seconds(30), response.addrInfo().front().ttl_);
                            dns_callback_executed2.Notify();
                          });
   ASSERT_NE(nullptr, query2);
@@ -961,8 +962,8 @@ TEST_F(AppleDnsImplFakeApiTest, MultipleQueriesOneFails) {
                            // state it had.
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
                            EXPECT_EQ(1, response.size());
-                           EXPECT_EQ("1.2.3.4:0", response.front().address_->asString());
-                           EXPECT_EQ(std::chrono::seconds(30), response.front().ttl_);
+                           EXPECT_EQ("1.2.3.4:0", response.front().addrInfo().address_->asString());
+                           EXPECT_EQ(std::chrono::seconds(30), response.front().addrInfo().ttl_);
                            dns_callback_executed.Notify();
                          });
   ASSERT_NE(nullptr, query);

--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -493,31 +493,31 @@ public:
 
           if (dns_lookup_family == DnsLookupFamily::Auto) {
             if (address_type == AddressType::V4) {
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv4());
             } else {
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv6());
             }
           }
 
           if (dns_lookup_family == DnsLookupFamily::V4Preferred) {
             if (address_type == AddressType::V6) {
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv6());
             } else {
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv4());
             }
           }
 
           if (dns_lookup_family == DnsLookupFamily::All) {
             switch (address_type) {
             case AddressType::V4:
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv4());
               break;
             case AddressType::V6:
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv6());
               break;
             case AddressType::Both:
-              EXPECT_NE(nullptr, response.addrInfo().front().address_->ip()->ipv4());
-              EXPECT_NE(nullptr, response.addrInfo().back().address_->ip()->ipv6());
+              EXPECT_NE(nullptr, response.front().addrInfo().address_->ip()->ipv4());
+              EXPECT_NE(nullptr, response.back().addrInfo().address_->ip()->ipv6());
               break;
             default:
               NOT_REACHED_GCOVR_EXCL_LINE;
@@ -713,7 +713,7 @@ TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
                            EXPECT_EQ(1, response.size());
                            EXPECT_EQ("1.2.3.4:0", response.front().addrInfo().address_->asString());
-                           EXPECT_EQ(std::chrono::seconds(30), response.addrInfo().front().ttl_);
+                           EXPECT_EQ(std::chrono::seconds(30), response.front().addrInfo().ttl_);
                            dns_callback_executed.Notify();
                          }));
   dns_callback_executed.WaitForNotification();
@@ -892,7 +892,7 @@ TEST_F(AppleDnsImplFakeApiTest, MultipleQueries) {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
                            EXPECT_EQ(1, response.size());
                            EXPECT_EQ("1.2.3.4:0", response.front().addrInfo().address_->asString());
-                           EXPECT_EQ(std::chrono::seconds(30), response.addrInfo().front().ttl_);
+                           EXPECT_EQ(std::chrono::seconds(30), response.front().addrInfo().ttl_);
                            dns_callback_executed.Notify();
                          });
   ASSERT_NE(nullptr, query);
@@ -914,7 +914,7 @@ TEST_F(AppleDnsImplFakeApiTest, MultipleQueries) {
                            EXPECT_EQ(DnsResolver::ResolutionStatus::Success, status);
                            EXPECT_EQ(1, response.size());
                            EXPECT_EQ("5.6.7.8:0", response.front().addrInfo().address_->asString());
-                           EXPECT_EQ(std::chrono::seconds(30), response.addrInfo().front().ttl_);
+                           EXPECT_EQ(std::chrono::seconds(30), response.front().addrInfo().ttl_);
                            dns_callback_executed2.Notify();
                          });
   ASSERT_NE(nullptr, query2);

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -643,7 +643,7 @@ public:
                                           const absl::optional<std::chrono::seconds> expected_ttl) {
     return resolver_->resolve(
         address, lookup_family,
-        [=](DnsResolver::ResolutionStatus status, const std::list<DnsResponse>&& results) -> void {
+        [=](DnsResolver::ResolutionStatus status, std::list<DnsResponse>&& results) -> void {
           EXPECT_EQ(expected_status, status);
 
           std::list<std::string> address_as_string_list = getAddressAsStringList(results);
@@ -675,16 +675,15 @@ public:
   ActiveDnsQuery* resolveWithUnreferencedParameters(const std::string& address,
                                                     const DnsLookupFamily lookup_family,
                                                     bool expected_to_execute) {
-    return resolver_->resolve(
-        address, lookup_family,
-        [expected_to_execute](DnsResolver::ResolutionStatus status,
-                              const std::list<DnsResponse>&& results) -> void {
-          if (!expected_to_execute) {
-            FAIL();
-          }
-          UNREFERENCED_PARAMETER(status);
-          UNREFERENCED_PARAMETER(results);
-        });
+    return resolver_->resolve(address, lookup_family,
+                              [expected_to_execute](DnsResolver::ResolutionStatus status,
+                                                    std::list<DnsResponse>&& results) -> void {
+                                if (!expected_to_execute) {
+                                  FAIL();
+                                }
+                                UNREFERENCED_PARAMETER(status);
+                                UNREFERENCED_PARAMETER(results);
+                              });
   }
 
   template <typename T>
@@ -692,7 +691,7 @@ public:
                                        const DnsLookupFamily lookup_family, T exception_object) {
     return resolver_->resolve(address, lookup_family,
                               [exception_object](DnsResolver::ResolutionStatus status,
-                                                 const std::list<DnsResponse>&& results) -> void {
+                                                 std::list<DnsResponse>&& results) -> void {
                                 UNREFERENCED_PARAMETER(status);
                                 UNREFERENCED_PARAMETER(results);
                                 throw exception_object;


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: dns: abstraction c-ares pending resolution
Additional Description: The purpose of this abstraction is to make the resolution process as common as possible when adding support for SRV query lookup in c-ares. With this abstraction, starting a pending resolution is as simple as calling `startResolution()`. The introduction of this function is the core of this refactor, and the implementation of `startResolution()` in the pending resolution object for SRV queries also simplifies the process of `DnsResolverImpl::resolve()`. Also, the DNS Response structure is abstracted by one level, and it can store the resolution of A/AAAA/SRV queries.
Risk Level: Low
Testing: N/A
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Related with #19091 