### PR TITLE
conn pool: refactor connecting capacity accounting

### DIFF
--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -605,8 +605,9 @@ void ConnPoolImplBase::onPendingStreamCancel(PendingStream& stream,
 void ConnPoolImplBase::decrConnectingAndConnectedStreamCapacity(uint32_t delta,
                                                                 ActiveClient& client) {
   state_.decrConnectingAndConnectedStreamCapacity(delta);
-  if (client.isContributingToConnectingStreamCapacity()) {
-    // If connecting, update the local connecting capacity as well.
+  if (!client.hasHandshakeCompleted()) {
+    // If still doing handshake, it is contributing to the local connecting stream capacity. Update
+    // the capacity as well.
     ASSERT(connecting_stream_capacity_ >= delta);
     connecting_stream_capacity_ -= delta;
   }
@@ -615,7 +616,7 @@ void ConnPoolImplBase::decrConnectingAndConnectedStreamCapacity(uint32_t delta,
 void ConnPoolImplBase::incrConnectingAndConnectedStreamCapacity(uint32_t delta,
                                                                 ActiveClient& client) {
   state_.incrConnectingAndConnectedStreamCapacity(delta);
-  if (client.isContributingToConnectingStreamCapacity()) {
+  if (!client.hasHandshakeCompleted()) {
     connecting_stream_capacity_ += delta;
   }
 }

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -605,7 +605,7 @@ void ConnPoolImplBase::onPendingStreamCancel(PendingStream& stream,
 void ConnPoolImplBase::decrConnectingAndConnectedStreamCapacity(uint32_t delta,
                                                                 ActiveClient& client) {
   state_.decrConnectingAndConnectedStreamCapacity(delta);
-  if (client.isConnecting()) {
+  if (client.isContributingToConnectingStreamCapacity()) {
     // If connecting, update the local connecting capacity as well.
     ASSERT(connecting_stream_capacity_ >= delta);
     connecting_stream_capacity_ -= delta;
@@ -615,7 +615,7 @@ void ConnPoolImplBase::decrConnectingAndConnectedStreamCapacity(uint32_t delta,
 void ConnPoolImplBase::incrConnectingAndConnectedStreamCapacity(uint32_t delta,
                                                                 ActiveClient& client) {
   state_.incrConnectingAndConnectedStreamCapacity(delta);
-  if (client.isConnecting()) {
+  if (client.isContributingToConnectingStreamCapacity()) {
     connecting_stream_capacity_ += delta;
   }
 }

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -428,8 +428,10 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
       event == Network::ConnectionEvent::LocalClose) {
     decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity(), client);
     if (client.connect_timer_) {
+      ASSERT(!client.has_handshake_completed_);
       client.connect_timer_->disableTimer();
       client.connect_timer_.reset();
+      client.has_handshake_completed_ = true;
     }
     // Make sure that onStreamClosed won't double count.
     client.remaining_streams_ = 0;
@@ -507,6 +509,8 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     connecting_stream_capacity_ -= client.currentUnusedCapacity();
     client.connect_timer_->disableTimer();
     client.connect_timer_.reset();
+    ASSERT(!client.has_handshake_completed_);
+    client.has_handshake_completed_ = true;
     client.conn_connect_ms_->complete();
     client.conn_connect_ms_.reset();
     ASSERT(client.state() == ActiveClient::State::CONNECTING);

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -606,6 +606,7 @@ void ConnPoolImplBase::decrConnectingAndConnectedStreamCapacity(uint32_t delta,
                                                                 ActiveClient& client) {
   state_.decrConnectingAndConnectedStreamCapacity(delta);
   if (client.isConnecting()) {
+    // If connecting, update the local connecting capacity as well.
     ASSERT(connecting_stream_capacity_ >= delta);
     connecting_stream_capacity_ -= delta;
   }

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -13,7 +13,7 @@ namespace {
 [[maybe_unused]] ssize_t connectingCapacity(const std::list<ActiveClientPtr>& connecting_clients) {
   ssize_t ret = 0;
   for (const auto& client : connecting_clients) {
-    ret += client->effectiveConcurrentStreamLimit();
+    ret += client->currentUnusedCapacity();
   }
   return ret;
 }
@@ -150,11 +150,10 @@ ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
     }
     ASSERT(client->state() == ActiveClient::State::CONNECTING);
     ASSERT(std::numeric_limits<uint64_t>::max() - connecting_stream_capacity_ >=
-           client->effectiveConcurrentStreamLimit());
+           static_cast<uint64_t>(client->currentUnusedCapacity()));
     ASSERT(client->real_host_description_);
     // Increase the connecting capacity to reflect the streams this connection can serve.
-    state_.incrConnectingAndConnectedStreamCapacity(client->effectiveConcurrentStreamLimit());
-    connecting_stream_capacity_ += client->effectiveConcurrentStreamLimit();
+    incrConnectingAndConnectedStreamCapacity(client->currentUnusedCapacity(), *client);
     LinkedList::moveIntoList(std::move(client), owningList(client->state()));
     return can_create_connection ? ConnectionResult::CreatedNewConnection
                                  : ConnectionResult::CreatedButRateLimited;
@@ -192,7 +191,7 @@ void ConnPoolImplBase::attachStreamToClient(Envoy::ConnectionPool::ActiveClient&
   // Decrement the capacity, as there's one less stream available for serving.
   // For HTTP/3, the capacity is updated in newStreamEncoder.
   if (trackStreamCapacity()) {
-    state_.decrConnectingAndConnectedStreamCapacity(1);
+    decrConnectingAndConnectedStreamCapacity(1, client);
   }
   // Track the new active stream.
   state_.incrActiveStreams(1);
@@ -227,7 +226,7 @@ void ConnPoolImplBase::onStreamClosed(Envoy::ConnectionPool::ActiveClient& clien
     // to avoid overflow.
     bool negative_capacity = client.concurrent_stream_limit_ < client.numActiveStreams() + 1;
     if (negative_capacity || limited_by_concurrency) {
-      state_.incrConnectingAndConnectedStreamCapacity(1);
+      incrConnectingAndConnectedStreamCapacity(1, client);
     }
   }
   if (client.state() == ActiveClient::State::DRAINING && client.numActiveStreams() == 0) {
@@ -425,19 +424,13 @@ void ConnPoolImplBase::checkForIdleAndCloseIdleConnsIfDraining() {
 
 void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view failure_reason,
                                          Network::ConnectionEvent event) {
-  if (client.state() == ActiveClient::State::CONNECTING) {
-    ASSERT(connecting_stream_capacity_ >= client.effectiveConcurrentStreamLimit());
-    connecting_stream_capacity_ -= client.effectiveConcurrentStreamLimit();
-  }
-
-  if (client.connect_timer_) {
-    client.connect_timer_->disableTimer();
-    client.connect_timer_.reset();
-  }
-
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-    state_.decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity());
+    decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity(), client);
+    if (client.connect_timer_) {
+      client.connect_timer_->disableTimer();
+      client.connect_timer_.reset();
+    }
     // Make sure that onStreamClosed won't double count.
     client.remaining_streams_ = 0;
     // The client died.
@@ -510,6 +503,10 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
       tryCreateNewConnections();
     }
   } else if (event == Network::ConnectionEvent::Connected) {
+    ASSERT(connecting_stream_capacity_ >= client.currentUnusedCapacity());
+    connecting_stream_capacity_ -= client.currentUnusedCapacity();
+    client.connect_timer_->disableTimer();
+    client.connect_timer_.reset();
     client.conn_connect_ms_->complete();
     client.conn_connect_ms_.reset();
     ASSERT(client.state() == ActiveClient::State::CONNECTING);
@@ -568,8 +565,7 @@ void ConnPoolImplBase::purgePendingStreams(
 }
 
 bool ConnPoolImplBase::connectingConnectionIsExcess() const {
-  ASSERT(connecting_stream_capacity_ >=
-         connecting_clients_.front()->effectiveConcurrentStreamLimit());
+  ASSERT(connecting_stream_capacity_ >= connecting_clients_.front()->currentUnusedCapacity());
   // If perUpstreamPreconnectRatio is one, this simplifies to checking if there would still be
   // sufficient connecting stream capacity to serve all pending streams if the most recent client
   // were removed from the picture.
@@ -578,8 +574,8 @@ bool ConnPoolImplBase::connectingConnectionIsExcess() const {
   // streams and active streams, and makes sure the connecting capacity would still be sufficient to
   // serve that even with the most recent client removed.
   return (pending_streams_.size() + num_active_streams_) * perUpstreamPreconnectRatio() <=
-         (connecting_stream_capacity_ -
-          connecting_clients_.front()->effectiveConcurrentStreamLimit() + num_active_streams_);
+         (connecting_stream_capacity_ - connecting_clients_.front()->currentUnusedCapacity() +
+          num_active_streams_);
 }
 
 void ConnPoolImplBase::onPendingStreamCancel(PendingStream& stream,
@@ -604,6 +600,23 @@ void ConnPoolImplBase::onPendingStreamCancel(PendingStream& stream,
 
   host_->cluster().stats().upstream_rq_cancelled_.inc();
   checkForIdleAndCloseIdleConnsIfDraining();
+}
+
+void ConnPoolImplBase::decrConnectingAndConnectedStreamCapacity(uint32_t delta,
+                                                                ActiveClient& client) {
+  state_.decrConnectingAndConnectedStreamCapacity(delta);
+  if (client.isConnecting()) {
+    ASSERT(connecting_stream_capacity_ >= delta);
+    connecting_stream_capacity_ -= delta;
+  }
+}
+
+void ConnPoolImplBase::incrConnectingAndConnectedStreamCapacity(uint32_t delta,
+                                                                ActiveClient& client) {
+  state_.incrConnectingAndConnectedStreamCapacity(delta);
+  if (client.isConnecting()) {
+    connecting_stream_capacity_ += delta;
+  }
 }
 
 namespace {
@@ -685,13 +698,7 @@ void ActiveClient::drain() {
   if (currentUnusedCapacity() <= 0) {
     return;
   }
-  if (state() == ActiveClient::State::CONNECTING) {
-    // If connecting, update both the cluster capacity and the local connecting
-    // capacity.
-    parent_.decrConnectingAndConnectedStreamCapacity(currentUnusedCapacity());
-  } else {
-    parent_.state().decrConnectingAndConnectedStreamCapacity(currentUnusedCapacity());
-  }
+  parent_.decrConnectingAndConnectedStreamCapacity(currentUnusedCapacity(), *this);
 
   remaining_streams_ = 0;
 }

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -102,6 +102,8 @@ public:
   // Sets the remaining streams to 0, and updates pool and cluster capacity.
   virtual void drain();
 
+  bool isConnecting() const { return connect_timer_ != nullptr; }
+
   ConnPoolImplBase& parent_;
   // The count of remaining streams allowed for this connection.
   // This will start out as the total number of streams per connection if capped
@@ -275,16 +277,8 @@ public:
   }
   Upstream::ClusterConnectivityState& state() { return state_; }
 
-  void decrConnectingAndConnectedStreamCapacity(uint32_t delta) {
-    state_.decrConnectingAndConnectedStreamCapacity(delta);
-    ASSERT(connecting_stream_capacity_ >= delta);
-    connecting_stream_capacity_ -= delta;
-  }
-
-  void incrConnectingAndConnectedStreamCapacity(uint32_t delta) {
-    state_.incrConnectingAndConnectedStreamCapacity(delta);
-    connecting_stream_capacity_ += delta;
-  }
+  void decrConnectingAndConnectedStreamCapacity(uint32_t delta, ActiveClient& client);
+  void incrConnectingAndConnectedStreamCapacity(uint32_t delta, ActiveClient& client);
 
   // Called when an upstream is ready to serve pending streams.
   void onUpstreamReady();

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -102,9 +102,7 @@ public:
   // Sets the remaining streams to 0, and updates pool and cluster capacity.
   virtual void drain();
 
-  virtual bool isContributingToConnectingStreamCapacity() const {
-    return state_ == State::CONNECTING;
-  }
+  virtual bool hasHandshakeCompleted() const { return state_ != State::CONNECTING; }
 
   ConnPoolImplBase& parent_;
   // The count of remaining streams allowed for this connection.

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -126,6 +126,8 @@ public:
   Event::TimerPtr connection_duration_timer_;
   bool resources_released_{false};
   bool timed_out_{false};
+  // TODO(danzh) remove this once http codec exposes the handshake state for h3.
+  bool has_handshake_completed_{false};
 
 private:
   State state_{State::CONNECTING};

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -102,7 +102,9 @@ public:
   // Sets the remaining streams to 0, and updates pool and cluster capacity.
   virtual void drain();
 
-  bool isConnecting() const { return connect_timer_ != nullptr; }
+  virtual bool isContributingToConnectingStreamCapacity() const {
+    return state_ == State::CONNECTING;
+  }
 
   ConnPoolImplBase& parent_;
   // The count of remaining streams allowed for this connection.

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -55,7 +55,7 @@ public:
 
   // Overridden to return true as long as the client is doing handshake even when it is ready for
   // early data streams.
-  bool hasHandshakeCompleted() const override { return connect_timer_ == nullptr; }
+  bool hasHandshakeCompleted() const override { return has_handshake_completed_; }
 
   void updateCapacity(uint64_t new_quiche_capacity) {
     // Each time we update the capacity make sure to reflect the update in the

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -53,6 +53,12 @@ public:
     return std::min<int64_t>(quiche_capacity_, effectiveConcurrentStreamLimit());
   }
 
+  // Overridden to return true as long as the client is doing handshake even when it is ready for
+  // early data streams.
+  bool isContributingToConnectingStreamCapacity() const override {
+    return connect_timer_ != nullptr;
+  }
+
   void updateCapacity(uint64_t new_quiche_capacity) {
     // Each time we update the capacity make sure to reflect the update in the
     // connection pool.

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -55,9 +55,7 @@ public:
 
   // Overridden to return true as long as the client is doing handshake even when it is ready for
   // early data streams.
-  bool isContributingToConnectingStreamCapacity() const override {
-    return connect_timer_ != nullptr;
-  }
+  bool hasHandshakeCompleted() const override { return connect_timer_ == nullptr; }
 
   void updateCapacity(uint64_t new_quiche_capacity) {
     // Each time we update the capacity make sure to reflect the update in the

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -66,18 +66,10 @@ public:
     quiche_capacity_ = new_quiche_capacity;
     uint64_t new_capacity = currentUnusedCapacity();
 
-    if (connect_timer_) {
-      if (new_capacity < old_capacity) {
-        parent_.decrConnectingAndConnectedStreamCapacity(old_capacity - new_capacity);
-      } else if (old_capacity < new_capacity) {
-        parent_.incrConnectingAndConnectedStreamCapacity(new_capacity - old_capacity);
-      }
-    } else {
-      if (new_capacity < old_capacity) {
-        parent_.decrClusterStreamCapacity(old_capacity - new_capacity);
-      } else if (old_capacity < new_capacity) {
-        parent_.incrClusterStreamCapacity(new_capacity - old_capacity);
-      }
+    if (new_capacity < old_capacity) {
+      parent_.decrConnectingAndConnectedStreamCapacity(old_capacity - new_capacity, *this);
+    } else if (old_capacity < new_capacity) {
+      parent_.incrConnectingAndConnectedStreamCapacity(new_capacity - old_capacity, *this);
     }
   }
 

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -164,7 +164,7 @@ public:
         connecting_client->remaining_streams_ = 1;
         if (connecting_client->effectiveConcurrentStreamLimit() < old_limit) {
           decrConnectingAndConnectedStreamCapacity(
-              old_limit - connecting_client->effectiveConcurrentStreamLimit());
+              old_limit - connecting_client->effectiveConcurrentStreamLimit(), *connecting_client);
         }
       }
     }

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -431,7 +431,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, NoAvailableStreams) {
   stream_limit_ = 1;
   newConnectingClient();
   clients_.back()->capacity_override_ = 0;
-  pool_.decrClusterStreamCapacity(stream_limit_);
+  pool_.decrConnectingAndConnectedStreamCapacity(stream_limit_, *clients_.back());
 
   // Make sure that when the connected event is raised, there is no call to
   // onPoolReady, and the client is marked as busy.


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: refactor decr|incrConnectingAndConnectedStreamCapacity() to take into consideration whether the client is connecting or not while updating cluster and conn pool connecting stream capacity.

Additional Description: also replace some call sites of effectiveConcurrentStreamLimit() with currentUnusedCapacity() where the client is connecting because that's when these two are the same.

This change is preparing for upcoming 0-RTT support in https://github.com/envoyproxy/envoy/pull/20167 which allows connecting client to open new streams and transit to other non-CONNECTING state.

Risk Level: low, no behavior change
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Part of #18715 
