### PR TITLE
quiche: enforce header verification in QUICHE

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -136,7 +136,7 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
     return;
   }
   quic::QuicSpdyStream::OnInitialHeadersComplete(fin, frame_len, header_list);
-  if (!headers_decompressed() || header_list.empty()) {
+  if (!headers_decompressed() || header_list.empty() || saw_invalid_header_) {
     onStreamError(!http3_options_.override_stream_error_on_invalid_http_message().value(),
                   quic::QUIC_BAD_APPLICATION_PAYLOAD);
     return;
@@ -355,6 +355,11 @@ void EnvoyQuicClientStream::onStreamError(absl::optional<bool> should_close_conn
 }
 
 bool EnvoyQuicClientStream::hasPendingData() { return BufferedDataBytes() > 0; }
+
+void EnvoyQuicClientStream::OnInvalidHeaders() {
+  details_ = Http3ResponseCodeDetailValues::invalid_http_header;
+  saw_invalid_header_ = true;
+}
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_client_stream.h
+++ b/source/common/quic/envoy_quic_client_stream.h
@@ -59,6 +59,7 @@ protected:
                                 const quic::QuicHeaderList& header_list) override;
   void OnTrailingHeadersComplete(bool fin, size_t frame_len,
                                  const quic::QuicHeaderList& header_list) override;
+  void OnInvalidHeaders() override;
 
   // Http::MultiplexedStreamImplBase
   bool hasPendingData() override;

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -141,7 +141,7 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
     return;
   }
   quic::QuicSpdyServerStreamBase::OnInitialHeadersComplete(fin, frame_len, header_list);
-  if (!headers_decompressed() || header_list.empty()) {
+  if (!headers_decompressed() || header_list.empty() || saw_invalid_header_) {
     onStreamError(absl::nullopt);
     return;
   }
@@ -415,6 +415,11 @@ bool EnvoyQuicServerStream::hasPendingData() {
   // Quic stream sends headers and trailers on the same stream, and buffers them in the same sending
   // buffer if needed. So checking this buffer is sufficient.
   return BufferedDataBytes() > 0;
+}
+
+void EnvoyQuicServerStream::OnInvalidHeaders() {
+  details_ = Http3ResponseCodeDetailValues::invalid_http_header;
+  saw_invalid_header_ = true;
 }
 
 } // namespace Quic

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -65,6 +65,7 @@ protected:
   void OnTrailingHeadersComplete(bool fin, size_t frame_len,
                                  const quic::QuicHeaderList& header_list) override;
   void OnHeadersTooLarge() override;
+  void OnInvalidHeaders() override;
 
   // Http::MultiplexedStreamImplBase
   void onPendingFlushTimer() override;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -169,6 +169,7 @@ protected:
   Buffer::BufferMemoryAccountSharedPtr buffer_memory_account_ = nullptr;
   bool got_304_response_{false};
   bool sent_head_request_{false};
+  bool saw_invalid_header_{false};
 
 private:
   // Keeps track of bytes buffered in the stream send buffer in QUICHE and reacts

--- a/source/common/quic/platform/quiche_flags_impl.cc
+++ b/source/common/quic/platform/quiche_flags_impl.cc
@@ -37,6 +37,9 @@ absl::flat_hash_map<absl::string_view, Flag*> makeFlagMap() {
   FLAGS_quic_reloadable_flag_quic_disable_version_draft_29->setValue(true);
   // This flag fixes a QUICHE issue which may crash Envoy during connection close.
   FLAGS_quic_reloadable_flag_quic_single_ack_in_packet2->setValue(true);
+  // These two flags enforce QUICHE headers verification.
+  FLAGS_quic_reloadable_flag_quic_verify_request_headers_2->setValue(true);
+  FLAGS_quic_reloadable_flag_quic_act_upon_invalid_header->setValue(true);
 
 #define QUIC_PROTOCOL_FLAG(type, flag, ...) flags.emplace(FLAGS_##flag->name(), FLAGS_##flag);
 #include "quiche/quic/core/quic_protocol_flags_list.h"


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: make QUICHE reject invalid request/response headers

Risk Level: low
Testing: added integration test
