### PR TITLE
route.proto: add is_optional field to ClusterSpecifierPlugin

### DIFF
--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -134,8 +134,8 @@ message ClusterSpecifierPlugin {
   // The name of the plugin and its opaque configuration.
   core.v3.TypedExtensionConfig extension = 1;
   // If is_optional is not set and the plugin defined by this message is not
-  // a supported type, the containing resource is NACKed.  If is_optional is
-  // set, the resource would not be NACKed for this reason.  In this case,
+  // a supported type, the containing resource is NACKed. If is_optional is
+  // set, the resource would not be NACKed for this reason. In this case,
   // routes referencing this plugin's name would not be treated as an illegal
   // configuration, but would result in a failure if the route is selected.
   bool is_optional = 2;

--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -133,6 +133,7 @@ message RouteConfiguration {
 message ClusterSpecifierPlugin {
   // The name of the plugin and its opaque configuration.
   core.v3.TypedExtensionConfig extension = 1;
+
   // If is_optional is not set and the plugin defined by this message is not
   // a supported type, the containing resource is NACKed. If is_optional is
   // set, the resource would not be NACKed for this reason. In this case,

--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -133,6 +133,12 @@ message RouteConfiguration {
 message ClusterSpecifierPlugin {
   // The name of the plugin and its opaque configuration.
   core.v3.TypedExtensionConfig extension = 1;
+  // If is_optional is not set and the plugin defined by this message is not
+  // a supported type, the containing resource is NACKed.  If is_optional is
+  // set, the resource would not be NACKed for this reason.  In this case,
+  // routes referencing this plugin's name would not be treated as an illegal
+  // configuration, but would result in a failure if the route is selected.
+  bool is_optional = 2;
 }
 
 message Vhds {


### PR DESCRIPTION
Signed-off-by: Doug Fawley <dfawley@google.com>

Commit Message: route.proto: add is_optional field to ClusterSpecifierPlugin
Additional Description:

When deploying a new cluster specifier plugin, it is often necessary to add it to the configuration before all clients can be updated to support it, with routing rules configured to prevent clients without support from selecting any routes referencing the plugin.  This field will allow those clients to suppress the default behavior of NACKing any resource containing the unknown plugin.

Risk Level: None
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None

@markdroth @ejona86 