### PR TITLE
Windows: fix the invalid tmp directory path

### DIFF
--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -42,7 +42,7 @@ namespace {
 
 std::string makeTempDir(std::string basename_template) {
 #ifdef WIN32
-  std::string name_template = "c:\\Windows\\TEMP\\" + basename_template;
+  std::string name_template = TestEnvironment::temporaryDirectory() + "/" + basename_template;
   char* dirname = ::_mktemp(&name_template[0]);
   RELEASE_ASSERT(dirname != nullptr, fmt::format("failed to create tempdir from template: {} {}",
                                                  name_template, errorDetails(errno)));


### PR DESCRIPTION
Commit Message: Windows: fix the invalid tmp directory path
Additional Description:
Some of test failed on windows due to create the tmp directory.  So build the tmp dir path by the env variable instead of own-build one.
```
Executing tests from //test/integration:quic_protocol_integration_test
-----------------------------------------------------------------------------
[2022-01-27 04:33:09.036][20216][critical][assert] [test/test_common/environment.cc:48] assert failure: dirname != nullptr. Details: failed to create tempdir from template:  :\Windows\TEMP\envoy_test_uds.z20216 The system cannot move the file to a different disk drive.
```
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: windows

Signed-off-by: He Jie Xu <hejie.xu@intel.com>