### PR TITLE
cache: clean up string-array declaration to avoid temp std::string conversion during lookup, and eliminate warning

### DIFF
--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -138,8 +138,11 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
   // Sun, 06 Nov 1994 08:49:37 GMT    ; IMF-fixdate.
   // Sunday, 06-Nov-94 08:49:37 GMT   ; obsolete RFC 850 format.
   // Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format.
-  static const char* rfc7231_date_formats[] = {"%a, %d %b %Y %H:%M:%S GMT",
-                                               "%A, %d-%b-%y %H:%M:%S GMT", "%a %b %e %H:%M:%S %Y"};
+  static constexpr absl::string_view rfc7231_date_formats[] = {
+    "%a, %d %b %Y %H:%M:%S GMT",
+    "%A, %d-%b-%y %H:%M:%S GMT",
+    "%a %b %e %H:%M:%S %Y"
+  };
 
   for (absl::string_view format : rfc7231_date_formats) {
     if (absl::ParseTime(format, input, &time, nullptr)) {

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -130,7 +130,7 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
     return {};
   }
   absl::Time time;
-  const std::string input(header_entry->value().getStringView());
+  const absl::string_view input(header_entry->value().getStringView());
 
   // Acceptable Date/Time Formats per:
   // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
@@ -141,7 +141,7 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
   static const char* rfc7231_date_formats[] = {"%a, %d %b %Y %H:%M:%S GMT",
                                                "%A, %d-%b-%y %H:%M:%S GMT", "%a %b %e %H:%M:%S %Y"};
 
-  for (const std::string& format : rfc7231_date_formats) {
+  for (absl::string_view format : rfc7231_date_formats) {
     if (absl::ParseTime(format, input, &time, nullptr)) {
       return ToChronoTime(time);
     }

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -139,10 +139,7 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
   // Sunday, 06-Nov-94 08:49:37 GMT   ; obsolete RFC 850 format.
   // Sun Nov  6 08:49:37 1994         ; ANSI C's asctime() format.
   static constexpr absl::string_view rfc7231_date_formats[] = {
-    "%a, %d %b %Y %H:%M:%S GMT",
-    "%A, %d-%b-%y %H:%M:%S GMT",
-    "%a %b %e %H:%M:%S %Y"
-  };
+      "%a, %d %b %Y %H:%M:%S GMT", "%A, %d-%b-%y %H:%M:%S GMT", "%a %b %e %H:%M:%S %Y"};
 
   for (absl::string_view format : rfc7231_date_formats) {
     if (absl::ParseTime(format, input, &time, nullptr)) {


### PR DESCRIPTION
Commit Message: During compilation of Envoy this warning was found:
```
source/extensions/filters/http/cache/cache_headers_utils.cc: In function 'Envoy::SystemTime Envoy::Extensions::HttpFilters::Cache::CacheHeadersUtils::httpTime(const Envoy::Http::HeaderEntry*)':
source/extensions/filters/http/cache/cache_headers_utils.cc:144:27: error: loop variable 'format' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char*' [-Werror=range-loop-construct]
  144 |   for (const std::string& format : rfc7231_date_formats) {
      |                           ^~~~~~
source/extensions/filters/http/cache/cache_headers_utils.cc:144:27: note: use non-reference type 'const string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying
cc1plus: all warnings being treated as errors
```

To me it looks like the compiler is making pointless string temps here which can be eliminated by using string_view.
Additional Description:
Risk Level: low
Testing:  //test/extensions/filters/http/cache/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

