### PR TITLE
quic: fix quic platform test TSAN failure

### DIFF
--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -230,7 +230,7 @@ TEST_F(QuicPlatformTest, QuicThread) {
   EXPECT_EQ(1, value);
 
   // QuicThread will panic if it's started but not joined.
-  EXPECT_DEATH({ AdderThread(&value, 2).Start(); },
+  EXPECT_DEATH({ QuicThread("test_thread").Start(); },
                "QuicThread should be joined before destruction");
 }
 

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -209,22 +209,22 @@ TEST_F(QuicPlatformTest, QuicThread) {
 
     void waitForRun() {
       // Wait for Run() to finish.
-      std::unique_lock<std::mutex> lk(m_);
-      cv_.wait(lk);
+      absl::MutexLock lk(&m_);
+      cv_.Wait(&m_);
     }
 
   protected:
     void Run() override {
-      std::unique_lock<std::mutex> lk(m_);
+      absl::MutexLock lk(&m_);
       *value_ += increment_;
-      cv_.notify_one();
+      cv_.Signal();
     }
 
   private:
     int* value_;
     int increment_;
-    std::mutex m_;
-    std::condition_variable cv_;
+    absl::Mutex m_;
+    absl::CondVar cv_;
   };
 
   int value = 0;


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: QuicThread test fails under TSAN because of racing between vtable pointer change and calling into its virtual method. Fix it by waiting till the virtual method finishes before destruction.

This is a test setup issue.

Risk Level: low, test only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
