### PR TITLE
filter: Add scheme field to cache keys and deprecate clear_http

### DIFF
--- a/source/extensions/filters/http/cache/key.proto
+++ b/source/extensions/filters/http/cache/key.proto
@@ -9,8 +9,14 @@ message Key {
   string path = 3;
   string query = 4;
   // True for http://, false for https://.
-  bool clear_http = 5;
+  bool clear_http = 5 [deprecated = true];  // Use scheme instead.
   // Cache implementations can store arbitrary content in these fields; never set by cache filter.
   repeated bytes custom_fields = 6;
   repeated int64 custom_ints = 7;
+  enum Scheme {
+    UNSPECIFIED = 0;
+    HTTP = 1;
+    HTTPS = 2;
+  }
+  Scheme scheme = 8;
 };


### PR DESCRIPTION
Signed-off-by: Edin Kadric <edin@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add `scheme` field to Envoy.Extensions.HttpFilters.Cache.Key and deprecate `clear_http`. The current state is confusing because the `clear_http` field is not marked "optional", so it doesn't have a "has" presence test, which means that if protocol information is ignored and the field isn't set, users of the proto will interpret clear_http=false as SSL=true.
Additional Description: An alternative would be to just add "optional" to the field, but the field is also confusing because "clear_http" sounds like an action where we "clear" an HTTP field. Also, adding presence tracking to an existing field may not be safe: If the field is set to its default value and passes through an old binary, the field will be dropped and any newer binaries downstream will think the field is unset.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: Added `scheme` field to Envoy.Extensions.HttpFilters.Cache.Key to replace `clear_http`.
Platform Specific Features: N/A
Deprecated: Deprecated `clear_http` field in Envoy.Extensions.HttpFilters.Cache.Key.
