### PR TITLE
Add note about max LC-trie entries to IP tagging / matching docs

### DIFF
--- a/api/envoy/extensions/matching/input_matchers/ip/v3/ip.proto
+++ b/api/envoy/extensions/matching/input_matchers/ip/v3/ip.proto
@@ -23,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <https://www.nada.kth.se/~snilsson/publications/IP-address-lookup-using-LC-tries/>`_
 // by S. Nilsson and G. Karlsson. For "big" lists of IPs, this matcher is more
 // efficient than multiple single IP matcher, that would have a linear cost.
+// Envoy's LC-trie implementation supports up to 262144 unique entries.
 message Ip {
   // Match if the IP belongs to any of these CIDR ranges.
   repeated config.core.v3.CidrRange cidr_ranges = 1 [(validate.rules).repeated = {min_items: 1}];

--- a/docs/root/configuration/http/http_filters/ip_tagging_filter.rst
+++ b/docs/root/configuration/http/http_filters/ip_tagging_filter.rst
@@ -11,7 +11,7 @@ The implementation for IP Tagging provides a scalable way to compare an IP addre
 ranges efficiently. The underlying algorithm for storing tags and IP address subnets is a Level-Compressed trie
 described in the paper `IP-address lookup using
 LC-tries <https://www.nada.kth.se/~snilsson/publications/IP-address-lookup-using-LC-tries/>`_ by S. Nilsson and
-G. Karlsson.
+G. Karlsson. Envoy's LC-trie implementation supports up to 262144 unique entries.
 
 
 Configuration


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add note about max LC-trie entries to IP tagging / matching docs
Additional Description: 
Risk Level: Low
Testing: N/A
Docs Changes: Add note about max LC-trie entries to IP tagging / matching docs
Release Notes: Add note about max LC-trie entries to IP tagging / matching docs
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]


This limit is a result of the address size used for each node in the LC-Trie (20 bits) combined with the default fill_factor of 0.5. This means the maximum number of populated nodes is 2 ^ 20 * 0.5 = 2 ^ 19. However, step 2 in the algorithm for populating the LC-Trie can cause up to 2 * N elements to be populated where N is the number of elements in the input. Thus in practice the maximum number of elements that can be supplied to the Trie by the IP matcher / IP tagging filter is 2 ^ 18 = 262144.

[Relevant code comment](https://github.com/envoyproxy/envoy/blob/81359e48a6d965d2b3630b40bf94fe074d44fa69/source/common/network/lc_trie.h#L61-L65)