### PR TITLE
dubbo: fix body length wrong assert for response type

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
@@ -101,9 +101,9 @@ DubboHessian2SerializerImpl::deserializeRpcResult(Buffer::Instance& buffer,
     result->setException(true);
     break;
   case RpcResponseType::ResponseWithNullValue:
-  case RpcResponseType::ResponseNullValueWithAttachments:
     has_value = false;
     FALLTHRU;
+  case RpcResponseType::ResponseNullValueWithAttachments:
   case RpcResponseType::ResponseWithValue:
   case RpcResponseType::ResponseValueWithAttachments:
     result->setException(false);


### PR DESCRIPTION
As for the RESPONSE_NULL_VALUE_WITH_ATTACHEMENTS type for dubbo response, the body contains attachments whose length is more than zero.
