### PR TITLE
HeaderValueMatch support custom descriptor key

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1793,6 +1793,9 @@ message RateLimit {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.route.RateLimit.Action.HeaderValueMatch";
 
+      // The key to use in the descriptor entry. Defaults to `header_match`.
+      string descriptor_key = 4;
+
       // The value to use in the descriptor entry.
       string descriptor_value = 1 [(validate.rules).string = {min_len: 1}];
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,7 +25,7 @@ Minor Behavior Changes
 * http: when writing custom filters, `injectEncodedDataToFilterChain` and `injectDecodedDataToFilterChain` now trigger sending of headers if they were not yet sent due to `StopIteration`. Previously, calling one of the inject functions in that state would trigger an assertion. See issue #19891 for more details.
 * listener: the :ref:`ipv4_compat <envoy_api_field_core.SocketAddress.ipv4_compat>` flag can only be set on Ipv6 address and Ipv4-mapped Ipv6 address. A runtime guard is added ``envoy.reloadable_features.strict_check_on_ipv4_compat`` and the default is true.
 * perf: ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
-* ratelimit: header_value_match support custom :ref:`descriptor_key <envoy_v3_api_msg_config.route.v3.ratelimit.action.HeaderValueMatch.descriptor_key>`.
+* ratelimit: the :ref:`header_value_match <envoy_v3_api_msg_config.route.v3.ratelimit.action.HeaderValueMatch>` support custom descriptor_key.
 * router: record upstream request timeouts for all the cases and not just for those requests which are awaiting headers. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` to false.
 * sip-proxy: add customized affinity support by adding :ref:`tra_service_config <envoy_v3_api_msg_extensions.filters.network.sip_proxy.tra.v3alpha.TraServiceConfig>` and :ref:`customized_affinity <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.CustomizedAffinity>`.
 * sip-proxy: add support for the ``503`` response code. When there is something wrong occurred, send ``503 Service Unavailable`` back to downstream.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,7 +25,7 @@ Minor Behavior Changes
 * http: when writing custom filters, `injectEncodedDataToFilterChain` and `injectDecodedDataToFilterChain` now trigger sending of headers if they were not yet sent due to `StopIteration`. Previously, calling one of the inject functions in that state would trigger an assertion. See issue #19891 for more details.
 * listener: the :ref:`ipv4_compat <envoy_api_field_core.SocketAddress.ipv4_compat>` flag can only be set on Ipv6 address and Ipv4-mapped Ipv6 address. A runtime guard is added ``envoy.reloadable_features.strict_check_on_ipv4_compat`` and the default is true.
 * perf: ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
-* ratelimit: header_value_match support custom descriptor key.
+* ratelimit: header_value_match support custom :ref:`descriptor_key <envoy_v3_api_msg_config.route.v3.ratelimit.action.HeaderValueMatch.descriptor_key>`.
 * router: record upstream request timeouts for all the cases and not just for those requests which are awaiting headers. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` to false.
 * sip-proxy: add customized affinity support by adding :ref:`tra_service_config <envoy_v3_api_msg_extensions.filters.network.sip_proxy.tra.v3alpha.TraServiceConfig>` and :ref:`customized_affinity <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.CustomizedAffinity>`.
 * sip-proxy: add support for the ``503`` response code. When there is something wrong occurred, send ``503 Service Unavailable`` back to downstream.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,6 +25,7 @@ Minor Behavior Changes
 * http: when writing custom filters, `injectEncodedDataToFilterChain` and `injectDecodedDataToFilterChain` now trigger sending of headers if they were not yet sent due to `StopIteration`. Previously, calling one of the inject functions in that state would trigger an assertion. See issue #19891 for more details.
 * listener: the :ref:`ipv4_compat <envoy_api_field_core.SocketAddress.ipv4_compat>` flag can only be set on Ipv6 address and Ipv4-mapped Ipv6 address. A runtime guard is added ``envoy.reloadable_features.strict_check_on_ipv4_compat`` and the default is true.
 * perf: ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
+* ratelimit: header_value_match support custom descriptor key.
 * router: record upstream request timeouts for all the cases and not just for those requests which are awaiting headers. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` to false.
 * sip-proxy: add customized affinity support by adding :ref:`tra_service_config <envoy_v3_api_msg_extensions.filters.network.sip_proxy.tra.v3alpha.TraServiceConfig>` and :ref:`customized_affinity <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.CustomizedAffinity>`.
 * sip-proxy: add support for the ``503`` response code. When there is something wrong occurred, send ``503 Service Unavailable`` back to downstream.

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -162,6 +162,7 @@ bool MetaDataAction::populateDescriptor(RateLimit::DescriptorEntry& descriptor_e
 HeaderValueMatchAction::HeaderValueMatchAction(
     const envoy::config::route::v3::RateLimit::Action::HeaderValueMatch& action)
     : descriptor_value_(action.descriptor_value()),
+      descriptor_key_(!action.descriptor_key().empty() ? action.descriptor_key() : "header_match"),
       expect_match_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, expect_match, true)),
       action_headers_(Http::HeaderUtility::buildHeaderDataVector(action.headers())) {}
 
@@ -170,7 +171,7 @@ bool HeaderValueMatchAction::populateDescriptor(RateLimit::DescriptorEntry& desc
                                                 const Http::RequestHeaderMap& headers,
                                                 const StreamInfo::StreamInfo&) const {
   if (expect_match_ == Http::HeaderUtility::matchHeaders(headers, action_headers_)) {
-    descriptor_entry = {"header_match", descriptor_value_};
+    descriptor_entry = {descriptor_key_, descriptor_value_};
     return true;
   } else {
     return false;

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -151,6 +151,7 @@ public:
 
 private:
   const std::string descriptor_value_;
+  const std::string descriptor_key_;
   const bool expect_match_;
   const std::vector<Http::HeaderUtility::HeaderDataPtr> action_headers_;
 };

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -844,7 +844,7 @@ actions:
               testing::ContainerEq(local_descriptors_));
 }
 
-TEST_F(RateLimitPolicyEntryTest, HeaderValueMatch) {
+TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchDescriptorKey) {
   const std::string yaml = R"EOF(
 actions:
 - header_value_match:

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -844,6 +844,29 @@ actions:
               testing::ContainerEq(local_descriptors_));
 }
 
+TEST_F(RateLimitPolicyEntryTest, HeaderValueMatch) {
+  const std::string yaml = R"EOF(
+actions:
+- header_value_match:
+    descriptor_key: fake_key
+    descriptor_value: fake_value
+    headers:
+    - name: x-header-name
+      string_match:
+        exact: test_value
+  )EOF";
+
+  setupTest(yaml);
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "", header, stream_info_);
+  rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"fake_key", "fake_value"}}}}),
+              testing::ContainerEq(descriptors_));
+  EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"fake_key", "fake_value"}}}}),
+              testing::ContainerEq(local_descriptors_));
+}
+
 TEST_F(RateLimitPolicyEntryTest, HeaderValueMatchNoMatch) {
   const std::string yaml = R"EOF(
 actions:


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

before:
```yaml
- header_value_match:
      descriptor_value: "svc1"
      expect_match: true
      headers:
        - name: :path
          prefix_match: /svc1
```
```console
[2022-03-14 13:45:02.793][3414241][debug][filter] [external/envoy/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc:120] populate descriptors: key=request_method value=GET
[2022-03-14 13:45:02.793][3414241][debug][filter] [external/envoy/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc:120] populate descriptors: key=header_match value=svc1
```

after:
```
- header_value_match:
      descriptor_key: path_match
      descriptor_value: "svc1"
      expect_match: true
      headers:
        - name: :path
          prefix_match: /svc1
```

```console
[2022-03-14 13:45:35.923][3414669][debug][filter] [external/envoy/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc:120] populate descriptors: key=request_method value=GET
[2022-03-14 13:45:35.923][3414669][debug][filter] [external/envoy/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc:120] populate descriptors: key=path_match value=svc1
```

Commit Message: HeaderValueMatch support custom descriptor key
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/20249
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
