### PR TITLE
owners: promote Yan to senior maintainer.

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -24,11 +24,11 @@ routing PRs, questions, etc. to the right place.
   * Upstream, host/priority sets, load balancing, and retry plugins.
 * Greg Greenway ([ggreenway](https://github.com/ggreenway)) (ggreenway@apple.com)
   * TLS, TCP proxy, listeners, and HTTP proxy/connection pooling.
+* Yan Avlasov ([yanavlasov](https://github.com/yanavlasov)) (yavlasov@google.com)
+  * Data plane, codecs, security, configuration.
 
 # Maintainers
 
-* Yan Avlasov ([yanavlasov](https://github.com/yanavlasov)) (yavlasov@google.com)
-  * Data plane, codecs, security, configuration.
 * Jose Nino ([junr03](https://github.com/junr03)) (jnino@lyft.com)
   * Outlier detection, HTTP routing, xDS, configuration/operational questions.
 * Dhi Aurrahman ([dio](https://github.com/dio)) (dio@rockybars.com)


### PR DESCRIPTION
There is consensus amongst @envoyproxy/senior-maintainers  around Yan
joining us. Welcome!

Risk level: Very low
Testing: Many years of Envoy contribution and maintainer efforts.

Signed-off-by: Harvey Tuch <htuch@google.com>