### PR TITLE
router, formatter: release notes for address formats in substitution_formatter & header_formatter

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -44,7 +44,9 @@ Removed Config or Runtime
 
 New Features
 ------------
+* access_log: make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
 * http: added support for :ref:`proxy_status_config <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.proxy_status_config>` for configuring `Proxy-Status <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-08>`_ HTTP response header fields.
+* http: make consistent custom header format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
 * http3: downstream HTTP/3 support is now GA! Upstream HTTP/3 also GA for specific deployments. See :ref:`here <arch_overview_http3>` for details.
 
 


### PR DESCRIPTION
PR#19613 missed the release note addition, which is added in this PR.

Risk Level: Zero
Testing: N/A. Documentation.
Docs Changes: Release notes
Release Notes: this change
Platform Specific Features: N/A
Signed-off-by: Robin H. Johnson <rjohnson@digitalocean.com>
Fixes: https://github.com/envoyproxy/envoy/pull/19613
Reference: https://github.com/envoyproxy/envoy/pull/19613#issuecomment-1021403630
