### PR TITLE
ext-authz: use uuid instead of streamid in authz request

### DIFF
--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -103,10 +103,10 @@ void CheckRequestUtils::setRequestTime(envoy::service::auth::v3::AttributeContex
 }
 
 void CheckRequestUtils::setHttpRequest(
-    envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq, uint64_t stream_id,
+    envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
     const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes) {
-  httpreq.set_id(std::to_string(stream_id));
+  httpreq.set_id(getHeaderStr(headers.RequestId()));
   httpreq.set_method(getHeaderStr(headers.Method()));
   httpreq.set_path(getHeaderStr(headers.Path()));
   httpreq.set_host(getHeaderStr(headers.Host()));
@@ -155,12 +155,12 @@ void CheckRequestUtils::setHttpRequest(
 }
 
 void CheckRequestUtils::setAttrContextRequest(
-    envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
+    envoy::service::auth::v3::AttributeContext::Request& req,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
     const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes) {
   setRequestTime(req, stream_info);
-  setHttpRequest(*req.mutable_http(), stream_id, stream_info, decoding_buffer, headers,
-                 max_request_bytes, pack_as_bytes);
+  setHttpRequest(*req.mutable_http(), stream_info, decoding_buffer, headers, max_request_bytes,
+                 pack_as_bytes);
 }
 
 void CheckRequestUtils::createHttpCheck(
@@ -182,8 +182,8 @@ void CheckRequestUtils::createHttpCheck(
                      include_peer_certificate);
   setAttrContextPeer(*attrs->mutable_destination(), *cb->connection(), EMPTY_STRING, true,
                      include_peer_certificate);
-  setAttrContextRequest(*attrs->mutable_request(), cb->streamId(), cb->streamInfo(),
-                        cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes);
+  setAttrContextRequest(*attrs->mutable_request(), cb->streamInfo(), cb->decodingBuffer(), headers,
+                        max_request_bytes, pack_as_bytes);
 
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
   // Fill in the context extensions and metadata context.

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -77,12 +77,11 @@ private:
   static void setRequestTime(envoy::service::auth::v3::AttributeContext::Request& req,
                              const StreamInfo::StreamInfo& stream_info);
   static void setHttpRequest(envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq,
-                             const uint64_t stream_id, const StreamInfo::StreamInfo& stream_info,
+                             const StreamInfo::StreamInfo& stream_info,
                              const Buffer::Instance* decoding_buffer,
                              const Envoy::Http::RequestHeaderMap& headers,
                              uint64_t max_request_bytes, bool pack_as_bytes);
   static void setAttrContextRequest(envoy::service::auth::v3::AttributeContext::Request& req,
-                                    const uint64_t stream_id,
                                     const StreamInfo::StreamInfo& stream_info,
                                     const Buffer::Instance* decoding_buffer,
                                     const Envoy::Http::RequestHeaderMap& headers,

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -38,7 +38,6 @@ public:
     connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
     connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
     EXPECT_CALL(Const(connection_), ssl()).Times(2).WillRepeatedly(Return(ssl_));
-    EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
     EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
     EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
     EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
@@ -301,7 +300,6 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeer) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(Const(connection_), ssl()).WillRepeatedly(Return(ssl_));
-  EXPECT_CALL(callbacks_, streamId()).WillRepeatedly(Return(0));
   EXPECT_CALL(callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(callbacks_, decodingBuffer());
   EXPECT_CALL(req_info_, protocol()).WillRepeatedly(ReturnPointee(&protocol_));


### PR DESCRIPTION
Commit Message:
Additional Description:For consistency with the [documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto.html#envoy-v3-api-msg-service-auth-v3-attributecontext-httprequest)， use uuid instead of streamid in authz request, fix #19551.
Risk Level: low
Testing: unit testing
Docs Changes: n/a
Release Notes: inline
Platform Specific Features:

