### PR TITLE
multi-envoy: fixing shutdown ordering bugs

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -467,12 +467,6 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
       server_stats_->initialization_time_ms_, timeSource());
   server_stats_->concurrency_.set(options_.concurrency());
   server_stats_->hot_restart_epoch_.set(options_.restartEpoch());
-
-  assert_action_registration_ = Assert::addDebugAssertionFailureRecordAction(
-      [this](const char*) { server_stats_->debug_assertion_failures_.inc(); });
-  envoy_bug_action_registration_ = Assert::addEnvoyBugFailureRecordAction(
-      [this](const char*) { server_stats_->envoy_bug_failures_.inc(); });
-
   InstanceImpl::failHealthcheck(false);
 
   // Check if bootstrap has server version override set, if yes, we should use that as
@@ -627,6 +621,13 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
   }
   initial_config.initAdminAccessLog(bootstrap_, *this);
   validation_context_.setRuntime(runtime());
+
+  if (!runtime().snapshot().getBoolean("envoy.disallow_global_stats", false)) {
+    assert_action_registration_ = Assert::addDebugAssertionFailureRecordAction(
+        [this](const char*) { server_stats_->debug_assertion_failures_.inc(); });
+    envoy_bug_action_registration_ = Assert::addEnvoyBugFailureRecordAction(
+        [this](const char*) { server_stats_->envoy_bug_failures_.inc(); });
+  }
 
   if (initial_config.admin().address()) {
     admin_->startHttpListener(initial_config.admin().accessLogs(), options_.adminAddressPath(),

--- a/test/integration/multi_envoy_test.cc
+++ b/test/integration/multi_envoy_test.cc
@@ -5,6 +5,11 @@ namespace {
 
 class MultiEnvoyTest : public HttpProtocolIntegrationTest {
 public:
+  void initialize() override {
+   config_helper_.addRuntimeOverride("envoy.disallow_global_stats", "true");
+   HttpProtocolIntegrationTest::initialize();
+  }
+
   ~MultiEnvoyTest() override { test_server_.reset(); }
 
   // Create an envoy in front of the original Envoy.
@@ -57,6 +62,36 @@ TEST_P(MultiEnvoyTest, SimpleRequestAndResponse) {
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   EXPECT_EQ(1, test_server_->counter("http.config_test.rq_total"));
   EXPECT_EQ(1, l1_server_->counter("http.config_test.rq_total"));
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  l1_server_.reset();
+
+  // At the point that the l1 is shut down, requests to the L2 should work.
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Similar to SimpleRequestAndResponse but tear down the L2 first.
+TEST_P(MultiEnvoyTest, SimpleRequestAndResponseL2Teardown) {
+  config_helper_.addRuntimeOverride("envoy.restart_features.no_runtime_singleton", "true");
+  initialize();
+  createL1Envoy();
+
+  codec_client_ = makeHttpConnection(lookupPort("http_l1"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  EXPECT_EQ(1, test_server_->counter("http.config_test.rq_total"));
+  EXPECT_EQ(1, l1_server_->counter("http.config_test.rq_total"));
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  test_server_.reset();
+
+  // At the point that the l2 is shut down, requests to the L2 should 503.
+  response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("503", response->headers().getStatusValue());
 
   l1_server_.reset();
 }

--- a/test/integration/multi_envoy_test.cc
+++ b/test/integration/multi_envoy_test.cc
@@ -6,8 +6,8 @@ namespace {
 class MultiEnvoyTest : public HttpProtocolIntegrationTest {
 public:
   void initialize() override {
-   config_helper_.addRuntimeOverride("envoy.disallow_global_stats", "true");
-   HttpProtocolIntegrationTest::initialize();
+    config_helper_.addRuntimeOverride("envoy.disallow_global_stats", "true");
+    HttpProtocolIntegrationTest::initialize();
   }
 
   ~MultiEnvoyTest() override { test_server_.reset(); }


### PR DESCRIPTION
the envoy bug stats are global and complicated, and I think we can just skip them for multi-envoy rather than switch to getpid() and hash maps. 