### PR TITLE
http: fix typo in filter manager

### DIFF
--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -78,7 +78,7 @@ void ActiveStreamFilterBase::commonContinue() {
   allowIteration();
 
   // Only resume with do1xxHeaders() if we've actually seen 1xx headers.
-  if (has1xxheaders()) {
+  if (has1xxHeaders()) {
     continued_1xx_headers_ = true;
     do1xxHeaders();
     // If the response headers have not yet come in, don't continue on with
@@ -1542,7 +1542,7 @@ Buffer::InstancePtr& ActiveStreamEncoderFilter::bufferedData() {
   return parent_.buffered_response_data_;
 }
 bool ActiveStreamEncoderFilter::complete() { return parent_.state_.local_complete_; }
-bool ActiveStreamEncoderFilter::has1xxheaders() {
+bool ActiveStreamEncoderFilter::has1xxHeaders() {
   return parent_.state_.has_1xx_headers_ && !continued_1xx_headers_;
 }
 void ActiveStreamEncoderFilter::do1xxHeaders() {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -118,7 +118,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   virtual Buffer::InstancePtr createBuffer() PURE;
   virtual Buffer::InstancePtr& bufferedData() PURE;
   virtual bool complete() PURE;
-  virtual bool has1xxheaders() PURE;
+  virtual bool has1xxHeaders() PURE;
   virtual void do1xxHeaders() PURE;
   virtual void doHeaders(bool end_stream) PURE;
   virtual void doData(bool end_stream) PURE;
@@ -226,7 +226,7 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
   Buffer::InstancePtr createBuffer() override;
   Buffer::InstancePtr& bufferedData() override;
   bool complete() override;
-  bool has1xxheaders() override { return false; }
+  bool has1xxHeaders() override { return false; }
   void do1xxHeaders() override { IS_ENVOY_BUG("unexpected 1xx headers"); }
   void doHeaders(bool end_stream) override;
   void doData(bool end_stream) override;
@@ -321,7 +321,7 @@ struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
   Buffer::InstancePtr createBuffer() override;
   Buffer::InstancePtr& bufferedData() override;
   bool complete() override;
-  bool has1xxheaders() override;
+  bool has1xxHeaders() override;
   void do1xxHeaders() override;
   void doHeaders(bool end_stream) override;
   void doData(bool end_stream) override;


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: http: fix typo in filter manager
Additional Description: the method name has1xxheaders does not comply with the camel case naming convention and should be has1xxHeaders like the following method do1xxHeaders
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
