### PR TITLE
tooling: Add dev requirements setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,11 @@ updates:
     interval: "daily"
 
 - package-ecosystem: "pip"
+  directory: "/tools/dev"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "pip"
   directory: "/tools/code_format"
   schedule:
     interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,6 @@ updates:
     interval: "daily"
 
 - package-ecosystem: "pip"
-  directory: "/tools/dev"
-  schedule:
-    interval: "daily"
-
-- package-ecosystem: "pip"
   directory: "/tools/code_format"
   schedule:
     interval: "daily"

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -15,6 +15,11 @@ def _python_deps():
         extra_pip_args = ["--require-hashes"],
     )
     pip_install(
+        # Note: dev requirements do *not* check hashes
+        name = "dev_pip3",
+        requirements = "@envoy//tools/dev:requirements.txt",
+    )
+    pip_install(
         name = "thrift_pip3",
         requirements = "@envoy//test/extensions/filters/network/thrift_proxy:requirements.txt",
         extra_pip_args = ["--require-hashes"],

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -9,7 +9,7 @@ envoy.base.runner
 envoy.base.utils>=0.0.12
 envoy.code_format.python_check>=0.0.4
 envoy.dependency.cve_scan
-envoy.dependency.pip_check>=0.0.4
+envoy.dependency.pip_check>=0.0.5
 envoy.distribution.release
 envoy.distribution.verify>=0.0.6
 envoy.docs.sphinx-runner>=0.0.3

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -299,8 +299,9 @@ envoy.dependency.cve-scan==0.0.1 \
     --hash=sha256:438973e6258deb271d60a9ad688c13ebf9c5360ccb9b6b0d4af3b3228235b153 \
     --hash=sha256:733fa5c6bdbe91da4afe1d46bca75279f717e410693866825d92208fa0d3418f
     # via -r requirements.in
-envoy.dependency.pip-check==0.0.4 \
-    --hash=sha256:3213d77959f65c3c97e9b5d74cb14c02bc02dae64bac2e7c3cb829a2f4e5e40e
+envoy.dependency.pip-check==0.0.5 \
+    --hash=sha256:9a4041dbc21f41191b34b92943060b015150ff837758c53f0e433c2233fb7074 \
+    --hash=sha256:b3eea3c9a9d2286271c93e477c04299ca44f4fbdbc757911399a7bfe4caacc90
     # via -r requirements.in
 envoy.distribution.distrotest==0.0.5 \
     --hash=sha256:042747ff9691fe33bfccbf7821bae5735b705b9488a9a97f702d6b5b37063245 \

--- a/tools/dev/BUILD
+++ b/tools/dev/BUILD
@@ -1,0 +1,1 @@
+licenses(["notice"])  # Apache 2

--- a/tools/dev/requirements.txt
+++ b/tools/dev/requirements.txt
@@ -1,0 +1,19 @@
+# Remote-pdb can be used inside build jobs, or parallelized aspects
+remote-pdb
+
+# Add temporary dev requirements with `-e` here
+#
+# Note: This should always be empty on `main`.
+#
+# Examples:
+#
+# Github pull request:
+#
+#   -e git+https://github.com/envoyproxy/pytooling@f862768556e747ce5a1d309850f9ba8ad72b0afa#egg=envoy.dependency.check&subdirectory=envoy.dependency.check
+#
+# Local filesystem (path must be available to bazel, eg inside container)
+#
+#   -e file:///src/workspace/pytooling/envoy.dependency.check#egg=envoy.dependency.check&cachebust=011
+#
+# `cachebust` can be used to signify change to bazel.
+#


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

This allows requirements without hashes - ie using `-e` to be used in development

They can either point to a git/hub requirement for testing in CI, or a local filesystem requirement for development of pytooling packages.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
