### PR TITLE
add ratelimit populate descriptors log

### DIFF
--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
@@ -114,6 +114,14 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   // Store descriptors which is used to generate x-ratelimit-* headers in encoding response headers.
   stored_descriptors_ = descriptors;
 
+  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
+    for (const auto& request_descriptor : descriptors) {
+      for (const Envoy::RateLimit::DescriptorEntry& entry : request_descriptor.entries_) {
+        ENVOY_LOG(debug, "populate descriptors: key={} value={}", entry.key_, entry.value_);
+      }
+    }
+  }
+
   if (requestAllowed(descriptors)) {
     config->stats().ok_.inc();
     return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.h
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.h
@@ -134,7 +134,7 @@ using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
  * HTTP local rate limit filter. Depending on the route configuration, this filter calls consults
  * with local token bucket before allowing further filter iteration.
  */
-class Filter : public Http::PassThroughFilter {
+class Filter : public Http::PassThroughFilter, Logger::Loggable<Logger::Id::filter> {
 public:
   Filter(FilterConfigSharedPtr config) : config_(config) {}
 


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

Commit Message: add ratelimit populate descriptors log to help debug
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
