### PR TITLE
doc: fix the command to run fuzzing test

### DIFF
--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -97,7 +97,7 @@ perform is specified with `-runs`. For example,
 
 ```console
 bazel run //test/common/common:base64_fuzz_test --config asan-fuzzer \
--- test/common/common/base64_corpus -runs=1000
+    -- test/common/common/base64_corpus -runs=1000
 ```
 
 The fuzzer prints information to stderr:

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -96,7 +96,7 @@ directory. Fuzzing continues indefinitely until a bug is found or the number of 
 perform is specified with `-runs`. For example,
 
 `bazel run //test/common/common:base64_fuzz_test --config asan-fuzzer
---test/common/common/base64_corpus -runs=1000`
+-- test/common/common/base64_corpus -runs=1000`
 
 The fuzzer prints information to stderr:
 

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -95,8 +95,10 @@ your local machine vs. the fuzz cluster). The binary takes the location of the s
 directory. Fuzzing continues indefinitely until a bug is found or the number of iterations it should
 perform is specified with `-runs`. For example,
 
-`bazel run //test/common/common:base64_fuzz_test --config asan-fuzzer
--- test/common/common/base64_corpus -runs=1000`
+```console
+bazel run //test/common/common:base64_fuzz_test --config asan-fuzzer \
+-- test/common/common/base64_corpus -runs=1000
+```
 
 The fuzzer prints information to stderr:
 


### PR DESCRIPTION
Commit Message: doc: fix the command to run fuzzing test
Additional Description:
The command is missing a space. lead to unknow param as below
```
ERROR: --test/common/common/base64_corpus :: Unrecognized option: --test/common/common/base64_corpus
```
Risk Level: low
Testing: n/a
Docs Changes: doc fix
Release Notes: n/a
Platform Specific Features: no

Signed-off-by: He Jie Xu <hejie.xu@intel.com>