### PR TITLE
c-ares: change from assert to logging for failure in getifaddrs

### DIFF
--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -430,7 +430,14 @@ DnsResolverImpl::AddrInfoPendingResolution::availableInterfaces() {
 
   Api::InterfaceAddressVector interface_addresses{};
   const Api::SysCallIntResult rc = Api::OsSysCallsSingleton::get().getifaddrs(interface_addresses);
-  RELEASE_ASSERT(!rc.return_value_, fmt::format("getiffaddrs error: {}", rc.errno_));
+  if (rc.return_value_ != 0) {
+    ENVOY_LOG_EVENT(debug, "cares_getiffaddrs_error",
+                    "dns resolution for {} could not obtain interface information with error={}",
+                    dns_name_, rc.errno_);
+    // Maintain no-op behavior if the system encountered an error while providing interface
+    // information.
+    return {true, true};
+  }
 
   DnsResolverImpl::AddrInfoPendingResolution::AvailableInterfaces available_interfaces{false,
                                                                                        false};

--- a/source/extensions/network/dns_resolver/cares/dns_impl.h
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.h
@@ -119,7 +119,7 @@ private:
 
     // Return the currently available network interfaces.
     // Note: this call uses syscalls.
-    static AvailableInterfaces availableInterfaces();
+    AvailableInterfaces availableInterfaces();
 
     // Perform a second resolution under certain conditions. If dns_lookup_family_ is V4Preferred
     // or Auto: perform a second resolution if the first one fails. If dns_lookup_family_ is All:

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -424,7 +424,8 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
   }
   {
       // No request trailer O(1) headers.
-  } {
+  }
+  {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -423,9 +423,8 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-    // No request trailer O(1) headers.
-  }
-  {
+      // No request trailer O(1) headers.
+  } {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -423,7 +423,7 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-      // No request trailer O(1) headers.
+    // No request trailer O(1) headers.
   }
   {
     auto header_map = ResponseHeaderMapImpl::create();

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -791,7 +791,9 @@ public:
                            const DnsLookupFamily lookup_family,
                            const std::list<std::string>& expected_addresses,
                            const DnsResolver::ResolutionStatus resolution_status =
-                               DnsResolver::ResolutionStatus::Success) {
+                               DnsResolver::ResolutionStatus::Success,
+                           const bool getifaddrs_supported = true,
+                           const bool getiffaddrs_success = true) {
     server_->addHosts("some.good.domain", {"201.134.56.7"}, RecordType::A);
     server_->addHosts("some.good.domain", {"1::2"}, RecordType::AAAA);
 
@@ -799,15 +801,24 @@ public:
     Api::MockOsSysCalls os_sys_calls;
     TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls(&os_sys_calls);
 
-    EXPECT_CALL(os_sys_calls, supportsGetifaddrs()).WillOnce(Return(true));
-    EXPECT_CALL(os_sys_calls, getifaddrs(_))
-        .WillOnce(Invoke([&](Api::InterfaceAddressVector& vector) -> Api::SysCallIntResult {
-          for (uint32_t i = 0; i < ifaddrs.size(); i++) {
-            auto addr = Network::Utility::parseInternetAddressAndPort(ifaddrs[i]);
-            vector.emplace_back(fmt::format("interface_{}", i), 0, addr);
-          }
-          return {0, 0};
-        }));
+    EXPECT_CALL(os_sys_calls, supportsGetifaddrs()).WillOnce(Return(getifaddrs_supported));
+    if (getifaddrs_supported) {
+      if (getiffaddrs_success) {
+        EXPECT_CALL(os_sys_calls, getifaddrs(_))
+            .WillOnce(Invoke([&](Api::InterfaceAddressVector& vector) -> Api::SysCallIntResult {
+              for (uint32_t i = 0; i < ifaddrs.size(); i++) {
+                auto addr = Network::Utility::parseInternetAddressAndPort(ifaddrs[i]);
+                vector.emplace_back(fmt::format("interface_{}", i), 0, addr);
+              }
+              return {0, 0};
+            }));
+      } else {
+        EXPECT_CALL(os_sys_calls, getifaddrs(_))
+            .WillOnce(Invoke([&](Api::InterfaceAddressVector&) -> Api::SysCallIntResult {
+              return {-1, 1};
+            }));
+      }
+    }
 
     // These passthrough calls are needed to let the resolver communicate with the DNS server
     EXPECT_CALL(os_sys_calls, accept(_, _, _))
@@ -1317,6 +1328,17 @@ TEST_P(DnsImplFilterUnroutableFamiliesTest, FilterAllV6) {
   testFilterAddresses({"1.2.3.4:80"}, DnsLookupFamily::All, {"201.134.56.7"});
 }
 
+TEST_P(DnsImplFilterUnroutableFamiliesTest, DontFilterIfGetiffaddrsIsNotSupported) {
+  testFilterAddresses({}, DnsLookupFamily::All, {"201.134.56.7", "1::2"},
+                      DnsResolver::ResolutionStatus::Success, false /* getifaddrs_supported */);
+}
+
+TEST_P(DnsImplFilterUnroutableFamiliesTest, DontFilterIfThereIsAGetiffaddrsFailure) {
+  testFilterAddresses({}, DnsLookupFamily::All, {"201.134.56.7", "1::2"},
+                      DnsResolver::ResolutionStatus::Success, true /* getifaddrs_supported */,
+                      false /* getifaddrs_success */);
+}
+
 class DnsImplFilterUnroutableFamiliesDontFilterTest : public DnsImplTest {
 protected:
   bool filterUnroutableFamilies() const override { return false; }
@@ -1359,12 +1381,12 @@ TEST_P(DnsImplFilterUnroutableFamiliesDontFilterTest, DontFilterAll) {
                       DnsLookupFamily::All, {"201.134.56.7", "1::2"});
 }
 
-TEST_P(DnsImplFilterUnroutableFamiliesDontFilterTest, FilterAllV4) {
+TEST_P(DnsImplFilterUnroutableFamiliesDontFilterTest, DontFilterAllV4) {
   testFilterAddresses({"[2001:0000:3238:DFE1:0063:0000:0000:FEFB]:54"}, DnsLookupFamily::All,
                       {"201.134.56.7", "1::2"});
 }
 
-TEST_P(DnsImplFilterUnroutableFamiliesDontFilterTest, FilterAllV6) {
+TEST_P(DnsImplFilterUnroutableFamiliesDontFilterTest, DontFilterAllV6) {
   testFilterAddresses({"1.2.3.4:80"}, DnsLookupFamily::All, {"201.134.56.7", "1::2"});
 }
 


### PR DESCRIPTION
Commit Message: c-ares - change from assert to logging for failure in getifaddrs
Additional Description: this assert crashes Envoy in situations where maintaining existing, non filtering behavior is more desirable.
Risk Level: low
Testing: existing

Signed-off-by: José Ulises Niño Rivera <junr03@users.noreply.github.com>
