### PR TITLE
examples: Fix flask import

### DIFF
--- a/examples/brotli/Dockerfile-service
+++ b/examples/brotli/Dockerfile-service
@@ -1,11 +1,11 @@
 FROM debian:buster-slim
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y python3 python3-pip \
+    && apt-get install --no-install-recommends -y python3 python3-pip python3-setuptools \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
-RUN pip3 install -q flask
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir -p /code/data
 RUN dd if=/dev/zero of="/code/data/file.txt" bs=1024 count=10240 \
     && dd if=/dev/zero of="/code/data/file.json" bs=1024 count=10240

--- a/examples/cache/Dockerfile-service
+++ b/examples/cache/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1 pyyaml
+RUN pip3 install -q Flask==2.0.3 pyyaml
 RUN mkdir /code
 COPY ./service.py /code
 CMD ["python3", "/code/service.py"]

--- a/examples/cors/backend/Dockerfile-service
+++ b/examples/cors/backend/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir /code
 ADD ./service.py /code/
 

--- a/examples/cors/frontend/Dockerfile-service
+++ b/examples/cors/frontend/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir /code
 ADD ./service.py ./index.html /code/
 

--- a/examples/csrf/crosssite/Dockerfile-service
+++ b/examples/csrf/crosssite/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir /code
 ADD ./crosssite/service.py ./index.html /code/
 CMD ["python3", "/code/service.py"]

--- a/examples/csrf/samesite/Dockerfile-service
+++ b/examples/csrf/samesite/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir /code
 ADD ./samesite/service.py ./index.html /code/
 CMD ["python3", "/code/service.py"]

--- a/examples/double-proxy/Dockerfile-app
+++ b/examples/double-proxy/Dockerfile-app
@@ -1,7 +1,7 @@
 FROM python:3.8-alpine
 
 RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev
-RUN pip3 install -q Flask==0.11.1 requests==2.18.4 psycopg2-binary
+RUN pip3 install -q Flask==2.0.3 requests==2.18.4 psycopg2-binary
 RUN mkdir /code
 ADD ./service.py /code
 ENTRYPOINT ["python3", "/code/service.py"]

--- a/examples/ext_authz/upstream/service/Dockerfile
+++ b/examples/ext_authz/upstream/service/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
 
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 COPY . ./app
 CMD ["python3", "/app/service/server.py"]

--- a/examples/front-proxy/Dockerfile-jaeger-service
+++ b/examples/front-proxy/Dockerfile-jaeger-service
@@ -1,7 +1,7 @@
 FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get -q install --no-install-recommends -y python3-pip curl
-RUN pip3 install -q Flask==0.11.1 requests==2.18.4
+RUN pip3 install -q Flask==2.0.3 requests==2.18.4
 RUN mkdir /code
 ADD ./service.py /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh

--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -1,7 +1,7 @@
 FROM envoyproxy/envoy-dev:latest
 
 RUN apt-get update && apt-get -q install --no-install-recommends -y python3-pip curl
-RUN pip3 install -q Flask==0.11.1 requests==2.18.4
+RUN pip3 install -q Flask==2.0.3 requests==2.18.4
 RUN mkdir /code
 ADD ./service.py /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh

--- a/examples/gzip/Dockerfile-service
+++ b/examples/gzip/Dockerfile-service
@@ -1,11 +1,11 @@
 FROM debian:buster-slim
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y python3 python3-pip \
+    && apt-get install --no-install-recommends -y python3 python3-pip python3-setuptools \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
-RUN pip3 install -q flask
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir -p /code/data
 RUN dd if=/dev/zero of="/code/data/file.txt" bs=1024 count=10240 \
     && dd if=/dev/zero of="/code/data/file.json" bs=1024 count=10240

--- a/examples/load-reporting-service/Dockerfile-http-server
+++ b/examples/load-reporting-service/Dockerfile-http-server
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir /code
 COPY ./service.py ./code
 

--- a/examples/locality-load-balancing/Dockerfile-server
+++ b/examples/locality-load-balancing/Dockerfile-server
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 RUN apk update && apk add py3-pip
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==2.0.3
 RUN mkdir /code
 COPY ./service.py /code
 

--- a/examples/win32-front-proxy/Dockerfile-service
+++ b/examples/win32-front-proxy/Dockerfile-service
@@ -3,7 +3,7 @@ FROM envoyproxy/envoy-windows-dev:latest
 COPY ./setup_python.ps1 /
 
 RUN powershell.exe .\\setup_python.ps1
-RUN pip3 install -q Flask==0.11.1 requests==2.18.4
+RUN pip3 install -q Flask==2.0.3 requests==2.18.4
 
 RUN powershell mkdir code
 ADD ./service.py ./code


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

Currently verify_examples is failing due to a problem with flask dependencies

I tested this with various versions of flask and all below v2 seem to have the problem - i have therefore updated all the examples to current latest 2.0.3

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #20037
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
