### PR TITLE
Fix deprecated GUARDED_BY macro and update doc

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -90,7 +90,7 @@
   NiceMock for mocks whose behavior is not the focus of a test.
 * [Thread
   annotations](https://github.com/abseil/abseil-cpp/blob/master/absl/base/thread_annotations.h),
-  such as `GUARDED_BY`, should be used for shared state guarded by
+  such as `ABSL_GUARDED_BY`, should be used for shared state guarded by
   locks/mutexes.
 * Functions intended to be local to a cc file should be declared in an anonymous namespace,
   rather than using the 'static' keyword. Note that the

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -74,7 +74,7 @@ private:
   // thread.
   std::atomic<std::thread::id> main_thread_id_;
 
-  int32_t main_thread_use_count_ GUARDED_BY(mutex_) = 0;
+  int32_t main_thread_use_count_ ABSL_GUARDED_BY(mutex_) = 0;
   mutable absl::Mutex mutex_;
 
   std::atomic<uint32_t> skip_asserts_{};


### PR DESCRIPTION
Additional Description:
GUARDED_BY is deprecated and replaced with ABSL_GUARDED_BY

Risk Level: Low
Testing: Unit Tests
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
