### PR TITLE
alpn: fixing config validation for socket matchers

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -1,10 +1,11 @@
-1.21.0 (Pending)
+g.21.0 (Pending)
 ================
 
 Incompatible Behavior Changes
 -----------------------------
 *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 
+* auto_config: :ref:`auto_config: <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` now verifies that any transport sockets configured via :ref:`transport_socket_matches <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket_matches>` support ALPN. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.correctly_validate_alpn`` to false..
 * xds: ``*`` became a reserved name for a wildcard resource that can be subscribed to and unsubscribed from at any time. This is a requirement for implementing the on-demand xDSes (like on-demand CDS) that can subscribe to specific resources next to their wildcard subscription. If such xDS is subscribed to both wildcard resource and to other specific resource, then in stream reconnection scenario, the xDS will not send an empty initial request, but a request containing ``*`` for wildcard subscription and the rest of the resources the xDS is subscribed to. If the xDS is only subscribed to wildcard resource, it will try to send a legacy wildcard request. This behavior implements the recent changes in :ref:`xDS protocol <xds_protocol>` and can be temporarily reverted by setting the ``envoy.restart_features.explicit_wildcard_resource`` runtime guard to false.
 
 Minor Behavior Changes

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -1,4 +1,4 @@
-g.21.0 (Pending)
+1.21.0 (Pending)
 ================
 
 Incompatible Behavior Changes

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -195,6 +195,11 @@ public:
    * @return the match information of the transport socket selected.
    */
   virtual MatchData resolve(const envoy::config::core::v3::Metadata* metadata) const PURE;
+
+  /*
+   * return true if all matches support ALPN, false otherwise.
+   */
+  virtual bool allMatchesSupportAlpn() const PURE;
 };
 
 using TransportSocketMatcherPtr = std::unique_ptr<TransportSocketMatcher>;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -59,6 +59,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.allow_response_for_timeout",
     "envoy.reloadable_features.conn_pool_delete_when_idle",
     "envoy.reloadable_features.correct_scheme_and_xfp",
+    "envoy.reloadable_features.correctly_validate_alpn",
     "envoy.reloadable_features.disable_tls_inspector_injection",
     "envoy.reloadable_features.fix_added_trailers",
     "envoy.reloadable_features.grpc_bridge_stats_disabled",

--- a/source/common/upstream/transport_socket_match_impl.h
+++ b/source/common/upstream/transport_socket_match_impl.h
@@ -40,6 +40,18 @@ public:
 
   MatchData resolve(const envoy::config::core::v3::Metadata* metadata) const override;
 
+  bool allMatchesSupportAlpn() const override {
+    if (!default_match_.factory->supportsAlpn()) {
+      return false;
+    }
+    for (const auto& match : matches_) {
+      if (!match.factory->supportsAlpn()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
 protected:
   TransportSocketMatchStats generateStats(const std::string& prefix);
   Stats::Scope& stats_scope_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1049,6 +1049,7 @@ ClusterImplBase::ClusterImplBase(
 
   auto socket_matcher = std::make_unique<TransportSocketMatcherImpl>(
       cluster.transport_socket_matches(), factory_context, socket_factory, *stats_scope);
+  const bool matcher_supports_alpn = socket_matcher->allMatchesSupportAlpn();
   auto& dispatcher = factory_context.mainThreadDispatcher();
   info_ = std::shared_ptr<const ClusterInfoImpl>(
       new ClusterInfoImpl(cluster, factory_context.clusterManager().bindConfig(), runtime,
@@ -1060,11 +1061,18 @@ ClusterImplBase::ClusterImplBase(
             std::unique_ptr<const Event::DispatcherThreadDeletable>(self));
       });
 
-  if ((info_->features() & ClusterInfoImpl::Features::USE_ALPN) &&
-      !raw_factory_pointer->supportsAlpn()) {
-    throw EnvoyException(
-        fmt::format("ALPN configured for cluster {} which has a non-ALPN transport socket: {}",
-                    cluster.name(), cluster.DebugString()));
+  if ((info_->features() & ClusterInfoImpl::Features::USE_ALPN)) {
+    if (!raw_factory_pointer->supportsAlpn()) {
+      throw EnvoyException(
+          fmt::format("ALPN configured for cluster {} which has a non-ALPN transport socket: {}",
+                      cluster.name(), cluster.DebugString()));
+    }
+    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.correctly_validate_alpn") &&
+        !matcher_supports_alpn) {
+      throw EnvoyException(fmt::format(
+          "ALPN configured for cluster {} which has a non-ALPN transport socket matcher: {}",
+          cluster.name(), cluster.DebugString()));
+    }
   }
 
   if (info_->features() & ClusterInfoImpl::Features::HTTP3) {

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -129,7 +130,7 @@ transport_socket:
 }
 
 TEST_F(TransportSocketMatcherTest, AlpnSupport) {
-  mock_default_factory_.reset(new NiceMock<FakeTransportSocketFactory>("default", true));
+  mock_default_factory_ = std::make_unique<NiceMock<FakeTransportSocketFactory>>("default", true);
   factory_.supports_alpn_ = true;
   init({R"EOF(
 name: "enableFooSocket"
@@ -164,7 +165,7 @@ transport_socket:
 }
 
 TEST_F(TransportSocketMatcherTest, NoMatcherAlpnSupport) {
-  mock_default_factory_.reset(new NiceMock<FakeTransportSocketFactory>("default", true));
+  mock_default_factory_ = std::make_unique<NiceMock<FakeTransportSocketFactory>>("default", true);
   init({R"EOF(
 name: "enableFooSocket"
 match:

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -31,10 +31,15 @@ class FakeTransportSocketFactory : public Network::TransportSocketFactory {
 public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
+  MOCK_METHOD(bool, supportsAlpn, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsConstSharedPtr), (const));
-  FakeTransportSocketFactory(std::string id) : id_(std::move(id)) {}
+  FakeTransportSocketFactory(std::string id, bool alpn) : supports_alpn_(alpn), id_(std::move(id)) {
+    ON_CALL(*this, supportsAlpn).WillByDefault(Invoke([this]() { return supports_alpn_; }));
+  }
   std::string id() const { return id_; }
+
+  bool supports_alpn_;
 
 private:
   const std::string id_;
@@ -58,7 +63,7 @@ public:
     if (!node.id().empty()) {
       id = node.id();
     }
-    return std::make_unique<FakeTransportSocketFactory>(id);
+    return std::make_unique<NiceMock<FakeTransportSocketFactory>>(id, supports_alpn_);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -66,12 +71,14 @@ public:
   }
 
   std::string name() const override { return "foo"; }
+  bool supports_alpn_{};
 };
 
 class TransportSocketMatcherTest : public testing::Test {
 public:
   TransportSocketMatcherTest()
-      : registration_(factory_), mock_default_factory_(new FakeTransportSocketFactory("default")),
+      : registration_(factory_),
+        mock_default_factory_(new NiceMock<FakeTransportSocketFactory>("default", false)),
         stats_scope_(stats_store_.createScope("transport_socket_match.test")) {}
 
   void init(const std::vector<std::string>& match_yaml) {
@@ -116,6 +123,61 @@ transport_socket:
 
   envoy::config::core::v3::Metadata metadata;
   validate(metadata, "default");
+
+  // Neither the defaults nor matcher support ALPN.
+  EXPECT_FALSE(matcher_->allMatchesSupportAlpn());
+}
+
+TEST_F(TransportSocketMatcherTest, AlpnSupport) {
+  mock_default_factory_.reset(new NiceMock<FakeTransportSocketFactory>("default", true));
+  factory_.supports_alpn_ = true;
+  init({R"EOF(
+name: "enableFooSocket"
+match:
+  hasSidecar: "true"
+transport_socket:
+  name: "foo"
+  typed_config:
+    "@type": type.googleapis.com/envoy.config.core.v3.Node
+    id: "abc"
+ )EOF"});
+
+  // Both default and matcher support ALPN
+  EXPECT_TRUE(matcher_->allMatchesSupportAlpn());
+}
+
+TEST_F(TransportSocketMatcherTest, NoDefaultAlpnSupport) {
+  factory_.supports_alpn_ = true;
+  init({R"EOF(
+name: "enableFooSocket"
+match:
+  hasSidecar: "true"
+transport_socket:
+  name: "foo"
+  typed_config:
+    "@type": type.googleapis.com/envoy.config.core.v3.Node
+    id: "abc"
+ )EOF"});
+
+  // The default doesn't support ALPN, matchers do.
+  EXPECT_FALSE(matcher_->allMatchesSupportAlpn());
+}
+
+TEST_F(TransportSocketMatcherTest, NoMatcherAlpnSupport) {
+  mock_default_factory_.reset(new NiceMock<FakeTransportSocketFactory>("default", true));
+  init({R"EOF(
+name: "enableFooSocket"
+match:
+  hasSidecar: "true"
+transport_socket:
+  name: "foo"
+  typed_config:
+    "@type": type.googleapis.com/envoy.config.core.v3.Node
+    id: "abc"
+ )EOF"});
+
+  // The default doesn't support ALPN, matchers do.
+  EXPECT_FALSE(matcher_->allMatchesSupportAlpn());
 }
 
 TEST_F(TransportSocketMatcherTest, BasicMatch) {

--- a/test/mocks/upstream/transport_socket_match.h
+++ b/test/mocks/upstream/transport_socket_match.h
@@ -19,6 +19,7 @@ public:
   ~MockTransportSocketMatcher() override;
   MOCK_METHOD(TransportSocketMatcher::MatchData, resolve,
               (const envoy::config::core::v3::Metadata*), (const));
+  MOCK_METHOD(bool, allMatchesSupportAlpn, (), (const));
 
   Network::TransportSocketFactoryPtr socket_factory_;
   Stats::TestUtil::TestStore stats_store_;


### PR DESCRIPTION
Making sure that socket matchers on alpn-required clusters support ALPN.

Risk Level: Medium
Testing: new unit tests
Docs Changes: n/a
Release Notes: inline
Runtime guard: envoy.reloadable_features.correctly_validate_alpn
Part of https://github.com/envoyproxy/envoy/issues/19149
