### PR TITLE
apple dns: add missing cancellation

### DIFF
--- a/source/extensions/network/dns_resolver/apple/apple_dns_impl.h
+++ b/source/extensions/network/dns_resolver/apple/apple_dns_impl.h
@@ -131,6 +131,8 @@ private:
     // be accumulated before firing callback_.
     PendingResponse pending_response_;
     DnsLookupFamily dns_lookup_family_;
+    // Was the query cancelled via cancel()?
+    bool cancelled_{};
   };
 
   Event::Dispatcher& dispatcher_;

--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -350,10 +350,7 @@ TEST_F(AppleDnsImplTest, CallbackExceptionLocalResolution) {
 // Validate working of cancellation provided by ActiveDnsQuery return.
 TEST_F(AppleDnsImplTest, Cancel) {
   ActiveDnsQuery* query =
-      resolveWithUnreferencedParameters("some.domain", DnsLookupFamily::Auto, false);
-
-  EXPECT_NE(nullptr, resolveWithExpectations("google.com", DnsLookupFamily::Auto,
-                                             DnsResolver::ResolutionStatus::Success, true));
+      resolveWithUnreferencedParameters("google.com", DnsLookupFamily::Auto, false);
 
   ASSERT_NE(nullptr, query);
   query->cancel(Network::ActiveDnsQuery::CancelReason::QueryAbandoned);


### PR DESCRIPTION
Commit Message: apple dns - add missing cancellation
Additional Description: I noticed this was missing.
Risk Level: low, fixing existing bug.
Testing: modified UT that failed before change.
