### PR TITLE
tools: Improve check_format error message for CondVar::waitFor().

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -659,7 +659,7 @@ class FormatChecker:
             if "RealTimeSource" in line or \
               ("RealTimeSystem" in line and not "TestRealTimeSystem" in line) or \
               "std::chrono::system_clock::now" in line or "std::chrono::steady_clock::now" in line or \
-              "std::this_thread::sleep_for" in line or" usleep(" in line or "::usleep(" in line:
+              "std::this_thread::sleep_for" in line or " usleep(" in line or "::usleep(" in line:
                 report_error(
                     "Don't reference real-world time sources; use TimeSystem::advanceTime(Wait|Async)"
                 )
@@ -667,8 +667,7 @@ class FormatChecker:
                 report_error(
                     "Don't use CondVar::waitFor(); use TimeSystem::waitFor() instead.  If this "
                     "already is TimeSystem::waitFor(), please name the TimeSystem variable "
-                    "time_system or time_system_ so the linter can understand."
-                )
+                    "time_system or time_system_ so the linter can understand.")
         duration_arg = DURATION_VALUE_REGEX.search(line)
         if duration_arg and duration_arg.group(1) != "0" and duration_arg.group(1) != "0.0":
             # Matching duration(int-const or float-const) other than zero

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -659,10 +659,15 @@ class FormatChecker:
             if "RealTimeSource" in line or \
               ("RealTimeSystem" in line and not "TestRealTimeSystem" in line) or \
               "std::chrono::system_clock::now" in line or "std::chrono::steady_clock::now" in line or \
-              "std::this_thread::sleep_for" in line or self.has_cond_var_wait_for(line) or \
-              " usleep(" in line or "::usleep(" in line:
+              "std::this_thread::sleep_for" in line or" usleep(" in line or "::usleep(" in line:
                 report_error(
                     "Don't reference real-world time sources; use TimeSystem::advanceTime(Wait|Async)"
+                )
+            if self.has_cond_var_wait_for(line):
+                report_error(
+                    "Don't use CondVar::waitFor(); use TimeSystem::waitFor() instead.  If this "
+                    "already is TimeSystem::waitFor(), please name the TimeSystem variable "
+                    "time_system or time_system_ so the linter can understand."
                 )
         duration_arg = DURATION_VALUE_REGEX.search(line)
         if duration_arg and duration_arg.group(1) != "0" and duration_arg.group(1) != "0.0":

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -174,7 +174,8 @@ def run_checks():
     errors += check_unfixable_error("steady_clock.cc", real_time_inject_error)
     errors += check_unfixable_error(
         "unpack_to.cc", "Don't use UnpackTo() directly, use MessageUtil::unpackTo() instead")
-    errors += check_unfixable_error("condvar_wait_for.cc", "Don't use CondVar::waitFor(); use TimeSystem::waitFor() instead.")
+    errors += check_unfixable_error(
+        "condvar_wait_for.cc", "Don't use CondVar::waitFor(); use TimeSystem::waitFor() instead.")
     errors += check_unfixable_error("sleep.cc", real_time_inject_error)
     errors += check_unfixable_error("std_atomic_free_functions.cc", "std::atomic_*")
     errors += check_unfixable_error("std_get_time.cc", "std::get_time")

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -174,7 +174,7 @@ def run_checks():
     errors += check_unfixable_error("steady_clock.cc", real_time_inject_error)
     errors += check_unfixable_error(
         "unpack_to.cc", "Don't use UnpackTo() directly, use MessageUtil::unpackTo() instead")
-    errors += check_unfixable_error("condvar_wait_for.cc", real_time_inject_error)
+    errors += check_unfixable_error("condvar_wait_for.cc", "Don't use CondVar::waitFor(); use TimeSystem::waitFor() instead.")
     errors += check_unfixable_error("sleep.cc", real_time_inject_error)
     errors += check_unfixable_error("std_atomic_free_functions.cc", "std::atomic_*")
     errors += check_unfixable_error("std_get_time.cc", "std::get_time")


### PR DESCRIPTION
Commit Message: tools: Improve check_format error message for CondVar::waitFor().
Additional Description: This check can have false positives if a TimeSystem variable has a name the linter doesn't expect, so clarify that.
Risk Level: Low
Testing: tools/code_format/check_format.py check (saw only clang-format errors); ./ci/run_envoy_docker.sh './ci/do_ci.sh tooling'
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A