### PR TITLE
runtime: flipping http2_new_codec_wrapper false

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -66,7 +66,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.fix_added_trailers",
     "envoy.reloadable_features.handle_stream_reset_during_hcm_encoding",
     "envoy.reloadable_features.http2_allow_capacity_increase_by_settings",
-    "envoy.reloadable_features.http2_new_codec_wrapper",
     "envoy.reloadable_features.http_ext_authz_do_not_skip_direct_response_and_redirect",
     "envoy.reloadable_features.http_reject_path_with_fragment",
     "envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled",
@@ -107,6 +106,8 @@ constexpr const char* disabled_runtime_features[] = {
     "envoy.reloadable_features.test_feature_false",
     // TODO(dmitri-d) reset to true to enable unified mux by default
     "envoy.reloadable_features.unified_mux",
+    // TODO(birenroy) flip after https://github.com/envoyproxy/envoy/issues/19761 sorted.
+    "envoy.reloadable_features.http2_new_codec_wrapper",
 };
 
 RuntimeFeatures::RuntimeFeatures() {


### PR DESCRIPTION
See https://github.com/envoyproxy/envoy/issues/19761
Fixes commit #19614