### PR TITLE
doc: remove alpine info

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -166,12 +166,6 @@ The following table shows the available Docker images
      -
      -
      -
-   * - `envoyproxy/envoy-alpine <https://hub.docker.com/r/envoyproxy/envoy-alpine/tags/>`_
-     - Release binary with symbols stripped on top of a **glibc** alpine base.
-     - |DOCKER_IMAGE_TAG_NAME|
-     -
-     -
-     -
    * - `envoyproxy/envoy-windows <https://hub.docker.com/r/envoyproxy/envoy-windows/tags/>`_
      - Release binary with symbols stripped on top of a Windows Server 1809 base.
      - |DOCKER_IMAGE_TAG_NAME|
@@ -204,12 +198,6 @@ The following table shows the available Docker images
      - latest
    * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
      - Release binary with symbols stripped on top of a distroless base.
-     -
-     -
-     - latest
-     -
-   * - `envoyproxy/envoy-alpine-dev <https://hub.docker.com/r/envoyproxy/envoy-alpine-dev/tags/>`_
-     - Release binary with symbols stripped on top of a **glibc** alpine base.
      -
      -
      - latest


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

Part of #19781

Commit Message: remove alpine image info.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
