### PR TITLE
docs: fix whitespace typo in transcoder documentation.

### DIFF
--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -153,8 +153,8 @@ message GrpcJsonTranscoder {
   //
   //     {"code":5,"details":[{"@type":"type.googleapis.com/google.rpc.RequestInfo","requestId":"r-1"}]}
   //
-  //  In order to transcode the message, the ``google.rpc.RequestInfo`` type from
-  //  the ``google/rpc/error_details.proto`` should be included in the configured
-  //  :ref:`proto descriptor set <config_grpc_json_generate_proto_descriptor_set>`.
+  // In order to transcode the message, the ``google.rpc.RequestInfo`` type from
+  // the ``google/rpc/error_details.proto`` should be included in the configured
+  // :ref:`proto descriptor set <config_grpc_json_generate_proto_descriptor_set>`.
   bool convert_grpc_status = 9;
 }

--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -206,9 +206,9 @@ message GrpcJsonTranscoder {
   //
   //     {"code":5,"details":[{"@type":"type.googleapis.com/google.rpc.RequestInfo","requestId":"r-1"}]}
   //
-  //  In order to transcode the message, the ``google.rpc.RequestInfo`` type from
-  //  the ``google/rpc/error_details.proto`` should be included in the configured
-  //  :ref:`proto descriptor set <config_grpc_json_generate_proto_descriptor_set>`.
+  // In order to transcode the message, the ``google.rpc.RequestInfo`` type from
+  // the ``google/rpc/error_details.proto`` should be included in the configured
+  // :ref:`proto descriptor set <config_grpc_json_generate_proto_descriptor_set>`.
   bool convert_grpc_status = 9;
 
   // URL unescaping policy.


### PR DESCRIPTION
The documentation for `convert_grpc_status` had two leading spaces in the text following a code block, causing the text to be rendered as part of the code block.

![image](https://user-images.githubusercontent.com/2805291/147422963-e8ff2699-df3f-4086-8f59-7baa4aae3c35.png)


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
