### PR TITLE
Revert "ci: Dont remove packages in ci jobs (#17146)"

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -25,10 +25,6 @@ steps:
     path: $(Build.StagingDirectory)/repository_cache
   continueOnError: true
 
-- bash: .azure-pipelines/cleanup.sh
-  displayName: "Removing tools from agent"
-  condition: ${{ parameters.managedAgent }}
-
 - bash: |
     echo "disk space at beginning of build:"
     df -h

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -25,6 +25,10 @@ steps:
     path: $(Build.StagingDirectory)/repository_cache
   continueOnError: true
 
+- bash: .azure-pipelines/cleanup.sh
+  displayName: "Removing tools from agent"
+  condition: ${{ parameters.managedAgent }}
+
 - bash: |
     echo "disk space at beginning of build:"
     df -h

--- a/.azure-pipelines/cleanup.sh
+++ b/.azure-pipelines/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Temporary script to remove tools from Azure pipelines agent to create more disk space room.
+sudo apt-get update -y || true
+sudo apt-get purge -y --no-upgrade 'ghc-*' 'zulu-*-azure-jdk' 'libllvm*' 'mysql-*' 'dotnet-*' 'libgl1' \
+  'adoptopenjdk-*' 'azure-cli' 'google-chrome-stable' 'firefox' 'hhvm'
+
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn

--- a/.azure-pipelines/cleanup.sh
+++ b/.azure-pipelines/cleanup.sh
@@ -3,8 +3,23 @@
 set -e
 
 # Temporary script to remove tools from Azure pipelines agent to create more disk space room.
+
+PURGE_PACKAGES=(
+     'adoptopenjdk-*'
+     azure-cli
+     'ghc-*'
+     'libllvm*'
+     'mysql-*'
+     'dotnet-*'
+     firefox
+     google-chrome-stable
+     hhvm
+     libgl1
+     mongodb-mongosh
+     'temurin-*-jdk'
+     'zulu-*-azure-jdk')
+
 sudo apt-get update -y || true
-sudo apt-get purge -y --no-upgrade 'ghc-*' 'zulu-*-azure-jdk' 'libllvm*' 'mysql-*' 'dotnet-*' 'libgl1' \
-  'adoptopenjdk-*' 'azure-cli' 'google-chrome-stable' 'firefox' 'hhvm'
+sudo apt-get purge -y --no-upgrade "${PURGE_PACKAGES[@]}"
 
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -302,6 +302,8 @@ stages:
     pool:
       vmImage: "ubuntu-18.04"
     steps:
+    - bash: .azure-pipelines/cleanup.sh
+      displayName: "Removing tools from agent"
     - bash: |
         echo "disk space at beginning of build:"
         df -h


### PR DESCRIPTION
This reverts commit e330009658366a518c54ee747caca0a5dae6abe9.

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

I added this previously as it was slowing down ci and it didnt seem necessary - but for #19275 i think we need to revert

i have some additional space saving that we could do, but tbh this is probably enough

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
