### PR TITLE
wasm: pass -Wno-invalid-offsetof when building V8.

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -29,7 +29,7 @@ rm -rf out/wee8
 
 # Export compiler configuration.
 export CFLAGS="$${CFLAGS-} -Wno-unknown-warning-option"
-export CXXFLAGS="$${CXXFLAGS-} -Wno-sign-compare -Wno-deprecated-copy -Wno-unknown-warning-option -Wno-range-loop-analysis -Wno-shorten-64-to-32"
+export CXXFLAGS="$${CXXFLAGS-} -Wno-sign-compare -Wno-deprecated-copy -Wno-unknown-warning-option -Wno-range-loop-analysis -Wno-shorten-64-to-32 -Wno-invalid-offsetof"
 if [[ ( $${SYSTEM} == "Darwin" && $${CXX-} == "" ) || $${CXX-} == *clang* ]]; then
   export CC=$${CC:-clang}
   export CXX=$${CXX:-clang++}


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/19379
Signed-off-by: Piotr Sikora <piotrsikora@google.com>