### PR TITLE
quic: plumb allow extended connect config

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -542,8 +542,9 @@ message Http3ProtocolOptions {
   // <https://datatracker.ietf.org/doc/html/rfc8441>`_
   // and settings `proposed for HTTP/3
   // <https://datatracker.ietf.org/doc/draft-ietf-httpbis-h3-websockets/>`_
-  // Note that HTTP/3 CONNECT is not yet an RFC.
-  bool allow_extended_connect = 5 [(xds.annotations.v3.field_status).work_in_progress = true];
+  //
+  // If absent, extended CONNECT is disallowed by default.
+  bool allow_extended_connect = 5;
 }
 
 // A message to control transformations to the :scheme header

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -391,8 +391,7 @@ message FilterStateRule {
 
   // A map of string keys to requirements. The string key is the string value
   // in the FilterState with the name specified in the *name* field above.
-  map<string, JwtRequirement>
-  requires = 3;
+  map<string, JwtRequirement> requires = 3;
 }
 
 // This is the Envoy HTTP filter config for JWT authentication.

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -583,8 +583,7 @@ message FilterStateRule {
 
   // A map of string keys to requirements. The string key is the string value
   // in the FilterState with the name specified in the *name* field above.
-  map<string, JwtRequirement>
-  requires = 3;
+  map<string, JwtRequirement> requires = 3;
 }
 
 // This is the Envoy HTTP filter config for JWT authentication.

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -171,6 +171,7 @@ void EnvoyQuicServerSession::setHttp3Options(
           quic::QuicTime::Delta::FromMilliseconds(initial_interval));
     }
   }
+  set_allow_extended_connect(http3_options_->allow_extended_connect());
 }
 
 void EnvoyQuicServerSession::storeConnectionMapPosition(FilterChainToConnectionMap& connection_map,

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -35,8 +35,6 @@ EnvoyQuicServerStream::EnvoyQuicServerStream(
       headers_with_underscores_action_(headers_with_underscores_action) {
   ASSERT(static_cast<uint32_t>(GetReceiveWindow().value()) > 8 * 1024,
          "Send buffer limit should be larger than 8KB.");
-  // TODO(alyssawilk, danzh) if http3_options_.allow_extended_connect() is true,
-  // send the correct SETTINGS.
 }
 
 void EnvoyQuicServerStream::encode1xxHeaders(const Http::ResponseHeaderMap& headers) {
@@ -160,7 +158,7 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
   }
   if (Http::HeaderUtility::requestHeadersValid(*headers) != absl::nullopt ||
       Http::HeaderUtility::checkRequiredRequestHeaders(*headers) != Http::okStatus() ||
-      (headers->Protocol() && !http3_options_.allow_extended_connect())) {
+      (headers->Protocol() && !spdy_session()->allow_extended_connect())) {
     details_ = Http3ResponseCodeDetailValues::invalid_http_header;
     onStreamError(absl::nullopt);
     return;

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -221,7 +221,6 @@ public:
       cluster->http3_options_ = ConfigHelper::http2ToHttp3ProtocolOptions(
           http2_options.value(), quic::kStreamReceiveWindowLimit);
     }
-    cluster->http3_options_.set_allow_extended_connect(true);
     *cluster->http3_options_.mutable_quic_protocol_options() = client_quic_options_;
     Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
         cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)),


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: make QUICHE HTTP/3 extended CONNECT configurable via `Http3ProtocolOptions::allow_extended_connect`. Currently QUICHE has it enabled by default.

Risk Level: low
Testing: added ExtendedConnectIsBlocked integration test, and existing tcp_tunneling_integration_test.cc passes
Docs Changes: Remove WAI on `allow_extended_connect`
Release Notes: N/A
Platform Specific Features: N/A

