### PR TITLE
Extract thrift proxy stat_prefix into a prometheus tag

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -1,5 +1,7 @@
 #include "source/common/config/well_known_names.h"
 
+#include "source/common/runtime/runtime_features.h"
+
 #include "absl/strings/str_replace.h"
 
 namespace Envoy {
@@ -143,6 +145,10 @@ TagNameValues::TagNameValues() {
 
   // mongo.(<stat_prefix>.)*
   addTokenized(MONGO_PREFIX, "mongo.$.**");
+
+  if (Runtime::runtimeFeatureEnabled("envoy.restart_features.thrift_stat_prefix_tag_extraction")) {
+    addTokenized(THRIFT_PREFIX, "thrift.$.**");
+  }
 
   // http.[<stat_prefix>.]rds.(<route_config_name>.)<base_stat>
   // Note: <route_config_name> can contain dots thus we have to maintain full

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -130,6 +130,8 @@ public:
   const std::string RDS_ROUTE_CONFIG = "envoy.rds_route_config";
   // Listener manager worker id
   const std::string WORKER_ID = "envoy.worker_id";
+  // Stats prefix for the Thrift Proxy network filter
+  const std::string THRIFT_PREFIX = "envoy.thrift_prefix";
 
   // Mapping from the names above to their respective regex strings.
   const std::vector<std::pair<std::string, std::string>> name_regex_pairs_;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -54,6 +54,7 @@ RUNTIME_GUARD(envoy_reloadable_features_update_expected_rq_timeout_on_retry);
 RUNTIME_GUARD(envoy_reloadable_features_use_dns_ttl);
 RUNTIME_GUARD(envoy_reloadable_features_validate_connect);
 RUNTIME_GUARD(envoy_restart_features_explicit_wildcard_resource);
+RUNTIME_GUARD(envoy_restart_features_thrift_stat_prefix_tag_extraction);
 RUNTIME_GUARD(envoy_restart_features_use_apple_api_for_dns_lookups);
 
 // Begin false flags. These should come with a TODO to flip true.
@@ -170,6 +171,7 @@ constexpr absl::Flag<bool>* runtime_features[] = {
   &FLAGS_envoy_reloadable_features_use_dns_ttl,
   &FLAGS_envoy_reloadable_features_validate_connect,
   &FLAGS_envoy_restart_features_explicit_wildcard_resource,
+  &FLAGS_envoy_restart_features_thrift_stat_prefix_tag_extraction,
   &FLAGS_envoy_restart_features_use_apple_api_for_dns_lookups,
   &FLAGS_envoy_restart_features_no_runtime_singleton,
 };

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -221,7 +221,27 @@ envoy_benchmark_test(
 
 envoy_cc_test(
     name = "tag_extractor_impl_test",
-    srcs = ["tag_extractor_impl_test.cc"],
+    srcs = [
+        "tag_extractor_impl_test.cc",
+        "tag_extractor_test_common.h",
+    ],
+    deps = [
+        "//source/common/stats:tag_extractor_lib",
+        "//source/common/stats:tag_producer_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "tag_extractor_impl_deprecated_test",
+    srcs = [
+        "tag_extractor_impl_deprecated_test.cc",
+        "tag_extractor_test_common.h",
+    ],
+    args = [
+        "--runtime-feature-disable-for-tests=envoy.restart_features.thrift_stat_prefix_tag_extraction",
+    ],
     deps = [
         "//source/common/stats:tag_extractor_lib",
         "//source/common/stats:tag_producer_lib",

--- a/test/common/stats/tag_extractor_impl_deprecated_test.cc
+++ b/test/common/stats/tag_extractor_impl_deprecated_test.cc
@@ -1,0 +1,12 @@
+#include "test/common/stats/tag_extractor_test_common.h"
+
+namespace Envoy {
+namespace Stats {
+
+TEST(TagExtractorTest, DeprecatedTagExtractors) {
+  DefaultTagRegexTester regex_tester;
+  regex_tester.testRegex("thrift.thrift_prefix.response", "thrift.thrift_prefix.response", {});
+}
+
+} // namespace Stats
+} // namespace Envoy

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -1,12 +1,6 @@
 #include <string>
 
-#include "envoy/common/exception.h"
-#include "envoy/config/metrics/v3/stats.pb.h"
-
-#include "source/common/config/well_known_names.h"
-#include "source/common/stats/tag_extractor_impl.h"
-#include "source/common/stats/tag_producer_impl.h"
-
+#include "test/common/stats/tag_extractor_test_common.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -84,79 +78,8 @@ TEST(TagExtractorTest, BadRegex) {
                           EnvoyException, "Invalid regex '\\+invalid':");
 }
 
-class DefaultTagRegexTester {
-public:
-  DefaultTagRegexTester() : tag_extractors_(envoy::config::metrics::v3::StatsConfig()) {}
-
-  void testRegex(const std::string& stat_name, const std::string& expected_tag_extracted_name,
-                 const TagVector& expected_tags) {
-
-    // Test forward iteration through the regexes
-    TagVector tags;
-    const std::string tag_extracted_name = tag_extractors_.produceTags(stat_name, tags);
-
-    auto cmp = [](const Tag& lhs, const Tag& rhs) {
-      return lhs.name_ == rhs.name_ && lhs.value_ == rhs.value_;
-    };
-
-    EXPECT_EQ(expected_tag_extracted_name, tag_extracted_name);
-    ASSERT_EQ(expected_tags.size(), tags.size())
-        << fmt::format("Stat name '{}' did not produce the expected number of tags", stat_name);
-    EXPECT_TRUE(std::is_permutation(expected_tags.begin(), expected_tags.end(), tags.begin(), cmp))
-        << fmt::format("Stat name '{}' did not produce the expected tags", stat_name);
-
-    // Reverse iteration through regexes to ensure ordering invariance
-    TagVector rev_tags;
-    const std::string rev_tag_extracted_name = produceTagsReverse(stat_name, rev_tags);
-
-    EXPECT_EQ(expected_tag_extracted_name, rev_tag_extracted_name);
-    ASSERT_EQ(expected_tags.size(), rev_tags.size())
-        << fmt::format("Stat name '{}' did not produce the expected number of tags when regexes "
-                       "were run in reverse order",
-                       stat_name);
-    EXPECT_TRUE(
-        std::is_permutation(expected_tags.begin(), expected_tags.end(), rev_tags.begin(), cmp))
-        << fmt::format("Stat name '{}' did not produce the expected tags when regexes were run in "
-                       "reverse order",
-                       stat_name);
-  }
-
-  /**
-   * Reimplements TagProducerImpl::produceTags, but extracts the tags in reverse order.
-   * This helps demonstrate that the order of extractors does not matter to the end result,
-   * assuming we don't care about tag-order. This is in large part correct by design because
-   * stat_name is not mutated until all the extraction is done.
-   * @param metric_name std::string a name of Stats::Metric (Counter, Gauge, Histogram).
-   * @param tags TagVector& a set of Stats::Tag.
-   * @return std::string the metric_name with tags removed.
-   */
-  std::string produceTagsReverse(const std::string& metric_name, TagVector& tags) const {
-    // TODO(jmarantz): Skip the creation of string-based tags, creating a StatNameTagVector instead.
-
-    // Note: one discrepancy between this and TagProducerImpl::produceTags is that this
-    // version does not add in tag_extractors_.default_tags_ into tags. That doesn't matter
-    // for this test, however.
-    std::list<const TagExtractor*> extractors; // Note push-front is used to reverse order.
-    tag_extractors_.forEachExtractorMatching(metric_name,
-                                             [&extractors](const TagExtractorPtr& tag_extractor) {
-                                               extractors.push_front(tag_extractor.get());
-                                             });
-
-    IntervalSetImpl<size_t> remove_characters;
-    TagExtractionContext tag_extraction_context(metric_name);
-    for (const TagExtractor* tag_extractor : extractors) {
-      tag_extractor->extractTag(tag_extraction_context, tags, remove_characters);
-    }
-    return StringUtil::removeCharacters(metric_name, remove_characters);
-  }
-
-  SymbolTableImpl symbol_table_;
-  TagProducerImpl tag_extractors_;
-};
-
 TEST(TagExtractorTest, DefaultTagExtractors) {
   const auto& tag_names = Config::TagNames::get();
-
   // General cluster name
   DefaultTagRegexTester regex_tester;
 
@@ -379,6 +302,12 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
 
   regex_tester.testRegex("listener_manager.worker_123.dispatcher.loop_duration_us",
                          "listener_manager.dispatcher.loop_duration_us", {worker_id});
+
+  // Thrift Proxy Prefix
+  Tag thrift_prefix;
+  thrift_prefix.name_ = tag_names.THRIFT_PREFIX;
+  thrift_prefix.value_ = "thrift_prefix";
+  regex_tester.testRegex("thrift.thrift_prefix.response", "thrift.response", {thrift_prefix});
 }
 
 TEST(TagExtractorTest, ExtractRegexPrefix) {

--- a/test/common/stats/tag_extractor_test_common.h
+++ b/test/common/stats/tag_extractor_test_common.h
@@ -12,8 +12,6 @@
 
 #include "gtest/gtest.h"
 
-using ::testing::ElementsAre;
-
 namespace Envoy {
 namespace Stats {
 

--- a/test/common/stats/tag_extractor_test_common.h
+++ b/test/common/stats/tag_extractor_test_common.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/config/metrics/v3/stats.pb.h"
+
+#include "source/common/config/well_known_names.h"
+#include "source/common/stats/tag_extractor_impl.h"
+#include "source/common/stats/tag_producer_impl.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+using ::testing::ElementsAre;
+
+namespace Envoy {
+namespace Stats {
+
+class DefaultTagRegexTester {
+public:
+  DefaultTagRegexTester() : tag_extractors_(envoy::config::metrics::v3::StatsConfig()) {}
+
+  void testRegex(const std::string& stat_name, const std::string& expected_tag_extracted_name,
+                 const TagVector& expected_tags) {
+
+    // Test forward iteration through the regexes
+    TagVector tags;
+    const std::string tag_extracted_name = tag_extractors_.produceTags(stat_name, tags);
+
+    auto cmp = [](const Tag& lhs, const Tag& rhs) {
+      return lhs.name_ == rhs.name_ && lhs.value_ == rhs.value_;
+    };
+
+    EXPECT_EQ(expected_tag_extracted_name, tag_extracted_name);
+    ASSERT_EQ(expected_tags.size(), tags.size())
+        << fmt::format("Stat name '{}' did not produce the expected number of tags", stat_name);
+    EXPECT_TRUE(std::is_permutation(expected_tags.begin(), expected_tags.end(), tags.begin(), cmp))
+        << fmt::format("Stat name '{}' did not produce the expected tags", stat_name);
+
+    // Reverse iteration through regexes to ensure ordering invariance
+    TagVector rev_tags;
+    const std::string rev_tag_extracted_name = produceTagsReverse(stat_name, rev_tags);
+
+    EXPECT_EQ(expected_tag_extracted_name, rev_tag_extracted_name);
+    ASSERT_EQ(expected_tags.size(), rev_tags.size())
+        << fmt::format("Stat name '{}' did not produce the expected number of tags when regexes "
+                       "were run in reverse order",
+                       stat_name);
+    EXPECT_TRUE(
+        std::is_permutation(expected_tags.begin(), expected_tags.end(), rev_tags.begin(), cmp))
+        << fmt::format("Stat name '{}' did not produce the expected tags when regexes were run in "
+                       "reverse order",
+                       stat_name);
+  }
+
+  /**
+   * Reimplements TagProducerImpl::produceTags, but extracts the tags in reverse order.
+   * This helps demonstrate that the order of extractors does not matter to the end result,
+   * assuming we don't care about tag-order. This is in large part correct by design because
+   * stat_name is not mutated until all the extraction is done.
+   * @param metric_name std::string a name of Stats::Metric (Counter, Gauge, Histogram).
+   * @param tags TagVector& a set of Stats::Tag.
+   * @return std::string the metric_name with tags removed.
+   */
+  std::string produceTagsReverse(const std::string& metric_name, TagVector& tags) const {
+    // TODO(jmarantz): Skip the creation of string-based tags, creating a StatNameTagVector instead.
+
+    // Note: one discrepancy between this and TagProducerImpl::produceTags is that this
+    // version does not add in tag_extractors_.default_tags_ into tags. That doesn't matter
+    // for this test, however.
+    std::list<const TagExtractor*> extractors; // Note push-front is used to reverse order.
+    tag_extractors_.forEachExtractorMatching(metric_name,
+                                             [&extractors](const TagExtractorPtr& tag_extractor) {
+                                               extractors.push_front(tag_extractor.get());
+                                             });
+
+    IntervalSetImpl<size_t> remove_characters;
+    TagExtractionContext tag_extraction_context(metric_name);
+    for (const TagExtractor* tag_extractor : extractors) {
+      tag_extractor->extractTag(tag_extraction_context, tags, remove_characters);
+    }
+    return StringUtil::removeCharacters(metric_name, remove_characters);
+  }
+
+  SymbolTableImpl symbol_table_;
+  TagProducerImpl tag_extractors_;
+};
+
+} // namespace Stats
+} // namespace Envoy


### PR DESCRIPTION
Commit Message:

Fixes issue #20201.

Thrift proxy stats prefix is not extracted as a tag in prometheus stats output. This makes it harder to generate generic graphs. 
Additional Description: N/A
Risk Level: Low (stats)
Testing: Unit + manual
Docs Changes: N/A
Release Notes: Pending (after we agree on the design to avoid merge conflicts)
Platform Specific Features: N/A
Optional Runtime guard:
Guard via: `envoy.restart_features.thrift_stat_prefix_tag_extraction` to maintain backwards compatibility if needed.
Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>