### PR TITLE
tooling: Use `envoy_entry_point`

### DIFF
--- a/tools/base/BUILD
+++ b/tools/base/BUILD
@@ -6,6 +6,10 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+exports_files([
+    "entry_point.py",
+])
+
 py_binary(
     name = "bazel_query",
     srcs = ["bazel_query.py"],

--- a/tools/base/entry_point.py
+++ b/tools/base/entry_point.py
@@ -1,10 +1,26 @@
+import pathlib
 import subprocess
 import sys
 
+ENTRY_POINT_ALIAS = "_ENTRY_POINT_ALIAS_"
+
+
+def find_tool_path():
+    entry_point_alias = ENTRY_POINT_ALIAS.split("/external/")[1]
+
+    for x in pathlib.Path(".").glob(f"**/{entry_point_alias}"):
+        return x
+
 
 def main(*args) -> int:
+    tool_path = find_tool_path()
+
+    if not tool_path:
+        print(f"Unable to locate tool: {ENTRY_POINT_ALIAS}")
+        return 1
+
     try:
-        return subprocess.run(args).returncode
+        return subprocess.run([tool_path, *args]).returncode
     except KeyboardInterrupt:
         return 1
 

--- a/tools/base/entry_point.py
+++ b/tools/base/entry_point.py
@@ -6,6 +6,11 @@ ENTRY_POINT_ALIAS = "_ENTRY_POINT_ALIAS_"
 
 
 def find_tool_path():
+    # In order to work in both build/run scenarios, and to work
+    # when the rule is invoked directly, or by another rule, the
+    # path to the entry_point binary has to be found from the
+    # `ENTRY_POINT_ALIAS` that is injected by the `genrule`
+
     entry_point_alias = f"external/{ENTRY_POINT_ALIAS.split('/external/')[1]}"
     if pathlib.Path(entry_point_alias).exists():
         return entry_point_alias

--- a/tools/base/entry_point.py
+++ b/tools/base/entry_point.py
@@ -6,8 +6,9 @@ ENTRY_POINT_ALIAS = "_ENTRY_POINT_ALIAS_"
 
 
 def find_tool_path():
-    entry_point_alias = ENTRY_POINT_ALIAS.split("/external/")[1]
-
+    entry_point_alias = f"external/{ENTRY_POINT_ALIAS.split('/external/')[1]}"
+    if pathlib.Path(entry_point_alias).exists():
+        return entry_point_alias
     for x in pathlib.Path(".").glob(f"**/{entry_point_alias}"):
         return x
 

--- a/tools/distribution/BUILD
+++ b/tools/distribution/BUILD
@@ -1,5 +1,5 @@
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("@base_pip3//:requirements.bzl", "entry_point")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point")
 
 licenses(["notice"])  # Apache 2
 
@@ -9,26 +9,17 @@ exports_files([
     "distrotest.sh",
 ])
 
-alias(
+envoy_entry_point(
     name = "release",
-    actual = entry_point(
-        pkg = "envoy.distribution.release",
-        script = "envoy.distribution.release",
-    ),
+    pkg = "envoy.distribution.release",
 )
 
-alias(
+envoy_entry_point(
     name = "sign",
-    actual = entry_point(
-        pkg = "envoy.gpg.sign",
-        script = "envoy.gpg.sign",
-    ),
+    pkg = "envoy.gpg.sign",
 )
 
-alias(
+envoy_entry_point(
     name = "verify",
-    actual = entry_point(
-        pkg = "envoy.distribution.verify",
-        script = "envoy.distribution.verify",
-    ),
+    pkg = "envoy.distribution.verify",
 )

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -1,7 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary")
-load("@base_pip3//:requirements.bzl", "entry_point", "requirement")
+load("@base_pip3//:requirements.bzl", "requirement")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_py_binary")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_py_binary")
 
 licenses(["notice"])  # Apache 2
 
@@ -40,12 +40,9 @@ py_binary(
 #
 #    https://github.com/envoyproxy/pytooling
 
-alias(
+envoy_entry_point(
     name = "sphinx_runner",
-    actual = entry_point(
-        pkg = "envoy.docs.sphinx_runner",
-        script = "envoy.docs.sphinx_runner",
-    ),
+    pkg = "envoy.docs.sphinx_runner",
 )
 
 envoy_py_binary(


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

This is a follow up to use the macro added in #19450 for existing entry_points

Also contains a fix to use a template to create the py_binary main to ensure the py_binary retains the path to the entry point

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
