### PR TITLE
conn pool: fixing overly aggressive connect 

### DIFF
--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -182,6 +182,31 @@ TEST_P(CdsIntegrationTest, CdsClusterUpDownUp) {
   cleanupUpstreamAndDownstream();
 }
 
+// Make sure that clusters won't create new connections on teardown.
+TEST_P(CdsIntegrationTest, CdsClusterTeardownWhileConnecting) {
+  initialize();
+  test_server_->waitForCounterGe("cluster_manager.cluster_added", 1);
+
+  // Make the usptreams stop working, to ensure the connection was not
+  // established.
+  fake_upstreams_[1]->dispatcher()->exit();
+  fake_upstreams_[2]->dispatcher()->exit();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/cluster1"}, {":scheme", "http"}, {":authority", "host"}});
+
+  // Tell Envoy that cluster_1 is gone.
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "55", {}, {}, {}));
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster, {}, {},
+                                                             {ClusterName1}, "42");
+  // We can continue the test once we're sure that Envoy's ClusterManager has made use of
+  // the DiscoveryResponse that says cluster_1 is gone.
+  test_server_->waitForCounterGe("cluster_manager.cluster_removed", 1);
+  cleanupUpstreamAndDownstream();
+  // Make sure there was only one connection attempt.
+  EXPECT_LE(test_server_->counter("cluster.cluster_1.upstream_cx_total")->value(), 1);
+}
+
 // Test the fast addition and removal of clusters when they use ThreadAwareLb.
 TEST_P(CdsIntegrationTest, CdsClusterWithThreadAwareLbCycleUpDownUp) {
   // Calls our initialize(), which includes establishing a listener, route, and cluster.

--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -187,7 +187,7 @@ TEST_P(CdsIntegrationTest, CdsClusterTeardownWhileConnecting) {
   initialize();
   test_server_->waitForCounterGe("cluster_manager.cluster_added", 1);
 
-  // Make the usptreams stop working, to ensure the connection was not
+  // Make the upstreams stop working, to ensure the connection was not
   // established.
   fake_upstreams_[1]->dispatcher()->exit();
   fake_upstreams_[2]->dispatcher()->exit();

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@base_pip3//:requirements.bzl", base_entry_point = "entry_point")
 
 def envoy_py_test(name, package, visibility, envoy_prefix = "@envoy"):


### PR DESCRIPTION
Fixing a bug where the connection pool attempts to establish new connections while draining.

Risk Level: low
Testing: integration test
Docs Changes: n/a
Release Notes: n/a