### PR TITLE
bazel: remove -pie on apple platforms

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -78,6 +78,7 @@ def _envoy_linkopts():
             "-Wl,--hash-style=gnu",
         ],
     }) + select({
+        "@envoy//bazel:apple": [],
         "@envoy//bazel:boringssl_fips": [],
         "@envoy//bazel:windows_x86_64": [],
         "//conditions:default": ["-pie"],


### PR DESCRIPTION
This is the default on apple platforms and is also ignored and produces
a warning:

```
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
```

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>