### PR TITLE
remove grpc als static cluster check

### DIFF
--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -27,10 +27,6 @@ AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
       const envoy::extensions::access_loggers::grpc::v3::HttpGrpcAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  const auto service_config = proto_config.common_config().grpc_service();
-  if (service_config.has_envoy_grpc()) {
-    context.clusterManager().checkActiveStaticCluster(service_config.envoy_grpc().cluster_name());
-  }
   return std::make_shared<HttpGrpcAccessLog>(
       std::move(filter), proto_config, context.threadLocal(),
       GrpcCommon::getGrpcAccessLoggerCacheSingleton(context));

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -27,10 +27,6 @@ AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
       const envoy::extensions::access_loggers::grpc::v3::TcpGrpcAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  const auto service_config = proto_config.common_config().grpc_service();
-  if (service_config.has_envoy_grpc()) {
-    context.clusterManager().checkActiveStaticCluster(service_config.envoy_grpc().cluster_name());
-  }
   return std::make_shared<TcpGrpcAccessLog>(std::move(filter), proto_config, context.threadLocal(),
                                             GrpcCommon::getGrpcAccessLoggerCacheSingleton(context));
 }

--- a/test/extensions/access_loggers/grpc/http_config_test.cc
+++ b/test/extensions/access_loggers/grpc/http_config_test.cc
@@ -34,12 +34,6 @@ public:
 
   void run(const std::string cluster_name) {
     const auto good_cluster = "good_cluster";
-    EXPECT_CALL(context_.cluster_manager_, checkActiveStaticCluster(cluster_name))
-        .WillOnce(Invoke([good_cluster](const std::string& cluster_name) {
-          if (cluster_name != good_cluster) {
-            throw EnvoyException("fake");
-          }
-        }));
 
     auto* common_config = http_grpc_access_log_.mutable_common_config();
     common_config->set_log_name("foo");

--- a/test/extensions/access_loggers/grpc/http_config_test.cc
+++ b/test/extensions/access_loggers/grpc/http_config_test.cc
@@ -67,9 +67,6 @@ public:
 // Normal OK configuration.
 TEST_F(HttpGrpcAccessLogConfigTest, Ok) { run("good_cluster"); }
 
-// Wrong configuration with invalid clusters.
-TEST_F(HttpGrpcAccessLogConfigTest, InvalidCluster) { run("invalid"); }
-
 } // namespace
 } // namespace HttpGrpc
 } // namespace AccessLoggers

--- a/test/extensions/access_loggers/grpc/tcp_config_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_config_test.cc
@@ -67,9 +67,6 @@ public:
 // Normal OK configuration.
 TEST_F(TcpGrpcAccessLogConfigTest, Ok) { run("good_cluster"); }
 
-// Wrong configuration with invalid clusters.
-TEST_F(TcpGrpcAccessLogConfigTest, InvalidCluster) { run("invalid"); }
-
 class MockGrpcAccessLoggerCache : public GrpcCommon::GrpcAccessLoggerCache {
 public:
   // GrpcAccessLoggerCache

--- a/test/extensions/access_loggers/grpc/tcp_config_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_config_test.cc
@@ -34,12 +34,6 @@ public:
 
   void run(const std::string cluster_name) {
     const auto good_cluster = "good_cluster";
-    EXPECT_CALL(context_.cluster_manager_, checkActiveStaticCluster(cluster_name))
-        .WillOnce(Invoke([good_cluster](const std::string& cluster_name) {
-          if (cluster_name != good_cluster) {
-            throw EnvoyException("fake");
-          }
-        }));
 
     auto* common_config = tcp_grpc_access_log_.mutable_common_config();
     common_config->set_log_name("foo");


### PR DESCRIPTION
Commit Message: remove grpc als static cluster check
Additional Description: This PR remove static cluster check in GRPC ALS, make behavior consistent with the OpenTelemetry ALS
Risk Level: low
Testing: unittests / integration tests
Docs Changes: TBD
Release Notes: TBD
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/19001
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
