### PR TITLE
runtime: plumbing down to TCP listeners

### DIFF
--- a/envoy/event/dispatcher.h
+++ b/envoy/event/dispatcher.h
@@ -227,13 +227,15 @@ public:
    * Creates a listener on a specific port.
    * @param socket supplies the socket to listen on.
    * @param cb supplies the callbacks to invoke for listener events.
+   * @param runtime supplies the runtime for this server.
    * @param bind_to_port controls whether the listener binds to a transport port or not.
    * @param ignore_global_conn_limit controls whether the listener is limited by the global
    * connection limit.
    * @return Network::ListenerPtr a new listener that is owned by the caller.
    */
   virtual Network::ListenerPtr createListener(Network::SocketSharedPtr&& socket,
-                                              Network::TcpListenerCallbacks& cb, bool bind_to_port,
+                                              Network::TcpListenerCallbacks& cb,
+                                              Runtime::Loader& runtime, bool bind_to_port,
                                               bool ignore_global_conn_limit) PURE;
 
   /**

--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
         ":connection_balancer_interface",
         ":listen_socket_interface",
         ":listener_interface",
+        "//envoy/runtime:runtime_interface",
         "//envoy/ssl:context_interface",
         "//source/common/common:interval_value",
     ],

--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -8,6 +8,7 @@
 #include "envoy/network/filter.h"
 #include "envoy/network/listen_socket.h"
 #include "envoy/network/listener.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/ssl/context.h"
 
 #include "source/common/common/interval_value.h"
@@ -44,9 +45,10 @@ public:
    * Adds a listener to the handler, optionally replacing the existing listener.
    * @param overridden_listener tag of the existing listener. nullopt if no previous listener.
    * @param config listener configuration options.
+   * @param runtime the runtime for the server.
    */
-  virtual void addListener(absl::optional<uint64_t> overridden_listener,
-                           ListenerConfig& config) PURE;
+  virtual void addListener(absl::optional<uint64_t> overridden_listener, ListenerConfig& config,
+                           Runtime::Loader& runtime) PURE;
 
   /**
    * Remove listeners using the listener tag as a key. All connections owned by the removed

--- a/envoy/server/BUILD
+++ b/envoy/server/BUILD
@@ -158,6 +158,7 @@ envoy_cc_library(
     name = "worker_interface",
     hdrs = ["worker.h"],
     deps = [
+        "//envoy/runtime:runtime_interface",
         "//envoy/server:guarddog_interface",
         "//envoy/server/overload:overload_manager_interface",
     ],

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "envoy/event/dispatcher.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/server/guarddog.h"
 #include "envoy/server/overload/overload_manager.h"
 
@@ -30,10 +31,11 @@ public:
    * @param listener supplies the listener to add.
    * @param completion supplies the completion to call when the listener has been added (or not) on
    *                   the worker.
+   * @param runtime, supplies the runtime for the server
    */
   virtual void addListener(absl::optional<uint64_t> overridden_listener,
-                           Network::ListenerConfig& listener,
-                           AddListenerCompletion completion) PURE;
+                           Network::ListenerConfig& listener, AddListenerCompletion completion,
+                           Runtime::Loader& runtime) PURE;
 
   /**
    * @return uint64_t the number of connections across all listeners that the worker owns.

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -171,11 +171,12 @@ Filesystem::WatcherPtr DispatcherImpl::createFilesystemWatcher() {
 
 Network::ListenerPtr DispatcherImpl::createListener(Network::SocketSharedPtr&& socket,
                                                     Network::TcpListenerCallbacks& cb,
-                                                    bool bind_to_port,
+                                                    Runtime::Loader& runtime, bool bind_to_port,
                                                     bool ignore_global_conn_limit) {
   ASSERT(isThreadSafe());
-  return std::make_unique<Network::TcpListenerImpl>(
-      *this, api_.randomGenerator(), std::move(socket), cb, bind_to_port, ignore_global_conn_limit);
+  return std::make_unique<Network::TcpListenerImpl>(*this, api_.randomGenerator(), runtime,
+                                                    std::move(socket), cb, bind_to_port,
+                                                    ignore_global_conn_limit);
 }
 
 Network::UdpListenerPtr

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -70,8 +70,8 @@ public:
                                uint32_t events) override;
   Filesystem::WatcherPtr createFilesystemWatcher() override;
   Network::ListenerPtr createListener(Network::SocketSharedPtr&& socket,
-                                      Network::TcpListenerCallbacks& cb, bool bind_to_port,
-                                      bool ignore_global_conn_limit) override;
+                                      Network::TcpListenerCallbacks& cb, Runtime::Loader& runtime,
+                                      bool bind_to_port, bool ignore_global_conn_limit) override;
   Network::UdpListenerPtr
   createUdpListener(Network::SocketSharedPtr socket, Network::UdpListenerCallbacks& cb,
                     const envoy::config::core::v3::UdpSocketConfig& config) override;

--- a/source/common/network/tcp_listener_impl.cc
+++ b/source/common/network/tcp_listener_impl.cc
@@ -22,12 +22,7 @@ const absl::string_view TcpListenerImpl::GlobalMaxCxRuntimeKey =
 
 bool TcpListenerImpl::rejectCxOverGlobalLimit() const {
   // Enforce the global connection limit if necessary, immediately closing the accepted connection.
-  Runtime::Loader* runtime = Runtime::LoaderSingleton::getExisting();
-
-  if (ignore_global_conn_limit_ || runtime == nullptr) {
-    // The runtime singleton won't exist in most unit tests that do not need global downstream limit
-    // enforcement. Therefore, there is no need to enforce limits if the singleton doesn't exist.
-    // TODO(tonya11en): Revisit this once runtime is made globally available.
+  if (ignore_global_conn_limit_) {
     return false;
   }
 
@@ -36,7 +31,7 @@ bool TcpListenerImpl::rejectCxOverGlobalLimit() const {
   // use a listener and do not run in a worker thread. In practice, this code path will always be
   // run on a worker thread, but to prevent failed assertions in test environments, threadsafe
   // snapshots must be used. This must be revisited.
-  const uint64_t global_cx_limit = runtime->threadsafeSnapshot()->getInteger(
+  const uint64_t global_cx_limit = runtime_.threadsafeSnapshot()->getInteger(
       GlobalMaxCxRuntimeKey, std::numeric_limits<uint64_t>::max());
   return AcceptedSocketImpl::acceptedSocketCount() >= global_cx_limit;
 }
@@ -97,9 +92,10 @@ void TcpListenerImpl::onSocketEvent(short flags) {
 }
 
 TcpListenerImpl::TcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::RandomGenerator& random,
-                                 SocketSharedPtr socket, TcpListenerCallbacks& cb,
-                                 bool bind_to_port, bool ignore_global_conn_limit)
-    : BaseListenerImpl(dispatcher, std::move(socket)), cb_(cb), random_(random),
+                                 Runtime::Loader& runtime, SocketSharedPtr socket,
+                                 TcpListenerCallbacks& cb, bool bind_to_port,
+                                 bool ignore_global_conn_limit)
+    : BaseListenerImpl(dispatcher, std::move(socket)), cb_(cb), random_(random), runtime_(runtime),
       bind_to_port_(bind_to_port), reject_fraction_(0.0),
       ignore_global_conn_limit_(ignore_global_conn_limit) {
   if (bind_to_port) {

--- a/source/common/network/tcp_listener_impl.h
+++ b/source/common/network/tcp_listener_impl.h
@@ -17,8 +17,8 @@ namespace Network {
 class TcpListenerImpl : public BaseListenerImpl {
 public:
   TcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::RandomGenerator& random,
-                  SocketSharedPtr socket, TcpListenerCallbacks& cb, bool bind_to_port,
-                  bool ignore_global_conn_limit);
+                  Runtime::Loader& runtime, SocketSharedPtr socket, TcpListenerCallbacks& cb,
+                  bool bind_to_port, bool ignore_global_conn_limit);
   ~TcpListenerImpl() override {
     if (bind_to_port_) {
       socket_->ioHandle().resetFileEvents();
@@ -41,6 +41,7 @@ private:
   bool rejectCxOverGlobalLimit() const;
 
   Random::RandomGenerator& random_;
+  Runtime::Loader& runtime_;
   bool bind_to_port_;
   UnitFloat reject_fraction_;
   const bool ignore_global_conn_limit_;

--- a/source/server/active_tcp_listener.cc
+++ b/source/server/active_tcp_listener.cc
@@ -13,11 +13,13 @@ namespace Envoy {
 namespace Server {
 
 ActiveTcpListener::ActiveTcpListener(Network::TcpConnectionHandler& parent,
-                                     Network::ListenerConfig& config, uint32_t worker_index)
+                                     Network::ListenerConfig& config, Runtime::Loader& runtime,
+                                     uint32_t worker_index)
     : OwnedActiveStreamListenerBase(parent, parent.dispatcher(),
                                     parent.dispatcher().createListener(
                                         config.listenSocketFactory().getListenSocket(worker_index),
-                                        *this, config.bindToPort(), config.ignoreGlobalConnLimit()),
+                                        *this, runtime, config.bindToPort(),
+                                        config.ignoreGlobalConnLimit()),
                                     config),
       tcp_conn_handler_(parent) {
   config.connectionBalancer().registerHandler(*this);
@@ -25,7 +27,7 @@ ActiveTcpListener::ActiveTcpListener(Network::TcpConnectionHandler& parent,
 
 ActiveTcpListener::ActiveTcpListener(Network::TcpConnectionHandler& parent,
                                      Network::ListenerPtr&& listener,
-                                     Network::ListenerConfig& config)
+                                     Network::ListenerConfig& config, Runtime::Loader&)
     : OwnedActiveStreamListenerBase(parent, parent.dispatcher(), std::move(listener), config),
       tcp_conn_handler_(parent) {
   config.connectionBalancer().registerHandler(*this);

--- a/source/server/active_tcp_listener.h
+++ b/source/server/active_tcp_listener.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/event/dispatcher.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/linked_object.h"
@@ -26,9 +27,9 @@ class ActiveTcpListener final : public Network::TcpListenerCallbacks,
                                 public Network::BalancedConnectionHandler {
 public:
   ActiveTcpListener(Network::TcpConnectionHandler& parent, Network::ListenerConfig& config,
-                    uint32_t worker_index);
+                    Runtime::Loader& runtime, uint32_t worker_index);
   ActiveTcpListener(Network::TcpConnectionHandler& parent, Network::ListenerPtr&& listener,
-                    Network::ListenerConfig& config);
+                    Network::ListenerConfig& config, Runtime::Loader& runtime);
   ~ActiveTcpListener() override;
 
   bool listenerConnectionLimitReached() const {

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -422,7 +422,7 @@ void AdminImpl::closeSocket() {
 
 void AdminImpl::addListenerToHandler(Network::ConnectionHandler* handler) {
   if (listener_) {
-    handler->addListener(absl::nullopt, *listener_);
+    handler->addListener(absl::nullopt, *listener_, server_.runtime());
   }
 }
 

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -16,8 +16,8 @@ Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
 }
 
 Network::ListenerPtr ValidationDispatcher::createListener(Network::SocketSharedPtr&&,
-                                                          Network::TcpListenerCallbacks&, bool,
-                                                          bool) {
+                                                          Network::TcpListenerCallbacks&,
+                                                          Runtime::Loader&, bool, bool) {
   return nullptr;
 }
 

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -24,7 +24,8 @@ public:
                          Network::Address::InstanceConstSharedPtr, Network::TransportSocketPtr&&,
                          const Network::ConnectionSocket::OptionsSharedPtr& options) override;
   Network::ListenerPtr createListener(Network::SocketSharedPtr&&, Network::TcpListenerCallbacks&,
-                                      bool bind_to_port, bool ignore_global_conn_limit) override;
+                                      Runtime::Loader& runtime, bool bind_to_port,
+                                      bool ignore_global_conn_limit) override;
 };
 
 } // namespace Event

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -29,7 +29,7 @@ void ConnectionHandlerImpl::decNumConnections() {
 }
 
 void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_listener,
-                                        Network::ListenerConfig& config) {
+                                        Network::ListenerConfig& config, Runtime::Loader& runtime) {
   const bool support_udp_in_place_filter_chain_update = Runtime::runtimeFeatureEnabled(
       "envoy.reloadable_features.udp_listener_updates_filter_chain_in_place");
   if (support_udp_in_place_filter_chain_update && overridden_listener.has_value()) {
@@ -64,7 +64,7 @@ void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_list
     }
     // worker_index_ doesn't have a value on the main thread for the admin server.
     auto tcp_listener = std::make_unique<ActiveTcpListener>(
-        *this, config, worker_index_.has_value() ? *worker_index_ : 0);
+        *this, config, runtime, worker_index_.has_value() ? *worker_index_ : 0);
     details->typed_listener_ = *tcp_listener;
     details->listener_ = std::move(tcp_listener);
   } else {

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -45,8 +45,8 @@ public:
   uint64_t numConnections() const override { return num_handler_connections_; }
   void incNumConnections() override;
   void decNumConnections() override;
-  void addListener(absl::optional<uint64_t> overridden_listener,
-                   Network::ListenerConfig& config) override;
+  void addListener(absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& config,
+                   Runtime::Loader& runtime) override;
   void removeListeners(uint64_t listener_tag) override;
   void removeFilterChains(uint64_t listener_tag,
                           const std::list<const Network::FilterChain*>& filter_chains,

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -607,16 +607,19 @@ void ListenerManagerImpl::addListenerToWorker(Worker& worker,
   if (overridden_listener.has_value()) {
     ENVOY_LOG(debug, "replacing existing listener {}", overridden_listener.value());
   }
-  worker.addListener(overridden_listener, listener, [this, completion_callback]() -> void {
-    // The add listener completion runs on the worker thread. Post back to the main thread to
-    // avoid locking.
-    server_.dispatcher().post([this, completion_callback]() -> void {
-      stats_.listener_create_success_.inc();
-      if (completion_callback) {
-        completion_callback();
-      }
-    });
-  });
+  worker.addListener(
+      overridden_listener, listener,
+      [this, completion_callback]() -> void {
+        // The add listener completion runs on the worker thread. Post back to the main thread to
+        // avoid locking.
+        server_.dispatcher().post([this, completion_callback]() -> void {
+          stats_.listener_create_success_.inc();
+          if (completion_callback) {
+            completion_callback();
+          }
+        });
+      },
+      server_.runtime());
 }
 
 void ListenerManagerImpl::onListenerWarmed(ListenerImpl& listener) {

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -43,9 +43,10 @@ WorkerImpl::WorkerImpl(ThreadLocal::Instance& tls, ListenerHooks& hooks,
 }
 
 void WorkerImpl::addListener(absl::optional<uint64_t> overridden_listener,
-                             Network::ListenerConfig& listener, AddListenerCompletion completion) {
-  dispatcher_->post([this, overridden_listener, &listener, completion]() -> void {
-    handler_->addListener(overridden_listener, listener);
+                             Network::ListenerConfig& listener, AddListenerCompletion completion,
+                             Runtime::Loader& runtime) {
+  dispatcher_->post([this, overridden_listener, &listener, &runtime, completion]() -> void {
+    handler_->addListener(overridden_listener, listener, runtime);
     hooks_.onWorkerListenerAdded();
     completion();
   });

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -53,7 +53,7 @@ public:
 
   // Server::Worker
   void addListener(absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& listener,
-                   AddListenerCompletion completion) override;
+                   AddListenerCompletion completion, Runtime::Loader& loader) override;
   uint64_t numConnections() const override;
 
   void removeListener(Network::ListenerConfig& listener, std::function<void()> completion) override;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -15,6 +15,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/environment.h"
@@ -63,6 +64,7 @@ public:
 
   ~CodecClientTest() override { EXPECT_EQ(0U, client_->numActiveRequests()); }
 
+  NiceMock<Runtime::MockLoader> runtime_;
   Event::MockDispatcher dispatcher_;
   Network::MockClientConnection* connection_;
   Http::MockClientConnection* codec_;
@@ -292,7 +294,7 @@ public:
         socket->connectionInfoProvider().localAddress(), source_address_,
         Network::Test::createRawBufferSocket(), nullptr);
     upstream_listener_ =
-        dispatcher_->createListener(std::move(socket), listener_callbacks_, true, false);
+        dispatcher_->createListener(std::move(socket), listener_callbacks_, runtime_, true, false);
     client_connection_ = client_connection.get();
     client_connection_->addConnectionCallbacks(client_callbacks_);
 
@@ -349,6 +351,7 @@ public:
 
 protected:
   Api::ApiPtr api_;
+  NiceMock<Runtime::MockLoader> runtime_;
   Event::DispatcherPtr dispatcher_;
   Network::ListenerPtr upstream_listener_;
   Network::MockTcpListenerCallbacks listener_callbacks_;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -25,6 +25,7 @@
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
@@ -152,7 +153,7 @@ protected:
     }
     socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
         Network::Test::getCanonicalLoopbackAddress(GetParam()));
-    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
+    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, runtime_, true, false);
     client_connection_ = std::make_unique<Network::TestClientConnectionImpl>(
         *dispatcher_, socket_->connectionInfoProvider().localAddress(), source_address_,
         Network::Test::createRawBufferSocket(), socket_options_);
@@ -276,6 +277,7 @@ protected:
   Event::DispatcherPtr dispatcher_;
   std::shared_ptr<Network::TcpListenSocket> socket_{nullptr};
   Network::MockTcpListenerCallbacks listener_callbacks_;
+  NiceMock<Runtime::MockLoader> runtime_;
   Network::ListenerPtr listener_;
   Network::ClientConnectionPtr client_connection_;
   StrictMock<MockConnectionCallbacks> client_callbacks_;
@@ -1371,7 +1373,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   dispatcher_ = api_->allocateDispatcher("test_thread");
   socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()));
-  listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
+  listener_ = dispatcher_->createListener(socket_, listener_callbacks_, runtime_, true, false);
 
   client_connection_ = dispatcher_->createClientConnection(
       socket_->connectionInfoProvider().localAddress(), source_address_,
@@ -2845,7 +2847,7 @@ public:
     dispatcher_ = api_->allocateDispatcher("test_thread");
     socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
         Network::Test::getCanonicalLoopbackAddress(GetParam()));
-    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
+    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, runtime_, true, false);
 
     client_connection_ =
         dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -10,6 +10,7 @@
 
 #include "test/common/network/listener_impl_test_base.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/test_runtime.h"
@@ -31,12 +32,13 @@ static void errorCallbackTest(Address::IpVersion version) {
   // test in the forked process to avoid confusion when the fork happens.
   Api::ApiPtr api = Api::createApiForTest();
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
+  NiceMock<Runtime::MockLoader> runtime;
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version));
   Network::MockTcpListenerCallbacks listener_callbacks;
   Network::ListenerPtr listener =
-      dispatcher->createListener(socket, listener_callbacks, true, false);
+      dispatcher->createListener(socket, listener_callbacks, runtime, true, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
@@ -67,9 +69,9 @@ TEST_P(ListenerImplDeathTest, ErrorCallback) {
 class TestTcpListenerImpl : public TcpListenerImpl {
 public:
   TestTcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::RandomGenerator& random_generator,
-                      SocketSharedPtr socket, TcpListenerCallbacks& cb, bool bind_to_port,
-                      bool ignore_global_conn_limit)
-      : TcpListenerImpl(dispatcher, random_generator, std::move(socket), cb, bind_to_port,
+                      Runtime::Loader& runtime, SocketSharedPtr socket, TcpListenerCallbacks& cb,
+                      bool bind_to_port, bool ignore_global_conn_limit)
+      : TcpListenerImpl(dispatcher, random_generator, runtime, std::move(socket), cb, bind_to_port,
                         ignore_global_conn_limit) {}
 
   MOCK_METHOD(Address::InstanceConstSharedPtr, getLocalAddress, (os_fd_t fd));
@@ -86,11 +88,13 @@ TEST_P(TcpListenerImplTest, UseActualDst) {
   auto socketDst = std::make_shared<TcpListenSocket>(alt_address_, nullptr, false);
   Network::MockTcpListenerCallbacks listener_callbacks1;
   Random::MockRandomGenerator random_generator;
+  NiceMock<Runtime::MockLoader> runtime;
+
   // Do not redirect since use_original_dst is false.
-  Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
+  Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
                                         listener_callbacks1, true, false);
   Network::MockTcpListenerCallbacks listener_callbacks2;
-  Network::TestTcpListenerImpl listenerDst(dispatcherImpl(), random_generator, socketDst,
+  Network::TestTcpListenerImpl listenerDst(dispatcherImpl(), random_generator, runtime, socketDst,
                                            listener_callbacks2, false, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
@@ -125,8 +129,8 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitEnforcement) {
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::ListenerPtr listener =
-      dispatcher_->createListener(socket, listener_callbacks, true, false);
+  Network::ListenerPtr listener = dispatcher_->createListener(
+      socket, listener_callbacks, *Runtime::LoaderSingleton::getExisting(), true, false);
 
   std::vector<Network::ClientConnectionPtr> client_connections;
   std::vector<Network::ConnectionPtr> server_connections;
@@ -194,8 +198,8 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitListenerOptOut) {
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::ListenerPtr listener =
-      dispatcher_->createListener(socket, listener_callbacks, true, true);
+  Network::ListenerPtr listener = dispatcher_->createListener(
+      socket, listener_callbacks, *Runtime::LoaderSingleton::getExisting(), true, true);
 
   std::vector<Network::ClientConnectionPtr> client_connections;
   std::vector<Network::ConnectionPtr> server_connections;
@@ -238,8 +242,9 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
       Network::Test::getCanonicalLoopbackAddress(version_));
   Network::MockTcpListenerCallbacks listener_callbacks;
   Random::MockRandomGenerator random_generator;
+  NiceMock<Runtime::MockLoader> runtime;
   // Do not redirect since use_original_dst is false.
-  Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
+  Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
                                         listener_callbacks, true, false);
 
   auto local_dst_address = Network::Utility::getAddressWithPort(
@@ -279,11 +284,12 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
       Network::Test::getAnyAddress(version_, true), options);
   Network::MockTcpListenerCallbacks listener_callbacks;
   Random::MockRandomGenerator random_generator;
+  NiceMock<Runtime::MockLoader> runtime;
 
   ASSERT_TRUE(socket->connectionInfoProvider().localAddress()->ip()->isAnyAddress());
 
   // Do not redirect since use_original_dst is false.
-  Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
+  Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
                                         listener_callbacks, true, false);
 
   auto listener_address = Network::Utility::getAddressWithPort(
@@ -323,8 +329,9 @@ TEST_P(TcpListenerImplTest, DisableAndEnableListener) {
   MockTcpListenerCallbacks listener_callbacks;
   MockConnectionCallbacks connection_callbacks;
   Random::MockRandomGenerator random_generator;
-  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks, true,
-                               false);
+  NiceMock<Runtime::MockLoader> runtime;
+  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
+                               listener_callbacks, true, false);
 
   // When listener is disabled, the timer should fire before any connection is accepted.
   listener.disable();
@@ -364,8 +371,9 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionZero) {
   MockTcpListenerCallbacks listener_callbacks;
   MockConnectionCallbacks connection_callbacks;
   Random::MockRandomGenerator random_generator;
-  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks, true,
-                               false);
+  NiceMock<Runtime::MockLoader> runtime;
+  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
+                               listener_callbacks, true, false);
 
   listener.setRejectFraction(UnitFloat(0));
 
@@ -395,8 +403,9 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
   MockTcpListenerCallbacks listener_callbacks;
   MockConnectionCallbacks connection_callbacks;
   Random::MockRandomGenerator random_generator;
-  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks, true,
-                               false);
+  NiceMock<Runtime::MockLoader> runtime;
+  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
+                               listener_callbacks, true, false);
 
   listener.setRejectFraction(UnitFloat(0.5f));
 
@@ -404,6 +413,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
   {
     testing::InSequence s1;
     EXPECT_CALL(random_generator, random()).WillOnce(Return(0));
+    NiceMock<Runtime::MockLoader> runtime;
     EXPECT_CALL(listener_callbacks, onReject(TcpListenerCallbacks::RejectCause::OverloadAction));
   }
   {
@@ -458,8 +468,9 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionAll) {
   MockTcpListenerCallbacks listener_callbacks;
   MockConnectionCallbacks connection_callbacks;
   Random::MockRandomGenerator random_generator;
-  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks, true,
-                               false);
+  NiceMock<Runtime::MockLoader> runtime;
+  TestTcpListenerImpl listener(dispatcherImpl(), random_generator, runtime, socket,
+                               listener_callbacks, true, false);
 
   listener.setRejectFraction(UnitFloat(1));
 

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -50,7 +50,7 @@ public:
     EXPECT_CALL(socket_factory_, localAddress())
         .WillRepeatedly(ReturnRef(socket_->connectionInfoProvider().localAddress()));
     EXPECT_CALL(socket_factory_, getListenSocket(_)).WillOnce(Return(socket_));
-    connection_handler_->addListener(absl::nullopt, *this);
+    connection_handler_->addListener(absl::nullopt, *this, runtime_);
     conn_ = dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),
                                                 Network::Address::InstanceConstSharedPtr(),
                                                 Network::Test::createRawBufferSocket(), nullptr);
@@ -180,6 +180,7 @@ public:
   const Network::FilterChainSharedPtr filter_chain_;
   const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
+  NiceMock<Runtime::MockLoader> runtime_;
 };
 
 // Parameterize the listener socket address version.

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -20,6 +20,7 @@
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/listener_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
@@ -64,7 +65,7 @@ public:
     EXPECT_CALL(socket_factory_, localAddress())
         .WillRepeatedly(ReturnRef(socket_->connectionInfoProvider().localAddress()));
     EXPECT_CALL(socket_factory_, getListenSocket(_)).WillOnce(Return(socket_));
-    connection_handler_->addListener(absl::nullopt, *this);
+    connection_handler_->addListener(absl::nullopt, *this, runtime_);
     conn_ = dispatcher_->createClientConnection(socket_->connectionInfoProvider().localAddress(),
                                                 Network::Address::InstanceConstSharedPtr(),
                                                 Network::Test::createRawBufferSocket(), nullptr);
@@ -187,6 +188,7 @@ public:
     EXPECT_EQ(stats_store_.counter("downstream_cx_proxy_proto_error").value(), 1);
   }
 
+  testing::NiceMock<Runtime::MockLoader> runtime_;
   Stats::TestUtil::TestStore stats_store_;
   Api::ApiPtr api_;
   BasicResourceLimitImpl open_connections_;
@@ -1371,7 +1373,7 @@ public:
     EXPECT_CALL(socket_factory_, localAddress())
         .WillRepeatedly(ReturnRef(socket_->connectionInfoProvider().localAddress()));
     EXPECT_CALL(socket_factory_, getListenSocket(_)).WillOnce(Return(socket_));
-    connection_handler_->addListener(absl::nullopt, *this);
+    connection_handler_->addListener(absl::nullopt, *this, runtime_);
     conn_ = dispatcher_->createClientConnection(local_dst_address_,
                                                 Network::Address::InstanceConstSharedPtr(),
                                                 Network::Test::createRawBufferSocket(), nullptr);
@@ -1466,6 +1468,7 @@ public:
     dispatcher_->run(Event::Dispatcher::RunType::Block);
   }
 
+  testing::NiceMock<Runtime::MockLoader> runtime_;
   Stats::IsolatedStoreImpl stats_store_;
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -24,6 +24,7 @@
 
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
@@ -674,7 +675,7 @@ public:
     server_ = std::make_unique<TestDnsServer>(*dispatcher_);
     socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
         Network::Test::getCanonicalLoopbackAddress(GetParam()));
-    listener_ = dispatcher_->createListener(socket_, *server_, true, false);
+    listener_ = dispatcher_->createListener(socket_, *server_, runtime_, true, false);
     updateDnsResolverOptions();
 
     // Create a resolver options on stack here to emulate what actually happens in envoy bootstrap.
@@ -840,6 +841,7 @@ protected:
   virtual void updateDnsResolverOptions(){};
   virtual bool setResolverInConstructor() const { return false; }
   virtual bool filterUnroutableFamilies() const { return false; }
+  NiceMock<Runtime::MockLoader> runtime_;
   std::unique_ptr<TestDnsServer> server_;
   std::unique_ptr<DnsResolverImplPeer> peer_;
   std::shared_ptr<Network::TcpListenSocket> socket_;

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -719,6 +719,7 @@ envoy_cc_test_library(
         "fake_upstream.h",
     ],
     deps = [
+        "//test/mocks/runtime:runtime_mocks",
         "//source/server:listener_manager_lib",
         "//envoy/api:api_interface",
         "//envoy/grpc:status",

--- a/test/integration/cx_limit_integration_test.cc
+++ b/test/integration/cx_limit_integration_test.cc
@@ -191,25 +191,13 @@ TEST_P(ConnectionLimitIntegrationTest, TestGlobalLimitOptOut) {
 
   std::vector<IntegrationTcpClientPtr> tcp_clients;
   std::vector<FakeRawConnectionPtr> raw_conns;
-  tcp_clients.emplace_back(makeTcpConnection(lookupPort("listener_0")));
-  raw_conns.emplace_back();
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(raw_conns.back()));
-  ASSERT_TRUE(tcp_clients.back()->connected());
 
-  tcp_clients.emplace_back(makeTcpConnection(lookupPort("listener_0")));
-  raw_conns.emplace_back();
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(raw_conns.back()));
-  ASSERT_TRUE(tcp_clients.back()->connected());
-
-  // 3rd connection should fail, not because listener_0 hit a limit, but because the
-  // upstream listener hit a limit (5 conns would exist when it goes to accept, so it rejects it).
-  // We can see that listener_0 didn't hit any limits because it's downstream_global_cx_overflow
-  // stat is still at 0, in contrast with the TestGlobalLimit test where it is 1
-  tcp_clients.emplace_back(makeTcpConnection(lookupPort("listener_0")));
-  raw_conns.emplace_back();
-  ASSERT_FALSE(
-      fake_upstreams_[0]->waitForRawConnection(raw_conns.back(), std::chrono::milliseconds(500)));
-  tcp_clients.back()->waitForDisconnect();
+  for (int i = 0; i < 6; ++i) {
+    tcp_clients.emplace_back(makeTcpConnection(lookupPort("listener_0")));
+    raw_conns.emplace_back();
+    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(raw_conns.back()));
+    ASSERT_TRUE(tcp_clients.back()->connected());
+  }
 
   // Get rid of the client that failed to connect.
   tcp_clients.back()->close();

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -630,7 +630,7 @@ void FakeUpstream::createUdpListenerFilterChain(Network::UdpListenerFilterManage
 
 void FakeUpstream::threadRoutine() {
   socket_factory_->doFinalPreWorkerInit();
-  handler_->addListener(absl::nullopt, listener_);
+  handler_->addListener(absl::nullopt, listener_, runtime_);
   server_initialized_.setReady();
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   handler_.reset();

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -44,6 +44,7 @@
 #include "source/server/active_raw_udp_listener_config.h"
 
 #include "test/mocks/common.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/test_common/test_time_system.h"
 #include "test/test_common/utility.h"
 
@@ -845,6 +846,7 @@ private:
   Event::DispatcherPtr dispatcher_;
   Network::ConnectionHandlerPtr handler_;
   std::list<SharedConnectionWrapperPtr> new_connections_ ABSL_GUARDED_BY(lock_);
+  testing::NiceMock<Runtime::MockLoader> runtime_;
 
   // When a QueuedConnectionWrapper is popped from new_connections_, ownership is transferred to
   // consumed_connections_. This allows later the Connection destruction (when the FakeUpstream is

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -70,10 +70,10 @@ public:
   }
 
   Network::ListenerPtr createListener(Network::SocketSharedPtr&& socket,
-                                      Network::TcpListenerCallbacks& cb, bool bind_to_port,
-                                      bool ignore_global_conn_limit) override {
+                                      Network::TcpListenerCallbacks& cb, Runtime::Loader& runtime,
+                                      bool bind_to_port, bool ignore_global_conn_limit) override {
     return Network::ListenerPtr{
-        createListener_(std::move(socket), cb, bind_to_port, ignore_global_conn_limit)};
+        createListener_(std::move(socket), cb, runtime, bind_to_port, ignore_global_conn_limit)};
   }
 
   Network::UdpListenerPtr
@@ -142,7 +142,7 @@ public:
   MOCK_METHOD(Filesystem::Watcher*, createFilesystemWatcher_, ());
   MOCK_METHOD(Network::Listener*, createListener_,
               (Network::SocketSharedPtr && socket, Network::TcpListenerCallbacks& cb,
-               bool bind_to_port, bool ignore_global_conn_limit));
+               Runtime::Loader& runtime, bool bind_to_port, bool ignore_global_conn_limit));
   MOCK_METHOD(Network::UdpListener*, createUdpListener_,
               (Network::SocketSharedPtr socket, Network::UdpListenerCallbacks& cb,
                const envoy::config::core::v3::UdpSocketConfig& config));

--- a/test/mocks/event/wrapped_dispatcher.h
+++ b/test/mocks/event/wrapped_dispatcher.h
@@ -60,9 +60,10 @@ public:
   }
 
   Network::ListenerPtr createListener(Network::SocketSharedPtr&& socket,
-                                      Network::TcpListenerCallbacks& cb, bool bind_to_port,
-                                      bool ignore_global_conn_limit) override {
-    return impl_.createListener(std::move(socket), cb, bind_to_port, ignore_global_conn_limit);
+                                      Network::TcpListenerCallbacks& cb, Runtime::Loader& runtime,
+                                      bool bind_to_port, bool ignore_global_conn_limit) override {
+    return impl_.createListener(std::move(socket), cb, runtime, bind_to_port,
+                                ignore_global_conn_limit);
   }
 
   Network::UdpListenerPtr

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -472,7 +472,8 @@ public:
   MOCK_METHOD(void, incNumConnections, ());
   MOCK_METHOD(void, decNumConnections, ());
   MOCK_METHOD(void, addListener,
-              (absl::optional<uint64_t> overridden_listener, ListenerConfig& config));
+              (absl::optional<uint64_t> overridden_listener, ListenerConfig& config,
+               Runtime::Loader& runtime));
   MOCK_METHOD(void, removeListeners, (uint64_t listener_tag));
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,

--- a/test/mocks/server/worker.cc
+++ b/test/mocks/server/worker.cc
@@ -12,15 +12,15 @@ using ::testing::_;
 using ::testing::Invoke;
 
 MockWorker::MockWorker() {
-  ON_CALL(*this, addListener(_, _, _))
-      .WillByDefault(
-          Invoke([this](absl::optional<uint64_t> overridden_listener,
-                        Network::ListenerConfig& config, AddListenerCompletion completion) -> void {
-            UNREFERENCED_PARAMETER(overridden_listener);
-            config.listenSocketFactory().getListenSocket(0);
-            EXPECT_EQ(nullptr, add_listener_completion_);
-            add_listener_completion_ = completion;
-          }));
+  ON_CALL(*this, addListener(_, _, _, _))
+      .WillByDefault(Invoke([this](absl::optional<uint64_t> overridden_listener,
+                                   Network::ListenerConfig& config,
+                                   AddListenerCompletion completion, Runtime::Loader&) -> void {
+        UNREFERENCED_PARAMETER(overridden_listener);
+        config.listenSocketFactory().getListenSocket(0);
+        EXPECT_EQ(nullptr, add_listener_completion_);
+        add_listener_completion_ = completion;
+      }));
 
   ON_CALL(*this, removeListener(_, _))
       .WillByDefault(

--- a/test/mocks/server/worker.h
+++ b/test/mocks/server/worker.h
@@ -33,7 +33,7 @@ public:
   // Server::Worker
   MOCK_METHOD(void, addListener,
               (absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& listener,
-               AddListenerCompletion completion));
+               AddListenerCompletion completion, Runtime::Loader&));
   MOCK_METHOD(uint64_t, numConnections, (), (const));
   MOCK_METHOD(void, removeListener,
               (Network::ListenerConfig & listener, std::function<void()> completion));

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -489,6 +489,7 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//source/server:worker_lib",
         "//test/mocks/network:network_mocks",
+        "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:guard_dog_mocks",
         "//test/mocks/server:instance_mocks",
         "//test/mocks/server:overload_manager_mocks",

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -982,7 +982,6 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListener) {
 }
 
 TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListenerOnOldBehavior) {
-  auto scoped_runtime = std::make_unique<TestScopedRuntime>();
   Runtime::LoaderSingleton::getExisting()->mergeValues(
       {{"envoy.reloadable_features.listener_wildcard_match_ip_family", "false"}});
 
@@ -1104,8 +1103,6 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
 }
 
 TEST_F(ConnectionHandlerTest, OldBehaviorWildcardListener) {
-  auto scoped_runtime = std::make_unique<TestScopedRuntime>();
-
   Runtime::LoaderSingleton::getExisting()->mergeValues(
       {{"envoy.reloadable_features.listener_wildcard_match_ip_family", "false"}});
 
@@ -1170,8 +1167,6 @@ TEST_F(ConnectionHandlerTest, OldBehaviorWildcardListener) {
 }
 
 TEST_F(ConnectionHandlerTest, MatchIPv6WildcardListener) {
-  auto scoped_runtime = std::make_unique<TestScopedRuntime>();
-
   Network::TcpListenerCallbacks* listener_callbacks1;
   auto listener1 = new NiceMock<Network::MockListener>();
   TestListener* test_listener1 =

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -243,10 +243,10 @@ public:
     EXPECT_CALL(listeners_.back()->socket_factory_, getListenSocket(_))
         .WillOnce(Return(listeners_.back()->socket_));
     if (socket_type == Network::Socket::Type::Stream) {
-      EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
-          .WillOnce(Invoke([listener, listener_callbacks](Network::SocketSharedPtr&&,
-                                                          Network::TcpListenerCallbacks& cb, bool,
-                                                          bool) -> Network::Listener* {
+      EXPECT_CALL(dispatcher_, createListener_(_, _, _, _, _))
+          .WillOnce(Invoke([listener, listener_callbacks](
+                               Network::SocketSharedPtr&&, Network::TcpListenerCallbacks& cb,
+                               Runtime::Loader&, bool, bool) -> Network::Listener* {
             if (listener_callbacks != nullptr) {
               *listener_callbacks = &cb;
             }
@@ -300,7 +300,7 @@ public:
         *Network::Utility::getIpv4AnyAddress(), normal_address->ip()->port());
     EXPECT_CALL(test_listener->socket_factory_, localAddress())
         .WillRepeatedly(ReturnRef(any_address));
-    handler_->addListener(absl::nullopt, *test_listener);
+    handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
     Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
     Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
@@ -343,6 +343,8 @@ public:
   bool udp_listener_deleted_ = false;
   bool deleted_before_listener_ = false;
   std::shared_ptr<AccessLog::MockInstance> access_log_;
+  TestScopedRuntime scoped_runtime_;
+  Runtime::Loader& runtime_{*Runtime::LoaderSingleton::getExisting()};
 };
 
 // Verify that if a listener is removed while a rebalanced connection is in flight, we correctly
@@ -363,7 +365,7 @@ TEST_F(ConnectionHandlerTest, RemoveListenerDuringRebalance) {
                   connection_balancer, &current_handler);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   // Fake a balancer posting a connection to us.
   Event::PostCb post_cb;
@@ -406,7 +408,7 @@ TEST_F(ConnectionHandlerTest, ListenerConnectionLimitEnforced) {
       .WillRepeatedly(ReturnRef(normal_address));
   // Only allow a single connection on this listener.
   test_listener1->setMaxConnections(1);
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   auto listener2 = new NiceMock<Network::MockListener>();
   Network::TcpListenerCallbacks* listener_callbacks2;
@@ -418,7 +420,7 @@ TEST_F(ConnectionHandlerTest, ListenerConnectionLimitEnforced) {
       .WillRepeatedly(ReturnRef(alt_address));
   // Do not allow any connections on this listener.
   test_listener2->setMaxConnections(0);
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   EXPECT_CALL(manager_, findFilterChain(_)).WillRepeatedly(Return(filter_chain_.get()));
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillRepeatedly(Return(true));
@@ -489,7 +491,7 @@ TEST_F(ConnectionHandlerTest, RemoveListener) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(*access_log_, log(_, _, _, _));
@@ -520,7 +522,7 @@ TEST_F(ConnectionHandlerTest, DisableListener) {
       addListener(1, false, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(*listener, disable());
   EXPECT_CALL(*listener, onDestroy());
@@ -538,7 +540,7 @@ TEST_F(ConnectionHandlerTest, StopAndDisableStoppedListener) {
       addListener(1, false, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(*listener, onDestroy());
   handler_->stopListeners(1);
@@ -563,7 +565,7 @@ TEST_F(ConnectionHandlerTest, AddDisabledListener) {
   EXPECT_CALL(*listener, onDestroy());
 
   handler_->disableListeners();
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 }
 
 TEST_F(ConnectionHandlerTest, SetListenerRejectFraction) {
@@ -575,7 +577,7 @@ TEST_F(ConnectionHandlerTest, SetListenerRejectFraction) {
       addListener(1, false, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.1234f)));
   EXPECT_CALL(*listener, onDestroy());
@@ -596,7 +598,7 @@ TEST_F(ConnectionHandlerTest, AddListenerSetRejectFraction) {
   EXPECT_CALL(*listener, onDestroy());
 
   handler_->setListenerRejectFraction(UnitFloat(0.12345f));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 }
 
 TEST_F(ConnectionHandlerTest, SetsTransportSocketConnectTimeout) {
@@ -609,7 +611,7 @@ TEST_F(ConnectionHandlerTest, SetsTransportSocketConnectTimeout) {
 
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   auto server_connection = new NiceMock<Network::MockServerConnection>();
 
@@ -635,7 +637,7 @@ TEST_F(ConnectionHandlerTest, DestroyCloseConnections) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(*access_log_, log(_, _, _, _));
@@ -656,7 +658,7 @@ TEST_F(ConnectionHandlerTest, CloseDuringFilterChainCreate) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(filter_chain_.get()));
   auto* connection = new NiceMock<Network::MockServerConnection>();
@@ -681,7 +683,7 @@ TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(filter_chain_.get()));
   auto* connection = new NiceMock<Network::MockServerConnection>();
@@ -706,7 +708,7 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
       new Network::Address::Ipv4Instance("127.0.0.1", 10001));
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(normal_address));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   Network::TcpListenerCallbacks* listener_callbacks2;
   auto listener2 = new NiceMock<Network::MockListener>();
@@ -716,7 +718,7 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
       new Network::Address::Ipv4Instance("127.0.0.2", 20002));
   EXPECT_CALL(test_listener2->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(alt_address));
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   auto* test_filter = new NiceMock<Network::MockListenerFilter>();
   EXPECT_CALL(*test_filter, destroy_());
@@ -776,7 +778,7 @@ TEST_F(ConnectionHandlerTest, MatchLatestListener) {
       addListener(1, true, true, "test_listener1", listener1, &listener_callbacks);
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   // Listener2 will be replaced by Listener3.
   auto listener2_overridden_filter_chain_manager =
@@ -790,7 +792,7 @@ TEST_F(ConnectionHandlerTest, MatchLatestListener) {
       new Network::Address::Ipv4Instance("127.0.0.1", 10002));
   EXPECT_CALL(test_listener2->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(listener2_address));
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   // Listener3 will replace the listener2.
   auto listener3_overridden_filter_chain_manager =
@@ -809,7 +811,7 @@ TEST_F(ConnectionHandlerTest, MatchLatestListener) {
   // add the new listener.
   EXPECT_CALL(*listener2, onDestroy());
   handler_->stopListeners(2);
-  handler_->addListener(absl::nullopt, *test_listener3);
+  handler_->addListener(absl::nullopt, *test_listener3, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -859,7 +861,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedListener) {
       addListener(1, true, true, "test_listener1", listener1, &listener_callbacks);
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   auto listener2_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
@@ -872,7 +874,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedListener) {
       new Network::Address::Ipv4Instance("127.0.0.1", 10002));
   EXPECT_CALL(test_listener2->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(listener2_address));
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
@@ -923,7 +925,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListener) {
       addListener(1, true, true, "test_listener1", listener1, &listener_callbacks);
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   auto listener2_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
@@ -936,7 +938,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListener) {
       new Network::Address::Ipv4Instance("0.0.0.0", 10002));
   EXPECT_CALL(test_listener2->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(listener2_address));
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
@@ -981,7 +983,6 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListener) {
 
 TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListenerOnOldBehavior) {
   auto scoped_runtime = std::make_unique<TestScopedRuntime>();
-
   Runtime::LoaderSingleton::getExisting()->mergeValues(
       {{"envoy.reloadable_features.listener_wildcard_match_ip_family", "false"}});
 
@@ -992,7 +993,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListenerOnOldBehavi
       addListener(1, true, true, "test_listener1", listener1, &listener_callbacks);
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   auto listener2_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
@@ -1005,7 +1006,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListenerOnOldBehavi
       new Network::Address::Ipv4Instance("0.0.0.0", 10002));
   EXPECT_CALL(test_listener2->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(listener2_address));
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
@@ -1057,7 +1058,7 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
       new Network::Address::Ipv4Instance("127.0.0.1", 10001));
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(normal_address));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   Network::TcpListenerCallbacks* listener_callbacks2;
   auto listener2 = new NiceMock<Network::MockListener>();
@@ -1066,7 +1067,7 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
   Network::Address::InstanceConstSharedPtr any_address = Network::Utility::getIpv4AnyAddress();
   EXPECT_CALL(test_listener2->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(any_address));
-  handler_->addListener(absl::nullopt, *test_listener2);
+  handler_->addListener(absl::nullopt, *test_listener2, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1116,7 +1117,7 @@ TEST_F(ConnectionHandlerTest, OldBehaviorWildcardListener) {
       new Network::Address::Ipv4Instance("127.0.0.1", 10001));
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(normal_address));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   auto ipv4_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
@@ -1130,7 +1131,7 @@ TEST_F(ConnectionHandlerTest, OldBehaviorWildcardListener) {
       new Network::Address::Ipv4Instance("0.0.0.0", 80));
   EXPECT_CALL(ipv4_any_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(any_address));
-  handler_->addListener(absl::nullopt, *ipv4_any_listener);
+  handler_->addListener(absl::nullopt, *ipv4_any_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1179,7 +1180,7 @@ TEST_F(ConnectionHandlerTest, MatchIPv6WildcardListener) {
       new Network::Address::Ipv4Instance("127.0.0.1", 10001));
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(normal_address));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   auto ipv4_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
@@ -1194,7 +1195,7 @@ TEST_F(ConnectionHandlerTest, MatchIPv6WildcardListener) {
       new Network::Address::Ipv4Instance("0.0.0.0", 80));
   EXPECT_CALL(ipv4_any_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(any_address));
-  handler_->addListener(absl::nullopt, *ipv4_any_listener);
+  handler_->addListener(absl::nullopt, *ipv4_any_listener, runtime_);
 
   auto ipv6_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
@@ -1208,7 +1209,7 @@ TEST_F(ConnectionHandlerTest, MatchIPv6WildcardListener) {
       new Network::Address::Ipv6Instance("::", 80));
   EXPECT_CALL(ipv6_any_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(any_address_ipv6));
-  handler_->addListener(absl::nullopt, *ipv6_any_listener);
+  handler_->addListener(absl::nullopt, *ipv6_any_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1278,7 +1279,7 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
       *Network::Utility::getIpv4AnyAddress(), normal_address->ip()->port());
   EXPECT_CALL(test_listener1->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(any_address));
-  handler_->addListener(absl::nullopt, *test_listener1);
+  handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1308,7 +1309,7 @@ TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(*accepted_socket, detectedTransportProtocol())
@@ -1328,7 +1329,7 @@ TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1363,7 +1364,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -1410,7 +1411,7 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
                   Network::Socket::Type::Stream, std::chrono::milliseconds(15000), true);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new NiceMock<Network::MockListenerFilter>();
   EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -1464,7 +1465,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -1512,7 +1513,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
                   Network::Socket::Type::Stream, std::chrono::milliseconds());
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -1543,7 +1544,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterReportError) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockListenerFilter* first_filter = new Network::MockListenerFilter();
   Network::MockListenerFilter* last_filter = new Network::MockListenerFilter();
@@ -1590,7 +1591,7 @@ TEST_F(ConnectionHandlerTest, UdpListenerNoFilter) {
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
 
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   // Make sure these calls don't crash.
   Network::UdpRecvData data;
@@ -1615,7 +1616,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerInplaceUpdate) {
                   &old_listener_callbacks, mock_connection_balancer, &current_handler);
   EXPECT_CALL(old_test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *old_test_listener);
+  handler_->addListener(absl::nullopt, *old_test_listener, runtime_);
   ASSERT_NE(old_test_listener, nullptr);
 
   Network::TcpListenerCallbacks* new_listener_callbacks = nullptr;
@@ -1626,7 +1627,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerInplaceUpdate) {
       new_listener_tag, true, false, "test_listener", /* Network::Listener */ nullptr,
       &new_listener_callbacks, mock_connection_balancer, nullptr, Network::Socket::Type::Stream,
       std::chrono::milliseconds(15000), false, overridden_filter_chain_manager);
-  handler_->addListener(old_listener_tag, *new_test_listener);
+  handler_->addListener(old_listener_tag, *new_test_listener, runtime_);
   ASSERT_EQ(new_listener_callbacks, nullptr)
       << "new listener should be inplace added and callback should not change";
 
@@ -1653,7 +1654,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveFilterChain) {
       addListener(listener_tag, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(filter_chain_.get()));
@@ -1702,7 +1703,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveFilterChainCalledAfterListenerIsR
       addListener(listener_tag, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(filter_chain_.get()));
@@ -1765,7 +1766,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveListener) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(*access_log_, log(_, _, _, _));
@@ -1795,7 +1796,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerGlobalCxLimitReject) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   listener_callbacks->onReject(Network::TcpListenerCallbacks::RejectCause::GlobalCxLimit);
 
@@ -1811,7 +1812,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerOverloadActionReject) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   listener_callbacks->onReject(Network::TcpListenerCallbacks::RejectCause::OverloadAction);
 
@@ -1828,7 +1829,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterWorks) {
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   EXPECT_CALL(test_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address_));
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   auto all_matcher = std::make_shared<Network::MockListenerFilterMatcher>();
   auto* disabled_listener_filter = new Network::MockListenerFilter();
@@ -1876,7 +1877,7 @@ TEST_F(ConnectionHandlerTest, ShutdownUdpListener) {
       .WillRepeatedly(ReturnRef(local_address_));
   EXPECT_CALL(dummy_callbacks.udp_listener_, onDestroy());
 
-  handler_->addListener(absl::nullopt, *test_listener);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_);
   handler_->stopListeners();
 
   ASSERT_TRUE(deleted_before_listener_)
@@ -1892,7 +1893,7 @@ TEST_F(ConnectionHandlerTest, DisableInternalListener) {
       addInternalListener(1, "test_internal_listener", std::chrono::milliseconds(), false, nullptr);
   EXPECT_CALL(internal_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address));
-  handler_->addListener(absl::nullopt, *internal_listener);
+  handler_->addListener(absl::nullopt, *internal_listener, runtime_);
   auto internal_listener_cb = handler_->findByAddress(local_address);
   ASSERT_TRUE(internal_listener_cb.has_value());
 
@@ -1918,7 +1919,7 @@ TEST_F(ConnectionHandlerTest, InternalListenerInplaceUpdate) {
       old_listener_tag, "test_internal_listener", std::chrono::milliseconds(), false, nullptr);
   EXPECT_CALL(internal_listener->socket_factory_, localAddress())
       .WillRepeatedly(ReturnRef(local_address));
-  handler_->addListener(absl::nullopt, *internal_listener);
+  handler_->addListener(absl::nullopt, *internal_listener, runtime_);
 
   ASSERT_NE(internal_listener, nullptr);
 
@@ -1928,7 +1929,7 @@ TEST_F(ConnectionHandlerTest, InternalListenerInplaceUpdate) {
       addInternalListener(new_listener_tag, "test_internal_listener", std::chrono::milliseconds(),
                           false, overridden_filter_chain_manager);
 
-  handler_->addListener(old_listener_tag, *new_test_listener);
+  handler_->addListener(old_listener_tag, *new_test_listener, runtime_);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
 

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -116,7 +116,7 @@ public:
   void expectAddListener(const envoy::config::listener::v3::Listener& listener_proto,
                          ListenerHandle*) {
     EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    EXPECT_CALL(*worker_, addListener(_, _, _));
+    EXPECT_CALL(*worker_, addListener(_, _, _, _));
     manager_->addOrUpdateListener(listener_proto, "", true);
     worker_->callAddCompletion();
     EXPECT_EQ(1UL, manager_->listeners().size());
@@ -137,7 +137,7 @@ public:
       new_socket = listener_factory_.socket_.get();
       EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, bind_type, _, 0));
     }
-    EXPECT_CALL(*worker_, addListener(_, _, _));
+    EXPECT_CALL(*worker_, addListener(_, _, _, _));
     EXPECT_CALL(*worker_, stopListener(_, _));
     EXPECT_CALL(*old_listener_handle->drain_manager_, startDrainSequence(_));
 
@@ -330,7 +330,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, UdpAddress) {
   EXPECT_TRUE(Protobuf::TextFormat::ParseFromString(proto_text, &listener_proto));
 
   EXPECT_CALL(server_.api_.random_, uuid());
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(listener_factory_,
               createListenSocket(_, Network::Socket::Type::Datagram, _,
                                  ListenerComponentFactory::BindType::ReusePort, _, 0))
@@ -760,7 +760,7 @@ dynamic_listeners:
         nanos: 2000000
 )EOF");
 
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(*worker_, start(_, _));
   manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
   worker_->callAddCompletion();
@@ -873,7 +873,7 @@ dynamic_listeners:
         nanos: 4000000
 )EOF");
 
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_baz_different_address->target_.ready();
   worker_->callAddCompletion();
 
@@ -1155,10 +1155,9 @@ filter_chains: {}
 
   // Start workers and capture ListenerImpl.
   Network::ListenerConfig* listener_config = nullptr;
-  EXPECT_CALL(*worker_, addListener(_, _, _))
-      .WillOnce(Invoke([&listener_config](auto, Network::ListenerConfig& config, auto) -> void {
-        listener_config = &config;
-      }))
+  EXPECT_CALL(*worker_, addListener(_, _, _, _))
+      .WillOnce(Invoke([&listener_config](auto, Network::ListenerConfig& config, auto,
+                                          Runtime::Loader&) -> void { listener_config = &config; }))
       .RetiresOnSaturation();
 
   EXPECT_CALL(*worker_, start(_, _));
@@ -1182,7 +1181,7 @@ filter_chains:
 
   ListenerHandle* listener_foo_update1 = expectListenerOverridden(false);
   EXPECT_CALL(*listener_factory_.socket_, duplicate());
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   auto* timer = new Event::MockTimer(dynamic_cast<Event::MockDispatcher*>(&server_.dispatcher()));
   EXPECT_CALL(*timer, enableTimer(_, _));
   EXPECT_TRUE(
@@ -1321,7 +1320,7 @@ dynamic_listeners:
                    .value());
 
   // Start workers.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(*worker_, start(_, _));
   manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
   // Validate that workers_started stat is still zero before workers set the status via
@@ -1348,7 +1347,7 @@ dynamic_listeners:
   // removal.
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
   EXPECT_CALL(*duplicated_socket, duplicate());
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(*worker_, stopListener(_, _));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(
@@ -1419,7 +1418,7 @@ filter_chains: {}
 
   ListenerHandle* listener_bar = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(
       manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml), "version4", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
@@ -1530,7 +1529,7 @@ filter_chains:
   checkStats(__LINE__, 3, 3, 0, 1, 2, 0, 0);
 
   // Finish initialization for baz which should make it active.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_baz_update1->target_.ready();
   EXPECT_EQ(3UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -1563,7 +1562,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -1626,7 +1625,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -1649,7 +1648,7 @@ filter_chains:
   // Add foo again.
   ListenerHandle* listener_foo2 = expectListenerCreate(false, true);
   EXPECT_CALL(*listener_factory_.socket_, duplicate());
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 2, 0, 1, 0, 1, 1, 0);
@@ -1686,7 +1685,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -1704,7 +1703,7 @@ filter_chains:
   // Add foo again. We should use the socket from draining.
   ListenerHandle* listener_foo2 = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 2, 0, 1, 0, 1, 1, 0);
@@ -1791,7 +1790,7 @@ filter_chains:
             return real_listener_factory.createListenSocket(
                 address, socket_type, options, bind_type, creation_options, worker_index);
           }));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
 
   worker_->callAddCompletion();
@@ -2054,7 +2053,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -2125,7 +2124,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 2, 0, 1, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2193,7 +2192,7 @@ filter_chains:
   auto foo_inbound_proto = parseListenerFromV3Yaml(listener_foo_yaml);
   EXPECT_TRUE(manager_->addOrUpdateListener(foo_inbound_proto, "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2216,7 +2215,7 @@ filter_chains:
   EXPECT_CALL(listener_foo_outbound->target_, initialize());
   EXPECT_TRUE(
       manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_outbound_yaml), "", true));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo_outbound->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(2UL, manager_->listeners().size());
@@ -2241,7 +2240,7 @@ filter_chains:
 
   ListenerHandle* listener_bar_outbound = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(
       manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_outbound_yaml), "", true));
   EXPECT_EQ(3UL, manager_->listeners().size());
@@ -2296,7 +2295,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2345,7 +2344,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2457,7 +2456,7 @@ filter_chains:
       "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
   // Move foo to active and then try to add again. This should still fail.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
 
@@ -4973,7 +4972,7 @@ per_connection_buffer_limit_bytes: 10
                    .value());
 
   // Start workers.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(*worker_, start(_, _));
   manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
   // Validate that workers_started stat is still zero before workers set the status via
@@ -4999,7 +4998,7 @@ per_connection_buffer_limit_bytes: 10
   // Update foo. Should go into warming, have an immediate warming callback, and start immediate
   // removal.
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(*worker_, stopListener(_, _));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(
@@ -5059,7 +5058,7 @@ per_connection_buffer_limit_bytes: 10
     )EOF";
 
   ListenerHandle* listener_bar = expectListenerCreate(false, true);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_TRUE(
       manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml), "version4", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
@@ -5160,7 +5159,7 @@ per_connection_buffer_limit_bytes: 10
   checkStats(__LINE__, 3, 3, 0, 1, 2, 0, 0);
 
   // Finish initialization for baz which should make it active.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_baz_update1->target_.ready();
   EXPECT_EQ(3UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -5196,7 +5195,7 @@ filter_chains:
   EXPECT_EQ(0, server_.stats_store_.counter("listener_manager.listener_in_place_updated").value());
 
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -5259,7 +5258,7 @@ filter_chains:
   EXPECT_EQ(0, server_.stats_store_.counter("listener_manager.listener_in_place_updated").value());
 
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -5329,7 +5328,7 @@ filter_chains:
   EXPECT_EQ(0, server_.stats_store_.counter("listener_manager.listener_in_place_updated").value());
 
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -5359,7 +5358,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // Listener warmed up.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(*listener_foo, onDestroy());
   listener_foo_update1->target_.ready();
   worker_->callAddCompletion();
@@ -5391,7 +5390,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -5421,7 +5420,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
@@ -5477,7 +5476,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -5506,7 +5505,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
@@ -5548,7 +5547,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "", true));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -5577,7 +5576,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -5,6 +5,7 @@
 #include "source/server/worker_impl.h"
 
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/guard_dog.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/overload_manager.h"
@@ -48,6 +49,7 @@ public:
     no_exit_timer_.reset();
   }
 
+  NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   Network::MockConnectionHandler* handler_ = new Network::MockConnectionHandler();
   NiceMock<MockGuardDog> guard_dog_;
@@ -69,13 +71,15 @@ TEST_F(WorkerImplTest, BasicFlow) {
   // thread starts running.
   NiceMock<Network::MockListenerConfig> listener;
   ON_CALL(listener, listenerTag()).WillByDefault(Return(1UL));
-  EXPECT_CALL(*handler_, addListener(_, _))
-      .WillOnce(Invoke(
-          [current_thread_id](absl::optional<uint64_t>, Network::ListenerConfig& config) -> void {
+  EXPECT_CALL(*handler_, addListener(_, _, _))
+      .WillOnce(
+          Invoke([current_thread_id](absl::optional<uint64_t>, Network::ListenerConfig& config,
+                                     Runtime::Loader&) -> void {
             EXPECT_EQ(config.listenerTag(), 1UL);
             EXPECT_NE(current_thread_id, std::this_thread::get_id());
           }));
-  worker_.addListener(absl::nullopt, listener, [&ci]() -> void { ci.setReady(); });
+  worker_.addListener(
+      absl::nullopt, listener, [&ci]() -> void { ci.setReady(); }, runtime_);
 
   NiceMock<Stats::MockStore> store;
   worker_.start(guard_dog_, emptyCallback);
@@ -85,13 +89,15 @@ TEST_F(WorkerImplTest, BasicFlow) {
   // After a worker is started adding/stopping/removing a listener happens on the worker thread.
   NiceMock<Network::MockListenerConfig> listener2;
   ON_CALL(listener2, listenerTag()).WillByDefault(Return(2UL));
-  EXPECT_CALL(*handler_, addListener(_, _))
-      .WillOnce(Invoke(
-          [current_thread_id](absl::optional<uint64_t>, Network::ListenerConfig& config) -> void {
+  EXPECT_CALL(*handler_, addListener(_, _, _))
+      .WillOnce(
+          Invoke([current_thread_id](absl::optional<uint64_t>, Network::ListenerConfig& config,
+                                     Runtime::Loader&) -> void {
             EXPECT_EQ(config.listenerTag(), 2UL);
             EXPECT_NE(current_thread_id, std::this_thread::get_id());
           }));
-  worker_.addListener(absl::nullopt, listener2, [&ci]() -> void { ci.setReady(); });
+  worker_.addListener(
+      absl::nullopt, listener2, [&ci]() -> void { ci.setReady(); }, runtime_);
   ci.waitReady();
 
   EXPECT_CALL(*handler_, stopListeners(2))
@@ -122,13 +128,15 @@ TEST_F(WorkerImplTest, BasicFlow) {
   // Now test adding and removing a listener without stopping it first.
   NiceMock<Network::MockListenerConfig> listener3;
   ON_CALL(listener3, listenerTag()).WillByDefault(Return(3UL));
-  EXPECT_CALL(*handler_, addListener(_, _))
-      .WillOnce(Invoke(
-          [current_thread_id](absl::optional<uint64_t>, Network::ListenerConfig& config) -> void {
+  EXPECT_CALL(*handler_, addListener(_, _, _))
+      .WillOnce(
+          Invoke([current_thread_id](absl::optional<uint64_t>, Network::ListenerConfig& config,
+                                     Runtime::Loader&) -> void {
             EXPECT_EQ(config.listenerTag(), 3UL);
             EXPECT_NE(current_thread_id, std::this_thread::get_id());
           }));
-  worker_.addListener(absl::nullopt, listener3, [&ci]() -> void { ci.setReady(); });
+  worker_.addListener(
+      absl::nullopt, listener3, [&ci]() -> void { ci.setReady(); }, runtime_);
   ci.waitReady();
 
   EXPECT_CALL(*handler_, removeListeners(3))


### PR DESCRIPTION
Plumbing runtime through to the TCP listener rather than accessing the runtime singleton

Risk Level: low
Testing: n/a
Docs Changes: n/a
part of https://github.com/envoyproxy/envoy/issues/19847
