### PR TITLE
CI: Increase shard count since CSRF times out under TSAN.

### DIFF
--- a/test/extensions/filters/http/csrf/BUILD
+++ b/test/extensions/filters/http/csrf/BUILD
@@ -31,6 +31,9 @@ envoy_extension_cc_test(
     name = "csrf_filter_integration_test",
     srcs = ["csrf_filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.csrf"],
+    # TODO(kbaichoo): remove when deferred processing is enabled by default and the
+    # test is no longer parameterized by it.
+    shard_count = 2,
     deps = [
         "//source/extensions/filters/http/csrf:config",
         "//test/config:utility_lib",


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: CI: Increase shard count since CSRF times out under TSAN.
Additional Description: 
Risk Level: low
Testing: ran under tsan with additional sharding:
 `Stats over 20 runs: max = 126.8s, min = 123.8s, avg = 125.5s, dev = 0.7s`
Docs Changes: na
Release Notes: na
Platform Specific Features: na
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
