### PR TITLE
build: Add a name to the CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -1,3 +1,5 @@
+name: CodeQL
+
 on:
   push:
     paths:


### PR DESCRIPTION
Instead of showing ".github/workflows/codeql-push.yml" for the CodeQL workflow it will now say "CodeQL"

Signed-off-by: Ryan Hamilton <rch@google.com>