### PR TITLE
dep: Dependency checker should give warning for only the latest tag

### DIFF
--- a/tools/dependency/release_dates.py
+++ b/tools/dependency/release_dates.py
@@ -23,7 +23,6 @@ import github
 import exports
 import utils
 from colorama import Fore, Style
-from packaging import version
 from packaging.version import parse as parse_version
 
 # Tag issues created with these labels.
@@ -233,14 +232,20 @@ def get_tagged_release_date(repo, metadata_version, github_release):
 
     tags = repo.get_tags()
     current_metadata_tag_commit_date = ''
+    current_version = parse_version(github_release.version)
+    latest_version = current_version
     for tag in tags.reversed:
         if tag.name == github_release.version:
             current_metadata_tag_commit_date = tag.commit.commit.committer.date
-        if not version.parse(tag.name).is_prerelease and version.parse(tag.name) > version.parse(
-                github_release.version):
-            print(
-                f'{Fore.YELLOW}*WARNING* {repo.name} has a newer release than {github_release.version}@<{current_metadata_tag_commit_date}>: '
-                f'{tag.name}@<{tag.commit.commit.committer.date}>{Style.RESET_ALL}')
+            continue
+        tag_version = parse_version(tag.name)
+        if not tag_version.is_prerelease and tag_version > latest_version:
+            latest = tag
+            latest_version = tag_version
+    if latest:
+        print(
+            f'{Fore.YELLOW}*WARNING* {repo.name} has a newer release than {github_release.version}@<{current_metadata_tag_commit_date}>: '
+            f'{latest.name}@<{latest.commit.commit.committer.date}>{Style.RESET_ALL}')
     return current_metadata_tag_commit_date
 
 

--- a/tools/dependency/release_dates.py
+++ b/tools/dependency/release_dates.py
@@ -270,10 +270,10 @@ def verify_and_print_release_dates(repository_locations, github_instance, create
         release_date = None
         # Obtain release information from GitHub API.
         github_release = utils.get_github_release_from_urls(metadata['urls'])
-        print('github_release: ', github_release)
         if not github_release:
             print(f'{dep} is not a GitHub repository')
             continue
+        print('github_release: ', github_release)
         repo = github_instance.get_repo(f'{github_release.organization}/{github_release.project}')
         if github_release.tagged:
             release_date = get_tagged_release_date(repo, metadata['version'], github_release)


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

A backup logic in dependency-checker for projects that do not have releases, is generating
warnings for all the tag versions greater than the current version. A sample output is given below, and the current 
patch tries to fix this.

github_release:  GitHubRelease(organization='emscripten-core', project='emsdk', version='2.0.8', tagged=True)
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.9@<2020-11-16 22:58:38>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.10@<2020-12-04 16:53:37>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.11@<2020-12-17 22:47:38>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.12@<2021-01-09 15:25:52>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.13@<2021-01-30 02:25:41>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.14@<2021-02-14 19:46:10>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.15@<2021-03-06 07:18:22>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.16@<2021-03-26 02:00:07>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.17@<2021-04-11 00:41:55>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.18@<2021-04-24 01:35:03>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.19@<2021-05-04 22:25:01>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.20@<2021-05-06 21:31:10>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.21@<2021-05-18 15:39:21>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.22@<2021-05-25 14:21:40>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.23@<2021-05-27 01:10:10>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.24@<2021-06-10 16:02:19>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.25@<2021-06-30 17:24:41>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.26@<2021-07-26 22:26:01>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.27@<2021-08-13 02:34:34>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.28@<2021-08-23 20:37:00>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.29@<2021-08-28 00:27:29>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.30@<2021-09-15 19:03:43>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.31@<2021-10-01 23:02:25>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.32@<2021-10-20 00:55:27>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.33@<2021-11-01 22:30:30>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 2.0.34@<2021-11-04 21:53:04>
*WARNING* emsdk has a newer release than 2.0.8@<2020-10-24 17:42:23>: 3.0.0@<2021-11-22 23:09:10>
emscripten_toolchain has a GitHub release date 2020-10-24
