### PR TITLE
conn pool: fix ActiveClient::State enum format

### DIFF
--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -126,7 +126,7 @@ ConnPoolImplBase::ConnectionResult ConnPoolImplBase::tryCreateNewConnections() {
 
 ConnPoolImplBase::ConnectionResult
 ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
-  // There are already enough CONNECTING connections for the number of queued streams.
+  // There are already enough Connecting connections for the number of queued streams.
   if (!shouldCreateNewConnection(global_preconnect_ratio)) {
     ENVOY_LOG(trace, "not creating a new connection, shouldCreateNewConnection returned false.");
     return ConnectionResult::ShouldNotConnect;
@@ -148,7 +148,7 @@ ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
       ENVOY_LOG(trace, "connection creation failed");
       return ConnectionResult::FailedToCreateConnection;
     }
-    ASSERT(client->state() == ActiveClient::State::CONNECTING);
+    ASSERT(client->state() == ActiveClient::State::Connecting);
     ASSERT(std::numeric_limits<uint64_t>::max() - connecting_stream_capacity_ >=
            static_cast<uint64_t>(client->currentUnusedCapacity()));
     ASSERT(client->real_host_description_);
@@ -165,7 +165,7 @@ ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
 
 void ConnPoolImplBase::attachStreamToClient(Envoy::ConnectionPool::ActiveClient& client,
                                             AttachContext& context) {
-  ASSERT(client.state() == Envoy::ConnectionPool::ActiveClient::State::READY);
+  ASSERT(client.state() == Envoy::ConnectionPool::ActiveClient::State::Ready);
 
   if (enforceMaxRequests() && !host_->cluster().resourceManager(priority_).requests().canCreate()) {
     ENVOY_LOG(debug, "max streams overflow");
@@ -180,12 +180,12 @@ void ConnPoolImplBase::attachStreamToClient(Envoy::ConnectionPool::ActiveClient&
   uint64_t capacity = client.currentUnusedCapacity();
   client.remaining_streams_--;
   if (client.remaining_streams_ == 0) {
-    ENVOY_CONN_LOG(debug, "maximum streams per connection, DRAINING", client);
+    ENVOY_CONN_LOG(debug, "maximum streams per connection, Draining", client);
     host_->cluster().stats().upstream_cx_max_requests_.inc();
-    transitionActiveClientState(client, Envoy::ConnectionPool::ActiveClient::State::DRAINING);
+    transitionActiveClientState(client, Envoy::ConnectionPool::ActiveClient::State::Draining);
   } else if (capacity == 1) {
     // As soon as the new stream is created, the client will be maxed out.
-    transitionActiveClientState(client, Envoy::ConnectionPool::ActiveClient::State::BUSY);
+    transitionActiveClientState(client, Envoy::ConnectionPool::ActiveClient::State::Busy);
   }
 
   // Decrement the capacity, as there's one less stream available for serving.
@@ -229,11 +229,11 @@ void ConnPoolImplBase::onStreamClosed(Envoy::ConnectionPool::ActiveClient& clien
       incrConnectingAndConnectedStreamCapacity(1, client);
     }
   }
-  if (client.state() == ActiveClient::State::DRAINING && client.numActiveStreams() == 0) {
+  if (client.state() == ActiveClient::State::Draining && client.numActiveStreams() == 0) {
     // Close out the draining client if we no longer have active streams.
     client.close();
-  } else if (client.state() == ActiveClient::State::BUSY && client.currentUnusedCapacity() > 0) {
-    transitionActiveClientState(client, ActiveClient::State::READY);
+  } else if (client.state() == ActiveClient::State::Busy && client.currentUnusedCapacity() > 0) {
+    transitionActiveClientState(client, ActiveClient::State::Ready);
     if (!delay_attaching_stream) {
       onUpstreamReady();
     }
@@ -315,15 +315,15 @@ void ConnPoolImplBase::onUpstreamReady() {
 
 std::list<ActiveClientPtr>& ConnPoolImplBase::owningList(ActiveClient::State state) {
   switch (state) {
-  case ActiveClient::State::CONNECTING:
+  case ActiveClient::State::Connecting:
     return connecting_clients_;
-  case ActiveClient::State::READY:
+  case ActiveClient::State::Ready:
     return ready_clients_;
-  case ActiveClient::State::BUSY:
+  case ActiveClient::State::Busy:
     return busy_clients_;
-  case ActiveClient::State::DRAINING:
+  case ActiveClient::State::Draining:
     return busy_clients_;
-  case ActiveClient::State::CLOSED:
+  case ActiveClient::State::Closed:
     break; // Fall through to PANIC.
   }
   PANIC("unexpected");
@@ -335,7 +335,7 @@ void ConnPoolImplBase::transitionActiveClientState(ActiveClient& client,
   auto& new_list = owningList(new_state);
   client.setState(new_state);
 
-  // old_list and new_list can be equal when transitioning from BUSY to DRAINING.
+  // old_list and new_list can be equal when transitioning from Busy to Draining.
   //
   // The documentation for list.splice() (which is what moveBetweenLists() calls) is
   // unclear whether it is allowed for src and dst to be the same, so check here
@@ -386,16 +386,16 @@ void ConnPoolImplBase::drainConnectionsImpl(DrainBehavior drain_behavior) {
   while (!ready_clients_.empty()) {
     ENVOY_LOG_EVENT(debug, "draining_ready_client", "draining active client {} for cluster {}",
                     ready_clients_.front()->id(), host_->cluster().name());
-    transitionActiveClientState(*ready_clients_.front(), ActiveClient::State::DRAINING);
+    transitionActiveClientState(*ready_clients_.front(), ActiveClient::State::Draining);
   }
 
-  // Changing busy_clients_ to DRAINING does not move them between lists,
+  // Changing busy_clients_ to Draining does not move them between lists,
   // so use a for-loop since the list is not mutated.
-  ASSERT(&owningList(ActiveClient::State::DRAINING) == &busy_clients_);
+  ASSERT(&owningList(ActiveClient::State::Draining) == &busy_clients_);
   for (auto& busy_client : busy_clients_) {
     ENVOY_LOG_EVENT(debug, "draining_busy_client", "draining busy client {} for cluster {}",
                     busy_client->id(), host_->cluster().name());
-    transitionActiveClientState(*busy_client, ActiveClient::State::DRAINING);
+    transitionActiveClientState(*busy_client, ActiveClient::State::Draining);
   }
 }
 
@@ -479,7 +479,7 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     // Again, since we know this object is going to be deferredDelete'd(), we take
     // this opportunity to disable and reset the connection duration timer so that
     // it doesn't trigger while on the deferred delete list. In theory it is safe
-    // to handle the CLOSED state in onConnectionDurationTimeout, but we handle
+    // to handle the Closed state in onConnectionDurationTimeout, but we handle
     // it here for simplicity and safety anyway.
     if (client.connection_duration_timer_) {
       client.connection_duration_timer_->disableTimer();
@@ -498,7 +498,7 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     // See CdsIntegrationTest.CdsClusterDownWithLotsOfIdleConnections for an example.
     checkForIdleAndNotify();
 
-    client.setState(ActiveClient::State::CLOSED);
+    client.setState(ActiveClient::State::Closed);
 
     // If we have pending streams and we just lost a connection we should make a new one.
     if (!pending_streams_.empty()) {
@@ -510,10 +510,10 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
     client.has_handshake_completed_ = true;
     client.conn_connect_ms_->complete();
     client.conn_connect_ms_.reset();
-    ASSERT(client.state() == ActiveClient::State::CONNECTING);
+    ASSERT(client.state() == ActiveClient::State::Connecting);
     bool streams_available = client.currentUnusedCapacity() > 0;
-    transitionActiveClientState(client, streams_available ? ActiveClient::State::READY
-                                                          : ActiveClient::State::BUSY);
+    transitionActiveClientState(client, streams_available ? ActiveClient::State::Ready
+                                                          : ActiveClient::State::Busy);
 
     // Now that the active client is ready, set up a timer for max connection duration.
     const absl::optional<std::chrono::milliseconds> max_connection_duration =
@@ -595,7 +595,7 @@ void ConnPoolImplBase::onPendingStreamCancel(PendingStream& stream,
   if (policy == Envoy::ConnectionPool::CancelPolicy::CloseExcess && !connecting_clients_.empty() &&
       connectingConnectionIsExcess()) {
     auto& client = *connecting_clients_.front();
-    transitionActiveClientState(client, ActiveClient::State::DRAINING);
+    transitionActiveClientState(client, ActiveClient::State::Draining);
     client.close();
   }
 
@@ -670,24 +670,24 @@ void ActiveClient::onConnectTimeout() {
 }
 
 void ActiveClient::onConnectionDurationTimeout() {
-  // The connection duration timer should only have started after we left the CONNECTING state.
-  ENVOY_BUG(state_ != ActiveClient::State::CONNECTING,
+  // The connection duration timer should only have started after we left the Connecting state.
+  ENVOY_BUG(state_ != ActiveClient::State::Connecting,
             "max connection duration reached while connecting");
 
   // The connection duration timer should have been disabled and reset in onConnectionEvent
   // for closing connections.
-  ENVOY_BUG(state_ != ActiveClient::State::CLOSED, "max connection duration reached while closed");
+  ENVOY_BUG(state_ != ActiveClient::State::Closed, "max connection duration reached while closed");
 
   // There's nothing to do if the client is connecting, closed or draining.
   // Two of these cases are bugs (see above), but it is safe to no-op either way.
-  if (state_ == ActiveClient::State::CONNECTING || state_ == ActiveClient::State::CLOSED ||
-      state_ == ActiveClient::State::DRAINING) {
+  if (state_ == ActiveClient::State::Connecting || state_ == ActiveClient::State::Closed ||
+      state_ == ActiveClient::State::Draining) {
     return;
   }
 
-  ENVOY_CONN_LOG(debug, "max connection duration reached, DRAINING", *this);
+  ENVOY_CONN_LOG(debug, "max connection duration reached, Draining", *this);
   parent_.host()->cluster().stats().upstream_cx_max_duration_reached_.inc();
-  parent_.transitionActiveClientState(*this, Envoy::ConnectionPool::ActiveClient::State::DRAINING);
+  parent_.transitionActiveClientState(*this, Envoy::ConnectionPool::ActiveClient::State::Draining);
 
   // Close out the draining client if we no longer have active streams.
   // We have to do this here because there won't be an onStreamClosed (because there are

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -80,12 +80,12 @@ public:
   virtual bool hadNegativeDeltaOnStreamClosed() { return false; }
 
   enum class State {
-    CONNECTING, // Connection is not yet established.
-    READY,      // Additional streams may be immediately dispatched to this connection.
-    BUSY,       // Connection is at its concurrent stream limit.
-    DRAINING,   // No more streams can be dispatched to this connection, and it will be closed
+    Connecting, // Connection is not yet established.
+    Ready,      // Additional streams may be immediately dispatched to this connection.
+    Busy,       // Connection is at its concurrent stream limit.
+    Draining,   // No more streams can be dispatched to this connection, and it will be closed
     // when all streams complete.
-    CLOSED // Connection is closed and object is queued for destruction.
+    Closed // Connection is closed and object is queued for destruction.
   };
 
   State state() const { return state_; }
@@ -93,7 +93,7 @@ public:
   void setState(State state) {
     // If the client is transitioning to draining, update the remaining
     // streams and pool and cluster capacity.
-    if (state == State::DRAINING) {
+    if (state == State::Draining) {
       drain();
     }
     state_ = state;
@@ -102,7 +102,7 @@ public:
   // Sets the remaining streams to 0, and updates pool and cluster capacity.
   virtual void drain();
 
-  virtual bool hasHandshakeCompleted() const { return state_ != State::CONNECTING; }
+  virtual bool hasHandshakeCompleted() const { return state_ != State::Connecting; }
 
   ConnPoolImplBase& parent_;
   // The count of remaining streams allowed for this connection.
@@ -130,7 +130,7 @@ public:
   bool has_handshake_completed_{false};
 
 private:
-  State state_{State::CONNECTING};
+  State state_{State::Connecting};
 };
 
 // PendingStream is the base class tracking streams for which a connection has been created but not
@@ -344,17 +344,17 @@ protected:
   std::list<PendingStreamPtr> pending_streams_to_purge_;
 
   // Clients that are ready to handle additional streams.
-  // All entries are in state READY.
+  // All entries are in state Ready.
   std::list<ActiveClientPtr> ready_clients_;
 
-  // Clients that are not ready to handle additional streams due to being BUSY or DRAINING.
+  // Clients that are not ready to handle additional streams due to being Busy or Draining.
   std::list<ActiveClientPtr> busy_clients_;
 
-  // Clients that are not ready to handle additional streams because they are CONNECTING.
+  // Clients that are not ready to handle additional streams because they are Connecting.
   std::list<ActiveClientPtr> connecting_clients_;
 
   // The number of streams that can be immediately dispatched
-  // if all CONNECTING connections become connected.
+  // if all Connecting connections become connected.
   uint32_t connecting_stream_capacity_{0};
 
 private:

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -98,11 +98,11 @@ static const uint64_t DEFAULT_MAX_STREAMS = (1 << 29);
 void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
   ENVOY_CONN_LOG(debug, "remote goaway", *codec_client_);
   parent_.host()->cluster().stats().upstream_cx_close_notify_.inc();
-  if (state() != ActiveClient::State::DRAINING) {
+  if (state() != ActiveClient::State::Draining) {
     if (codec_client_->numActiveRequests() == 0) {
       codec_client_->close();
     } else {
-      parent_.transitionActiveClientState(*this, ActiveClient::State::DRAINING);
+      parent_.transitionActiveClientState(*this, ActiveClient::State::Draining);
     }
   }
 }
@@ -127,10 +127,10 @@ void MultiplexedActiveClientBase::onSettings(ReceivedSettings& settings) {
           std::min(settings.maxConcurrentStreams().value(), configured_stream_limit_);
 
       int64_t delta = old_unused_capacity - currentUnusedCapacity();
-      if (state() == ActiveClient::State::READY && currentUnusedCapacity() <= 0) {
-        parent_.transitionActiveClientState(*this, ActiveClient::State::BUSY);
-      } else if (state() == ActiveClient::State::BUSY && currentUnusedCapacity() > 0) {
-        parent_.transitionActiveClientState(*this, ActiveClient::State::READY);
+      if (state() == ActiveClient::State::Ready && currentUnusedCapacity() <= 0) {
+        parent_.transitionActiveClientState(*this, ActiveClient::State::Busy);
+      } else if (state() == ActiveClient::State::Busy && currentUnusedCapacity() > 0) {
+        parent_.transitionActiveClientState(*this, ActiveClient::State::Ready);
       }
 
       if (delta > 0) {
@@ -151,8 +151,8 @@ void MultiplexedActiveClientBase::onSettings(ReceivedSettings& settings) {
       ASSERT(std::numeric_limits<int32_t>::max() >= old_unused_capacity);
       concurrent_stream_limit_ = settings.maxConcurrentStreams().value();
       int64_t delta = old_unused_capacity - currentUnusedCapacity();
-      if (state() == ActiveClient::State::READY && currentUnusedCapacity() <= 0) {
-        parent_.transitionActiveClientState(*this, ActiveClient::State::BUSY);
+      if (state() == ActiveClient::State::Ready && currentUnusedCapacity() <= 0) {
+        parent_.transitionActiveClientState(*this, ActiveClient::State::Busy);
       }
       parent_.decrClusterStreamCapacity(delta);
       ENVOY_CONN_LOG(trace, "Decreasing stream capacity by {}", *codec_client_, delta);
@@ -160,7 +160,7 @@ void MultiplexedActiveClientBase::onSettings(ReceivedSettings& settings) {
     // As we don't increase stream limits when maxConcurrentStreams goes up, treat
     // a stream limit of 0 as a GOAWAY.
     if (concurrent_stream_limit_ == 0) {
-      parent_.transitionActiveClientState(*this, ActiveClient::State::DRAINING);
+      parent_.transitionActiveClientState(*this, ActiveClient::State::Draining);
     }
   }
 }

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -31,7 +31,7 @@ ActiveClient::ActiveClient(Envoy::Http::HttpConnPoolImplBase& parent,
     : MultiplexedActiveClientBase(parent, getMaxStreams(parent.host()->cluster()),
                                   parent.host()->cluster().stats().upstream_cx_http3_total_, data),
       async_connect_callback_(parent_.dispatcher().createSchedulableCallback([this]() {
-        if (state() == Envoy::ConnectionPool::ActiveClient::State::CONNECTING) {
+        if (state() == Envoy::ConnectionPool::ActiveClient::State::Connecting) {
           codec_client_->connect();
         }
       })) {
@@ -46,13 +46,13 @@ ActiveClient::ActiveClient(Envoy::Http::HttpConnPoolImplBase& parent,
 
 void ActiveClient::onMaxStreamsChanged(uint32_t num_streams) {
   updateCapacity(num_streams);
-  if (state() == ActiveClient::State::BUSY && currentUnusedCapacity() != 0) {
-    parent_.transitionActiveClientState(*this, ActiveClient::State::READY);
+  if (state() == ActiveClient::State::Busy && currentUnusedCapacity() != 0) {
+    parent_.transitionActiveClientState(*this, ActiveClient::State::Ready);
     // If there's waiting streams, make sure the pool will now serve them.
     parent_.onUpstreamReady();
-  } else if (currentUnusedCapacity() == 0 && state() == ActiveClient::State::READY) {
+  } else if (currentUnusedCapacity() == 0 && state() == ActiveClient::State::Ready) {
     // With HTTP/3 this can only happen during a rejected 0-RTT handshake.
-    parent_.transitionActiveClientState(*this, ActiveClient::State::BUSY);
+    parent_.transitionActiveClientState(*this, ActiveClient::State::Busy);
   }
 }
 

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -74,7 +74,7 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
     state_.incrConnectingAndConnectedStreamCapacity(new_client->effectiveConcurrentStreamLimit() -
                                                     1);
   }
-  new_client->setState(ActiveClient::State::CONNECTING);
+  new_client->setState(ActiveClient::State::Connecting);
   LinkedList::moveIntoList(std::move(new_client), owningList(new_client->state()));
 }
 

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -39,7 +39,7 @@ ActiveTcpClient::~ActiveTcpClient() {
   // TcpConnectionData. Make sure the TcpConnectionData will not refer to this ActiveTcpClient
   // and handle clean up normally done in clearCallbacks()
   if (tcp_connection_data_) {
-    ASSERT(state() == ActiveClient::State::CLOSED);
+    ASSERT(state() == ActiveClient::State::Closed);
     tcp_connection_data_->release();
     parent_.onStreamClosed(*this, true);
     parent_.checkForIdleAndCloseIdleConnsIfDraining();
@@ -47,7 +47,7 @@ ActiveTcpClient::~ActiveTcpClient() {
 }
 
 void ActiveTcpClient::clearCallbacks() {
-  if (state() == Envoy::ConnectionPool::ActiveClient::State::BUSY && parent_.hasPendingStreams()) {
+  if (state() == Envoy::ConnectionPool::ActiveClient::State::Busy && parent_.hasPendingStreams()) {
     auto* pool = &parent_;
     pool->scheduleOnUpstreamReady();
   }

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -139,14 +139,14 @@ public:
     EXPECT_CALL(pool_, instantiateActiveClient);
     pool_.newStreamImpl(context_, /*can_send_early_data=*/false);
     ASSERT_EQ(1, clients_.size());
-    EXPECT_EQ(ActiveClient::State::CONNECTING, clients_.back()->state());
+    EXPECT_EQ(ActiveClient::State::Connecting, clients_.back()->state());
 
     // Verify that the connection duration timer isn't set yet. This shouldn't happen
     // until after connect.
     EXPECT_EQ(nullptr, clients_.back()->connection_duration_timer_);
   }
 
-  void newActiveClientAndStream(ActiveClient::State expected_state = ActiveClient::State::BUSY) {
+  void newActiveClientAndStream(ActiveClient::State expected_state = ActiveClient::State::Busy) {
     // Start with a connecting client
     newConnectingClient();
 
@@ -167,7 +167,7 @@ public:
   void newDrainingClient() {
     // Use a stream limit of 1 to force draining. Then, connect and expect draining.
     stream_limit_ = 1;
-    newActiveClientAndStream(ActiveClient::State::DRAINING);
+    newActiveClientAndStream(ActiveClient::State::Draining);
   }
 
   void newClosedClient() {
@@ -192,7 +192,7 @@ public:
   void closeStreamAndDrainClient() {
     // Close the active stream and expect the client to be ready.
     closeStream();
-    EXPECT_EQ(ActiveClient::State::READY, clients_.back()->state());
+    EXPECT_EQ(ActiveClient::State::Ready, clients_.back()->state());
 
     // The client is still ready. So, to clean up, we have to drain the pool manually.
     pool_.drainConnectionsImpl(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
@@ -348,13 +348,13 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxConnectionDurationBusy) {
   // connection.
   advanceTimeAndRun(max_connection_duration_ - 1);
   EXPECT_EQ(0, pool_.host()->cluster().stats().upstream_cx_max_duration_reached_.value());
-  EXPECT_EQ(ActiveClient::State::BUSY, clients_.back()->state());
+  EXPECT_EQ(ActiveClient::State::Busy, clients_.back()->state());
 
   // Verify that advancing past the connection duration timeout drains the connection,
   // because there's a busy client.
   advanceTimeAndRun(2);
   EXPECT_EQ(1, pool_.host()->cluster().stats().upstream_cx_max_duration_reached_.value());
-  EXPECT_EQ(ActiveClient::State::DRAINING, clients_.back()->state());
+  EXPECT_EQ(ActiveClient::State::Draining, clients_.back()->state());
   closeStream();
 }
 
@@ -363,13 +363,13 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxConnectionDurationReady) {
 
   // Close active stream and expect that the client goes back to ready
   closeStream();
-  EXPECT_EQ(ActiveClient::State::READY, clients_.back()->state());
+  EXPECT_EQ(ActiveClient::State::Ready, clients_.back()->state());
 
   // Verify that advancing to just before the connection duration timeout doesn't close the
   // connection.
   advanceTimeAndRun(max_connection_duration_ - 1);
   EXPECT_EQ(0, pool_.host()->cluster().stats().upstream_cx_max_duration_reached_.value());
-  EXPECT_EQ(ActiveClient::State::READY, clients_.back()->state());
+  EXPECT_EQ(ActiveClient::State::Ready, clients_.back()->state());
 
   // Verify that advancing past the connection duration timeout closes the connection,
   // because there's nothing to drain.
@@ -385,7 +385,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxConnectionDurationAlreadyDraining) {
   // that is already draining.
   advanceTimeAndRun(max_connection_duration_ + 1);
   EXPECT_EQ(0, pool_.host()->cluster().stats().upstream_cx_max_duration_reached_.value());
-  EXPECT_EQ(ActiveClient::State::DRAINING, clients_.back()->state());
+  EXPECT_EQ(ActiveClient::State::Draining, clients_.back()->state());
   closeStream();
 }
 
@@ -403,7 +403,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxConnectionDurationCallbackWhileClosedB
   // Start with a connecting client
   newClosedClient();
 
-  // Expect an ENVOY_BUG if the connection duration callback fires while in the CLOSED state.
+  // Expect an ENVOY_BUG if the connection duration callback fires while in the Closed state.
   // We forcibly call the connection duration callback here because under normal circumstances there
   // is no timer set up.
   EXPECT_ENVOY_BUG(clients_.back()->onConnectionDurationTimeout(),
@@ -414,7 +414,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxConnectionDurationCallbackWhileConnect
   // Start with a connecting client
   newConnectingClient();
 
-  // Expect an ENVOY_BUG if the connection duration callback fires while still in the CONNECTING
+  // Expect an ENVOY_BUG if the connection duration callback fires while still in the Connecting
   // state. We forcibly call the connection duration callback here because under normal
   // circumstances there is no timer set up.
   EXPECT_ENVOY_BUG(clients_.back()->onConnectionDurationTimeout(),
@@ -437,7 +437,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, NoAvailableStreams) {
   // onPoolReady, and the client is marked as busy.
   EXPECT_CALL(pool_, onPoolReady).Times(0);
   clients_.back()->onEvent(Network::ConnectionEvent::Connected);
-  EXPECT_EQ(ActiveClient::State::BUSY, clients_.back()->state());
+  EXPECT_EQ(ActiveClient::State::Busy, clients_.back()->state());
 
   // Clean up.
   EXPECT_CALL(pool_, instantiateActiveClient);

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -1457,27 +1457,27 @@ TEST_F(Http2ConnPoolImplTest, IncreaseCapacityWithSettingsFrame) {
   EXPECT_CALL(r1.callbacks_.pool_ready_, ready());
   expectClientConnect(0);
   CHECK_STATE(1 /*active*/, 0 /*pending*/, 99 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 1);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
 
-  // Settings frame results in 0 capacity, the state of client changes from READY to BUSY.
+  // Settings frame results in 0 capacity, the state of client changes from Ready to BUSY.
   NiceMock<MockReceivedSettings> settings;
   settings.max_concurrent_streams_ = 1;
   test_clients_[0].codec_client_->onSettings(settings);
   CHECK_STATE(1 /*active*/, 0 /*pending*/, 0 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 0);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 0);
 
-  // Settings frame results in 9 capacity, the state of client changes from BUSY to READY.
+  // Settings frame results in 9 capacity, the state of client changes from BUSY to Ready.
   settings.max_concurrent_streams_ = 10;
   test_clients_[0].codec_client_->onSettings(settings);
   CHECK_STATE(1 /*active*/, 0 /*pending*/, 9 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 1);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
 
   // Settings frame with capacity of 150 which will be restricted by configured
   // max_concurrent_streams, then results in 99 capacity.
   settings.max_concurrent_streams_ = 150;
   test_clients_[0].codec_client_->onSettings(settings);
   CHECK_STATE(1 /*active*/, 0 /*pending*/, 99 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 1);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
 
   // Close connection.
   closeAllClients();
@@ -1514,30 +1514,30 @@ TEST_F(Http2ConnPoolImplTest, DisconnectWithNegativeCapacity) {
   EXPECT_CALL(r5.callbacks_.pool_ready_, ready());
   expectClientConnect(0);
   CHECK_STATE(5 /*active*/, 0 /*pending*/, 1 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 1);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
 
   // Settings frame results in -2 capacity.
   NiceMock<MockReceivedSettings> settings;
   settings.max_concurrent_streams_ = 3;
   test_clients_[0].codec_client_->onSettings(settings);
   CHECK_STATE(5 /*active*/, 0 /*pending*/, -2 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 0);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 0);
 
   // Close 1 stream, concurrency capacity goes to -1, still no ready client available.
   completeRequest(r1);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 0);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 0);
 
   // Close 2 streams, concurrency capacity goes to 1, there should be one ready client.
   completeRequest(r2);
   completeRequest(r3);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 1);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
   CHECK_STATE(2 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
   // Another settings frame results in -1 capacity.
   settings.max_concurrent_streams_ = 1;
   test_clients_[0].codec_client_->onSettings(settings);
   CHECK_STATE(2 /*active*/, 0 /*pending*/, -1 /*capacity*/);
-  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::READY).size(), 0);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 0);
 
   // Close connection with negative capacity.
   closeAllClients();

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -194,7 +194,7 @@ TEST_F(Http3ConnPoolImplTest, NewAndCancelStreamBeforeConnect) {
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   cancellable->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   EXPECT_TRUE(clients.empty());
-  EXPECT_EQ(Envoy::ConnectionPool::ActiveClient::State::CLOSED, client_ref.state());
+  EXPECT_EQ(Envoy::ConnectionPool::ActiveClient::State::Closed, client_ref.state());
   EXPECT_EQ(dispatcher_.to_delete_.front().get(), &client_ref);
 
   EXPECT_CALL(*async_connect_callback, cancel());

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -85,8 +85,8 @@ public:
 
   ~TestActiveTcpClient() override { parent().onConnDestroyed(); }
   void clearCallbacks() override {
-    if (state() == Envoy::ConnectionPool::ActiveClient::State::BUSY ||
-        state() == Envoy::ConnectionPool::ActiveClient::State::DRAINING) {
+    if (state() == Envoy::ConnectionPool::ActiveClient::State::Busy ||
+        state() == Envoy::ConnectionPool::ActiveClient::State::Draining) {
       parent().onConnReleased(*this);
     }
     ActiveTcpClient::clearCallbacks();


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: change ConnectionPool::ActiveClient::State enum values to Camel casing according to Envoy style guide. All the enum values are single word right now, so upper casing isn't blowing up the format check, but once there is state value represented by more than one word, it's gonna cause format check to fail.

Risk Level: low, refactoring only
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
