### PR TITLE
filter_state: add shared pointer accessor

### DIFF
--- a/envoy/stream_info/filter_state.h
+++ b/envoy/stream_info/filter_state.h
@@ -117,6 +117,13 @@ public:
   virtual Object* getDataMutableGeneric(absl::string_view data_name) PURE;
 
   /**
+   * @param data_name the name of the data being looked up (mutable/readonly).
+   * @return a shared pointer to the stored data or nullptr if the data does not exist.
+   * An exception will be thrown if the data is not mutable.
+   */
+  virtual std::shared_ptr<Object> getDataSharedMutableGeneric(absl::string_view data_name) PURE;
+
+  /**
    * @param data_name the name of the data being probed.
    * @return Whether data of the type and name specified exists in the
    * data store.

--- a/source/common/stream_info/filter_state_impl.cc
+++ b/source/common/stream_info/filter_state_impl.cc
@@ -61,22 +61,7 @@ FilterStateImpl::getDataReadOnlyGeneric(absl::string_view data_name) const {
 }
 
 FilterState::Object* FilterStateImpl::getDataMutableGeneric(absl::string_view data_name) {
-  const auto& it = data_storage_.find(data_name);
-
-  if (it == data_storage_.end()) {
-    if (parent_) {
-      return parent_->getDataMutableGeneric(data_name);
-    }
-    return nullptr;
-  }
-
-  FilterStateImpl::FilterObject* current = it->second.get();
-  if (current->state_type_ == FilterState::StateType::ReadOnly) {
-    throw EnvoyException(
-        "FilterState::getDataMutable<T> tried to access immutable data as mutable.");
-  }
-
-  return current->data_.get();
+  return getDataSharedMutableGeneric(data_name).get();
 }
 
 std::shared_ptr<FilterState::Object>
@@ -92,8 +77,7 @@ FilterStateImpl::getDataSharedMutableGeneric(absl::string_view data_name) {
 
   FilterStateImpl::FilterObject* current = it->second.get();
   if (current->state_type_ == FilterState::StateType::ReadOnly) {
-    throw EnvoyException(
-        "FilterState::getDataSharedMutableGeneric tried to access immutable data as mutable.");
+    throw EnvoyException("FilterState tried to access immutable data as mutable.");
   }
 
   return current->data_;

--- a/source/common/stream_info/filter_state_impl.h
+++ b/source/common/stream_info/filter_state_impl.h
@@ -46,6 +46,7 @@ public:
   bool hasDataWithName(absl::string_view) const override;
   const Object* getDataReadOnlyGeneric(absl::string_view data_name) const override;
   Object* getDataMutableGeneric(absl::string_view data_name) override;
+  std::shared_ptr<Object> getDataSharedMutableGeneric(absl::string_view data_name) override;
   bool hasDataAtOrAboveLifeSpan(FilterState::LifeSpan life_span) const override;
 
   FilterState::LifeSpan lifeSpan() const override { return life_span_; }

--- a/test/common/stream_info/filter_state_impl_test.cc
+++ b/test/common/stream_info/filter_state_impl_test.cc
@@ -224,12 +224,11 @@ TEST_F(FilterStateImplTest, ErrorAccessingReadOnlyAsMutable) {
   // Accessing read only data as mutable should throw error
   filter_state().setData("test_name", std::make_unique<TestStoredTypeTracking>(5, nullptr, nullptr),
                          FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
-  EXPECT_THROW_WITH_MESSAGE(
-      filter_state().getDataMutable<TestStoredTypeTracking>("test_name"), EnvoyException,
-      "FilterState::getDataMutable<T> tried to access immutable data as mutable.");
-  EXPECT_THROW_WITH_MESSAGE(
-      filter_state().getDataSharedMutableGeneric("test_name"), EnvoyException,
-      "FilterState::getDataSharedMutableGeneric tried to access immutable data as mutable.");
+  EXPECT_THROW_WITH_MESSAGE(filter_state().getDataMutable<TestStoredTypeTracking>("test_name"),
+                            EnvoyException,
+                            "FilterState tried to access immutable data as mutable.");
+  EXPECT_THROW_WITH_MESSAGE(filter_state().getDataSharedMutableGeneric("test_name"), EnvoyException,
+                            "FilterState tried to access immutable data as mutable.");
 }
 
 namespace {
@@ -288,15 +287,13 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromParent) {
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_4"));
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_5"));
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_6"));
-  EXPECT_THROW_WITH_MESSAGE(
-      new_filter_state.getDataMutable<SimpleType>("test_3"), EnvoyException,
-      "FilterState::getDataMutable<T> tried to access immutable data as mutable.");
+  EXPECT_THROW_WITH_MESSAGE(new_filter_state.getDataMutable<SimpleType>("test_3"), EnvoyException,
+                            "FilterState tried to access immutable data as mutable.");
 
   EXPECT_EQ(4, new_filter_state.getDataMutable<SimpleType>("test_4")->access());
 
-  EXPECT_THROW_WITH_MESSAGE(
-      new_filter_state.getDataMutable<SimpleType>("test_5"), EnvoyException,
-      "FilterState::getDataMutable<T> tried to access immutable data as mutable.");
+  EXPECT_THROW_WITH_MESSAGE(new_filter_state.getDataMutable<SimpleType>("test_5"), EnvoyException,
+                            "FilterState tried to access immutable data as mutable.");
 
   EXPECT_EQ(6, new_filter_state.getDataMutable<SimpleType>("test_6")->access());
 }
@@ -323,9 +320,8 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromGrandparent) {
   EXPECT_FALSE(new_filter_state.hasDataWithName("test_4"));
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_5"));
   EXPECT_TRUE(new_filter_state.hasDataWithName("test_6"));
-  EXPECT_THROW_WITH_MESSAGE(
-      new_filter_state.getDataMutable<SimpleType>("test_5"), EnvoyException,
-      "FilterState::getDataMutable<T> tried to access immutable data as mutable.");
+  EXPECT_THROW_WITH_MESSAGE(new_filter_state.getDataMutable<SimpleType>("test_5"), EnvoyException,
+                            "FilterState tried to access immutable data as mutable.");
   EXPECT_EQ(6, new_filter_state.getDataMutable<SimpleType>("test_6")->access());
 }
 

--- a/test/common/stream_info/filter_state_impl_test.cc
+++ b/test/common/stream_info/filter_state_impl_test.cc
@@ -86,14 +86,18 @@ TEST_F(FilterStateImplTest, SharedPointerAccessor) {
   EXPECT_EQ(0u, access_count);
   EXPECT_EQ(0u, destruction_count);
 
-  auto obj = filter_state().getDataSharedMutableGeneric("test_name");
-  EXPECT_EQ(5, dynamic_cast<TestStoredTypeTracking*>(obj.get())->access());
-  EXPECT_EQ(1u, access_count);
-  EXPECT_EQ(0u, destruction_count);
+  {
+    auto obj = filter_state().getDataSharedMutableGeneric("test_name");
+    EXPECT_EQ(5, dynamic_cast<TestStoredTypeTracking*>(obj.get())->access());
+    EXPECT_EQ(1u, access_count);
+    EXPECT_EQ(0u, destruction_count);
 
-  resetFilterState();
-  EXPECT_EQ(1u, access_count);
-  EXPECT_EQ(0u, destruction_count);
+    resetFilterState();
+    EXPECT_EQ(1u, access_count);
+    EXPECT_EQ(0u, destruction_count);
+  }
+
+  EXPECT_EQ(1u, destruction_count);
 }
 
 TEST_F(FilterStateImplTest, SameTypes) {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Allow access to mutable filter state objects via shared pointer. This allows copying objects to different streams (e.g. from downstream to upstream filter state, or from downstream to another internal downstream filter state). Read-only objects are locked to the stream to avoid mutation via another stream.
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none