### PR TITLE
Reset Consecutive Local Origin Failure counter

### DIFF
--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -357,6 +357,7 @@ void DetectorImpl::checkHostForUneject(HostSharedPtr host, DetectorHostMonitorIm
     // to the non-triggering counter being close to its trigger value.
     host_monitors_[host]->resetConsecutive5xx();
     host_monitors_[host]->resetConsecutiveGatewayFailure();
+    host_monitors_[host]->resetConsecutiveLocalOriginFailure();
     monitor->uneject(now);
     runCallbacks(host);
 


### PR DESCRIPTION
Commit Message: Reset Consecutive Local Origin Failure counter when unejecting a host
Additional Description:
  to ensure that the host will be re-ejected when envoy experiences
  local origin failure for the host.
  
  this commit fixes #18950

Risk Level: Low
Testing: Verfied that I can no longer reproduce the bug with the fix
Docs Changes:
Release Notes:
Platform Specific Features:
