### PR TITLE
access_log: envoy.reloadable_features.unquote_log_string_values deprecation

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -26,6 +26,7 @@ Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
+* access_log: removed ``envoy.reloadable_features.unquote_log_string_values`` and legacy code paths.
 * grpc_bridge_filter: removed ``envoy.reloadable_features.grpc_bridge_stats_disabled`` and legacy code paths.
 * http: removed ``envoy.reloadable_features.hash_multiple_header_values`` and legacy code paths.
 * http: removed ``envoy.reloadable_features.preserve_downstream_scheme`` and legacy code paths.

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1412,8 +1412,7 @@ MetadataFormatter::formatMetadata(const envoy::config::core::v3::Metadata& metad
   }
 
   std::string str;
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.unquote_log_string_values") &&
-      value.kind_case() == ProtobufWkt::Value::kStringValue) {
+  if (value.kind_case() == ProtobufWkt::Value::kStringValue) {
     str = value.string_value();
   } else {
     str = MessageUtil::getJsonStringFromMessageOrDie(value, false, true);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -81,7 +81,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.proxy_102_103",
     "envoy.reloadable_features.remove_legacy_json",
     "envoy.reloadable_features.udp_listener_updates_filter_chain_in_place",
-    "envoy.reloadable_features.unquote_log_string_values",
     "envoy.reloadable_features.update_expected_rq_timeout_on_retry",
     "envoy.reloadable_features.use_dns_ttl",
     "envoy.reloadable_features.validate_connect",

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1616,18 +1616,6 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFormatter) {
                                       stream_info, body),
                 ProtoEq(ValueUtil::stringValue("test_value")));
   }
-  // Disable string value unquoting and expect the same result as above but quoted.
-  {
-    TestScopedRuntime scoped_runtime;
-    Runtime::LoaderSingleton::getExisting()->mergeValues(
-        {{"envoy.reloadable_features.unquote_log_string_values", "false"}});
-    DynamicMetadataFormatter formatter("com.test", {"test_key"}, absl::optional<size_t>());
-    EXPECT_EQ("\"test_value\"", formatter.format(request_headers, response_headers,
-                                                 response_trailers, stream_info, body));
-    EXPECT_THAT(formatter.formatValue(request_headers, response_headers, response_trailers,
-                                      stream_info, body),
-                ProtoEq(ValueUtil::stringValue("test_value")));
-  }
   {
     DynamicMetadataFormatter formatter("com.test", {"test_obj"}, absl::optional<size_t>());
     EXPECT_EQ(


### PR DESCRIPTION
Signed-off-by: changran <changran.wang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
