### PR TITLE
docs: Fix Deprecated Tap Request Examples

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/tap-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/tap-filter.yaml
@@ -1,0 +1,144 @@
+static_resources:
+  listeners:
+  - name: listener1
+    address:
+      socket_address: {address: 0.0.0.0, port_value: 51051}
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: grpc_json
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              # NOTE: by default, matching happens based on the gRPC route, and not on the incoming request path.
+              # Reference: https://envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter#route-configs-for-transcoded-requests
+              - match: {prefix: "/helloworld.Greeter"}
+                route: {cluster: grpc, timeout: 60s}
+          http_filters:
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                admin_config:
+                  config_id: test_config_id
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                admin_config:
+                  config_id: test_config_id
+                  tap_config:
+                    match:
+                      and_match:
+                        rules:
+                          - http_request_headers_match:
+                              headers:
+                                - name: foo
+                                  string_match:
+                                    exact: bar
+                          - http_response_headers_match:
+                              headers:
+                                - name: bar
+                                  string_match:
+                                    exact: baz
+                    output_config:
+                      sinks:
+                        - streaming_admin: {}
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                admin_config:
+                  config_id: test_config_id
+                  tap_config:
+                    match:
+                      or_match:
+                        rules:
+                          - http_request_headers_match:
+                              headers:
+                                - name: foo
+                                  string_match:
+                                    exact: bar
+                          - http_response_headers_match:
+                              headers:
+                                - name: bar
+                                  string_match:
+                                    exact: baz
+                    output_config:
+                      sinks:
+                        - streaming_admin: {}
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                admin_config:
+                  config_id: test_config_id
+                  tap_config:
+                    match:
+                      any_match: true
+                    output_config:
+                      sinks:
+                        - streaming_admin: {}
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                admin_config:
+                  config_id: test_config_id
+                  tap_config:
+                    match:
+                      and_match:
+                        rules:
+                          - http_request_headers_match:
+                              headers:
+                                - name: foo
+                                  string_match:
+                                    exact: bar
+                          - http_request_generic_body_match:
+                              patterns:
+                                - string_match: test
+                                - binary_match: 3q2+7w==
+                              bytes_limit: 128
+                          - http_response_generic_body_match:
+                              patterns:
+                                - binary_match: vu8=
+                              bytes_limit: 64
+                    output_config:
+                      sinks:
+                        - streaming_admin: {}
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                admin_config:
+                  config_id: test_config_id
+                  tap_config:
+                    match:
+                      any_match: true
+                    output_config:
+                      sinks:
+                        - format: JSON_BODY_AS_STRING
+                          streaming_admin: {}
+          - name: envoy.filters.http.tap
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
+              common_config:
+                static_config:
+                  match:
+                    http_response_headers_match:
+                      headers:
+                        - name: bar
+                          string_match:
+                            exact: baz
+                  output_config:
+                    streaming: true
+                    sinks:
+                      - format: PROTO_BINARY_LENGTH_DELIMITED
+                        file_per_tap:
+                          path_prefix: /tmp/

--- a/docs/root/configuration/http/http_filters/tap_filter.rst
+++ b/docs/root/configuration/http/http_filters/tap_filter.rst
@@ -28,14 +28,11 @@ Example configuration
 
 Example filter configuration:
 
-.. code-block:: yaml
-
-  name: envoy.filters.http.tap
-  typed_config:
-    "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
-    common_config:
-      admin_config:
-        config_id: test_config_id
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 24-29
+    :linenos:
+    :lineno-start: 1
 
 The previous snippet configures the filter for control via the :http:post:`/tap` admin handler.
 See the following section for more details.
@@ -68,26 +65,11 @@ tapping and debugging of HTTP traffic. It works as follows:
 
 An example POST body:
 
-.. code-block:: yaml
-
-  config_id: test_config_id
-  tap_config:
-    match:
-      and_match:
-        rules:
-          - http_request_headers_match:
-              headers:
-                - name: foo
-                  string_match:
-                    exact: bar
-          - http_response_headers_match:
-              headers:
-                - name: bar
-                  string_match:
-                    exact: baz
-    output_config:
-      sinks:
-        - streaming_admin: {}
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 35-52
+    :linenos:
+    :lineno-start: 1
 
 The preceding configuration instructs the tap filter to match any HTTP requests in which a request
 header ``foo: bar`` is present AND a response header ``bar: baz`` is present. If both of these
@@ -95,26 +77,11 @@ conditions are met, the request will be tapped and streamed out the admin endpoi
 
 Another example POST body:
 
-.. code-block:: yaml
-
-  config_id: test_config_id
-  tap_config:
-    match:
-      or_match:
-        rules:
-          - http_request_headers_match:
-              headers:
-                - name: foo
-                  string_match:
-                    exact: bar
-          - http_response_headers_match:
-              headers:
-                - name: bar
-                  string_match:
-                    exact: baz
-    output_config:
-      sinks:
-        - streaming_admin: {}
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 58-75
+    :linenos:
+    :lineno-start: 1
 
 The preceding configuration instructs the tap filter to match any HTTP requests in which a request
 header ``foo: bar`` is present OR a response header ``bar: baz`` is present. If either of these
@@ -122,45 +89,22 @@ conditions are met, the request will be tapped and streamed out the admin endpoi
 
 Another example POST body:
 
-.. code-block:: yaml
-
-  config_id: test_config_id
-  tap_config:
-    match:
-      any_match: true
-    output_config:
-      sinks:
-        - streaming_admin: {}
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 81-87
+    :linenos:
+    :lineno-start: 1
 
 The preceding configuration instructs the tap filter to match any HTTP requests. All requests will
 be tapped and streamed out the admin endpoint.
 
 Another example POST body:
 
-.. code-block:: yaml
-
-  config_id: test_config_id
-  tap_config:
-    match:
-      and_match:
-        rules:
-          - http_request_headers_match:
-              headers:
-                - name: foo
-                  string_match:
-                    exact: bar
-          - http_request_generic_body_match:
-              patterns:
-                - string_match: test
-                - binary_match: 3q2+7w==
-              bytes_limit: 128
-          - http_response_generic_body_match:
-              patterns:
-                - binary_match: vu8=
-              bytes_limit: 64
-    output_config:
-      sinks:
-        - streaming_admin: {}
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 93-114
+    :linenos:
+    :lineno-start: 1
 
 The preceding configuration instructs the tap filter to match any HTTP requests in which a request
 header ``foo: bar`` is present AND request body contains string ``test`` and hex bytes ``deadbeef`` (``3q2+7w==`` in base64 format)
@@ -188,16 +132,11 @@ more user friendly. See the reference documentation for more information on othe
 An example of a streaming admin tap configuration that uses the :ref:`JSON_BODY_AS_STRING
 <envoy_v3_api_enum_value_config.tap.v3.OutputSink.Format.JSON_BODY_AS_STRING>` format:
 
-.. code-block:: yaml
-
-  config_id: test_config_id
-  tap_config:
-    match:
-      any_match: true
-    output_config:
-      sinks:
-        - format: JSON_BODY_AS_STRING
-          streaming_admin: {}
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 120-127
+    :linenos:
+    :lineno-start: 1
 
 Buffered body limits
 --------------------
@@ -236,25 +175,11 @@ format should be used.
 
 An static filter configuration to enable streaming output looks like:
 
-.. code-block:: yaml
-
-  name: envoy.filters.http.tap
-  typed_config:
-    "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
-    common_config:
-      static_config:
-        match:
-          http_response_headers_match:
-            headers:
-              - name: bar
-                string_match:
-                  exact: baz
-        output_config:
-          streaming: true
-          sinks:
-            - format: PROTO_BINARY_LENGTH_DELIMITED
-              file_per_tap:
-                path_prefix: /tmp/
+.. literalinclude:: _include/tap-filter.yaml
+    :language: yaml
+    :lines: 128-144
+    :linenos:
+    :lineno-start: 1
 
 The previous configuration will match response headers, and as such will buffer request headers,
 body, and trailers until a match can be determined (buffered data limits still apply as described

--- a/docs/root/configuration/http/http_filters/tap_filter.rst
+++ b/docs/root/configuration/http/http_filters/tap_filter.rst
@@ -72,7 +72,7 @@ An example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       and_match:
         rules:
           - http_request_headers_match:
@@ -99,7 +99,7 @@ Another example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       or_match:
         rules:
           - http_request_headers_match:
@@ -126,7 +126,7 @@ Another example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       any_match: true
     output_config:
       sinks:
@@ -141,7 +141,7 @@ Another example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       and_match:
         rules:
           - http_request_headers_match:
@@ -192,7 +192,7 @@ An example of a streaming admin tap configuration that uses the :ref:`JSON_BODY_
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       any_match: true
     output_config:
       sinks:
@@ -243,7 +243,7 @@ An static filter configuration to enable streaming output looks like:
     "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
     common_config:
       static_config:
-        match_config:
+        match:
           http_response_headers_match:
             headers:
               - name: bar


### PR DESCRIPTION
**Commit Message:** 
Update the Tap documentation to avoid use of `match_config` as this is deprecated and use of this field causes errors in CI.

Signed-off-by: David Peet <davidpeet@tutanota.com>

**Additional Description:** n/a
**Risk Level:** low
**Testing:** n/a
**Docs Changes:** Update documentation for Tap filter to use `match` instead of `match_config`
**Release Notes:** n/a
**Platform Specific Features:** n/a
**Fixes:** #20190
