### PR TITLE
ext_proc: Add an explicit logger ID

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -42,6 +42,7 @@ namespace Logger {
   FUNCTION(dubbo)                                                                                  \
   FUNCTION(envoy_bug)                                                                              \
   FUNCTION(ext_authz)                                                                              \
+  FUNCTION(ext_proc)                                                                               \
   FUNCTION(rocketmq)                                                                               \
   FUNCTION(file)                                                                                   \
   FUNCTION(filter)                                                                                 \

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -38,7 +38,7 @@ private:
 
 class ExternalProcessorStreamImpl : public ExternalProcessorStream,
                                     public Grpc::AsyncStreamCallbacks<ProcessingResponse>,
-                                    public Logger::Loggable<Logger::Id::filter> {
+                                    public Logger::Loggable<Logger::Id::ext_proc> {
 public:
   ExternalProcessorStreamImpl(Grpc::AsyncClient<ProcessingRequest, ProcessingResponse>&& client,
                               ExternalProcessorCallbacks& callbacks,

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -96,7 +96,7 @@ private:
   absl::optional<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode> processing_mode_;
 };
 
-class Filter : public Logger::Loggable<Logger::Id::filter>,
+class Filter : public Logger::Loggable<Logger::Id::ext_proc>,
                public Http::PassThroughFilter,
                public ExternalProcessorCallbacks {
   // The result of an attempt to open the stream

--- a/source/extensions/filters/http/ext_proc/mutation_utils.h
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.h
@@ -15,7 +15,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExternalProcessing {
 
-class MutationUtils : public Logger::Loggable<Logger::Id::filter> {
+class MutationUtils : public Logger::Loggable<Logger::Id::ext_proc> {
 public:
   // Convert a header map until a protobuf
   static void headersToProto(const Http::HeaderMap& headers_in,

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -53,7 +53,7 @@ private:
   uint32_t bytes_enqueued_{};
 };
 
-class ProcessorState : public Logger::Loggable<Logger::Id::filter> {
+class ProcessorState : public Logger::Loggable<Logger::Id::ext_proc> {
 public:
   // This describes whether the filter is waiting for a response to a gRPC message.
   // We use it to determine how to respond to stream messages send back from


### PR DESCRIPTION
Commit Message: Create an "ext_proc" logger ID, like other filters have. 
Additional Description: Previously, ext_proc was using the generic "filter" ID.
Risk Level: Low
Testing: Existing tests
Docs Changes:
Release Notes:
Platform Specific Features:
