### PR TITLE
Router check tool: add redirect response code validation

### DIFF
--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -152,6 +152,9 @@ validate
   path_redirect
     *(optional, string)* Match the returned redirect path.
 
+  code_redirect
+    *(optional, integer)* Match the redirect response code.
+
   request_header_fields, response_header_fields
     *(optional, array, deprecated)*  Match the listed header fields. Example header fields include the "path", "cookie",
     and "date" fields. The header fields are checked after all other test cases. Thus, the header fields checked

--- a/test/tools/router_check/coverage.cc
+++ b/test/tools/router_check/coverage.cc
@@ -18,7 +18,7 @@ std::vector<bool> RouteCoverage::coverageFields() {
     return std::vector<bool>{cluster_covered_, virtual_cluster_covered_, virtual_host_covered_,
                              path_rewrite_covered_, host_rewrite_covered_};
   } else if (direct_response_entry_ != nullptr) {
-    return std::vector<bool>{redirect_path_covered_};
+    return std::vector<bool>{redirect_path_covered_, redirect_code_covered_};
   } else {
     return std::vector<bool>{};
   }
@@ -46,6 +46,10 @@ void Coverage::markHostRewriteCovered(const Envoy::Router::Route& route) {
 
 void Coverage::markRedirectPathCovered(const Envoy::Router::Route& route) {
   coveredRoute(route).setRedirectPathCovered();
+}
+
+void Coverage::markRedirectCodeCovered(const Envoy::Router::Route& route) {
+  coveredRoute(route).setRedirectCodeCovered();
 }
 
 double Coverage::report() {

--- a/test/tools/router_check/coverage.h
+++ b/test/tools/router_check/coverage.h
@@ -18,6 +18,7 @@ public:
   void setPathRewriteCovered() { path_rewrite_covered_ = true; }
   void setHostRewriteCovered() { host_rewrite_covered_ = true; }
   void setRedirectPathCovered() { redirect_path_covered_ = true; }
+  void setRedirectCodeCovered() { redirect_code_covered_ = true; }
   bool covers(const Envoy::Router::RouteEntry* route) { return route_entry_ == route; }
   bool covers(const Envoy::Router::DirectResponseEntry* route) {
     return direct_response_entry_ == route;
@@ -34,6 +35,7 @@ private:
   bool path_rewrite_covered_{false};
   bool host_rewrite_covered_{false};
   bool redirect_path_covered_{false};
+  bool redirect_code_covered_{false};
   std::vector<bool> coverageFields();
 };
 
@@ -46,6 +48,7 @@ public:
   void markPathRewriteCovered(const Envoy::Router::Route& route);
   void markHostRewriteCovered(const Envoy::Router::Route& route);
   void markRedirectPathCovered(const Envoy::Router::Route& route);
+  void markRedirectCodeCovered(const Envoy::Router::Route& route);
   double report();
   double detailedReport();
 

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -537,7 +537,7 @@ bool RouterCheckTool::matchHeaderField(const HeaderMap& header_map,
   return false;
 }
 
-template<typename U, typename V>
+template <typename U, typename V>
 bool RouterCheckTool::compareResults(const U& actual, const V& expected,
                                      const std::string& test_type, const bool expect_match) {
   if ((expected == actual) != expect_match) {
@@ -547,12 +547,12 @@ bool RouterCheckTool::compareResults(const U& actual, const V& expected,
   return true;
 }
 
-template<typename U, typename V>
+template <typename U, typename V>
 void RouterCheckTool::reportFailure(const U& actual, const V& expected,
                                     const std::string& test_type, const bool expect_match) {
   std::stringstream ss;
-  ss << "expected: [" << expected << "], actual: "
-     << (expect_match ? "" : "NOT ") << "[" << actual << "],"
+  ss << "expected: [" << expected << "], actual: " << (expect_match ? "" : "NOT ") << "[" << actual
+     << "],"
      << " test type: " << test_type;
   tests_.back().second.emplace_back(ss.str());
 }

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -2,12 +2,14 @@
 
 #include <functional>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/route/v3/route.pb.h"
 #include "envoy/type/v3/percent.pb.h"
 
+#include "source/common/common/enum_to_int.h"
 #include "source/common/common/macros.h"
 #include "source/common/common/random_generator.h"
 #include "source/common/network/socket_impl.h"
@@ -263,6 +265,7 @@ bool RouterCheckTool::compareEntries(const std::string& expected_routes) {
         [this](auto&... params) -> bool { return this->compareRewritePath(params...); },
         [this](auto&... params) -> bool { return this->compareRewriteHost(params...); },
         [this](auto&... params) -> bool { return this->compareRedirectPath(params...); },
+        [this](auto&... params) -> bool { return this->compareRedirectCode(params...); },
         [this](auto&... params) -> bool { return this->compareRequestHeaderFields(params...); },
         [this](auto&... params) -> bool { return this->compareResponseHeaderFields(params...); },
     };
@@ -423,6 +426,29 @@ bool RouterCheckTool::compareRedirectPath(
   return compareRedirectPath(tool_config, expected.path_redirect().value());
 }
 
+bool RouterCheckTool::compareRedirectCode(ToolConfig& tool_config, uint32_t expected) {
+  uint32_t actual = 0;
+  if (tool_config.route_->directResponseEntry() != nullptr) {
+    actual = Envoy::enumToInt(tool_config.route_->directResponseEntry()->responseCode());
+  }
+  const bool matches = compareResults(actual, expected, "code_redirect");
+  if (matches && tool_config.route_->directResponseEntry() != nullptr) {
+    coverage_.markRedirectCodeCovered(*tool_config.route_);
+  }
+  return matches;
+}
+
+bool RouterCheckTool::compareRedirectCode(
+    ToolConfig& tool_config, const envoy::RouterCheckToolSchema::ValidationAssert& expected) {
+  if (!expected.has_code_redirect()) {
+    return true;
+  }
+  if (tool_config.route_ == nullptr) {
+    return compareResults(0u, expected.code_redirect().value(), "code_redirect");
+  }
+  return compareRedirectCode(tool_config, expected.code_redirect().value());
+}
+
 bool RouterCheckTool::compareRequestHeaderFields(
     ToolConfig& tool_config, const envoy::RouterCheckToolSchema::ValidationAssert& expected) {
   bool no_failures = true;
@@ -511,7 +537,8 @@ bool RouterCheckTool::matchHeaderField(const HeaderMap& header_map,
   return false;
 }
 
-bool RouterCheckTool::compareResults(const std::string& actual, const std::string& expected,
+template<typename U, typename V>
+bool RouterCheckTool::compareResults(const U& actual, const V& expected,
                                      const std::string& test_type, const bool expect_match) {
   if ((expected == actual) != expect_match) {
     reportFailure(actual, expected, test_type, expect_match);
@@ -520,11 +547,14 @@ bool RouterCheckTool::compareResults(const std::string& actual, const std::strin
   return true;
 }
 
-void RouterCheckTool::reportFailure(const std::string& actual, const std::string& expected,
+template<typename U, typename V>
+void RouterCheckTool::reportFailure(const U& actual, const V& expected,
                                     const std::string& test_type, const bool expect_match) {
-  tests_.back().second.emplace_back("expected: [" + expected + "], " +
-                                    "actual: " + (expect_match ? "" : "NOT ") + "[" + actual +
-                                    "]," + " test type: " + test_type);
+  std::stringstream ss;
+  ss << "expected: [" << expected << "], actual: "
+     << (expect_match ? "" : "NOT ") << "[" << actual << "],"
+     << " test type: " << test_type;
+  tests_.back().second.emplace_back(ss.str());
 }
 
 void RouterCheckTool::printResults() {

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -155,13 +154,13 @@ private:
    * @param expect_match negates the expectation if false.
    * @return bool if actual and expected match.
    */
-  template<typename U, typename V>
-  bool compareResults(const U& actual, const V& expected,
-                      const std::string& test_type, const bool expect_match = true);
+  template <typename U, typename V>
+  bool compareResults(const U& actual, const V& expected, const std::string& test_type,
+                      const bool expect_match = true);
 
-  template<typename U, typename V>
-  void reportFailure(const U& actual, const V& expected,
-                     const std::string& test_type, const bool expect_match = true);
+  template <typename U, typename V>
+  void reportFailure(const U& actual, const V& expected, const std::string& test_type,
+                     const bool expect_match = true);
 
   void printResults();
 

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -134,6 +135,9 @@ private:
   bool compareRedirectPath(ToolConfig& tool_config, const std::string& expected);
   bool compareRedirectPath(ToolConfig& tool_config,
                            const envoy::RouterCheckToolSchema::ValidationAssert& expected);
+  bool compareRedirectCode(ToolConfig& tool_config, uint32_t expected);
+  bool compareRedirectCode(ToolConfig& tool_config,
+                           const envoy::RouterCheckToolSchema::ValidationAssert& expected);
   bool compareRequestHeaderFields(ToolConfig& tool_config,
                                   const envoy::RouterCheckToolSchema::ValidationAssert& expected);
   bool compareResponseHeaderFields(ToolConfig& tool_config,
@@ -151,10 +155,12 @@ private:
    * @param expect_match negates the expectation if false.
    * @return bool if actual and expected match.
    */
-  bool compareResults(const std::string& actual, const std::string& expected,
+  template<typename U, typename V>
+  bool compareResults(const U& actual, const V& expected,
                       const std::string& test_type, const bool expect_match = true);
 
-  void reportFailure(const std::string& actual, const std::string& expected,
+  template<typename U, typename V>
+  void reportFailure(const U& actual, const V& expected,
                      const std::string& test_type, const bool expect_match = true);
 
   void printResults();

--- a/test/tools/router_check/test/config/DirectResponse.golden.proto.json
+++ b/test/tools/router_check/test/config/DirectResponse.golden.proto.json
@@ -9,6 +9,7 @@
       },
       "validate": {
         "path_redirect": "http://lyft.com/ping",
+        "code_redirect": 200,
         "cluster_name": "",
         "host_rewrite": "",
         "path_rewrite": "",
@@ -39,6 +40,7 @@
       },
       "validate": {
         "path_redirect": "http://lyft.com/ping-json",
+        "code_redirect": 200,
         "cluster_name": "",
         "host_rewrite": "",
         "path_rewrite": "",
@@ -69,6 +71,7 @@
       },
       "validate": {
         "path_redirect": "http://lyft.com/ping-json2",
+        "code_redirect": 200,
         "cluster_name": "",
         "host_rewrite": "",
         "path_rewrite": "",
@@ -93,6 +96,7 @@
       },
       "validate": {
         "path_redirect": "http://lyft.com/ping-empty",
+        "code_redirect": 200,
         "cluster_name": "",
         "host_rewrite": "",
         "path_rewrite": "",

--- a/test/tools/router_check/test/config/Redirect4.golden.proto.json
+++ b/test/tools/router_check/test/config/Redirect4.golden.proto.json
@@ -1,0 +1,30 @@
+{
+  "tests": [
+    {
+      "test_name": "Test_1",
+      "input": {
+        "authority": "redirect.lyft.com",
+        "path": "/foo",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "",
+        "path_redirect": "http://new.lyft.com/foo",
+        "code_redirect": 301
+      }
+    },
+    {
+      "test_name": "Test_2",
+      "input": {
+        "authority": "redirect.lyft.com",
+        "path": "/bar",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "",
+        "path_redirect": "http://new.lyft.com/new_bar",
+        "code_redirect": 302
+      }
+    }
+  ]
+}

--- a/test/tools/router_check/test/config/Redirect4.yaml
+++ b/test/tools/router_check/test/config/Redirect4.yaml
@@ -1,0 +1,15 @@
+virtual_hosts:
+- name: redirect
+  domains:
+  - redirect.lyft.com
+  routes:
+  - match:
+      prefix: /foo
+    redirect:
+      host_redirect: new.lyft.com
+  - match:
+      prefix: /bar
+    redirect:
+      host_redirect: new.lyft.com
+      path_redirect: /new_bar
+      response_code: "FOUND"

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -8,7 +8,7 @@ PATH_BIN="${TEST_SRCDIR}/envoy"/test/tools/router_check/router_check_tool
 # Config json path
 PATH_CONFIG="${TEST_SRCDIR}/envoy"/test/tools/router_check/test/config
 
-TESTS=("ContentType" "ClusterHeader" "DirectResponse" "HeaderMatchedRouting" "Redirect" "Redirect2" "Redirect3" "Runtime" "TestRoutes" "Weighted")
+TESTS=("ContentType" "ClusterHeader" "DirectResponse" "HeaderMatchedRouting" "Redirect" "Redirect2" "Redirect3" "Redirect4" "Runtime" "TestRoutes" "Weighted")
 
 # Testing expected matches
 for t in "${TESTS[@]}"

--- a/test/tools/router_check/validation.proto
+++ b/test/tools/router_check/validation.proto
@@ -111,4 +111,7 @@ message ValidationAssert {
   // applicable.
   repeated envoy.config.route.v3.HeaderMatcher request_header_matches = 11;
   repeated envoy.config.route.v3.HeaderMatcher response_header_matches = 12;
+
+  // Match the redirect response code
+  google.protobuf.UInt32Value code_redirect = 13;
 }


### PR DESCRIPTION
Signed-off-by: Zurab Svianadze <zurab@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: A new validation has been added to the router check tool that allows to write tests with redirect response code assertions.
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
