### PR TITLE
Alt Service Cache: Alt srv-cache no longer modifies the keystore while iterating.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -681,6 +681,10 @@ def _com_google_absl():
         name = "abseil_status",
         actual = "@com_google_absl//absl/status",
     )
+    native.bind(
+        name = "abseil_cleanup",
+        actual = "@com_google_absl//absl/cleanup:cleanup",
+    )
 
 def _com_google_protobuf():
     external_http_archive(

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -153,6 +153,9 @@ envoy_cc_library(
     name = "key_value_store_lib",
     srcs = ["key_value_store_base.cc"],
     hdrs = ["key_value_store_base.h"],
+    external_deps = [
+        "abseil_cleanup",
+    ],
     deps = [
         "//envoy/common:key_value_store_interface",
         "//envoy/event:dispatcher_interface",

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -65,9 +65,6 @@ bool KeyValueStoreBase::parseContents(absl::string_view contents,
 }
 
 void KeyValueStoreBase::addOrUpdate(absl::string_view key, absl::string_view value) {
-  // Avoids rehashing if the key already exists, moving the value into the map.
-  // If the key did not already exists, inserts both into the map, which
-  // might trigger a rehash.
   store_.insert_or_assign(key, std::string(value));
   if (!flush_timer_->enabled()) {
     flush();

--- a/source/common/http/alternate_protocols_cache_impl.cc
+++ b/source/common/http/alternate_protocols_cache_impl.cc
@@ -127,7 +127,7 @@ AlternateProtocolsCacheImpl::AlternateProtocolsCacheImpl(
     // Apply updates.
     for (auto& [origin, origin_data] : queued_origin_updates) {
       setAlternativesImpl(origin, origin_data.protocols);
-      setSrtt(origin, origin_data.srtt);
+      setSrttImpl(origin, origin_data.srtt);
     }
   }
 }
@@ -145,6 +145,11 @@ void AlternateProtocolsCacheImpl::setAlternatives(const Origin& origin,
 }
 
 void AlternateProtocolsCacheImpl::setSrtt(const Origin& origin, std::chrono::microseconds srtt) {
+  setSrttImpl(origin, srtt);
+}
+
+void AlternateProtocolsCacheImpl::setSrttImpl(const Origin& origin,
+                                              std::chrono::microseconds srtt) {
   auto entry_it = protocols_.find(origin);
   if (entry_it == protocols_.end()) {
     return;

--- a/source/common/http/alternate_protocols_cache_impl.cc
+++ b/source/common/http/alternate_protocols_cache_impl.cc
@@ -104,31 +104,26 @@ AlternateProtocolsCacheImpl::originDataFromString(absl::string_view origin_data_
 
 AlternateProtocolsCacheImpl::AlternateProtocolsCacheImpl(
     TimeSource& time_source, std::unique_ptr<KeyValueStore>&& key_value_store, size_t max_entries)
-    : time_source_(time_source), key_value_store_(std::move(key_value_store)),
-      max_entries_(max_entries > 0 ? max_entries : 1024) {
-  if (key_value_store_) {
-    std::vector<std::pair<Origin, OriginData>> queued_origin_updates;
-
-    KeyValueStore::ConstIterateCb delayed_load =
-        [&queued_origin_updates, &time_source = time_source_](const std::string& key,
-                                                              const std::string& value) {
-          absl::optional<OriginData> origin_data = originDataFromString(value, time_source, true);
-          absl::optional<Origin> origin = stringToOrigin(key);
-          if (origin_data.has_value() && origin.has_value()) {
-            queued_origin_updates.emplace_back(origin.value(), origin_data.value());
-          } else {
-            ENVOY_LOG(warn, fmt::format("Unable to parse cache entry with key: {} value: {}", key,
-                                        value));
-          }
-          return KeyValueStore::Iterate::Continue;
-        };
-    key_value_store_->iterate(delayed_load);
-
-    // Apply updates.
-    for (auto& [origin, origin_data] : queued_origin_updates) {
-      setAlternativesImpl(origin, origin_data.protocols);
-      setSrttImpl(origin, origin_data.srtt);
-    }
+    : time_source_(time_source), max_entries_(max_entries > 0 ? max_entries : 1024) {
+  if (key_value_store) {
+    KeyValueStore::ConstIterateCb load_protocols = [this](const std::string& key,
+                                                          const std::string& value) {
+      absl::optional<OriginData> origin_data = originDataFromString(value, time_source_, true);
+      absl::optional<Origin> origin = stringToOrigin(key);
+      if (origin_data.has_value() && origin.has_value()) {
+        // We deferred transfering ownership into key_value_store_ prior, so
+        // that we won't end up doing redundant updates to the store while
+        // iterating.
+        setAlternativesImpl(origin.value(), origin_data.value().protocols);
+        setSrttImpl(origin.value(), origin_data.value().srtt);
+      } else {
+        ENVOY_LOG(warn,
+                  fmt::format("Unable to parse cache entry with key: {} value: {}", key, value));
+      }
+      return KeyValueStore::Iterate::Continue;
+    };
+    key_value_store->iterate(load_protocols);
+    key_value_store_ = std::move(key_value_store);
   }
 }
 

--- a/source/common/http/alternate_protocols_cache_impl.h
+++ b/source/common/http/alternate_protocols_cache_impl.h
@@ -71,6 +71,7 @@ public:
 
 private:
   void setAlternativesImpl(const Origin& origin, std::vector<AlternateProtocol>& protocols);
+  void setSrttImpl(const Origin& origin, std::chrono::microseconds srtt);
   // Time source used to check expiration of entries.
   TimeSource& time_source_;
 

--- a/test/common/http/alternate_protocols_cache_impl_test.cc
+++ b/test/common/http/alternate_protocols_cache_impl_test.cc
@@ -284,6 +284,14 @@ TEST_F(AlternateProtocolsCacheImplTest, CacheLoad) {
   EXPECT_EQ(protocols1_, protocols.ref());
 }
 
+TEST_F(AlternateProtocolsCacheImplTest, ShouldNotUpdateStoreOnCacheLoad) {
+  EXPECT_CALL(*store_, addOrUpdate(_, _)).Times(0);
+  EXPECT_CALL(*store_, iterate(_)).WillOnce(Invoke([&](KeyValueStore::ConstIterateCb fn) {
+    fn("https://hostname1:1", "alpn1=\"hostname1:1\"; ma=5|0");
+  }));
+  initialize();
+}
+
 } // namespace
 } // namespace Http
 } // namespace Envoy

--- a/test/extensions/key_value/file_based/key_value_store_test.cc
+++ b/test/extensions/key_value/file_based/key_value_store_test.cc
@@ -103,6 +103,33 @@ TEST_F(KeyValueStoreTest, Iterate) {
   EXPECT_EQ(1, stop_early_counter);
 }
 
+#ifndef NDEBUG
+TEST_F(KeyValueStoreTest, ShouldCrashIfIterateCallbackAddsOrUpdatesStore) {
+  store_->addOrUpdate("foo", "bar");
+  store_->addOrUpdate("baz", "eep");
+  KeyValueStore::ConstIterateCb update_value_callback = [this](const std::string& key,
+                                                               const std::string&) {
+    EXPECT_TRUE(key == "foo" || key == "baz");
+    store_->addOrUpdate("foo", "updated-bar");
+    return KeyValueStore::Iterate::Continue;
+  };
+
+  EXPECT_DEATH(store_->iterate(update_value_callback),
+               "Expected iterate to not modify the underlying store.");
+
+  KeyValueStore::ConstIterateCb add_key_callback = [this](const std::string& key,
+                                                          const std::string&) {
+    EXPECT_TRUE(key == "foo" || key == "baz" || key == "new-key");
+    if (key == "foo") {
+      store_->addOrUpdate("new-key", "new-value");
+    }
+    return KeyValueStore::Iterate::Continue;
+  };
+  EXPECT_DEATH(store_->iterate(add_key_callback),
+               "Expected iterate to not modify the underlying store.");
+}
+#endif
+
 TEST_F(KeyValueStoreTest, HandleBadFile) {
   auto checkBadFile = [this](std::string file, std::string error) {
     TestEnvironment::writeStringToFileForTest(filename_, file, true);


### PR DESCRIPTION
Was brought up to Envoy Security team.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:  Alt srv-cache no longer modifies the keystore while iterating.
Additional Description: modifications to keystore during iterate can cause us to rehash but we have no iterator stability => sad times.
Risk Level: low
Testing: unit tests
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

