### PR TITLE
ext_authz: forward typed_filter_metadata to external auth service

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -84,7 +84,8 @@ message ExtAuthz {
   type.v3.HttpStatus status_on_error = 7;
 
   // Specifies a list of metadata namespaces whose values, if present, will be passed to the
-  // ext_authz service as an opaque *protobuf::Struct*.
+  // ext_authz service. :ref:`filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.filter_metadata>` is passed as an opaque *protobuf::Struct* while
+  // :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` is passed as an *protobuf::Any*.
   //
   // For example, if the *jwt_authn* filter is used and :ref:`payload_in_metadata
   // <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.payload_in_metadata>` is set,

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -15,6 +15,7 @@ Minor Behavior Changes
 * access_log: log all header values in the grpc access log.
 * dynamic_forward_proxy: if a DNS resolution fails, failing immediately with a specific resolution error, rather than finishing up all local filters and failing to select an upstream host.
 * ext_authz: added requested server name in ext_authz network filter for auth review.
+* ext_authz: forward typed_filter_metadata to external auth service.
 * file: changed disk based files to truncate files which are not being appended to. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.append_or_truncate`` to false.
 * grpc: flip runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to be default enabled. async grpc client created through getOrCreateRawAsyncClient will be cached by default.
 * http: avoiding delay-close for HTTP/1.0 responses framed by connection: close as well as HTTP/1.1 if the request is fully read. This means for responses to such requests, the FIN will be sent immediately after the response. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.skip_delay_close`` to false.  If clients are are seen to be receiving sporadic partial responses and flipping this flag fixes it, please notify the project immediately.

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -43,7 +43,8 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers,
     context_extensions = maybe_merged_per_route_config.value().takeContextExtensions();
   }
 
-  // If metadata_context_namespaces is specified, pass matching metadata to the ext_authz service.
+  // If metadata_context_namespaces is specified, pass matching filter metadata to
+  // the ext_authz service.
   envoy::config::core::v3::Metadata metadata_context;
   const auto& request_metadata =
       decoder_callbacks_->streamInfo().dynamicMetadata().filter_metadata();
@@ -51,6 +52,16 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers,
     const auto& metadata_it = request_metadata.find(context_key);
     if (metadata_it != request_metadata.end()) {
       (*metadata_context.mutable_filter_metadata())[metadata_it->first] = metadata_it->second;
+    }
+  }
+  // If metadata_context_namespaces is specified, pass matching typed filter metadata to
+  // the ext_authz service as well.
+  const auto& request_typed_metadata =
+      decoder_callbacks_->streamInfo().dynamicMetadata().typed_filter_metadata();
+  for (const auto& context_key : config_->metadataContextNamespaces()) {
+    const auto& metadata_it = request_typed_metadata.find(context_key);
+    if (metadata_it != request_typed_metadata.end()) {
+      (*metadata_context.mutable_typed_filter_metadata())[metadata_it->first] = metadata_it->second;
     }
   }
 

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/proto:helloworld_proto_cc_proto",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -26,6 +26,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
+#include "test/proto/helloworld.pb.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
@@ -1160,6 +1161,7 @@ TEST_F(HttpFilterTest, MetadataContext) {
   - jazz.sax
   - rock.guitar
   - hiphop.drums
+  - blues.piano
   )EOF");
 
   const std::string yaml = R"EOF(
@@ -1173,6 +1175,16 @@ TEST_F(HttpFilterTest, MetadataContext) {
     rock.guitar:
       hendrix: jimi
       richards: keith
+  typed_filter_metadata:
+    blues.piano:
+      '@type': type.googleapis.com/helloworld.HelloRequest
+      name: jack dupree
+    jazz.sax:
+      '@type': type.googleapis.com/helloworld.HelloRequest
+      name: shorter wayne
+    rock.bass:
+      '@type': type.googleapis.com/helloworld.HelloRequest
+      name: geddy lee
   )EOF";
 
   envoy::config::core::v3::Metadata metadata;
@@ -1213,6 +1225,24 @@ TEST_F(HttpFilterTest, MetadataContext) {
 
   EXPECT_EQ(0,
             check_request.attributes().metadata_context().filter_metadata().count("hiphop.drums"));
+
+  helloworld::HelloRequest hello;
+  check_request.attributes()
+      .metadata_context()
+      .typed_filter_metadata()
+      .at("blues.piano")
+      .UnpackTo(&hello);
+  EXPECT_EQ("jack dupree", hello.name());
+
+  check_request.attributes()
+      .metadata_context()
+      .typed_filter_metadata()
+      .at("jazz.sax")
+      .UnpackTo(&hello);
+  EXPECT_EQ("shorter wayne", hello.name());
+
+  EXPECT_EQ(
+      0, check_request.attributes().metadata_context().typed_filter_metadata().count("rock.bass"));
 }
 
 // Test that filter can be disabled via the filter_enabled field.


### PR DESCRIPTION
filter_metadata is already forwarded to external auth service
but typed_filter_metadata is not, this commit fixes this.

Signed-off-by: Wanli Li <wanlil@netflix.com>

Commit Message: ext_authz: forward typed_filter_metadata to external auth service
Additional Description: filter_metadata is already forwarded to external auth service
but typed_filter_metadata is not, this commit fixes this.
Risk Level: low
Testing: unit test changed to cover this change.
Docs Changes: protobuf comment changed to cover this.
Release Notes: updated current.rst.
Platform Specific Features: no