### PR TITLE
xray: make Unknown as the default SamplingDecision

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,7 +61,7 @@ extensions/filters/common/original_src @snowp @klarose
 # tracers.datadog extension
 /*/extensions/tracers/datadog @cgilmour @palazzem @mattklein123
 # tracers.xray extension
-/*/extensions/tracers/xray @abaptiste @lavignes @mattklein123
+/*/extensions/tracers/xray @abaptiste @suniltheta @mattklein123
 # tracers.skywalking extension
 /*/extensions/tracers/skywalking @wbpcode @dio @lizan @Shikugawa
 # quic extension

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -22,6 +22,7 @@ Bug Fixes
 
 * data plane: fixing error handling where writing to a socket failed while under the stack of processing. This should genreally affect HTTP/3. This behavioral change can be reverted by setting ``envoy.reloadable_features.allow_upstream_inline_write`` to false.
 * eds: fix the eds cluster update by allowing update on the locality of the cluster endpoints. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.support_locality_update_on_eds_cluster_endpoints`` to false.
+* xray: fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header ``x-amzn-trace-id``.
 
 Removed Config or Runtime
 -------------------------

--- a/source/extensions/tracers/xray/xray_configuration.h
+++ b/source/extensions/tracers/xray/xray_configuration.h
@@ -22,9 +22,9 @@ struct XRayConfiguration {
 };
 
 enum class SamplingDecision {
+  Unknown, // default
   Sampled,
   NotSampled,
-  Unknown,
 };
 
 /**

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -89,7 +89,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderWithoutSamplingDecision) {
     "rate": 0
   }
 }
-	     )EOF" /*sampling_rules*/,
+        )EOF" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
   Driver driver(config, context_);
 

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -72,10 +72,37 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
   auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
                                tracing_decision);
   // sampling should fall back to the default manifest since:
-  // a) there is sampling decision in the X-Ray header
+  // a) there is no valid sampling decision in the X-Ray header
   // b) there are no sampling rules passed, so the default rules apply (1 req/sec and 5% after that
   // within that second)
   ASSERT_NE(span, nullptr);
+}
+
+TEST_F(XRayDriverTest, XRayTraceHeaderWithoutSamplingDecision) {
+  request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;");
+  // sampling rules with default fixed_target = 0 & rate = 0
+  XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", R"EOF(
+	 {
+	   "version": 2,
+	   "default": {
+	     "fixed_target": 0,
+	     "rate": 0
+	   }
+	 }
+	     )EOF" /*sampling_rules*/,
+                           "" /*origin*/, aws_metadata_};
+  Driver driver(config, context_);
+
+  Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
+  Envoy::SystemTime start_time;
+  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+                               tracing_decision);
+  // sampling will not be done since:
+  // a) there is no sampling decision in the X-Ray header
+  // b) there is a custom sampling rule passed which still doesn't enforce sampling
+  ASSERT_NE(span, nullptr);
+  auto* xray_span = static_cast<XRay::Span*>(span.get());
+  ASSERT_FALSE(xray_span->sampled());
 }
 
 TEST_F(XRayDriverTest, NoXRayTracerHeader) {

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -82,13 +82,13 @@ TEST_F(XRayDriverTest, XRayTraceHeaderWithoutSamplingDecision) {
   request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;");
   // sampling rules with default fixed_target = 0 & rate = 0
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", R"EOF(
-	 {
-	   "version": 2,
-	   "default": {
-	     "fixed_target": 0,
-	     "rate": 0
-	   }
-	 }
+{
+  "version": 2,
+  "default": {
+    "fixed_target": 0,
+    "rate": 0
+  }
+}
 	     )EOF" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
   Driver driver(config, context_);


### PR DESCRIPTION
Signed-off-by: Sunil Narasimhamurthy <13044744+suniltheta@users.noreply.github.com>

Commit Message: xray: make Unknown as the default SamplingDecision

**Additional Description:** Earlier the default value in `enum SamplingDecision` is `Sampled`. This will cause a bug in AWS X-Ray extension where if a request with header: `x-amzn-trace-id` is supplied without `"sampled="` key then it ends up considering the request as sampled. All the requests originating from Amazon Load Balancer has header `x-amzn-trace-id` without sampling decision set. This forces envoy to sample 100% of the request without any regard for the sampling rate set in the envoy.

Risk Level: low
Testing: Unit testing
Docs Changes: NA
Release Notes: Include bug fix description on version history
Platform Specific Features: NA
