### PR TITLE
route: graceful handling of non-object header formatter metadata parsing

### DIFF
--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -80,6 +80,11 @@ parseMetadataField(absl::string_view params_str, bool upstream = true) {
   TRY_ASSERT_MAIN_THREAD {
     Json::ObjectSharedPtr parsed_params = Json::Factory::loadFromString(std::string(json));
 
+    // The given json string may be an invalid object.
+    if (!parsed_params) {
+      throw EnvoyException(formatUpstreamMetadataParseException(json));
+    }
+
     for (const auto& param : parsed_params->asObjectArray()) {
       params.emplace_back(param->asString());
     }

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -682,6 +682,17 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithUpstreamMetadataVariableMiss
   testFormatting(stream_info, "UPSTREAM_METADATA([\"namespace\", \"key\"])", "");
 }
 
+TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithInvalidUpstreamMetadata) {
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> host;
+  stream_info.upstreamInfo()->setUpstreamHost(host);
+
+  EXPECT_THROW_WITH_MESSAGE(
+      testFormatting(stream_info, "UPSTREAM_METADATA(1)", ""), EnvoyException,
+      "Invalid header configuration. Expected format UPSTREAM_METADATA([\"namespace\", \"k\", "
+      "...]), actual format UPSTREAM_METADATA1");
+}
+
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithRequestMetadata) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   envoy::config::core::v3::Metadata metadata;

--- a/test/common/router/route_corpus/non_parsable_metadata
+++ b/test/common/router/route_corpus/non_parsable_metadata
@@ -1,0 +1,8 @@
+config {
+  request_headers_to_add {
+    header {
+      key: "l"
+      value: "%UPSTREAM_METADATA(1)%"
+    }
+  }
+}


### PR DESCRIPTION
Commit Message: route: graceful handling of non-object header formatter metadata parsing
Additional Description:
Fixing a crash due to a control-plane invalid metadata header format, where the format string doesn't include an object.
In this PR the output from the json converter is validated, and an EnvoyException is thrown in case it is incorrect.

Risk Level: low
Testing: Added unit test + fuzz test
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
Fixes fuzz isse: 42385

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
