### PR TITLE
attributes: add request.query

### DIFF
--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -60,6 +60,7 @@ processing, which makes them suitable for RBAC policies.
    request.time, timestamp, Time of the first byte received
    request.id, string, Request ID corresponding to ``x-request-id`` header value
    request.protocol, string, "Request protocol ('"HTTP/1.0'", '"HTTP/1.1'", '"HTTP/2'", or '"HTTP/3'")"
+   request.query, string, The query portion of the URL in the format of "name1=value1&name2=value2".
 
 Header values in ``request.headers`` associative array are comma-concatenated in case of multiple values.
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -128,6 +128,15 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
       return convertHeaderEntry(headers_.value_->RequestId());
     } else if (value == UserAgent) {
       return convertHeaderEntry(headers_.value_->UserAgent());
+    } else if (value == Query) {
+      absl::string_view path = headers_.value_->getPathValue();
+      auto query_offset = path.find('?');
+      if (query_offset == absl::string_view::npos) {
+        return CelValue::CreateStringView(absl::string_view());
+      }
+      path = path.substr(query_offset + 1);
+      auto fragment_offset = path.find('#');
+      return CelValue::CreateStringView(path.substr(0, fragment_offset));
     }
   }
   return {};

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -23,6 +23,7 @@ using CelValue = google::api::expr::runtime::CelValue;
 using CelProtoWrapper = google::api::expr::runtime::CelProtoWrapper;
 
 // Symbols for traversing the request properties
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Request = "request";
 constexpr absl::string_view Path = "path";
 constexpr absl::string_view UrlPath = "url_path";
@@ -38,8 +39,10 @@ constexpr absl::string_view Size = "size";
 constexpr absl::string_view TotalSize = "total_size";
 constexpr absl::string_view Duration = "duration";
 constexpr absl::string_view Protocol = "protocol";
+constexpr absl::string_view Query = "query";
 
 // Symbols for traversing the response properties
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Response = "response";
 constexpr absl::string_view Code = "code";
 constexpr absl::string_view CodeDetails = "code_details";
@@ -48,12 +51,15 @@ constexpr absl::string_view Flags = "flags";
 constexpr absl::string_view GrpcStatus = "grpc_status";
 
 // Per-request or per-connection metadata
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Metadata = "metadata";
 
 // Per-request or per-connection filter state
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view FilterState = "filter_state";
 
 // Connection properties
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Connection = "connection";
 constexpr absl::string_view MTLS = "mtls";
 constexpr absl::string_view RequestedServerName = "requested_server_name";
@@ -67,14 +73,17 @@ constexpr absl::string_view DNSSanLocalCertificate = "dns_san_local_certificate"
 constexpr absl::string_view DNSSanPeerCertificate = "dns_san_peer_certificate";
 
 // Source properties
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Source = "source";
 constexpr absl::string_view Address = "address";
 constexpr absl::string_view Port = "port";
 
 // Destination properties
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Destination = "destination";
 
 // Upstream properties
+// New symbols must be added to WrapperFieldValues.
 constexpr absl::string_view Upstream = "upstream";
 constexpr absl::string_view UpstreamLocalAddress = "local_address";
 constexpr absl::string_view UpstreamTransportFailureReason = "transport_failure_reason";
@@ -90,7 +99,8 @@ public:
        CelValue::CreateStringView(Headers), CelValue::CreateStringView(Time),
        CelValue::CreateStringView(ID), CelValue::CreateStringView(UserAgent),
        CelValue::CreateStringView(Size), CelValue::CreateStringView(TotalSize),
-       CelValue::CreateStringView(Duration), CelValue::CreateStringView(Protocol)}};
+       CelValue::CreateStringView(Duration), CelValue::CreateStringView(Protocol),
+       CelValue::CreateStringView(Query)}};
   const ContainerBackedListImpl Response{{
       CelValue::CreateStringView(Code),
       CelValue::CreateStringView(CodeDetails),

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -63,7 +63,7 @@ TEST(Context, RequestAttributes) {
   EXPECT_CALL(info, requestComplete()).WillRepeatedly(Return(dur));
   EXPECT_CALL(info, protocol()).WillRepeatedly(Return(Http::Protocol::Http2));
 
-  EXPECT_EQ(14, request.size());
+  EXPECT_EQ(15, request.size());
   EXPECT_FALSE(request.empty());
 
   {
@@ -107,6 +107,13 @@ TEST(Context, RequestAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("/meow", value.value().StringOrDie().value());
+  }
+
+  {
+    auto value = request[CelValue::CreateStringView(Query)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("yes=1", value.value().StringOrDie().value());
   }
 
   {
@@ -236,6 +243,30 @@ TEST(Context, RequestFallbackAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ("/meow", value.value().StringOrDie().value());
+  }
+
+  {
+    auto value = request[CelValue::CreateStringView(Query)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("", value.value().StringOrDie().value());
+  }
+}
+
+TEST(Context, RequestPathFragment) {
+  NiceMock<StreamInfo::MockStreamInfo> info;
+  Http::TestRequestHeaderMapImpl header_map{
+      {":method", "POST"},
+      {":scheme", "http"},
+      {":path", "/meow?page=1&item=3#heading"},
+  };
+  Protobuf::Arena arena;
+  RequestWrapper request(arena, &header_map, info);
+  {
+    auto value = request[CelValue::CreateStringView(Query)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("page=1&item=3", value.value().StringOrDie().value());
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Add ability to get request query from the URL without any decoding as an attribute.
Additional Description:
Risk Level: low (new attribute)
Testing: unit
Docs Changes: yes
Release Notes:
Platform Specific Features:
Fixes: https://github.com/envoyproxy/envoy/issues/19724