### PR TITLE
cryptomb: remove PKCS1_5 padding support.

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -7,7 +7,6 @@
 
 #include "source/common/config/datasource.h"
 
-#include "openssl/ec.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -170,31 +169,22 @@ ssl_private_key_result_t rsaPrivateKeySignInternal(CryptoMbPrivateKeyConnection*
     return status;
   }
 
+  // Add RSA padding to the the hash. Only `PSS` padding is supported.
+  if (!SSL_is_signature_algorithm_rsa_pss(signature_algorithm)) {
+    return status;
+  }
+
   uint8_t* msg;
   size_t msg_len;
-  int prefix_allocated = 0;
 
-  // Add RSA padding to the the hash. Supported types are `PSS` and `PKCS1`.
-  if (SSL_is_signature_algorithm_rsa_pss(signature_algorithm)) {
-    msg_len = RSA_size(rsa.get());
-    // We have to do manual memory management here, because BoringSSL tells in `prefix_allocated`
-    // variable whether or not memory needs to be freed.
-    msg = static_cast<uint8_t*>(OPENSSL_malloc(msg_len));
-    if (msg == nullptr) {
-      return status;
-    }
-    prefix_allocated = 1;
-    if (!RSA_padding_add_PKCS1_PSS_mgf1(rsa.get(), msg, hash, md, nullptr, -1)) {
-      OPENSSL_free(msg);
-      return status;
-    }
-  } else {
-    if (!RSA_add_pkcs1_prefix(&msg, &msg_len, &prefix_allocated, EVP_MD_type(md), hash, hash_len)) {
-      if (prefix_allocated) {
-        OPENSSL_free(msg);
-      }
-      return status;
-    }
+  msg_len = RSA_size(rsa.get());
+  msg = static_cast<uint8_t*>(OPENSSL_malloc(msg_len));
+  if (msg == nullptr) {
+    return status;
+  }
+  if (!RSA_padding_add_PKCS1_PSS_mgf1(rsa.get(), msg, hash, md, nullptr, -1)) {
+    OPENSSL_free(msg);
+    return status;
   }
 
   // Create MB context which will be used for this particular
@@ -203,18 +193,13 @@ ssl_private_key_result_t rsaPrivateKeySignInternal(CryptoMbPrivateKeyConnection*
       std::make_shared<CryptoMbRsaContext>(std::move(pkey), ops->dispatcher_, ops->cb_);
 
   if (!mb_ctx->rsaInit(msg, msg_len)) {
-    if (prefix_allocated) {
-      OPENSSL_free(msg);
-    }
-    return status;
-  }
-
-  if (prefix_allocated) {
     OPENSSL_free(msg);
+    return status;
   }
 
   ops->addToQueue(mb_ctx);
   status = ssl_private_key_retry;
+  OPENSSL_free(msg);
   return status;
 }
 

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -170,7 +170,9 @@ ssl_private_key_result_t rsaPrivateKeySignInternal(CryptoMbPrivateKeyConnection*
   }
 
   // Add RSA padding to the the hash. Only `PSS` padding is supported.
+  // TODO(ipuustin): add PKCS #1 v1.5 padding scheme later if requested.
   if (!SSL_is_signature_algorithm_rsa_pss(signature_algorithm)) {
+    ops->logDebugMsg("non-supported RSA padding");
     return status;
   }
 

--- a/contrib/cryptomb/private_key_providers/test/ops_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/ops_test.cc
@@ -132,6 +132,16 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaSigning) {
   EXPECT_EQ(res_, ssl_private_key_success);
 }
 
+TEST_F(CryptoMbProviderRsaTest, TestRsaPkcs1Signing) {
+  // PKCS #1 v1.5 is not supported.
+  TestCallbacks cb;
+  CryptoMbPrivateKeyConnection op(cb, *dispatcher_, bssl::UpRef(pkey_), queue_);
+
+  res_ = rsaPrivateKeySignForTest(&op, nullptr, nullptr, max_out_len_, SSL_SIGN_RSA_PKCS1_SHA256,
+                                  in_, in_len_);
+  EXPECT_EQ(res_, ssl_private_key_failure);
+}
+
 TEST_F(CryptoMbProviderRsaTest, TestRsaPssSigning) {
   // Initialize connections.
   TestCallbacks cbs[CryptoMbQueue::MULTIBUFF_BATCH];

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -14,6 +14,7 @@ Minor Behavior Changes
 
 * access_log: log all header values in the grpc access log.
 * config: warning messages for protobuf unknown fields now contain ancestors for easier troubleshooting.
+* cryptomb: remove RSA PKCS1 v1.5 padding support.
 * decompressor: decompressor does not duplicate `accept-encoding` header values anymore. This behavioral change can be reverted by setting runtime guard ``envoy.reloadable_features.append_to_accept_content_encoding_only_once`` to false.
 * dynamic_forward_proxy: if a DNS resolution fails, failing immediately with a specific resolution error, rather than finishing up all local filters and failing to select an upstream host.
 * ext_authz: added requested server name in ext_authz network filter for auth review.


### PR DESCRIPTION
Commit Message:

cryptomb: drop RSA signing PKCS1 v1.5 padding support.

Additional Description:

Drop RSA signing PKCS1 v1.5 padding support (which wasn't functional). Only keep the RSA-PSS for now. If someone needs PKCS1 v1.5, we can re-add it properly later.

Risk Level: low
Testing: unit tests, manual testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: CryptoMB extension works on 3rd Gen Intel Xeon Scalable processors.
