### PR TITLE
ext_proc: Clean up errors in configuration proto

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -30,8 +30,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 //
 // * Request and response attributes are not sent and not processed.
 // * Dynamic metadata in responses from the external processor is ignored.
-// * "async mode" is not implemented
-// * Per-route configuration is not implemented
+// * "async mode" is not implemented.
 
 // The filter communicates with an external gRPC service called an "external processor"
 // that can do a variety of things with the request and response:
@@ -147,7 +146,6 @@ message ExternalProcessor {
   // mode. Default is 200 milliseconds.
   google.protobuf.Duration message_timeout = 7;
 
-  // [#not-implemented-hide:]
   // Optional additional prefix to use when emitting statistics. This allows to distinguish
   // emitted statistics between configured *ext_proc* filters in an HTTP filter chain.
   string stat_prefix = 8;
@@ -180,10 +178,12 @@ message ExtProcOverrides {
   bool async_mode = 2;
 
   // [#not-implemented-hide:]
-  // Set different optional properties than the default.
-  repeated string request_properties = 3;
+  // Set different optional attributes than the default setting of the
+  // *request_attributes* field.
+  repeated string request_attributes = 3;
 
   // [#not-implemented-hide:]
-  // Set different optional properties than the default.
-  repeated string response_properties = 4;
+  // Set different optional properties than the default setting of the
+  // *response_attributes* field.
+  repeated string response_attributes = 4;
 }

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -188,11 +188,11 @@ message ExtProcOverrides {
 
   // [#not-implemented-hide:]
   // Set different optional attributes than the default setting of the
-  // *request_attributes* field.
+  // ``request_attributes`` field.
   repeated string request_attributes = 3;
 
   // [#not-implemented-hide:]
   // Set different optional properties than the default setting of the
-  // *response_attributes* field.
+  // ``response_attributes`` field.
   repeated string response_attributes = 4;
 }


### PR DESCRIPTION
Commit Message: Clean up errors in the ext_proc configuration proto

Additional Description:
* Fix comments regarding what is and isn't implemented.
* Indicate that "stat_prefix" really is implemented, because it is.
* Re-name two misnamed (but as yet unimplemented) fields in per-route
configuration.

Risk Level: Low
Testing: Existing integration and unit tests
Docs Changes:
Release Notes:
Platform Specific Features:
