### PR TITLE
test: use NO_END_STREAM of AutonomousStream correctly

### DIFF
--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -605,10 +605,11 @@ TEST_P(MultiplexedUpstreamIntegrationTest, MultipleRequestsLowStreamLimit) {
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
                                      {":authority", "host"},
-                                     {AutonomousStream::NO_END_STREAM, ""}});
+                                     {AutonomousStream::NO_END_STREAM, "true"}});
   // Wait until the response is sent to ensure the SETTINGS frame has been read
   // by Envoy.
   response->waitForHeaders();
+  ASSERT_FALSE(response->complete());
 
   // Now send a second request and make sure it is processed. Previously it
   // would be queued on the original connection, as Envoy would ignore the
@@ -617,6 +618,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, MultipleRequestsLowStreamLimit) {
   FakeStreamPtr upstream_request2;
   auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   ASSERT_TRUE(response2->waitForEndStream());
+  cleanupUpstreamAndDownstream();
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/13933


### PR DESCRIPTION
Signed-off-by: YaoZengzeng <yaozengzeng@huawei.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: the value of header `NO_END_STREAM` should not be empty, otherwise it won't take effect
Additional Description: ref: https://github.com/envoyproxy/envoy/blob/main/test/test_common/utility.h#L944 
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
