### PR TITLE
[fuzz] Fixing path_utility fuzzer to pass clusterfuzz check_build

### DIFF
--- a/test/common/http/path_utility_fuzz_test.cc
+++ b/test/common/http/path_utility_fuzz_test.cc
@@ -15,6 +15,10 @@ DEFINE_PROTO_FUZZER(const test::common::http::PathUtilityTestCase& input) {
     return;
   }
 
+  // The following log is needed to pass the `check_build` tests of
+  // Cluster-Fuzz for empty inputs.
+  ENVOY_LOG_MISC(trace, "Input: {}", input.DebugString());
+
   switch (input.path_utility_selector_case()) {
   case test::common::http::PathUtilityTestCase::kCanonicalPath: {
     auto request_headers = fromHeaders<Http::TestRequestHeaderMapImpl>(


### PR DESCRIPTION
Commit Message: fuzz: Fixing path_utility fuzzer to pass clusterfuzz check_build.
Additional Description:
Currently the fuzzer is not passing the check_build step of OSS-fuzz when running with empty input,
because it doesn't cover any code. This PR adds an output to the log that is covers some of the Envoy code, and makes that step happy.

Risk Level: Low - fuzz code only
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
