### PR TITLE
Add X41 team to the setec ACL

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -83,6 +83,11 @@ contributors to envoy-setec and relevant Slack channels from:
   * Adam Meily ([ameily](https://github.com/ameily))
   * Alessandro Gario ([alessandrogario](https://github.com/alessandrogario))
   * Mike Myers ([mike-myers-tob](https://github.com/mike-myers-tob))
+* [X41 S-Sec](https://x41-dsec.de/) expiring 12/31/2022. Triage and fixes for OSS-Fuzz bugs.
+  * Markus Vervier ([markusx41](https://github.com/markusx41))
+  * Eric Sesterhenn ([ericsesterhennx41](https://github.com/ericsesterhennx41))
+  * Ralf Weinmann ([rpw-x41](https://github.com/rpw-x41))
+  * Dr. Andre Vehreschild ([vehre-x41](https://github.com/vehre-x41))
 
 # Emeritus maintainers
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -83,7 +83,7 @@ contributors to envoy-setec and relevant Slack channels from:
   * Adam Meily ([ameily](https://github.com/ameily))
   * Alessandro Gario ([alessandrogario](https://github.com/alessandrogario))
   * Mike Myers ([mike-myers-tob](https://github.com/mike-myers-tob))
-* [X41 S-Sec](https://x41-dsec.de/) expiring 12/31/2022. Triage and fixes for OSS-Fuzz bugs.
+* [X41 D-Sec](https://x41-dsec.de/) expiring 12/31/2022. Triage and fixes for OSS-Fuzz bugs.
   * Markus Vervier ([markusx41](https://github.com/markusx41))
   * Eric Sesterhenn ([ericsesterhennx41](https://github.com/ericsesterhennx41))
   * Ralf Weinmann ([rpw-x41](https://github.com/rpw-x41))


### PR DESCRIPTION
Additional Description:
X41 team is working on fixing OSS-Fuzz bugs and need access to the `setec` repo for PRs that may be a security vulnerability.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
