### PR TITLE
admin:reduce logging severity in filter from error to info

### DIFF
--- a/source/server/admin/admin_filter.cc
+++ b/source/server/admin/admin_filter.cc
@@ -78,7 +78,7 @@ void AdminFilter::onComplete() {
     Buffer::OwnedImpl response;
     more_data = handler->nextChunk(response);
     bool end_stream = end_stream_on_complete_ && !more_data;
-    ENVOY_LOG_MISC(error, "nextChunk: response.length={} more_data={} end_stream={}",
+    ENVOY_LOG_MISC(info, "nextChunk: response.length={} more_data={} end_stream={}",
                    response.length(), more_data, end_stream);
     if (response.length() > 0 || end_stream) {
       decoder_callbacks_->encodeData(response, end_stream);


### PR DESCRIPTION
Commit Message: Reduce logging severity from error to info in admin filter
Additional Description: Nighthawk is reliant on no error logs to determine successful runs. Logging this message as an error causes nighthawk tests to fail. 
Risk Level: Low
Testing: unit testing.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Signed-off-by: tomjzzhang <4367421+tomjzzhang@users.noreply.github.com>