### PR TITLE
Use byteMeter in QUIC streams

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -144,7 +144,8 @@ void EnvoyQuicClientStream::switchStreamBlockState() {
 void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
                                                      const quic::QuicHeaderList& header_list) {
   if (stream_bytes_read() > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() -
+                                              bytesMeter()->wireBytesReceived());
   }
   mutableBytesMeter()->addHeaderBytesReceived(frame_len);
   if (read_side_closed()) {
@@ -203,7 +204,8 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
 
 void EnvoyQuicClientStream::OnBodyAvailable() {
   if (stream_bytes_read() > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() -
+                                              bytesMeter()->wireBytesReceived());
   }
   ASSERT(FinishedReadingHeaders());
   if (read_side_closed()) {
@@ -255,7 +257,8 @@ void EnvoyQuicClientStream::OnBodyAvailable() {
 void EnvoyQuicClientStream::OnTrailingHeadersComplete(bool fin, size_t frame_len,
                                                       const quic::QuicHeaderList& header_list) {
   if (stream_bytes_read() > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() -
+                                              bytesMeter()->wireBytesReceived());
   }
   mutableBytesMeter()->addHeaderBytesReceived(frame_len);
   if (read_side_closed()) {

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -201,7 +201,8 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
 void EnvoyQuicClientStream::OnStreamFrame(const quic::QuicStreamFrame& frame) {
   uint64_t highest_byte_received = frame.data_length + frame.offset;
   if (highest_byte_received > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(highest_byte_received - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(highest_byte_received -
+                                              bytesMeter()->wireBytesReceived());
   }
   quic::QuicSpdyClientStream::OnStreamFrame(frame);
 }

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -57,10 +57,10 @@ Http::Status EnvoyQuicClientStream::encodeHeaders(const Http::RequestHeaderMap& 
       sent_head_request_ = true;
     }
   }
-  IncrementalBytesSentTracker tracker(*this);
-  WriteHeaders(std::move(spdy_headers), end_stream, nullptr);
-  mutableBytesMeter()->addHeaderBytesSent(tracker.incrementalBytesSent());
-  mutableBytesMeter()->addWireBytesSent(tracker.incrementalBytesSent());
+  {
+    IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), true);
+    WriteHeaders(std::move(spdy_headers), end_stream, nullptr);
+  }
 
   if (local_end_stream_) {
     onLocalEndStream();
@@ -90,9 +90,10 @@ void EnvoyQuicClientStream::encodeData(Buffer::Instance& data, bool end_stream) 
   }
   absl::Span<quic::QuicMemSlice> span(quic_slices);
   // QUIC stream must take all.
-  IncrementalBytesSentTracker tracker(*this);
-  WriteBodySlices(span, end_stream);
-  mutableBytesMeter()->addWireBytesSent(tracker.incrementalBytesSent());
+  {
+    IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), false);
+    WriteBodySlices(span, end_stream);
+  }
   if (data.length() > 0) {
     // Send buffer didn't take all the data, threshold needs to be adjusted.
     Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
@@ -109,10 +110,10 @@ void EnvoyQuicClientStream::encodeTrailers(const Http::RequestTrailerMap& traile
   ENVOY_STREAM_LOG(debug, "encodeTrailers: {}.", *this, trailers);
   ScopedWatermarkBufferUpdater updater(this, this);
 
-  IncrementalBytesSentTracker tracker(*this);
-  WriteTrailers(envoyHeadersToSpdyHeaderBlock(trailers), nullptr);
-  mutableBytesMeter()->addHeaderBytesSent(tracker.incrementalBytesSent());
-  mutableBytesMeter()->addWireBytesSent(tracker.incrementalBytesSent());
+  {
+    IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), true);
+    WriteTrailers(envoyHeadersToSpdyHeaderBlock(trailers), nullptr);
+  }
 
   onLocalEndStream();
 }

--- a/source/common/quic/envoy_quic_client_stream.h
+++ b/source/common/quic/envoy_quic_client_stream.h
@@ -36,6 +36,8 @@ public:
   void resetStream(Http::StreamResetReason reason) override;
   void setFlushTimeout(std::chrono::milliseconds) override {}
 
+  // quic::QuicStream
+  void OnStreamFrame(const quic::QuicStreamFrame& frame) override;
   // quic::QuicSpdyStream
   void OnBodyAvailable() override;
   void OnStreamReset(const quic::QuicRstStreamFrame& frame) override;

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -144,7 +144,8 @@ void EnvoyQuicServerStream::switchStreamBlockState() {
 void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
                                                      const quic::QuicHeaderList& header_list) {
   if (stream_bytes_read() > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() -
+                                              bytesMeter()->wireBytesReceived());
   }
   mutableBytesMeter()->addHeaderBytesReceived(frame_len);
   // TODO(danzh) Fix in QUICHE. If the stream has been reset in the call stack,
@@ -184,7 +185,8 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
 
 void EnvoyQuicServerStream::OnBodyAvailable() {
   if (stream_bytes_read() > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() -
+                                              bytesMeter()->wireBytesReceived());
   }
   ASSERT(FinishedReadingHeaders());
   if (read_side_closed()) {
@@ -237,7 +239,8 @@ void EnvoyQuicServerStream::OnBodyAvailable() {
 void EnvoyQuicServerStream::OnTrailingHeadersComplete(bool fin, size_t frame_len,
                                                       const quic::QuicHeaderList& header_list) {
   if (stream_bytes_read() > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(stream_bytes_read() -
+                                              bytesMeter()->wireBytesReceived());
   }
   mutableBytesMeter()->addHeaderBytesReceived(frame_len);
   if (read_side_closed()) {

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -182,7 +182,8 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
 void EnvoyQuicServerStream::OnStreamFrame(const quic::QuicStreamFrame& frame) {
   uint64_t highest_byte_received = frame.data_length + frame.offset;
   if (highest_byte_received > bytesMeter()->wireBytesReceived()) {
-    mutableBytesMeter()->addWireBytesReceived(highest_byte_received - bytesMeter()->wireBytesReceived());
+    mutableBytesMeter()->addWireBytesReceived(highest_byte_received -
+                                              bytesMeter()->wireBytesReceived());
   }
   quic::QuicSpdyServerStreamBase::OnStreamFrame(frame);
 }

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -36,8 +36,6 @@ public:
   // Http::Stream
   void resetStream(Http::StreamResetReason reason) override;
 
-  // quic::QuicStream
-  void OnStreamDataConsumed(quic::QuicByteCount bytes_consumed) override;
   // quic::QuicSpdyStream
   void OnBodyAvailable() override;
   bool OnStopSending(quic::QuicResetStreamError error) override;

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -36,6 +36,8 @@ public:
   // Http::Stream
   void resetStream(Http::StreamResetReason reason) override;
 
+  // quic::QuicStream
+  void OnStreamFrame(const quic::QuicStreamFrame& frame) override;
   // quic::QuicSpdyStream
   void OnBodyAvailable() override;
   bool OnStopSending(quic::QuicResetStreamError error) override;

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -36,6 +36,8 @@ public:
   // Http::Stream
   void resetStream(Http::StreamResetReason reason) override;
 
+  // quic::QuicStream
+  void OnStreamDataConsumed(quic::QuicByteCount bytes_consumed) override;
   // quic::QuicSpdyStream
   void OnBodyAvailable() override;
   bool OnStopSending(quic::QuicResetStreamError error) override;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -198,11 +198,14 @@ private:
   http2::adapter::HeaderValidator header_validator_;
 };
 
-// Object used for updating a BytesMeter to track bytes sent on a QuicStream since this object was constructed.
+// Object used for updating a BytesMeter to track bytes sent on a QuicStream since this object was
+// constructed.
 class IncrementalBytesSentTracker {
 public:
-  IncrementalBytesSentTracker(const quic::QuicStream& stream, StreamInfo::BytesMeter& bytes_meter, bool update_header_bytes)
-      : stream_(stream), bytes_meter_(bytes_meter), update_header_bytes_(update_header_bytes), initial_bytes_sent_(totalStreamBytesWritten()) {}
+  IncrementalBytesSentTracker(const quic::QuicStream& stream, StreamInfo::BytesMeter& bytes_meter,
+                              bool update_header_bytes)
+      : stream_(stream), bytes_meter_(bytes_meter), update_header_bytes_(update_header_bytes),
+        initial_bytes_sent_(totalStreamBytesWritten()) {}
 
   ~IncrementalBytesSentTracker() {
     if (update_header_bytes_) {
@@ -211,7 +214,7 @@ public:
     bytes_meter_.addWireBytesSent(incrementalBytesWritten());
   }
 
- private:
+private:
   // Returns the number of newly sent bytes since the tracker was constructed.
   uint64_t incrementalBytesWritten() {
     ASSERT(totalStreamBytesWritten() >= initial_bytes_sent_);

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -198,5 +198,26 @@ private:
   http2::adapter::HeaderValidator header_validator_;
 };
 
+// Object used for tracking bytes sent on a QuicStream since this object was constructed.
+class IncrementalBytesSentTracker {
+ public:
+  IncrementalBytesSentTracker(const quic::QuicStream& stream)
+      : stream_(stream), initial__bytes_sent_(totalStreamBytesSent()) {}
+
+  // Returns the number of newly sent bytes since the tracker was constructed.
+  uint64_t incrementalBytesSent() {
+    ASSERT(totalStreamBytesSent() >= initial__bytes_sent_);
+    return totalStreamBytesSent() - initial__bytes_sent_;
+  }
+
+ private:
+  uint64_t totalStreamBytesSent() const {
+    return  stream_.stream_bytes_written() + stream_.BufferedDataBytes();
+  }
+
+  const quic::QuicStream& stream_;
+  uint64_t initial__bytes_sent_;
+};
+
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -200,7 +200,7 @@ private:
 
 // Object used for tracking bytes sent on a QuicStream since this object was constructed.
 class IncrementalBytesSentTracker {
- public:
+public:
   IncrementalBytesSentTracker(const quic::QuicStream& stream)
       : stream_(stream), initial__bytes_sent_(totalStreamBytesSent()) {}
 
@@ -210,9 +210,9 @@ class IncrementalBytesSentTracker {
     return totalStreamBytesSent() - initial__bytes_sent_;
   }
 
- private:
+private:
   uint64_t totalStreamBytesSent() const {
-    return  stream_.stream_bytes_written() + stream_.BufferedDataBytes();
+    return stream_.stream_bytes_written() + stream_.BufferedDataBytes();
   }
 
   const quic::QuicStream& stream_;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -153,6 +153,8 @@ protected:
     }
   }
 
+  StreamInfo::BytesMeterSharedPtr& mutableBytesMeter() { return bytes_meter_; }
+
   // True once end of stream is propagated to Envoy. Envoy doesn't expect to be
   // notified more than once about end of stream. So once this is true, no need
   // to set it in the callback to Envoy stream any more.

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -202,12 +202,12 @@ private:
 class IncrementalBytesSentTracker {
 public:
   IncrementalBytesSentTracker(const quic::QuicStream& stream)
-      : stream_(stream), initial__bytes_sent_(totalStreamBytesSent()) {}
+      : stream_(stream), initial_bytes_sent_(totalStreamBytesSent()) {}
 
   // Returns the number of newly sent bytes since the tracker was constructed.
   uint64_t incrementalBytesSent() {
-    ASSERT(totalStreamBytesSent() >= initial__bytes_sent_);
-    return totalStreamBytesSent() - initial__bytes_sent_;
+    ASSERT(totalStreamBytesSent() >= initial_bytes_sent_);
+    return totalStreamBytesSent() - initial_bytes_sent_;
   }
 
 private:
@@ -216,7 +216,7 @@ private:
   }
 
   const quic::QuicStream& stream_;
-  uint64_t initial__bytes_sent_;
+  uint64_t initial_bytes_sent_;
 };
 
 } // namespace Quic

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -220,17 +220,20 @@ TEST_F(EnvoyQuicClientStreamTest, PostRequestAndResponseWithAccounting) {
   quic_stream_->encodeData(request_body_, false);
   body_bytes = quic_stream_->stream_bytes_written() - body_bytes;
   EXPECT_EQ(quic_stream_->stream_bytes_written(), quic_stream_->bytesMeter()->wireBytesSent());
-  EXPECT_EQ(quic_stream_->stream_bytes_written() - body_bytes, quic_stream_->bytesMeter()->headerBytesSent());
+  EXPECT_EQ(quic_stream_->stream_bytes_written() - body_bytes,
+            quic_stream_->bytesMeter()->headerBytesSent());
   quic_stream_->encodeTrailers(request_trailers_);
   EXPECT_EQ(quic_stream_->stream_bytes_written(), quic_stream_->bytesMeter()->wireBytesSent());
-  EXPECT_EQ(quic_stream_->stream_bytes_written() - body_bytes, quic_stream_->bytesMeter()->headerBytesSent());
+  EXPECT_EQ(quic_stream_->stream_bytes_written() - body_bytes,
+            quic_stream_->bytesMeter()->headerBytesSent());
 
   EXPECT_EQ(0, quic_stream_->bytesMeter()->wireBytesReceived());
   EXPECT_EQ(0, quic_stream_->bytesMeter()->headerBytesReceived());
 
   size_t offset = receiveResponseHeaders(false);
   // Received header bytes do not include the HTTP/3 frame overhead.
-  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2, quic_stream_->bytesMeter()->headerBytesReceived());
+  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2,
+            quic_stream_->bytesMeter()->headerBytesReceived());
   EXPECT_EQ(quic_stream_->stream_bytes_read(), quic_stream_->bytesMeter()->wireBytesReceived());
   EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
       .WillOnce(Invoke([](const Http::ResponseTrailerMapPtr& headers) {
@@ -249,7 +252,9 @@ TEST_F(EnvoyQuicClientStreamTest, PostRequestAndResponseWithAccounting) {
                                      spdyHeaderToHttp3StreamPayload(spdy_trailers_));
   quic::QuicStreamFrame frame(stream_id_, true, offset, payload);
   quic_stream_->OnStreamFrame(frame);
-  EXPECT_EQ(quic_stream_->stream_bytes_read() - 4 - bodyToHttp3StreamPayload(more_response_body).length(), quic_stream_->bytesMeter()->headerBytesReceived());
+  EXPECT_EQ(quic_stream_->stream_bytes_read() - 4 -
+                bodyToHttp3StreamPayload(more_response_body).length(),
+            quic_stream_->bytesMeter()->headerBytesReceived());
   EXPECT_EQ(quic_stream_->stream_bytes_read(), quic_stream_->bytesMeter()->wireBytesReceived());
 }
 

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -122,6 +122,19 @@ public:
     return offset + data.length();
   }
 
+  size_t receiveResponseHeaders(bool end_stream) {
+    EXPECT_CALL(stream_decoder_, decodeHeaders_(_, end_stream))
+        .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& headers, bool) {
+          EXPECT_EQ("200", headers->getStatusValue());
+        }));
+
+    std::string data = spdyHeaderToHttp3StreamPayload(spdy_response_headers_);
+    quic::QuicStreamFrame frame(stream_id_, end_stream, 0, data);
+    quic_stream_->OnStreamFrame(frame);
+    EXPECT_TRUE(quic_stream_->FinishedReadingHeaders());
+    return data.length();
+  }
+
 protected:
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
@@ -192,6 +205,52 @@ TEST_F(EnvoyQuicClientStreamTest, PostRequestAndResponse) {
                                      spdyHeaderToHttp3StreamPayload(spdy_trailers_));
   quic::QuicStreamFrame frame(stream_id_, true, offset, payload);
   quic_stream_->OnStreamFrame(frame);
+}
+
+TEST_F(EnvoyQuicClientStreamTest, PostRequestAndResponseWithAccounting) {
+  EXPECT_EQ(absl::nullopt, quic_stream_->http1StreamEncoderOptions());
+  EXPECT_EQ(0, quic_stream_->bytesMeter()->wireBytesSent());
+  EXPECT_EQ(0, quic_stream_->bytesMeter()->headerBytesSent());
+  const auto result = quic_stream_->encodeHeaders(request_headers_, false);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(quic_stream_->stream_bytes_written(), quic_stream_->bytesMeter()->wireBytesSent());
+  EXPECT_EQ(quic_stream_->stream_bytes_written(), quic_stream_->bytesMeter()->headerBytesSent());
+
+  uint64_t body_bytes = quic_stream_->stream_bytes_written();
+  quic_stream_->encodeData(request_body_, false);
+  body_bytes = quic_stream_->stream_bytes_written() - body_bytes;
+  EXPECT_EQ(quic_stream_->stream_bytes_written(), quic_stream_->bytesMeter()->wireBytesSent());
+  EXPECT_EQ(quic_stream_->stream_bytes_written() - body_bytes, quic_stream_->bytesMeter()->headerBytesSent());
+  quic_stream_->encodeTrailers(request_trailers_);
+  EXPECT_EQ(quic_stream_->stream_bytes_written(), quic_stream_->bytesMeter()->wireBytesSent());
+  EXPECT_EQ(quic_stream_->stream_bytes_written() - body_bytes, quic_stream_->bytesMeter()->headerBytesSent());
+
+  EXPECT_EQ(0, quic_stream_->bytesMeter()->wireBytesReceived());
+  EXPECT_EQ(0, quic_stream_->bytesMeter()->headerBytesReceived());
+
+  size_t offset = receiveResponseHeaders(false);
+  // Received header bytes do not include the HTTP/3 frame overhead.
+  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2, quic_stream_->bytesMeter()->headerBytesReceived());
+  EXPECT_EQ(quic_stream_->stream_bytes_read(), quic_stream_->bytesMeter()->wireBytesReceived());
+  EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
+      .WillOnce(Invoke([](const Http::ResponseTrailerMapPtr& headers) {
+        Http::LowerCaseString key1("key1");
+        Http::LowerCaseString key2(":final-offset");
+        EXPECT_EQ("value1", headers->get(key1)[0]->value().getStringView());
+        EXPECT_TRUE(headers->get(key2).empty());
+      }));
+  std::string more_response_body{"bbb"};
+  EXPECT_CALL(stream_decoder_, decodeData(_, _))
+      .WillOnce(Invoke([&](Buffer::Instance& buffer, bool finished_reading) {
+        EXPECT_EQ(more_response_body, buffer.toString());
+        EXPECT_EQ(false, finished_reading);
+      }));
+  std::string payload = absl::StrCat(bodyToHttp3StreamPayload(more_response_body),
+                                     spdyHeaderToHttp3StreamPayload(spdy_trailers_));
+  quic::QuicStreamFrame frame(stream_id_, true, offset, payload);
+  quic_stream_->OnStreamFrame(frame);
+  EXPECT_EQ(quic_stream_->stream_bytes_read() - 4 - bodyToHttp3StreamPayload(more_response_body).length(), quic_stream_->bytesMeter()->headerBytesReceived());
+  EXPECT_EQ(quic_stream_->stream_bytes_read(), quic_stream_->bytesMeter()->wireBytesReceived());
 }
 
 TEST_F(EnvoyQuicClientStreamTest, PostRequestAnd1xx) {

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -237,11 +237,13 @@ TEST_F(EnvoyQuicServerStreamTest, PostRequestAndResponseWithAccounting) {
   EXPECT_EQ(0, quic_stream_->bytesMeter()->headerBytesReceived());
   size_t offset = receiveRequestHeaders(false);
   // Received header bytes do not include the HTTP/3 frame overhead.
-  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2, quic_stream_->bytesMeter()->headerBytesReceived());
+  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2,
+            quic_stream_->bytesMeter()->headerBytesReceived());
   EXPECT_EQ(quic_stream_->stream_bytes_read(), quic_stream_->bytesMeter()->wireBytesReceived());
   size_t body_size = receiveRequestBody(offset, request_body_, true, request_body_.size() * 2);
   EXPECT_EQ(quic_stream_->stream_bytes_read(), quic_stream_->bytesMeter()->wireBytesReceived());
-  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2 - body_size, quic_stream_->bytesMeter()->headerBytesReceived());
+  EXPECT_EQ(quic_stream_->stream_bytes_read() - 2 - body_size,
+            quic_stream_->bytesMeter()->headerBytesReceived());
   // Wire bytes received will be slightly larger than the body + headers because of body framing.
   EXPECT_EQ(4 + request_body_.size() + quic_stream_->bytesMeter()->headerBytesReceived(),
             quic_stream_->bytesMeter()->wireBytesReceived());

--- a/test/integration/http_protocol_integration.cc
+++ b/test/integration/http_protocol_integration.cc
@@ -72,7 +72,8 @@ std::string HttpProtocolIntegrationTest::protocolTestParamsToString(
 }
 
 void HttpProtocolIntegrationTest::expectUpstreamBytesSentAndReceived(
-    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation, BytesCountExpectation h3_expectation, const int id) {
+    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation,
+    BytesCountExpectation h3_expectation, const int id) {
   auto integer_near = [](int x, int y) -> bool { return std::abs(x - y) <= (x / 20); };
   std::string access_log = waitForAccessLog(access_log_name_, id);
   std::vector<std::string> log_entries = absl::StrSplit(access_log, ' ');
@@ -106,7 +107,7 @@ void HttpProtocolIntegrationTest::expectUpstreamBytesSentAndReceived(
         << ", actual: " << header_bytes_received;
     return;
   }
-    case Http::CodecType::HTTP3: {
+  case Http::CodecType::HTTP3: {
     // Because of non-deterministic h2 compression, the same plain text length don't map to the
     // Same number of wire bytes.
     EXPECT_TRUE(integer_near(h3_expectation.wire_bytes_sent_, wire_bytes_sent))
@@ -127,7 +128,8 @@ void HttpProtocolIntegrationTest::expectUpstreamBytesSentAndReceived(
 }
 
 void HttpProtocolIntegrationTest::expectDownstreamBytesSentAndReceived(
-    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation, BytesCountExpectation h3_expectation, const int id) {
+    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation,
+    BytesCountExpectation h3_expectation, const int id) {
   auto integer_near = [](int x, int y) -> bool { return std::abs(x - y) <= (x / 5); };
   std::string access_log = waitForAccessLog(access_log_name_, id);
   std::vector<std::string> log_entries = absl::StrSplit(access_log, ' ');

--- a/test/integration/http_protocol_integration.cc
+++ b/test/integration/http_protocol_integration.cc
@@ -72,14 +72,15 @@ std::string HttpProtocolIntegrationTest::protocolTestParamsToString(
 }
 
 void HttpProtocolIntegrationTest::expectUpstreamBytesSentAndReceived(
-    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation, const int id) {
+    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation, BytesCountExpectation h3_expectation, const int id) {
   auto integer_near = [](int x, int y) -> bool { return std::abs(x - y) <= (x / 20); };
   std::string access_log = waitForAccessLog(access_log_name_, id);
   std::vector<std::string> log_entries = absl::StrSplit(access_log, ' ');
   int wire_bytes_sent = std::stoi(log_entries[0]), wire_bytes_received = std::stoi(log_entries[1]),
       header_bytes_sent = std::stoi(log_entries[2]),
       header_bytes_received = std::stoi(log_entries[3]);
-  if (upstreamProtocol() == Http::CodecType::HTTP1) {
+  switch (upstreamProtocol()) {
+  case Http::CodecType::HTTP1: {
     EXPECT_EQ(h1_expectation.wire_bytes_sent_, wire_bytes_sent)
         << "expect: " << h1_expectation.wire_bytes_sent_ << ", actual: " << wire_bytes_sent;
     EXPECT_EQ(h1_expectation.wire_bytes_received_, wire_bytes_received)
@@ -89,8 +90,9 @@ void HttpProtocolIntegrationTest::expectUpstreamBytesSentAndReceived(
     EXPECT_EQ(h1_expectation.header_bytes_received_, header_bytes_received)
         << "expect: " << h1_expectation.header_bytes_received_
         << ", actual: " << header_bytes_received;
+    return;
   }
-  if (upstreamProtocol() == Http::CodecType::HTTP2) {
+  case Http::CodecType::HTTP2: {
     // Because of non-deterministic h2 compression, the same plain text length don't map to the
     // same number of wire bytes.
     EXPECT_TRUE(integer_near(h2_expectation.wire_bytes_sent_, wire_bytes_sent))
@@ -102,18 +104,38 @@ void HttpProtocolIntegrationTest::expectUpstreamBytesSentAndReceived(
     EXPECT_TRUE(integer_near(h2_expectation.header_bytes_received_, header_bytes_received))
         << "expect: " << h2_expectation.header_bytes_received_
         << ", actual: " << header_bytes_received;
+    return;
+  }
+    case Http::CodecType::HTTP3: {
+    // Because of non-deterministic h2 compression, the same plain text length don't map to the
+    // Same number of wire bytes.
+    EXPECT_TRUE(integer_near(h3_expectation.wire_bytes_sent_, wire_bytes_sent))
+        << "expect: " << h3_expectation.wire_bytes_sent_ << ", actual: " << wire_bytes_sent;
+    EXPECT_TRUE(integer_near(h3_expectation.wire_bytes_received_, wire_bytes_received))
+        << "expect: " << h3_expectation.wire_bytes_received_ << ", actual: " << wire_bytes_received;
+    EXPECT_TRUE(integer_near(h3_expectation.header_bytes_sent_, header_bytes_sent))
+        << "expect: " << h3_expectation.header_bytes_sent_ << ", actual: " << header_bytes_sent;
+    EXPECT_TRUE(integer_near(h3_expectation.header_bytes_received_, header_bytes_received))
+        << "expect: " << h3_expectation.header_bytes_received_
+        << ", actual: " << header_bytes_received;
+    return;
+  }
+
+  default:
+    EXPECT_TRUE(false) << "Unexpected codec type: " << static_cast<int>(upstreamProtocol());
   }
 }
 
 void HttpProtocolIntegrationTest::expectDownstreamBytesSentAndReceived(
-    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation, const int id) {
+    BytesCountExpectation h1_expectation, BytesCountExpectation h2_expectation, BytesCountExpectation h3_expectation, const int id) {
   auto integer_near = [](int x, int y) -> bool { return std::abs(x - y) <= (x / 5); };
   std::string access_log = waitForAccessLog(access_log_name_, id);
   std::vector<std::string> log_entries = absl::StrSplit(access_log, ' ');
   int wire_bytes_sent = std::stoi(log_entries[0]), wire_bytes_received = std::stoi(log_entries[1]),
       header_bytes_sent = std::stoi(log_entries[2]),
       header_bytes_received = std::stoi(log_entries[3]);
-  if (downstreamProtocol() == Http::CodecType::HTTP1) {
+  switch (downstreamProtocol()) {
+  case Http::CodecType::HTTP1: {
     EXPECT_TRUE(integer_near(h1_expectation.wire_bytes_sent_, wire_bytes_sent))
         << "expect: " << h1_expectation.wire_bytes_sent_ << ", actual: " << wire_bytes_sent;
     EXPECT_EQ(h1_expectation.wire_bytes_received_, wire_bytes_received)
@@ -123,8 +145,9 @@ void HttpProtocolIntegrationTest::expectDownstreamBytesSentAndReceived(
     EXPECT_EQ(h1_expectation.header_bytes_received_, header_bytes_received)
         << "expect: " << h1_expectation.header_bytes_received_
         << ", actual: " << header_bytes_received;
+    return;
   }
-  if (downstreamProtocol() == Http::CodecType::HTTP2) {
+  case Http::CodecType::HTTP2: {
     // Because of non-deterministic h2 compression, the same plain text length don't map to the
     // same number of wire bytes.
     EXPECT_TRUE(integer_near(h2_expectation.wire_bytes_sent_, wire_bytes_sent))
@@ -136,6 +159,24 @@ void HttpProtocolIntegrationTest::expectDownstreamBytesSentAndReceived(
     EXPECT_TRUE(integer_near(h2_expectation.header_bytes_received_, header_bytes_received))
         << "expect: " << h2_expectation.header_bytes_received_
         << ", actual: " << header_bytes_received;
+    return;
+  }
+  case Http::CodecType::HTTP3: {
+    // Because of non-deterministic h3 compression, the same plain text length don't map to the
+    // same number of wire bytes.
+    EXPECT_TRUE(integer_near(h3_expectation.wire_bytes_sent_, wire_bytes_sent))
+        << "expect: " << h3_expectation.wire_bytes_sent_ << ", actual: " << wire_bytes_sent;
+    EXPECT_TRUE(integer_near(h3_expectation.wire_bytes_received_, wire_bytes_received))
+        << "expect: " << h3_expectation.wire_bytes_received_ << ", actual: " << wire_bytes_received;
+    EXPECT_TRUE(integer_near(h3_expectation.header_bytes_sent_, header_bytes_sent))
+        << "expect: " << h3_expectation.header_bytes_sent_ << ", actual: " << header_bytes_sent;
+    EXPECT_TRUE(integer_near(h3_expectation.header_bytes_received_, header_bytes_received))
+        << "expect: " << h3_expectation.header_bytes_received_
+        << ", actual: " << header_bytes_received;
+    return;
+  }
+  default:
+    EXPECT_TRUE(false) << "Unexpected codec type: " << static_cast<int>(downstreamProtocol());
   }
 }
 

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -76,10 +76,14 @@ protected:
   };
 
   void expectUpstreamBytesSentAndReceived(BytesCountExpectation h1_expectation,
-                                          BytesCountExpectation h2_expectation, const int id = 0);
+                                          BytesCountExpectation h2_expectation,
+                                          BytesCountExpectation h3_expectation,
+                                          const int id = 0);
 
   void expectDownstreamBytesSentAndReceived(BytesCountExpectation h1_expectation,
-                                            BytesCountExpectation h2_expectation, const int id = 0);
+                                            BytesCountExpectation h2_expectation,
+                                            BytesCountExpectation h3_expectation,
+                                            const int id = 0);
 };
 
 } // namespace Envoy

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -77,13 +77,11 @@ protected:
 
   void expectUpstreamBytesSentAndReceived(BytesCountExpectation h1_expectation,
                                           BytesCountExpectation h2_expectation,
-                                          BytesCountExpectation h3_expectation,
-                                          const int id = 0);
+                                          BytesCountExpectation h3_expectation, const int id = 0);
 
   void expectDownstreamBytesSentAndReceived(BytesCountExpectation h1_expectation,
                                             BytesCountExpectation h2_expectation,
-                                            BytesCountExpectation h3_expectation,
-                                            const int id = 0);
+                                            BytesCountExpectation h3_expectation, const int id = 0);
 };
 
 } // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -819,8 +819,7 @@ TEST_P(ProtocolIntegrationTest, Retry) {
   const size_t quic_https_extra_bytes = (downstreamProtocol() == Http::CodecType::HTTP3 ? 2u : 0u);
   expectUpstreamBytesSentAndReceived(
       BytesCountExpectation(2550 + quic_https_extra_bytes, 635, 414 + quic_https_extra_bytes, 54),
-      BytesCountExpectation(2262, 548, 184, 27),
-      BytesCountExpectation(2204, 520, 150, 6));
+      BytesCountExpectation(2262, 548, 184, 27), BytesCountExpectation(2204, 520, 150, 6));
 }
 
 TEST_P(ProtocolIntegrationTest, RetryStreaming) {
@@ -3389,7 +3388,6 @@ TEST_P(ProtocolIntegrationTest, TrailersWireBytesCountUpstream) {
   expectUpstreamBytesSentAndReceived(BytesCountExpectation(248, 120, 196, 67),
                                      BytesCountExpectation(172, 81, 154, 52),
                                      BytesCountExpectation(154, 33, 142, 7));
-
 }
 
 TEST_P(ProtocolIntegrationTest, TrailersWireBytesCountDownstream) {
@@ -3437,7 +3435,6 @@ TEST_P(ProtocolIntegrationTest, DownstreamDisconnectBeforeRequestCompleteWireByt
   expectDownstreamBytesSentAndReceived(BytesCountExpectation(0, 71, 0, 38),
                                        BytesCountExpectation(0, 28, 0, 28),
                                        BytesCountExpectation(0, 8, 0, 6));
-
 }
 
 TEST_P(ProtocolIntegrationTest, UpstreamDisconnectBeforeRequestCompleteWireBytesCountUpstream) {

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -214,8 +214,10 @@ TEST_P(RedirectIntegrationTest, BasicInternalRedirectDownstreamBytesCount) {
   ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   expectDownstreamBytesSentAndReceived(BytesCountExpectation(0, 63, 0, 31),
+                                       BytesCountExpectation(0, 42, 0, 42),
                                        BytesCountExpectation(0, 42, 0, 42), 0);
   expectDownstreamBytesSentAndReceived(BytesCountExpectation(140, 63, 121, 31),
+                                       BytesCountExpectation(77, 42, 77, 42),
                                        BytesCountExpectation(77, 42, 77, 42), 1);
 }
 
@@ -246,8 +248,10 @@ TEST_P(RedirectIntegrationTest, BasicInternalRedirectUpstreamBytesCount) {
   ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   expectUpstreamBytesSentAndReceived(BytesCountExpectation(195, 110, 164, 85),
+                                     BytesCountExpectation(137, 64, 137, 64),
                                      BytesCountExpectation(137, 64, 137, 64), 0);
   expectUpstreamBytesSentAndReceived(BytesCountExpectation(244, 38, 219, 18),
+                                     BytesCountExpectation(85, 10, 85, 10),
                                      BytesCountExpectation(85, 10, 85, 10), 1);
 }
 


### PR DESCRIPTION
Use byteMeter in QUIC client and server streams

Fixes #19051

Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A