### PR TITLE
listener: add note for the reuse port old default value compatible code

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -525,6 +525,9 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
   const auto parent_admin_shutdown_response = restarter_.sendParentAdminShutdownRequest();
   if (parent_admin_shutdown_response.has_value()) {
     original_start_time_ = parent_admin_shutdown_response.value().original_start_time_;
+    // TODO(soulxu): This is added for switching the reuse port default value as true (#17259).
+    // It ensures the same default value during the hot restart. This can be removed when
+    // everyone switches to the new default value.
     enable_reuse_port_default_ =
         parent_admin_shutdown_response.value().enable_reuse_port_default_ ? true : false;
   }


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: listener: listener: add note for the reuse port old default value compatible code
Additional Description:
according the discussion https://github.com/envoyproxy/envoy/pull/19977#discussion_r812126652
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

