### PR TITLE
fix: remove extra symbols in comments

### DIFF
--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -168,7 +168,7 @@ public:
   }
 
   /**
-   * @return the number of bytes available to be reserve()d.
+   * @return the number of bytes available to be reserved.
    * @note Read-only implementations of Slice should return zero from this method.
    */
   uint64_t reservableSize() const {


### PR DESCRIPTION
minor fix to the  extra symbols in comments