### PR TITLE
remove useless entry from quiche.genrule_cmd

### DIFF
--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -19,7 +19,6 @@ src_base_dir=$$(dirname $$(dirname $$(dirname $(rootpath quic/core/quic_constant
 # sed commands to apply to each source file.
 cat <<EOF >sed_commands
 # Rewrite include directives for testonly platform impl files.
-/^#include/ s!net/http2/platform/impl/http2_reconstruct_object_impl.h!test/common/quic/platform/http2_reconstruct_object_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_expect_bug_impl.h!test/common/quic/platform/quic_expect_bug_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_mock_log_impl.h!test/common/quic/platform/quic_mock_log_impl.h!
 /^#include/ s!net/quic/platform/impl/quic_port_utils_impl.h!test/common/quic/platform/quic_port_utils_impl.h!


### PR DESCRIPTION
remove useless entry from quiche.genrule_cmd

Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Ryan Hamilton <rch@google.com>
