### PR TITLE
lua: clear LDFLAGS for host tools.

### DIFF
--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -125,7 +125,7 @@ new file mode 100755
 index 0000000..3eb74ff
 --- /dev/null
 +++ b/build.py
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,49 @@
 +#!/usr/bin/env python3
 +
 +import argparse
@@ -145,14 +145,7 @@ index 0000000..3eb74ff
 +    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["CFLAGS"] = ""
-+    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
-+    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't
-+    # fail on it.
-+    os.environ["LSAN_OPTIONS"] = "exitcode=0"
-+
-+    if "ENVOY_MSAN" in os.environ:
-+      os.environ["HOST_CFLAGS"] = "-fno-sanitize=memory"
-+      os.environ["HOST_LDFLAGS"] = "-fno-sanitize=memory"
++    os.environ["LDFLAGS"] = ""
 +
 +    # Remove LuaJIT from ASAN for now.
 +    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.

--- a/bazel/foreign_cc/moonjit.patch
+++ b/bazel/foreign_cc/moonjit.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..dab3606c
 --- /dev/null
 +++ b/build.py
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,32 @@
 +#!/usr/bin/env python3
 +
 +import argparse
@@ -23,14 +23,7 @@ index 00000000..dab3606c
 +    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["CFLAGS"] = ""
-+    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
-+    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't
-+    # fail on it.
-+    os.environ["LSAN_OPTIONS"] = "exitcode=0"
-+
-+    if "ENVOY_MSAN" in os.environ:
-+      os.environ["HOST_CFLAGS"] = "-fno-sanitize=memory"
-+      os.environ["HOST_LDFLAGS"] = "-fno-sanitize=memory"
++    os.environ["LDFLAGS"] = ""
 +
 +    # Remove LuaJIT from ASAN for now.
 +    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.


### PR DESCRIPTION
This prevents target LDFLAGS from affecting host tools,
and it matches the existing behavior of CFLAGS.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>