### PR TITLE
minor perf: reduce unnecessaary slice move when reserve buffer

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -355,10 +355,10 @@ Reservation OwnedImpl::reserveWithMaxLength(uint64_t max_length) {
 
     // We will tag the reservation slices on commit. This avoids unnecessary
     // work in the case that the entire reservation isn't used.
-    Slice slice(size, nullptr, slices_owner->free_list_);
-    const auto raw_slice = slice.reserve(size);
+    slices_owner->owned_slices_.emplace_back(size, nullptr, slices_owner->free_list_);
+    const auto raw_slice = slices_owner->owned_slices_.back().reserve(size);
     reservation_slices.push_back(raw_slice);
-    slices_owner->owned_slices_.emplace_back(std::move(slice));
+
     bytes_remaining -= std::min<uint64_t>(raw_slice.len_, bytes_remaining);
     reserved += raw_slice.len_;
   }


### PR DESCRIPTION

Commit Message: minor perf: reduce unnecessaary slice move when reserve buffer
Additional Description:

Minor optimization by minor code update. Replace move by the in-place constructing.

Before:
![image](https://user-images.githubusercontent.com/12389633/150133328-b0bb5378-ccea-4b66-a6d5-4ccbec0b9b77.png)

After:
![image](https://user-images.githubusercontent.com/12389633/150133457-3a8813fd-6513-4183-a3f3-64e246ce1310.png)

These results come from `valgrind`. I run Envoy with the most simple config and emit 100000 HTTP1.1 requests by the wrk.


Risk Level: Low.
Testing: N/A.
Docs Changes:  N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
