### PR TITLE
grpc_http1_bridge: support for prepending and trimming the grpc frame header

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
@@ -19,5 +19,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Config {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.grpc_http1_bridge.v2.Config";
+
+  // If true then requests with content type set to `application/x-protobuf` will be automatically converted to gRPC.
+  // This works by prepending the payload data with the gRPC header frame, as defined by the wiring format, and
+  // Content-Type will be updated accordingly before sending the request.
+  // For the requests that went through this upgrade the filter will also strip the frame before forwarding the
+  // response to the client.
   bool upgrade_protobuf_to_grpc = 1;
 }

--- a/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
@@ -19,4 +19,5 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Config {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.grpc_http1_bridge.v2.Config";
+  bool upgrade_protobuf_to_grpc = 1;
 }

--- a/docs/root/configuration/http/http_filters/grpc_http1_bridge_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_http1_bridge_filter.rst
@@ -43,6 +43,20 @@ More info: wire format in `gRPC over HTTP/2 <https://github.com/grpc/grpc/blob/m
    has been disabled. Set the runtime value of ``envoy.reloadable_features.grpc_bridge_stats_disabled``
    to false to turn on stat collection.
 
+Protobuf upgrade support
+------------------------
+
+The filter will automatically frame requests with content-type *application/x-protobuf* as gRPC requests if
+:ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` is set.
+In this case the filter will prepend the body with the gRPC frame described above, and update the content-type header to
+`application/grpc` before sending the request to the gRPC server.
+
+In case the client sends a *content-length* header it will be removed before proceeding, as the value may conflict with
+the size specified in the gRPC frame.
+
+The response body returned to the client will not contain the gRPC header frame for requests that are upgraded in this
+fashion, i.e. the body will contain only the encoded Protobuf.
+
 Statistics
 ----------
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -78,7 +78,7 @@ New Features
 * dns_resolver: added :ref:`use_resolvers_as_fallback<envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.filter_unroutable_families>` to the c-ares DNS resolver.
 * dns_resolver: added :ref:`AppleDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>` to support apple DNS resolver as an extension.
 * ext_authz: added :ref:`query_parameters_to_set <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_set>` and :ref:`query_parameters_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_remove>` for adding and removing query string parameters when using a gRPC authorization server.
-* grpc_http_bridge:: added :ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` option for automatically framing protobuf payloads as gRPC requests.
+* grpc_http_bridge: added :ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` option for automatically framing protobuf payloads as gRPC requests.
 * grpc_json_transcoder: added support for matching unregistered custom verb :ref:`match_unregistered_custom_verb <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.match_unregistered_custom_verb>`.
 * http: added support for %REQUESTED_SERVER_NAME% to extract SNI as a custom header.
 * http: added support for %VIRTUAL_CLUSTER_NAME% to extract the matched Virtual Cluster name as a custom header.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -78,6 +78,7 @@ New Features
 * dns_resolver: added :ref:`use_resolvers_as_fallback<envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.filter_unroutable_families>` to the c-ares DNS resolver.
 * dns_resolver: added :ref:`AppleDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>` to support apple DNS resolver as an extension.
 * ext_authz: added :ref:`query_parameters_to_set <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_set>` and :ref:`query_parameters_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_remove>` for adding and removing query string parameters when using a gRPC authorization server.
+* grpc_http_bridge:: added :ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` option for automatically framing protobuf payloads as gRPC requests.
 * grpc_json_transcoder: added support for matching unregistered custom verb :ref:`match_unregistered_custom_verb <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.match_unregistered_custom_verb>`.
 * http: added support for %REQUESTED_SERVER_NAME% to extract SNI as a custom header.
 * http: added support for %VIRTUAL_CLUSTER_NAME% to extract the matched Virtual Cluster name as a custom header.

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -37,8 +37,7 @@ bool Common::hasGrpcContentType(const Http::RequestOrResponseHeaderMap& headers)
 }
 
 bool Common::hasProtobufContentType(const Http::RequestOrResponseHeaderMap& headers) {
-  const absl::string_view content_type = headers.getContentTypeValue();
-  return absl::EqualsIgnoreCase(content_type, Http::Headers::get().ContentTypeValues.Protobuf);
+  return headers.getContentTypeValue() == Http::Headers::get().ContentTypeValues.Protobuf;
 }
 
 bool Common::isGrpcRequestHeaders(const Http::RequestHeaderMap& headers) {

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -36,11 +36,23 @@ bool Common::hasGrpcContentType(const Http::RequestOrResponseHeaderMap& headers)
           content_type[Http::Headers::get().ContentTypeValues.Grpc.size()] == '+');
 }
 
+bool Common::hasProtobufContentType(const Http::RequestOrResponseHeaderMap& headers) {
+  const absl::string_view content_type = headers.getContentTypeValue();
+  return absl::EqualsIgnoreCase(content_type, Http::Headers::get().ContentTypeValues.Protobuf);
+}
+
 bool Common::isGrpcRequestHeaders(const Http::RequestHeaderMap& headers) {
   if (!headers.Path()) {
     return false;
   }
   return hasGrpcContentType(headers);
+}
+
+bool Common::isProtobufRequestHeaders(const Http::RequestHeaderMap& headers) {
+  if (!headers.Path()) {
+    return false;
+  }
+  return hasProtobufContentType(headers);
 }
 
 bool Common::isGrpcResponseHeaders(const Http::ResponseHeaderMap& headers, bool end_stream) {

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -38,7 +38,7 @@ public:
 
   /**
    * @param headers the headers to parse.
-   * @return bool indicating whether content-type is gRPC.
+   * @return bool indicating whether content-type is Protobuf.
    */
   static bool hasProtobufContentType(const Http::RequestOrResponseHeaderMap& headers);
 

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -38,11 +38,25 @@ public:
 
   /**
    * @param headers the headers to parse.
+   * @return bool indicating whether content-type is gRPC.
+   */
+  static bool hasProtobufContentType(const Http::RequestOrResponseHeaderMap& headers);
+
+  /**
+   * @param headers the headers to parse.
    * @return bool indicating whether the header is a gRPC request header.
    * Currently headers are considered gRPC request headers if they have the gRPC
    * content type, and have a path header.
    */
   static bool isGrpcRequestHeaders(const Http::RequestHeaderMap& headers);
+
+  /**
+   * @param headers the headers to parse.
+   * @return bool indicating whether the header is a protobuf request header.
+   * Currently headers are considered gRPC request headers if they have the protobuf
+   * content type, and have a path header.
+   */
+  static bool isProtobufRequestHeaders(const Http::RequestHeaderMap& headers);
 
   /**
    * @param headers the headers to parse.

--- a/source/extensions/filters/http/grpc_http1_bridge/BUILD
+++ b/source/extensions/filters/http/grpc_http1_bridge/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "//source/common/grpc:context_lib",
         "//source/common/http:headers_lib",
         "//source/common/http/http1:codec_lib",
+        "@envoy_api//envoy/extensions/filters/http/grpc_http1_bridge/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/grpc_http1_bridge/BUILD
+++ b/source/extensions/filters/http/grpc_http1_bridge/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//envoy/upstream:cluster_manager_interface",
         "//source/common/common:enum_to_int",
         "//source/common/common:utility_lib",
+        "//source/common/grpc:codec_lib",
         "//source/common/grpc:common_lib",
         "//source/common/grpc:context_lib",
         "//source/common/http:headers_lib",

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -10,10 +10,11 @@ namespace HttpFilters {
 namespace GrpcHttp1Bridge {
 
 Http::FilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config&, const std::string&,
-    Server::Configuration::FactoryContext& factory_context) {
-  return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {
-    callbacks.addStreamFilter(std::make_shared<Http1BridgeFilter>(factory_context.grpcContext()));
+    const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& factory_context) {
+  return [&factory_context, proto_config](Http::FilterChainFactoryCallbacks& callbacks) {
+    callbacks.addStreamFilter(std::make_shared<Http1BridgeFilter>(
+        factory_context.grpcContext(), proto_config.upgrade_protobuf_to_grpc()));
   };
 }
 

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -13,8 +13,8 @@ Http::FilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoT
     const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
     const std::string&, Server::Configuration::FactoryContext& factory_context) {
   return [&factory_context, proto_config](Http::FilterChainFactoryCallbacks& callbacks) {
-    callbacks.addStreamFilter(std::make_shared<Http1BridgeFilter>(
-        factory_context.grpcContext(), proto_config.upgrade_protobuf_to_grpc()));
+    callbacks.addStreamFilter(
+        std::make_shared<Http1BridgeFilter>(factory_context.grpcContext(), proto_config));
   };
 }
 

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -1,7 +1,6 @@
 #include "source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h"
 
 #include <cstdint>
-#include <limits>
 #include <string>
 #include <vector>
 

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -64,7 +64,6 @@ public:
 private:
   void chargeStat(const Http::ResponseHeaderOrTrailerMap& headers);
   void setupStatTracking(const Http::RequestHeaderMap& headers);
-  void updateContentLength(Http::RequestHeaderMap& headers, uint64_t delta);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -327,6 +327,16 @@ TEST(GrpcContextTest, IsGrpcResponseHeader) {
   EXPECT_FALSE(Common::isGrpcResponseHeaders(json_response_header, false));
 }
 
+TEST(GrpcContextTest, IsProtobufRequestHeader) {
+  Http::TestRequestHeaderMapImpl is{
+      {":method", "GET"}, {":path", "/"}, {"content-type", "application/x-protobuf"}};
+  EXPECT_TRUE(Common::isProtobufRequestHeaders(is));
+
+  Http::TestRequestHeaderMapImpl is_not{{":method", "CONNECT"},
+                                        {"content-type", "application/x-protobuf"}};
+  EXPECT_FALSE(Common::isProtobufRequestHeaders(is_not));
+}
+
 TEST(GrpcContextTest, ValidateResponse) {
   {
     Http::ResponseMessageImpl response(

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -423,8 +423,9 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-      // No request trailer O(1) headers.
-  } {
+    // No request trailer O(1) headers.
+  }
+  {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -423,9 +423,8 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-    // No request trailer O(1) headers.
-  }
-  {
+      // No request trailer O(1) headers.
+  } {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/extensions/filters/http/grpc_http1_bridge/BUILD
+++ b/test/extensions/filters/http/grpc_http1_bridge/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",
+        "//source/extensions/filters/http/grpc_http1_bridge:config",
         "//source/extensions/filters/http/grpc_http1_bridge:http1_bridge_filter_lib",
         "//test/mocks/http:http_mocks",
         "//test/test_common:global_lib",

--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -293,8 +293,8 @@ TEST_F(GrpcHttp1BridgeFilterTest, ProtobufNotUpgradedToGrpc) {
   EXPECT_EQ("200", response_headers.get_(":status"));
 }
 
-// Verifies that requests with protobuf content are framed as gRPC when the filterned is configured
-// as such
+// Verifies that requests with protobuf content are framed as gRPC when the filter is configured as
+// such
 TEST_F(GrpcHttp1BridgeFilterTest, ProtobufUpgradedToGrpc) {
   initialize(true);
   Http::TestRequestHeaderMapImpl request_headers{{"content-type", "application/x-protobuf"},

--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -1,3 +1,7 @@
+#include <memory>
+
+#include "envoy/http/filter.h"
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/grpc/common.h"
 #include "source/common/http/header_map_impl.h"
@@ -21,23 +25,30 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1Bridge {
+
+using FilterPtr = std::unique_ptr<Http1BridgeFilter>;
+
 namespace {
 
 class GrpcHttp1BridgeFilterTest : public testing::Test {
-public:
-  GrpcHttp1BridgeFilterTest() : context_(*symbol_table_), filter_(context_) {
-    filter_.setDecoderFilterCallbacks(decoder_callbacks_);
-    filter_.setEncoderFilterCallbacks(encoder_callbacks_);
+protected:
+  void initialize(bool upgrade_protobuf = false) {
+    filter_ = std::make_unique<Http1BridgeFilter>(context_, upgrade_protobuf);
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_->setEncoderFilterCallbacks(encoder_callbacks_);
     ON_CALL(decoder_callbacks_.stream_info_, protocol()).WillByDefault(ReturnPointee(&protocol_));
     ON_CALL(*decoder_callbacks_.cluster_info_, statsScope())
         .WillByDefault(testing::ReturnRef(stats_store_));
   }
 
-  ~GrpcHttp1BridgeFilterTest() override { filter_.onDestroy(); }
+public:
+  GrpcHttp1BridgeFilterTest() : context_(*symbol_table_) {}
 
+  ~GrpcHttp1BridgeFilterTest() override { filter_->onDestroy(); }
+
+  FilterPtr filter_;
   Stats::TestUtil::TestSymbolTable symbol_table_;
   Grpc::ContextImpl context_;
-  Http1BridgeFilter filter_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
@@ -45,6 +56,7 @@ public:
 };
 
 TEST_F(GrpcHttp1BridgeFilterTest, NoRoute) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
   ON_CALL(decoder_callbacks_, route()).WillByDefault(Return(nullptr));
 
@@ -52,14 +64,15 @@ TEST_F(GrpcHttp1BridgeFilterTest, NoRoute) {
       {"content-type", "application/grpc"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
-  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_.decodeMetadata(metadata_map));
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "404"}};
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, NoCluster) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
   ON_CALL(decoder_callbacks_, clusterInfo()).WillByDefault(Return(nullptr));
 
@@ -67,27 +80,28 @@ TEST_F(GrpcHttp1BridgeFilterTest, NoCluster) {
       {"content-type", "application/grpc"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "404"}};
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, Http2HeaderOnlyResponse) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
 
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   Http::TestResponseHeaderMapImpl continue_headers{{":status", "100"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encode1xxHeaders(continue_headers));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encode1xxHeaders(continue_headers));
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
-  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_.encodeMetadata(metadata_map));
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->encodeMetadata(metadata_map));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   EXPECT_FALSE(
       stats_store_.findCounterByString("grpc.lyft.users.BadCompanions.GetBadCompanions.failure"));
   EXPECT_FALSE(
@@ -95,6 +109,7 @@ TEST_F(GrpcHttp1BridgeFilterTest, Http2HeaderOnlyResponse) {
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2HeaderOnlyResponse) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
 
   Http::TestRequestHeaderMapImpl request_headers{
@@ -105,15 +120,15 @@ TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2HeaderOnlyResponse) {
   Runtime::LoaderSingleton::getExisting()->mergeValues(
       {{"envoy.reloadable_features.grpc_bridge_stats_disabled", "false"}});
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   Http::TestResponseHeaderMapImpl continue_headers{{":status", "100"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encode1xxHeaders(continue_headers));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encode1xxHeaders(continue_headers));
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
-  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_.encodeMetadata(metadata_map));
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->encodeMetadata(metadata_map));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "1"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
   EXPECT_TRUE(
       stats_store_.findCounterByString("grpc.lyft.users.BadCompanions.GetBadCompanions.failure"));
   EXPECT_TRUE(
@@ -129,20 +144,21 @@ TEST_F(GrpcHttp1BridgeFilterTest, StatsHttp2HeaderOnlyResponse) {
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, Http2NormalResponse) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
 
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data, false));
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
   EXPECT_FALSE(
       stats_store_.findCounterByString("grpc.lyft.users.BadCompanions.GetBadCompanions.success"));
   EXPECT_FALSE(
@@ -150,18 +166,19 @@ TEST_F(GrpcHttp1BridgeFilterTest, Http2NormalResponse) {
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, Http2ContentTypeGrpcPlusProto) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
 
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc+proto"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
   EXPECT_FALSE(
       stats_store_.findCounterByString("grpc.lyft.users.BadCompanions.GetBadCompanions.success"));
   EXPECT_FALSE(
@@ -169,83 +186,134 @@ TEST_F(GrpcHttp1BridgeFilterTest, Http2ContentTypeGrpcPlusProto) {
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, NotHandlingHttp2) {
+  initialize();
   protocol_ = Http::Protocol::Http2;
 
   Http::TestRequestHeaderMapImpl request_headers{{"content-type", "application/foo"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data, false));
   Http::TestResponseTrailerMapImpl response_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
   EXPECT_EQ("200", response_headers.get_(":status"));
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, NotHandlingHttp1) {
+  initialize();
   Http::TestRequestHeaderMapImpl request_headers{{"content-type", "application/foo"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data, false));
   Http::TestResponseTrailerMapImpl response_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
   EXPECT_EQ("200", response_headers.get_(":status"));
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, HandlingNormalResponse) {
+  initialize();
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   Buffer::InstancePtr buffer(new Buffer::OwnedImpl("hello"));
   ON_CALL(encoder_callbacks_, encodingBuffer()).WillByDefault(Return(buffer.get()));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_.encodeHeaders(response_headers, false));
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.encodeData(data, false));
+            filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(data, false));
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
   EXPECT_EQ("200", response_headers.get_(":status"));
   EXPECT_EQ("5", response_headers.get_("content-length"));
   EXPECT_EQ("0", response_headers.get_("grpc-status"));
 }
 
 TEST_F(GrpcHttp1BridgeFilterTest, HandlingBadGrpcStatus) {
+  initialize();
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/grpc"},
       {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_.encodeHeaders(response_headers, false));
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.encodeData(data, false));
+            filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(data, false));
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "1"}, {"grpc-message", "foo"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
   EXPECT_EQ("503", response_headers.get_(":status"));
   EXPECT_EQ("0", response_headers.get_("content-length"));
   EXPECT_EQ("1", response_headers.get_("grpc-status"));
   EXPECT_EQ("foo", response_headers.get_("grpc-message"));
+}
+
+TEST_F(GrpcHttp1BridgeFilterTest, ProtobufNotUpgradedToGrpc) {
+  initialize();
+  Http::TestRequestHeaderMapImpl request_headers{{"content-type", "application/x-protobuf"},
+                                                 {":path", "/v1/spotify.Concat/Concat"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+  Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data, false));
+  Http::TestResponseTrailerMapImpl response_trailers{{"hello", "world"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
+  EXPECT_EQ("200", response_headers.get_(":status"));
+}
+
+TEST_F(GrpcHttp1BridgeFilterTest, ProtobufUpgradedToGrpc) {
+  initialize(true);
+  Http::TestRequestHeaderMapImpl request_headers{{"content-type", "application/x-protobuf"},
+                                                 {"content-length", "5"},
+                                                 {":path", "/v1/spotify.Concat/Concat"}};
+  Buffer::OwnedImpl data("hello");
+
+  EXPECT_CALL(decoder_callbacks_, clearRouteCache());
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc, request_headers.getContentTypeValue());
+  EXPECT_EQ("10",
+            request_headers.getContentLengthValue()); // original + Grpc::GRPC_FRAME_HEADER_SIZE
+
+  EXPECT_CALL(decoder_callbacks_,
+              addDecodedData(_, true)) // todo: find a better way of testing this
+      .WillOnce(Invoke(([&](Buffer::Instance& d, bool) { ASSERT_EQ(data.length(), d.length()); })));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
+  Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(data, false));
+  Http::TestResponseTrailerMapImpl response_trailers{{"hello", "world"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
+  EXPECT_EQ("200", response_headers.get_(":status"));
 }
 
 } // namespace

--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -1,7 +1,3 @@
-#include <limits>
-#include <memory>
-#include <string>
-
 #include "envoy/http/filter.h"
 
 #include "source/common/buffer/buffer_impl.h"


### PR DESCRIPTION
This is an implementation based on the discussion in #19198.

When application/x-protobuf is used the filter will prepend the payload with the gRPC header, as defined by the wire format. Before returning the response the frame is also trimmed. This functionality is behind a configuration setting.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: Medium
Testing: Unit tests
Docs Changes: WIP
Fixes #19198
