### PR TITLE
Add Source Attribution to hot-restarter.py

### DIFF
--- a/restarter/hot-restarter.py
+++ b/restarter/hot-restarter.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# source: https://github.com/envoyproxy/envoy/blob/main/restarter/hot-restarter.py
 from __future__ import print_function
 
 import os


### PR DESCRIPTION
Super simple PR

Basically adds a single comment with the link back to the "original" hot restart script

This way, people can depend on it in external repositories and know the files origin

Commit Message: add source attribution to hot-restarter
Additional Description: Adds a source link to the hot-restart python script. This is useful in case people pull it into external repositories.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: Adds source attribution to hot-restarter
Platform Specific Features: N/A
