### PR TITLE
perf: show benchmark library help in addition to tclap when --help is specfied

### DIFF
--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -64,7 +64,14 @@ int main(int argc, char** argv) {
     cmd.parse(argc, argv);
   } catch (const TCLAP::ExitException& e) {
     // parse() throws an ExitException with status 0 after printing the output
-    // for --help and --version.
+    // for --help and --version. But first pass the args to
+    // benchmark::Initialize to give it a chance to print the benchmark library
+    // help.
+
+    if (contains_help_flag) {
+      ::benchmark::Initialize(&argc, argv);
+    }
+
     return 0;
   }
 


### PR DESCRIPTION
Commit Message: currently running a benchmark binary with `--help` just shows the help for the TCLAP options: `--runtime_feature`, `--skip_expensive_benchmark`, and `--version`, but doesn't tell you about any of the google benchmark library options, such as filtering for which tests to run, or adding a repeat-count with statistical analysis.

This change emits the benchmark help after the tclap help when the user specifies --help.
Additional Description:
Risk Level: low
Testing: just ran a perf test with --help and without
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes: #15076