### PR TITLE
Fix starttls emitting double connected events

### DIFF
--- a/source/extensions/transport_sockets/starttls/starttls_socket.cc
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.cc
@@ -8,7 +8,7 @@ namespace StartTls {
 // Switch clear-text to secure transport.
 bool StartTlsSocket::startSecureTransport() {
   if (!using_tls_) {
-    tls_socket_->setTransportSocketCallbacks(*callbacks_);
+    tls_socket_->setTransportSocketCallbacks(callbacks_);
     tls_socket_->onConnected();
     // TODO(cpakulski): deleting active_socket_ assumes
     // that active_socket_ does not contain any buffered data.

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -2,8 +2,8 @@
 
 #include "envoy/extensions/transport_sockets/starttls/v3/starttls.pb.h"
 #include "envoy/extensions/transport_sockets/starttls/v3/starttls.pb.validate.h"
-#include "envoy/network/transport_socket.h"
 #include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -65,8 +65,9 @@ private:
     void raiseEvent(Network::ConnectionEvent event) override {
       if (event == Network::ConnectionEvent::Connected) {
         // Don't send the connected event if we're already open
-        if (isopen_)
+        if (isopen_) {
           return;
+        }
         isopen_ = true;
       } else {
         isopen_ = false;

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -256,7 +256,7 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromClient) {
 
   // The upstream connection should only report a single connected event
   EXPECT_CALL(upstream_callbacks_, onEvent(_));
-  EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::Connected)).Times(1);
+  EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::Connected));
 
   // Open clear-text connection.
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("starttls_test"));

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -255,6 +255,7 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromClient) {
   initialize();
 
   // The upstream connection should only report a single connected event
+  EXPECT_CALL(upstream_callbacks_, onEvent(_));
   EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::Connected)).Times(1);
 
   // Open clear-text connection.


### PR DESCRIPTION
Fix double event issue in #19232 

When using the starttls filter, it breaks the expectation that connections should only raise the connected event once. This expectation is relied on for proper operation of core envoy functions like the connection pooler.

Risk Level: Low

Testing: Added regression test.