### PR TITLE
docs: recommend clang-format 12.0.1

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -885,7 +885,7 @@ Note that if you run the `check_spelling.py` script you will need to have `aspel
 Edit the paths shown here to reflect the installation locations on your system:
 
 ```shell
-export CLANG_FORMAT="$HOME/ext/clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-20.04/bin/clang-format"
+export CLANG_FORMAT="$HOME/ext/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04/bin/clang-format"
 export BUILDIFIER_BIN="/usr/bin/buildifier"
 ```
 


### PR DESCRIPTION
Commit Message: docs: recommend clang-format 12.0.1

Additional Description:
Recommend clang-format 12.0.1 because 11.* known to fail:

```sh
❯ /opt/local/bin/clang-format-mp-11 --version
clang-format version 11.1.0
❯ /opt/local/bin/clang-format-mp-11 -n ./test/common/http/header_map_impl_test.cc
./test/common/http/header_map_impl_test.cc:425:4: warning: code should be clang-formatted [-Wclang-format-violations]
  {
   ^
./test/common/http/header_map_impl_test.cc:427:4: warning: code should be clang-formatted [-Wclang-format-violations]
  }
   ^
```

Also use fix directory name to match https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.1

Risk Level:  n/a
Testing: n/a
Docs Changes: recommend clang-format 12.0.1

