### PR TITLE
Double open event

### DIFF
--- a/source/extensions/transport_sockets/starttls/starttls_socket.cc
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.cc
@@ -8,7 +8,7 @@ namespace StartTls {
 // Switch clear-text to secure transport.
 bool StartTlsSocket::startSecureTransport() {
   if (!using_tls_) {
-    tls_socket_->setTransportSocketCallbacks(*callbacks_);
+    tls_socket_->setTransportSocketCallbacks(callbacks_);
     tls_socket_->onConnected();
     // TODO(cpakulski): deleting active_socket_ assumes
     // that active_socket_ does not contain any buffered data.

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -2,8 +2,8 @@
 
 #include "envoy/extensions/transport_sockets/starttls/v3/starttls.pb.h"
 #include "envoy/extensions/transport_sockets/starttls/v3/starttls.pb.validate.h"
-#include "envoy/network/transport_socket.h"
 #include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 
@@ -51,8 +51,8 @@ public:
   bool startSecureTransport() override;
 
 private:
-  // This is a proxy for wrapping the transport callback object passed from the consumer
-  // Its primary purpose is to filter Connected events to ensure they only happen once per open
+  // This is a proxy for wrapping the transport callback object passed from the consumer.
+  // Its primary purpose is to filter Connected events to ensure they only happen once per open.
   class CallbackProxy : public Network::TransportSocketCallbacks {
   public:
     CallbackProxy(Network::TransportSocketCallbacks* callbacks) : parent_(callbacks) {}
@@ -67,11 +67,12 @@ private:
     void raiseEvent(Network::ConnectionEvent event) override {
       if (event == Network::ConnectionEvent::Connected) {
         // Don't send the connected event if we're already open
-        if (isopen_)
+        if (is_open_) {
           return;
-        isopen_ = true;
+        }
+        is_open_ = true;
       } else {
-        isopen_ = false;
+        is_open_ = false;
       }
 
       parent_->raiseEvent(event);
@@ -80,7 +81,7 @@ private:
 
   private:
     Network::TransportSocketCallbacks* parent_;
-    bool isopen_{false};
+    bool is_open_{false};
   };
 
   // Socket used in all transport socket operations.

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -58,7 +58,9 @@ private:
     CallbackProxy(Network::TransportSocketCallbacks* callbacks) : parent_(callbacks) {}
 
     Network::IoHandle& ioHandle() override { return parent_->ioHandle(); }
-    const Network::IoHandle& ioHandle() const override { return parent_->ioHandle(); }
+    const Network::IoHandle& ioHandle() const override {
+      return const_cast<const Network::TransportSocketCallbacks*>(parent_)->ioHandle();
+    }
     Network::Connection& connection() override { return parent_->connection(); }
     bool shouldDrainReadBuffer() override { return parent_->shouldDrainReadBuffer(); }
     void setTransportSocketIsReadable() override { return parent_->setTransportSocketIsReadable(); }

--- a/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
@@ -125,8 +125,8 @@ TEST(StartTlsTest, CallbackProxy) {
   // Verify raiseEvent logic
 
   // Connected should only called once. When ssl_socket takes over it also raises Connected,
-  // which we don't want to propogate.
-  EXPECT_CALL(transport_callbacks, raiseEvent(Network::ConnectionEvent::Connected)).Times(1);
+  // which we don't want to propagate.
+  EXPECT_CALL(transport_callbacks, raiseEvent(Network::ConnectionEvent::Connected));
   proxy->raiseEvent(Network::ConnectionEvent::Connected);
   proxy->raiseEvent(Network::ConnectionEvent::Connected);
 
@@ -136,7 +136,7 @@ TEST(StartTlsTest, CallbackProxy) {
   proxy->raiseEvent(Network::ConnectionEvent::RemoteClose);
 
   // Connected should get raised again after !Connected but only once
-  EXPECT_CALL(transport_callbacks, raiseEvent(Network::ConnectionEvent::Connected)).Times(1);
+  EXPECT_CALL(transport_callbacks, raiseEvent(Network::ConnectionEvent::Connected));
   proxy->raiseEvent(Network::ConnectionEvent::Connected);
   proxy->raiseEvent(Network::ConnectionEvent::Connected);
 

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -256,7 +256,7 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromClient) {
 
   // The upstream connection should only report a single connected event
   EXPECT_CALL(upstream_callbacks_, onEvent(_));
-  EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::Connected)).Times(1);
+  EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::Connected));
 
   // Open clear-text connection.
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("starttls_test"));

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -255,6 +255,7 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromClient) {
   initialize();
 
   // The upstream connection should only report a single connected event
+  EXPECT_CALL(upstream_callbacks_, onEvent(_));
   EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::Connected)).Times(1);
 
   // Open clear-text connection.


### PR DESCRIPTION
Reopen of #19249

Fix double event issue in #19232

When using the starttls filter, it breaks the expectation that connections should only raise the connected event once. This expectation is relied on for proper operation of core envoy functions like the connection pooler.

Risk Level: Low

Testing: Added regression test and tests for new code.