### PR TITLE
docker: Delete CI build artefacts after loading

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -336,10 +336,16 @@ stages:
         targetPath: $(Build.StagingDirectory)
     - bash: |
         set -e
-        mkdir -p linux/amd64 && tar zxf $(Build.StagingDirectory)/bazel.release/envoy_binary.tar.gz -C ./linux/amd64
+        mkdir -p linux/amd64
+        tar zxf $(Build.StagingDirectory)/bazel.release/envoy_binary.tar.gz -C ./linux/amd64
         tar zxf $(Build.StagingDirectory)/bazel.release/envoy-contrib_binary.tar.gz -C ./linux/amd64
-        mkdir -p linux/arm64 && tar zxf $(Build.StagingDirectory)/bazel.release.arm64/envoy_binary.tar.gz -C ./linux/arm64
+        rm $(Build.StagingDirectory)/bazel.release/envoy_binary.tar.gz
+        rm $(Build.StagingDirectory)/bazel.release/envoy-contrib_binary.tar.gz
+        mkdir -p linux/arm64
+        tar zxf $(Build.StagingDirectory)/bazel.release.arm64/envoy_binary.tar.gz -C ./linux/arm64
         tar zxf $(Build.StagingDirectory)/bazel.release.arm64/envoy-contrib_binary.tar.gz -C ./linux/arm64
+        rm $(Build.StagingDirectory)/bazel.release.arm64/envoy_binary.tar.gz
+        rm $(Build.StagingDirectory)/bazel.release.arm64/envoy-contrib_binary.tar.gz
         ci/docker_ci.sh
       workingDirectory: $(Build.SourcesDirectory)
       env:


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

CI is failing on https://github.com/envoyproxy/envoy/pull/19275 due to running out of diskpace during the docker build

This PR should free up ~1GB of extra space

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
