### PR TITLE
socket options: re-add support for directly setting options

### DIFF
--- a/source/common/network/addr_family_aware_socket_option_impl.h
+++ b/source/common/network/addr_family_aware_socket_option_impl.h
@@ -29,6 +29,9 @@ public:
                                   SocketOptionName ipv6_optname, absl::string_view ipv6_value)
       : ipv4_option_(std::make_unique<SocketOptionImpl>(in_state, ipv4_optname, ipv4_value)),
         ipv6_option_(std::make_unique<SocketOptionImpl>(in_state, ipv6_optname, ipv6_value)) {}
+  AddrFamilyAwareSocketOptionImpl(Socket::OptionConstPtr&& ipv4_option,
+                                  Socket::OptionConstPtr&& ipv6_option)
+      : ipv4_option_(std::move(ipv4_option)), ipv6_option_(std::move(ipv6_option)) {}
 
   // Socket::Option
   bool setOption(Socket& socket,

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -23,6 +23,22 @@ protected:
   }
 };
 
+// Set options directly
+TEST_F(AddrFamilyAwareSocketOptionImplTest, SetSocketOptionsDirectly) {
+  AddrFamilyAwareSocketOptionImpl socket_option(
+      std::make_unique<SocketOptionImpl>(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                                         ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1),
+      std::make_unique<SocketOptionImpl>(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                                         ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 2));
+
+  EXPECT_CALL(socket_, ipVersion()).WillRepeatedly(testing::Return(Address::IpVersion::v4));
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1,
+                             {envoy::config::core::v3::SocketOption::STATE_PREBIND});
+  EXPECT_CALL(socket_, ipVersion()).WillRepeatedly(testing::Return(Address::IpVersion::v6));
+  testSetSocketOptionSuccess(socket_option, ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 2,
+                             {envoy::config::core::v3::SocketOption::STATE_PREBIND});
+}
+
 // Different values for v4 and v6
 TEST_F(AddrFamilyAwareSocketOptionImplTest, DifferentV4AndV6OptionValue) {
   AddrFamilyAwareSocketOptionImpl socket_option{


### PR DESCRIPTION
Commit Message: socket options - re-add support for directly setting options
Additional Description: originally added in https://github.com/envoyproxy/envoy/pull/18769 and removed in https://github.com/envoyproxy/envoy/pull/19684 due to missing coverage. Added here with coverage.
Risk Level: low
Testing: added UT