### PR TITLE
http cache: add boundaries to simple http cache implementation

### DIFF
--- a/api/envoy/extensions/cache/simple_http_cache/v3/config.proto
+++ b/api/envoy/extensions/cache/simple_http_cache/v3/config.proto
@@ -18,5 +18,5 @@ message SimpleHttpCacheConfig {
   // The maximum size of the cache to the specified number of bytes.
   // When the cache is full, entries will be evicted following LRU. If not set
   // defaults to 100 MiB.
-  google.protobuf.UInt64Value approximated_max_size = 1;
+  google.protobuf.Int64Value max_size = 1;
 }

--- a/api/envoy/extensions/cache/simple_http_cache/v3/config.proto
+++ b/api/envoy/extensions/cache/simple_http_cache/v3/config.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.cache.simple_http_cache.v3;
 
+import "google/protobuf/wrappers.proto";
 import "udpa/annotations/status.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.cache.simple_http_cache.v3";
@@ -14,4 +15,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#extension: envoy.cache.simple_http_cache]
 message SimpleHttpCacheConfig {
+  // The maximum size of the cache to the specified number of bytes.
+  // When the cache is full, entries will be evicted following LRU. If not set
+  // defaults to 100 MiB.
+  google.protobuf.UInt64Value approximated_max_size = 1;
 }

--- a/source/extensions/filters/http/cache/simple_http_cache/BUILD
+++ b/source/extensions/filters/http/cache/simple_http_cache/BUILD
@@ -14,6 +14,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["simple_http_cache.cc"],
     hdrs = ["simple_http_cache.h"],
+    external_deps = ["simple_lru_cache_lib"],
     deps = [
         "//envoy/registry",
         "//envoy/runtime:runtime_interface",

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -298,8 +298,10 @@ void SimpleHttpCache::varyInsert(const Key& request_key,
   }
 }
 
-void SimpleHttpCache::setMaxSize(uint64_t bytes) {
-  if (uint64_t(lru_cache_->maxSize()) != bytes) {
+void SimpleHttpCache::setMaxSize(int64_t bytes) {
+  ASSERT(bytes > 0);
+
+  if (bytes > 0 && lru_cache_.maxSize() != bytes) {
     lru_cache_->setMaxSize(bytes);
   }
 }
@@ -333,8 +335,8 @@ public:
     envoy::extensions::cache::simple_http_cache::v3::SimpleHttpCacheConfig typed_config;
     MessageUtil::unpackTo(config.typed_config(), typed_config);
 
-    uint64_t approximated_max_size = typed_config.approximated_max_size().value();
-    cache_.setMaxSize(approximated_max_size > 0 ? approximated_max_size : kSimpleHttpCacheDefaultSize);
+    uint64_t max_size = typed_config.max_size().value();
+    cache_.setMaxSize(max_size > 0 ? max_size : kSimpleHttpCacheDefaultSize);
     return cache_;
   }
 

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -188,7 +188,7 @@ void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
 }
 
 SimpleHttpCache::Entry SimpleHttpCache::lookup(const LookupRequest& request) {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::MutexLock lock(&mutex_);
 
   LRUCache::ScopedLookup lookup(&lru_cache_, request.key());
   if (!lookup.found()) {

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -77,6 +77,10 @@ public:
   // If necessary, entries will be evicted to comply with the new size.
   void setMaxSize(int64_t bytes);
 
+  // Remove all items from the LRU cache as per
+  // https://github.com/google/jwt_verify_lib/blob/master/simple_lru_cache/simple_lru_cache_inl.h#L289
+  ~SimpleHttpCache() { lru_cache_.clear(); }
+
   absl::Mutex mutex_;
   LRUCache lru_cache_ ABSL_GUARDED_BY(mutex_);
 };

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -47,11 +47,11 @@ private:
   // https://www.ietf.org/archive/id/draft-ietf-httpbis-cache-18.html s3.2
   static const absl::flat_hash_set<Http::LowerCaseString> headersNotToUpdate();
 
-  typedef SimpleLRUCache<Key, Entry, MessageUtil, MessageUtil> LRUCache;
+  typedef google::simple_lru_cache::SimpleLRUCache<Key, Entry, MessageUtil, MessageUtil> LRUCache;
 
 public:
   // HttpCache
-  SimpleHttpCache() { lru_cache_ = std::make_unique<LRUCache>(kSimpleHttpCacheDefaultSize); }
+  SimpleHttpCache() : lru_cache_(LRUCache(kSimpleHttpCacheDefaultSize)) {}
 
   LookupContextPtr makeLookupContext(LookupRequest&& request,
                                      Http::StreamDecoderFilterCallbacks& callbacks) override;
@@ -78,7 +78,7 @@ public:
   void setMaxSize(int64_t bytes);
 
   absl::Mutex mutex_;
-  std::unique_ptr<LRUCache> lru_cache_ ABSL_GUARDED_BY(mutex_);
+  LRUCache lru_cache_ ABSL_GUARDED_BY(mutex_);
 };
 
 } // namespace Cache


### PR DESCRIPTION
Commit Message: This change allows to evict old or rarely use entries by using an existing LRU implementation in the repo.
Risk Level: low
Testing: TBD
Docs Changes: No
Release Notes: No
Platform Specific Features: No