### PR TITLE
router: avoid injecting entry span's context if envoy generates exit span

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -656,7 +656,11 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
   // Inject the active span's tracing context into the request headers.
-  callbacks_->activeSpan().injectContext(headers);
+  // If envoy will generate child span, it ignores to inject header and delegate it to upstream
+  // request.
+  if (!config_.start_child_span_) {
+    callbacks_->activeSpan().injectContext(headers);
+  }
 
   route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
                                        !config_.suppress_envoy_headers_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -655,9 +655,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
-  // Inject the active span's tracing context into the request headers.
-  // If envoy will generate child span, it ignores to inject header and delegate it to upstream
-  // request.
+  // If configured to generate a child span, delegate injecting headers to the upstream request
+  // which generates the child span?
+  // TODO(shikugawa): Add integration test to check whether the headers are injected or not.
   if (!config_.start_child_span_) {
     callbacks_->activeSpan().injectContext(headers);
   }

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -365,6 +365,7 @@ TEST_F(RouterTestChildSpan, ResetFlow) {
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_.active_span_, injectContext(_)).Times(0);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
   EXPECT_CALL(callbacks_, tracingConfig());
@@ -417,6 +418,7 @@ TEST_F(RouterTestChildSpan, CancelFlow) {
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_.active_span_, injectContext(_)).Times(0);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
   EXPECT_CALL(callbacks_, tracingConfig());
@@ -465,6 +467,7 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
   // Upstream responds back to envoy simulating an upstream reset.
   Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_.active_span_, injectContext(_)).Times(0);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span_1));
   EXPECT_CALL(callbacks_, tracingConfig());
@@ -506,6 +509,7 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
             return nullptr;
           }));
 
+  EXPECT_CALL(callbacks_.active_span_, injectContext(_)).Times(0);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span_2));
   EXPECT_CALL(callbacks_, tracingConfig());


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: router: avoid injecting entry span's context if envoy generates exit span
Additional Description: In the current envoy, it injects trace context twice for entry and exit span if it generates exit span. This PR avoids this redundant `injectContext` call and only injects exit span's context if it generates them.
Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
