### PR TITLE
quic: use oghttp2 header validator to validate request/response headers

### DIFF
--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -146,6 +146,7 @@ envoy_cc_library(
         "//envoy/event:dispatcher_interface",
         "//envoy/http:codec_interface",
         "//source/common/http:codec_helper_lib",
+        "@com_github_google_quiche//:http2_adapter",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -166,12 +166,6 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
   }
   const uint64_t status = optional_status.value();
   if (Http::CodeUtility::is1xx(status)) {
-    if (status == enumToInt(Http::Code::SwitchingProtocols)) {
-      // HTTP3 doesn't support the HTTP Upgrade mechanism or 101 (Switching Protocols) status code.
-      Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
-      return;
-    }
-
     // These are Informational 1xx headers, not the actual response headers.
     set_headers_decompressed(false);
   }

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -1975,4 +1975,32 @@ TEST_P(MultiplexedIntegrationTest, InconsistentContentLength) {
   }
 }
 
+// HTTP/2 and HTTP/3 don't support 101 SwitchProtocol response code, the client should
+// reset the request.
+TEST_P(MultiplexedIntegrationTest, Reset101SwitchProtocolResponse) {
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void { hcm.set_proxy_100_continue(true); });
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                 {":path", "/dynamo/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"expect", "100-continue"}});
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  // Wait for the request headers to be received upstream.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "101"}}, false);
+  ASSERT_TRUE(response->waitForReset());
+  codec_client_->close();
+  EXPECT_FALSE(response->complete());
+}
+
 } // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3609,7 +3609,7 @@ TEST_P(ProtocolIntegrationTest, HandleUpstreamSocketFail) {
 }
 
 #ifdef NDEBUG
-// These tests send invalid request and response header names which voilate ASSESRT while creating
+// These tests send invalid request and response header names which violate ASSERT while creating
 // such request/response headers. So they can only be run in NDEBUG mode.
 TEST_P(DownstreamProtocolIntegrationTest, InvalidReqestHeaderName) {
   initialize();

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3608,4 +3608,48 @@ TEST_P(ProtocolIntegrationTest, HandleUpstreamSocketFail) {
   test_server_.reset();
 }
 
+#ifdef NDEBUG
+// These tests send invalid request and response header names which voilate ASSESRT while creating
+// such request/response headers. So they can only be run in NDEBUG mode.
+TEST_P(DownstreamProtocolIntegrationTest, InvalidReqestHeaderName) {
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":authority", "host"},
+                                                                 {"foo\nname", "foo_value"}});
+  auto response = std::move(encoder_decoder.second);
+
+  if (downstream_protocol_ == Http::CodecType::HTTP1) {
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+    ASSERT_TRUE(response->complete());
+    EXPECT_EQ("400", response->headers().getStatusValue());
+    test_server_->waitForCounterGe("http.config_test.downstream_rq_4xx", 1);
+  } else {
+    ASSERT_TRUE(response->waitForReset());
+    EXPECT_EQ(Http::StreamResetReason::ConnectionTermination, response->resetReason());
+  }
+}
+
+TEST_P(DownstreamProtocolIntegrationTest, InvalidResponseHeaderName) {
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"foo\rname", "foo_value"}}, false);
+
+  ASSERT_TRUE(response->waitForEndStream());
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("502", response->headers().getStatusValue());
+  test_server_->waitForCounterGe("http.config_test.downstream_rq_5xx", 1);
+}
+#endif
+
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: switch to use `http2::adapter::HeaderValidator` from QUICHE to validate request/response header names and values. This library validate both header name and value to protect against header smuggling attack.

Additional Description: this change also fix a bug where `override_stream_error_on_invalid_http_message` didn't take effect on invalid headers rejected by EnvoyQuicStream::validateHeader() .

Risk Level: low
Testing: added integration tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
