### PR TITLE
test: harden key/value test

### DIFF
--- a/test/extensions/key_value/file_based/key_value_store_test.cc
+++ b/test/extensions/key_value/file_based/key_value_store_test.cc
@@ -119,9 +119,9 @@ TEST_F(KeyValueStoreTest, HandleBadFile) {
 
 #ifndef WIN32
 TEST_F(KeyValueStoreTest, HandleInvalidFile) {
-  filename_ = "/foo";
+  filename_ = TestEnvironment::temporaryPath("some/unlikely/bad/path/bar");
   createStore();
-  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file /foo", store_->flush());
+  EXPECT_LOG_CONTAINS("error", "Failed to flush cache to file " + filename_, store_->flush());
 }
 #endif
 


### PR DESCRIPTION
Path `/foo` might be writable so the flush actually works therefore the
test fails. Replacing it with a path that's more likely to fail upon an
attempt to write works better.

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>
