### PR TITLE
Add test coverage for json package

### DIFF
--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -219,7 +219,11 @@ TEST_F(JsonLoaderTest, Basic) {
 
   {
     ObjectSharedPtr json1 = Factory::loadFromString("[ [ ] , { } ]");
-    EXPECT_EQ(json1->asJsonString(), "[null,null]");
+    if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.remove_legacy_json")) {
+      EXPECT_EQ(json1->asJsonString(), "[[],{}]");
+    } else {
+      EXPECT_EQ(json1->asJsonString(), "[null,null]");
+    }
   }
 
   {
@@ -234,12 +238,20 @@ TEST_F(JsonLoaderTest, Basic) {
 
   {
     ObjectSharedPtr json = Factory::loadFromString("{\"hello\": {}}");
-    EXPECT_EQ(json->getObject("hello")->asJsonString(), "null");
+    if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.remove_legacy_json")) {
+      EXPECT_EQ(json->getObject("hello")->asJsonString(), "{}");
+    } else {
+      EXPECT_EQ(json->getObject("hello")->asJsonString(), "null");
+    }
   }
 
   {
     ObjectSharedPtr json = Factory::loadFromString("{\"hello\": [] }");
-    EXPECT_EQ(json->asJsonString(), "{\"hello\":null}");
+    if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.remove_legacy_json")) {
+      EXPECT_EQ(json->asJsonString(), "{\"hello\":[]}");
+    } else {
+      EXPECT_EQ(json->asJsonString(), "{\"hello\":null}");
+    }
   }
 }
 

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -211,6 +211,36 @@ TEST_F(JsonLoaderTest, Basic) {
     ObjectSharedPtr json = Factory::loadFromString("{}");
     EXPECT_TRUE(json->getObjectArray("hello", true).empty());
   }
+
+  {
+    ObjectSharedPtr json = Factory::loadFromString("[ null ]");
+    EXPECT_EQ(json->asJsonString(), "[null]");
+  }
+
+  {
+    ObjectSharedPtr json1 = Factory::loadFromString("[ [ ] , { } ]");
+    EXPECT_EQ(json1->asJsonString(), "[null,null]");
+  }
+
+  {
+    ObjectSharedPtr json1 = Factory::loadFromString("[ true ]");
+    EXPECT_EQ(json1->asJsonString(), "[true]");
+  }
+
+  {
+    ObjectSharedPtr json1 = Factory::loadFromString("{\"foo\": 123, \"bar\": \"cat\"}");
+    EXPECT_EQ(json1->asJsonString(), "{\"bar\":\"cat\",\"foo\":123}");
+  }
+
+  {
+    ObjectSharedPtr json = Factory::loadFromString("{\"hello\": {}}");
+    EXPECT_EQ(json->getObject("hello")->asJsonString(), "null");
+  }
+
+  {
+    ObjectSharedPtr json = Factory::loadFromString("{\"hello\": [] }");
+    EXPECT_EQ(json->asJsonString(), "{\"hello\":null}");
+  }
 }
 
 TEST_F(JsonLoaderTest, Integer) {


### PR DESCRIPTION
Improving test line coverage for json tests
Signed-off-by: Tom Hadlaw <tomhadlaw@gmail.com>

Additional Description: Adding more tests to increase line coverage for json package. Adding coverage for missing code paths by testing various loadFromString inputs.
Risk Level: Low
Testing: Added tests to json_loader_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

This PR seeks to improve this issue: https://github.com/envoyproxy/envoy/issues/1963