### PR TITLE
Decouple unit tests with the existing Protobuf DebugString format

### DIFF
--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -74,8 +74,10 @@ TEST(ResolverTest, InternalListenerNameFromProtoAddress) {
 TEST(ResolverTest, UninitializedInternalAddressFromProtoAddress) {
   envoy::config::core::v3::Address internal_address;
   internal_address.mutable_envoy_internal_address();
-  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(internal_address), EnvoyException,
-                            "Failed to resolve address:envoy_internal_address {\n}\n");
+  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(internal_address),
+                            EnvoyException,
+                            fmt::format("Failed to resolve address:{}",
+                                        internal_address.DebugString()));
 }
 
 // Validate correct handling of ipv4_compat field.

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -74,10 +74,9 @@ TEST(ResolverTest, InternalListenerNameFromProtoAddress) {
 TEST(ResolverTest, UninitializedInternalAddressFromProtoAddress) {
   envoy::config::core::v3::Address internal_address;
   internal_address.mutable_envoy_internal_address();
-  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(internal_address),
-                            EnvoyException,
-                            fmt::format("Failed to resolve address:{}",
-                                        internal_address.DebugString()));
+  EXPECT_THROW_WITH_MESSAGE(
+      resolveProtoAddress(internal_address), EnvoyException,
+      fmt::format("Failed to resolve address:{}", internal_address.DebugString()));
 }
 
 // Validate correct handling of ipv4_compat field.

--- a/test/common/tracing/http_tracer_manager_impl_test.cc
+++ b/test/common/tracing/http_tracer_manager_impl_test.cc
@@ -130,12 +130,13 @@ TEST_F(HttpTracerManagerImplTest, ShouldFailIfProviderSpecificConfigIsNotValid) 
   tracing_config.set_name("envoy.tracers.sample");
   tracing_config.mutable_typed_config()->PackFrom(ValueUtil::stringValue("value"));
 
+  ProtobufWkt::Any expected_any_proto;
+  expected_any_proto.PackFrom(ValueUtil::stringValue("value"));
   EXPECT_THROW_WITH_MESSAGE(
-      http_tracer_manager_.getOrCreateHttpTracer(&tracing_config), EnvoyException,
-      R"(Unable to unpack as google.protobuf.Struct: [type.googleapis.com/google.protobuf.Value] {
-  string_value: "value"
-}
-)");
+      http_tracer_manager_.getOrCreateHttpTracer(&tracing_config),
+      EnvoyException,
+      fmt::format("Unable to unpack as google.protobuf.Struct: {}",
+                  expected_any_proto.DebugString()));
 }
 
 class HttpTracerManagerImplCacheTest : public testing::Test {

--- a/test/common/tracing/http_tracer_manager_impl_test.cc
+++ b/test/common/tracing/http_tracer_manager_impl_test.cc
@@ -132,11 +132,10 @@ TEST_F(HttpTracerManagerImplTest, ShouldFailIfProviderSpecificConfigIsNotValid) 
 
   ProtobufWkt::Any expected_any_proto;
   expected_any_proto.PackFrom(ValueUtil::stringValue("value"));
-  EXPECT_THROW_WITH_MESSAGE(
-      http_tracer_manager_.getOrCreateHttpTracer(&tracing_config),
-      EnvoyException,
-      fmt::format("Unable to unpack as google.protobuf.Struct: {}",
-                  expected_any_proto.DebugString()));
+  EXPECT_THROW_WITH_MESSAGE(http_tracer_manager_.getOrCreateHttpTracer(&tracing_config),
+                            EnvoyException,
+                            fmt::format("Unable to unpack as google.protobuf.Struct: {}",
+                                        expected_any_proto.DebugString()));
 }
 
 class HttpTracerManagerImplCacheTest : public testing::Test {

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -123,13 +123,10 @@ api_listener:
   envoy::config::cluster::v3::Cluster expected_cluster_proto;
   expected_cluster_proto.set_name("cluster1");
   expected_cluster_proto.set_type(envoy::config::cluster::v3::Cluster::EDS);
-  expected_cluster_proto.mutable_eds_cluster_config()
-      ->mutable_eds_config()
-      ->set_path("eds path");
+  expected_cluster_proto.mutable_eds_cluster_config()->mutable_eds_config()->set_path("eds path");
   expected_any_proto.PackFrom(expected_cluster_proto);
   EXPECT_THROW_WITH_MESSAGE(
-      HttpApiListener(config, *listener_manager_, config.name()),
-      EnvoyException,
+      HttpApiListener(config, *listener_manager_, config.name()), EnvoyException,
       fmt::format("Unable to unpack as "
                   "envoy.extensions.filters.network.http_connection_manager.v3."
                   "HttpConnectionManager: {}",

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -119,13 +119,21 @@ api_listener:
 
   const envoy::config::listener::v3::Listener config = parseListenerFromV3Yaml(yaml);
 
+  ProtobufWkt::Any expected_any_proto;
+  envoy::config::cluster::v3::Cluster expected_cluster_proto;
+  expected_cluster_proto.set_name("cluster1");
+  expected_cluster_proto.set_type(envoy::config::cluster::v3::Cluster::EDS);
+  expected_cluster_proto.mutable_eds_cluster_config()
+      ->mutable_eds_config()
+      ->set_path("eds path");
+  expected_any_proto.PackFrom(expected_cluster_proto);
   EXPECT_THROW_WITH_MESSAGE(
-      HttpApiListener(config, *listener_manager_, config.name()), EnvoyException,
-      "Unable to unpack as "
-      "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager: "
-      "[type.googleapis.com/envoy.config.cluster.v3.Cluster] {\n  name: \"cluster1\"\n  type: "
-      "EDS\n  "
-      "eds_cluster_config {\n    eds_config {\n      path: \"eds path\"\n    }\n  }\n}\n");
+      HttpApiListener(config, *listener_manager_, config.name()),
+      EnvoyException,
+      fmt::format("Unable to unpack as "
+                  "envoy.extensions.filters.network.http_connection_manager.v3."
+                  "HttpConnectionManager: {}",
+                  expected_any_proto.DebugString()));
 }
 
 TEST_F(ApiListenerTest, HttpApiListenerShutdown) {


### PR DESCRIPTION
Problem description:

Having the unit tests bound to the existing format is fragile. 

Solution:

This PR decouple the unit tests with the existing format.




<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
