### PR TITLE
Update incorrect docs for gRPC-JSON transcoder.

### DIFF
--- a/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
@@ -39,7 +39,7 @@ Then run protoc to generate the descriptor set. For example using the test
 
 .. code-block:: console
 
-  $ protoc -I$(GOOGLEAPIS_DIR) -I. --include_imports --include_source_info \
+  $ protoc -I${GOOGLEAPIS_DIR} -I. --include_imports --include_source_info \
       --descriptor_set_out=proto.pb test/proto/bookstore.proto
 
 If you have more than one proto source files, you can pass all of them in one command.


### PR DESCRIPTION
Previously, the `protoc` command used `-I$(GOOGLEAPIS_DIR)`, which
attempts to run the `GOOGLEAPIS_DIR` as a command in a subshell.

This commit replaces `-I$(GOOGLEAPIS_DIR)` with`-I${GOOGLEAPIS_DIR}`,
which correctly dereferences the env variable.

Signed-off-by: Henry Qin <root@hq6.me>
