### PR TITLE
quic: fix conn pool grid test

### DIFF
--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -737,6 +737,9 @@ TEST_F(ConnectivityGridTest, ConnectionCloseDuringCreation) {
   EXPECT_CALL(os_sys_calls, setsocketblocking(1, false))
       .WillOnce(Return(Api::SysCallIntResult{1, 0}));
 #endif
+  EXPECT_CALL(os_sys_calls, setsockopt_(_, _, _, _, _))
+      .Times(testing::AtLeast(0u))
+      .WillRepeatedly(Return(0));
   EXPECT_CALL(os_sys_calls, bind(_, _, _)).WillOnce(Return(Api::SysCallIntResult{1, 0}));
   EXPECT_CALL(os_sys_calls, setsockopt_(_, _, _, _, _)).WillRepeatedly(Return(0));
   EXPECT_CALL(os_sys_calls, sendmsg(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{-1, 101}));


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: adjust EXPECT_CALL on setsockopt() in ConnectionCloseDuringCreation test  to work with possibly pre-bind socket options. The fix is needed to make the test pass under Google internal gtest suite.

Risk Level: low, test only
Testing: n/a

