### PR TITLE
data plane: allowing upstream inline writes

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -15,6 +15,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* data plane: fixing error handling where writing to a socket failed while under the stack of processing. This should genreally affect HTTP/3. This behavioral change can be reverted by setting ``envoy.reloadable_features.allow_upstream_inline_write`` to false.
 
 Removed Config or Runtime
 -------------------------

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -57,6 +57,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.test_feature_true",
     // Begin alphabetically sorted section.
     "envoy.reloadable_features.allow_response_for_timeout",
+    "envoy.reloadable_features.allow_upstream_inline_write",
     "envoy.reloadable_features.conn_pool_delete_when_idle",
     "envoy.reloadable_features.correct_scheme_and_xfp",
     "envoy.reloadable_features.correctly_validate_alpn",
@@ -111,8 +112,6 @@ constexpr const char* runtime_features[] = {
 constexpr const char* disabled_runtime_features[] = {
     // TODO(alyssawilk, junr03) flip (and add release notes + docs) these after Lyft tests
     "envoy.reloadable_features.allow_multiple_dns_addresses",
-    // TODO(alyssawilk) flip true after release.
-    "envoy.reloadable_features.allow_upstream_inline_write",
     // Sentinel and test flag.
     "envoy.reloadable_features.test_feature_false",
     // When the runtime is flipped to true, use shared cache in getOrCreateRawAsyncClient method if


### PR DESCRIPTION
This largely fixes issues with HTTP/3, iff there's a upstream write error under the stack of reading.

Risk Level: Medium (data plane refactor)
Testing: yes
Docs Changes: n/a
Release Notes: inline
[Optional Runtime guard:] envoy.reloadable_features.allow_upstream_inline_write
