### PR TITLE
To fix missing url in best practices doc for RFC3986

### DIFF
--- a/docs/root/configuration/best_practices/edge.rst
+++ b/docs/root/configuration/best_practices/edge.rst
@@ -34,9 +34,9 @@ If Envoy is configured with RBAC filter or makes route selection based on URL pa
 
 Additionally the :ref:`path_with_escaped_slashes_action setting <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>` should be set according to following recommendations:
 
-* REJECT_REQUEST if dowstream clients are expected to use rfc3986 compliant normalized paths (i.e. gRPC clients).
+* REJECT_REQUEST if dowstream clients are expected to use `RFC 3986 <https://www.ietf.org/rfc/rfc3986.txt>`_ compliant normalized paths (i.e. gRPC clients).
 * UNESCAPE_AND_REDIRECT if downstream client supports HTTP redirect (i.e. a browser). This option minimizes possibility of path confusion by forcing request to be re-issued with the same path across all parties: downstream client, Envoy and upstream server. Note that gRPC requests will still be rejected with the INTERNAL (13) error code, as gRPC clients do not support redirect.
-* KEEP_UNCHANGED for servers that are not rfc3986 compliant and require encoded slashes.
+* KEEP_UNCHANGED for servers that are not `RFC 3986 <https://www.ietf.org/rfc/rfc3986.txt>`_ compliant and require encoded slashes.
 * UNESCAPE_AND_FORWARD for servers that are known to treat escaped and unescaped slashes equivalently. Choosing this option may increase probablity of path confusion vulnerabilities if intermediaries perform path based access control.
 
 The following is a YAML example of the above recommendation (taken from the :ref:`Google VRP


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: Missing url in best practices doc for RFC3986.
Additional Description: url path https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge
Docs Changes: Yes
