### PR TITLE
[bazel] allow specifying `exec_properties` in `envoy_cc_test`

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -157,7 +157,8 @@ def envoy_cc_test(
         local = False,
         size = "medium",
         flaky = False,
-        env = {}):
+        env = {},
+        exec_properties = {}):
     coverage_tags = tags + ([] if coverage else ["nocoverage"])
 
     cc_test(
@@ -184,6 +185,7 @@ def envoy_cc_test(
         size = size,
         flaky = flaky,
         env = env,
+        exec_properties = exec_properties,
     )
 
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified


### PR DESCRIPTION
Commit Message: [bazel] allow specifying `exec_properties` in `envoy_cc_test`
Additional Description: In order to pass properties such as `sandboxNetwork` as we are trying to do in Envoy Mobile here: https://github.com/envoyproxy/envoy-mobile/pull/2022
Risk Level: Low