### PR TITLE
code_format: fix path matching

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1084,10 +1084,10 @@ class FormatChecker:
 
 def normalize_path(path):
     """Convert path to form ./path/to/dir/ for directories and ./path/to/file otherwise"""
-    isdir = os.path.isdir(args.target_path)
     if not path.startswith("./"):
         path = "./" + path
 
+    isdir = os.path.isdir(path)
     if isdir and not path.endswith("/"):
         path += "/"
 


### PR DESCRIPTION
**Commit Message:** This change fixes an issue in the code formatter where explicitly
excluded paths are incorrectly matched when the script is provided
arguments that do not start with './' or that end with a trailing
slash.

To address this issue this change normalizes paths before checking
if the path is excluded.

**Additional Description:** I think the core issue here is the use of direct string matching for excluded files. Refactoring to address the root cause is out of scope for this change, but will likely need to be done in the future.

**Risk Level:** low

**Testing:** Ran code format with arguments of the form 'path/to/dir' and './path/to/dir/', verifying that excluded files are not formatted as expected.

**Docs Changes:** n/a
**Release Notes:** n/a
**Platform Specific Features:** n/a
**Fixes:** #20077