### PR TITLE
dep: dependency checker should ignore pre-releases

### DIFF
--- a/tools/dependency/release_dates.py
+++ b/tools/dependency/release_dates.py
@@ -67,6 +67,8 @@ def get_latest_release(repo, version_min):
     latest_version = current_version
     latest_release = None
     for release in repo.get_releases():
+        if release.prerelease:
+            continue
         version = parse_version(release.tag_name)
         if not version:
             continue


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Fixes #19263
