### PR TITLE
docker: remove alpine build

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -49,25 +49,6 @@ ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]
 
 
-# STAGE: envoy-alpine
-# TODO(https://github.com/envoyproxy/envoy/issues/19781): Deprecate and remove this image
-FROM frolvlad/alpine-glibc:alpine-3.14_glibc-2.33 AS envoy-alpine
-
-RUN mkdir -p /etc/envoy
-
-COPY --from=binary /usr/local/bin/envoy /usr/local/bin/
-COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
-
-RUN apk add --no-cache shadow su-exec \
-    && addgroup -S envoy && adduser --no-create-home -S envoy -G envoy
-
-EXPOSE 10000
-
-COPY ci/docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
-
-
 # STAGE: envoy-google-vrp
 FROM ${ENVOY_VRP_BASE_IMAGE} AS envoy-google-vrp
 

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -117,7 +117,7 @@ if is_windows; then
   BUILD_COMMAND=("build")
 else
   # "-google-vrp" must come afer "" to ensure we rebuild the local base image dependency.
-  BUILD_TYPES=("" "-debug" "-contrib" "-contrib-debug" "-alpine" "-distroless" "-google-vrp")
+  BUILD_TYPES=("" "-debug" "-contrib" "-contrib-debug" "-distroless" "-google-vrp")
 
   # Configure docker-buildx tools
   BUILD_COMMAND=("buildx" "build")


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

Part of #19781

Commit Message: do not build for alpine anymore.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
