### PR TITLE
Fix IgnoreUnknownOptionalHttpFilter test to work in IPv6 only environment

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -314,7 +314,7 @@ TEST_P(ListenerIntegrationTest, IgnoreUnknownOptionalHttpFilter) {
       name: fake_listener
       address:
         socket_address:
-          address: 127.0.0.1
+          address: "::"
           port_value: 0
       filter_chains:
         - filters:


### PR DESCRIPTION
Risk Level: Low, Test Only
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
