### PR TITLE
Only allow valid fuzz inputs for result field in ext_authz_fuzz.proto.

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto
@@ -22,7 +22,7 @@ message ExtAuthzTestCase {
   // HTTP request data.
   test.fuzz.HttpData request_data = 2 [(validate.rules).message = {required: true}];
   // Set default auth check result.
-  AuthResult result = 3 [(validate.rules).enum.defined_only = true]; 
+  AuthResult result = 3 [(validate.rules).enum.defined_only = true];
   // Filter metadata.
   envoy.config.core.v3.Metadata filter_metadata = 4;
   // TODO: Add headers and data to ExtAuthz::Response and check that the request headers and data

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto
@@ -22,7 +22,7 @@ message ExtAuthzTestCase {
   // HTTP request data.
   test.fuzz.HttpData request_data = 2 [(validate.rules).message = {required: true}];
   // Set default auth check result.
-  AuthResult result = 3;
+  AuthResult result = 3 [(validate.rules).enum.defined_only = true]; 
   // Filter metadata.
   envoy.config.core.v3.Metadata filter_metadata = 4;
   // TODO: Add headers and data to ExtAuthz::Response and check that the request headers and data


### PR DESCRIPTION
Fuzz inputs to ext authz extension hit ASSERT because of unhandled value of result field. Add validation rules in ext authz fuzz proto to only allow enum defined values for result field. 

Signed-off-by: Kirtimaan <krajshiva@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Only allow valid fuzz inputs for result field in ext_authz_fuzz.proto for fuzz test to not Assert.
Additional Description: ext_authz_fuzz_test hits ASSERT due to invalid values for result field. ext authz result field will always be from defined enums as it is set internally in the code. Adding validation rules to only allow defined enum values will prevent fuzz test to ASSERT prematurely.
Risk Level:Low
Testing: $ bazel test ext_authz_fuzz_test --config=remote
INFO: Invocation ID: f3bf6669-a44d-4f77-8904-0b79ee6c86d3
INFO: Build options --action_env, --crosstool_top, --define, and 6 more have changed, discarding analysis cache.
INFO: Analyzed target //test/extensions/filters/http/ext_authz:ext_authz_fuzz_test (344 packages loaded, 16957 targets configured).
INFO: Found 1 test target...
INFO: From Generating C++ proto_library //test/extensions/filters/http/ext_authz:ext_authz_fuzz_proto:
test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto:7:1: warning: Import google/protobuf/empty.proto is unused.
INFO: From Generating Descriptor Set proto_library //test/extensions/filters/http/ext_authz:ext_authz_fuzz_proto:
test/extensions/filters/http/ext_authz/ext_authz_fuzz.proto:7:1: warning: Import google/protobuf/empty.proto is unused.
Target //test/extensions/filters/http/ext_authz:ext_authz_fuzz_test up-to-date:
  bazel-bin/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test
INFO: Elapsed time: 81.994s, Critical Path: 78.07s
INFO: 3192 processes: 2040 remote cache hit, 1052 internal, 100 remote.
INFO: Build completed successfully, 3192 total actions
//test/extensions/filters/http/ext_authz:ext_authz_fuzz_test             PASSED in 4.4s

Executed 1 out of 1 test: 1 test passes.

Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
