### PR TITLE
sip_proxy: fix EnvoyException caught by value

### DIFF
--- a/contrib/sip_proxy/filters/network/source/router/router_impl.h
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.h
@@ -241,7 +241,7 @@ public:
   std::shared_ptr<UpstreamRequest> getUpstreamRequest(const std::string& host) {
     try {
       return tls_->getTyped<ThreadLocalTransactionInfo>().upstream_request_map_.at(host);
-    } catch (std::out_of_range) {
+    } catch (std::out_of_range const&) {
       return nullptr;
     }
   }


### PR DESCRIPTION
Change the catching to references to fix compilation failed because Envoy::EnvoyException values were caught by value
The error message was this:
```
./contrib/sip_proxy/filters/network/source/router/router_impl.h:244:19: error: catching polymorphic type 'class std::out_of_range' by value [-Werror=catch-value=]
  244 |     } catch (std::out_of_range) {
      |                   ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors

```
Signed-off-by: giantcroc <changran.wang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
