### PR TITLE
bazel: Add rules for debian packaging

### DIFF
--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -1,0 +1,47 @@
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+load(":packages.bzl", "envoy_pkg_distros")
+load("@envoy_repo//:version.bzl", "VERSION")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+MAINTAINER = "Envoy maintainers <envoy-maintainers@googlegroups.com>"
+
+genrule(
+    name = "envoy-bin",
+    srcs = ["//source/exe:envoy-static.stripped"],
+    outs = ["envoy"],
+    cmd = "cp -L $< $@",
+)
+
+envoy_pkg_distros(
+    name = "packages",
+    maintainer = MAINTAINER,
+    version = VERSION,
+)
+
+genrule(
+    name = "verification",
+    outs = ["verification.sh"],
+    cmd = """
+    echo 'exec $${@}' > $@ \
+    && chmod +x $@
+    """,
+)
+
+sh_binary(
+    name = "verify_packages",
+    srcs = [":verification.sh"],
+    args = [
+        "$(location //tools/distribution:verify)",
+        "$(location :distrotest.sh)",
+        VERSION,
+        "$(location :distros.yaml)",
+    ],
+    data = [
+        ":distros.yaml",
+        ":distrotest.sh",
+        "//tools/distribution:verify",
+    ],
+)

--- a/distribution/debian/BUILD
+++ b/distribution/debian/BUILD
@@ -1,0 +1,11 @@
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+exports_files([
+    "copyright",
+    "preinst",
+    "postinst",
+])

--- a/distribution/debian/copyright
+++ b/distribution/debian/copyright
@@ -1,0 +1,8 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Envoy
+Source: <https://github.com/envoyproxy/envoy>
+
+Files: *
+Copyright: Copyright 2016-2018 Envoy Project Authors
+License: Apache
+/usr/share/common-licenses/Apache-2.0

--- a/distribution/debian/copyright
+++ b/distribution/debian/copyright
@@ -3,6 +3,6 @@ Upstream-Name: Envoy
 Source: <https://github.com/envoyproxy/envoy>
 
 Files: *
-Copyright: Copyright 2016-2018 Envoy Project Authors
+Copyright: Copyright 2016-2022 Envoy Project Authors
 License: Apache
 /usr/share/common-licenses/Apache-2.0

--- a/distribution/debian/packages.bzl
+++ b/distribution/debian/packages.bzl
@@ -1,0 +1,102 @@
+load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
+
+GLIBC_MIN_VERSION = "2.27"
+
+def envoy_pkg_deb(
+        name,
+        data,
+        homepage = "https://www.envoyproxy.io/",
+        description = "Envoy built for Debian/Ubuntu",
+        preinst = "//distribution/debian:preinst",
+        postinst = "//distribution/debian:postinst",
+        supported_distributions = "buster bullseye bionic focal impish",
+        architecture = select({
+            "//bazel:x86": "amd64",
+            "//conditions:default": "arm64",
+        }),
+        depends = [
+            "libc6 (>= %s)" % GLIBC_MIN_VERSION,
+        ],
+        version = None,
+        maintainer = None,
+        **kwargs):
+    """Wrapper for `pkg_deb` with Envoy defaults"""
+    pkg_deb(
+        name = "%s-deb" % name,
+        architecture = architecture,
+        data = data,
+        depends = depends,
+        description = description,
+        distribution = supported_distributions,
+        homepage = homepage,
+        maintainer = maintainer,
+        package = name,
+        version = version,
+        preinst = preinst,
+        postinst = postinst,
+        **kwargs
+    )
+
+    native.filegroup(
+        name = "%s.changes" % name,
+        srcs = ["%s-deb" % name],
+        output_group = "changes",
+    )
+    native.filegroup(
+        name = "%s.deb" % name,
+        srcs = ["%s-deb" % name],
+        output_group = "deb",
+    )
+
+def envoy_pkg_debs(name, version, release_version, maintainer, bin_files = ":envoy-bin-files", config = ":envoy-config"):
+    """Package the Envoy .debs with their .changes files.
+
+    Packages are created for the version *and* the release version, eg
+
+    - envoy_1.21.0_amd64.deb
+    - envoy-1.21_1.21.0_amd64.deb
+
+    This way packages are available for both "envoy" and "envoy-1.21" in package managers.
+    """
+
+    # generate deb data for all packages
+    pkg_tar(
+        name = "deb-data",
+        srcs = [
+            "//distribution/debian:copyright",
+            config,
+            bin_files,
+        ],
+        remap_paths = {"/copyright": "/usr/share/doc/envoy/copyright"},
+    )
+
+    # generate package for this patch version
+    envoy_pkg_deb(
+        name = "envoy",
+        data = ":deb-data",
+        version = version,
+        maintainer = maintainer,
+    )
+
+    # generate package for this minor version
+    envoy_pkg_deb(
+        name = "envoy-%s" % release_version,
+        data = ":deb-data",
+        version = version,
+        conflicts = ["envoy"],
+        provides = ["envoy"],
+        maintainer = maintainer,
+    )
+
+    pkg_tar(
+        name = name,
+        srcs = [
+            "envoy.changes",
+            "envoy.deb",
+            "envoy-%s.changes" % release_version,
+            "envoy-%s.deb" % release_version,
+        ],
+        extension = "tar",
+        package_dir = "deb",
+    )

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# postinst script for envoy
+
+set -e
+
+case "$1" in
+
+  configure)
+        cat <<BANNER
+
+You have installed the Envoy proxy server.
+
+You can check your Envoy version by running the following in a terminal:
+
+  $ envoy --version
+
+Documentation for your version is available at:
+
+  https://www.envoyproxy.io/docs
+
+The Envoy project can be found at:
+
+  https://github.com/envoyproxy/envoy
+
+BANNER
+  ;;
+
+  abort-upgrade|abort-remove|abort-deconfigure)
+    exit 0
+  ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+  ;;
+
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/distribution/debian/preinst
+++ b/distribution/debian/preinst
@@ -1,0 +1,47 @@
+#! /bin/sh
+
+# preinst script for envoy
+
+set -e
+
+addenvoyuser() {
+    if ! getent group envoy >/dev/null; then
+        addgroup --system envoy >/dev/null
+    fi
+
+    if ! getent passwd envoy >/dev/null; then
+        adduser \
+          --system \
+          --disabled-login \
+          --ingroup envoy \
+          --no-create-home \
+          --home /nonexistent \
+          --gecos "envoy user" \
+          --shell /bin/false \
+          envoy  >/dev/null
+
+    fi
+}
+
+case "$1" in
+
+    install)
+        addenvoyuser
+        ;;
+
+    upgrade)
+        addenvoyuser
+        ;;
+
+    abort-upgrade)
+        ;;
+
+    *)
+        echo "preinst called with unknown argument \`$1'" >&2
+        exit 0
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/distribution/distros.yaml
+++ b/distribution/distros.yaml
@@ -1,0 +1,20 @@
+
+debian_buster:
+  image: debian:buster-slim
+  ext: buster.changes
+
+debian_bullseye:
+  image: debian:bullseye-slim
+  ext: bullseye.changes
+
+ubuntu_bionic:
+  image: ubuntu:18.04
+  ext: bionic.changes
+
+ubuntu_focal:
+  image: ubuntu:20.04
+  ext: focal.changes
+
+ubuntu_impish:
+  image: ubuntu:21.10
+  ext: impish.changes

--- a/distribution/distrotest.sh
+++ b/distribution/distrotest.sh
@@ -84,7 +84,8 @@ test "$(stat -L -c "%a %G %U" /usr/bin/envoy)" == "$BINARY_PERMISSIONS" && echo 
 run_log config-permissions "Check ownership/permissions of envoy config"
 test "$(stat -L -c "%a %G %U" /etc/envoy/envoy.yaml)" == "$CONFIG_PERMISSIONS" && echo "Correct permissions: ${CONFIG_PERMISSIONS}"
 
-run_log envoy-version "Envoy version"
+run_log envoy-version "Envoy version: ${ENVOY_VERSION}"
+envoy --version
 envoy --version | grep "$ENVOY_VERSION"
 
 run_log start-envoy "Start Envoy"
@@ -99,7 +100,7 @@ pgrep envoy
 
 run_log proxy-responds "Check proxy responds"
 RESPONSE=$(curl -s http://localhost:10000/)
-echo "$RESPONSE" | grep "Welcome to Envoy"
+echo "$RESPONSE" | grep "Envoy is an open source edge and service proxy, designed for cloud-native applications"
 
 run_log stop-envoy "Stop envoy"
 sudo -u envoy pkill envoy && echo "Envoy stopped"

--- a/distribution/packages.bzl
+++ b/distribution/packages.bzl
@@ -1,0 +1,76 @@
+load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("//distribution/debian:packages.bzl", "envoy_pkg_debs")
+
+def _release_version_for(version):
+    if "-" in version:
+        version, version_suffix = version.split("-")
+
+    major, minor, patch = version.split(".")
+    return ".".join((major, minor))
+
+def envoy_pkg_distros(
+        name,
+        envoy_bin = ":envoy-bin",
+        version = None,
+        maintainer = None,
+        config = "//configs:envoyproxy_io_proxy.yaml"):
+    # data common to all packages
+    pkg_files(
+        name = "envoy-config",
+        srcs = [config],
+        renames = {
+            config: "/etc/envoy/envoy.yaml",
+        },
+    )
+
+    pkg_files(
+        name = "envoy-bin-files",
+        srcs = [envoy_bin],
+        attributes = pkg_attributes(mode = "0755"),
+        renames = {envoy_bin: "/usr/bin/envoy"},
+    )
+
+    # build debs
+    envoy_pkg_debs(
+        name = "debs",
+        version = version,
+        release_version = _release_version_for(version),
+        maintainer = maintainer,
+    )
+
+    # bundle distro packages into a tarball
+    pkg_tar(
+        name = "distro_packages",
+        extension = "tar",
+        deps = [
+            ":debs",
+        ],
+    )
+
+    # sign the packages
+    native.genrule(
+        name = name,
+        cmd = """
+        SIGNING_ARGS=() \
+        && if [[ -n $${PACKAGES_GEN_KEY+x} ]]; then \
+               SIGNING_ARGS+=("--gen-key"); \
+           fi \
+        && if [[ -n $${PACKAGES_MAINTAINER_NAME+x} ]]; then \
+               SIGNING_ARGS+=("--maintainer-name" "$${PACKAGES_MAINTAINER_NAME}"); \
+           fi \
+        && if [[ -n $${PACKAGES_MAINTAINER_EMAIL+x} ]]; then \
+               SIGNING_ARGS+=("--maintainer-email" "$${PACKAGES_MAINTAINER_EMAIL}"); \
+           fi \
+        && $(location //tools/distribution:sign) \
+            --extract \
+            --tar $@ \
+            "$${SIGNING_ARGS[@]}" \
+            $(location :distro_packages)
+        """,
+        outs = ["%s.tar.gz" % name],
+        srcs = [":distro_packages"],
+        tools = [
+            "//tools/distribution:sign",
+        ],
+    )

--- a/tools/distribution/BUILD
+++ b/tools/distribution/BUILD
@@ -5,10 +5,6 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-exports_files([
-    "distrotest.sh",
-])
-
 envoy_entry_point(
     name = "release",
     pkg = "envoy.distribution.release",


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

breakout pr from #17979 containing only the bazel rules (and no ci changes)

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
