### PR TITLE
grpc stat: copy request path attributes instead of keeping them as a reference

### DIFF
--- a/source/common/grpc/context_impl.cc
+++ b/source/common/grpc/context_impl.cc
@@ -90,6 +90,9 @@ ContextImpl::resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) {
     return {};
   }
 
+  // service/method will live until the request is finished to emit resulting stats (e.g. request status)
+  // values in request_names_ might get changed, for example by routing rules (i.e. "prefix_rewrite"),
+  // so we copy them here to preserve the initial value and get a proper stat
   Stats::Element service = Stats::DynamicSavedName(request_names->service_);
   Stats::Element method = Stats::DynamicSavedName(request_names->method_);
   return RequestStatNames{service, method};

--- a/source/common/grpc/context_impl.cc
+++ b/source/common/grpc/context_impl.cc
@@ -90,9 +90,9 @@ ContextImpl::resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) {
     return {};
   }
 
-  // service/method will live until the request is finished to emit resulting stats (e.g. request status)
-  // values in request_names_ might get changed, for example by routing rules (i.e. "prefix_rewrite"),
-  // so we copy them here to preserve the initial value and get a proper stat
+  // service/method will live until the request is finished to emit resulting stats (e.g. request
+  // status) values in request_names_ might get changed, for example by routing rules (i.e.
+  // "prefix_rewrite"), so we copy them here to preserve the initial value and get a proper stat
   Stats::Element service = Stats::DynamicSavedName(request_names->service_);
   Stats::Element method = Stats::DynamicSavedName(request_names->method_);
   return RequestStatNames{service, method};

--- a/source/common/grpc/context_impl.cc
+++ b/source/common/grpc/context_impl.cc
@@ -85,12 +85,13 @@ void ContextImpl::chargeUpstreamStat(const Upstream::ClusterInfo& cluster,
 absl::optional<ContextImpl::RequestStatNames>
 ContextImpl::resolveDynamicServiceAndMethod(const Http::HeaderEntry* path) {
   absl::optional<Common::RequestNames> request_names = Common::resolveServiceAndMethod(path);
+
   if (!request_names) {
     return {};
   }
 
-  Stats::Element service = Stats::DynamicName(request_names->service_);
-  Stats::Element method = Stats::DynamicName(request_names->method_);
+  Stats::Element service = Stats::DynamicSavedName(request_names->service_);
+  Stats::Element method = Stats::DynamicSavedName(request_names->method_);
   return RequestStatNames{service, method};
 }
 

--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -52,7 +52,6 @@ struct ElementVisitor {
   // Overloads provides for absl::visit to call.
   void operator()(StatName stat_name) { stat_names_.push_back(stat_name); }
   void operator()(absl::string_view name) { stat_names_.push_back(pool_.add(name)); }
-  void operator()(const std::string& name) { stat_names_.push_back(pool_.add(name)); }
 
   /**
    * @return the StatName constructed by joining the elements.

--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -52,6 +52,7 @@ struct ElementVisitor {
   // Overloads provides for absl::visit to call.
   void operator()(StatName stat_name) { stat_names_.push_back(stat_name); }
   void operator()(absl::string_view name) { stat_names_.push_back(pool_.add(name)); }
+  void operator()(const std::string &name) { stat_names_.push_back(pool_.add(name)); }
 
   /**
    * @return the StatName constructed by joining the elements.

--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -52,7 +52,7 @@ struct ElementVisitor {
   // Overloads provides for absl::visit to call.
   void operator()(StatName stat_name) { stat_names_.push_back(stat_name); }
   void operator()(absl::string_view name) { stat_names_.push_back(pool_.add(name)); }
-  void operator()(const std::string &name) { stat_names_.push_back(pool_.add(name)); }
+  void operator()(const std::string& name) { stat_names_.push_back(pool_.add(name)); }
 
   /**
    * @return the StatName constructed by joining the elements.

--- a/source/common/stats/utility.h
+++ b/source/common/stats/utility.h
@@ -44,8 +44,7 @@ class DynamicSavedName : public std::string {
 public:
   // This is intentionally left as an implicit conversion from string_view to
   // make call-sites easier to read, e.g.
-  //    Utility::counterFromElements(*scope, {DynamicName("a"), DynamicName("b")});
-  explicit DynamicSavedName(const std::string& str) : std::string(str) {}
+  //    Utility::counterFromElements(*scope, {DynamicSavedName("a"), DynamicSavedName("b")});
   explicit DynamicSavedName(absl::string_view str) : std::string(str.begin(), str.end()) {}
 };
 

--- a/source/common/stats/utility.h
+++ b/source/common/stats/utility.h
@@ -31,6 +31,25 @@ public:
 };
 
 /**
+ * Represents a dynamically created stat name token based on std::string.
+ * This class wrapper is used in the 'Element' variant so that call-sites
+ * can express explicit intent to create dynamic stat names, which are more
+ * expensive than symbolic stat names. We use dynamic stat names only for
+ * building stats based on names discovered in the line of a request.
+ *
+ * Specifically, this class should be used only when the content of the string
+ * can be changed between the object creation and usage.
+ */
+class DynamicSavedName : public std::string {
+public:
+  // This is intentionally left as an implicit conversion from string_view to
+  // make call-sites easier to read, e.g.
+  //    Utility::counterFromElements(*scope, {DynamicName("a"), DynamicName("b")});
+  explicit DynamicSavedName(const std::string &str) : std::string(str) {}
+  explicit DynamicSavedName(absl::string_view str) : std::string(str.begin(), str.end()) {}
+};
+
+/**
  * Holds either a symbolic StatName or a dynamic string, for the purpose of
  * composing a vector to pass to Utility::counterFromElements, etc. This is
  * a programming convenience to create joined stat names. It is easier to
@@ -38,7 +57,7 @@ public:
  * hide the memory management of the joined storage, and they allow easier
  * co-mingling of symbolic and dynamic stat-name components.
  */
-using Element = absl::variant<StatName, DynamicName>;
+using Element = absl::variant<StatName, DynamicName, DynamicSavedName>;
 using ElementVec = absl::InlinedVector<Element, 8>;
 
 /**

--- a/source/common/stats/utility.h
+++ b/source/common/stats/utility.h
@@ -45,7 +45,7 @@ public:
   // This is intentionally left as an implicit conversion from string_view to
   // make call-sites easier to read, e.g.
   //    Utility::counterFromElements(*scope, {DynamicName("a"), DynamicName("b")});
-  explicit DynamicSavedName(const std::string &str) : std::string(str) {}
+  explicit DynamicSavedName(const std::string& str) : std::string(str) {}
   explicit DynamicSavedName(absl::string_view str) : std::string(str.begin(), str.end()) {}
 };
 

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -88,7 +88,7 @@ TEST(GrpcContextTest, ResolveServiceAndMethod) {
   EXPECT_FALSE(context.resolveDynamicServiceAndMethod(path));
 }
 
-TEST(GrpcContextTest, ResolveServiceAndMethodNotChanged) {
+TEST(GrpcContextTest, ResolvedServiceAndMethodOutliveChangesInRequestNames) {
   Http::TestRequestHeaderMapImpl headers;
   headers.setPath("/service_name/method_name?a=b");
   const Http::HeaderEntry* path = headers.Path();

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -7,6 +7,7 @@
 #include "source/common/http/utility.h"
 #include "source/common/stats/symbol_table_impl.h"
 
+#include "source/common/stats/utility.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/global.h"
 #include "test/test_common/utility.h"
@@ -73,8 +74,8 @@ TEST(GrpcContextTest, ResolveServiceAndMethod) {
   absl::optional<Context::RequestStatNames> request_names =
       context.resolveDynamicServiceAndMethod(path);
   EXPECT_TRUE(request_names);
-  EXPECT_EQ("service_name", absl::get<Stats::DynamicName>(request_names->service_));
-  EXPECT_EQ("method_name", absl::get<Stats::DynamicName>(request_names->method_));
+  EXPECT_EQ("service_name", absl::get<Stats::DynamicSavedName>(request_names->service_));
+  EXPECT_EQ("method_name", absl::get<Stats::DynamicSavedName>(request_names->method_));
   headers.setPath("");
   EXPECT_FALSE(context.resolveDynamicServiceAndMethod(path));
   headers.setPath("/");
@@ -85,6 +86,29 @@ TEST(GrpcContextTest, ResolveServiceAndMethod) {
   EXPECT_FALSE(context.resolveDynamicServiceAndMethod(path));
   headers.setPath("/service_name/");
   EXPECT_FALSE(context.resolveDynamicServiceAndMethod(path));
+}
+
+TEST(GrpcContextTest, ResolveServiceAndMethodNotChanged) {
+  Http::TestRequestHeaderMapImpl headers;
+  headers.setPath("/service_name/method_name?a=b");
+  const Http::HeaderEntry* path = headers.Path();
+  Stats::TestUtil::TestSymbolTable symbol_table;
+  ContextImpl context(*symbol_table);
+
+  auto request_names = context.resolveDynamicServiceAndMethod(path);
+
+  EXPECT_TRUE(request_names);
+  EXPECT_EQ("service_name", absl::get<Stats::DynamicSavedName>(request_names->service_));
+  EXPECT_EQ("method_name", absl::get<Stats::DynamicSavedName>(request_names->method_));
+
+  headers.setPath("/service_name1/method1");
+  // old values stay the same
+  EXPECT_EQ("service_name", absl::get<Stats::DynamicSavedName>(request_names->service_));
+  EXPECT_EQ("method_name", absl::get<Stats::DynamicSavedName>(request_names->method_));
+
+  auto new_request_names = context.resolveDynamicServiceAndMethod(path);
+  EXPECT_EQ("service_name1", absl::get<Stats::DynamicSavedName>(new_request_names->service_));
+  EXPECT_EQ("method1", absl::get<Stats::DynamicSavedName>(new_request_names->method_));
 }
 
 } // namespace Grpc

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -6,8 +6,8 @@
 #include "source/common/http/message_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/stats/symbol_table_impl.h"
-
 #include "source/common/stats/utility.h"
+
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/global.h"
 #include "test/test_common/utility.h"

--- a/test/common/stats/utility_test.cc
+++ b/test/common/stats/utility_test.cc
@@ -130,8 +130,8 @@ protected:
   template <class StatType> void storeAll(const MakeStatFn make_stat) {
     init(make_stat);
     EXPECT_TRUE(store_->iterate(iterAll<StatType>()));
-    EXPECT_THAT(results_,
-                UnorderedElementsAre("symbolic1", "dynamic1", "scope.symbolic2", "scope.dynamicsaved3", "scope.dynamic2"));
+    EXPECT_THAT(results_, UnorderedElementsAre("symbolic1", "dynamic1", "scope.symbolic2",
+                                               "scope.dynamicsaved3", "scope.dynamic2"));
   }
 
   template <class StatType> void scopeOnce(const MakeStatFn make_stat) {
@@ -153,7 +153,8 @@ protected:
   template <class StatType> void scopeAll(const MakeStatFn make_stat) {
     init(make_stat);
     EXPECT_TRUE(scope_->iterate(iterAll<StatType>()));
-    EXPECT_THAT(results_, UnorderedElementsAre("scope.symbolic2", "scope.dynamic2", "scope.dynamicsaved3"));
+    EXPECT_THAT(results_,
+                UnorderedElementsAre("scope.symbolic2", "scope.dynamic2", "scope.dynamicsaved3"));
   }
 
   SymbolTablePtr symbol_table_;

--- a/test/common/stats/utility_test.cc
+++ b/test/common/stats/utility_test.cc
@@ -58,6 +58,7 @@ protected:
     make_stat(*store_, {Stats::DynamicName("dynamic1")});
     make_stat(*scope_, {pool_.add("symbolic2")});
     make_stat(*scope_, {Stats::DynamicName("dynamic2")});
+    make_stat(*scope_, {Stats::DynamicSavedName("dynamicsaved3")});
   }
 
   template <class StatType> IterateFn<StatType> iterOnce() {
@@ -130,7 +131,7 @@ protected:
     init(make_stat);
     EXPECT_TRUE(store_->iterate(iterAll<StatType>()));
     EXPECT_THAT(results_,
-                UnorderedElementsAre("symbolic1", "dynamic1", "scope.symbolic2", "scope.dynamic2"));
+                UnorderedElementsAre("symbolic1", "dynamic1", "scope.symbolic2", "scope.dynamicsaved3", "scope.dynamic2"));
   }
 
   template <class StatType> void scopeOnce(const MakeStatFn make_stat) {
@@ -152,7 +153,7 @@ protected:
   template <class StatType> void scopeAll(const MakeStatFn make_stat) {
     init(make_stat);
     EXPECT_TRUE(scope_->iterate(iterAll<StatType>()));
-    EXPECT_THAT(results_, UnorderedElementsAre("scope.symbolic2", "scope.dynamic2"));
+    EXPECT_THAT(results_, UnorderedElementsAre("scope.symbolic2", "scope.dynamic2", "scope.dynamicsaved3"));
   }
 
   SymbolTablePtr symbol_table_;


### PR DESCRIPTION

Fixes #16715

The service/method attributes might be changed due to the routing config.

It looks safer to preserve them to be able able to get the
correct statistics once the request is over.

Signed-off-by: Mikhail Galanin <mikhail.galanin@team.bumble.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
