### PR TITLE
xray tracer: correctly annotate child spans as xray subsegments

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,6 +38,7 @@ Bug Fixes
 * tls: fix a bug while matching a certificate SAN with an exact value in ``match_typed_subject_alt_names`` of a listener where wildcard ``*`` character is not the only character of the dns label. Example, ``baz*.example.net`` and ``*baz.example.net`` and ``b*z.example.net`` will match ``baz1.example.net`` and ``foobaz.example.net`` and ``buzz.example.net``, respectively.
 * upstream: fix stack overflow when a cluster with large number of idle connections is removed.
 * xray: fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header ``x-amzn-trace-id``.
+* xray: fix the AWS X-Ray tracer extension to annotate a child span with ``type=subsegment`` to correctly relate subsegments to a parent segment. Previously a subsegment would be treated as an independent segment.
 
 Removed Config or Runtime
 -------------------------

--- a/source/extensions/tracers/xray/daemon.proto
+++ b/source/extensions/tracers/xray/daemon.proto
@@ -43,7 +43,7 @@ message Segment {
   }
   // Object containing one or more fields that X-Ray indexes for use with filter expressions.
   map<string, string> annotations = 8;
-  // Set type to "subsegment" when sending a child span so XRay treats it as a subsegment.
+  // Set type to "subsegment" when sending a child span so X-Ray treats it as a subsegment.
   // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
   string type = 14;
 }

--- a/source/extensions/tracers/xray/daemon.proto
+++ b/source/extensions/tracers/xray/daemon.proto
@@ -43,6 +43,9 @@ message Segment {
   }
   // Object containing one or more fields that X-Ray indexes for use with filter expressions.
   map<string, string> annotations = 8;
+  // Set type to "subsegment" when sending a child span so XRay treats it as a subsegment.
+  // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
+  string type = 14;
 }
 
 message Header {

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -26,6 +26,7 @@ namespace Tracers {
 namespace XRay {
 
 constexpr auto XRayTraceHeader = "x-amzn-trace-id";
+constexpr absl::string_view Subsegment = "subsegment";
 
 class Span : public Tracing::Span, Logger::Loggable<Logger::Id::config> {
 public:
@@ -102,6 +103,12 @@ public:
   }
 
   /**
+   * Sets the type of the Span. In XRay, an independent subsegment has a type of "subsegment".
+   * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
+   */
+  void setType(absl::string_view type) { type_ = std::string(type); }
+
+  /**
    * Sets the aws metadata field of the Span.
    */
   void setAwsMetadata(const absl::flat_hash_map<std::string, ProtobufWkt::Value>& aws_metadata) {
@@ -155,6 +162,11 @@ public:
    * Gets this Span's direction.
    */
   const std::string& direction() const { return direction_; }
+
+  /**
+   * Gets this Span's type.
+   */
+  const std::string& type() const { return type_; }
 
   /**
    * Gets this Span's name.
@@ -216,6 +228,7 @@ private:
   std::string parent_segment_id_;
   std::string name_;
   std::string origin_;
+  std::string type_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> aws_metadata_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> http_request_annotations_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> http_response_annotations_;

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -103,7 +103,7 @@ public:
   }
 
   /**
-   * Sets the type of the Span. In XRay, an independent subsegment has a type of "subsegment".
+   * Sets the type of the Span. In X-Ray, an independent subsegment has a type of "subsegment".
    * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
    */
   void setType(absl::string_view type) { type_ = std::string(type); }

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -97,6 +97,7 @@ TEST_F(XRayTracerTest, SerializeSpanTest) {
     EXPECT_FALSE(s.id().empty());
     EXPECT_EQ(2, s.annotations().size());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.fault());    /*server error*/
     EXPECT_FALSE(s.error());    /*client error*/
     EXPECT_FALSE(s.throttle()); /*request throttled*/
@@ -142,6 +143,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestServerError) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_TRUE(s.fault());  /*server error*/
     EXPECT_FALSE(s.error()); /*client error*/
     EXPECT_EQ(expected_status_code,
@@ -175,6 +177,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestClientError) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.fault());    /*server error*/
     EXPECT_TRUE(s.error());     /*client error*/
     EXPECT_FALSE(s.throttle()); /*request throttled*/
@@ -208,6 +211,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestClientErrorWithThrottle) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.fault());   /*server error*/
     EXPECT_TRUE(s.error());    /*client error*/
     EXPECT_TRUE(s.throttle()); /*request throttled*/
@@ -239,6 +243,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithEmptyValue) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.http().request().fields().contains(Tracing::Tags::get().Status));
   };
 
@@ -270,6 +275,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithStatusCodeNotANumber) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.http().request().fields().contains(Tracing::Tags::get().Status));
     EXPECT_FALSE(s.http().request().fields().contains("content_length"));
   };
@@ -346,7 +352,9 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
     TestUtility::validate(s);
     // Hex encoded 64 bit identifier
     EXPECT_STREQ("00000000000003e7", s.parent_id().c_str());
-    EXPECT_EQ(expected_->span_name, s.name().c_str());
+    EXPECT_EQ(expected_->operation_name, s.name().c_str());
+    EXPECT_TRUE(xray_parent_span->type().empty());
+    EXPECT_EQ(Subsegment, s.type().c_str());
     EXPECT_STREQ(xray_parent_span->traceId().c_str(), s.trace_id().c_str());
     EXPECT_STREQ("0000003d25bebe62", s.id().c_str());
   };

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -401,9 +401,7 @@ XFF
 XML
 XN
 XNOR
-XRay
 XSS
-Xray
 YAML
 ZXID
 absl

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -401,7 +401,9 @@ XFF
 XML
 XN
 XNOR
+XRay
 XSS
+Xray
 YAML
 ZXID
 absl
@@ -1176,6 +1178,7 @@ subnets
 suboptimal
 subsecond
 subseconds
+subsegment
 subsequence
 subsetting
 substr


### PR DESCRIPTION
Commit Message: 
In Xray tracing, there is the concept of an xray segment and each segment can contain subsegments. The segment and subsegment maps to Envoy's parent and child spans. In the existing xray extension implementation, each span is emitted independently without the distinction whether the span is a child or not, so Xray treats each span as its own segment. 

Whereas in fact, the Xray extension should annotate child spans as subsegments by setting a key value pair "type=subsegment" in the segment payload: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments. This PR is to perform this annotation so Xray subsegments are correctly related to their parent segment. 

Additional Description: N/A
Risk Level: low
Testing: unit tests, manual setup using https://github.com/aws/aws-app-mesh-examples/tree/main/walkthroughs/howto-ecs-basics that exercises Xray integration with Envoy. 
Docs Changes: Added this change to version history. 
Release Notes: Added this change to version history. 
Platform Specific Features: N/A
[Optional Fixes #Issue] This will partially address https://github.com/aws/aws-app-mesh-roadmap/issues/354

