### PR TITLE
stats: Stats handler test cleanup

### DIFF
--- a/source/server/admin/stats_handler.cc
+++ b/source/server/admin/stats_handler.cc
@@ -111,16 +111,24 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     }
   }
 
+  Stats::Store& stats = server_.stats();
+  std::vector<Stats::ParentHistogramSharedPtr> histograms = stats.histograms();
+  stats.symbolTable().sortByStatNames<Stats::ParentHistogramSharedPtr>(
+      histograms.begin(), histograms.end(),
+      [](const Stats::ParentHistogramSharedPtr& a) -> Stats::StatName {
+        return a->statName();
+      });
+
   if (!format_value.has_value()) {
     // Display plain stats if format query param is not there.
-    statsAsText(all_stats, text_readouts, server_.stats().histograms(), used_only, regex, response);
+    statsAsText(all_stats, text_readouts, histograms, used_only, regex, response);
     return Http::Code::OK;
   }
 
   if (format_value.value() == "json") {
     response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
     response.add(
-        statsAsJson(all_stats, text_readouts, server_.stats().histograms(), used_only, regex));
+        statsAsJson(all_stats, text_readouts, histograms, used_only, regex));
     return Http::Code::OK;
   }
 


### PR DESCRIPTION
Commit Message: Refactors redundant patterns and declarations in the test to make it easier to review a other PR that changes the implementation. This set of refactors makes the test a bit easier to read and to change.

Functionally this sorts histograms before emitting them for text or json, which should improve predictability of results.
Additional Description:
Risk Level: low
Testing: just the one test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: na
