### PR TITLE
jwt_authn: not use default locations if from_cookie is used

### DIFF
--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -208,7 +208,8 @@ void ExtractorImpl::addProvider(const JwtProvider& provider) {
     addCookieConfig(provider.issuer(), cookie);
   }
   // If not specified, use default locations.
-  if (provider.from_headers().empty() && provider.from_params().empty()) {
+  if (provider.from_headers().empty() && provider.from_params().empty() &&
+      provider.from_cookies().empty()) {
     addHeaderConfig(provider.issuer(), Http::CustomHeaders::get().Authorization,
                     JwtConstValues::get().BearerPrefix);
     addQueryParamConfig(provider.issuer(), JwtConstValues::get().AccessTokenParam);

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -118,6 +118,11 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocation) {
   EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer3"));
   EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer4"));
   EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer5"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer6"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer7"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer8"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer9"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer10"));
   EXPECT_FALSE(tokens[0]->isIssuerAllowed("unknown_issuer"));
 
   // Test token remove
@@ -299,6 +304,26 @@ TEST_F(ExtractorTest, TestCookieToken) {
   EXPECT_TRUE(tokens[2]->isIssuerAllowed("issuer10"));
   EXPECT_FALSE(tokens[2]->isIssuerAllowed("issuer9"));
   tokens[2]->removeJwt(headers);
+}
+
+// Test extracting token from a cookie, but not from default location
+TEST_F(ExtractorTest, TestCookieTokenAndDefault) {
+  setUp(R"(
+providers:
+  provider11:
+    issuer: issuer11
+    from_cookies:
+      - token-cookie
+)");
+  // Headers has token in both cookie and default location.
+  auto headers = TestRequestHeaderMapImpl{{"Authorization", "Bearer jwt_token"},
+                                          {"cookie", "token-cookie=\"token-cookie-value\""}};
+  // token from the default location is not extracted
+  auto tokens = extractor_->extract(headers);
+  EXPECT_EQ(tokens.size(), 1);
+
+  EXPECT_EQ(tokens[0]->token(), "token-cookie-value");
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer11"));
 }
 
 // Test extracting multiple tokens.


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix https://github.com/envoyproxy/envoy/issues/19772

Even if "from_cookie" is specified, the current code is still trying to find JWT token from the default location.

Risk Level: None
Testing: unit-test
Docs Changes: No
Release Notes: No
