### PR TITLE
GoogleGrpc: Always call Finish(), even if the stream is cancelled.

### DIFF
--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -235,6 +235,13 @@ void GoogleAsyncStreamImpl::closeStream() {
 
 void GoogleAsyncStreamImpl::resetStream() {
   ENVOY_LOG(debug, "resetStream");
+  // The gRPC API requires calling Finish() at the end of a stream, even
+  // if the stream is cancelled.
+  if (!finish_pending_) {
+    finish_pending_ = true;
+    rw_->Finish(&status_, &finish_tag_);
+    ++inflight_tags_;
+  }
   cleanup();
 }
 


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: GoogleGrpc: Always call Finish(), even if the stream is cancelled.
Additional Description: The gRPC API has always required this, but until now, nothing bad has happened if the application failed to do so.  However, an upcoming change in gRPC (grpc/grpc#28548) will enable transparent retries by default, at which point failing to call Finish() will cause a memory leak and/or connection leak.  This PR fixes Envoy to use the gRPC API properly, so that it will not see this problem when it starts using a version of gRPC that supports transparent retries.
Risk Level: Low
Testing: Performed internal testing at Google with the gRPC change
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

CC @htuch 