### PR TITLE
api docs: improve wording of ext_proc ImmediateResponse.Details field

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -298,7 +298,8 @@ message ImmediateResponse {
   GrpcStatus grpc_status = 4;
 
   // A string detailing why this local reply was sent, which may be included
-  // in log and debug output.
+  // in log and debug output (e.g. this populates the %RESPONSE_CODE_DETAILS%
+  // command operator field for use in access logging).
   string details = 5;
 }
 


### PR DESCRIPTION
Signed-off-by: Chet Nichols III chet@apple.com

Commit Message: api docs: improve wording of ext_proc ImmediateResponse.Details field

Addition Details: I had been trying to figure out a good way to provide more internally-derived feedback from an *ext_proc* implementation to *envoy* (without needing to do things like set response headers or rely on a separate log file), and was led to the discovery that the `ImmediateResponse.Details` field actually populates `%RESPONSE_CODE_DETAILS%` for use in access logging.

Due to how much better this discovery made my life, I am hoping it will make other people's lives better as well.

Risk Level: Low
Testing: Leveraged existing unit tests
Docs Changes: Yes
Release Notes: None
Platform Specific Features: None