### PR TITLE
health_check: envoy.reloadable_features.health_check.graceful_goaway_handling deprecation

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -35,7 +35,6 @@ Removed Config or Runtime
 * http: removed ``envoy.reloadable_features.http_transport_failure_reason_in_body`` and legacy code paths.
 * http: removed ``envoy.reloadable_features.allow_response_for_timeout`` and legacy code paths.
 * udp: removed ``envoy.reloadable_features.udp_per_event_loop_read_limit`` and legacy code paths.
-
 * upstream: removed ``envoy.reloadable_features.health_check.graceful_goaway_handling`` and legacy code paths.
 
 New Features

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -36,6 +36,7 @@ Removed Config or Runtime
 * http: removed ``envoy.reloadable_features.allow_response_for_timeout`` and legacy code paths.
 * udp: removed ``envoy.reloadable_features.udp_per_event_loop_read_limit`` and legacy code paths.
 
+* upstream: removed ``envoy.reloadable_features.health_check.graceful_goaway_handling`` and legacy code paths.
 
 New Features
 ------------

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -65,7 +65,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.enable_grpc_async_client_cache",
     "envoy.reloadable_features.fix_added_trailers",
     "envoy.reloadable_features.handle_stream_reset_during_hcm_encoding",
-    "envoy.reloadable_features.health_check.graceful_goaway_handling",
     "envoy.reloadable_features.http2_allow_capacity_increase_by_settings",
     "envoy.reloadable_features.http2_consume_stream_refused_errors",
     "envoy.reloadable_features.http2_new_codec_wrapper",

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -325,13 +325,6 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onGoAway(
   ENVOY_CONN_LOG(debug, "connection going away goaway_code={}, health_flags={}", *client_,
                  error_code, HostUtility::healthFlagsToString(*host_));
 
-  // Runtime guard around graceful handling of NO_ERROR GOAWAY handling. The old behavior is to
-  // ignore GOAWAY completely.
-  if (!parent_.runtime_.snapshot().runtimeFeatureEnabled(
-          "envoy.reloadable_features.health_check.graceful_goaway_handling")) {
-    return;
-  }
-
   if (request_in_flight_ && error_code == Http::GoAwayErrorCode::NoError) {
     // The server is starting a graceful shutdown. Allow the in flight request
     // to finish without treating this as a health check error, and then


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #18438
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
