### PR TITLE
[fuzz] Fixing ext_proc_grpc fuzzer to pass clusterfuzz check_build

### DIFF
--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_fuzz_test",
     "envoy_package",
+    "envoy_proto_library",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -188,12 +189,18 @@ envoy_extension_cc_test_library(
     ],
 )
 
+envoy_proto_library(
+    name = "ext_proc_grpc_fuzz_proto",
+    srcs = ["ext_proc_grpc_fuzz.proto"],
+)
+
 envoy_cc_fuzz_test(
     name = "ext_proc_grpc_fuzz_test",
     srcs = ["ext_proc_grpc_fuzz.cc"],
     corpus = "ext_proc_grpc_corpus",
     deps = [
         ":ext_proc_grpc_fuzz_lib",
+        ":ext_proc_grpc_fuzz_proto_cc_proto",
         ":test_processor_lib",
         "//source/common/network:address_lib",
         "//source/extensions/filters/http/ext_proc:config",

--- a/test/extensions/filters/http/ext_proc/ext_proc_grpc_fuzz.proto
+++ b/test/extensions/filters/http/ext_proc/ext_proc_grpc_fuzz.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package test.extensions.filters.http.ext_proc;
+
+// Structured input for ext_proc_grpc_fuzz_test.
+message ExtProcGrpcTestCase {
+  bytes downstream_data = 1;
+  bytes ext_proc_data = 2;
+}


### PR DESCRIPTION
Commit Message: fuzz: Fixing ext_proc_grpc fuzzer to pass clusterfuzz check_build.
Additional Description:
Currently the fuzzer is not passing the `check_build` step of OSS-fuzz when running with empty input,
because it doesn't cover any code. This PR modifies the input from arbitrary buffer that is divided to 2 internal inputs,
into a proto-based input that has 2 `bytes` entries.

Risk Level: Low - fuzzer only
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
