### PR TITLE
test: Improve headers test robustness.

### DIFF
--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -493,7 +493,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, TestManyResponseHeadersRejected) {
 
   Http::TestResponseHeaderMapImpl many_headers(default_response_headers_);
   for (int i = 0; i < 100; i++) {
-    many_headers.addCopy("many", std::string(1, 'a'));
+    many_headers.addCopy(absl::StrCat("many", i), std::string(1, 'a'));
   }
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();


### PR DESCRIPTION
This small testing change improves header test robustness by ensuring
that multiple headers are (as intended) counted distinctly.

The intention of
MultiplexedUpstreamIntegrationTest.TestManyResponseHeadersRejected is to
verify that a response with over 100 headers is rejected.

Based on https://httpwg.org/specs/rfc7230.html#field.order, "[a] sender
MUST NOT generate multiple header fields with the same field name in a
message unless either the entire field value for that header field is
defined as a comma-separated list [i.e., #(values)] or the header field
is a well-known exception [...]" and "[a] recipient MAY combine multiple
header fields with the same field name into one "field-name:
field-value" pair, without changing the semantics of the message [...]"

By changing the test to use unique header field names, we can guarantee
that the count of headers reaches the desired number regardless of the
spec language above.

Signed-off-by: Dianna Hu <diannahu@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: low
Testing: //test/integration:multiplexed_upstream_integration_test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
