### PR TITLE
access logger: don't always create retry config.

### DIFF
--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -77,7 +77,7 @@ template <typename LogRequest, typename LogResponse> class GrpcAccessLogClient {
 public:
   GrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
                       const Protobuf::MethodDescriptor& service_method,
-                      const envoy::config::core::v3::RetryPolicy& retry_policy)
+                      OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
       : client_(client), service_method_(service_method), grpc_stream_retry_policy_(retry_policy) {}
 
 public:
@@ -177,7 +177,7 @@ public:
                    uint64_t max_buffer_size_bytes, Event::Dispatcher& dispatcher,
                    Stats::Scope& scope, std::string access_log_prefix,
                    const Protobuf::MethodDescriptor& service_method,
-                   const envoy::config::core::v3::RetryPolicy& retry_policy)
+                   OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
       : client_(client, service_method, retry_policy),
         buffer_flush_interval_msec_(buffer_flush_interval_msec),
         flush_timer_(dispatcher.createTimer([this]() {

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
@@ -15,6 +15,14 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace GrpcCommon {
 
+OptRef<const envoy::config::core::v3::RetryPolicy> optionalRetryPolicy(
+    const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config) {
+  if (!config.has_grpc_stream_retry_policy()) {
+    return {};
+  }
+  return config.grpc_stream_retry_policy();
+}
+
 GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
     const Grpc::RawAsyncClientSharedPtr& client,
     const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
@@ -24,7 +32,7 @@ GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
                        dispatcher, scope, GRPC_LOG_STATS_PREFIX,
                        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
                            "envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs"),
-                       config.grpc_stream_retry_policy()),
+                       optionalRetryPolicy(config)),
       log_name_(config.log_name()), local_info_(local_info) {}
 
 void GrpcAccessLoggerImpl::addEntry(envoy::data::accesslog::v3::HTTPAccessLogEntry&& entry) {


### PR DESCRIPTION
Previously we always created the proto and so always created the retry config

Risk Level: low (bugfix)
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a

h/t Raven who caught and root caused this.