### PR TITLE
test: allow disabling IP versions in iohandle test

### DIFF
--- a/test/common/network/io_socket_handle_impl_test.cc
+++ b/test/common/network/io_socket_handle_impl_test.cc
@@ -155,8 +155,7 @@ TEST(IoSocketHandleImpl, NullptrIfaddrs) {
 
 class IoSocketHandleImplTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 INSTANTIATE_TEST_SUITE_P(IpVersions, IoSocketHandleImplTest,
-                         testing::ValuesIn({Network::Address::IpVersion::v4,
-                                            Network::Address::IpVersion::v6}),
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
 TEST_P(IoSocketHandleImplTest, InterfaceNameForLoopback) {


### PR DESCRIPTION
Commit Message: test: allow disabling IP versions in iohandle test
Additional Description: The test case "IoSocketHandleImplTest" attempts to open a TCP socket listening on the loopback interface, parameterized over both IPv4 and IPv6.  This does not respect configuration in the environment variable
`ENVOY_IP_TEST_VERSIONS`.  As a result, test cases run with `ENVOY_IP_TEST_VERSIONS=v4only` still attempt to open a TCP socket with a link-local IPv6 address, failing in IPv4-only environments.

It seems like the canonical way to parameterize the IP versions is to simply use the output of `TestEnvironment::getIpVersionsForTest()` as the test parameter set.  After applying this patch, an IPv4-only environment used for development begins to pass tests on v1.21.0.
Risk Level: Low
Testing: This only modifies an existing test suite.
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Noah Goldman <ngoldman@uber.com>