### PR TITLE
filter: Add scheme field to cache keys and deprecate clear_http

### DIFF
--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -51,9 +51,9 @@ LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, Syst
   key_.set_host(std::string(request_headers.getHostValue()));
   key_.set_path(std::string(request_headers.getPathValue()));
   if (scheme == scheme_values.Http) {
-    key.set_scheme(Key::HTTP);
-  } else if (bdn_cache_key.protocol() == "https") {
-    key.set_scheme(Key::HTTPS);
+    key_.set_scheme(Key::HTTP);
+  } else if (scheme == "https") {
+    key_.set_scheme(Key::HTTPS);
   }
 }
 

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -50,7 +50,11 @@ LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, Syst
   key_.set_cluster_name("cluster_name_goes_here");
   key_.set_host(std::string(request_headers.getHostValue()));
   key_.set_path(std::string(request_headers.getPathValue()));
-  key_.set_clear_http(scheme == scheme_values.Http);
+  if (scheme == scheme_values.Http) {
+    key.set_scheme(Key::HTTP);
+  } else if (bdn_cache_key.protocol() == "https") {
+    key.set_scheme(Key::HTTPS);
+  }
 }
 
 // Unless this API is still alpha, calls to stableHashKey() must always return

--- a/source/extensions/filters/http/cache/key.proto
+++ b/source/extensions/filters/http/cache/key.proto
@@ -15,6 +15,9 @@ message Key {
     HTTP = 1;
     HTTPS = 2;
   }
+  // If UNSPECIFIED, the scheme is not included in the cache key, so http and
+  // https will map to the same cache entry. Otherwise, the scheme is included
+  // in the cache key.
   Scheme scheme = 8;
   // Cache implementations can store arbitrary content in these fields; never set by cache filter.
   repeated bytes custom_fields = 6;

--- a/source/extensions/filters/http/cache/key.proto
+++ b/source/extensions/filters/http/cache/key.proto
@@ -10,13 +10,13 @@ message Key {
   string query = 4;
   // True for http://, false for https://.
   bool clear_http = 5 [deprecated = true]; // Use scheme instead.
-  // Cache implementations can store arbitrary content in these fields; never set by cache filter.
-  repeated bytes custom_fields = 6;
-  repeated int64 custom_ints = 7;
   enum Scheme {
     UNSPECIFIED = 0;
     HTTP = 1;
     HTTPS = 2;
   }
   Scheme scheme = 8;
+  // Cache implementations can store arbitrary content in these fields; never set by cache filter.
+  repeated bytes custom_fields = 6;
+  repeated int64 custom_ints = 7;
 };

--- a/source/extensions/filters/http/cache/key.proto
+++ b/source/extensions/filters/http/cache/key.proto
@@ -9,8 +9,14 @@ message Key {
   string path = 3;
   string query = 4;
   // True for http://, false for https://.
-  bool clear_http = 5;
+  bool clear_http = 5 [deprecated = true]; // Use scheme instead.
   // Cache implementations can store arbitrary content in these fields; never set by cache filter.
   repeated bytes custom_fields = 6;
   repeated int64 custom_ints = 7;
+  enum Scheme {
+    UNSPECIFIED = 0;
+    HTTP = 1;
+    HTTPS = 2;
+  }
+  Scheme scheme = 8;
 };

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -372,6 +372,26 @@ TEST_F(LookupRequestTest, NotSatisfiableRange) {
   EXPECT_FALSE(lookup_response.has_trailers_);
 }
 
+TEST_F(LookupRequestTest, HttpScheme) {
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
+                                                 {":method", "GET"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "example.com"}};
+  const LookupRequest lookup_request(request_headers, currentTime(),
+                                     vary_allow_list_);
+  EXPECT_EQ(lookup_request.key().scheme(), Key::HTTP);
+}
+
+TEST_F(LookupRequestTest, HttpsScheme) {
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
+                                                 {":method", "GET"},
+                                                 {":scheme", "https"},
+                                                 {":authority", "example.com"}};
+  const LookupRequest lookup_request(request_headers, currentTime(),
+                                     vary_allow_list_);
+  EXPECT_EQ(lookup_request.key().scheme(), Key::HTTPS);
+}
+
 TEST(RawByteRangeTest, IsSuffix) {
   auto r = RawByteRange(UINT64_MAX, 4);
   ASSERT_TRUE(r.isSuffix());

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -373,22 +373,16 @@ TEST_F(LookupRequestTest, NotSatisfiableRange) {
 }
 
 TEST_F(LookupRequestTest, HttpScheme) {
-  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
-                                                 {":method", "GET"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "example.com"}};
-  const LookupRequest lookup_request(request_headers, currentTime(),
-                                     vary_allow_list_);
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":path", "/"}, {":method", "GET"}, {":scheme", "http"}, {":authority", "example.com"}};
+  const LookupRequest lookup_request(request_headers, currentTime(), vary_allow_list_);
   EXPECT_EQ(lookup_request.key().scheme(), Key::HTTP);
 }
 
 TEST_F(LookupRequestTest, HttpsScheme) {
-  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
-                                                 {":method", "GET"},
-                                                 {":scheme", "https"},
-                                                 {":authority", "example.com"}};
-  const LookupRequest lookup_request(request_headers, currentTime(),
-                                     vary_allow_list_);
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":path", "/"}, {":method", "GET"}, {":scheme", "https"}, {":authority", "example.com"}};
+  const LookupRequest lookup_request(request_headers, currentTime(), vary_allow_list_);
   EXPECT_EQ(lookup_request.key().scheme(), Key::HTTPS);
 }
 


### PR DESCRIPTION
Signed-off-by: Edin Kadric <edin@google.com>

Commit Message: Add scheme field to Envoy.Extensions.HttpFilters.Cache.Key and deprecate clear_http. The current state is confusing because the clear_http field is not marked "optional", so it doesn't have a "has" presence test, which means that if protocol information is ignored and the field isn't set, users of the proto will interpret clear_http=false as SSL=true.
Additional Description: An alternative would be to just add "optional" to the field, but the field is also confusing because "clear_http" sounds like an action where we "clear" an HTTP field. Also, adding presence tracking to an existing field may not be safe: If the field is set to its default value and passes through an old binary, the field will be dropped and any newer binaries downstream will think the field is unset.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A (the CacheFilter is still in Alpha)
Platform Specific Features: N/A
