### PR TITLE
dubbo: fix unexpected exception for null but with attachments response type

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
@@ -101,9 +101,9 @@ DubboHessian2SerializerImpl::deserializeRpcResult(Buffer::Instance& buffer,
     result->setException(true);
     break;
   case RpcResponseType::ResponseWithNullValue:
-  case RpcResponseType::ResponseNullValueWithAttachments:
     has_value = false;
     FALLTHRU;
+  case RpcResponseType::ResponseNullValueWithAttachments:
   case RpcResponseType::ResponseWithValue:
   case RpcResponseType::ResponseValueWithAttachments:
     result->setException(false);

--- a/test/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl_test.cc
@@ -358,7 +358,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         't',
     }));
 
-    context->setBodySize(4);
+    context->setBodySize(buffer.length());
 
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcResult(buffer, context), EnvoyException,
                               "Cannot parse RpcResult type from buffer");
@@ -370,7 +370,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x94',                   // return type
         0x04, 't', 'e', 's', 't', // return body
     }));
-    context->setBodySize(4);
+    context->setBodySize(buffer.length());
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
     EXPECT_FALSE(result.first->hasException());
@@ -382,7 +382,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x93',                   // return type
         0x04, 't', 'e', 's', 't', // return body
     }));
-    context->setBodySize(4);
+    context->setBodySize(buffer.length());
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
     EXPECT_TRUE(result.first->hasException());
@@ -412,12 +412,36 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
     EXPECT_FALSE(result.first->hasException());
   }
 
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({
+        '\x95', // return type
+        'H',    // return attachment
+        0x03,
+        'k',
+        'e',
+        'y',
+        0x05,
+        'v',
+        'a',
+        'l',
+        'u',
+        'e',
+        'Z',
+    }));
+
+    context->setBodySize(buffer.length());
+    auto result = serializer.deserializeRpcResult(buffer, context);
+    EXPECT_TRUE(result.second);
+    EXPECT_FALSE(result.first->hasException());
+  }
+
   // incorrect body size
   {
     Buffer::OwnedImpl buffer;
     buffer.add(std::string({
         '\x94',                   // return type
-        0x05, 't', 'e', 's', 't', // return body
+        0x04, 't', 'e', 's', 't', // return body
     }));
     context->setBodySize(0);
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcResult(buffer, context), EnvoyException,
@@ -429,7 +453,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
     Buffer::OwnedImpl buffer;
     buffer.add(std::string({
         '\x96',                   // incorrect return type
-        0x05, 't', 'e', 's', 't', // return body
+        0x04, 't', 'e', 's', 't', // return body
     }));
     context->setBodySize(buffer.length());
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcResult(buffer, context), EnvoyException,
@@ -441,7 +465,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
     Buffer::OwnedImpl buffer;
     buffer.add(std::string({
         '\x92',                   // without the value of the return type
-        0x05, 't', 'e', 's', 't', // return body
+        0x04, 't', 'e', 's', 't', // return body
     }));
     std::string exception_string =
         fmt::format("RpcResult is no value, but the rest of the body size({}) not equal 0",


### PR DESCRIPTION
Commit Message: dubbo: fix unexpected exception for null but with attachments response type
Additional Description:

When dubbo providers response null value but with attachments, the error body length check will result in an unexpected exception.

And this PR fix it.

**This bug is reported by the @zhnxin in the #19635. But @zhnxin is unresponsive, so I pick this up to complete this fix.
Thanks a lot to the @zhnxin. 🌷 **

Risk Level: Low.
Testing: Added.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.