### PR TITLE
Revert "Defer Processing: Parameterize test for filters to avoid bit rot (#20244)"

### DIFF
--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -27,7 +27,6 @@ envoy_cc_library(
         "//envoy/http:header_map_interface",
         "//envoy/stats:stats_macros",
         "//source/common/buffer:buffer_lib",
-        "//source/common/runtime:runtime_features_lib",
         "//source/extensions/filters/common/mutation_rules:mutation_rules_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@com_google_absl//absl/status",

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -3,7 +3,6 @@
 #include "envoy/config/common/mutation_rules/v3/mutation_rules.pb.h"
 
 #include "source/common/http/utility.h"
-#include "source/common/runtime/runtime_features.h"
 #include "source/extensions/filters/http/ext_proc/mutation_utils.h"
 
 #include "absl/strings/str_format.h"
@@ -309,37 +308,28 @@ FilterDataStatus Filter::onData(ProcessorState& state, Buffer::Instance& data, b
       state.setPaused(true);
       result = FilterDataStatus::StopIterationNoBuffer;
     } else if (end_stream || state.queueOverHighLimit()) {
-      bool terminate;
-      std::tie(terminate, result) = sendStreamChunk(state, data, end_stream);
-
-      if (terminate) {
-        return result;
+      switch (openStream()) {
+      case StreamOpenState::Error:
+        return FilterDataStatus::StopIterationNoBuffer;
+      case StreamOpenState::IgnoreError:
+        return FilterDataStatus::Continue;
+      case StreamOpenState::Ok:
+        // Fall through
+        break;
       }
+      state.enqueueStreamingChunk(data, false, false);
+      // Put all buffered data so far into one big buffer
+      const auto& all_data = state.consolidateStreamedChunks(true);
+      ENVOY_LOG(debug, "Sending {} bytes of data in buffered partial mode. end_stream = {}",
+                all_data.data.length(), end_stream);
+      sendBodyChunk(state, all_data.data,
+                    ProcessorState::CallbackState::BufferedPartialBodyCallback, end_stream);
+      result = FilterDataStatus::StopIterationNoBuffer;
+      state.setPaused(true);
     } else {
       // Keep on running and buffering
       state.enqueueStreamingChunk(data, false, false);
-
-      if (Runtime::runtimeFeatureEnabled(Runtime::defer_processing_backedup_streams) &&
-          state.queueOverHighLimit()) {
-        // When we transition to queue over high limit, we read disable the
-        // stream. With deferred processing, this means new data will buffer in
-        // the receiving codec buffer (not reaching this filter) and data
-        // already queued in this filter hasn't yet been sent externally.
-        //
-        // The filter would send the queued data if it was invoked again, or if
-        // we explicitly kick it off. The former wouldn't happen with deferred
-        // processing since we would be buffering in the receiving codec buffer,
-        // so we opt for the latter, explicitly kicking it off.
-        bool terminate;
-        Buffer::OwnedImpl empty_buffer{};
-        std::tie(terminate, result) = sendStreamChunk(state, empty_buffer, false);
-
-        if (terminate) {
-          return result;
-        }
-      } else {
-        result = FilterDataStatus::Continue;
-      }
+      result = FilterDataStatus::Continue;
     }
     break;
   case ProcessingMode::NONE:
@@ -363,28 +353,6 @@ FilterDataStatus Filter::onData(ProcessorState& state, Buffer::Instance& data, b
     return FilterDataStatus::StopIterationAndBuffer;
   }
   return result;
-}
-
-std::pair<bool, Http::FilterDataStatus>
-Filter::sendStreamChunk(ProcessorState& state, Buffer::Instance& data, bool end_stream) {
-  switch (openStream()) {
-  case StreamOpenState::Error:
-    return {true, FilterDataStatus::StopIterationNoBuffer};
-  case StreamOpenState::IgnoreError:
-    return {true, FilterDataStatus::Continue};
-  case StreamOpenState::Ok:
-    // Fall through
-    break;
-  }
-  state.enqueueStreamingChunk(data, false, false);
-  // Put all buffered data so far into one big buffer
-  const auto& all_data = state.consolidateStreamedChunks(true);
-  ENVOY_LOG(debug, "Sending {} bytes of data in buffered partial mode. end_stream = {}",
-            all_data.data.length(), end_stream);
-  sendBodyChunk(state, all_data.data, ProcessorState::CallbackState::BufferedPartialBodyCallback,
-                end_stream);
-  state.setPaused(true);
-  return {false, FilterDataStatus::StopIterationNoBuffer};
 }
 
 FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -166,9 +166,6 @@ private:
 
   Http::FilterHeadersStatus onHeaders(ProcessorState& state,
                                       Http::RequestOrResponseHeaderMap& headers, bool end_stream);
-  // Return a pair of whether to terminate returning the current result.
-  std::pair<bool, Http::FilterDataStatus> sendStreamChunk(ProcessorState& state,
-                                                          Buffer::Instance& data, bool end_stream);
   Http::FilterDataStatus onData(ProcessorState& state, Buffer::Instance& data, bool end_stream);
   Http::FilterTrailersStatus onTrailers(ProcessorState& state, Http::HeaderMap& trailers);
 

--- a/test/common/grpc/grpc_client_integration.h
+++ b/test/common/grpc/grpc_client_integration.h
@@ -60,32 +60,6 @@ public:
   ClientType clientType() const override { return std::get<1>(GetParam()); }
 };
 
-// TODO(kbaichoo): Revert to using GrpcClientIntegrationParamTest for all
-// derived classes when deferred processing is enabled by default. It's
-// parameterized by deferred processing now to avoid bit rot since the feature
-// is off by default.
-class GrpcClientIntegrationParamTestWithDeferredProcessing
-    : public Grpc::BaseGrpcClientIntegrationParamTest,
-      public testing::TestWithParam<
-          std::tuple<std::tuple<Network::Address::IpVersion, Grpc::ClientType>, bool>> {
-public:
-  static std::string protocolTestParamsToString(
-      const ::testing::TestParamInfo<
-          std::tuple<std::tuple<Network::Address::IpVersion, Grpc::ClientType>, bool>>& p) {
-    return fmt::format(
-        "{}_{}_{}",
-        std::get<0>(std::get<0>(p.param)) == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6",
-        std::get<1>(std::get<0>(p.param)) == Grpc::ClientType::GoogleGrpc ? "GoogleGrpc"
-                                                                          : "EnvoyGrpc",
-        std::get<1>(p.param) ? "WithDeferredProcessing" : "NoDeferredProcessing");
-  }
-  Network::Address::IpVersion ipVersion() const override {
-    return std::get<0>(std::get<0>(GetParam()));
-  }
-  Grpc::ClientType clientType() const override { return std::get<1>(std::get<0>(GetParam())); }
-  bool deferredProcessing() const { return std::get<1>(GetParam()); }
-};
-
 class UnifiedOrLegacyMuxIntegrationParamTest
     : public BaseGrpcClientIntegrationParamTest,
       public testing::TestWithParam<
@@ -140,8 +114,6 @@ public:
 #define GRPC_CLIENT_INTEGRATION_PARAMS                                                             \
   testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),                     \
                    testing::ValuesIn(TestEnvironment::getsGrpcVersionsForTest()))
-#define GRPC_CLIENT_INTEGRATION_DEFERRED_PROCESSING_PARAMS                                         \
-  testing::Combine(GRPC_CLIENT_INTEGRATION_PARAMS, testing::Bool())
 #define DELTA_SOTW_GRPC_CLIENT_INTEGRATION_PARAMS                                                  \
   testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),                     \
                    testing::ValuesIn(TestEnvironment::getsGrpcVersionsForTest()),                  \

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -100,10 +100,9 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "ext_proc_integration_test",
-    size = "large",  # This test can take a while under tsan.
+    size = "medium",
     srcs = ["ext_proc_integration_test.cc"],
     extension_names = ["envoy.filters.http.ext_proc"],
-    shard_count = 2,
     deps = [
         ":utils_lib",
         "//source/extensions/filters/http/ext_proc:config",

--- a/test/extensions/filters/http/ext_proc/ordering_test.cc
+++ b/test/extensions/filters/http/ext_proc/ordering_test.cc
@@ -8,10 +8,10 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/router/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
-#include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -917,31 +917,6 @@ TEST_F(FastFailOrderingTest, GrpcErrorOnStartRequestBodyBufferedPartial) {
   Buffer::OwnedImpl req_body("Hello!");
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_body, true));
-}
-
-TEST_F(FastFailOrderingTest,
-       GrpcErrorOnTransitionAboveQueueLimitWhenSendingStreamChunkWithDeferredProcessing) {
-  auto scoped_runtime_guard = std::make_unique<TestScopedRuntime>();
-  Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{std::string(Runtime::defer_processing_backedup_streams), "true"}});
-
-  initialize([](ExternalProcessor& cfg) {
-    auto* pm = cfg.mutable_processing_mode();
-    pm->set_request_header_mode(ProcessingMode::SKIP);
-    pm->set_request_body_mode(ProcessingMode::BUFFERED_PARTIAL);
-  });
-
-  sendRequestHeadersPost(false);
-
-  // Set the limit low so we transition over the queue limit and start sending
-  // the stream chunk.
-  Buffer::OwnedImpl req_body("Hello!");
-  EXPECT_CALL(decoder_callbacks_, decoderBufferLimit())
-      .WillRepeatedly(Return(req_body.length() / 2));
-  EXPECT_CALL(decoder_callbacks_, onDecoderFilterAboveWriteBufferHighWatermark());
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
-
-  EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_body, false));
 }
 
 // gRPC failure while opening stream with only request body enabled in streaming mode

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -31,7 +31,7 @@ static const uint32_t BufferSize = 100000;
 // for the external processor. This lets us more fully exercise all the things that happen
 // with larger, streamed payloads.
 class StreamingIntegrationTest : public HttpIntegrationTest,
-                                 public Grpc::GrpcClientIntegrationParamTestWithDeferredProcessing {
+                                 public Grpc::GrpcClientIntegrationParamTest {
 
 protected:
   StreamingIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion()) {}
@@ -85,10 +85,6 @@ protected:
 
     // Make sure that we have control over when buffers will fill up.
     config_helper_.setBufferLimits(BufferSize, BufferSize);
-    // Parameterize with defer processing to prevent bit rot as filter made
-    // assumptions of data flow, prior relying on eager processing.
-    config_helper_.addRuntimeOverride(Runtime::defer_processing_backedup_streams,
-                                      deferredProcessing() ? "true" : "false");
 
     setUpstreamProtocol(Http::CodecType::HTTP2);
     setDownstreamProtocol(Http::CodecType::HTTP2);
@@ -140,10 +136,8 @@ protected:
 };
 
 // Ensure that the test suite is run with all combinations the Envoy and Google gRPC clients.
-INSTANTIATE_TEST_SUITE_P(
-    StreamingProtocols, StreamingIntegrationTest,
-    GRPC_CLIENT_INTEGRATION_DEFERRED_PROCESSING_PARAMS,
-    Grpc::GrpcClientIntegrationParamTestWithDeferredProcessing::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(StreamingProtocols, StreamingIntegrationTest,
+                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Send a body that's larger than the buffer limit, and have the processor return immediately
 // after the headers come in. Also check the metadata in this test.

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -24,27 +24,11 @@ namespace {
 // A magic header value which marks header as not expected.
 constexpr char UnexpectedHeaderValue[] = "Unexpected header value";
 
-std::string ipAndDeferredProcessingParamsToString(
-    const ::testing::TestParamInfo<std::tuple<Network::Address::IpVersion, bool>>& p) {
-  return fmt::format("{}_{}",
-                     std::get<0>(p.param) == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6",
-                     std::get<1>(p.param) ? "WithDeferredProcessing" : "NoDeferredProcessing");
-}
-
-// TODO(kbaichoo): Remove parameterizing by deferred processing when the feature
-// is enabled by default. The parameterization is to avoid bit rot since it's
-// off by default.
 class GrpcJsonTranscoderIntegrationTest
-    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, bool>>,
+    : public testing::TestWithParam<Network::Address::IpVersion>,
       public HttpIntegrationTest {
 public:
-  GrpcJsonTranscoderIntegrationTest()
-      : HttpIntegrationTest(Http::CodecType::HTTP1, std::get<0>(GetParam())) {
-    // Parameterize with defer processing to prevent bit rot as filter made
-    // assumptions of data flow, prior relying on eager processing.
-    config_helper_.addRuntimeOverride(Runtime::defer_processing_backedup_streams,
-                                      deferredProcessing() ? "true" : "false");
-  }
+  GrpcJsonTranscoderIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
 
   void SetUp() override {
     setUpstreamProtocol(Http::CodecType::HTTP2);
@@ -212,14 +196,11 @@ protected:
 
     config_helper_.addConfigModifier(modifier);
   }
-
-  bool deferredProcessing() const { return std::get<1>(GetParam()); }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    IpVersionsDeferredProcessing, GrpcJsonTranscoderIntegrationTest,
-    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool()),
-    ipAndDeferredProcessingParamsToString);
+INSTANTIATE_TEST_SUITE_P(IpVersions, GrpcJsonTranscoderIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryPost) {
   HttpIntegrationTest::initialize();
@@ -1223,57 +1204,35 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingGetExceedsBufferLimit) 
       Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
       R"([{"id":"1","author":"Neal Stephenson","title":"Readme"}])");
 
-  if (Runtime::runtimeFeatureEnabled(Runtime::defer_processing_backedup_streams)) {
-    // Over limit: The server streams two response messages. Because this is
-    // larger than the buffer limits, we end up buffering both results in the
-    // codec towards the upstream. When we finally process the buffered data, we
-    // end up resetting the stream as we've over the transcoder limit.
-    testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
-        Http::TestRequestHeaderMapImpl{
-            {":method", "GET"}, {":path", "/shelves/1/books"}, {":authority", "host"}},
-        "", {"shelf: 1"},
-        {R"(id: 1 author: "Neal Stephenson" title: "Readme")",
-         R"(id: 2 author: "George R.R. Martin" title: "A Game of Thrones")"},
-        Status(),
-        Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
-        /*expected_response_body=*/"", false, false, "", true, /*expect_response_complete=*/false);
-
-  } else {
-    // Over limit: The server streams two response messages. Even through the transcoder
-    // handles them independently, portions of the first message are still in the
-    // internal buffers while the second one is processed.
-    //
-    // Because the headers and body is already sent, the stream is closed with
-    // an incomplete response.
-    testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
-        Http::TestRequestHeaderMapImpl{
-            {":method", "GET"}, {":path", "/shelves/1/books"}, {":authority", "host"}},
-        "", {"shelf: 1"},
-        {R"(id: 1 author: "Neal Stephenson" title: "Readme")",
-         R"(id: 2 author: "George R.R. Martin" title: "A Game of Thrones")"},
-        Status(),
-        Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
-        // Incomplete response, not valid JSON.
-        R"([{"id":"1","author":"Neal Stephenson","title":"Readme"})", false, false, "", true,
-        /*expect_response_complete=*/false);
-  }
+  // Over limit: The server streams two response messages. Even through the transcoder
+  // handles them independently, portions of the first message are still in the
+  // internal buffers while the second one is processed.
+  //
+  // Because the headers and body is already sent, the stream is closed with
+  // an incomplete response.
+  testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/shelves/1/books"}, {":authority", "host"}},
+      "", {"shelf: 1"},
+      {R"(id: 1 author: "Neal Stephenson" title: "Readme")",
+       R"(id: 2 author: "George R.R. Martin" title: "A Game of Thrones")"},
+      Status(),
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      // Incomplete response, not valid JSON.
+      R"([{"id":"1","author":"Neal Stephenson","title":"Readme"})", false, false, "", true,
+      /*expect_response_complete=*/false);
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingGetUnderBufferLimit) {
-  const int num_messages = 100;
-  const std::string grpc_response_message = R"(id: 1 author: "Neal Stephenson" title: "Readme")";
-  // The upstream will encode all of the response back to back, as such some of
-  // the responses will cluster together. It's unlikely that a majority of them
-  // will have been sent to the Envoy before it has streamed them to the
-  // downstream.
-  config_helper_.setBufferLimits(2 << 20, 60 * grpc_response_message.size());
+  const int num_messages = 20;
+  config_helper_.setBufferLimits(2 << 20, 80);
   HttpIntegrationTest::initialize();
 
   // Craft multiple response messages. IF combined together, they exceed the buffer limit.
   std::vector<std::string> grpc_response_messages;
   grpc_response_messages.reserve(num_messages);
   for (int i = 0; i < num_messages; i++) {
-    grpc_response_messages.push_back(grpc_response_message);
+    grpc_response_messages.push_back(R"(id: 1 author: "Neal Stephenson" title: "Readme")");
   }
 
   // Craft expected response.
@@ -1331,10 +1290,9 @@ public:
     config_helper_.prependFilter(filter);
   }
 };
-INSTANTIATE_TEST_SUITE_P(
-    IpVersionsDeferredProcessing, OverrideConfigGrpcJsonTranscoderIntegrationTest,
-    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool()),
-    ipAndDeferredProcessingParamsToString);
+INSTANTIATE_TEST_SUITE_P(IpVersions, OverrideConfigGrpcJsonTranscoderIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 
 TEST_P(OverrideConfigGrpcJsonTranscoderIntegrationTest, RouteOverride) {
   // add bookstore per-route override


### PR DESCRIPTION

This reverts commit 3b75d302bb67cc2b2594c81b7695626c8e96462d.

This commit was causing CI flakes. See example [here](https://github.com/envoyproxy/envoy/pull/20244#issuecomment-1071538849)

Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
