### PR TITLE
stats: set used-only bit and when updating text-readouts, and test it.

### DIFF
--- a/source/common/html/utility.cc
+++ b/source/common/html/utility.cc
@@ -7,7 +7,7 @@
 namespace Envoy {
 namespace Html {
 
-std::string Utility::sanitize(const std::string& text) {
+std::string Utility::sanitize(absl::string_view text) {
   return absl::StrReplaceAll(
       text, {{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}, {"\"", "&quot;"}, {"'", "&#39;"}});
 }

--- a/source/common/html/utility.h
+++ b/source/common/html/utility.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Html {
 
@@ -14,7 +16,7 @@ public:
    * Sanitizes arbitrary text so it can be included in HTML.
    * @param text arbitrary text to be escaped for safe inclusion in HTML.
    */
-  static std::string sanitize(const std::string& text);
+  static std::string sanitize(absl::string_view text);
 };
 
 } // namespace Html

--- a/source/common/stats/allocator_impl.cc
+++ b/source/common/stats/allocator_impl.cc
@@ -271,6 +271,7 @@ public:
     std::string value_copy(value);
     absl::MutexLock lock(&mutex_);
     value_ = std::move(value_copy);
+    flags_ |= Flags::Used;
   }
   std::string value() const override {
     absl::MutexLock lock(&mutex_);


### PR DESCRIPTION
Commit Message: Text-readout stats were not setting their 'Used' bit, so `?usedonly` omitted all text-readouts. This PR sets the bit and adds a unit test for that. It also switches an html util that previously took a `const std::string&` to take an `absl::string_view` intead.
Additional Description:
Risk Level: low
Testing: Just the new test, plus //test/common/html/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
