### PR TITLE
tools: not warning about deprecated declarations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,7 @@ common --experimental_allow_tags_propagation
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fPIC
+build:linux --copt=-Wno-deprecated-declarations
 build:linux --cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
@@ -41,7 +42,6 @@ build --action_env=CC
 build --action_env=CXX
 build --action_env=LLVM_CONFIG
 build --action_env=PATH
-build --copt=-Wno-deprecated-declarations
 
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled

--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,7 @@ build --action_env=CC
 build --action_env=CXX
 build --action_env=LLVM_CONFIG
 build --action_env=PATH
+build --copt=-Wno-deprecated-declarations
 
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled

--- a/test/integration/filters/add_body_filter.proto
+++ b/test/integration/filters/add_body_filter.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package test.integration.filters;
 
-import "validate/validate.proto";
-
 message AddBodyFilterConfig {
   enum FilterCallback {
     DEFAULT = 0;

--- a/test/integration/filters/crash_filter.proto
+++ b/test/integration/filters/crash_filter.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package test.integration.filters;
 
-import "validate/validate.proto";
-
 message CrashFilterConfig {
   bool crash_in_encode_headers = 1;
   bool crash_in_encode_data = 2;

--- a/test/integration/filters/set_is_terminal_filter_config.proto
+++ b/test/integration/filters/set_is_terminal_filter_config.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package test.integration.filters;
 
-import "validate/validate.proto";
-
 message SetIsTerminalFilterConfig {
   bool is_terminal_filter = 1;
 }

--- a/test/integration/filters/stop_and_continue_filter_config.proto
+++ b/test/integration/filters/stop_and_continue_filter_config.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package test.integration.filters;
 
-import "validate/validate.proto";
-
 message StopAndContinueConfig {
   // Whether the filter should add tracked object itself to the dispatcher when
   // created.


### PR DESCRIPTION
Also removing a couple of unnecessary validate.proto files.
This removes several thousands of lines worth of warnings from our build logs.