### PR TITLE
listener: ensure Ipv6 any address is valid on ipv4_compat set

### DIFF
--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -351,7 +351,8 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
   if ((address_->type() == Network::Address::Type::Ip &&
        config.address().socket_address().ipv4_compat()) &&
       (address_->ip()->version() != Network::Address::IpVersion::v6 ||
-       address_->ip()->ipv6()->v4CompatibleAddress() == nullptr)) {
+       (!address_->ip()->isAnyAddress() &&
+        address_->ip()->ipv6()->v4CompatibleAddress() == nullptr))) {
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.strict_check_on_ipv4_compat")) {
       throw EnvoyException(fmt::format(
           "Only IPv6 address '::' or valid IPv4-mapped IPv6 address can set ipv4_compat: {}",

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -599,6 +599,36 @@ TEST_F(ListenerManagerImplTest, RejectIpv4CompatOnNonIpv4MappedIpv6address) {
       "Only IPv6 address '::' or valid IPv4-mapped IPv6 address can set ipv4_compat: [::1]:13333");
 }
 
+TEST_F(ListenerManagerImplTest, AcceptIpv4CompatOnIpv6AnyAddress) {
+  const std::string yaml = R"EOF(
+    name: "foo"
+    address:
+      socket_address:
+        address: "::"
+        port_value: 13333
+        ipv4_compat: true
+    filter_chains:
+    - filters: []
+  )EOF";
+
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(yaml), "", true));
+}
+
+TEST_F(ListenerManagerImplTest, AcceptIpv4CompatOnNonCanonicalIpv6AnyAddress) {
+  const std::string yaml = R"EOF(
+    name: "foo"
+    address:
+      socket_address:
+        address: "::0"
+        port_value: 13333
+        ipv4_compat: true
+    filter_chains:
+    - filters: []
+  )EOF";
+
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(yaml), "", true));
+}
+
 TEST_F(ListenerManagerImplTest, AcceptIpv4CompatOnNonIpv4MappedIpv6address) {
   auto scoped_runtime_guard = std::make_unique<TestScopedRuntime>();
   Runtime::LoaderSingleton::getExisting()->mergeValues(


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: listener: ensure Ipv6 any address is valid on ipv4_compat set
Additional Description:
The Ipv6 address is valid when ipv4_compat set. This check is missing https://github.com/envoyproxy/envoy/pull/19716
Risk Level: low
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

