### PR TITLE
wasm: increase the maximum number of WasmVMs when using V8.

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -103,6 +103,8 @@ WEE8_BUILD_ARGS+=" v8_use_external_startup_data=false"
 # Disable read-only heap, since it's leaky and HEAPCHECK complains about it.
 # TODO(PiotrSikora): remove when fixed upstream.
 WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
+# Disable pointer compression (limits the maximum number of WasmVMs).
+WEE8_BUILD_ARGS+=" v8_enable_pointer_compression=false"
 
 # Set target architecture.
 if [[ $${ARCH} == "x86_64" ]]; then


### PR DESCRIPTION
New features in V8 severely limited the maximum number of WasmVMs
that can be created in a single process, so disable them for now.

See: https://bugs.chromium.org/p/v8/issues/detail?id=12592

This increases the maximum number of WasmVMs from 268 to 6,479.

Fixes #19720.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>