### PR TITLE
decompressor: add config flag to ignore no-transform

### DIFF
--- a/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
+++ b/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
@@ -26,8 +26,7 @@ message Decompressor {
     // filter will operate as a pass-through filter. If the message is unspecified, the filter will be enabled.
     config.core.v3.RuntimeFeatureFlag enabled = 1;
 
-    // If set to true, will decompress response even if a 'no-transform' cache control header is set.
-    // Defaults to false.
+    // If set to true, will decompress response even if a *no-transform* cache control header is set.
     bool ignore_no_transform_header = 2;
   }
 

--- a/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
+++ b/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
@@ -28,7 +28,7 @@ message Decompressor {
 
     // If set to true, will decompress response even if a 'no-transform' cache control header is set.
     // Defaults to false.
-    google.protobuf.BoolValue ignore_no_transform_header = 2;
+    bool ignore_no_transform_header = 2;
   }
 
   // Configuration for filter behavior on the request direction.

--- a/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
+++ b/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
@@ -25,6 +25,9 @@ message Decompressor {
     // Runtime flag that controls whether the filter is enabled for decompression or not. If set to false, the
     // filter will operate as a pass-through filter. If the message is unspecified, the filter will be enabled.
     config.core.v3.RuntimeFeatureFlag enabled = 1;
+    // If set to true, will decompress response even if a 'no-transform' cache control header is set.
+    // Defaults to false.
+    google.protobuf.BoolValue ignore_no_transform_header = 2;
   }
 
   // Configuration for filter behavior on the request direction.

--- a/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
+++ b/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
@@ -25,6 +25,7 @@ message Decompressor {
     // Runtime flag that controls whether the filter is enabled for decompression or not. If set to false, the
     // filter will operate as a pass-through filter. If the message is unspecified, the filter will be enabled.
     config.core.v3.RuntimeFeatureFlag enabled = 1;
+
     // If set to true, will decompress response even if a 'no-transform' cache control header is set.
     // Defaults to false.
     google.protobuf.BoolValue ignore_no_transform_header = 2;

--- a/docs/root/configuration/http/http_filters/decompressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/decompressor_filter.rst
@@ -39,7 +39,9 @@ By *default* decompression will be *skipped* when:
 - A request/response does NOT contain *content-encoding* header.
 - A request/response includes *content-encoding* header, but it does not contain the configured
   decompressor's content-encoding.
-- A request/response contains a *cache-control* header whose value includes "no-transform".
+- A request/response contains a *cache-control* header whose value includes "no-transform",
+  unless :ref:`ignore_no_transform_header <envoy_v3_api_msg_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>`
+  is set to *true*.
 
 When decompression is *applied*:
 

--- a/docs/root/configuration/http/http_filters/decompressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/decompressor_filter.rst
@@ -40,7 +40,7 @@ By *default* decompression will be *skipped* when:
 - A request/response includes *content-encoding* header, but it does not contain the configured
   decompressor's content-encoding.
 - A request/response contains a *cache-control* header whose value includes "no-transform",
-  unless :ref:`ignore_no_transform_header <envoy_v3_api_msg_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>`
+  unless :ref:`ignore_no_transform_header <envoy_v3_api_field_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>`
   is set to *true*.
 
 When decompression is *applied*:

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -70,6 +70,7 @@ New Features
 * bootstrap: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>` in the bootstrap to support DNS resolver as an extension.
 * cluster: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>` in the cluster to support DNS resolver as an extension.
 * config: added :ref:`environment_variable <envoy_v3_api_field_config.core.v3.datasource.environment_variable>` to the :ref:`DataSource <envoy_v3_api_msg_config.core.v3.datasource>`.
+* decompressor: added :ref:`ignore_no_transform_header <envoy_v3_api_msg_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>` to run decompression regardless of the value of the *no-transform* cache control header.
 * dns: added :ref:`ALL <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` option to return both IPv4 and IPv6 addresses.
 * dns_cache: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.typed_dns_resolver_config>` in the dns_cache to support DNS resolver as an extension.
 * dns_filter: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.typed_dns_resolver_config>` in the dns_filter to support DNS resolver as an extension.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -70,7 +70,7 @@ New Features
 * bootstrap: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>` in the bootstrap to support DNS resolver as an extension.
 * cluster: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>` in the cluster to support DNS resolver as an extension.
 * config: added :ref:`environment_variable <envoy_v3_api_field_config.core.v3.datasource.environment_variable>` to the :ref:`DataSource <envoy_v3_api_msg_config.core.v3.datasource>`.
-* decompressor: added :ref:`ignore_no_transform_header <envoy_v3_api_msg_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>` to run decompression regardless of the value of the *no-transform* cache control header.
+* decompressor: added :ref:`ignore_no_transform_header <envoy_v3_api_field_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>` to run decompression regardless of the value of the *no-transform* cache control header.
 * dns: added :ref:`ALL <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` option to return both IPv4 and IPv6 addresses.
 * dns_cache: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.typed_dns_resolver_config>` in the dns_cache to support DNS resolver as an extension.
 * dns_filter: added :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.typed_dns_resolver_config>` in the dns_filter to support DNS resolver as an extension.

--- a/source/extensions/filters/http/decompressor/decompressor_filter.cc
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.cc
@@ -43,15 +43,15 @@ DecompressorFilterConfig::DirectionConfig::DirectionConfig(
     const std::string& stats_prefix, Stats::Scope& scope, Runtime::Loader& runtime)
     : stats_(generateStats(stats_prefix, scope)),
       decompression_enabled_(proto_config.enabled(), runtime),
-      ignore_no_transform_header_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, ignore_no_transform_header, false)) {}
+      ignore_no_transform_header_(proto_config.ignore_no_transform_header()) {}
 
 DecompressorFilterConfig::RequestDirectionConfig::RequestDirectionConfig(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor::RequestDirectionConfig&
         proto_config,
     const std::string& stats_prefix, Stats::Scope& scope, Runtime::Loader& runtime)
     : DirectionConfig(proto_config.common_config(), stats_prefix + "request.", scope, runtime),
-      advertise_accept_encoding_(proto_config.advertise_accept_encoding()) {}
+      advertise_accept_encoding_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, advertise_accept_encoding, true)) {}
 
 DecompressorFilterConfig::ResponseDirectionConfig::ResponseDirectionConfig(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor::ResponseDirectionConfig&

--- a/source/extensions/filters/http/decompressor/decompressor_filter.cc
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.cc
@@ -42,7 +42,9 @@ DecompressorFilterConfig::DirectionConfig::DirectionConfig(
         proto_config,
     const std::string& stats_prefix, Stats::Scope& scope, Runtime::Loader& runtime)
     : stats_(generateStats(stats_prefix, scope)),
-      decompression_enabled_(proto_config.enabled(), runtime) {}
+      decompression_enabled_(proto_config.enabled(), runtime),
+      ignore_no_transform_header_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, ignore_no_transform_header, false)) {}
 
 DecompressorFilterConfig::RequestDirectionConfig::RequestDirectionConfig(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor::RequestDirectionConfig&

--- a/source/extensions/filters/http/decompressor/decompressor_filter.cc
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.cc
@@ -51,8 +51,7 @@ DecompressorFilterConfig::RequestDirectionConfig::RequestDirectionConfig(
         proto_config,
     const std::string& stats_prefix, Stats::Scope& scope, Runtime::Loader& runtime)
     : DirectionConfig(proto_config.common_config(), stats_prefix + "request.", scope, runtime),
-      advertise_accept_encoding_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config, advertise_accept_encoding, true)) {}
+      advertise_accept_encoding_(proto_config.advertise_accept_encoding()) {}
 
 DecompressorFilterConfig::ResponseDirectionConfig::ResponseDirectionConfig(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor::ResponseDirectionConfig&

--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -167,7 +167,7 @@ private:
   maybeInitDecompress(const DecompressorFilterConfig::DirectionConfig& direction_config,
                       Compression::Decompressor::DecompressorPtr& decompressor,
                       Http::StreamFilterCallbacks& callbacks, HeaderType& headers) {
-    bool should_decompress =
+    const bool should_decompress =
         direction_config.decompressionEnabled() &&
         (!hasCacheControlNoTransform(headers) || direction_config.ignoreNoTransformHeader()) &&
         contentEncodingMatches(headers);

--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -47,6 +47,7 @@ public:
     virtual const std::string& logString() const PURE;
     const DecompressorStats& stats() const { return stats_; }
     bool decompressionEnabled() const { return decompression_enabled_.enabled(); }
+    bool ignoreNoTransformHeader() const { return ignore_no_transform_header_; }
 
   private:
     static DecompressorStats generateStats(const std::string& prefix, Stats::Scope& scope) {
@@ -55,6 +56,7 @@ public:
 
     const DecompressorStats stats_;
     const Runtime::FeatureFlag decompression_enabled_;
+    const bool ignore_no_transform_header_;
   };
 
   class RequestDirectionConfig : public DirectionConfig {
@@ -165,8 +167,11 @@ private:
   maybeInitDecompress(const DecompressorFilterConfig::DirectionConfig& direction_config,
                       Compression::Decompressor::DecompressorPtr& decompressor,
                       Http::StreamFilterCallbacks& callbacks, HeaderType& headers) {
-    if (direction_config.decompressionEnabled() && !hasCacheControlNoTransform(headers) &&
-        contentEncodingMatches(headers)) {
+    // TODO(jpsim): Add unit tests for ignoreNoTransformHeader.
+    bool should_decompress = direction_config.decompressionEnabled() &&
+        (!hasCacheControlNoTransform(headers) || direction_config.ignoreNoTransformHeader()) &&
+        contentEncodingMatches(headers);
+    if (should_decompress) {
       direction_config.stats().decompressed_.inc();
       decompressor = config_->makeDecompressor();
 

--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -167,7 +167,6 @@ private:
   maybeInitDecompress(const DecompressorFilterConfig::DirectionConfig& direction_config,
                       Compression::Decompressor::DecompressorPtr& decompressor,
                       Http::StreamFilterCallbacks& callbacks, HeaderType& headers) {
-    // TODO(jpsim): Add unit tests for ignoreNoTransformHeader.
     bool should_decompress = direction_config.decompressionEnabled() &&
         (!hasCacheControlNoTransform(headers) || direction_config.ignoreNoTransformHeader()) &&
         contentEncodingMatches(headers);

--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -167,7 +167,8 @@ private:
   maybeInitDecompress(const DecompressorFilterConfig::DirectionConfig& direction_config,
                       Compression::Decompressor::DecompressorPtr& decompressor,
                       Http::StreamFilterCallbacks& callbacks, HeaderType& headers) {
-    bool should_decompress = direction_config.decompressionEnabled() &&
+    bool should_decompress =
+        direction_config.decompressionEnabled() &&
         (!hasCacheControlNoTransform(headers) || direction_config.ignoreNoTransformHeader()) &&
         contentEncodingMatches(headers);
     if (should_decompress) {

--- a/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
+++ b/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
@@ -391,6 +391,59 @@ response_direction_config:
   }
 }
 
+TEST_P(DecompressorFilterTest, DecompressionDisabledWhenNoTransformIsSet) {
+  EXPECT_CALL(*decompressor_factory_, createDecompressor(_)).Times(0);
+  Http::TestRequestHeaderMapImpl headers_before_filter{{"content-encoding", "mock, br , gzip "},
+                                                       {"content-length", "256"},
+                                                       {"cache-control", "no-transform"}};
+  std::unique_ptr<Http::RequestOrResponseHeaderMap> headers_after_filter =
+      doHeaders(headers_before_filter, false /* end_stream */);
+
+  if (isRequestDirection()) {
+    ASSERT_EQ(headers_after_filter->get(Http::LowerCaseString("accept-encoding"))[0]
+                  ->value()
+                  .getStringView(),
+              "mock");
+    // The request direction adds Accept-Encoding by default. Other than this header, the rest of
+    // the headers should be the same before and after the filter.
+    headers_after_filter->remove(Http::LowerCaseString("accept-encoding"));
+  }
+  EXPECT_THAT(headers_after_filter, HeaderMapEqualIgnoreOrder(&headers_before_filter));
+
+  expectNoDecompression();
+}
+
+TEST_P(DecompressorFilterTest, DecompressionEnabledWhenNoTransformAndIgnoreNoTransformHeaderAreSet) {
+  setUpFilter(R"EOF(
+decompressor_library:
+  typed_config:
+    "@type": "type.googleapis.com/envoy.extensions.compression.gzip.decompressor.v3.Gzip"
+response_direction_config:
+  common_config:
+    ignore_no_transform_header: true
+)EOF");
+
+  Http::TestRequestHeaderMapImpl headers_before_filter{{"content-encoding", "mock"},
+                                                       {"content-length", "256"},
+                                                       {"cache-control", "no-transform"}};
+  if (isRequestDirection()) {
+    EXPECT_CALL(*decompressor_factory_, createDecompressor(_)).Times(0);
+    std::unique_ptr<Http::RequestOrResponseHeaderMap> headers_after_filter =
+        doHeaders(headers_before_filter, false /* end_stream */);
+
+    // The request direction adds Accept-Encoding by default. Other than this header, the rest of
+    // the headers should be the same before and after the filter.
+    headers_after_filter->remove(Http::LowerCaseString("accept-encoding"));
+    EXPECT_THAT(headers_after_filter, HeaderMapEqualIgnoreOrder(&headers_before_filter));
+
+    expectNoDecompression();
+  } else {
+    decompressionActive(headers_before_filter, true /* end_with_data */,
+                        absl::nullopt /* expected_content_encoding*/,
+                        "mock" /* expected_accept_encoding */);
+  }
+}
+
 TEST_P(DecompressorFilterTest, NoDecompressionHeadersOnly) {
   EXPECT_CALL(*decompressor_factory_, createDecompressor(_)).Times(0);
   Http::TestRequestHeaderMapImpl headers_before_filter;

--- a/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
+++ b/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
@@ -413,7 +413,8 @@ TEST_P(DecompressorFilterTest, DecompressionDisabledWhenNoTransformIsSet) {
   expectNoDecompression();
 }
 
-TEST_P(DecompressorFilterTest, DecompressionEnabledWhenNoTransformAndIgnoreNoTransformHeaderAreSet) {
+TEST_P(DecompressorFilterTest,
+       DecompressionEnabledWhenNoTransformAndIgnoreNoTransformHeaderAreSet) {
   setUpFilter(R"EOF(
 decompressor_library:
   typed_config:
@@ -423,9 +424,8 @@ response_direction_config:
     ignore_no_transform_header: true
 )EOF");
 
-  Http::TestRequestHeaderMapImpl headers_before_filter{{"content-encoding", "mock"},
-                                                       {"content-length", "256"},
-                                                       {"cache-control", "no-transform"}};
+  Http::TestRequestHeaderMapImpl headers_before_filter{
+      {"content-encoding", "mock"}, {"content-length", "256"}, {"cache-control", "no-transform"}};
   if (isRequestDirection()) {
     EXPECT_CALL(*decompressor_factory_, createDecompressor(_)).Times(0);
     std::unique_ptr<Http::RequestOrResponseHeaderMap> headers_after_filter =


### PR DESCRIPTION
Commit Message: Add config flag to decompress even when no-transform is specified
Additional Description: This allows matching the more lenient behavior of other client-side networking libraries such as OkHttp or URLSession, especially in cases where the remote server is not under the client developer's control.
Risk Level: Low, defaults are unaffected, change is opt-in.
Testing: Added unit tests for existing `no-transform` behavior (there was none) and a new test validating the new configuration flag.
Docs Changes: Updated.
Release Notes: Added.
Platform Specific Features: