### PR TITLE
test: deflaking yet another test

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -172,7 +172,7 @@ std::string ConfigHelper::httpProxyConfig(bool downstream_use_quic) {
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           stat_prefix: config_test
           delayed_close_timeout:
-            nanos: 100
+            nanos: 10000000
           http_filters:
             name: envoy.filters.http.router
           codec_type: HTTP1

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -458,7 +458,6 @@ typed_config:
 
   initialize();
 
-
   {
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -544,7 +544,6 @@ typed_config:
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("200"));
-    codec_client_->close();
   }
 
   auto second_codec = makeHttpConnection(lookupPort("http"));

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -464,6 +464,7 @@ typed_config:
     auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("403"));
+    codec_client_->close();
   }
 
   {
@@ -477,6 +478,7 @@ typed_config:
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("200"));
+    codec_client_->close();
   }
 
   auto second_codec = makeHttpConnection(lookupPort("http"));
@@ -524,12 +526,12 @@ typed_config:
 
   initialize();
 
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-
   {
+    codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("403"));
+    codec_client_->close();
   }
 
   {
@@ -543,6 +545,7 @@ typed_config:
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("200"));
+    codec_client_->close();
   }
 
   auto second_codec = makeHttpConnection(lookupPort("http"));

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -458,9 +458,9 @@ typed_config:
 
   initialize();
 
-  codec_client_ = makeHttpConnection(lookupPort("http"));
 
   {
+    codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("403"));
@@ -478,7 +478,6 @@ typed_config:
 
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), HttpStatusIs("200"));
-    codec_client_->close();
   }
 
   auto second_codec = makeHttpConnection(lookupPort("http"));

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -1345,7 +1345,7 @@ TEST_P(MultiplexedIntegrationTest, DelayedCloseDisabled) {
   EXCLUDE_DOWNSTREAM_HTTP3; // Needs HTTP/3 "bad frame" equivalent.
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-             hcm) { hcm.mutable_delayed_close_timeout()->set_seconds(0); });
+             hcm) { hcm.mutable_delayed_close_timeout()->set_nanos(0); });
   initialize();
   std::string response;
   auto connection = createConnectionDriver(

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3454,10 +3454,6 @@ TEST_P(DownstreamProtocolIntegrationTest, HandleDownstreamSocketFail) {
 }
 
 TEST_P(ProtocolIntegrationTest, HandleUpstreamSocketFail) {
-#ifdef WIN32
-  // Debug info for https://github.com/envoyproxy/envoy/issues/19430
-  LogLevelSetter save_levels(spdlog::level::trace);
-#endif
   SocketInterfaceSwap socket_swap;
 
   useAccessLog("%RESPONSE_CODE_DETAILS%");


### PR DESCRIPTION
As detailed in the linked issue, the lack of delay-close in integration tests was causing windows to react to FINs before reading error bodies, so turning up delay close.

Fixes https://github.com/envoyproxy/envoy/issues/19430
