### PR TITLE
Restore ManyLargeSimultaneousRequestWithRandomBackup test.

### DIFF
--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -337,7 +337,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithBuffe
   manySimultaneousRequests(1024 * 20, 1024 * 20);
 }
 
-TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithRandomBackup) {
+TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithBackup) {
   if (upstreamProtocol() == Http::CodecType::HTTP3 &&
       downstreamProtocol() == Http::CodecType::HTTP2) {
     // This test depends on fragile preconditions.
@@ -352,6 +352,19 @@ TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithRando
   typed_config:
     "@type": type.googleapis.com/google.protobuf.Empty)EOF",
                   downstreamProtocol() == Http::CodecType::HTTP3 ? "-for-quic" : ""));
+
+  manySimultaneousRequests(1024 * 20, 1024 * 20);
+}
+
+TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithRandomBackup) {
+  // random-pause-filter does not support HTTP3.
+  if (upstreamProtocol() == Http::CodecType::HTTP3) {
+    return;
+  }
+  config_helper_.prependFilter(R"EOF(
+  name: random-pause-filter
+  typed_config:
+    "@type": type.googleapis.com/google.protobuf.Empty)EOF");
 
   manySimultaneousRequests(1024 * 20, 1024 * 20);
 }

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -337,25 +337,6 @@ TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithBuffe
   manySimultaneousRequests(1024 * 20, 1024 * 20);
 }
 
-TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithBackup) {
-  if (upstreamProtocol() == Http::CodecType::HTTP3 &&
-      downstreamProtocol() == Http::CodecType::HTTP2) {
-    // This test depends on fragile preconditions.
-    // With HTTP/2 downstream all the requests are processed before the
-    // responses are sent, then the connection read-disable results in not
-    // receiving flow control window updates.
-    return;
-  }
-  config_helper_.prependFilter(
-      fmt::format(R"EOF(
-  name: pause-filter{}
-  typed_config:
-    "@type": type.googleapis.com/google.protobuf.Empty)EOF",
-                  downstreamProtocol() == Http::CodecType::HTTP3 ? "-for-quic" : ""));
-
-  manySimultaneousRequests(1024 * 20, 1024 * 20);
-}
-
 TEST_P(MultiplexedUpstreamIntegrationTest, ManyLargeSimultaneousRequestWithRandomBackup) {
   // random-pause-filter does not support HTTP3.
   if (upstreamProtocol() == Http::CodecType::HTTP3) {


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Restore ManyLargeSimultaneousRequestWithRandomBackup test.
Additional Description: Seems to have been dropped by mistake when adding pause-filter tests that support QUIC.

Originally added here: https://github.com/envoyproxy/envoy/pull/4675/files#diff-ca12a5f228df0c283c4135e6a49ce6eb90d719eb0b26b48565765fef1db38aa5R285

Replaced with pause-filter here: https://github.com/envoyproxy/envoy/pull/15841/files#diff-f87cd0fb4494001b7c81830045c827969604aa1d2c5ab405ea3fa45248cf46b3R328

Risk Level: low
Testing: ran tests
Docs Changes:NA
Release Notes: NA
Platform Specific Features:NA

