### PR TITLE
fix invalid ruby_package gen from protoxform

### DIFF
--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -16,7 +16,7 @@ option java_outer_classname = "CircuitBreakerProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy::Api::V2::ClusterNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/cluster/filter.proto
+++ b/api/envoy/api/v2/cluster/filter.proto
@@ -13,7 +13,7 @@ option java_outer_classname = "FilterProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy::Api::V2::ClusterNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -14,7 +14,7 @@ option java_outer_classname = "OutlierDetectionProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster";
 option csharp_namespace = "Envoy.Api.V2.ClusterNS";
-option ruby_package = "Envoy.Api.V2.ClusterNS";
+option ruby_package = "Envoy::Api::V2::ClusterNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -9,4 +9,4 @@ option java_outer_classname = "ListenerProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";

--- a/api/envoy/api/v2/listener/listener_components.proto
+++ b/api/envoy/api/v2/listener/listener_components.proto
@@ -20,7 +20,7 @@ option java_outer_classname = "ListenerComponentsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/listener/quic_config.proto
+++ b/api/envoy/api/v2/listener/quic_config.proto
@@ -13,7 +13,7 @@ option java_outer_classname = "QuicConfigProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/listener/udp_listener_config.proto
+++ b/api/envoy/api/v2/listener/udp_listener_config.proto
@@ -13,7 +13,7 @@ option java_outer_classname = "UdpListenerConfigProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener";
 option csharp_namespace = "Envoy.Api.V2.ListenerNS";
-option ruby_package = "Envoy.Api.V2.ListenerNS";
+option ruby_package = "Envoy::Api::V2::ListenerNS";
 option (udpa.annotations.file_migrate).move_to_package = "envoy.config.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/tools/protoxform/protoprint.py
+++ b/tools/protoxform/protoprint.py
@@ -230,9 +230,9 @@ def format_header_from_file(
     # TODO(htuch): remove once v3 fixes this naming issue in
     # https://github.com/envoyproxy/envoy/issues/8120.
     if file_proto.package in ['envoy.api.v2.listener', 'envoy.api.v2.cluster']:
-        qualified_package = '.'.join(s.capitalize() for s in file_proto.package.split('.')) + 'NS'
-        options.csharp_namespace = qualified_package
-        options.ruby_package = qualified_package
+        names = [s.capitalize() for s in file_proto.package.split('.')]
+        options.csharp_namespace = '.'.join(names) + 'NS'
+        options.ruby_package = '::'.join(names) + 'NS'
 
     if file_proto.service:
         options.java_generic_services = True


### PR DESCRIPTION
Commit Message:

fixes us generating an invalid ruby_package for protobuf.

Signed-off-by: Cynthia <cynthia@coan.dev>

Additional Description:

We should probably talk about back-porting as right now generating any packages with ruby is broken.

Risk Level: Should be none, this only changes `ruby_package` which was broken before.

Testing:
  - Generated the protobufs with the changed package names, and validated that generation succeeds.

Docs Changes: N/A
Release Notes: Pending backport discussions.
Fixes #19814 
