### PR TITLE
bazel: copy .bazelversion for envoy filter examples (#18730)

### DIFF
--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -25,6 +25,8 @@ sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter
 mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
 cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
+rm -f "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/.bazelversion
+cp -f "${ENVOY_SRCDIR}"/.bazelversion "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
 cp -f "$(bazel info workspace)"/*.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
 
 export FILTER_WORKSPACE_SET=1


### PR DESCRIPTION
This file needs to be copied otherwise bazelisk picks whichever current
version is out there which could break with any release

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
Signed-off-by: Yan Avlasov <yavlasov@google.com>
