### PR TITLE
redis: add support for hostnames returned in cluster_slots response

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -232,7 +232,7 @@ RedisCluster::RedisDiscoverySession::RedisDiscoverySession::processClusterByIP(
   try {
     return Network::Utility::parseInternetAddress(array[0].asString(), array[1].asInteger(), false);
   } catch (const EnvoyException& ex) {
-    // Probably elasticache use case: hostname instead of IP
+    // Probably ElastiCache use case: hostname instead of IP
     return nullptr;
   }
 }
@@ -438,7 +438,7 @@ void RedisCluster::RedisDiscoverySession::onResponse(
       return;
     }
     // Try to parse primary slot address as IP address
-    // It may fail in AWS elasticache use case: it uses hostnames instead of IPs.
+    // It may fail in AWS ElastiCache use case: it uses hostnames instead of IPs.
     // If this is the case - we'll come back later and try to resolve hostnames asynchronously.
     ClusterSlot slot(slot_range[SlotRangeStart].asInteger(), slot_range[SlotRangeEnd].asInteger(),
                      processClusterByIP(slot_range[SlotPrimary]));
@@ -460,7 +460,7 @@ void RedisCluster::RedisDiscoverySession::onResponse(
       if (replica_address) {
         slot.addReplica(std::move(replica_address));
       } else {
-        // Possible AWS elasticache use case: hostname instead of IP
+        // Possible AWS ElastiCache use case: hostname instead of IP
         const auto& array = replica->asArray();
         slot.addReplicaToResolve(array[0].asString(), array[1].asInteger());
       }

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -225,22 +225,14 @@ RedisCluster::RedisDiscoverySession::RedisDiscoverySession(
 // Convert the cluster slot IP/Port response to and address, return null if the response
 // does not match the expected type.
 Network::Address::InstanceConstSharedPtr
-RedisCluster::RedisDiscoverySession::RedisDiscoverySession::ProcessCluster(
+RedisCluster::RedisDiscoverySession::RedisDiscoverySession::processClusterByIP(
     const NetworkFilters::Common::Redis::RespValue& value) {
-  if (value.type() != NetworkFilters::Common::Redis::RespType::Array) {
-    return nullptr;
-  }
-  auto& array = value.asArray();
 
-  if (array.size() < 2 || array[0].type() != NetworkFilters::Common::Redis::RespType::BulkString ||
-      array[1].type() != NetworkFilters::Common::Redis::RespType::Integer) {
-    return nullptr;
-  }
-
+  const auto& array = value.asArray();
   try {
     return Network::Utility::parseInternetAddress(array[0].asString(), array[1].asInteger(), false);
   } catch (const EnvoyException& ex) {
-    ENVOY_LOG(debug, "Invalid ip address in CLUSTER SLOTS response: {}", ex.what());
+    // Probably elasticache use case: hostname instead of IP
     return nullptr;
   }
 }
@@ -316,6 +308,78 @@ void RedisCluster::RedisDiscoverySession::startResolveRedis() {
   current_request_ = client->client_->makeRequest(ClusterSlotsRequest::instance_, *this);
 }
 
+void RedisCluster::RedisDiscoverySession::updateDnsStats(Network::DnsResolver::ResolutionStatus status, bool emptyResponse)
+{
+  if (status == Network::DnsResolver::ResolutionStatus::Failure || emptyResponse) {
+    if (status == Network::DnsResolver::ResolutionStatus::Failure) {
+      parent_.info_->stats().update_failure_.inc();
+    } else {
+      parent_.info_->stats().update_empty_.inc();
+    }
+  }
+}
+
+
+void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(ClusterSlotsPtr&& slots)
+{
+  // Iterate over all slots replicate and resolve all missing addresses one at a time
+  for (ClusterSlot& slot : *slots) {
+    // Resolve primary
+    if (slot.primary() == nullptr) {
+      ENVOY_LOG(trace, "starting async DNS resolution for primary slot address {}", slot.primary_hostname_);
+      parent_.dns_resolver_->resolve(slot.primary_hostname_, parent_.dns_lookup_family_,
+          [this, &slot, &slots](Network::DnsResolver::ResolutionStatus status,
+                std::list<Network::DnsResponse>&& response) -> void {
+            ENVOY_LOG(trace, "async DNS resolution complete for {}", slot.primary_hostname_);
+            updateDnsStats(status, response.empty());
+            if (status != Network::DnsResolver::ResolutionStatus::Success) {
+              // Failed
+              ENVOY_LOG(debug, "Unable to resolve cluster slot primary address {}", slot.primary_hostname_);
+              resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+              return;
+            }
+            // Primary slot address resolved
+            slot.setPrimary(Network::Utility::getAddressWithPort(*response.front().address_, slot.primary_port_));
+            // Continue resolving slot's addresses until everything is resolved
+            resolveClusterHostnames(std::move(slots));
+          }
+      );
+      // do one resolution at a time: once resolved, callback will invoke this function again
+      return;
+    }
+    // Resolve all replicas of the slot, one replica at a time
+    if (!slot.replicas_to_resolve_.empty()) {
+      const std::string& host = slot.replicas_to_resolve_.back().first;
+      uint16_t port = slot.replicas_to_resolve_.back().second;
+      slot.replicas_to_resolve_.pop_back();
+      ENVOY_LOG(trace, "starting async DNS resolution for replica address {}", host);
+      parent_.dns_resolver_->resolve(host, parent_.dns_lookup_family_,
+          [this, &slot, &slots, port, host](Network::DnsResolver::ResolutionStatus status,
+                std::list<Network::DnsResponse>&& response) -> void {
+            ENVOY_LOG(trace, "async DNS resolution complete for {}", host);
+            updateDnsStats(status, response.empty());
+            if (status != Network::DnsResolver::ResolutionStatus::Success) {
+              // Failed
+              ENVOY_LOG(debug, "Unable to resolve cluster replica address {}", host);
+              resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+              return;
+            }
+            // Replica resolved
+            slot.addReplica(Network::Utility::getAddressWithPort(*response.front().address_, port));
+            // Continue resolving slot's addresses until everything is resolved
+            resolveClusterHostnames(std::move(slots));
+          }
+      );
+      // do one resolution at a time: once resolved, callback will invoke this function again
+      return;
+    }
+  } // of for(clusters slots)
+
+  // All slots addresses were represented by DNS hostname lookup.
+  parent_.onClusterSlotUpdate(std::move(slots));
+  resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+}
+
 void RedisCluster::RedisDiscoverySession::onResponse(
     NetworkFilters::Common::Redis::RespValuePtr&& value) {
   current_request_ = nullptr;
@@ -331,14 +395,30 @@ void RedisCluster::RedisDiscoverySession::onResponse(
     return;
   }
 
-  auto slots = std::make_unique<std::vector<ClusterSlot>>();
+  auto cluster_slots = std::make_unique<std::vector<ClusterSlot>>();
 
+  // CLUSTER SLOTS represents nested array of redis instances, like this:
+  //
+  // 1) 1) (integer) 0                <-- start slot range
+  //    2) (integer) 5460             <-- end slot range
+  //
+  //    3) 1) "127.0.0.1"                                   |
+  //       2) (integer) 30001                               <-  master for slot as IP(HOST) / Port / ID
+  //       3) "09dbe9720cda62f7865eabc5fd8857c5d2678366"    |
+  //
+  //    4) 1) "127.0.0.1"                                   |
+  //       2) (integer) 30004                               <- replicas in the same format as master
+  //       3) "821d8ca00d7ccf931ed3ffc7e3db0599d2271abf"    |
+  //
   // Loop through the cluster slot response and error checks for each field.
+  bool address_resolve_required = false;
   for (const NetworkFilters::Common::Redis::RespValue& part : value->asArray()) {
     if (part.type() != NetworkFilters::Common::Redis::RespType::Array) {
       onUnexpectedResponse(value);
       return;
     }
+
+    // Row 1-2: Slot ranges
     const std::vector<NetworkFilters::Common::Redis::RespValue>& slot_range = part.asArray();
     if (slot_range.size() < 3 ||
         slot_range[SlotRangeStart].type() !=
@@ -351,29 +431,77 @@ void RedisCluster::RedisDiscoverySession::onResponse(
       return;
     }
 
-    // Field 2: Primary address for slot range
-    auto primary_address = ProcessCluster(slot_range[SlotPrimary]);
-    if (!primary_address) {
+    // Row 3: Primary slot address
+    if (!validateCluster(slot_range[SlotPrimary])) {
       onUnexpectedResponse(value);
       return;
     }
+    // Try to parse primary slot address as IP address
+    // It may fail in AWS elasticache use case: it uses hostnames instead of IPs.
+    // If this is the case - we'll come back later and try to resolve hostnames asynchronously.
+    ClusterSlot slot(slot_range[SlotRangeStart].asInteger(), slot_range[SlotRangeEnd].asInteger(), processClusterByIP(slot_range[SlotPrimary]));
+    if (slot.primary() == nullptr) {
+      // Primary address is hostname: save the name for further resolving
+      const auto& array = slot_range[SlotPrimary].asArray();
+      slot.primary_hostname_ = array[0].asString();
+      slot.primary_port_ = array[1].asInteger();
+    }
 
-    slots->emplace_back(slot_range[SlotRangeStart].asInteger(),
-                        slot_range[SlotRangeEnd].asInteger(), primary_address);
-
+    // Row 4-N: Replica(s) addresses
     for (auto replica = std::next(slot_range.begin(), SlotReplicaStart);
          replica != slot_range.end(); ++replica) {
-      auto replica_address = ProcessCluster(*replica);
-      if (!replica_address) {
+      if (!validateCluster(*replica)) {
         onUnexpectedResponse(value);
         return;
       }
-      slots->back().addReplica(std::move(replica_address));
+      auto replica_address = processClusterByIP(*replica);
+      if (replica_address) {
+        slot.addReplica(std::move(replica_address));
+      } else {
+        // Possible AWS elasticache use case: hostname instead of IP
+        const auto& array = replica->asArray();
+        slot.addReplicaToResolve(array[0].asString(), array[1].asInteger());
+      }
     }
+    // If at least one (primary, replicas) address is hostname, schedule DNS resolving
+    if (slot.primary() == nullptr || !slot.replicas_to_resolve_.empty()) {
+      address_resolve_required = true;
+    }
+    cluster_slots->push_back(std::move(slot));
   }
 
-  parent_.onClusterSlotUpdate(std::move(slots));
-  resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+  if (!address_resolve_required) {
+    // All slots addresses were represented by IP/Port pairs.
+    parent_.onClusterSlotUpdate(std::move(cluster_slots));
+    resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+  } else {
+    // Resolve hostnames, once completed run onClusterSlotUpdate() / enable timer
+    resolveClusterHostnames(std::move(cluster_slots));
+  }
+}
+
+// Ensure that Slot Cluster response has valid format
+bool RedisCluster::RedisDiscoverySession::validateCluster(const NetworkFilters::Common::Redis::RespValue& value)
+{
+  // Verify data types
+  if (value.type() != NetworkFilters::Common::Redis::RespType::Array) {
+    return false;
+  }
+  const auto& array = value.asArray();
+  if (array.size() < 2 || array[0].type() != NetworkFilters::Common::Redis::RespType::BulkString ||
+      array[1].type() != NetworkFilters::Common::Redis::RespType::Integer) {
+    return false;
+  }
+  // Verify IP/Host address
+  if (array[0].asString().empty()) {
+    return false;
+  }
+  // Verify port
+  if (array[1].asInteger() > 0xffff) {
+    return false;
+  }
+
+  return true;
 }
 
 void RedisCluster::RedisDiscoverySession::onUnexpectedResponse(

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -1,11 +1,12 @@
 #include "redis_cluster.h"
 
+#include <memory>
+
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/redis/v3/redis_cluster.pb.h"
 #include "envoy/extensions/clusters/redis/v3/redis_cluster.pb.validate.h"
 #include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.h"
 #include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.validate.h"
-#include <memory>
 
 namespace Envoy {
 namespace Extensions {
@@ -344,7 +345,8 @@ void RedisCluster::RedisDiscoverySession::resolveHostname(std::shared_ptr<Cluste
           auto& slot = (**slots)[index];
           ENVOY_LOG(trace, "async DNS resolution complete for {}", slot.primary_hostname_);
           updateDnsStats(status, response.empty());
-          // If DNS resolution for a primary fails, we stop resolution for remaining, and reset the timer.
+          // If DNS resolution for a primary fails, we stop resolution for remaining, and reset the
+          // timer.
           if (status != Network::DnsResolver::ResolutionStatus::Success) {
             ENVOY_LOG(error, "Unable to resolve cluster slot primary hostname {}",
                       slot.primary_hostname_);

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -309,8 +309,8 @@ void RedisCluster::RedisDiscoverySession::startResolveRedis() {
 }
 
 void RedisCluster::RedisDiscoverySession::updateDnsStats(
-    Network::DnsResolver::ResolutionStatus status, bool emptyResponse) {
-  if (status == Network::DnsResolver::ResolutionStatus::Failure || emptyResponse) {
+    Network::DnsResolver::ResolutionStatus status, bool empty_response) {
+  if (status == Network::DnsResolver::ResolutionStatus::Failure || empty_response) {
     if (status == Network::DnsResolver::ResolutionStatus::Failure) {
       parent_.info_->stats().update_failure_.inc();
     } else {

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -242,7 +242,10 @@ private:
     void onUnexpectedResponse(const NetworkFilters::Common::Redis::RespValuePtr&);
 
     Network::Address::InstanceConstSharedPtr
-    ProcessCluster(const NetworkFilters::Common::Redis::RespValue& value);
+    processClusterByIP(const NetworkFilters::Common::Redis::RespValue& value);
+    bool validateCluster(const NetworkFilters::Common::Redis::RespValue& value);
+    void resolveClusterHostnames(ClusterSlotsPtr&& slots);
+    void updateDnsStats(Network::DnsResolver::ResolutionStatus status, bool emptyResponse);
 
     RedisCluster& parent_;
     Event::Dispatcher& dispatcher_;

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -245,6 +245,9 @@ private:
     processClusterByIP(const NetworkFilters::Common::Redis::RespValue& value);
     bool validateCluster(const NetworkFilters::Common::Redis::RespValue& value);
     void resolveClusterHostnames(ClusterSlotsPtr&& slots);
+    void resolveHostname(std::shared_ptr<ClusterSlotsPtr> slots, std::size_t index);
+    void resolveReplicas(std::shared_ptr<ClusterSlotsPtr> slots, std::size_t index);
+    void finishClusterHostnameResolution(std::shared_ptr<ClusterSlotsPtr> slots);
     void updateDnsStats(Network::DnsResolver::ResolutionStatus status, bool empty_response);
 
     RedisCluster& parent_;

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -245,7 +245,7 @@ private:
     processClusterByIP(const NetworkFilters::Common::Redis::RespValue& value);
     bool validateCluster(const NetworkFilters::Common::Redis::RespValue& value);
     void resolveClusterHostnames(ClusterSlotsPtr&& slots);
-    void updateDnsStats(Network::DnsResolver::ResolutionStatus status, bool emptyResponse);
+    void updateDnsStats(Network::DnsResolver::ResolutionStatus status, bool empty_response);
 
     RedisCluster& parent_;
     Event::Dispatcher& dispatcher_;

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -55,6 +55,7 @@ public:
   std::string primary_hostname_;
   uint16_t primary_port_;
   std::vector<ReplicaToResolve> replicas_to_resolve_;
+
 private:
   int64_t start_;
   int64_t end_;

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -693,7 +693,8 @@ TEST_F(RedisClusterTest, AddressAsHostnameFailure) {
   expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "foo.bar.com", resolved_addresses);
 
   // 1. Primary resolution is successful, but replica fails.
-  // Expect cluster slot update to be successful, with just one healthy host, and failure counter to be updated.
+  // Expect cluster slot update to be successful, with just one healthy host, and failure counter to
+  // be updated.
   expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "primary.com",
                          primary_resolved_addresses);
   expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "replica.org",
@@ -713,15 +714,18 @@ TEST_F(RedisClusterTest, AddressAsHostnameFailure) {
   EXPECT_EQ(1UL, cluster_->info()->stats().update_failure_.value());
 
   // 2. Primary resolution fails, so replica resolution is not even called.
-  // Expect cluster slot update to be successful, with just one healthy host, and failure counter to be updated.
+  // Expect cluster slot update to be successful, with just one healthy host, and failure counter to
+  // be updated.
   expectRedisResolve(true);
   resolve_timer_->invokeCallback();
   expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "primary.com",
                          primary_resolved_addresses,
                          Network::DnsResolver::ResolutionStatus::Failure);
-  // NOTE: Intentionally commented out. Replica DNS resolution should even reach. It's here for illustrative purposes.
+  // NOTE: Intentionally commented out. Replica DNS resolution should even reach. It's here for
+  // illustrative purposes.
+
   // expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "replica.org",
-  //                        replica_resolved_addresses);
+  // replica_resolved_addresses);
   expectClusterSlotResponse(singleSlotPrimaryReplica("primary.com", "replica.org", 22120));
   // healthy hosts is same as before, but failure count increases by 1
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -411,8 +411,7 @@ protected:
         replica_1_array.push_back(
             createStringField(replica_flags.test(replica_ip_type), "127.0.0.2"));
       } else {
-        replica_1_array.push_back(
-            createStringField(replica_flags.test(replica_ip_type), ""));
+        replica_1_array.push_back(createStringField(replica_flags.test(replica_ip_type), ""));
       }
       // Port field.
       replica_1_array.push_back(createIntegerField(replica_flags.test(replica_port_type), 22120));
@@ -668,8 +667,7 @@ TEST_F(RedisClusterTest, PrimaryAddressAsHostname) {
   const std::list<std::string> resolved_addresses{"127.0.0.1", "127.0.0.2"};
   const std::list<std::string> primary_resolved_addresses{"127.0.1.1"};
   const std::list<std::string> replica_resolved_addresses{"127.0.1.2"};
-  expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "foo.bar.com",
-                          resolved_addresses);
+  expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "foo.bar.com", resolved_addresses);
   expectRedisResolve(true);
 
   EXPECT_CALL(membership_updated_, ready());
@@ -678,9 +676,9 @@ TEST_F(RedisClusterTest, PrimaryAddressAsHostname) {
 
   EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
   expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "primary.com",
-                          primary_resolved_addresses);
+                         primary_resolved_addresses);
   expectResolveDiscovery(Network::DnsLookupFamily::V4Only, "replica.org",
-                          replica_resolved_addresses);
+                         replica_resolved_addresses);
   expectClusterSlotResponse(singleSlotPrimaryReplica("primary.com", "replica.org", 22120));
   expectHealthyHosts(std::list<std::string>({"127.0.1.1:22120", "127.0.1.2:22120"}));
 }

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1323,3 +1323,4 @@ suri
 transid
 routable
 vhosts
+ElastiCache


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Currently, `CLUSTER SLOTS` response is expected to contain the IP address of each redis host in the response.
However, response from AWS Elasticache contains the hostnames instead. This PR adds support to DNS resolve the hostnames asynchronously before cluster slot updates are applied.


Co-authored-by: Konstantin Belyalov <arsenicus@mail.ru>

Additional Description:

This PR builds directly on top of #19192 and fixes the bugs in it.

Testing:

- Unit tests
- We also tested this manually in an AWS setup, and it worked great
Docs Changes:
Release Notes:
Platform Specific Features:

Fixes #8440 
