### PR TITLE
repo: Set python version (for dependabot)

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,2 @@
+# Must be one of https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/python_versions.rb#L12-L17
+3.8.12


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

This should fix problems - as seen here:

https://github.com/envoyproxy/envoy/pull/19722/files#diff-bb622deaf176384b0aeb5bf4f767ea4ac5d71a1f371100ce2c46813564cb936fL409

...where dependabot is trying to uninstall libs that are required for 3.8 and 3.9, but not for 3.10

(officially/in ci we use 3.8, i tend to test locally with 3.9)

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
