### PR TITLE
quic: mention about monitored stats and best practice 

### DIFF
--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -36,6 +36,10 @@ use BPF on Linux by default if multiple worker threads are configured, but may r
 sudo-with-permissions (e.g. sudo setcap cap_bpf+ep). If multiple worker threads are configured, Envoy will
 log a warning on start-up if BPF is unsupported on the platform, or is attempted and fails.
 
+It is recommanded to monitor some UDP listener and QUIC connection stats:
+* :ref:`UDP listener downstream_rx_datagram_dropped </docs/root/configuration/listeners/stats.rst#udp-statistics>`: non-zero means kernel's UDP listen socket's receive buffer isn't large enough. In Linux, it can be configured via listener :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>` by setting prebinding socket option SO_RCVBUF at SOL_SOCKET level.
+* :ref:`QUIC connection error codes and stream reset error codes </docs/root/configuration/http/http_conn_man/stats.rst#http3-per-listener-statistics>`: please refer to :refer:`quic_error_codes.h <https://github.com/google/quiche/blob/main/quic/core/quic_error_codes.h>` for the meaning of each error codes.
+
 HTTP3 upstream
 --------------
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -732,11 +732,11 @@ Api::IoErrorPtr Utility::readPacketsFromSocket(IoHandle& handle,
               ? (packets_dropped - old_packets_dropped)
               : (packets_dropped + (std::numeric_limits<uint32_t>::max() - old_packets_dropped) +
                  1);
-      ENVOY_LOG_MISC(
-          debug,
-          "Kernel dropped {} datagram(s). Consider increasing receive buffer size and/or "
-          "max datagram size.",
-          delta);
+      ENVOY_BUG(false,
+                fmt::format(
+                    "Kernel dropped {} datagram(s). Consider increasing receive buffer size and/or "
+                    "max datagram size.",
+                    delta));
       udp_packet_processor.onDatagramsDropped(delta);
     }
     if (honor_read_limit) {


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message:  Mention some QUIC stats in h3 document which can be helpful for debugging. 
Additional Description: Convert debugging log about packet dropped in kernel to ENVOY_BUG and mention about SO_RCVBUF.

Risk Level: low
Testing: log-only change
Docs Changes: docs/root/intro/arch_overview/http/http3.rst 
Release Notes: N/A
Platform Specific Features: N/A
