### PR TITLE
config: add path_config_source and watched_directory config

### DIFF
--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -167,8 +167,9 @@ message PathConfigSource {
   // If configured, this directory will be watched for *moves.* When an entry in this directory is
   // moved to, the `path` will be reloaded. This is required in certain deployment scenarios.
   //
-  // Specifically, if trying to load an xDS resource using a Kubernetes ConfigMap, the following
-  // configuration might be used:
+  // Specifically, if trying to load an xDS resource using a
+  // `Kubernetes ConfigMap <https://kubernetes.io/docs/concepts/configuration/configmap/>`_, the
+  // following configuration might be used:
   // 1. Store xds.yaml inside a ConfigMap.
   // 2. Mount the ConfigMap to `/config_map/xds`
   // 3. Configure path `/config_map/xds/xds.yaml`

--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
+import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 
 import "google/protobuf/duration.proto";
@@ -143,13 +144,48 @@ message RateLimitSettings {
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 }
 
+// Local filesystem path configuration source.
+message PathConfigSource {
+  // Path on the filesystem to source and watch for configuration updates.
+  // When sourcing configuration for a :ref:`secret <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.Secret>`,
+  // the certificate and key files are also watched for updates.
+  //
+  // .. note::
+  //
+  //  The path to the source must exist at config load time.
+  //
+  // .. note::
+  //
+  //   If `watched_directory` is *not* configured, Envoy will watch the file path for *moves.*
+  //   This is because in general only moves are atomic. The same method of swapping files as is
+  //   demonstrated in the :ref:`runtime documentation <config_runtime_symbolic_link_swap>` can be
+  //   used here also. If `watched_directory` is configured, no watch will be placed directly on
+  //   this path. Instead, the configured `watched_directory` will be used to trigger reloads of
+  //   this path. This is required in certain deployment scenarios. See below for more information.
+  string path = 1 [(validate.rules).string = {min_len: 1}];
+
+  // If configured, this directory will be watched for *moves.* When an entry in this directory is
+  // moved to, the `path` will be reloaded. This is required in certain deployment scenarios.
+  //
+  // Specifically, if trying to load an xDS resource using a Kubernetes ConfigMap, the following
+  // configuration might be used:
+  // 1. Store xds.yaml inside a ConfigMap.
+  // 2. Mount the ConfigMap to `/config_map/xds`
+  // 3. Configure path `/config_map/xds/xds.yaml`
+  // 4. Configure watched directory `/config_map/xds`
+  //
+  // The above configuration will ensure that Envoy watches the owning directory for moves which is
+  // required due to how Kubernetes manages ConfigMap symbolic links during atomic updates.
+  WatchedDirectory watched_directory = 2;
+}
+
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters
 // <config_cluster_manager>`, :ref:`routes
 // <envoy_v3_api_msg_config.route.v3.RouteConfiguration>`, :ref:`endpoints
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.ConfigSource";
 
@@ -162,20 +198,11 @@ message ConfigSource {
   oneof config_source_specifier {
     option (validate.required) = true;
 
-    // Path on the filesystem to source and watch for configuration updates.
-    // When sourcing configuration for :ref:`secret <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.Secret>`,
-    // the certificate and key files are also watched for updates.
-    //
-    // .. note::
-    //
-    //  The path to the source must exist at config load time.
-    //
-    // .. note::
-    //
-    //   Envoy will only watch the file path for *moves.* This is because in general only moves
-    //   are atomic. The same method of swapping files as is demonstrated in the
-    //   :ref:`runtime documentation <config_runtime_symbolic_link_swap>` can be used here also.
-    string path = 1;
+    // Deprecated in favor of `path_config_source`. Use that field instead.
+    string path = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+    // Local filesystem path configuration source.
+    PathConfigSource path_config_source = 8;
 
     // API configuration source.
     ApiConfigSource api_config_source = 2;

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -53,6 +53,10 @@ Removed Config or Runtime
 New Features
 ------------
 * access_log: make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
+* config: added new file based xDS configuration via :ref:`path_config_source <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`.
+  :ref:`watched_directory <envoy_v3_api_field_config.core.v3.PathConfigSource.watched_directory>` can
+  be used to setup an independent watch for when to reload the file path, for example when using
+  Kubernetes ConfigMaps to deliver configuration. See the linked documentation for more information.
 * cors: add dynamic support for headers ``access-control-allow-methods`` and ``access-control-allow-headers`` in cors.
 * http: added random_value_specifier in :ref:`weighted_clusters <envoy_v3_api_field_config.route.v3.RouteAction.weighted_clusters>` to allow random value to be specified from configuration proto.
 * http: added support for :ref:`proxy_status_config <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.proxy_status_config>` for configuring `Proxy-Status <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-08>`_ HTTP response header fields.
@@ -64,4 +68,6 @@ New Features
 Deprecated
 ----------
 
+* config: deprecated :ref:`path <envoy_v3_api_field_config.core.v3.ConfigSource.path>` in favor of
+  :ref:`path_config_source <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`
 * http: removing support for long-deprecated old style filter names, e.g. envoy.router, envoy.lua.

--- a/envoy/config/subscription_factory.h
+++ b/envoy/config/subscription_factory.h
@@ -14,6 +14,16 @@ public:
   virtual ~SubscriptionFactory() = default;
 
   /**
+   * @return true if a config source comes from the local filesystem.
+   */
+  static bool
+  isPathBasedConfigSource(envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase type) {
+    return type == envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPath ||
+           type ==
+               envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPathConfigSource;
+  }
+
+  /**
    * Subscription factory interface.
    *
    * @param config envoy::config::core::v3::ConfigSource to construct from.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -383,7 +383,7 @@ public:
   /**
    * Determine whether a request should be retried based on the response headers.
    * @param response_headers supplies the response headers.
-   * @param original_request supplies the orignal request headers.
+   * @param original_request supplies the original request headers.
    * @param callback supplies the callback that will be invoked when the retry should take place.
    *                 This is used to add timed backoff, etc. The callback will never be called
    *                 inline.
@@ -401,7 +401,7 @@ public:
    * the information about whether a response is "good" or not is useful, but a retry should
    * not be attempted for other reasons.
    * @param response_headers supplies the response headers.
-   * @param original_request supplies the orignal request headers.
+   * @param original_request supplies the original request headers.
    * @param retry_as_early_data output argument to tell the caller if a retry should be sent as
    *        early data if it is warranted.
    * @return RetryDecision if a retry would be warranted based on the retry policy and if it would

--- a/examples/dynamic-config-fs/envoy.yaml
+++ b/examples/dynamic-config-fs/envoy.yaml
@@ -4,9 +4,11 @@ node:
 
 dynamic_resources:
   cds_config:
-    path: /var/lib/envoy/cds.yaml
+    path_config_source:
+      path: /var/lib/envoy/cds.yaml
   lds_config:
-    path: /var/lib/envoy/lds.yaml
+    path_config_source:
+      path: /var/lib/envoy/lds.yaml
 
 admin:
   address:

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -120,6 +120,7 @@ envoy_cc_library(
     hdrs = ["filesystem_subscription_impl.h"],
     deps = [
         ":decoded_resource_lib",
+        ":watched_directory_lib",
         "//envoy/config:subscription_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/filesystem:filesystem_interface",
@@ -129,6 +130,7 @@ envoy_cc_library(
         "//source/common/protobuf",
         "//source/common/protobuf:message_validator_lib",
         "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/config/filesystem_subscription_impl.cc
+++ b/source/common/config/filesystem_subscription_impl.cc
@@ -97,8 +97,8 @@ void FilesystemSubscriptionImpl::refresh() {
     } else {
       ENVOY_LOG(warn, "Filesystem config update failure: {}", e.what());
       stats_.update_failure_.inc();
-      // This could happen due to filesystem issues or a bad configuration (e.g. proto
-      // validation). Since the latter is more likely, for now we will treat it as rejection.
+      // This could happen due to filesystem issues or a bad configuration (e.g. proto validation).
+      // Since the latter is more likely, for now we will treat it as rejection.
       callbacks_.onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, &e);
     }
   }

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -1,15 +1,19 @@
 #pragma once
 
 #include "envoy/api/api.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/protobuf/message_validator.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/config/watched_directory.h"
 
 namespace Envoy {
 namespace Config {
+
+envoy::config::core::v3::PathConfigSource makePathConfigSource(const std::string& path);
 
 /**
  * Filesystem inotify implementation of the API Subscription interface. This allows the API to be
@@ -19,7 +23,8 @@ namespace Config {
 class FilesystemSubscriptionImpl : public Config::Subscription,
                                    protected Logger::Loggable<Logger::Id::config> {
 public:
-  FilesystemSubscriptionImpl(Event::Dispatcher& dispatcher, absl::string_view path,
+  FilesystemSubscriptionImpl(Event::Dispatcher& dispatcher,
+                             const envoy::config::core::v3::PathConfigSource& path_config_source,
                              SubscriptionCallbacks& callbacks,
                              OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
                              ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api);
@@ -40,7 +45,8 @@ protected:
 
   bool started_{};
   const std::string path_;
-  std::unique_ptr<Filesystem::Watcher> watcher_;
+  std::unique_ptr<Filesystem::Watcher> file_watcher_;
+  WatchedDirectoryPtr directory_watcher_;
   SubscriptionCallbacks& callbacks_;
   OpaqueResourceDecoder& resource_decoder_;
   SubscriptionStats stats_;
@@ -52,12 +58,12 @@ protected:
 // non-inline collection resources.
 class FilesystemCollectionSubscriptionImpl : public FilesystemSubscriptionImpl {
 public:
-  FilesystemCollectionSubscriptionImpl(Event::Dispatcher& dispatcher, absl::string_view path,
-                                       SubscriptionCallbacks& callbacks,
-                                       OpaqueResourceDecoder& resource_decoder,
-                                       SubscriptionStats stats,
-                                       ProtobufMessage::ValidationVisitor& validation_visitor,
-                                       Api::Api& api);
+  FilesystemCollectionSubscriptionImpl(
+      Event::Dispatcher& dispatcher,
+      const envoy::config::core::v3::PathConfigSource& path_config_source,
+      SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+      SubscriptionStats stats, ProtobufMessage::ValidationVisitor& validation_visitor,
+      Api::Api& api);
 
   std::string refreshInternal(ProtobufTypes::MessagePtr* config_update) override;
 };

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -36,7 +36,14 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPath: {
     Utility::checkFilesystemSubscriptionBackingPath(config.path(), api_);
     return std::make_unique<Config::FilesystemSubscriptionImpl>(
-        dispatcher_, config.path(), callbacks, resource_decoder, stats, validation_visitor_, api_);
+        dispatcher_, makePathConfigSource(config.path()), callbacks, resource_decoder, stats,
+        validation_visitor_, api_);
+  }
+  case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPathConfigSource: {
+    Utility::checkFilesystemSubscriptionBackingPath(config.path_config_source().path(), api_);
+    return std::make_unique<Config::FilesystemSubscriptionImpl>(
+        dispatcher_, config.path_config_source(), callbacks, resource_decoder, stats,
+        validation_visitor_, api_);
   }
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kApiConfigSource: {
     const envoy::config::core::v3::ApiConfigSource& api_config_source = config.api_config_source();
@@ -134,7 +141,8 @@ SubscriptionPtr SubscriptionFactoryImpl::collectionSubscriptionFromUrl(
     const std::string path = Http::Utility::localPathFromFilePath(collection_locator.id());
     Utility::checkFilesystemSubscriptionBackingPath(path, api_);
     return std::make_unique<Config::FilesystemCollectionSubscriptionImpl>(
-        dispatcher_, path, callbacks, resource_decoder, stats, validation_visitor_, api_);
+        dispatcher_, makePathConfigSource(path), callbacks, resource_decoder, stats,
+        validation_visitor_, api_);
   }
   case xds::core::v3::ResourceLocator::XDSTP: {
     if (resource_type != collection_locator.resource_type()) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -315,8 +315,8 @@ ClusterManagerImpl::ClusterManagerImpl(
   auto is_primary_cluster = [](const envoy::config::cluster::v3::Cluster& cluster) -> bool {
     return cluster.type() != envoy::config::cluster::v3::Cluster::EDS ||
            (cluster.type() == envoy::config::cluster::v3::Cluster::EDS &&
-            cluster.eds_cluster_config().eds_config().config_source_specifier_case() ==
-                envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPath);
+            Config::SubscriptionFactory::isPathBasedConfigSource(
+                cluster.eds_cluster_config().eds_config().config_source_specifier_case()));
   };
   // Build book-keeping for which clusters are primary. This is useful when we
   // invoke loadCluster() below and it needs the complete set of primaries.
@@ -399,8 +399,8 @@ ClusterManagerImpl::ClusterManagerImpl(
   for (const auto& cluster : bootstrap.static_resources().clusters()) {
     // Now load all the secondary clusters.
     if (cluster.type() == envoy::config::cluster::v3::Cluster::EDS &&
-        cluster.eds_cluster_config().eds_config().config_source_specifier_case() !=
-            envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPath) {
+        !Config::SubscriptionFactory::isPathBasedConfigSource(
+            cluster.eds_cluster_config().eds_config().config_source_specifier_case())) {
       loadCluster(cluster, MessageUtil::hash(cluster), "", false, active_clusters_);
     }
   }

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -28,8 +28,8 @@ EdsClusterImpl::EdsClusterImpl(
   Event::Dispatcher& dispatcher = factory_context.mainThreadDispatcher();
   assignment_timeout_ = dispatcher.createTimer([this]() -> void { onAssignmentTimeout(); });
   const auto& eds_config = cluster.eds_cluster_config().eds_config();
-  if (eds_config.config_source_specifier_case() ==
-      envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPath) {
+  if (Config::SubscriptionFactory::isPathBasedConfigSource(
+          eds_config.config_source_specifier_case())) {
     initialize_phase_ = InitializePhase::Primary;
   } else {
     initialize_phase_ = InitializePhase::Secondary;

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -123,6 +123,7 @@ envoy_cc_test(
         "//test/mocks/event:event_mocks",
         "//test/mocks/filesystem:filesystem_mocks",
         "//test/test_common:logging_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
     ],

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -112,9 +112,9 @@ TEST_F(SdsApiTest, InitManagerInitialised) {
                                 Stats::Scope&, Config::SubscriptionCallbacks& cbs,
                                 Config::OpaqueResourceDecoder&,
                                 const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
-        return std::make_unique<Config::FilesystemSubscriptionImpl>(*dispatcher_, sds_config_path,
-                                                                    cbs, resource_decoder, stats,
-                                                                    validation_visitor_, *api_);
+        return std::make_unique<Config::FilesystemSubscriptionImpl>(
+            *dispatcher_, Config::makePathConfigSource(sds_config_path), cbs, resource_decoder,
+            stats, validation_visitor_, *api_);
       }));
 
   auto init_manager = Init::ManagerImpl("testing");

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -92,7 +92,8 @@ resources:
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 )EOF";
   auto response1 =
       TestUtility::parseYaml<envoy::service::discovery::v3::DiscoveryResponse>(response1_yaml);
@@ -264,14 +265,16 @@ resources:
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster2
   type: EDS
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 )EOF";
   auto response1 =
       TestUtility::parseYaml<envoy::service::discovery::v3::DiscoveryResponse>(response1_yaml);
@@ -295,14 +298,16 @@ resources:
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster3
   type: EDS
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 )EOF";
   auto response2 =
       TestUtility::parseYaml<envoy::service::discovery::v3::DiscoveryResponse>(response2_yaml);
@@ -333,14 +338,16 @@ resources:
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster1
   type: EDS
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: eds path
+      path_config_source:
+        path: eds path
 )EOF";
   auto response1 =
       TestUtility::parseYaml<envoy::service::discovery::v3::DiscoveryResponse>(response1_yaml);

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -151,7 +151,6 @@ stats_sinks:
   typed_config:
     "@type": type.googleapis.com/envoy.config.metrics.v3.StatsdSink
     tcp_cluster_name: statsd
-watchdog: {}
 layered_runtime:
   layers:
   - name: root

--- a/test/config/integration/server_unix_listener.yaml
+++ b/test/config/integration/server_unix_listener.yaml
@@ -37,7 +37,6 @@ static_resources:
                 port_value: 0
     dns_lookup_family: V4_ONLY
 cluster_manager: {}
-watchdog: {}
 admin:
   access_log:
   - name: envoy.access_loggers.file

--- a/test/config/integration/server_xds.bootstrap.udpa.yaml
+++ b/test/config/integration/server_xds.bootstrap.udpa.yaml
@@ -2,7 +2,8 @@ dynamic_resources:
   lds_resources_locator: "file:///{{ lds_json_path }}"
   cds_config:
     resource_api_version: V3
-    path: "{{ cds_json_path }}"
+    path_config_source:
+      path: "{{ cds_json_path }}"
 admin:
   access_log:
   - name: envoy.access_loggers.file

--- a/test/config/integration/server_xds.bootstrap.yml
+++ b/test/config/integration/server_xds.bootstrap.yml
@@ -1,10 +1,12 @@
 dynamic_resources:
   lds_config:
     resource_api_version: V3
-    path: "{{ lds_json_path }}"
+    path_config_source:
+      path: "{{ lds_json_path }}"
   cds_config:
     resource_api_version: V3
-    path: "{{ cds_json_path }}"
+    path_config_source:
+      path: "{{ cds_json_path }}"
 admin:
   access_log:
   - name: envoy.access_loggers.file

--- a/test/config/integration/server_xds.cds.with_unknown_field.yaml
+++ b/test/config/integration/server_xds.cds.with_unknown_field.yaml
@@ -7,7 +7,8 @@ resources:
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: "{{ eds_json_path }}"
+      path_config_source:
+        path: "{{ eds_json_path }}"
   lb_policy: ROUND_ROBIN
   typed_extension_protocol_options:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/test/config/integration/server_xds.cds.yaml
+++ b/test/config/integration/server_xds.cds.yaml
@@ -7,7 +7,8 @@ resources:
   eds_cluster_config:
     eds_config:
       resource_api_version: V3
-      path: "{{ eds_json_path }}"
+      path_config_source:
+        path: "{{ eds_json_path }}"
   lb_policy: ROUND_ROBIN
   typed_extension_protocol_options:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/test/config/integration/server_xds.lds.typed_struct.yaml
+++ b/test/config/integration/server_xds.lds.typed_struct.yaml
@@ -20,5 +20,6 @@ resources:
             route_config_name: route_config_0
             config_source:
               resource_api_version: V3
-              path: "{{ rds_json_path }}"
+              path_config_source:
+                path: "{{ rds_json_path }}"
           http_filters: [{name: envoy.filters.http.router}]

--- a/test/config/integration/server_xds.lds.udpa.list_collection.yaml
+++ b/test/config/integration/server_xds.lds.udpa.list_collection.yaml
@@ -24,5 +24,6 @@ resource:
                 route_config_name: route_config_0
                 config_source:
                   resource_api_version: V3
-                  path: "{{ rds_json_path }}"
+                  path_config_source:
+                    path: "{{ rds_json_path }}"
               http_filters: [{name: envoy.filters.http.router}]

--- a/test/config/integration/server_xds.lds.with_unknown_field.typed_struct.yaml
+++ b/test/config/integration/server_xds.lds.with_unknown_field.typed_struct.yaml
@@ -20,6 +20,7 @@ resources:
             route_config_name: route_config_0
             config_source:
               resource_api_version: V3
-              path: "{{ rds_json_path }}"
+              path_config_source:
+                path: "{{ rds_json_path }}"
           http_filters: [{name: envoy.filters.http.router}]
           foo: bar

--- a/test/config/integration/server_xds.lds.with_unknown_field.yaml
+++ b/test/config/integration/server_xds.lds.with_unknown_field.yaml
@@ -19,6 +19,7 @@ resources:
           transport_api_version: V3
           config_source:
             resource_api_version: V3
-            path: "{{ rds_json_path }}"
+            path_config_source:
+              path: "{{ rds_json_path }}"
         http_filters: [{name: envoy.filters.http.router}]
         foo: bar

--- a/test/config/integration/server_xds.lds.yaml
+++ b/test/config/integration/server_xds.lds.yaml
@@ -18,5 +18,6 @@ resources:
           route_config_name: route_config_0
           config_source:
             resource_api_version: V3
-            path: "{{ rds_json_path }}"
+            path_config_source:
+              path: "{{ rds_json_path }}"
         http_filters: [{name: envoy.filters.http.router}]

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -44,7 +44,8 @@ admin:
 dynamic_resources:
   lds_config:
     resource_api_version: V3
-    path: {}
+    path_config_source:
+      path: {}
 static_resources:
   secrets:
   - name: "secret_static_0"
@@ -1330,7 +1331,8 @@ void ConfigHelper::setLds(absl::string_view version_info) {
     resource->PackFrom(listener);
   }
 
-  const std::string lds_filename = bootstrap().dynamic_resources().lds_config().path();
+  const std::string lds_filename =
+      bootstrap().dynamic_resources().lds_config().path_config_source().path();
   std::string file = TestEnvironment::writeStringToFileForTest(
       "new_lds_file", MessageUtil::getJsonStringFromMessageOrDie(lds));
   TestEnvironment::renameFile(file, lds_filename);

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -56,7 +56,10 @@ typed_config:
       // Switch predefined cluster_0 to CDS filesystem sourcing.
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
           envoy::config::core::v3::ApiVersion::V3);
-      bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
+      bootstrap.mutable_dynamic_resources()
+          ->mutable_cds_config()
+          ->mutable_path_config_source()
+          ->set_path(cds_helper_.cds_path());
       bootstrap.mutable_static_resources()->clear_clusters();
     });
 

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -96,12 +96,14 @@ typed_config:
       token_secret:
         name: token
         sds_config:
-          path: "{{ test_tmpdir }}/token_secret.yaml"
+          path_config_source:
+            path: "{{ test_tmpdir }}/token_secret.yaml"
           resource_api_version: V3
       hmac_secret:
         name: hmac
         sds_config:
-          path: "{{ test_tmpdir }}/hmac_secret.yaml"
+          path_config_source:
+            path: "{{ test_tmpdir }}/hmac_secret.yaml"
           resource_api_version: V3
     auth_scopes:
     - user

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -573,7 +573,10 @@ typed_config:
       // Switch predefined cluster_0 to CDS filesystem sourcing.
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
           envoy::config::core::v3::ApiVersion::V3);
-      bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
+      bootstrap.mutable_dynamic_resources()
+          ->mutable_cds_config()
+          ->mutable_path_config_source()
+          ->set_path(cds_helper_.cds_path());
       bootstrap.mutable_static_resources()->clear_clusters();
     });
 

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -32,7 +32,10 @@ public:
       // Switch predefined cluster_0 to CDS filesystem sourcing.
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
           envoy::config::core::v3::ApiVersion::V3);
-      bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
+      bootstrap.mutable_dynamic_resources()
+          ->mutable_cds_config()
+          ->mutable_path_config_source()
+          ->set_path(cds_helper_.cds_path());
       bootstrap.mutable_static_resources()->clear_clusters();
 
       const std::string filter =

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -1292,7 +1292,7 @@ public:
       // Path to EDS for ads_cluster
       const std::string eds_path = TestEnvironment::temporaryFileSubstitute(
           "test/config/integration/server_xds.eds.ads_cluster.yaml", port_map_, version_);
-      ads_cluster_eds_config->set_path(eds_path);
+      ads_cluster_eds_config->mutable_path_config_source()->set_path(eds_path);
       ads_cluster_eds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
 
       // Add EDS static Cluster that uses ADS as config Source.

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -173,7 +173,10 @@ void BaseIntegrationTest::createEnvoy() {
         [lds_path](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
           bootstrap.mutable_dynamic_resources()->mutable_lds_config()->set_resource_api_version(
               envoy::config::core::v3::V3);
-          bootstrap.mutable_dynamic_resources()->mutable_lds_config()->set_path(lds_path);
+          bootstrap.mutable_dynamic_resources()
+              ->mutable_lds_config()
+              ->mutable_path_config_source()
+              ->set_path(lds_path);
         });
   }
 
@@ -185,7 +188,8 @@ void BaseIntegrationTest::createEnvoy() {
   envoy::config::bootstrap::v3::Bootstrap bootstrap = config_helper_.bootstrap();
   if (use_lds_) {
     // After the config has been finalized, write the final listener config to the lds file.
-    const std::string lds_path = config_helper_.bootstrap().dynamic_resources().lds_config().path();
+    const std::string lds_path =
+        config_helper_.bootstrap().dynamic_resources().lds_config().path_config_source().path();
     envoy::service::discovery::v3::DiscoveryResponse lds;
     lds.set_version_info("0");
     for (auto& listener : config_helper_.bootstrap().static_resources().listeners()) {

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -102,7 +102,10 @@ public:
       // Switch predefined cluster_0 to CDS filesystem sourcing.
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
           envoy::config::core::v3::ApiVersion::V3);
-      bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
+      bootstrap.mutable_dynamic_resources()
+          ->mutable_cds_config()
+          ->mutable_path_config_source()
+          ->set_path(cds_helper_.cds_path());
       bootstrap.mutable_static_resources()->clear_clusters();
     });
 
@@ -118,7 +121,8 @@ public:
     auto* eds_cluster_config = cluster_.mutable_eds_cluster_config();
     eds_cluster_config->mutable_eds_config()->set_resource_api_version(
         envoy::config::core::v3::ApiVersion::V3);
-    eds_cluster_config->mutable_eds_config()->set_path(eds_helper_.eds_path());
+    eds_cluster_config->mutable_eds_config()->mutable_path_config_source()->set_path(
+        eds_helper_.eds_path());
     if (http_active_hc) {
       auto* health_check = cluster_.add_health_checks();
       health_check->mutable_timeout()->set_seconds(30);

--- a/test/integration/leds_integration_test.cc
+++ b/test/integration/leds_integration_test.cc
@@ -236,7 +236,10 @@ protected:
       // Remove the static cluster (cluster_0) and set up CDS.
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
           envoy::config::core::v3::ApiVersion::V3);
-      bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
+      bootstrap.mutable_dynamic_resources()
+          ->mutable_cds_config()
+          ->mutable_path_config_source()
+          ->set_path(cds_helper_.cds_path());
       bootstrap.mutable_static_resources()->mutable_clusters()->erase(
           bootstrap.mutable_static_resources()->mutable_clusters()->begin());
 

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -129,7 +129,8 @@ public:
       auto* eds_cluster_config = cluster_0->mutable_eds_cluster_config();
       eds_cluster_config->mutable_eds_config()->set_resource_api_version(
           envoy::config::core::v3::ApiVersion::V3);
-      eds_cluster_config->mutable_eds_config()->set_path(eds_helper_.eds_path());
+      eds_cluster_config->mutable_eds_config()->mutable_path_config_source()->set_path(
+          eds_helper_.eds_path());
       eds_cluster_config->set_service_name("service_name_0");
       if (locality_weighted_lb_) {
         cluster_0->mutable_common_lb_config()->mutable_locality_weighted_lb_config();

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -148,7 +148,15 @@ INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDelta, RtdsIntegrationTest,
 // TODO): The directory rotation via TestEnvironment::renameFile() fails on Windows. The
 // renameFile() implementation does not correctly handle symlinks.
 
-// This test mimics what K8s does when it swaps a ConfigMap.
+// This test mimics what K8s does when it swaps a ConfigMap. The K8s directory structure looks like:
+// 1. ConfigMap mounted to `/config_map/xds`
+// 2. Read data directory `/config_map/xds/real_data`
+// 3. Real file `/config_map/xds/real_data/xds.yaml`
+// 4. Symlink `/config_map/xds/..data` -> `/config_map/xds/real_data`
+// 5. Symlink `/config_map/xds/xds.yaml -> `/config_map/xds/..data/xds.yaml`
+//
+// 2 symlinks are used so that multiple files can be updated in a single atomic swap of ..data to
+// a new real target.
 TEST_P(RtdsIntegrationTest, FileRtdsReload) {
   // Create an initial setup that looks similar to a K8s ConfigMap deployment. This is a file
   // contained in a directory and referenced via an intermediate symlink on the directory.

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -144,6 +144,10 @@ public:
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDelta, RtdsIntegrationTest,
                          DELTA_SOTW_GRPC_CLIENT_INTEGRATION_PARAMS);
 
+#ifndef WIN32
+// TODO): The directory rotation via TestEnvironment::renameFile() fails on Windows. The
+// renameFile() implementation does not correctly handle symlinks.
+
 // This test mimics what K8s does when it swaps a ConfigMap.
 TEST_P(RtdsIntegrationTest, FileRtdsReload) {
   // Create an initial setup that looks similar to a K8s ConfigMap deployment. This is a file
@@ -170,7 +174,9 @@ resources:
     layer->set_name("file_rtds");
     auto* rtds_layer = layer->mutable_rtds_layer();
     rtds_layer->set_name("file_rtds");
-    auto* path_config_source = rtds_layer->mutable_rtds_config()->mutable_path_config_source();
+    auto* rtds_config = rtds_layer->mutable_rtds_config();
+    rtds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+    auto* path_config_source = rtds_config->mutable_path_config_source();
     path_config_source->set_path(temp_path + "/rtds.yaml");
     path_config_source->mutable_watched_directory()->set_path(temp_path);
   });
@@ -200,6 +206,7 @@ resources:
 
   TestEnvironment::removePath(temp_path);
 }
+#endif
 
 TEST_P(RtdsIntegrationTest, RtdsReload) {
   initialize();

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -150,7 +150,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDelta, RtdsIntegrationTest,
 
 // This test mimics what K8s does when it swaps a ConfigMap. The K8s directory structure looks like:
 // 1. ConfigMap mounted to `/config_map/xds`
-// 2. Read data directory `/config_map/xds/real_data`
+// 2. Real data directory `/config_map/xds/real_data`
 // 3. Real file `/config_map/xds/real_data/xds.yaml`
 // 4. Symlink `/config_map/xds/..data` -> `/config_map/xds/real_data`
 // 5. Symlink `/config_map/xds/xds.yaml -> `/config_map/xds/..data/xds.yaml`

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -266,7 +266,7 @@ resources:
 
       auto sds_path =
           TestEnvironment::writeStringToFileForTest("server_cert_ecdsa.sds.yaml", sds_content);
-      config_source->set_path(sds_path);
+      config_source->mutable_path_config_source()->set_path(sds_path);
       config_source->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
     }
   }

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -114,7 +114,8 @@ api_listener:
     type: EDS
     eds_cluster_config:
       eds_config:
-        path: eds path
+        path_config_source:
+          path: eds path
   )EOF";
 
   const envoy::config::listener::v3::Listener config = parseListenerFromV3Yaml(yaml);
@@ -123,7 +124,10 @@ api_listener:
   envoy::config::cluster::v3::Cluster expected_cluster_proto;
   expected_cluster_proto.set_name("cluster1");
   expected_cluster_proto.set_type(envoy::config::cluster::v3::Cluster::EDS);
-  expected_cluster_proto.mutable_eds_cluster_config()->mutable_eds_config()->set_path("eds path");
+  expected_cluster_proto.mutable_eds_cluster_config()
+      ->mutable_eds_config()
+      ->mutable_path_config_source()
+      ->set_path("eds path");
   expected_any_proto.PackFrom(expected_cluster_proto);
   EXPECT_THROW_WITH_MESSAGE(
       HttpApiListener(config, *listener_manager_, config.name()), EnvoyException,


### PR DESCRIPTION
For xDS over the file system, sometimes more control is required over
what directory/file is watched for symbolic link swaps. Specifically,
in order to deliver xDS over a Kubernetes ConfigMap, this extra
configuration is required.

Fixes https://github.com/envoyproxy/envoy/issues/10979

Risk Level: Low, new feature
Testing: Integration test
Docs Changes: Added
Release Notes: Added
Platform Specific Features: N/A
Deprecated: Yes, details added
