### PR TITLE
Use ubuntu2004 on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,7 @@
 tasks:
   rbe:
     name: "RBE"
-    platform: ubuntu1804
+    platform: ubuntu2004
     test_targets:
     - "//test/common/common/..."
     - "//test/integration/..."
@@ -14,7 +14,7 @@ tasks:
     - "--jobs=75"
   coverage:
     name: "Coverage"
-    platform: ubuntu1804
+    platform: ubuntu2004
     shell_commands:
     - "sudo apt -y update && sudo apt -y install automake autotools-dev cmake libtool m4 ninja-build"
     - "wget https://apt.llvm.org/llvm.sh && sudo bash llvm.sh 10"


### PR DESCRIPTION
Commit Message: Use ubuntu2004 on Bazel CI
Additional Description:
gcc version is too old on ubuntu1804, which caused envoyproxy/envoy#19196
