### PR TITLE
Adding an integration test to verify CONNECT termination works with DFP config

### DIFF
--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -577,5 +577,60 @@ TEST_P(ProxyFilterIntegrationTest, MultipleRequestsLowStreamLimit) {
   EXPECT_EQ("200", response2->headers().getStatusValue());
 }
 
+// The utility function to send bidirectional data used by
+// below 'CONNECT termination + dynamic forward proxy' test.
+void sendBidirectionalData(
+    IntegrationCodecClientPtr& codec_client, Http::RequestEncoder& request_encoder,
+    FakeRawConnectionPtr& fake_raw_upstream_connection, IntegrationStreamDecoderPtr& response,
+    const char* downstream_send_data = "hello", const char* upstream_received_data = "hello",
+    const char* upstream_send_data = "there!", const char* downstream_received_data = "there!") {
+  // Send some data upstream.
+  codec_client->sendData(request_encoder, downstream_send_data, false);
+  ASSERT_TRUE(fake_raw_upstream_connection->waitForData(
+      FakeRawConnection::waitForInexactMatch(upstream_received_data)));
+  // Send some data downstream.
+  ASSERT_TRUE(fake_raw_upstream_connection->write(upstream_send_data));
+  response->waitForBodyData(strlen(downstream_received_data));
+  EXPECT_EQ(downstream_received_data, response->body());
+}
+
+// Test Envoy CONNECT request termination works with dynamic forward proxy config.
+TEST_P(ProxyFilterIntegrationTest, ConnectRequestWithDFPConfig) {
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void { ConfigHelper::setConnectConfig(hcm, true, false); });
+
+  enableHalfClose(true);
+  initializeWithArgs();
+
+  const Http::TestRequestHeaderMapImpl connect_headers{
+      {":method", "CONNECT"},
+      {":scheme", "http"},
+      {":authority",
+       fmt::format("localhost:{}", fake_upstreams_[0]->localAddress()->ip()->port())}};
+
+  FakeRawConnectionPtr fake_raw_upstream_connection;
+  IntegrationStreamDecoderPtr response;
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(connect_headers);
+  request_encoder_ = &encoder_decoder.first;
+  response = std::move(encoder_decoder.second);
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_raw_upstream_connection));
+  response->waitForHeaders();
+
+  sendBidirectionalData(codec_client_, *request_encoder_, fake_raw_upstream_connection, response,
+                        "hello", "hello", "there!", "there!");
+  // Send a second set of data to make sure for example headers are only sent once.
+  sendBidirectionalData(codec_client_, *request_encoder_, fake_raw_upstream_connection, response,
+                        ",bye", "hello,bye", "ack", "there!ack");
+
+  // Send an end stream. This should result in half close upstream.
+  codec_client_->sendData(*request_encoder_, "", true);
+  ASSERT_TRUE(fake_raw_upstream_connection->waitForHalfClose());
+  // Now send a FIN from upstream. This should result in clean shutdown downstream.
+  ASSERT_TRUE(fake_raw_upstream_connection->close());
+  ASSERT_TRUE(codec_client_->waitForDisconnect());
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Problem description:

Envoy CONNECT message handling can terminate the CONNECT message and send the payload upstream as raw TCP data.  

This PR is to add a integration test for it.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
