### PR TITLE
Add -y for installing dependencies

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -36,7 +36,7 @@ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867
 .. code-block:: console
 
    $ sudo apt update
-   $ sudo apt install apt-transport-https gnupg2 curl lsb-release
+   $ sudo apt install -y apt-transport-https gnupg2 curl lsb-release
    $ curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | sudo gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
    # Verify the keyring - this should yield "OK"
    $ echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check


### PR DESCRIPTION
This is just a super simple addition of the '-y' flag when installing the dependencies. Only tested on Ubuntu.