### PR TITLE
Adding test to check the Host header in HTTP/1.1 CONNECT message is i…

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -243,6 +243,24 @@ TEST_P(ConnectTerminationIntegrationTest, BasicMaxStreamDuration) {
   }
 }
 
+// Verify Envoy ignores the Host field in HTTP/1.1 CONNECT message.
+TEST_P(ConnectTerminationIntegrationTest, IgnoreH11HostField) {
+  // This test is HTTP/1.1 specific.
+  if (downstream_protocol_ != Http::CodecType::HTTP1) {
+    return;
+  }
+  initialize();
+
+  std::string response;
+  const std::string full_request = "CONNECT www.foo.com:443 HTTP/1.1\r\n"
+                                   "Host: www.bar.com:443\r\n\r\n";
+  EXPECT_LOG_CONTAINS(
+      "",
+      "':authority', 'www.foo.com:443'\n"
+      "':method', 'CONNECT'",
+      sendRawHttpAndWaitForResponse(lookupPort("http"), full_request.c_str(), &response, false););
+}
+
 // For this class, forward the CONNECT request upstream
 class ProxyingConnectIntegrationTest : public HttpProtocolIntegrationTest {
 public:


### PR DESCRIPTION
Problem description:
Adding a test to check the Host field in HTTP/1.1 CONNECT message is ignored. And the authority data in request target is used as Host in Envoy next stage processing. This is required by spec. 

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
