### PR TITLE
wasm: exclude C++ tests on all unsupported platforms.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -426,7 +426,7 @@ config_setting(
 )
 
 config_setting(
-    name = "wasm_none",
+    name = "wasm_disabled",
     values = {"define": "wasm=disabled"},
 )
 
@@ -588,6 +588,30 @@ selects.config_setting_group(
         ":ios_x86_64",
         ":linux_x86_64",
         ":windows_x86_64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "not_x86",
+    match_any = [
+        ":darwin_arm64",
+        ":ios_arm64",
+        ":ios_arm64e",
+        ":ios_armv7",
+        ":ios_armv7s",
+        ":ios_i386",
+        ":linux_aarch64",
+        ":linux_mips64",
+        ":linux_ppc",
+        ":linux_s390x",
+    ],
+)
+
+selects.config_setting_group(
+    name = "not_x86_or_wasm_disabled",
+    match_any = [
+        ":not_x86",
+        ":wasm_disabled",
     ],
 )
 

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -43,9 +43,7 @@ def envoy_select_hot_restart(xs, repository = ""):
 # and the ability to build tests using Proxy-Wasm C++ SDK on the current platform.
 def envoy_select_wasm_cpp_tests(xs):
     return select({
-        "@envoy//bazel:darwin_arm64": [],
-        "@envoy//bazel:linux_aarch64": [],
-        "@envoy//bazel:wasm_none": [],
+        "@envoy//bazel:not_x86_or_wasm_disabled": [],
         "//conditions:default": xs,
     })
 
@@ -53,7 +51,7 @@ def envoy_select_wasm_cpp_tests(xs):
 # and the ability to build tests using Proxy-Wasm Rust SDK on the current platform.
 def envoy_select_wasm_rust_tests(xs):
     return select({
-        "@envoy//bazel:wasm_none": [],
+        "@envoy//bazel:wasm_disabled": [],
         "//conditions:default": xs,
     })
 
@@ -64,7 +62,7 @@ def envoy_select_wasm_v8(xs):
         "@envoy//bazel:wasm_wamr": [],
         "@envoy//bazel:wasm_wasmtime": [],
         "@envoy//bazel:wasm_wavm": [],
-        "@envoy//bazel:wasm_none": [],
+        "@envoy//bazel:wasm_disabled": [],
         "//conditions:default": xs,  # implicit default (v8)
     })
 
@@ -75,7 +73,7 @@ def envoy_select_wasm_v8_bool():
         "@envoy//bazel:wasm_wamr": False,
         "@envoy//bazel:wasm_wasmtime": False,
         "@envoy//bazel:wasm_wavm": False,
-        "@envoy//bazel:wasm_none": False,
+        "@envoy//bazel:wasm_disabled": False,
         "//conditions:default": True,  # implicit default (v8)
     })
 

--- a/test/extensions/access_loggers/wasm/config_test.cc
+++ b/test/extensions/access_loggers/wasm/config_test.cc
@@ -56,8 +56,8 @@ TEST_P(WasmAccessLogConfigTest, CreateWasmFromEmpty) {
 }
 
 TEST_P(WasmAccessLogConfigTest, CreateWasmFromWASM) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/bootstrap/wasm/config_test.cc
+++ b/test/extensions/bootstrap/wasm/config_test.cc
@@ -72,8 +72,8 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmFactoryTest,
                          Envoy::Extensions::Common::Wasm::runtime_values);
 
 TEST_P(WasmFactoryTest, CreateWasmFromWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -90,8 +90,8 @@ TEST_P(WasmFactoryTest, CreateWasmFromWasm) {
 }
 
 TEST_P(WasmFactoryTest, CreateWasmFromWasmPerThread) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -105,8 +105,8 @@ TEST_P(WasmFactoryTest, CreateWasmFromWasmPerThread) {
 }
 
 TEST_P(WasmFactoryTest, MissingImport) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -122,8 +122,8 @@ TEST_P(WasmFactoryTest, MissingImport) {
 }
 
 TEST_P(WasmFactoryTest, UnspecifiedRuntime) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -136,8 +136,8 @@ TEST_P(WasmFactoryTest, UnspecifiedRuntime) {
 }
 
 TEST_P(WasmFactoryTest, UnknownRuntime) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -149,8 +149,8 @@ TEST_P(WasmFactoryTest, UnknownRuntime) {
 }
 
 TEST_P(WasmFactoryTest, StartFailed) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -165,8 +165,8 @@ TEST_P(WasmFactoryTest, StartFailed) {
 }
 
 TEST_P(WasmFactoryTest, StartFailedOpen) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -182,8 +182,8 @@ TEST_P(WasmFactoryTest, StartFailedOpen) {
 }
 
 TEST_P(WasmFactoryTest, ConfigureFailed) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/bootstrap/wasm/wasm_integration_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_integration_test.cc
@@ -73,8 +73,8 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmIntegrationTest,
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WasmIntegrationTest);
 
 TEST_P(WasmIntegrationTest, FilterMakesCallInConfigureTime) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/bootstrap/wasm/wasm_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_test.cc
@@ -170,8 +170,8 @@ TEST_P(WasmTestMatrix, LoggingWithEnvVars) {
 }
 
 TEST_P(WasmTest, BadSignature) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -186,8 +186,8 @@ TEST_P(WasmTest, BadSignature) {
 }
 
 TEST_P(WasmTest, Segv) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -205,8 +205,8 @@ TEST_P(WasmTest, Segv) {
 }
 
 TEST_P(WasmTest, DivByZero) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -224,8 +224,8 @@ TEST_P(WasmTest, DivByZero) {
 }
 
 TEST_P(WasmTest, IntrinsicGlobals) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -249,8 +249,8 @@ TEST_P(WasmTest, IntrinsicGlobals) {
 // change this behavior by providing non-trapping instructions, but in the mean time we support the
 // default Emscripten behavior.
 TEST_P(WasmTest, Asm2Wasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -267,8 +267,8 @@ TEST_P(WasmTest, Asm2Wasm) {
 }
 
 TEST_P(WasmNullTest, Stats) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -292,8 +292,8 @@ TEST_P(WasmNullTest, Stats) {
 }
 
 TEST_P(WasmNullTest, StatsHigherLevel) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -323,8 +323,8 @@ TEST_P(WasmNullTest, StatsHigherLevel) {
 }
 
 TEST_P(WasmNullTest, StatsHighLevel) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/common/wasm/wasm_runtime.cc
+++ b/test/extensions/common/wasm/wasm_runtime.cc
@@ -30,8 +30,8 @@ std::vector<std::string> sandboxRuntimes() {
 
 std::vector<std::string> languages() {
   std::vector<std::string> languages;
-#if !defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !!defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   languages.push_back("cpp");
 #endif
   languages.push_back("rust");

--- a/test/extensions/common/wasm/wasm_runtime.cc
+++ b/test/extensions/common/wasm/wasm_runtime.cc
@@ -30,7 +30,7 @@ std::vector<std::string> sandboxRuntimes() {
 
 std::vector<std::string> languages() {
   std::vector<std::string> languages;
-#if !!defined(__x86_64__)
+#if defined(__x86_64__)
   // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   languages.push_back("cpp");
 #endif

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -172,8 +172,8 @@ TEST_P(WasmCommonTest, Logging) {
 
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -237,8 +237,8 @@ TEST_P(WasmCommonTest, Logging) {
 }
 
 TEST_P(WasmCommonTest, BadSignature) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -271,8 +271,8 @@ TEST_P(WasmCommonTest, BadSignature) {
 }
 
 TEST_P(WasmCommonTest, Segv) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -320,8 +320,8 @@ TEST_P(WasmCommonTest, Segv) {
 }
 
 TEST_P(WasmCommonTest, DivByZero) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -379,8 +379,8 @@ TEST_P(WasmCommonTest, IntrinsicGlobals) {
 
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -425,8 +425,8 @@ TEST_P(WasmCommonTest, Utilities) {
 
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -498,8 +498,8 @@ TEST_P(WasmCommonTest, Stats) {
 
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -554,8 +554,8 @@ TEST_P(WasmCommonTest, Foreign) {
   EXPECT_NE(wasm, nullptr);
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -599,8 +599,8 @@ TEST_P(WasmCommonTest, OnForeign) {
   EXPECT_NE(wasm, nullptr);
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -651,8 +651,8 @@ TEST_P(WasmCommonTest, WASI) {
   EXPECT_NE(wasm, nullptr);
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -709,8 +709,8 @@ TEST_P(WasmCommonTest, VmCache) {
   vm_config->mutable_configuration()->PackFrom(vm_configuration_string);
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -775,8 +775,8 @@ TEST_P(WasmCommonTest, VmCache) {
 }
 
 TEST_P(WasmCommonTest, RemoteCode) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -895,8 +895,8 @@ TEST_P(WasmCommonTest, RemoteCode) {
 }
 
 TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1023,8 +1023,8 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
 
 // test that wasm imports/exports do not work when ABI restriction is enforced
 TEST_P(WasmCommonTest, RestrictCapabilities) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1083,8 +1083,8 @@ TEST_P(WasmCommonTest, RestrictCapabilities) {
 
 // test with proxy_on_vm_start allowed, but proxy_log restricted
 TEST_P(WasmCommonTest, AllowOnVmStart) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1145,8 +1145,8 @@ TEST_P(WasmCommonTest, AllowOnVmStart) {
 
 // test with both proxy_on_vm_start and proxy_log allowed, but WASI restricted
 TEST_P(WasmCommonTest, AllowLog) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1204,8 +1204,8 @@ TEST_P(WasmCommonTest, AllowLog) {
 
 // test with both proxy_on_vm_start and fd_write allowed, but proxy_log restricted
 TEST_P(WasmCommonTest, AllowWASI) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1263,8 +1263,8 @@ TEST_P(WasmCommonTest, AllowWASI) {
 
 // test a different callback besides proxy_on_vm_start
 TEST_P(WasmCommonTest, AllowOnContextCreate) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1324,8 +1324,8 @@ TEST_P(WasmCommonTest, AllowOnContextCreate) {
 
 // test that a copy-constructed thread-local Wasm still enforces the same policy
 TEST_P(WasmCommonTest, ThreadLocalCopyRetainsEnforcement) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -1425,8 +1425,8 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmCommonContextTest,
 TEST_P(WasmCommonContextTest, OnDnsResolve) {
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(absl::StrCat(
@@ -1481,8 +1481,8 @@ TEST_P(WasmCommonContextTest, OnDnsResolve) {
 TEST_P(WasmCommonContextTest, EmptyContext) {
   std::string code;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(absl::StrCat(

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -69,8 +69,8 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmFilterConfigTest,
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WasmFilterConfigTest);
 
 TEST_P(WasmFilterConfigTest, JsonLoadFromFileWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -107,8 +107,8 @@ TEST_P(WasmFilterConfigTest, JsonLoadFromFileWasm) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -156,8 +156,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasm) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasmFailOpenOk) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -190,8 +190,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasmFailOpenOk) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadInlineWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -240,8 +240,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadInlineBadCode) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -295,8 +295,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasm) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailOnUncachedThenSucceed) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -367,8 +367,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailOnUncachedThenSucceed) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -565,8 +565,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteConnectionReset) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -613,8 +613,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteConnectionReset) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessWith503) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -664,8 +664,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessWith503) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessIncorrectSha256) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -715,8 +715,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessIncorrectSha256) {
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteMultipleRetries) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/filters/network/wasm/config_test.cc
+++ b/test/extensions/filters/network/wasm/config_test.cc
@@ -60,8 +60,8 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmNetworkFilterConfigTest,
                          Envoy::Extensions::Common::Wasm::runtime_values);
 
 TEST_P(WasmNetworkFilterConfigTest, YamlLoadFromFileWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -106,8 +106,8 @@ TEST_P(WasmNetworkFilterConfigTest, YamlLoadFromFileWasm) {
 }
 
 TEST_P(WasmNetworkFilterConfigTest, YamlLoadInlineWasm) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -180,8 +180,8 @@ TEST_P(WasmNetworkFilterConfigTest, YamlLoadInlineBadCodeFailOpenNackConfig) {
 }
 
 TEST_P(WasmNetworkFilterConfigTest, FilterConfigFailClosed) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -209,8 +209,8 @@ TEST_P(WasmNetworkFilterConfigTest, FilterConfigFailClosed) {
 }
 
 TEST_P(WasmNetworkFilterConfigTest, FilterConfigFailOpen) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -237,8 +237,8 @@ TEST_P(WasmNetworkFilterConfigTest, FilterConfigFailOpen) {
 }
 
 TEST_P(WasmNetworkFilterConfigTest, FilterConfigCapabilitiesUnrestrictedByDefault) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -270,8 +270,8 @@ TEST_P(WasmNetworkFilterConfigTest, FilterConfigCapabilitiesUnrestrictedByDefaul
 }
 
 TEST_P(WasmNetworkFilterConfigTest, FilterConfigCapabilityRestriction) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }
@@ -305,8 +305,8 @@ TEST_P(WasmNetworkFilterConfigTest, FilterConfigCapabilityRestriction) {
 }
 
 TEST_P(WasmNetworkFilterConfigTest, FilterConfigAllowOnVmStart) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/stats_sinks/wasm/config_test.cc
+++ b/test/extensions/stats_sinks/wasm/config_test.cc
@@ -81,8 +81,8 @@ TEST_P(WasmStatSinkConfigTest, CreateWasmFailOpen) {
 }
 
 TEST_P(WasmStatSinkConfigTest, CreateWasmFromWASM) {
-#if defined(__aarch64__)
-  // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+  // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
   if (GetParam() != "null") {
     return;
   }

--- a/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
+++ b/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
@@ -62,8 +62,8 @@ TEST_P(WasmCommonContextTest, OnStat) {
   std::string code;
   NiceMock<Stats::MockMetricSnapshot> snapshot_;
   if (GetParam() != "null") {
-#if defined(__aarch64__)
-    // TODO(PiotrSikora): There are no Emscripten releases for arm64.
+#if !defined(__x86_64__)
+    // TODO(PiotrSikora): Emscripten ships binaries only for x86_64.
     return;
 #endif
     code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(absl::StrCat(


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>