### PR TITLE
ci: remove useless assign

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -57,7 +57,6 @@ build_args() {
 use_builder() {
   # BuildKit is not available for Windows images, skip this
   if ! is_windows; then
-    TYPE=$1
     docker buildx use multi-builder
   fi
 }


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

No doc for `docker buildx` that `TYPE` is useful.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
