### PR TITLE
Docs: Clarify docs for Overload Manager disable_keep_alive action.

### DIFF
--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -81,7 +81,7 @@ The following overload actions are supported:
     - Envoy will immediately respond with a 503 response code to new requests
 
   * - envoy.overload_actions.disable_http_keepalive
-    - Envoy will drain HTTP/2, HTTP/3 connections using `GOAWAY` with a drain
+    - Envoy will drain HTTP/2, HTTP/3 connections using ``GOAWAY`` with a drain
       grace period. For HTTP/1, Envoy will set a drain timer to close the more
       idle recently used connections.
 

--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -81,9 +81,9 @@ The following overload actions are supported:
     - Envoy will immediately respond with a 503 response code to new requests
 
   * - envoy.overload_actions.disable_http_keepalive
-    - Envoy will drain HTTP/2, HTTP/3 connections using ``GOAWAY`` with a drain
-      grace period. For HTTP/1, Envoy will set a drain timer to close the more
-      idle recently used connections.
+    - Envoy will drain HTTP/2 and HTTP/3 connections using ``GOAWAY`` with a
+      drain grace period. For HTTP/1, Envoy will set a drain timer to close the
+      more idle recently used connections.
 
   * - envoy.overload_actions.stop_accepting_connections
     - Envoy will stop accepting new network connections on its configured listeners

--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -7,9 +7,9 @@ The :ref:`overload manager <arch_overview_overload_manager>` is configured in th
 :ref:`overload_manager <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.overload_manager>`
 field.
 
-An example configuration of the overload manager is shown below. It shows a configuration to
-disable HTTP/1.x keepalive when heap memory usage reaches 95% and to stop accepting
-requests when heap memory usage reaches 99%.
+An example configuration of the overload manager is shown below. It shows a
+configuration to drain HTTP/X connections when heap memory usage reaches 95%
+and to stop accepting requests when heap memory usage reaches 99%.
 
 .. code-block:: yaml
 
@@ -81,7 +81,9 @@ The following overload actions are supported:
     - Envoy will immediately respond with a 503 response code to new requests
 
   * - envoy.overload_actions.disable_http_keepalive
-    - Envoy will stop accepting streams on incoming HTTP connections
+    - Envoy will drain HTTP/2, HTTP/3 connections using `GOAWAY` with a drain
+      grace period. For HTTP/1, Envoy will set a drain timer to close the more
+      idle recently used connections.
 
   * - envoy.overload_actions.stop_accepting_connections
     - Envoy will stop accepting new network connections on its configured listeners


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:  Clarify docs for Overload Manager disable_keep_alive action.
Additional Description:

Looking at the code: https://github.com/envoyproxy/envoy/blob/0a4e3d990ae865c6753432322e9b2eaec8057548/source/common/http/conn_manager_impl.cc#L1382-L1401 

We seem to use GoAways for H2/H3 and a drain timer for H/1 which will close the connection if it has no stream and nothing to write when the timer fires.


Risk Level: NA
Testing: NA
Docs Changes: Included
Release Notes: NA
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
