### PR TITLE
buffer: add explicit cast to remove narrowing warning

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -392,7 +392,7 @@ ReservationSingleSlice OwnedImpl::reserveSingleSlice(uint64_t length, bool separ
   } else {
     slice_owner->owned_storage_ = Slice::newStorage(length);
     ASSERT(slice_owner->owned_storage_.len_ >= length);
-    reservation_slice = {slice_owner->owned_storage_.mem_.get(), length};
+    reservation_slice = {slice_owner->owned_storage_.mem_.get(), static_cast<size_t>(length)};
   }
 
   reservation.bufferImplUseOnlySliceOwner() = std::move(slice_owner);

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -369,7 +369,7 @@ public:
    */
   static inline SizedStorage newStorage(uint64_t min_capacity) {
     const uint64_t slice_size = sliceSize(min_capacity);
-    return {StoragePtr{new uint8_t[slice_size]}, slice_size};
+    return {StoragePtr{new uint8_t[slice_size]}, static_cast<size_t>(slice_size)};
   }
 
 protected:


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>
