### PR TITLE
redis: fix hostname resolution bug introduced in #19541

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -342,8 +342,8 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
       parent_.dns_resolver_->resolve(
           slot.primary_hostname_, parent_.dns_lookup_family_,
           [this, slot_idx, slots,
-           &hostname_resolution_required_cnt](Network::DnsResolver::ResolutionStatus status,
-                                              std::list<Network::DnsResponse>&& response) -> void {
+           hostname_resolution_required_cnt](Network::DnsResolver::ResolutionStatus status,
+                                             std::list<Network::DnsResponse>&& response) -> void {
             auto& slot = (*slots)[slot_idx];
             ENVOY_LOG(debug, "async DNS resolution complete for {}", slot.primary_hostname_);
             updateDnsStats(status, response.empty());
@@ -401,8 +401,8 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
     parent_.dns_resolver_->resolve(
         replica.first, parent_.dns_lookup_family_,
         [this, index, slots, replica_idx,
-         &hostname_resolution_required_cnt](Network::DnsResolver::ResolutionStatus status,
-                                            std::list<Network::DnsResponse>&& response) -> void {
+         hostname_resolution_required_cnt](Network::DnsResolver::ResolutionStatus status,
+                                           std::list<Network::DnsResponse>&& response) -> void {
           auto& slot = (*slots)[index];
           auto& replica = slot.replicas_to_resolve_[replica_idx];
           ENVOY_LOG(debug, "async DNS resolution complete for {}", replica.first);

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -332,6 +332,8 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
     ClusterSlotsSharedPtr&& slots,
     std::shared_ptr<std::uint64_t> hostname_resolution_required_cnt) {
   for (uint64_t slot_idx = 0; slot_idx < slots->size(); slot_idx++) {
+    ENVOY_LOG(debug, "resolveClusterHostnames: hostname_resolution_required_cnt at beginning: {}",
+              *hostname_resolution_required_cnt);
     auto& slot = (*slots)[slot_idx];
     if (slot.primary() == nullptr) {
       ENVOY_LOG(debug,
@@ -357,6 +359,10 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
             slot.setPrimary(Network::Utility::getAddressWithPort(
                 *response.front().addrInfo().address_, slot.primary_port_));
             (*hostname_resolution_required_cnt)--;
+            ENVOY_LOG(debug,
+                      "resolveClusterHostnames: hostname_resolution_required_cnt at end after "
+                      "resolving primary {}: {}",
+                      slot.primary_hostname_, *hostname_resolution_required_cnt);
             // Continue on to resolve replicas
             resolveReplicas(slots, slot_idx, hostname_resolution_required_cnt);
           });
@@ -380,6 +386,8 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
     ClusterSlotsSharedPtr slots, std::size_t index,
     std::shared_ptr<std::uint64_t> hostname_resolution_required_cnt) {
   auto& slot = (*slots)[index];
+  ENVOY_LOG(debug, "resolveReplicas: hostname_resolution_required_cnt at beginning: {}",
+            *hostname_resolution_required_cnt);
   if (slot.replicas_to_resolve_.empty()) {
     if (*hostname_resolution_required_cnt == 0) {
       finishClusterHostnameResolution(slots);
@@ -409,6 +417,10 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
                 *response.front().addrInfo().address_, replica.second));
           }
           (*hostname_resolution_required_cnt)--;
+          ENVOY_LOG(debug,
+                    "resolveReplicas: hostname_resolution_required_cnt at end after "
+                    "resolving replica {}: {}",
+                    replica.first, *hostname_resolution_required_cnt);
           // finish resolution if all the addresses have been resolved.
           if (*hostname_resolution_required_cnt <= 0) {
             finishClusterHostnameResolution(slots);

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -332,8 +332,6 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
     ClusterSlotsSharedPtr&& slots,
     std::shared_ptr<std::uint64_t> hostname_resolution_required_cnt) {
   for (uint64_t slot_idx = 0; slot_idx < slots->size(); slot_idx++) {
-    ENVOY_LOG(debug, "resolveClusterHostnames: hostname_resolution_required_cnt at beginning: {}",
-              *hostname_resolution_required_cnt);
     auto& slot = (*slots)[slot_idx];
     if (slot.primary() == nullptr) {
       ENVOY_LOG(debug,
@@ -359,10 +357,6 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
             slot.setPrimary(Network::Utility::getAddressWithPort(
                 *response.front().addrInfo().address_, slot.primary_port_));
             (*hostname_resolution_required_cnt)--;
-            ENVOY_LOG(debug,
-                      "resolveClusterHostnames: hostname_resolution_required_cnt at end after "
-                      "resolving primary {}: {}",
-                      slot.primary_hostname_, *hostname_resolution_required_cnt);
             // Continue on to resolve replicas
             resolveReplicas(slots, slot_idx, hostname_resolution_required_cnt);
           });
@@ -386,8 +380,6 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
     ClusterSlotsSharedPtr slots, std::size_t index,
     std::shared_ptr<std::uint64_t> hostname_resolution_required_cnt) {
   auto& slot = (*slots)[index];
-  ENVOY_LOG(debug, "resolveReplicas: hostname_resolution_required_cnt at beginning: {}",
-            *hostname_resolution_required_cnt);
   if (slot.replicas_to_resolve_.empty()) {
     if (*hostname_resolution_required_cnt == 0) {
       finishClusterHostnameResolution(slots);
@@ -417,10 +409,6 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
                 *response.front().addrInfo().address_, replica.second));
           }
           (*hostname_resolution_required_cnt)--;
-          ENVOY_LOG(debug,
-                    "resolveReplicas: hostname_resolution_required_cnt at end after "
-                    "resolving replica {}: {}",
-                    replica.first, *hostname_resolution_required_cnt);
           // finish resolution if all the addresses have been resolved.
           if (*hostname_resolution_required_cnt <= 0) {
             finishClusterHostnameResolution(slots);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
In #19541 , one of the latter commits changed the `hostname_resolution_required_cnt` from a simple `uint64_t` to a `shared_ptr<uint64_t>`. This meant that we didn't need to pass the variable by reference into the capture-list of the DNS resolution lambda. However, this was overlooked, and results in segfaults due to `shared_ptr` semantics.

Simply passing this by value solves the problem.

Testing:
Unsure why this didn't fail earlier, and what test scenarios would catch it. Happy to add a test as per reviewer suggestions.

