### PR TITLE
kafka: handle all request types (requires handling of int64_t)

### DIFF
--- a/contrib/kafka/filters/network/source/protocol/generator.py
+++ b/contrib/kafka/filters/network/source/protocol/generator.py
@@ -128,9 +128,8 @@ class StatefulProcessor:
                     amended = re.sub(r'-2147483648', 'INT32_MIN', without_empty_newlines)
                     message_spec = json.loads(amended)
                     api_key = message_spec['apiKey']
-                    if api_key <= 51 or api_key in [56, 57, 60, 61]:
-                        message = self.parse_top_level_element(message_spec)
-                        messages.append(message)
+                    message = self.parse_top_level_element(message_spec)
+                    messages.append(message)
             except Exception as e:
                 print('could not process %s' % input_file)
                 raise
@@ -201,7 +200,8 @@ class StatefulProcessor:
                 if child is not None:
                     fields.append(child)
             # Some structures share the same name, use request/response as prefix.
-            if type_name in ['EntityData', 'EntryData', 'PartitionData', 'TopicData']:
+            if type_name in ['EntityData', 'EntryData', 'PartitionData', 'PartitionSnapshot',
+                             'SnapshotId', 'TopicData', 'TopicSnapshot']:
                 type_name = self.type.capitalize() + type_name
             # Some of the types repeat multiple times (e.g. AlterableConfig).
             # In such a case, every second or later occurrence of the same name is going to be prefixed
@@ -541,6 +541,8 @@ class Primitive(TypeSpecification):
             'static_cast<int8_t>(8)',
         'int16':
             'static_cast<int16_t>(16)',
+        'uint16':
+            'static_cast<uint16_t>(17)',
         'int32':
             'static_cast<int32_t>(32)',
         'int64':

--- a/contrib/kafka/filters/network/source/serialization.h
+++ b/contrib/kafka/filters/network/source/serialization.h
@@ -1137,6 +1137,14 @@ template <> inline uint32_t EncodingContext::computeCompactSize(const int32_t& a
 }
 
 /**
+ * Template overload for int64_t.
+ * This data type is not compacted, so we just point to non-compact implementation.
+ */
+template <> inline uint32_t EncodingContext::computeCompactSize(const int64_t& arg) const {
+  return computeSize(arg);
+}
+
+/**
  * Template overload for uint32_t.
  * For this data type, we notice that the result's length depends on whether there are any bits set
  * in groups (1-7, 8-14, 15-21, 22-28, 29-32).
@@ -1374,6 +1382,14 @@ inline uint32_t EncodingContext::encodeCompact(const T& arg, Buffer::Instance& d
  */
 template <>
 inline uint32_t EncodingContext::encodeCompact(const int32_t& arg, Buffer::Instance& dst) {
+  return encode(arg, dst);
+}
+
+/**
+ * int64_t is not encoded in compact fashion, so we just delegate to normal implementation.
+ */
+template <>
+inline uint32_t EncodingContext::encodeCompact(const int64_t& arg, Buffer::Instance& dst) {
   return encode(arg, dst);
 }
 

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -6,7 +6,7 @@ Kafka Broker filter
 The Apache Kafka broker filter decodes the client protocol for
 `Apache Kafka <https://kafka.apache.org/>`_, both the requests and responses in the payload.
 The message versions in `Kafka 3.1.0 <http://kafka.apache.org/31/protocol.html#protocol_api_keys>`_
-are supported (apart from API keys 65-67 which were introduced recently).
+are supported.
 The filter attempts not to influence the communication between client and brokers, so the messages
 that could not be decoded (due to Kafka client or broker running a newer version than supported by
 this filter) are forwarded as-is.


### PR DESCRIPTION
Commit Message: kafka: handle all request types (requires handling of int64_t)
Additional Description: add the remaining request types there were missed over the most recent updates.
Risk Level: Low
Testing: integration tests; manual tests (new APIs)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A