### PR TITLE
formatter: escape percent sign in response format

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -460,6 +460,15 @@ SubstitutionFormatParser::parse(const std::string& format,
       continue;
     }
 
+    // escape '%%'
+    if (format.length() > pos+1) {
+      if (format[pos+1] == '%') {
+        current_token += '%';
+        pos++;
+        continue;
+      }
+    }
+
     if (!current_token.empty()) {
       formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
       current_token = "";

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <regex>
 #include <string>
@@ -454,15 +455,15 @@ SubstitutionFormatParser::parse(const std::string& format,
   std::vector<FormatterProviderPtr> formatters;
   const std::regex command_w_args_regex(R"EOF(^%([A-Z]|[0-9]|_)+(\([^\)]*\))?(:[0-9]+)?(%))EOF");
 
-  for (size_t pos = 0; pos < format.length(); ++pos) {
+  for (size_t pos = 0; pos < format.size(); ++pos) {
     if (format[pos] != '%') {
       current_token += format[pos];
       continue;
     }
 
     // escape '%%'
-    if (format.length() > pos+1) {
-      if (format[pos+1] == '%') {
+    if (format.size() > pos + 1) {
+      if (format[pos + 1] == '%') {
         current_token += '%';
         pos++;
         continue;

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -3084,9 +3084,9 @@ TEST(SubstitutionFormatterTest, EscapingFormatParse) {
 
   auto providers = SubstitutionFormatParser::parse("%%");
 
-  EXPECT_EQ(providers.size(), 1);
+  ASSERT_EQ(providers.size(), 1);
   EXPECT_EQ("%", providers[0]->format(request_headers, response_headers, response_trailers,
-                                     stream_info, body));
+                                      stream_info, body));
 }
 
 TEST(SubstitutionFormatterTest, FormatterExtension) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -3017,8 +3017,7 @@ TEST(SubstitutionFormatterTest, ParserFailures) {
       "RESP(FIRST)%",
       "%REQ(valid)% %NOT_VALID%",
       "%REQ(FIRST?SECOND%",
-      "%%",
-      "%%HOSTNAME%PROTOCOL%",
+      "%HOSTNAME%PROTOCOL%",
       "%protocol%",
       "%REQ(TEST):%",
       "%REQ(TEST):3q4%",
@@ -3073,6 +3072,20 @@ TEST(SubstitutionFormatterTest, EmptyFormatParse) {
 
   EXPECT_EQ(providers.size(), 1);
   EXPECT_EQ("", providers[0]->format(request_headers, response_headers, response_trailers,
+                                     stream_info, body));
+}
+
+TEST(SubstitutionFormatterTest, EscapingFormatParse) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  std::string body;
+
+  auto providers = SubstitutionFormatParser::parse("%%");
+
+  EXPECT_EQ(providers.size(), 1);
+  EXPECT_EQ("%", providers[0]->format(request_headers, response_headers, response_trailers,
                                      stream_info, body));
 }
 


### PR DESCRIPTION
Add a case in the SubstitutionFormatter to replace '%%' with '%'. 
This allows users to escape % in their configurations, fixing #15159.

Signed-off-by: Aidan Hahn <aidanhahn@datawire.io>

Commit Message: formatter: escape percent sign in response format 
Additional Description:
Risk Level: Low
Testing: Unit testing
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes: #15159
