### PR TITLE
async_client: add the option to keep parent sampling status for child spans

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_authz_filter.rst
@@ -195,3 +195,7 @@ Runtime
 The fraction of requests for which the filter is enabled can be configured via the :ref:`runtime_key
 <envoy_v3_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` value of the :ref:`filter_enabled
 <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.filter_enabled>` field.
+
+Tracing
+-------
+The ext_authz span keeps the sampling status of the parent span, i.e. in the tracing backend we will either see both the parent span and the child ext_authz span, or none of them.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -15,6 +15,7 @@ Minor Behavior Changes
 * bandwidth_limit: added :ref:`response trailers <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_response_trailers>` when request or response delay are enforced.
 * bandwidth_limit: added :ref:`bandwidth limit stats <config_http_filters_bandwidth_limit>` *request_enforced* and *response_enforced*.
 * dns: now respecting the returned DNS TTL for resolved hosts, rather than always relying on the hard-coded :ref:`dns_refresh_rate. <envoy_v3_api_field_config.cluster.v3.Cluster.dns_refresh_rate>` This behavior can be temporarily reverted by setting the runtime guard ``envoy.reloadable_features.use_dns_ttl`` to false.
+* ext_authz: the ext_authz span was always getting sampled, even if the parent span was not; now the ext_authz span follows the parent's sampling status.
 * http: directly response with http status code 1xx isn't valid usecase, so the status code 1xx was refused by the :ref:`direct_response <envoy_v3_api_field_config.route.v3.Route.direct_response>` field.
 * http: envoy will now proxy 102 and 103 headers from upstream, though as with 100s only the first 1xx response headers will be sent. This behavioral change by can temporarily reverted by setting runtime guard ``envoy.reloadable_features.proxy_102_103`` to false.
 * http: usage of the experimental matching API is no longer guarded behind a feature flag, as the corresponding protobuf fields have been marked as WIP.
@@ -25,7 +26,6 @@ Minor Behavior Changes
 * router: take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries, and never send a value that's longer than the request timeout. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
 * stream_info: response code details with empty space characters (' ', '\t', '\f', '\v', '\n', '\r') is not accepted by the ``setResponseCodeDetails()`` API.
 * upstream: fixed a bug where auto_config didn't work for wrapped TLS sockets (e.g. if proxy proto were configured for TLS).
-* ext_authz: the ext_authz span was always getting sampled, even if the parent span was not; now the ext_authz span follows the parent's sampling status.
 
 Bug Fixes
 ---------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,6 +25,7 @@ Minor Behavior Changes
 * router: take elapsed time into account when setting the x-envoy-expected-rq-timeout-ms header for retries, and never send a value that's longer than the request timeout. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
 * stream_info: response code details with empty space characters (' ', '\t', '\f', '\v', '\n', '\r') is not accepted by the ``setResponseCodeDetails()`` API.
 * upstream: fixed a bug where auto_config didn't work for wrapped TLS sockets (e.g. if proxy proto were configured for TLS).
+* ext_authz: the ext_authz span was always getting sampled, even if the parent span was not; now the ext_authz span follows the parent's sampling status.
 
 Bug Fixes
 ---------

--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -295,7 +295,6 @@ public:
       return *this;
     }
     RequestOptions& setSampled(absl::optional<bool> sampled) {
-      sampled_.reset();
       sampled_ = sampled;
       return *this;
     }

--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -294,7 +294,7 @@ public:
       child_span_name_ = child_span_name;
       return *this;
     }
-    RequestOptions& setSampled(bool sampled) {
+    RequestOptions& setSampled(absl::optional<bool> sampled) {
       sampled_ = sampled;
       return *this;
     }

--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -295,6 +295,7 @@ public:
       return *this;
     }
     RequestOptions& setSampled(absl::optional<bool> sampled) {
+      sampled_.reset();
       sampled_ = sampled;
       return *this;
     }

--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -313,7 +313,7 @@ public:
     // Only used if parent_span_ is set.
     std::string child_span_name_{""};
     // Sampling decision for the tracing span. The span is sampled by default.
-    bool sampled_{true};
+    absl::optional<bool> sampled_{true};
   };
 
   /**

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -257,7 +257,7 @@ AsyncRequestImpl::AsyncRequestImpl(RequestMessagePtr&& request, AsyncClientImpl&
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }
   if (options.sampled_.has_value()) {
-    // Change span's sampling status; otherwise keep sampling status of the parent
+    // Change span's sampling status; otherwise keep sampling status of the parent.
     child_span_->setSampled(options.sampled_.value());
   }
 }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -256,8 +256,9 @@ AsyncRequestImpl::AsyncRequestImpl(RequestMessagePtr&& request, AsyncClientImpl&
   } else {
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }
+  // Span gets sampled by default, as sampled_ defaults to true.
+  // If caller overrides sampled_ with empty value, sampling status of the parent is kept.
   if (options.sampled_.has_value()) {
-    // Change span's sampling status; otherwise keep sampling status of the parent.
     child_span_->setSampled(options.sampled_.value());
   }
 }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -256,9 +256,9 @@ AsyncRequestImpl::AsyncRequestImpl(RequestMessagePtr&& request, AsyncClientImpl&
   } else {
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }
-  if (options.sampled_) {
-    // Force span to get sampled; otherwise keep sampling status of the parent
-    child_span_->setSampled(true);
+  if (options.sampled_.has_value()) {
+    // Change span's sampling status; otherwise keep sampling status of the parent
+    child_span_->setSampled(options.sampled_.value());
   }
 }
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -256,7 +256,10 @@ AsyncRequestImpl::AsyncRequestImpl(RequestMessagePtr&& request, AsyncClientImpl&
   } else {
     child_span_ = std::make_unique<Tracing::NullSpan>();
   }
-  child_span_->setSampled(options.sampled_);
+  if (options.sampled_) {
+    // Force span to get sampled; otherwise keep sampling status of the parent
+    child_span_->setSampled(true);
+  }
 }
 
 void AsyncRequestImpl::initialize() {

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -277,11 +277,12 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
     callbacks_->onComplete(std::make_unique<Response>(errorResponse()));
     callbacks_ = nullptr;
   } else {
+    // Do not enforce a sampling decision on this span; instead keep the parent's sampling status.
     auto options = Http::AsyncClient::RequestOptions()
                        .setTimeout(config_->timeout())
                        .setParentSpan(parent_span)
                        .setChildSpanName(config_->tracingName())
-                       .setSampled(absl::nullopt); // do not enforce a sampling decision and keep the parent's sampling.
+                       .setSampled(absl::nullopt);
 
     request_ = thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
   }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -281,7 +281,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
                        .setTimeout(config_->timeout())
                        .setParentSpan(parent_span)
                        .setChildSpanName(config_->tracingName())
-                       .setSampled(absl::nullopt);
+                       .setSampled(absl::nullopt); // do not enforce a sampling decision and keep the parent's sampling.
 
     request_ = thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
   }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -279,7 +279,8 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
     auto options = Http::AsyncClient::RequestOptions()
                        .setTimeout(config_->timeout())
                        .setParentSpan(parent_span)
-                       .setChildSpanName(config_->tracingName());
+                       .setChildSpanName(config_->tracingName())
+                       .setSampled(false);
 
     request_ = thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
   }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -13,6 +13,7 @@
 #include "source/common/runtime/runtime_features.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -280,7 +281,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
                        .setTimeout(config_->timeout())
                        .setParentSpan(parent_span)
                        .setChildSpanName(config_->tracingName())
-                       .setSampled(false);
+                       .setSampled(absl::nullopt);
 
     request_ = thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
   }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -274,7 +274,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
                                             .setParentSpan(parent_span_)
                                             .setChildSpanName(child_span_name_)
                                             .setSampled(false);
-  EXPECT_CALL(*child_span, setSampled(false));
+  EXPECT_CALL(*child_span, setSampled(_)).Times(0);
   EXPECT_CALL(*child_span, injectContext(_));
 
   auto* request = client_.send(std::move(message_), callbacks_, options);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -274,6 +274,56 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   AsyncClient::RequestOptions options = AsyncClient::RequestOptions()
                                             .setParentSpan(parent_span_)
                                             .setChildSpanName(child_span_name_)
+                                            .setSampled(false);
+  EXPECT_CALL(*child_span, setSampled(false));
+  EXPECT_CALL(*child_span, injectContext(_));
+
+  auto* request = client_.send(std::move(message_), callbacks_, options);
+  EXPECT_NE(request, nullptr);
+
+  expectSuccess(request, 200);
+
+  EXPECT_CALL(*child_span, setTag(Eq("onBeforeFinalizeUpstreamSpan"), Eq("called")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
+  EXPECT_CALL(*child_span, finishSpan());
+
+  ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
+  response_decoder_->decodeHeaders(std::move(response_headers), false);
+  response_decoder_->decodeData(data, true);
+}
+
+TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpanKeepParentSampling) {
+  Tracing::MockSpan* child_span{new Tracing::MockSpan()};
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
+
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseDecoder& decoder,
+                           ConnectionPool::Callbacks& callbacks) -> ConnectionPool::Cancellable* {
+        callbacks.onPoolReady(stream_encoder_, cm_.thread_local_cluster_.conn_pool_.host_,
+                              stream_info_, {});
+        response_decoder_ = &decoder;
+        return nullptr;
+      }));
+
+  TestRequestHeaderMapImpl copy(message_->headers());
+  copy.addCopy("x-envoy-internal", "true");
+  copy.addCopy("x-forwarded-for", "127.0.0.1");
+  copy.addCopy(":scheme", "http");
+
+  EXPECT_CALL(parent_span_, spawnChild_(_, child_span_name_, _)).WillOnce(Return(child_span));
+
+  AsyncClient::RequestOptions options = AsyncClient::RequestOptions()
+                                            .setParentSpan(parent_span_)
+                                            .setChildSpanName(child_span_name_)
                                             .setSampled(absl::nullopt);
   EXPECT_CALL(*child_span, setSampled(_)).Times(0);
   EXPECT_CALL(*child_span, injectContext(_));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -24,6 +24,7 @@
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/test_common/printers.h"
 
+#include "absl/types/optional.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -273,7 +274,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   AsyncClient::RequestOptions options = AsyncClient::RequestOptions()
                                             .setParentSpan(parent_span_)
                                             .setChildSpanName(child_span_name_)
-                                            .setSampled(false);
+                                            .setSampled(absl::nullopt);
   EXPECT_CALL(*child_span, setSampled(_)).Times(0);
   EXPECT_CALL(*child_span, injectContext(_));
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4781,7 +4781,7 @@ TEST_F(RouterTest, Shadow) {
         EXPECT_NE(request->body().length(), 0);
         EXPECT_NE(nullptr, request->trailers());
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
-        EXPECT_TRUE(options.sampled_);
+        EXPECT_TRUE(options.sampled_.value());
       }));
   EXPECT_CALL(*shadow_writer_, shadow_("fizz", _, _))
       .WillOnce(Invoke([](const std::string&, Http::RequestMessagePtr& request,
@@ -4789,7 +4789,7 @@ TEST_F(RouterTest, Shadow) {
         EXPECT_NE(request->body().length(), 0);
         EXPECT_NE(nullptr, request->trailers());
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
-        EXPECT_FALSE(options.sampled_);
+        EXPECT_FALSE(options.sampled_.value());
       }));
   router_.decodeTrailers(trailers);
   EXPECT_EQ(1U,


### PR DESCRIPTION
Commit Message: async_client: add the option to keep parent sampling status for child spans
Additional Description: ext authz requests always get traced, regardless of parent sampling status; this happens because the HTTP async client (used by ext authz) overrides the span's sampling status with `true`.
Risk Level: low
Testing: added a test case for keeping the parent's sampling status; built envoy and ran it with a config, confirming that authz spans keep the parent sampling status.
Docs Changes: Added
Release Notes: Added
Fixes #17085

Signed-off-by: Caroline Stere <stere@adobe.com>