### PR TITLE
cluster: Lazy initialization of update callbacks in PrioritySetImpl

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -554,11 +554,14 @@ PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
   if (host_sets_.size() < priority + 1) {
     for (size_t i = host_sets_.size(); i <= priority; ++i) {
       HostSetImplPtr host_set = createHostSet(i, overprovisioning_factor);
-      host_sets_priority_update_cbs_.push_back(
-          host_set->addPriorityUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
-                                               const HostVector& hosts_removed) {
-            runReferenceUpdateCallbacks(priority, hosts_added, hosts_removed);
-          }));
+      // Delay adding priority update callbacks until one is added
+      if (lazy_host_sets_cbs_ != nullptr) {
+        lazy_host_sets_cbs_->priority_update_cbs_.push_back(
+            host_set->addPriorityUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
+                                                 const HostVector& hosts_removed) {
+              runReferenceUpdateCallbacks(priority, hosts_added, hosts_removed);
+            }));
+      }
       host_sets_.push_back(std::move(host_set));
     }
   }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -554,14 +554,7 @@ PrioritySetImpl::getOrCreateHostSet(uint32_t priority,
   if (host_sets_.size() < priority + 1) {
     for (size_t i = host_sets_.size(); i <= priority; ++i) {
       HostSetImplPtr host_set = createHostSet(i, overprovisioning_factor);
-      // Delay adding priority update callbacks until one is added
-      if (lazy_host_sets_cbs_ != nullptr) {
-        lazy_host_sets_cbs_->priority_update_cbs_.push_back(
-            host_set->addPriorityUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
-                                                 const HostVector& hosts_removed) {
-              runReferenceUpdateCallbacks(priority, hosts_added, hosts_removed);
-            }));
-      }
+      addHostSet(host_set.get());
       host_sets_.push_back(std::move(host_set));
     }
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -483,11 +483,7 @@ public:
   // From PrioritySet
   ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addMemberUpdateCb(MemberUpdateCb callback) const override {
-    if (member_update_cb_helper_ == nullptr) {
-      member_update_cb_helper_ =
-          std::make_unique<Common::CallbackManager<const HostVector&, const HostVector&>>();
-    }
-    return member_update_cb_helper_->add(callback);
+    return member_update_cb_helper_.add(callback);
   }
   ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addPriorityUpdateCb(PriorityUpdateCb callback) const override {
@@ -533,9 +529,7 @@ protected:
 
 protected:
   virtual void runUpdateCallbacks(const HostVector& hosts_added, const HostVector& hosts_removed) {
-    if (member_update_cb_helper_ != nullptr) {
-      member_update_cb_helper_->runCallbacks(hosts_added, hosts_removed);
-    }
+      member_update_cb_helper_.runCallbacks(hosts_added, hosts_removed);
   }
   virtual void runReferenceUpdateCallbacks(uint32_t priority, const HostVector& hosts_added,
                                            const HostVector& hosts_removed) const {
@@ -554,7 +548,7 @@ protected:
 
 private:
   // TODO(mattklein123): Remove mutable.
-  mutable std::unique_ptr<Common::CallbackManager<const HostVector&, const HostVector&>>
+  mutable Common::LazyCallbackManager<const HostVector&, const HostVector&>
       member_update_cb_helper_;
 
   struct HostSetCbLazyWrapper {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Initialize PrioritySetImpl callbacks only when needed, in order to save memory
Additional Description: Encapsulate host_set_ - related callbacks inside a separate structure, which initializes its callbacks only when a callback is added via addPriorityUpdateCb. Initialize member_update_cb_helper_ lazily
Risk Level: Medium
Testing: Unit test (test/common/...)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
#19332 
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
