### PR TITLE
Add factory context arg to http cache factory

### DIFF
--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -22,7 +22,7 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
           http_cache_factory](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
                                                             context.timeSource(),
-                                                            http_cache_factory->getCache(config)));
+                                                            http_cache_factory->getCache(config, context)));
   };
 }
 

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -20,9 +20,9 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
 
   return [config, stats_prefix, &context,
           http_cache_factory](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
-                                                            context.timeSource(),
-                                                            http_cache_factory->getCache(config, context)));
+    callbacks.addStreamFilter(
+        std::make_shared<CacheFilter>(config, stats_prefix, context.scope(), context.timeSource(),
+                                      http_cache_factory->getCache(config, context)));
   };
 }
 

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -5,11 +5,11 @@
 #include <vector>
 
 #include "envoy/buffer/buffer.h"
-#include "envoy/server/factory_context.h"
 #include "envoy/common/time.h"
 #include "envoy/config/typed_config.h"
 #include "envoy/extensions/filters/http/cache/v3/cache.pb.h"
 #include "envoy/http/header_map.h"
+#include "envoy/server/factory_context.h"
 
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
@@ -373,7 +373,7 @@ public:
   // Pass factory context to allow HttpCache to use async client, stats scope
   // etc.
   virtual HttpCache&
-  getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config, 
+  getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
            Server::Configuration::FactoryContext& context) PURE;
   ~HttpCacheFactory() override = default;
 

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/common/time.h"
 #include "envoy/config/typed_config.h"
 #include "envoy/extensions/filters/http/cache/v3/cache.pb.h"
@@ -369,7 +370,8 @@ public:
   // Returns an HttpCache that will remain valid indefinitely (at least as long
   // as the calling CacheFilter).
   virtual HttpCache&
-  getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config) PURE;
+  getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config, 
+           Server::Configuration::FactoryContext& context) PURE;
   ~HttpCacheFactory() override = default;
 
 private:

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -369,6 +369,9 @@ public:
 
   // Returns an HttpCache that will remain valid indefinitely (at least as long
   // as the calling CacheFilter).
+  //
+  // Pass factory context to allow HttpCache to use async client, stats scope
+  // etc.
   virtual HttpCache&
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config, 
            Server::Configuration::FactoryContext& context) PURE;

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -294,7 +294,8 @@ public:
         envoy::extensions::cache::simple_http_cache::v3::SimpleHttpCacheConfig>();
   }
   // From HttpCacheFactory
-  HttpCache& getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig&) override {
+  HttpCache& getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig&,
+                      Server::Configuration::FactoryContext&) override {
     return cache_;
   }
 

--- a/test/extensions/filters/http/cache/simple_http_cache/BUILD
+++ b/test/extensions/filters/http/cache/simple_http_cache/BUILD
@@ -17,5 +17,6 @@ envoy_extension_cc_test(
         "//test/extensions/filters/http/cache:common",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
+        "//test/mocks/server:factory_context_mocks",
     ],
 )

--- a/test/extensions/filters/http/cache/simple_http_cache/BUILD
+++ b/test/extensions/filters/http/cache/simple_http_cache/BUILD
@@ -15,8 +15,8 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/cache/simple_http_cache:config",
         "//test/extensions/filters/http/cache:common",
+        "//test/mocks/server:factory_context_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
-        "//test/mocks/server:factory_context_mocks",
     ],
 )

--- a/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -8,6 +8,7 @@
 #include "test/extensions/filters/http/cache/common.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
+#include "test/mocks/server/factory_context.h"
 
 #include "gtest/gtest.h"
 
@@ -275,8 +276,9 @@ TEST(Registration, GetFactory) {
       "envoy.extensions.cache.simple_http_cache.v3.SimpleHttpCacheConfig");
   ASSERT_NE(factory, nullptr);
   envoy::extensions::filters::http::cache::v3::CacheConfig config;
+  testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   config.mutable_typed_config()->PackFrom(*factory->createEmptyConfigProto());
-  EXPECT_EQ(factory->getCache(config).cacheInfo().name_, "envoy.extensions.http.cache.simple");
+  EXPECT_EQ(factory->getCache(config, factory_context).cacheInfo().name_, "envoy.extensions.http.cache.simple");
 }
 
 TEST_F(SimpleHttpCacheTest, VaryResponses) {

--- a/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -6,9 +6,9 @@
 #include "source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h"
 
 #include "test/extensions/filters/http/cache/common.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
-#include "test/mocks/server/factory_context.h"
 
 #include "gtest/gtest.h"
 
@@ -278,7 +278,8 @@ TEST(Registration, GetFactory) {
   envoy::extensions::filters::http::cache::v3::CacheConfig config;
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   config.mutable_typed_config()->PackFrom(*factory->createEmptyConfigProto());
-  EXPECT_EQ(factory->getCache(config, factory_context).cacheInfo().name_, "envoy.extensions.http.cache.simple");
+  EXPECT_EQ(factory->getCache(config, factory_context).cacheInfo().name_,
+            "envoy.extensions.http.cache.simple");
 }
 
 TEST_F(SimpleHttpCacheTest, VaryResponses) {


### PR DESCRIPTION

Commit Message: Add factory context arg to http cache factory
Additional Description: Http Cache factory needs access to factory context to bootstrap async clients, and child stats scopes.
Risk Level: L
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
