### PR TITLE
test: Update tests that use proto DebugString

### DIFF
--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -353,11 +353,16 @@ TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux, GrpcCollectionSubscriptionUnsu
   Upstream::ClusterManager::ClusterSet primary_clusters;
   primary_clusters.insert("static_cluster");
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
+  std::string expected_config_text = R"pb(api_type: GRPC)pb";
+  envoy::config::core::v3::ApiConfigSource expected_config_proto;
+  Protobuf::TextFormat::ParseFromString(expected_config_text, &expected_config_proto);
   EXPECT_THROW_WITH_REGEX(
       collectionSubscriptionFromUrl(
           "xdstp://foo/envoy.config.endpoint.v3.ClusterLoadAssignment/bar", config)
           ->start({}),
-      EnvoyException, "Unknown xdstp:// transport API type in api_type: GRPC");
+      EnvoyException,
+      fmt::format("Unknown xdstp:// transport API type in {}",
+                  expected_config_proto.DebugString()));
 }
 
 TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux,

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -37,6 +37,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/container/node_hash_set.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "udpa/type/v1/typed_struct.pb.h"
 #include "xds/type/v3/typed_struct.pb.h"
@@ -179,9 +180,11 @@ TEST_F(ProtobufUtilityTest, RepeatedPtrUtilDebugString) {
   Protobuf::RepeatedPtrField<ProtobufWkt::UInt32Value> repeated;
   EXPECT_EQ("[]", RepeatedPtrUtil::debugString(repeated));
   repeated.Add()->set_value(10);
-  EXPECT_EQ("[value: 10\n]", RepeatedPtrUtil::debugString(repeated));
+  EXPECT_THAT(RepeatedPtrUtil::debugString(repeated),
+              testing::ContainsRegex("\\[value:\\s*10\n\\]"));
   repeated.Add()->set_value(20);
-  EXPECT_EQ("[value: 10\n, value: 20\n]", RepeatedPtrUtil::debugString(repeated));
+  EXPECT_THAT(RepeatedPtrUtil::debugString(repeated),
+              testing::ContainsRegex("\\[value:\\s*10\n, value:\\s*20\n\\]"));
 }
 
 // Validated exception thrown when downcastAndValidate observes a PGV failures.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -50,8 +50,9 @@ using ::testing::HasSubstr;
 
 template <class M> bool checkProtoEquality(M proto1, std::string text_proto2) {
   M proto2;
-  if (!Protobuf::TextFormat::ParseFromString(text_proto2, &proto2))
+  if (!Protobuf::TextFormat::ParseFromString(text_proto2, &proto2)) {
     return false;
+  }
   return Envoy::Protobuf::util::MessageDifferencer::Equals(proto1, proto2);
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -48,8 +48,8 @@ namespace Envoy {
 
 using ::testing::HasSubstr;
 
-template <class M> bool checkProtoEquality(M proto1, std::string text_proto2) {
-  M proto2;
+bool checkProtoEquality(const ProtobufWkt::Value& proto1, std::string text_proto2) {
+  ProtobufWkt::Value proto2;
   if (!Protobuf::TextFormat::ParseFromString(text_proto2, &proto2)) {
     return false;
   }

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -48,7 +48,7 @@ namespace Envoy {
 
 using ::testing::HasSubstr;
 
-template <class M> bool CheckProtoEquality(M proto1, std::string text_proto2) {
+template <class M> bool checkProtoEquality(M proto1, std::string text_proto2) {
   M proto2;
   if (!Protobuf::TextFormat::ParseFromString(text_proto2, &proto2))
     return false;
@@ -1238,26 +1238,26 @@ TEST_F(ProtobufUtilityTest, MessageUtilLoadYamlDouble) {
 }
 
 TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlScalar) {
-  EXPECT_TRUE(CheckProtoEquality(ValueUtil::loadFromYaml("null"), "null_value: NULL_VALUE"));
-  EXPECT_TRUE(CheckProtoEquality(ValueUtil::loadFromYaml("true"), "bool_value: true"));
-  EXPECT_TRUE(CheckProtoEquality(ValueUtil::loadFromYaml("1"), "number_value: 1"));
-  EXPECT_TRUE(CheckProtoEquality(ValueUtil::loadFromYaml("9223372036854775807"),
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("null"), "null_value: NULL_VALUE"));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("true"), "bool_value: true"));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("1"), "number_value: 1"));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("9223372036854775807"),
                                  "string_value: \"9223372036854775807\""));
-  EXPECT_TRUE(CheckProtoEquality(ValueUtil::loadFromYaml("\"foo\""), "string_value: \"foo\""));
-  EXPECT_TRUE(CheckProtoEquality(ValueUtil::loadFromYaml("foo"), "string_value: \"foo\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("\"foo\""), "string_value: \"foo\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("foo"), "string_value: \"foo\""));
 }
 
 TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlObject) {
-  EXPECT_TRUE(CheckProtoEquality(
+  EXPECT_TRUE(checkProtoEquality(
       ValueUtil::loadFromYaml("[foo, bar]"),
       "list_value { values { string_value: \"foo\" } values { string_value: \"bar\" } }"));
-  EXPECT_TRUE(CheckProtoEquality(
+  EXPECT_TRUE(checkProtoEquality(
       ValueUtil::loadFromYaml("foo: bar"),
       "struct_value { fields { key: \"foo\" value { string_value: \"bar\" } } }"));
 }
 
 TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlObjectWithIgnoredEntries) {
-  EXPECT_TRUE(CheckProtoEquality(
+  EXPECT_TRUE(checkProtoEquality(
       ValueUtil::loadFromYaml("!ignore foo: bar\nbaz: qux"),
       "struct_value { fields { key: \"baz\" value { string_value: \"qux\" } } }"));
 }

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -719,8 +719,11 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
             getCallback(
                 "/config_dump?resource=static_clusters&mask=cluster.transport_socket_matches.name",
                 header_map, response));
-  EXPECT_EQ("FieldMask paths: \"cluster.transport_socket_matches.name\"\n could not be "
-            "successfully used.",
+  std::string expected_mask_text = R"pb(paths: "cluster.transport_socket_matches.name")pb";
+  Protobuf::FieldMask expected_mask_proto;
+  Protobuf::TextFormat::ParseFromString(expected_mask_text, &expected_mask_proto);
+  EXPECT_EQ(fmt::format("FieldMask {} could not be successfully used.",
+                        expected_mask_proto.DebugString()),
             response.toString());
   EXPECT_EQ(header_map.ContentType()->value().getStringView(),
             Http::Headers::get().ContentTypeValues.Text);


### PR DESCRIPTION
Additional Description:
Upcoming updates to proto library use different whitespace between name and value pairs.This change preemptively modifies tests to use matchers that work with both new and old versions on proto library.

Risk Level: Low, Test Only
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
