### PR TITLE
access log: cleanup arguments in gRPC access log

### DIFF
--- a/source/extensions/access_loggers/common/BUILD
+++ b/source/extensions/access_loggers/common/BUILD
@@ -23,6 +23,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "grpc_access_logger_utils_lib",
+    srcs = ["grpc_access_logger_utils.cc"],
+    hdrs = ["grpc_access_logger_utils.h"],
+    deps = [
+        "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "file_access_log_lib",
     srcs = ["file_access_log_impl.cc"],
     hdrs = ["file_access_log_impl.h"],
@@ -49,6 +58,7 @@ envoy_cc_library(
     name = "grpc_access_logger",
     hdrs = ["grpc_access_logger.h"],
     deps = [
+        ":grpc_access_logger_utils_lib",
         "//envoy/event:dispatcher_interface",
         "//envoy/grpc:async_client_manager_interface",
         "//envoy/singleton:instance_interface",

--- a/source/extensions/access_loggers/common/grpc_access_logger_utils.cc
+++ b/source/extensions/access_loggers/common/grpc_access_logger_utils.cc
@@ -1,0 +1,19 @@
+#include "source/extensions/access_loggers/common/grpc_access_logger_utils.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace AccessLoggers {
+namespace GrpcCommon {
+
+OptRef<const envoy::config::core::v3::RetryPolicy> optionalRetryPolicy(
+    const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config) {
+  if (!config.has_grpc_stream_retry_policy()) {
+    return {};
+  }
+  return config.grpc_stream_retry_policy();
+}
+
+} // namespace GrpcCommon
+} // namespace AccessLoggers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/access_loggers/common/grpc_access_logger_utils.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "envoy/common/optref.h"
+#include "envoy/extensions/access_loggers/grpc/v3/als.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace AccessLoggers {
+namespace GrpcCommon {
+
+OptRef<const envoy::config::core::v3::RetryPolicy> optionalRetryPolicy(
+    const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config);
+
+}
+} // namespace AccessLoggers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
@@ -15,24 +15,13 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace GrpcCommon {
 
-OptRef<const envoy::config::core::v3::RetryPolicy> optionalRetryPolicy(
-    const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config) {
-  if (!config.has_grpc_stream_retry_policy()) {
-    return {};
-  }
-  return config.grpc_stream_retry_policy();
-}
-
 GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
     const Grpc::RawAsyncClientSharedPtr& client,
     const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-    std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
     Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope)
-    : GrpcAccessLogger(std::move(client), buffer_flush_interval_msec, max_buffer_size_bytes,
-                       dispatcher, scope, GRPC_LOG_STATS_PREFIX,
+    : GrpcAccessLogger(std::move(client), config, dispatcher, scope, GRPC_LOG_STATS_PREFIX,
                        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-                           "envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs"),
-                       optionalRetryPolicy(config)),
+                           "envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs")),
       log_name_(config.log_name()), local_info_(local_info) {}
 
 void GrpcAccessLoggerImpl::addEntry(envoy::data::accesslog::v3::HTTPAccessLogEntry&& entry) {
@@ -61,12 +50,8 @@ GrpcAccessLoggerCacheImpl::GrpcAccessLoggerCacheImpl(Grpc::AsyncClientManager& a
 
 GrpcAccessLoggerImpl::SharedPtr GrpcAccessLoggerCacheImpl::createLogger(
     const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-    const Grpc::RawAsyncClientSharedPtr& client,
-    std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
-    Event::Dispatcher& dispatcher) {
-  return std::make_shared<GrpcAccessLoggerImpl>(client, config, buffer_flush_interval_msec,
-                                                max_buffer_size_bytes, dispatcher, local_info_,
-                                                scope_);
+    const Grpc::RawAsyncClientSharedPtr& client, Event::Dispatcher& dispatcher) {
+  return std::make_shared<GrpcAccessLoggerImpl>(client, config, dispatcher, local_info_, scope_);
 }
 
 } // namespace GrpcCommon

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.h
@@ -26,7 +26,6 @@ public:
   GrpcAccessLoggerImpl(
       const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-      std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
       Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope);
 
 private:
@@ -53,9 +52,7 @@ private:
   // Common::GrpcAccessLoggerCache
   GrpcAccessLoggerImpl::SharedPtr
   createLogger(const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-               const Grpc::RawAsyncClientSharedPtr& client,
-               std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
-               Event::Dispatcher& dispatcher) override;
+               const Grpc::RawAsyncClientSharedPtr& client, Event::Dispatcher& dispatcher) override;
 
   const LocalInfo::LocalInfo& local_info_;
 };

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -23,13 +23,10 @@ namespace OpenTelemetry {
 GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
     const Grpc::RawAsyncClientSharedPtr& client,
     const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-    std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
     Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope)
-    : GrpcAccessLogger(client, buffer_flush_interval_msec, max_buffer_size_bytes, dispatcher, scope,
-                       GRPC_LOG_STATS_PREFIX,
+    : GrpcAccessLogger(client, config, dispatcher, scope, GRPC_LOG_STATS_PREFIX,
                        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-                           "opentelemetry.proto.collector.logs.v1.LogsService.Export"),
-                       config.grpc_stream_retry_policy()) {
+                           "opentelemetry.proto.collector.logs.v1.LogsService.Export")) {
   initMessageRoot(config.log_name(), local_info);
 }
 
@@ -76,12 +73,8 @@ GrpcAccessLoggerCacheImpl::GrpcAccessLoggerCacheImpl(Grpc::AsyncClientManager& a
 
 GrpcAccessLoggerImpl::SharedPtr GrpcAccessLoggerCacheImpl::createLogger(
     const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-    const Grpc::RawAsyncClientSharedPtr& client,
-    std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
-    Event::Dispatcher& dispatcher) {
-  return std::make_shared<GrpcAccessLoggerImpl>(client, config, buffer_flush_interval_msec,
-                                                max_buffer_size_bytes, dispatcher, local_info_,
-                                                scope_);
+    const Grpc::RawAsyncClientSharedPtr& client, Event::Dispatcher& dispatcher) {
+  return std::make_shared<GrpcAccessLoggerImpl>(client, config, dispatcher, local_info_, scope_);
 }
 
 } // namespace OpenTelemetry

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
@@ -38,7 +38,6 @@ public:
   GrpcAccessLoggerImpl(
       const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-      std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
       Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope);
 
 private:
@@ -67,9 +66,7 @@ private:
   // Common::GrpcAccessLoggerCache
   GrpcAccessLoggerImpl::SharedPtr
   createLogger(const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-               const Grpc::RawAsyncClientSharedPtr& client,
-               std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
-               Event::Dispatcher& dispatcher) override;
+               const Grpc::RawAsyncClientSharedPtr& client, Event::Dispatcher& dispatcher) override;
 
   const LocalInfo::LocalInfo& local_info_;
 };

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <memory>
 
 #include "envoy/config/core/v3/grpc_service.pb.h"
@@ -71,9 +72,11 @@ public:
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
     EXPECT_CALL(*timer_, enableTimer(_, _));
     *config_.mutable_log_name() = "test_log_name";
-    logger_ = std::make_unique<GrpcAccessLoggerImpl>(Grpc::RawAsyncClientPtr{async_client_},
-                                                     config_, FlushInterval, BUFFER_SIZE_BYTES,
-                                                     dispatcher_, local_info_, stats_store_);
+    config_.mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
+    config_.mutable_buffer_flush_interval()->set_nanos(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(FlushInterval).count());
+    logger_ = std::make_unique<GrpcAccessLoggerImpl>(
+        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, local_info_, stats_store_);
   }
 
   Grpc::MockAsyncClient* async_client_;

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <memory>
 
 #include "envoy/config/core/v3/grpc_service.pb.h"
@@ -81,9 +82,11 @@ public:
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
     EXPECT_CALL(*timer_, enableTimer(_, _));
     *config_.mutable_log_name() = "test_log_name";
-    logger_ = std::make_unique<GrpcAccessLoggerImpl>(Grpc::RawAsyncClientPtr{async_client_},
-                                                     config_, FlushInterval, BUFFER_SIZE_BYTES,
-                                                     dispatcher_, local_info_, stats_store_);
+    config_.mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
+    config_.mutable_buffer_flush_interval()->set_nanos(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(FlushInterval).count());
+    logger_ = std::make_unique<GrpcAccessLoggerImpl>(
+        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, local_info_, stats_store_);
   }
 
   Grpc::MockAsyncClient* async_client_;


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: access log: cleanup arguments in gRPC access log
Additional Description: This refactor is needed to draw proto config around the various classes in access log. 
Risk Level: Low
Testing: N/A
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
