### PR TITLE
bazel: Add python `envoy_entry_point`

### DIFF
--- a/tools/base/entry_point.py
+++ b/tools/base/entry_point.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+
+
+def main(*args):
+    subprocess.run(args)
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/tools/base/entry_point.py
+++ b/tools/base/entry_point.py
@@ -2,9 +2,12 @@ import subprocess
 import sys
 
 
-def main(*args):
-    subprocess.run(args)
+def main(*args) -> int:
+    try:
+        return subprocess.run(args).returncode
+    except KeyboardInterrupt:
+        return 1
 
 
 if __name__ == "__main__":
-    main(*sys.argv[1:])
+    sys.exit(main(*sys.argv[1:]))

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -1,4 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@base_pip3//:requirements.bzl", base_entry_point = "entry_point")
 
 def envoy_py_test(name, package, visibility, envoy_prefix = "@envoy"):
     filepath = "$(location %s//tools/testing:base_pytest_runner.py)" % envoy_prefix
@@ -71,3 +72,28 @@ def envoy_py_binary(
 
     if test:
         envoy_py_test(name, package, visibility, envoy_prefix = envoy_prefix)
+
+def envoy_entry_point(
+        name,
+        pkg,
+        main = "//tools/base:entry_point.py",
+        entry_point = base_entry_point,
+        script = None,
+        data = None,
+        args = None):
+    script = script or pkg
+    entry_point_name = "%s_entry_point" % name
+    native.alias(
+        name = entry_point_name,
+        actual = entry_point(
+            pkg = pkg,
+            script = script,
+        ),
+    )
+    py_binary(
+        name = name,
+        srcs = [main],
+        main = main,
+        args = ["$(location %s)" % entry_point_name] + args,
+        data = [entry_point_name] + data,
+    )

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -81,6 +81,22 @@ def envoy_entry_point(
         script = None,
         data = None,
         args = None):
+    """This macro provides the convenience of using an `entry_point` while
+    also being able to create a rule with associated `args` and `data`, as is
+    possible with the normal `py_binary` rule.
+
+    We may wish to remove this macro should https://github.com/bazelbuild/rules_python/issues/600
+    be resolved.
+
+    The `script` and `pkg` args are passed directly to the `entry_point`.
+
+    By default, the pip `entry_point` from `@base_pip3` is used. You can provide
+    a custom `entry_point` if eg you want to provide an `entry_point` with dev
+    requirements, or from some other requirements set.
+
+    A `py_binary` is dynamically created to wrap the `entry_point` with provided
+    `args` and `data`.
+    """
     script = script or pkg
     entry_point_name = "%s_entry_point" % name
     native.alias(


### PR DESCRIPTION
This extends the `rules_python` `entry_point` to allow data to be
added to the sandbox, and args to pass the data to the tool.

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
