### PR TITLE
IoHandle: simplify interfaceName()

### DIFF
--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -608,17 +608,10 @@ absl::optional<std::string> IoSocketHandleImpl::interfaceName() {
     if (socket_address->ip()->version() == interface_address.interface_addr_->ip()->version()) {
       // Compare address _without port_.
       // TODO: create common addressAsStringWithoutPort method to simplify code here.
-      absl::uint128 interface_address_value;
-      switch (interface_address.interface_addr_->ip()->version()) {
-      case Address::IpVersion::v4:
-        interface_address_value = interface_address.interface_addr_->ip()->ipv4()->address();
-        break;
-      case Address::IpVersion::v6:
-        interface_address_value = interface_address.interface_addr_->ip()->ipv6()->address();
-        break;
-      default:
-        NOT_REACHED_GCOVR_EXCL_LINE;
-      }
+      absl::uint128 interface_address_value =
+          interface_address.interface_addr_->ip()->version() == Address::IpVersion::v4
+              ? interface_address.interface_addr_->ip()->ipv4()->address()
+              : interface_address.interface_addr_->ip()->ipv6()->address();
 
       if (socket_address_value == interface_address_value) {
         selected_interface_name = interface_address.interface_name_;


### PR DESCRIPTION
Was reading through #18531 and seeing the socket address being looked
up for each interface confused me a bit, so let's do it only once.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
