### PR TITLE
Add a configureInitialCongestionWindow method to Envoy::Network::Connection

### DIFF
--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -334,6 +334,10 @@ public:
    * @param bandwidth_bits_per_sec The estimated bandwidth between the two endpoints of the
    * connection.
    * @param rtt The estimated round trip time between the two endpoints of the connection.
+   *
+   * @note Envoy does not provide an implementation for TCP connections because
+   * there is no portable system api to do so. Applications can implement it
+   * with a proprietary api in a customized TransportSocket.
    */
   virtual void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
                                                 std::chrono::microseconds rtt) PURE;

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -326,6 +326,17 @@ public:
    *  returned.
    */
   virtual absl::optional<std::chrono::milliseconds> lastRoundTripTime() const PURE;
+
+  /**
+   * Try to configure the connection's initial congestion window.
+   * The operation is advisory - the connection may not support it, even if it's supported, it may
+   * not do anything after the first few network round trips with the peer.
+   * @param bandwidth_bits_per_sec The estimated bandwidth between the two endpoints of the
+   * connection.
+   * @param rtt The estimated round trip time between the two endpoints of the connection.
+   */
+  virtual void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                                std::chrono::microseconds rtt) PURE;
 };
 
 using ConnectionPtr = std::unique_ptr<Connection>;

--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -156,6 +156,17 @@ public:
    * @return boolean indicating if the transport socket was able to start secure transport.
    */
   virtual bool startSecureTransport() PURE;
+
+  /**
+   * Try to configure the connection's initial congestion window.
+   * The operation is advisory - the connection may not support it, even if it's supported, it may
+   * not do anything after the first few network round trips with the peer.
+   * @param bandwidth_bits_per_sec The estimated bandwidth between the two endpoints of the
+   * connection.
+   * @param rtt The estimated round trip time between the two endpoints of the connection.
+   */
+  virtual void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                                std::chrono::microseconds rtt) PURE;
 };
 
 using TransportSocketPtr = std::unique_ptr<TransportSocket>;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -781,7 +781,12 @@ absl::string_view ConnectionImpl::transportFailureReason() const {
 
 absl::optional<std::chrono::milliseconds> ConnectionImpl::lastRoundTripTime() const {
   return socket_->lastRoundTripTime();
-};
+}
+
+void ConnectionImpl::configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                                      std::chrono::microseconds rtt) {
+  return transport_socket_->configureInitialCongestionWindow(bandwidth_bits_per_sec, rtt);
+}
 
 void ConnectionImpl::flushWriteBuffer() {
   if (state() == State::Open && write_buffer_->length() > 0) {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -99,6 +99,8 @@ public:
   absl::string_view transportFailureReason() const override;
   bool startSecureTransport() override { return transport_socket_->startSecureTransport(); }
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override;
+  void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                        std::chrono::microseconds rtt) override;
 
   // Network::FilterManagerConnection
   void rawWrite(Buffer::Instance& data, bool end_stream) override;

--- a/source/common/network/happy_eyeballs_connection_impl.h
+++ b/source/common/network/happy_eyeballs_connection_impl.h
@@ -68,6 +68,7 @@ public:
   void setBufferLimits(uint32_t limit) override;
   bool startSecureTransport() override;
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override;
+  void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
 
   // Simple getters which always delegate to the first connection in connections_.
   bool isHalfCloseEnabled() override;

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -22,6 +22,7 @@ public:
   IoResult doWrite(Buffer::Instance& buffer, bool end_stream) override;
   Ssl::ConnectionInfoConstSharedPtr ssl() const override { return nullptr; }
   bool startSecureTransport() override { return false; }
+  void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
 
 private:
   TransportSocketCallbacks* callbacks_{};

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -217,5 +217,19 @@ void QuicFilterManagerConnectionImpl::onSendBufferLowWatermark() {
   }
 }
 
+void QuicFilterManagerConnectionImpl::configureInitialCongestionWindow(
+    uint64_t bandwidth_bits_per_sec, std::chrono::microseconds rtt) {
+  if (quicConnection() != nullptr) {
+    quic::SendAlgorithmInterface::NetworkParams params(
+        quic::QuicBandwidth::FromBitsPerSecond(bandwidth_bits_per_sec),
+        quic::QuicTime::Delta::FromMicroseconds(rtt.count()),
+        /*allow_cwnd_to_decrease=*/false);
+    // NOTE: Different QUIC congestion controllers implement this method differently, for example,
+    // the cubic implementation does not respect |params.allow_cwnd_to_decrease|. Check the
+    // implementations for the exact behavior.
+    quicConnection()->AdjustNetworkParameters(params);
+  }
+}
+
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -116,6 +116,8 @@ public:
   bool startSecureTransport() override { return false; }
   // TODO(#2557) Implement this.
   absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override { return {}; }
+  void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                        std::chrono::microseconds rtt) override;
 
   // Network::FilterManagerConnection
   void rawWrite(Buffer::Instance& data, bool end_stream) override;

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -68,6 +68,7 @@ public:
   bool canFlushClose() override { return handshake_complete_; }
   Envoy::Ssl::ConnectionInfoConstSharedPtr ssl() const override { return nullptr; }
   bool startSecureTransport() override { return false; }
+  void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
   Network::IoResult doWrite(Buffer::Instance& buffer, bool end_stream) override;
   void closeSocket(Network::ConnectionEvent event) override;
   Network::IoResult doRead(Buffer::Instance& buffer) override;

--- a/source/extensions/transport_sockets/common/passthrough.cc
+++ b/source/extensions/transport_sockets/common/passthrough.cc
@@ -42,6 +42,11 @@ Ssl::ConnectionInfoConstSharedPtr PassthroughSocket::ssl() const {
   return transport_socket_->ssl();
 }
 
+void PassthroughSocket::configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                                         std::chrono::microseconds rtt) {
+  return transport_socket_->configureInitialCongestionWindow(bandwidth_bits_per_sec, rtt);
+}
+
 } // namespace TransportSockets
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/transport_sockets/common/passthrough.h
+++ b/source/extensions/transport_sockets/common/passthrough.h
@@ -44,6 +44,8 @@ public:
   Ssl::ConnectionInfoConstSharedPtr ssl() const override;
   // startSecureTransport method should not be called for this transport socket.
   bool startSecureTransport() override { return false; }
+  void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                        std::chrono::microseconds rtt) override;
 
 protected:
   Network::TransportSocketPtr transport_socket_;

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -49,6 +49,11 @@ public:
   // Method to enable TLS.
   bool startSecureTransport() override;
 
+  void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,
+                                        std::chrono::microseconds rtt) override {
+    return active_socket_->configureInitialCongestionWindow(bandwidth_bits_per_sec, rtt);
+  }
+
 private:
   // Socket used in all transport socket operations.
   // initially it is set to use raw buffer socket but

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -42,6 +42,7 @@ public:
   void onConnected() override {}
   Ssl::ConnectionInfoConstSharedPtr ssl() const override { return nullptr; }
   bool startSecureTransport() override { return false; }
+  void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
 };
 
 } // namespace

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -62,6 +62,7 @@ public:
   void onConnected() override;
   Ssl::ConnectionInfoConstSharedPtr ssl() const override;
   bool startSecureTransport() override { return false; }
+  void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
   // Ssl::PrivateKeyConnectionCallbacks
   void onPrivateKeyMethodComplete() override;
   // Ssl::HandshakeCallbacks

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -161,6 +161,7 @@ protected:
         return false;
       }
       absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override { return {}; };
+      void configureInitialCongestionWindow(uint64_t, std::chrono::microseconds) override {}
       // ScopeTrackedObject
       void dumpState(std::ostream& os, int) const override { os << "SyntheticConnection"; }
 

--- a/test/extensions/transport_sockets/common/passthrough_test.cc
+++ b/test/extensions/transport_sockets/common/passthrough_test.cc
@@ -88,6 +88,13 @@ TEST_F(PassthroughTest, FailOnStartSecureTransport) {
   EXPECT_FALSE(passthrough_socket_->startSecureTransport());
 }
 
+// Test configureInitialCongestionWindow method defers to inner socket
+TEST_F(PassthroughTest, ConfigureInitialCongestionWindowDefersToInnerSocket) {
+  EXPECT_CALL(*inner_socket_,
+              configureInitialCongestionWindow(100, std::chrono::microseconds(123)));
+  passthrough_socket_->configureInitialCongestionWindow(100, std::chrono::microseconds(123));
+}
+
 TEST(PassthroughFactoryTest, TestDelegation) {
   auto inner_factory_ptr = std::make_unique<NiceMock<Network::MockTransportSocketFactory>>();
   Network::MockTransportSocketFactory* inner_factory = inner_factory_ptr.get();

--- a/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
@@ -50,6 +50,10 @@ TEST(StartTlsTest, BasicSwitch) {
   EXPECT_CALL(*ssl_socket, canFlushClose()).Times(0);
   socket->canFlushClose();
 
+  EXPECT_CALL(*raw_socket, configureInitialCongestionWindow(100, std::chrono::microseconds(123)));
+  EXPECT_CALL(*ssl_socket, configureInitialCongestionWindow(_, _)).Times(0);
+  socket->configureInitialCongestionWindow(100, std::chrono::microseconds(123));
+
   EXPECT_CALL(*raw_socket, ssl());
   EXPECT_CALL(*ssl_socket, ssl()).Times(0);
   socket->ssl();
@@ -89,6 +93,9 @@ TEST(StartTlsTest, BasicSwitch) {
 
   EXPECT_CALL(*ssl_socket, canFlushClose());
   socket->canFlushClose();
+
+  EXPECT_CALL(*ssl_socket, configureInitialCongestionWindow(200, std::chrono::microseconds(223)));
+  socket->configureInitialCongestionWindow(200, std::chrono::microseconds(223));
 
   EXPECT_CALL(*ssl_socket, ssl());
   socket->ssl();

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4936,6 +4936,8 @@ TEST_P(SslSocketTest, DownstreamNotReadySslSocket) {
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                    std::vector<std::string>{});
   auto transport_socket = server_ssl_socket_factory.createTransportSocket(nullptr);
+  EXPECT_FALSE(transport_socket->startSecureTransport());                                  // Noop
+  transport_socket->configureInitialCongestionWindow(200, std::chrono::microseconds(223)); // Noop
   EXPECT_EQ(EMPTY_STRING, transport_socket->protocol());
   EXPECT_EQ(nullptr, transport_socket->ssl());
   EXPECT_EQ(true, transport_socket->canFlushClose());

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -366,9 +366,12 @@ void testUtil(const TestUtilOptions& options) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   EXPECT_CALL(callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
-        server_connection = dispatcher->createServerConnection(
-            std::move(socket), server_ssl_socket_factory.createTransportSocket(nullptr),
-            stream_info);
+        auto ssl_socket = server_ssl_socket_factory.createTransportSocket(nullptr);
+        // configureInitialCongestionWindow is an unimplemented empty function, this is just to
+        // increase code coverage.
+        ssl_socket->configureInitialCongestionWindow(100, std::chrono::microseconds(123));
+        server_connection = dispatcher->createServerConnection(std::move(socket),
+                                                               std::move(ssl_socket), stream_info);
         server_connection->addConnectionCallbacks(server_connection_callbacks);
       }));
 

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -86,6 +86,8 @@ public:
   MOCK_METHOD(absl::string_view, transportFailureReason, (), (const));                             \
   MOCK_METHOD(bool, startSecureTransport, ());                                                     \
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, lastRoundTripTime, (), (const));          \
+  MOCK_METHOD(void, configureInitialCongestionWindow,                                              \
+              (uint64_t bandwidth_bits_per_sec, std::chrono::microseconds rtt), ());               \
   MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));
 
 class MockConnection : public Connection, public MockConnectionBase {

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -27,6 +27,8 @@ public:
   MOCK_METHOD(void, onConnected, ());
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, ssl, (), (const));
   MOCK_METHOD(bool, startSecureTransport, ());
+  MOCK_METHOD(void, configureInitialCongestionWindow,
+              (uint64_t bandwidth_bits_per_sec, std::chrono::microseconds rtt));
 
   TransportSocketCallbacks* callbacks_{};
 };

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -171,6 +171,10 @@ api_listener:
   // ForTest function.
   http_api_listener.readCallbacksForTest().connection().addConnectionCallbacks(
       network_connection_callbacks);
+  EXPECT_FALSE(
+      http_api_listener.readCallbacksForTest().connection().lastRoundTripTime().has_value());
+  http_api_listener.readCallbacksForTest().connection().configureInitialCongestionWindow(
+      100, std::chrono::microseconds(123));
 
   EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
   // Shutting down the ApiListener should raise an event on all connection callback targets.

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -32,6 +32,7 @@ cbor
 CDN
 CDS
 CEL
+CWND
 DSR
 DSS
 EBADF


### PR DESCRIPTION
Add a configureInitialCongestionWindow method to Envoy::Network::Connection to set the initial congestion window.

QUIC connections will use QuicConnection::AdjustNetworkParameters to set
the congestion window.
TCP connections will delegate to the TransportSocket, which is a no-op
by default because there is no portable api to set TCP congestion
window. An application can use a custom TransportSocket and override the
method to set the congestion window in a proprietary way.

Signed-off-by: Bin Wu <wub@google.com>


Commit Message: Add a configureInitialCongestionWindow method to Envoy::Network::Connection to set the initial congestion window.
Risk Level: Low.
Testing: None, just adding an interface that is not used in OSS envoy. I'll test it in my application tests.
