### PR TITLE
quic: mark http3 confirmed from H3 conn pool

### DIFF
--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -228,9 +228,11 @@ absl::optional<ConnectivityGrid::PoolIterator> ConnectivityGrid::createNextPool(
   // HTTP/3 is hard-coded as higher priority, H2 as secondary.
   ConnectionPool::InstancePtr pool;
   if (pools_.empty()) {
-    pool = Http3::allocateConnPool(dispatcher_, random_generator_, host_, priority_, options_,
-                                   transport_socket_options_, state_, time_source_,
-                                   quic_stat_names_, scope_);
+    auto h3_pool = Http3::allocateConnPool(dispatcher_, random_generator_, host_, priority_,
+                                           options_, transport_socket_options_, state_,
+                                           time_source_, quic_stat_names_, scope_);
+    h3_pool->setConnectResultCallback(*this);
+    pool = std::move(h3_pool);
   } else {
     pool = std::make_unique<HttpConnPoolImplMixed>(dispatcher_, random_generator_, host_, priority_,
                                                    options_, transport_socket_options_, state_);

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -409,7 +409,7 @@ void ConnectivityGrid::onConnectSucceeded() {
 }
 
 void ConnectivityGrid::onConnectFailedWithEarlyData() {
-  // TODO(danzh) mark HTTP/3 suspecious once we support 0-RTT.
+  // TODO(danzh) mark HTTP/3 suspicious once we support 0-RTT.
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -228,10 +228,10 @@ absl::optional<ConnectivityGrid::PoolIterator> ConnectivityGrid::createNextPool(
   // HTTP/3 is hard-coded as higher priority, H2 as secondary.
   ConnectionPool::InstancePtr pool;
   if (pools_.empty()) {
-    auto h3_pool = Http3::allocateConnPool(dispatcher_, random_generator_, host_, priority_,
-                                           options_, transport_socket_options_, state_,
-                                           time_source_, quic_stat_names_, scope_);
-    h3_pool->setConnectResultCallback(*this);
+    auto h3_pool =
+        Http3::allocateConnPool(dispatcher_, random_generator_, host_, priority_, options_,
+                                transport_socket_options_, state_, time_source_, quic_stat_names_,
+                                scope_, makeOptRefFromPtr<Http3::PoolConnectResultCallback>(this));
     pool = std::move(h3_pool);
   } else {
     pool = std::make_unique<HttpConnPoolImplMixed>(dispatcher_, random_generator_, host_, priority_,
@@ -406,10 +406,6 @@ bool ConnectivityGrid::shouldAttemptHttp3() {
 void ConnectivityGrid::onConnectSucceeded() {
   ENVOY_LOG(trace, "Marking HTTP/3 confirmed for host '{}'.", host_->hostname());
   markHttp3Confirmed();
-}
-
-void ConnectivityGrid::onConnectFailedWithEarlyData() {
-  // TODO(danzh) mark HTTP/3 suspicious once we support 0-RTT.
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -228,11 +228,10 @@ absl::optional<ConnectivityGrid::PoolIterator> ConnectivityGrid::createNextPool(
   // HTTP/3 is hard-coded as higher priority, H2 as secondary.
   ConnectionPool::InstancePtr pool;
   if (pools_.empty()) {
-    auto h3_pool =
+    pool =
         Http3::allocateConnPool(dispatcher_, random_generator_, host_, priority_, options_,
                                 transport_socket_options_, state_, time_source_, quic_stat_names_,
                                 scope_, makeOptRefFromPtr<Http3::PoolConnectResultCallback>(this));
-    pool = std::move(h3_pool);
   } else {
     pool = std::make_unique<HttpConnPoolImplMixed>(dispatcher_, random_generator_, host_, priority_,
                                                    options_, transport_socket_options_, state_);
@@ -403,7 +402,7 @@ bool ConnectivityGrid::shouldAttemptHttp3() {
   return false;
 }
 
-void ConnectivityGrid::onConnectSucceeded() {
+void ConnectivityGrid::onHandshakeComplete() {
   ENVOY_LOG(trace, "Marking HTTP/3 confirmed for host '{}'.", host_->hostname());
   markHttp3Confirmed();
 }

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -174,7 +174,7 @@ public:
   void markHttp3Confirmed();
 
   // Http3::PoolConnectResultCallback
-  void onConnectSucceeded() override;
+  void onHandshakeComplete() override;
 
 protected:
   // Set the required idle callback on the pool.

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -2,6 +2,7 @@
 
 #include "source/common/http/alternate_protocols_cache_impl.h"
 #include "source/common/http/conn_pool_base.h"
+#include "source/common/http/http3/conn_pool.h"
 #include "source/common/http/http3_status_tracker.h"
 #include "source/common/quic/quic_stat_names.h"
 
@@ -14,6 +15,7 @@ namespace Http {
 // [WiFi / cellular] [ipv4 / ipv6] [QUIC / TCP].
 // Currently only [QUIC / TCP are handled]
 class ConnectivityGrid : public ConnectionPool::Instance,
+                         public Http3::PoolConnectResultCallback,
                          protected Logger::Loggable<Logger::Id::pool> {
 public:
   struct ConnectivityOptions {
@@ -170,6 +172,10 @@ public:
   // Marks that HTTP/3 is working, which resets the exponential backoff counter in the
   // event that HTTP/3 is marked broken again.
   void markHttp3Confirmed();
+
+  // Http3::PoolConnectResultCallback
+  void onConnectSucceeded() override;
+  void onConnectFailedWithEarlyData() override;
 
 protected:
   // Set the required idle callback on the pool.

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -175,7 +175,6 @@ public:
 
   // Http3::PoolConnectResultCallback
   void onConnectSucceeded() override;
-  void onConnectFailedWithEarlyData() override;
 
 protected:
   // Set the required idle callback on the pool.

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -1,6 +1,7 @@
 #include "source/common/http/http3/conn_pool.h"
 
 #include <cstdint>
+#include <memory>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/upstream/upstream.h"
@@ -81,7 +82,7 @@ void Http3ConnPoolImpl::onConnected(Envoy::ConnectionPool::ActiveClient&) {
 // Make sure all connections are torn down before quic_info_ is deleted.
 Http3ConnPoolImpl::~Http3ConnPoolImpl() { destructAllConnections(); }
 
-ConnectionPool::InstancePtr
+std::unique_ptr<Http3ConnPoolImpl>
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -72,6 +72,12 @@ Http3ConnPoolImpl::Http3ConnPoolImpl(
       host->cluster().perConnectionBufferLimitBytes());
 }
 
+void Http3ConnPoolImpl::onConnected(Envoy::ConnectionPool::ActiveClient&) {
+  if (connect_callback_ != absl::nullopt) {
+    connect_callback_->get().onConnectSucceeded();
+  }
+}
+
 // Make sure all connections are torn down before quic_info_ is deleted.
 Http3ConnPoolImpl::~Http3ConnPoolImpl() { destructAllConnections(); }
 

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -76,7 +76,7 @@ Http3ConnPoolImpl::Http3ConnPoolImpl(
 
 void Http3ConnPoolImpl::onConnected(Envoy::ConnectionPool::ActiveClient&) {
   if (connect_callback_ != absl::nullopt) {
-    connect_callback_->onConnectSucceeded();
+    connect_callback_->onHandshakeComplete();
   }
 }
 

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -104,7 +104,7 @@ public:
   virtual ~PoolConnectResultCallback() = default;
 
   // Called when the handshake completes.
-  virtual void onConnectSucceeded() PURE;
+  virtual void onHandshakeComplete() PURE;
 };
 
 // Http3 subclass of FixedHttpConnPoolImpl which exists to store quic data.

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -99,11 +99,13 @@ public:
 };
 
 // An interface to propagate H3 handshake result.
+// TODO(danzh) add an API to propagate 0-RTT handshake failure.
 class PoolConnectResultCallback {
 public:
   virtual ~PoolConnectResultCallback() = default;
 
-  // Called when the handshake completes.
+  // Called when the mandatory handshake is complete. This is when a HTTP/3 connection is regarded
+  // as connected and is able to send requests.
   virtual void onHandshakeComplete() PURE;
 };
 
@@ -140,6 +142,7 @@ private:
   // Store quic helpers which can be shared between connections and must live
   // beyond the lifetime of individual connections.
   std::unique_ptr<Quic::PersistentQuicInfoImpl> quic_info_;
+  // If not nullopt, called when the handshake state changes.
   OptRef<PoolConnectResultCallback> connect_callback_;
 };
 

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -137,13 +137,15 @@ protected:
   void onConnected(Envoy::ConnectionPool::ActiveClient&) override;
 
 private:
+  friend class Http3ConnPoolImplPeer;
+
   // Store quic helpers which can be shared between connections and must live
   // beyond the lifetime of individual connections.
   std::unique_ptr<Quic::PersistentQuicInfoImpl> quic_info_;
   absl::optional<std::reference_wrapper<PoolConnectResultCallback>> connect_callback_;
 };
 
-ConnectionPool::InstancePtr
+std::unique_ptr<Http3ConnPoolImpl>
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -138,6 +138,7 @@ void EnvoyQuicClientSession::OnTlsHandshakeComplete() {
   streamInfo().upstreamInfo()->upstreamTiming().onUpstreamConnectComplete(dispatcher_.timeSource());
   streamInfo().upstreamInfo()->upstreamTiming().onUpstreamHandshakeComplete(
       dispatcher_.timeSource());
+
   raiseConnectionEvent(Network::ConnectionEvent::Connected);
 }
 

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -138,7 +138,6 @@ void EnvoyQuicClientSession::OnTlsHandshakeComplete() {
   streamInfo().upstreamInfo()->upstreamTiming().onUpstreamConnectComplete(dispatcher_.timeSource());
   streamInfo().upstreamInfo()->upstreamTiming().onUpstreamHandshakeComplete(
       dispatcher_.timeSource());
-
   raiseConnectionEvent(Network::ConnectionEvent::Connected);
 }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1722,9 +1722,10 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
   if (protocols.size() == 1 && protocols[0] == Http::Protocol::Http3 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http3", 100)) {
 #ifdef ENVOY_ENABLE_QUIC
-    return Http::Http3::allocateConnPool(dispatcher, context_.api().randomGenerator(), host,
-                                         priority, options, transport_socket_options, state, source,
-                                         quic_stat_names_, stats_);
+    return Http::Http3::allocateConnPool(
+        dispatcher, context_.api().randomGenerator(), host, priority, options,
+        transport_socket_options, state, source, quic_stat_names_, stats_,
+        makeOptRefFromPtr<Http::Http3::PoolConnectResultCallback>(nullptr));
 #else
     UNREFERENCED_PARAMETER(source);
     // Should be blocked by configuration checking at an earlier point.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1722,10 +1722,9 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
   if (protocols.size() == 1 && protocols[0] == Http::Protocol::Http3 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http3", 100)) {
 #ifdef ENVOY_ENABLE_QUIC
-    return Http::Http3::allocateConnPool(
-        dispatcher, context_.api().randomGenerator(), host, priority, options,
-        transport_socket_options, state, source, quic_stat_names_, stats_,
-        makeOptRefFromPtr<Http::Http3::PoolConnectResultCallback>(nullptr));
+    return Http::Http3::allocateConnPool(dispatcher, context_.api().randomGenerator(), host,
+                                         priority, options, transport_socket_options, state, source,
+                                         quic_stat_names_, stats_, {});
 #else
     UNREFERENCED_PARAMETER(source);
     // Should be blocked by configuration checking at an earlier point.

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -88,6 +88,8 @@ public:
 
   ConnectionPool::Callbacks* callbacks(int index = 0) { return callbacks_[index]; }
 
+  bool isHttp3Confirmed() const { return http3_status_tracker_.isHttp3Confirmed(); }
+
   StreamInfo::MockStreamInfo* info_;
   NiceMock<MockRequestEncoder>* encoder_;
   void setDestroying() { destroying_ = true; }
@@ -161,9 +163,10 @@ TEST_F(ConnectivityGridTest, Success) {
 
   // onPoolReady should be passed from the pool back to the original caller.
   ASSERT_NE(grid_.callbacks(), nullptr);
+  grid_.onConnectSucceeded();
+  EXPECT_TRUE(grid_.isHttp3Confirmed());
   EXPECT_CALL(callbacks_.pool_ready_, ready());
   grid_.callbacks()->onPoolReady(encoder_, host_, info_, absl::nullopt);
-  EXPECT_FALSE(grid_.isHttp3Broken());
 }
 
 // Test the first pool successfully connecting under the stack of newStream.
@@ -175,6 +178,7 @@ TEST_F(ConnectivityGridTest, ImmediateSuccess) {
   EXPECT_EQ(grid_.newStream(decoder_, callbacks_), nullptr);
   EXPECT_NE(grid_.first(), nullptr);
   EXPECT_FALSE(grid_.isHttp3Broken());
+  EXPECT_FALSE(grid_.isHttp3Confirmed());
 }
 
 // Test the first pool failing and the second connecting.

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -163,7 +163,7 @@ TEST_F(ConnectivityGridTest, Success) {
 
   // onPoolReady should be passed from the pool back to the original caller.
   ASSERT_NE(grid_.callbacks(), nullptr);
-  grid_.onConnectSucceeded();
+  grid_.onHandshakeComplete();
   EXPECT_TRUE(grid_.isHttp3Confirmed());
   EXPECT_CALL(callbacks_.pool_ready_, ready());
   grid_.callbacks()->onPoolReady(encoder_, host_, info_, absl::nullopt);

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -51,7 +51,7 @@ public:
 
 class MockPoolConnectResultCallback : public PoolConnectResultCallback {
 public:
-  MOCK_METHOD(void, onConnectSucceeded, ());
+  MOCK_METHOD(void, onHandshakeComplete, ());
 };
 
 class Http3ConnPoolImplTest : public Event::TestUsingSimulatedTime, public testing::Test {
@@ -165,7 +165,7 @@ TEST_F(Http3ConnPoolImplTest, CreationAndNewStream) {
   std::list<Envoy::ConnectionPool::ActiveClientPtr>& clients =
       Http3ConnPoolImplPeer::connectingClients(*pool_);
   EXPECT_EQ(1u, clients.size());
-  EXPECT_CALL(connect_result_callback_, onConnectSucceeded()).WillOnce(Invoke([cancellable]() {
+  EXPECT_CALL(connect_result_callback_, onHandshakeComplete()).WillOnce(Invoke([cancellable]() {
     cancellable->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   }));
   pool_->onConnectionEvent(*clients.front(), "", Network::ConnectionEvent::Connected);

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -1,6 +1,10 @@
+#include <chrono>
+#include <memory>
+
 #include "source/common/http/http3/conn_pool.h"
 #include "source/common/quic/quic_transport_socket_factory.h"
 
+#include "test/common/http/common.h"
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
@@ -37,11 +41,31 @@ TEST(Convert, Basic) {
             protocol_options->initial_stream_window_size().value());
 }
 
+class Http3ConnPoolImplPeer {
+public:
+  static std::list<Envoy::ConnectionPool::ActiveClientPtr>&
+  connectingClients(Http3ConnPoolImpl& pool) {
+    return pool.connecting_clients_;
+  }
+};
+
 class Http3ConnPoolImplTest : public Event::TestUsingSimulatedTime, public testing::Test {
 public:
+  Http3ConnPoolImplTest() {
+    EXPECT_CALL(context_.context_manager_, createSslClientContext(_, _, _))
+        .WillRepeatedly(Return(ssl_context_));
+    factory_.emplace(std::unique_ptr<Envoy::Ssl::ClientContextConfig>(
+                         new NiceMock<Ssl::MockClientContextConfig>),
+                     context_);
+    factory_->initialize();
+  }
+
   void initialize() {
     EXPECT_CALL(mockHost(), address()).WillRepeatedly(Return(test_address_));
-    EXPECT_CALL(mockHost(), transportSocketFactory()).WillRepeatedly(testing::ReturnRef(factory_));
+    EXPECT_CALL(mockHost(), transportSocketFactory()).WillRepeatedly(testing::ReturnRef(*factory_));
+    EXPECT_CALL(mockHost().cluster_, connectTimeout())
+        .WillRepeatedly(Return(std::chrono::milliseconds(10000)));
+
     new Event::MockSchedulableCallback(&dispatcher_);
     Network::ConnectionSocket::OptionsSharedPtr options;
     Network::TransportSocketOptionsConstSharedPtr transport_options;
@@ -53,19 +77,17 @@ public:
   Upstream::MockHost& mockHost() { return static_cast<Upstream::MockHost&>(*host_); }
 
   NiceMock<Event::MockDispatcher> dispatcher_;
-  std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostSharedPtr host_{new NiceMock<Upstream::MockHost>};
   NiceMock<Random::MockRandomGenerator> random_;
   Upstream::ClusterConnectivityState state_;
   Network::Address::InstanceConstSharedPtr test_address_ =
       Network::Utility::resolveUrl("tcp://127.0.0.1:3000");
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
-  Quic::QuicClientTransportSocketFactory factory_{
-      std::unique_ptr<Envoy::Ssl::ClientContextConfig>(new NiceMock<Ssl::MockClientContextConfig>),
-      context_};
+  absl::optional<Quic::QuicClientTransportSocketFactory> factory_;
+  Ssl::ClientContextSharedPtr ssl_context_{new Ssl::MockClientContext()};
   Stats::IsolatedStoreImpl store_;
   Quic::QuicStatNames quic_stat_names_{store_.symbolTable()};
-  ConnectionPool::InstancePtr pool_;
+  std::unique_ptr<Http3ConnPoolImpl> pool_;
 };
 
 class MockQuicClientTransportSocketFactory : public Quic::QuicClientTransportSocketFactory {
@@ -122,9 +144,30 @@ TEST_F(Http3ConnPoolImplTest, FailWithSecretsBecomeEmpty) {
   EXPECT_EQ(static_cast<Http3ConnPoolImpl*>(pool.get())->instantiateActiveClient(), nullptr);
 }
 
-TEST_F(Http3ConnPoolImplTest, CreationWithBufferLimits) {
+class MockPoolConnectResultCallback : public PoolConnectResultCallback {
+public:
+  MOCK_METHOD(void, onConnectSucceeded, ());
+  MOCK_METHOD(void, onConnectFailedWithEarlyData, ());
+};
+
+TEST_F(Http3ConnPoolImplTest, CreationAndNewStream) {
   EXPECT_CALL(mockHost().cluster_, perConnectionBufferLimitBytes);
   initialize();
+
+  MockPoolConnectResultCallback connect_result_callback;
+  MockResponseDecoder decoder;
+  ConnPoolCallbacks callbacks;
+  pool_->setConnectResultCallback(connect_result_callback);
+
+  ConnectionPool::Cancellable* cancellable = pool_->newStream(decoder, callbacks);
+  EXPECT_NE(nullptr, cancellable);
+  std::list<Envoy::ConnectionPool::ActiveClientPtr>& clients =
+      Http3ConnPoolImplPeer::connectingClients(*pool_);
+  EXPECT_EQ(1u, clients.size());
+  EXPECT_CALL(connect_result_callback, onConnectSucceeded()).WillOnce(Invoke([cancellable]() {
+    cancellable->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
+  }));
+  pool_->onConnectionEvent(*clients.front(), "", Network::ConnectionEvent::Connected);
 }
 
 TEST_F(Http3ConnPoolImplTest, CreationWithConfig) {


### PR DESCRIPTION
Commit Message: mark h3 conn pool Confirmed via a new callback interface PoolConnectResultCallback instead of `WrapperCallbacks::onConnectionAttemptReady()`. The new interface is called from h3 pool based on handshake result. 

Moving marking Confirmed logic out of `onConnectionAttemptReady()` is needed to support 0-RTT handshakes. This is because if a connection is using 0-RTT credentials, onPoolReady() doesn't necessarily means the handshake succeeds. And it will also be used to notify conn pool grid about 0-RTT handshake failure when h3 conn pool starts sending 0-RTT requests.

Risk Level: low, conn pool grid change
Testing: added unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Part of #19593 #18715
