### PR TITLE
source: removing NOT_IMPLEMENTED_GCOVR_EXCL_LINE

### DIFF
--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -192,7 +192,7 @@ Decoder::Result DecoderImpl::onData(Buffer::Instance& data, bool frontend) {
   case State::InSyncState:
     return onDataInSync(data, frontend);
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 }
 

--- a/contrib/vcl/source/vcl_io_handle.cc
+++ b/contrib/vcl/source/vcl_io_handle.cc
@@ -372,7 +372,7 @@ Api::IoCallUint64Result VclIoHandle::recvmsg(Buffer::RawSlice* slices, const uin
 }
 
 Api::IoCallUint64Result VclIoHandle::recvmmsg(RawSliceArrays&, uint32_t, RecvMsgOutput&) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 }
 
 bool VclIoHandle::supportsMmsg() const { return false; }

--- a/envoy/config/config_provider.h
+++ b/envoy/config/config_provider.h
@@ -147,20 +147,20 @@ protected:
    * @return Protobuf::Message* the config proto corresponding to the Config instantiated by the
    *         provider.
    */
-  virtual const Protobuf::Message* getConfigProto() const { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  virtual const Protobuf::Message* getConfigProto() const { return nullptr; }
 
   /**
    * Returns the config protos associated with the provider.
    * @return const ConfigProtoVector the config protos corresponding to the Config instantiated by
    *         the provider.
    */
-  virtual ConfigProtoVector getConfigProtos() const { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  virtual ConfigProtoVector getConfigProtos() const { PANIC("not implemented"); }
 
   /**
    * Returns the config version associated with the provider.
    * @return std::string the config version.
    */
-  virtual std::string getConfigVersion() const { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  virtual std::string getConfigVersion() const { return ""; }
 
   /**
    * Returns the config implementation associated with the provider.

--- a/envoy/config/config_provider_manager.h
+++ b/envoy/config/config_provider_manager.h
@@ -71,7 +71,7 @@ public:
     UNREFERENCED_PARAMETER(config_proto);
     UNREFERENCED_PARAMETER(factory_context);
     UNREFERENCED_PARAMETER(optarg);
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return nullptr;
   }
 
   /**
@@ -89,7 +89,7 @@ public:
     UNREFERENCED_PARAMETER(config_protos);
     UNREFERENCED_PARAMETER(factory_context);
     UNREFERENCED_PARAMETER(optarg);
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return nullptr;
   }
 };
 

--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -63,7 +63,7 @@ SysCallIntResult OsSysCallsImpl::recvmmsg(os_fd_t sockfd, struct mmsghdr* msgvec
   UNREFERENCED_PARAMETER(vlen);
   UNREFERENCED_PARAMETER(flags);
   UNREFERENCED_PARAMETER(timeout);
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  return {false, EOPNOTSUPP};
 #endif
 }
 
@@ -325,7 +325,7 @@ SysCallIntResult OsSysCallsImpl::getifaddrs([[maybe_unused]] InterfaceAddressVec
 // TODO: eliminate this branching by upstreaming an alternative Android implementation
 // e.g.: https://github.com/envoyproxy/envoy-mobile/blob/main/third_party/android/ifaddrs-android.h
 #if defined(__ANDROID_API__) && __ANDROID_API__ < 24
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 #else
   struct ifaddrs* ifaddr;
   struct ifaddrs* ifa;

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -173,7 +173,7 @@ SysCallSizeResult OsSysCallsImpl::recvmsg(os_fd_t sockfd, msghdr* msg, int flags
 
 SysCallIntResult OsSysCallsImpl::recvmmsg(os_fd_t sockfd, struct mmsghdr* msgvec, unsigned int vlen,
                                           int flags, struct timespec* timeout) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 }
 
 bool OsSysCallsImpl::supportsMmsg() const {
@@ -420,7 +420,7 @@ SysCallIntResult OsSysCallsImpl::getifaddrs([[maybe_unused]] InterfaceAddressVec
   if (alternate_getifaddrs_.has_value()) {
     return alternate_getifaddrs_.value()(interfaces);
   }
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 }
 
 } // namespace Api

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -247,11 +247,6 @@ void resetEnvoyBugCountersForTest();
  */
 #define ENVOY_BUG(...) PASS_ON(PASS_ON(_ENVOY_BUG_VERBOSE)(__VA_ARGS__))
 
-// NOT_IMPLEMENTED_GCOVR_EXCL_LINE is for overridden functions that are expressly not implemented.
-// The macro name includes "GCOVR_EXCL_LINE" to exclude the macro's usage from code coverage
-// reports.
-#define NOT_IMPLEMENTED_GCOVR_EXCL_LINE PANIC("not implemented")
-
 // NOT_REACHED_GCOVR_EXCL_LINE is for spots the compiler insists on having a return, but where we
 // know that it shouldn't be possible to arrive there, assuming no horrendous bugs. For example,
 // after a switch (some_enum) with all enum values included in the cases. The macro name includes

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -30,7 +30,7 @@ public:
   void start(const absl::flat_hash_set<std::string>&) override;
   void updateResourceInterest(const absl::flat_hash_set<std::string>&) override;
   void requestOnDemandUpdate(const absl::flat_hash_set<std::string>&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    ENVOY_BUG(false, "unexpected request for on demand update");
   }
 
 protected:

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -61,7 +61,6 @@ public:
                            const SubscriptionOptions& options) override;
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   void handleDiscoveryResponse(
@@ -214,7 +213,7 @@ public:
   }
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    ENVOY_BUG(false, "unexpected request for on demand update");
   }
 
   void onWriteable() override {}

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -36,7 +36,7 @@ public:
   void
   updateResourceInterest(const absl::flat_hash_set<std::string>& update_to_these_names) override;
   void requestOnDemandUpdate(const absl::flat_hash_set<std::string>&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    ENVOY_BUG(false, "unexpected request for on demand update");
   }
 
   // Http::RestApiFetcher

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -192,7 +192,7 @@ SubscriptionPtr SubscriptionFactoryImpl::collectionSubscriptionFromUrl(
   }
   default:
     // TODO(htuch): Implement HTTP semantics for collection ResourceLocators.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    throw EnvoyException("Unsupported code path");
   }
   NOT_REACHED_GCOVR_EXCL_LINE;
 }

--- a/source/common/config/xds_mux/grpc_mux_impl.h
+++ b/source/common/config/xds_mux/grpc_mux_impl.h
@@ -231,7 +231,7 @@ public:
 
   // GrpcStreamCallbacks
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    ENVOY_BUG(false, "unexpected request for on demand update");
   }
 };
 
@@ -251,7 +251,7 @@ public:
                                    const SubscriptionOptions&) override;
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    ENVOY_BUG(false, "unexpected request for on demand update");
   }
 };
 

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -134,7 +134,7 @@ private:
 
     Router::RouteConstSharedPtr route(const Router::RouteCallback&, const Http::RequestHeaderMap&,
                                       const StreamInfo::StreamInfo&, uint64_t) const override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      return nullptr;
     }
 
     const std::list<LowerCaseString>& internalOnlyHeaders() const override {
@@ -327,10 +327,8 @@ private:
   Event::Dispatcher& dispatcher() override { return parent_.dispatcher_; }
   void resetStream() override;
   Router::RouteConstSharedPtr route() override { return route_; }
-  Router::RouteConstSharedPtr route(const Router::RouteCallback&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  void setRoute(Router::RouteConstSharedPtr) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  Router::RouteConstSharedPtr route(const Router::RouteCallback&) override { return nullptr; }
+  void setRoute(Router::RouteConstSharedPtr) override {}
   Upstream::ClusterInfoConstSharedPtr clusterInfo() override { return parent_.cluster_; }
   void clearRouteCache() override {}
   uint64_t streamId() const override { return stream_id_; }
@@ -338,22 +336,18 @@ private:
   Buffer::BufferMemoryAccountSharedPtr account() const override { return nullptr; }
   Tracing::Span& activeSpan() override { return active_span_; }
   const Tracing::Config& tracingConfig() override { return tracing_config_; }
-  void continueDecoding() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  RequestTrailerMap& addDecodedTrailers() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void continueDecoding() override {}
+  RequestTrailerMap& addDecodedTrailers() override { PANIC("not implemented"); }
   void addDecodedData(Buffer::Instance&, bool) override {
     // This should only be called if the user has set up buffering. The request is already fully
     // buffered. Note that this is only called via the async client's internal use of the router
     // filter which uses this function for buffering.
     ASSERT(buffered_body_ != nullptr);
   }
-  MetadataMapVector& addDecodedMetadata() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  void injectDecodedDataToFilterChain(Buffer::Instance&, bool) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  MetadataMapVector& addDecodedMetadata() override { PANIC("not implemented"); }
+  void injectDecodedDataToFilterChain(Buffer::Instance&, bool) override {}
   const Buffer::Instance* decodingBuffer() override { return buffered_body_.get(); }
-  void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {}
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
@@ -379,13 +373,13 @@ private:
   }
   // The async client won't pause if sending 1xx headers so simply swallow any.
   void encode1xxHeaders(ResponseHeaderMapPtr&&) override {}
-  ResponseHeaderMapOptRef informationalHeaders() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ResponseHeaderMapOptRef informationalHeaders() const override { return {}; }
   void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
                      absl::string_view details) override;
-  ResponseHeaderMapOptRef responseHeaders() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ResponseHeaderMapOptRef responseHeaders() const override { return {}; }
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(ResponseTrailerMapPtr&& trailers) override;
-  ResponseTrailerMapOptRef responseTrailers() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ResponseTrailerMapOptRef responseTrailers() const override { return {}; }
   void encodeMetadata(MetadataMapPtr&&) override {}
   void onDecoderFilterAboveWriteBufferHighWatermark() override { ++high_watermark_calls_; }
   void onDecoderFilterBelowWriteBufferLowWatermark() override {
@@ -403,10 +397,8 @@ private:
   }
   void addUpstreamSocketOptions(const Network::Socket::OptionsSharedPtr&) override {}
   Network::Socket::OptionsSharedPtr getUpstreamSocketOptions() const override { return {}; }
-  void requestRouteConfigUpdate(Http::RouteConfigUpdatedCallbackSharedPtr) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  void resetIdleTimer() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void requestRouteConfigUpdate(Http::RouteConfigUpdatedCallbackSharedPtr) override {}
+  void resetIdleTimer() override {}
 
   // ScopeTrackedObject
   void dumpState(std::ostream& os, int indent_level) const override {
@@ -461,9 +453,7 @@ private:
     // internal use of the router filter which uses this function for buffering.
   }
   const Buffer::Instance* decodingBuffer() override { return &request_->body(); }
-  void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {}
 
   RequestMessagePtr request_;
   AsyncClient::Callbacks& callbacks_;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -748,7 +748,7 @@ void FilterManager::addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::In
   } else {
     // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
     // throw an exception here.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("fatal error adding decoded data");
   }
 }
 
@@ -1229,7 +1229,7 @@ void FilterManager::addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::In
   } else {
     // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
     // throw an exception here.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("fatal error adding decoded data");
   }
 }
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -499,7 +499,7 @@ private:
 
   // ParserCallbacks.
   Status onUrl(const char* data, size_t length) override;
-  Status onStatus(const char*, size_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  Status onStatus(const char*, size_t) override { return okStatus(); }
   // ConnectionImpl
   void onEncodeComplete() override;
   StreamInfo::BytesMeter& getBytesMeter() override {
@@ -593,7 +593,7 @@ private:
   bool cannotHaveBody();
 
   // ParserCallbacks.
-  Status onUrl(const char*, size_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  Status onUrl(const char*, size_t) override { return okStatus(); }
   Status onStatus(const char* data, size_t length) override;
   // ConnectionImpl
   Http::Status dispatch(Buffer::Instance& data) override;

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -146,7 +146,7 @@ LegacyHttpParserImpl::LegacyHttpParserImpl(MessageType type, ParserCallbacks* da
     parser_type = HTTP_RESPONSE;
     break;
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 
   impl_ = std::make_unique<Impl>(parser_type, data);

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1063,7 +1063,7 @@ Status ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
 
     default:
       // We do not currently support push.
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      ENVOY_BUG(false, "push not supported");
     }
 
     break;

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -190,11 +190,11 @@ private:
       };
     }
     case MatcherType::MatcherTree::kPrefixMatchMap:
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      PANIC("unsupported");
     case MatcherType::MatcherTree::kCustomMatch:
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      PANIC("unsupported");
     default:
-      NOT_REACHED_GCOVR_EXCL_LINE;
+      PANIC("unsupported");
     }
   }
 

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -167,7 +167,8 @@ public:
 
   Api::SysCallIntResult bind(Network::Address::InstanceConstSharedPtr) override {
     // internal listener socket does not support bind semantic.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    // TODO(lambdai) return an error.
+    PANIC("not implemented");
   }
 
   void close() override { ASSERT(io_handle_ == nullptr); }

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -88,7 +88,7 @@ public:
   SocketPtr duplicate() override {
     // Implementing the functionality here for all sockets is tricky because it leads
     // into object slicing issues.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return nullptr;
   }
 
   IoHandle& ioHandle() override { return *io_handle_; }

--- a/source/common/network/socket_interface_impl.cc
+++ b/source/common/network/socket_interface_impl.cc
@@ -60,8 +60,9 @@ IoHandlePtr SocketInterfaceImpl::socket(Socket::Type socket_type, Address::Type 
     domain = AF_UNIX;
   } else {
     ASSERT(addr_type == Address::Type::EnvoyInternal);
+    PANIC("not implemented");
     // TODO(lambdai): Add InternalIoSocketHandleImpl to support internal address.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return nullptr;
   }
 
   const Api::SysCallSocketResult result =

--- a/source/common/quic/spdy_server_push_utils_for_envoy.cc
+++ b/source/common/quic/spdy_server_push_utils_for_envoy.cc
@@ -14,28 +14,26 @@ namespace quic {
 // static
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string SpdyServerPushUtils::GetPromisedUrlFromHeaders(const SpdyHeaderBlock& /*headers*/) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  return "";
 }
 
 // static
 std::string
 // NOLINTNEXTLINE(readability-identifier-naming)
 SpdyServerPushUtils::GetPromisedHostNameFromHeaders(const SpdyHeaderBlock& /*headers*/) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  return "";
 }
 
 // static
 // NOLINTNEXTLINE(readability-identifier-naming)
-bool SpdyServerPushUtils::PromisedUrlIsValid(const SpdyHeaderBlock& /*headers*/) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-}
+bool SpdyServerPushUtils::PromisedUrlIsValid(const SpdyHeaderBlock& /*headers*/) { return false; }
 
 // static
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string SpdyServerPushUtils::GetPushPromiseUrl(absl::string_view /*scheme*/,
                                                    absl::string_view /*authority*/,
                                                    absl::string_view /*path*/) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  return "";
 }
 
 } // namespace quic

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -82,9 +82,7 @@ public:
   SystemTime lastUpdated() const override { return last_updated_; }
   void onConfigUpdate() override {}
   void requestVirtualHostsUpdate(const std::string&, Event::Dispatcher&,
-                                 std::weak_ptr<Http::RouteConfigUpdatedCallback>) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+                                 std::weak_ptr<Http::RouteConfigUpdatedCallback>) override {}
 
 private:
   ConfigConstSharedPtr config_;

--- a/source/common/router/vhds.h
+++ b/source/common/router/vhds.h
@@ -59,9 +59,7 @@ public:
 private:
   // Config::SubscriptionCallbacks
   void onConfigUpdate(const std::vector<Envoy::Config::DecodedResourceRef>&,
-                      const std::string&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+                      const std::string&) override {}
   void onConfigUpdate(const std::vector<Envoy::Config::DecodedResourceRef>&,
                       const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override;
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,

--- a/source/common/signal/signal_action.cc
+++ b/source/common/signal/signal_action.cc
@@ -40,7 +40,7 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
     // running. We should add support for this scenario, even though the
     // probability of it occurring is low.
     // TODO(kbaichoo): Implement a configurable call to sleep
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
     break;
   }
   case FatalAction::Status::AlreadyRanOnThisThread:

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -516,7 +516,7 @@ void HdsCluster::updateHosts(
                             hosts_added, hosts_removed, absl::nullopt);
 }
 
-ClusterSharedPtr HdsCluster::create() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+ClusterSharedPtr HdsCluster::create() { return nullptr; }
 
 ClusterInfoConstSharedPtr
 ProdClusterInfoFactory::createClusterInfo(const CreateClusterInfoParams& params) {
@@ -569,9 +569,7 @@ void HdsCluster::initialize(std::function<void()> callback) {
   }
 }
 
-void HdsCluster::setOutlierDetector(const Outlier::DetectorSharedPtr&) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-}
+void HdsCluster::setOutlierDetector(const Outlier::DetectorSharedPtr&) {}
 
 } // namespace Upstream
 } // namespace Envoy

--- a/source/common/upstream/leds.h
+++ b/source/common/upstream/leds.h
@@ -55,8 +55,6 @@ public:
 private:
   // Config::SubscriptionCallbacks
   void onConfigUpdate(const std::vector<Config::DecodedResourceRef>&, const std::string&) override {
-    // LEDS is not used in SotW mode.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
   void onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                       const Protobuf::RepeatedPtrField<std::string>& removed_resources,

--- a/source/common/upstream/logical_host.h
+++ b/source/common/upstream/logical_host.h
@@ -86,9 +86,9 @@ public:
 
   // Upstream:HostDescription
   bool canary() const override { return logical_host_->canary(); }
-  void canary(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void canary(bool) override {}
   MetadataConstSharedPtr metadata() const override { return logical_host_->metadata(); }
-  void metadata(MetadataConstSharedPtr) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void metadata(MetadataConstSharedPtr) override {}
 
   Network::TransportSocketFactory& transportSocketFactory() const override {
     return logical_host_->transportSocketFactory();
@@ -114,13 +114,12 @@ public:
     return logical_host_->localityZoneStatName();
   }
   Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
-    // Should never be called since real hosts are used only for forwarding and not health
-    // checking.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    // Should never be called since real hosts are used only for forwarding.
+    return nullptr;
   }
   MonotonicTime creationTime() const override { return logical_host_->creationTime(); }
   uint32_t priority() const override { return logical_host_->priority(); }
-  void priority(uint32_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void priority(uint32_t) override {}
 
 private:
   const Network::Address::InstanceConstSharedPtr address_;

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -88,7 +88,7 @@ public:
   void initialize() override;
 
   // Upstream::LoadBalancer
-  HostConstSharedPtr chooseHost(LoadBalancerContext*) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  HostConstSharedPtr chooseHost(LoadBalancerContext*) override { return nullptr; }
   // Preconnect not implemented for hash based load balancing
   HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
   // Pool selection not implemented.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -698,12 +698,12 @@ public:
   TimeSource& timeSource() override { return api().timeSource(); }
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     // TODO(davinci26): Needs an implementation for this context. Currently not used.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("unimplemented");
   }
 
   AccessLog::AccessLogManager& accessLogManager() override {
     // TODO(davinci26): Needs an implementation for this context. Currently not used.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("unimplemented");
   }
 
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
@@ -712,12 +712,12 @@ public:
 
   Server::ServerLifecycleNotifier& lifecycleNotifier() override {
     // TODO(davinci26): Needs an implementation for this context. Currently not used.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("unimplemented");
   }
 
   Init::Manager& initManager() override {
     // TODO(davinci26): Needs an implementation for this context. Currently not used.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("unimplemented");
   }
 
   Api::Api& api() override { return api_; }

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -308,7 +308,7 @@ WasmEvent toWasmEvent(const std::shared_ptr<WasmHandleBase>& wasm) {
   case FailState::RuntimeError:
     return WasmEvent::RuntimeError;
   }
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("corrupt enum");
 }
 
 bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scope,

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -101,9 +101,7 @@ public:
   }
   int size() const override { return value_ == nullptr ? 0 : value_->size(); }
   bool empty() const override { return value_ == nullptr ? true : value_->empty(); }
-  const google::api::expr::runtime::CelList* ListKeys() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  const google::api::expr::runtime::CelList* ListKeys() const override { return nullptr; }
 
 private:
   friend class RequestWrapper;
@@ -120,9 +118,7 @@ class BaseWrapper : public google::api::expr::runtime::CelMap,
 public:
   int size() const override { return 0; }
   bool empty() const override { return false; }
-  const google::api::expr::runtime::CelList* ListKeys() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  const google::api::expr::runtime::CelList* ListKeys() const override { return nullptr; }
   CelValue Produce(ProtobufWkt::Arena* arena) override {
     // Producer is unique per evaluation arena since activation is re-created.
     arena_ = arena;

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -237,7 +237,7 @@ void CacheFilter::onHeaders(LookupResult&& result, Http::RequestHeaderMap& reque
   // TODO(yosrym93): Handle request only-if-cached directive
   switch (result.cache_entry_status_) {
   case CacheEntryStatus::FoundNotModified:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE; // We don't yet return or support these codes.
+    PANIC("unsupported code");
   case CacheEntryStatus::RequiresValidation:
     // If a cache entry requires validation, inject validation headers in the request and let it
     // pass through as if no cache entry was found.

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -31,8 +31,8 @@ public:
   }
 
   void getTrailers(LookupTrailersCallback&&) override {
+    ENVOY_BUG(false, "trailers not supported");
     // TODO(toddmgreer): Support trailers.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   const LookupRequest& request() const { return request_; }
@@ -78,7 +78,7 @@ public:
   }
 
   void insertTrailers(const Http::ResponseTrailerMap&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE; // TODO(toddmgreer): support trailers
+    ENVOY_BUG(false, "trailers not supported");
   }
 
   void onDestroy() override {}

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -805,10 +805,10 @@ void Filter::scriptLog(spdlog::level::level_enum level, absl::string_view messag
     ENVOY_LOG(critical, "script log: {}", message);
     return;
   case spdlog::level::off:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("unsupported");
     return;
   case spdlog::level::n_levels:
-    NOT_REACHED_GCOVR_EXCL_LINE;
+    PANIC("unsupported");
   }
 }
 

--- a/source/extensions/filters/network/dubbo_proxy/active_message.h
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.h
@@ -41,7 +41,7 @@ public:
 
   // ResponseDecoderCallbacks
   StreamHandler& newStream() override { return *this; }
-  void onHeartbeat(MessageMetadataSharedPtr) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void onHeartbeat(MessageMetadataSharedPtr) override {}
 
   uint64_t requestId() const { return metadata_ ? metadata_->requestId() : 0; }
 

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -208,9 +208,9 @@ bool DubboProtocolImpl::encode(Buffer::Instance& buffer, const MessageMetadata& 
   case MessageType::Request:
   case MessageType::Oneway:
   case MessageType::Exception:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   default:
-    NOT_REACHED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 }
 

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -51,7 +51,7 @@ public:
    * (e.g. transport-level) information).
    * @param type ProtocolType to explicitly set
    */
-  virtual void setType(ProtocolType) { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  virtual void setType(ProtocolType) {}
 
   /**
    * Reads the start of a Thrift protocol message from the buffer and updates the metadata
@@ -429,7 +429,7 @@ public:
    *
    * @return a DecoderEventHandlerSharedPtr that decodes a downstream client's upgrade request
    */
-  virtual DecoderEventHandlerSharedPtr upgradeRequestDecoder() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  virtual DecoderEventHandlerSharedPtr upgradeRequestDecoder() { return nullptr; }
 
   /**
    * Writes a response to a downstream client's upgrade request.
@@ -438,7 +438,7 @@ public:
    */
   virtual DirectResponsePtr upgradeResponse(const DecoderEventHandler& decoder) {
     UNREFERENCED_PARAMETER(decoder);
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return nullptr;
   }
 
   /**
@@ -457,7 +457,7 @@ public:
     UNREFERENCED_PARAMETER(transport);
     UNREFERENCED_PARAMETER(state);
     UNREFERENCED_PARAMETER(buffer);
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return nullptr;
   }
 
   /**
@@ -468,7 +468,6 @@ public:
   virtual void completeUpgrade(ThriftConnectionState& state, ThriftObject& response) {
     UNREFERENCED_PARAMETER(state);
     UNREFERENCED_PARAMETER(response);
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 };
 

--- a/source/extensions/io_socket/user_space/file_event_impl.h
+++ b/source/extensions/io_socket/user_space/file_event_impl.h
@@ -27,8 +27,8 @@ public:
 
   // This event always acts as edge triggered regardless the underlying OS is level or
   // edge triggered. The event owner on windows platform should not emulate edge events.
-  void unregisterEventIfEmulatedEdge(uint32_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  void registerEventIfEmulatedEdge(uint32_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void unregisterEventIfEmulatedEdge(uint32_t) override {}
+  void registerEventIfEmulatedEdge(uint32_t) override {}
 
   // Notify events. Unlike activate() method, this method activates the given events only if the
   // events are enabled.

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -275,7 +275,7 @@ Api::SysCallIntResult IoHandleImpl::bind(Network::Address::InstanceConstSharedPt
 Api::SysCallIntResult IoHandleImpl::listen(int) { return makeInvalidSyscallResult(); }
 
 Network::IoHandlePtr IoHandleImpl::accept(struct sockaddr*, socklen_t*) {
-  ENVOY_BUG(false, "unsupportred call to accept");
+  ENVOY_BUG(false, "unsupported call to accept");
   return nullptr;
 }
 
@@ -342,7 +342,7 @@ void IoHandleImpl::initializeFileEvent(Event::Dispatcher& dispatcher, Event::Fil
 Network::IoHandlePtr IoHandleImpl::duplicate() {
   // duplicate() is supposed to be used on listener io handle while this implementation doesn't
   // support listen.
-  ENVOY_BUG(false, "unsupportred call to duplicate");
+  ENVOY_BUG(false, "unsupported call to duplicate");
   return nullptr;
 }
 

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -275,7 +275,8 @@ Api::SysCallIntResult IoHandleImpl::bind(Network::Address::InstanceConstSharedPt
 Api::SysCallIntResult IoHandleImpl::listen(int) { return makeInvalidSyscallResult(); }
 
 Network::IoHandlePtr IoHandleImpl::accept(struct sockaddr*, socklen_t*) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  ENVOY_BUG(false, "unsupportred call to accept");
+  return nullptr;
 }
 
 Api::SysCallIntResult IoHandleImpl::connect(Network::Address::InstanceConstSharedPtr address) {
@@ -341,7 +342,8 @@ void IoHandleImpl::initializeFileEvent(Event::Dispatcher& dispatcher, Event::Fil
 Network::IoHandlePtr IoHandleImpl::duplicate() {
   // duplicate() is supposed to be used on listener io handle while this implementation doesn't
   // support listen.
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  ENVOY_BUG(false, "unsupportred call to duplicate");
+  return nullptr;
 }
 
 void IoHandleImpl::activateFileEvents(uint32_t events) {

--- a/source/server/active_internal_listener.h
+++ b/source/server/active_internal_listener.h
@@ -60,7 +60,7 @@ public:
   getBalancedHandlerByAddress(const Network::Address::Instance&) override {
     // Internal listener doesn't support migrate connection to another worker.
     // TODO(lambdai): implement the function of handling off to another listener of the same worker.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 
   void pauseListening() override {

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -232,9 +232,7 @@ private:
     SystemTime lastUpdated() const override { return time_source_.systemTime(); }
     void onConfigUpdate() override {}
     void requestVirtualHostsUpdate(const std::string&, Event::Dispatcher&,
-                                   std::weak_ptr<Http::RouteConfigUpdatedCallback>) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    }
+                                   std::weak_ptr<Http::RouteConfigUpdatedCallback>) override {}
 
     Router::ConfigConstSharedPtr config_;
     TimeSource& time_source_;
@@ -294,7 +292,6 @@ private:
 
     bool registerForAction(const std::string&, Event::Dispatcher&, OverloadActionCb) override {
       // This method shouldn't be called by the admin listener
-      NOT_REACHED_GCOVR_EXCL_LINE;
       return false;
     }
 

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -44,10 +44,7 @@ public:
   // Network::DrainDecision
   // TODO(junr03): hook up draining to listener state management.
   bool drainClose() const override { return false; }
-  Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb) const override {
-    NOT_REACHED_GCOVR_EXCL_LINE;
-    return nullptr;
-  }
+  Common::CallbackHandlePtr addOnDrainCloseCb(DrainCloseCb) const override { return nullptr; }
 
 protected:
   ApiListenerImplBase(const envoy::config::listener::v3::Listener& config,
@@ -63,16 +60,12 @@ protected:
         : parent_(parent), connection_(SyntheticConnection(*this)) {}
 
     // Network::ReadFilterCallbacks
-    void continueReading() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-    void injectReadDataToFilterChain(Buffer::Instance&, bool) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    }
+    void continueReading() override {}
+    void injectReadDataToFilterChain(Buffer::Instance&, bool) override {}
     Upstream::HostDescriptionConstSharedPtr upstreamHost() override { return nullptr; }
-    void upstreamHost(Upstream::HostDescriptionConstSharedPtr) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    }
+    void upstreamHost(Upstream::HostDescriptionConstSharedPtr) override {}
     Network::Connection& connection() override { return connection_; }
-    const Network::Socket& socket() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+    const Network::Socket& socket() override { PANIC("not implemented"); }
 
     // Synthetic class that acts as a stub for the connection backing the
     // Network::ReadFilterCallbacks.
@@ -88,14 +81,10 @@ protected:
       void raiseConnectionEvent(Network::ConnectionEvent event);
 
       // Network::FilterManager
-      void addWriteFilter(Network::WriteFilterSharedPtr) override {
-        NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-      }
-      void addFilter(Network::FilterSharedPtr) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-      void addReadFilter(Network::ReadFilterSharedPtr) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-      void removeReadFilter(Network::ReadFilterSharedPtr) override {
-        NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-      }
+      void addWriteFilter(Network::WriteFilterSharedPtr) override {}
+      void addFilter(Network::FilterSharedPtr) override {}
+      void addReadFilter(Network::ReadFilterSharedPtr) override {}
+      void removeReadFilter(Network::ReadFilterSharedPtr) override {}
       bool initializeReadFilters() override { return true; }
 
       // Network::Connection
@@ -105,11 +94,9 @@ protected:
       void removeConnectionCallbacks(Network::ConnectionCallbacks& cb) override {
         callbacks_.remove(&cb);
       }
-      void addBytesSentCallback(Network::Connection::BytesSentCb) override {
-        NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-      }
-      void enableHalfClose(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-      bool isHalfCloseEnabled() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+      void addBytesSentCallback(Network::Connection::BytesSentCb) override {}
+      void enableHalfClose(bool) override {}
+      bool isHalfCloseEnabled() override { return false; }
       void close(Network::ConnectionCloseType) override {}
       Event::Dispatcher& dispatcher() override {
         return parent_.parent_.factory_context_.mainThreadDispatcher();
@@ -117,9 +104,9 @@ protected:
       uint64_t id() const override { return 12345; }
       void hashKey(std::vector<uint8_t>&) const override {}
       std::string nextProtocol() const override { return EMPTY_STRING; }
-      void noDelay(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+      void noDelay(bool) override {}
       void readDisable(bool) override {}
-      void detectEarlyCloseWhenReadDisabled(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+      void detectEarlyCloseWhenReadDisabled(bool) override {}
       bool readEnabled() const override { return true; }
       const Network::ConnectionInfoSetter& connectionInfoProvider() const override {
         return *connection_info_provider_;
@@ -136,8 +123,8 @@ protected:
       absl::string_view requestedServerName() const override { return EMPTY_STRING; }
       State state() const override { return Network::Connection::State::Open; }
       bool connecting() const override { return false; }
-      void write(Buffer::Instance&, bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-      void setBufferLimits(uint32_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+      void write(Buffer::Instance&, bool) override {}
+      void setBufferLimits(uint32_t) override {}
       uint32_t bufferLimit() const override { return 65000; }
       bool aboveHighWatermark() const override { return false; }
       const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() const override {
@@ -147,7 +134,7 @@ protected:
       const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
       void setDelayedCloseTimeout(std::chrono::milliseconds) override {}
       absl::string_view transportFailureReason() const override { return EMPTY_STRING; }
-      bool startSecureTransport() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+      bool startSecureTransport() override { return false; }
       absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override { return {}; };
       // ScopeTrackedObject
       void dumpState(std::ostream& os, int) const override { os << "SyntheticConnection"; }

--- a/source/server/config_validation/admin.cc
+++ b/source/server/config_validation/admin.cc
@@ -18,18 +18,14 @@ void ValidationAdmin::startHttpListener(const std::list<AccessLog::InstanceShare
                                         const std::string&,
                                         Network::Address::InstanceConstSharedPtr,
                                         const Network::Socket::OptionsSharedPtr&,
-                                        Stats::ScopePtr&&) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-}
+                                        Stats::ScopePtr&&) {}
 
 Http::Code ValidationAdmin::request(absl::string_view, absl::string_view, Http::ResponseHeaderMap&,
                                     std::string&) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 }
 
-void ValidationAdmin::addListenerToHandler(Network::ConnectionHandler*) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-}
+void ValidationAdmin::addListenerToHandler(Network::ConnectionHandler*) {}
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -18,7 +18,7 @@ Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
 Network::ListenerPtr ValidationDispatcher::createListener(Network::SocketSharedPtr&&,
                                                           Network::TcpListenerCallbacks&, bool,
                                                           bool) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  return nullptr;
 }
 
 } // namespace Event

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -82,11 +82,11 @@ public:
         Network::createDefaultDnsResolverFactory(typed_dns_resolver_config);
     return dns_resolver_factory.createDnsResolver(dispatcher(), api(), typed_dns_resolver_config);
   }
-  void drainListeners() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  DrainManager& drainManager() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void drainListeners() override {}
+  DrainManager& drainManager() override { PANIC("not implemented"); }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
-  void failHealthcheck(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  HotRestart& hotRestart() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void failHealthcheck(bool) override {}
+  HotRestart& hotRestart() override { PANIC("not implemented"); }
   Init::Manager& initManager() override { return init_manager_; }
   ServerLifecycleNotifier& lifecycleNotifier() override { return *this; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
@@ -94,13 +94,13 @@ public:
   Runtime::Loader& runtime() override { return Runtime::LoaderSingleton::get(); }
   void shutdown() override;
   bool isShutdown() override { return false; }
-  void shutdownAdmin() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void shutdownAdmin() override {}
   Singleton::Manager& singletonManager() override { return *singleton_manager_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
-  bool healthCheckFailed() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  bool healthCheckFailed() override { return false; }
   const Options& options() override { return options_; }
-  time_t startTimeCurrentEpoch() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  time_t startTimeFirstEpoch() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  time_t startTimeCurrentEpoch() override { PANIC("not implemented"); }
+  time_t startTimeFirstEpoch() override { PANIC("not implemented"); }
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
@@ -110,7 +110,7 @@ public:
   LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return api_->timeSource(); }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
-  void flushStats() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void flushStats() override {}
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
   }

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -798,7 +798,7 @@ const envoy::config::core::v3::Metadata& FactoryContextImpl::listenerMetadata() 
 }
 const Envoy::Config::TypedMetadata& FactoryContextImpl::listenerTypedMetadata() const {
   // TODO(nareddyt): Needs an implementation for this context. Currently not used.
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 }
 envoy::config::core::v3::TrafficDirection FactoryContextImpl::direction() const {
   return config_.traffic_direction();

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -290,7 +290,7 @@ Network::DrainDecision& ListenerFactoryContextBaseImpl::drainDecision() { return
 Server::DrainManager& ListenerFactoryContextBaseImpl::drainManager() { return *drain_manager_; }
 
 // Must be overridden
-Init::Manager& ListenerFactoryContextBaseImpl::initManager() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+Init::Manager& ListenerFactoryContextBaseImpl::initManager() { PANIC("not implemented"); }
 
 ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
                            const std::string& version_info, ListenerManagerImpl& parent,
@@ -709,9 +709,7 @@ Event::Dispatcher& PerListenerFactoryContextImpl::mainThreadDispatcher() {
 const Server::Options& PerListenerFactoryContextImpl::options() {
   return listener_factory_context_base_->options();
 }
-Network::DrainDecision& PerListenerFactoryContextImpl::drainDecision() {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-}
+Network::DrainDecision& PerListenerFactoryContextImpl::drainDecision() { PANIC("not implemented"); }
 Grpc::Context& PerListenerFactoryContextImpl::grpcContext() {
   return listener_factory_context_base_->grpcContext();
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -339,7 +339,7 @@ void registerCustomInlineHeadersFromBootstrap(
           Http::ResponseTrailerMap::header_map_type>(lower_case_name);
       break;
     default:
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      PANIC("not implemented");
     }
   }
 }
@@ -1010,7 +1010,7 @@ bool InstanceImpl::enableReusePortDefault() {
         "envoy.reloadable_features.listener_reuse_port_default_enabled");
   }
 
-  NOT_REACHED_GCOVR_EXCL_LINE;
+  return false;
 }
 
 } // namespace Server

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -135,7 +135,7 @@ public:
     return mutableStart();
   }
 
-  Buffer::SliceDataPtr extractMutableFrontSlice() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  Buffer::SliceDataPtr extractMutableFrontSlice() override { PANIC("not implemented"); }
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }
 

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -93,7 +93,7 @@ public:
   // Envoy::Config::SubscriptionCallbacks
   void onConfigUpdate(const std::vector<DecodedResourceRef>&,
                       const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason,
@@ -564,7 +564,7 @@ public:
   }
   void onConfigUpdate(const std::vector<DecodedResourceRef>&,
                       const Protobuf::RepeatedPtrField<std::string>&, const std::string&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason,
                             const EnvoyException*) override {

--- a/test/common/config/grpc_stream_test.cc
+++ b/test/common/config/grpc_stream_test.cc
@@ -226,7 +226,7 @@ TEST_F(GrpcStreamTest, QueueSizeStat) {
 }
 
 // Just to add coverage to the no-op implementations of these callbacks (without exposing us to
-// crashes from a badly behaved peer like NOT_IMPLEMENTED_GCOVR_EXCL_LINE would).
+// crashes from a badly behaved peer like PANIC("not implemented") would).
 TEST_F(GrpcStreamTest, HeaderTrailerJustForCodeCoverage) {
   Http::ResponseHeaderMapPtr response_headers{new Http::TestResponseHeaderMapImpl{}};
   grpc_stream_.onReceiveInitialMetadata(std::move(response_headers));

--- a/test/common/config/xds_grpc_mux_impl_test.cc
+++ b/test/common/config/xds_grpc_mux_impl_test.cc
@@ -967,7 +967,8 @@ TEST_F(NullGrpcMuxImplTest, PauseMultipleArgsImplemented) {
 }
 
 TEST_F(NullGrpcMuxImplTest, RequestOnDemandNotImplemented) {
-  EXPECT_DEATH(null_mux_->requestOnDemandUpdate("type_url", {"for_update"}), "not implemented");
+  EXPECT_ENVOY_BUG(null_mux_->requestOnDemandUpdate("type_url", {"for_update"}),
+                   "unexpected request for on demand update");
 }
 
 TEST_F(NullGrpcMuxImplTest, AddWatchRaisesException) {

--- a/test/common/quic/platform/quic_test_impl.h
+++ b/test/common/quic/platform/quic_test_impl.h
@@ -23,6 +23,6 @@ using QuicTestImpl = ::testing::Test;
 
 template <class T> using QuicTestWithParamImpl = ::testing::TestWithParam<T>;
 
-inline std::string QuicGetTestMemoryCachePathImpl() {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE; // TODO(mpwarres): implement
+inline std::string QuicGetTestMemoryCachePathImpl() { // NOLINT(readability-identifier-naming)
+  PANIC("not implemented");                           // TODO(mpwarres): implement
 }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -7906,7 +7906,7 @@ public:
 
     Http::FilterFactoryCb createFilter(const std::string&,
                                        Server::Configuration::FactoryContext&) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      PANIC("not implemented");
     }
     ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
       return ProtobufTypes::MessagePtr{new ProtobufWkt::Timestamp()};
@@ -7930,7 +7930,7 @@ public:
 
     Http::FilterFactoryCb createFilter(const std::string&,
                                        Server::Configuration::FactoryContext&) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      PANIC("not implemented");
     }
     ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
       return ProtobufTypes::MessagePtr{new ProtobufWkt::Struct()};

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -89,11 +89,9 @@ public:
   using LoadBalancerBase::percentageDegradedLoad;
   using LoadBalancerBase::percentageLoad;
 
-  HostConstSharedPtr chooseHost(LoadBalancerContext*) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  HostConstSharedPtr chooseHost(LoadBalancerContext*) override { PANIC("not implemented"); }
 
-  HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { PANIC("not implemented"); }
 };
 
 class LoadBalancerBaseTest : public LoadBalancerTestBase {
@@ -578,9 +576,7 @@ public:
   HostConstSharedPtr chooseHostOnce(LoadBalancerContext*) override {
     return choose_host_once_host_;
   }
-  HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { PANIC("not implemented"); }
 
   HostConstSharedPtr choose_host_once_host_{std::make_shared<NiceMock<MockHost>>()};
 };

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -3235,9 +3235,9 @@ public:
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&,
                                Server::Configuration::FactoryContext&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override { PANIC("not implemented"); }
   ProtobufTypes::MessagePtr createEmptyProtocolOptionsProto() override {
     return parent_.createEmptyProtocolOptionsProto();
   }
@@ -3260,17 +3260,15 @@ public:
   Http::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::FactoryContext&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override { PANIC("not implemented"); }
+  ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override { PANIC("not implemented"); }
   Router::RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfig(const Protobuf::Message&,
                                   Server::Configuration::ServerFactoryContext&,
                                   ProtobufMessage::ValidationVisitor&) override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 
   ProtobufTypes::MessagePtr createEmptyProtocolOptionsProto() override {

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
@@ -48,7 +48,7 @@ Filters::Common::ExtAuthz::CheckStatus resultCaseToCheckStatus(
   }
   default: {
     // Unhandled status.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
   }
   return check_status;

--- a/test/extensions/io_socket/user_space/file_event_impl_test.cc
+++ b/test/extensions/io_socket/user_space/file_event_impl_test.cc
@@ -419,8 +419,8 @@ TEST_F(FileEventImplTest, NotImplementedEmulatedEdge) {
   user_file_event_ = std::make_unique<FileEventImpl>(
       *dispatcher_, [this](uint32_t arg) { ready_cb_.called(arg); },
       Event::FileReadyType::Write | Event::FileReadyType::Closed, io_source_);
-  EXPECT_DEATH({ user_file_event_->registerEventIfEmulatedEdge(0); }, "not implemented");
-  EXPECT_DEATH({ user_file_event_->unregisterEventIfEmulatedEdge(0); }, "not implemented");
+  user_file_event_->registerEventIfEmulatedEdge(0);
+  user_file_event_->unregisterEventIfEmulatedEdge(0);
 }
 } // namespace
 } // namespace UserSpace

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -1094,10 +1094,10 @@ TEST_F(IoHandleImplTest, DeathOnEnablingDestroyedEvents) {
                      "Null user_file_event_");
 }
 
-TEST_F(IoHandleImplTest, NotImplementDuplicate) { ASSERT_DEATH(io_handle_->duplicate(), ""); }
+TEST_F(IoHandleImplTest, NotImplementDuplicate) { EXPECT_ENVOY_BUG(io_handle_->duplicate(), ""); }
 
 TEST_F(IoHandleImplTest, NotImplementAccept) {
-  ASSERT_DEATH(io_handle_->accept(nullptr, nullptr), "");
+  EXPECT_ENVOY_BUG(io_handle_->accept(nullptr, nullptr), "");
 }
 
 TEST_F(IoHandleImplTest, LastRoundtripTimeNullOpt) {

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -279,7 +279,7 @@ public:
     queries_.emplace_back(query);
   }
 
-  void onReject(RejectCause) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void onReject(RejectCause) override { PANIC("not implemented"); }
 
   void addHosts(const std::string& hostname, const IpList& ip, const RecordType& type) {
     if (type == RecordType::A) {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -733,7 +733,7 @@ private:
       return parent_.onRecvDatagram(data);
     }
     Network::FilterStatus onReceiveError(Api::IoError::IoErrorCode) override {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+      PANIC("not implemented");
     }
 
   private:

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -251,7 +251,7 @@ TEST_P(IntegrationAdminTest, Admin) {
               response->body());
     break;
   case Http::CodecType::HTTP3:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    PANIC("not implemented");
   }
 
   EXPECT_EQ("200", request("admin", "GET", "/certs", response));

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -76,7 +76,7 @@ void BufferingStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream)
 }
 
 void BufferingStreamDecoder::decodeTrailers(Http::ResponseTrailerMapPtr&&) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  PANIC("not implemented");
 }
 
 void BufferingStreamDecoder::onComplete() {


### PR DESCRIPTION
Replacing sneaky "not implemented" macros which cause PANIC with ENVOY_BUG or explicit panic.
Replaces 119 misleading production PANIC calls with 36 clear PANICs and 83 more graceful failures

Part of https://github.com/envoyproxy/envoy/issues/19172