### PR TITLE
sip-proxy: get load address from context localInfo

### DIFF
--- a/contrib/sip_proxy/filters/network/source/BUILD
+++ b/contrib/sip_proxy/filters/network/source/BUILD
@@ -56,7 +56,6 @@ envoy_cc_library(
         "//envoy/event:dispatcher_interface",
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
-        "//envoy/server:transport_socket_config_interface",
         "//envoy/stats:stats_interface",
         "//envoy/stats:timespan_interface",
         "//source/common/buffer:buffer_lib",
@@ -127,6 +126,8 @@ envoy_cc_library(
     deps = [
         ":utility_interface",
         "//contrib/sip_proxy/filters/network/source/filters:filter_interface",
+        "//envoy/server:factory_context_interface",
+        "//envoy/server:transport_socket_config_interface",
     ],
 )
 

--- a/contrib/sip_proxy/filters/network/source/BUILD
+++ b/contrib/sip_proxy/filters/network/source/BUILD
@@ -56,6 +56,7 @@ envoy_cc_library(
         "//envoy/event:dispatcher_interface",
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
+        "//envoy/server:transport_socket_config_interface",
         "//envoy/stats:stats_interface",
         "//envoy/stats:timespan_interface",
         "//source/common/buffer:buffer_lib",

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -231,7 +231,7 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectRe
 
   Buffer::OwnedImpl buffer;
 
-  metadata.setEP(getLocalIp());
+  metadata.setEP(localAddress());
   const DirectResponse::ResponseType result = response.encode(metadata, buffer);
 
   read_callbacks_->connection().write(buffer, end_stream);
@@ -348,7 +348,7 @@ FilterStatus ConnectionManager::ResponseDecoder::transportEnd() {
 
   Buffer::OwnedImpl buffer;
 
-  metadata_->setEP(getLocalIp());
+  metadata_->setEP(cm.localAddress());
   std::shared_ptr<Encoder> encoder = std::make_shared<EncoderImpl>();
 
   encoder->encode(metadata_, buffer);

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -231,7 +231,7 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectRe
 
   Buffer::OwnedImpl buffer;
 
-  metadata.setEP(localAddress());
+  metadata.setEP(Utility::localAddress(context_));
   const DirectResponse::ResponseType result = response.encode(metadata, buffer);
 
   read_callbacks_->connection().write(buffer, end_stream);
@@ -348,7 +348,7 @@ FilterStatus ConnectionManager::ResponseDecoder::transportEnd() {
 
   Buffer::OwnedImpl buffer;
 
-  metadata_->setEP(cm.localAddress());
+  metadata_->setEP(Utility::localAddress(cm.context_));
   std::shared_ptr<Encoder> encoder = std::make_shared<EncoderImpl>();
 
   encoder->encode(metadata_, buffer);

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -5,7 +5,6 @@
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
-#include "envoy/server/transport_socket_config.h"
 #include "envoy/stats/timespan.h"
 #include "envoy/upstream/upstream.h"
 
@@ -337,12 +336,6 @@ private:
   void sendLocalReply(MessageMetadata& metadata, const DirectResponse& response, bool end_stream);
   void doDeferredTransDestroy(ActiveTrans& trans);
   void resetAllTrans(bool local_reset);
-  absl::string_view localAddress() {
-    auto& local_address =
-        context_.getTransportSocketFactoryContext().localInfo().address()->ip()->addressAsString();
-    ENVOY_LOG(debug, "localAddress {}", local_address);
-    return local_address;
-  }
 
   Config& config_;
   SipFilterStats& stats_;

--- a/contrib/sip_proxy/filters/network/source/decoder.h
+++ b/contrib/sip_proxy/filters/network/source/decoder.h
@@ -92,7 +92,6 @@ public:
    * @return DecoderEventHandler& a new DecoderEventHandler for a message.
    */
   virtual DecoderEventHandler& newDecoderEventHandler(MessageMetadataSharedPtr metadata) PURE;
-  virtual absl::string_view getLocalIp() PURE;
   virtual std::shared_ptr<SipSettings> settings() const PURE;
 };
 

--- a/contrib/sip_proxy/filters/network/source/router/BUILD
+++ b/contrib/sip_proxy/filters/network/source/router/BUILD
@@ -49,7 +49,6 @@ envoy_cc_library(
         "//contrib/sip_proxy/filters/network/source/filters:filter_interface",
         "//contrib/sip_proxy/filters/network/source/filters:well_known_names",
         "//contrib/sip_proxy/filters/network/source/tra:tra_lib",
-        "//envoy/server:transport_socket_config_interface",
         "//envoy/tcp:conn_pool_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//envoy/upstream:load_balancer_interface",

--- a/contrib/sip_proxy/filters/network/source/router/BUILD
+++ b/contrib/sip_proxy/filters/network/source/router/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
         "//contrib/sip_proxy/filters/network/source/filters:filter_interface",
         "//contrib/sip_proxy/filters/network/source/filters:well_known_names",
         "//contrib/sip_proxy/filters/network/source/tra:tra_lib",
+        "//envoy/server:transport_socket_config_interface",
         "//envoy/tcp:conn_pool_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//envoy/upstream:load_balancer_interface",

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -428,8 +428,8 @@ FilterStatus Router::messageEnd() {
   Buffer::OwnedImpl transport_buffer;
 
   // set EP/Opaque, used in upstream
-  ENVOY_STREAM_LOG(debug, "set EP {}", *callbacks_, upstream_request_->localAddress());
-  metadata_->setEP(upstream_request_->localAddress());
+  ENVOY_STREAM_LOG(debug, "set EP {}", *callbacks_, localAddress());
+  metadata_->setEP(localAddress());
 
   std::shared_ptr<Encoder> encoder = std::make_shared<EncoderImpl>();
   ENVOY_STREAM_LOG(debug, "before encode", *callbacks_);
@@ -658,8 +658,6 @@ FilterStatus ResponseDecoder::transportBegin(MessageMetadataSharedPtr metadata) 
 
   return FilterStatus::Continue;
 }
-
-absl::string_view ResponseDecoder::getLocalIp() { return parent_.localAddress(); }
 
 std::shared_ptr<SipSettings> ResponseDecoder::settings() const { return parent_.settings(); }
 

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -428,8 +428,8 @@ FilterStatus Router::messageEnd() {
   Buffer::OwnedImpl transport_buffer;
 
   // set EP/Opaque, used in upstream
-  ENVOY_STREAM_LOG(debug, "set EP {}", *callbacks_, localAddress());
-  metadata_->setEP(localAddress());
+  ENVOY_STREAM_LOG(debug, "set EP {}", *callbacks_, Utility::localAddress(context_));
+  metadata_->setEP(Utility::localAddress(context_));
 
   std::shared_ptr<Encoder> encoder = std::make_shared<EncoderImpl>();
   ENVOY_STREAM_LOG(debug, "before encode", *callbacks_);

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.h
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "envoy/router/router.h"
-#include "envoy/server/transport_socket_config.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/tcp/conn_pool.h"
@@ -293,13 +292,6 @@ private:
 
   QueryStatus handleCustomizedAffinity(std::string type, std::string key,
                                        MessageMetadataSharedPtr metadata);
-
-  absl::string_view localAddress() {
-    auto& local_address =
-        context_.getTransportSocketFactoryContext().localInfo().address()->ip()->addressAsString();
-    ENVOY_LOG(debug, "localAddress {}", local_address);
-    return local_address;
-  }
 
   Upstream::ClusterManager& cluster_manager_;
   RouterStats stats_;

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.h
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/router/router.h"
+#include "envoy/server/transport_socket_config.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/tcp/conn_pool.h"
@@ -293,6 +294,13 @@ private:
   QueryStatus handleCustomizedAffinity(std::string type, std::string key,
                                        MessageMetadataSharedPtr metadata);
 
+  absl::string_view localAddress() {
+    auto& local_address =
+        context_.getTransportSocketFactoryContext().localInfo().address()->ip()->addressAsString();
+    ENVOY_LOG(debug, "localAddress {}", local_address);
+    return local_address;
+  }
+
   Upstream::ClusterManager& cluster_manager_;
   RouterStats stats_;
 
@@ -333,7 +341,6 @@ public:
     UNREFERENCED_PARAMETER(metadata);
     return *this;
   }
-  absl::string_view getLocalIp() override;
   std::shared_ptr<SipSettings> settings() const override;
 
 private:
@@ -379,14 +386,6 @@ public:
   void setConnectionState(ConnectionState state) { conn_state_ = state; }
   void write(Buffer::Instance& data, bool end_stream) {
     return conn_data_->connection().write(data, end_stream);
-  }
-
-  absl::string_view localAddress() {
-    return conn_data_->connection()
-        .connectionInfoProvider()
-        .localAddress()
-        ->ip()
-        ->addressAsString();
   }
 
   std::shared_ptr<TransactionInfo> transactionInfo() { return transaction_info_; }

--- a/contrib/sip_proxy/filters/network/source/utility.h
+++ b/contrib/sip_proxy/filters/network/source/utility.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/server/transport_socket_config.h"
 
 #include "source/common/protobuf/protobuf.h"
 
@@ -134,6 +136,17 @@ public:
       const std::string& type, const std::string& key,
       std::function<void(MessageMetadataSharedPtr, DecoderEventHandler&)> func) PURE;
   virtual void eraseActiveTransFromPendingList(std::string& transaction_id) PURE;
+};
+
+class Utility {
+public:
+  static const std::string& localAddress(Server::Configuration::FactoryContext& context) {
+    return context.getTransportSocketFactoryContext()
+        .localInfo()
+        .address()
+        ->ip()
+        ->addressAsString();
+  }
 };
 
 } // namespace SipProxy

--- a/contrib/sip_proxy/filters/network/test/conn_manager_test.cc
+++ b/contrib/sip_proxy/filters/network/test/conn_manager_test.cc
@@ -46,7 +46,11 @@ class SipConnectionManagerTest : public testing::Test {
 public:
   SipConnectionManagerTest()
       : stats_(SipFilterStats::generateStats("test.", store_)),
-        transaction_infos_(std::make_shared<Router::TransactionInfos>()) {}
+        transaction_infos_(std::make_shared<Router::TransactionInfos>()) {
+    EXPECT_CALL(context_, getTransportSocketFactoryContext())
+        .WillRepeatedly(testing::ReturnRef(factory_context_));
+    EXPECT_CALL(factory_context_, localInfo()).WillRepeatedly(testing::ReturnRef(local_info_));
+  }
   ~SipConnectionManagerTest() override {
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
   }
@@ -440,6 +444,8 @@ settings:
     decoder->onReset();
   }
 
+  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   std::shared_ptr<SipFilters::MockDecoderFilter> decoder_filter_;
   Stats::TestUtil::TestStore store_;

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -32,7 +32,6 @@ MockDecoderCallbacks::MockDecoderCallbacks() {
   service1.set_domain("pcsf-cfed.cncs.svc.cluster.local");
   local_services_.emplace_back(service1);
   local_services_.emplace_back(service2); */
-  ON_CALL(*this, getLocalIp()).WillByDefault(Return("127.0.0.1"));
 }
 MockDecoderCallbacks::~MockDecoderCallbacks() = default;
 

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -54,7 +54,6 @@ public:
 
   // SipProxy::DecoderCallbacks
   MOCK_METHOD(DecoderEventHandler&, newDecoderEventHandler, (MessageMetadataSharedPtr));
-  MOCK_METHOD(absl::string_view, getLocalIp, ());
   MOCK_METHOD(std::string, getDomainMatchParamName, ());
   MOCK_METHOD(void, setMetadata, (MessageMetadataSharedPtr metadata));
   MOCK_METHOD(std::shared_ptr<SipSettings>, settings, (), (const));


### PR DESCRIPTION
Signed-off-by: Felix Du <durd07@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: sip-proxy: get load address from context localInfo
Additional Description: Use the unique service ip from localinfo instead of connection info
Risk Level: Low
Testing: Ut/Mt
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
