### PR TITLE
perf: add runtime guard to disable looking up local interface name for upstream connections

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -22,6 +22,7 @@ Bug Fixes
 
 * data plane: fixing error handling where writing to a socket failed while under the stack of processing. This should genreally affect HTTP/3. This behavioral change can be reverted by setting ``envoy.reloadable_features.allow_upstream_inline_write`` to false.
 * eds: fix the eds cluster update by allowing update on the locality of the cluster endpoints. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.support_locality_update_on_eds_cluster_endpoints`` to false.
+* perf: adds ``envoy.reloadable_features.disable_local_interface_name_for_upstream_connection`` runtime flag to disable accessing connection data which has a non-negligible performance hit.
 * xray: fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header ``x-amzn-trace-id``.
 
 Removed Config or Runtime

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -93,6 +93,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/event:libevent_lib",
         "//source/common/network:listen_socket_lib",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/stream_info:stream_info_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -265,6 +265,7 @@ private:
   void onConnected() override;
 
   StreamInfo::StreamInfoImpl stream_info_;
+  const bool disable_local_interface_name_for_upstream_connection_{};
 };
 
 } // namespace Network

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -61,6 +61,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.conn_pool_delete_when_idle",
     "envoy.reloadable_features.correct_scheme_and_xfp",
     "envoy.reloadable_features.correctly_validate_alpn",
+    "envoy.reloadable_features.disable_local_interface_name_for_upstream_connection",
     "envoy.reloadable_features.disable_tls_inspector_injection",
     "envoy.reloadable_features.enable_grpc_async_client_cache",
     "envoy.reloadable_features.fix_added_trailers",

--- a/test/integration/filters/stream_info_to_headers_filter.cc
+++ b/test/integration/filters/stream_info_to_headers_filter.cc
@@ -48,6 +48,12 @@ public:
       }
       headers.addCopy(Http::LowerCaseString("num_streams"),
                       decoder_callbacks_->streamInfo().upstreamInfo()->upstreamNumStreams());
+      const auto maybe_local_interface_name =
+          decoder_callbacks_->streamInfo().upstreamInfo()->upstreamInterfaceName();
+      if (maybe_local_interface_name.has_value()) {
+        headers.addCopy(Http::LowerCaseString("local_interface_name"),
+                        maybe_local_interface_name.value());
+      }
     }
 
     return Http::FilterHeadersStatus::Continue;


### PR DESCRIPTION
Commit Message: perf - add runtime guard to disable looking up local interface name for upstream connections
Risk Level: low, bug fix
Testing: integration test
Release Notes: added
Runtime guard: envoy.reloadable_features.disable_local_interface_name_for_upstream_connection
Fixes #19717 
