### PR TITLE
coverage: exclude win32 tests from coverage.

### DIFF
--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -101,6 +101,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "win32_scm_test",
     srcs = ["win32_scm_test.cc"],
+    coverage = False,
     data = [
         "//source/exe:envoy-static",
         "//test/config/integration:google_com_proxy_port_0",
@@ -121,6 +122,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "win32_outofproc_main_test",
     srcs = ["win32_outofproc_main_test.cc"],
+    coverage = False,
     data = [
         "//source/exe:envoy-static",
         "//test/config/integration:google_com_proxy_port_0",


### PR DESCRIPTION
All other tests that depend on //source/exe:envoy-static are already
excluded from the coverage. Also, those tests run only on win32, but
its dependencies are build on all platforms leading to the increased
build times and other issues.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>