### PR TITLE
router: fix mirror policy runtime_fraction runtime lookup

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -46,6 +46,11 @@ Bug Fixes
 * eds: fix the eds cluster update by allowing update on the locality of the cluster endpoints. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.support_locality_update_on_eds_cluster_endpoints`` to false.
 * jwt_authn: fixed a bug where a JWT with empty "iss" is passed even the field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` is specified. If the "issuer" field is specified, "iss" in the JWT should match it.
 * jwt_authn: fixed the crash when a CONNECT request is sent to JWT filter configured with regex match on the Host header.
+* router: fixed mirror policy :ref:`runtime_fraction <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.runtime_fraction>` to
+  correctly allow reading from a fractional percent value stored in runtime in all cases. Previously
+  it would only do this if the default numerator was above 0, otherwise it would use the integer
+  variant with a default of 0. The default of 0 is retained, but runtime lookup will happen in
+  all cases and recognize a stored fractional percent.
 * tcp_proxy: fix a crash that occurs when configured for :ref:`upstream tunneling <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection disconnects while the the upstream connection or http/2 stream is still being established.
 * tls: fix a bug while matching a certificate SAN with an exact value in ``match_typed_subject_alt_names`` of a listener where wildcard ``*`` character is not the only character of the dns label. Example, ``baz*.example.net`` and ``*baz.example.net`` and ``b*z.example.net`` will match ``baz1.example.net`` and ``foobaz.example.net`` and ``buzz.example.net``, respectively.
 * upstream: cluster slow start config add ``min_weight_percent`` field to avoid too big EDF deadline which cause slow start endpoints receiving no traffic, default 10%. This fix is releted to `issue#19526 <https://github.com/envoyproxy/envoy/issues/19526>`_.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -103,14 +103,11 @@ bool FilterUtility::shouldShadow(const ShadowPolicy& policy, Runtime::Loader& ru
     return false;
   }
 
-  if (policy.defaultValue().numerator() > 0) {
+  if (!policy.runtimeKey().empty()) {
+    // The default is 0/100, which means that the default for a key set but no default value
+    // explicitly set is 0% mirrored.
     return runtime.snapshot().featureEnabled(policy.runtimeKey(), policy.defaultValue(),
                                              stable_random);
-  }
-
-  if (!policy.runtimeKey().empty() &&
-      !runtime.snapshot().featureEnabled(policy.runtimeKey(), 0, stable_random, 10000UL)) {
-    return false;
   }
 
   return true;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4402,8 +4402,16 @@ TEST_F(RouterTest, Shadow) {
 
   expectResponseTimerCreate();
 
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("bar", 0, 43, 10000)).WillOnce(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("buzz", 0, 43, 10000)).WillOnce(Return(true));
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("bar", testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0)),
+                     43))
+      .WillOnce(Return(true));
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("buzz",
+                     testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0)), 43))
+      .WillOnce(Return(true));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -5383,25 +5391,39 @@ TEST(RouterFilterUtilityTest, ShouldShadow) {
   {
     TestShadowPolicy policy;
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled(_, _, _, _)).Times(0);
+    EXPECT_CALL(
+        runtime.snapshot_,
+        featureEnabled(_, testing::Matcher<const envoy::type::v3::FractionalPercent&>(_), _))
+        .Times(0);
     EXPECT_FALSE(FilterUtility::shouldShadow(policy, runtime, 5));
   }
   {
     TestShadowPolicy policy("cluster");
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled(_, _, _, _)).Times(0);
+    EXPECT_CALL(
+        runtime.snapshot_,
+        featureEnabled(_, testing::Matcher<const envoy::type::v3::FractionalPercent&>(_), _))
+        .Times(0);
     EXPECT_TRUE(FilterUtility::shouldShadow(policy, runtime, 5));
   }
   {
     TestShadowPolicy policy("cluster", "foo");
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("foo", 0, 5, 10000)).WillOnce(Return(false));
+    EXPECT_CALL(
+        runtime.snapshot_,
+        featureEnabled("foo",
+                       testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0)), 5))
+        .WillOnce(Return(false));
     EXPECT_FALSE(FilterUtility::shouldShadow(policy, runtime, 5));
   }
   {
     TestShadowPolicy policy("cluster", "foo");
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("foo", 0, 5, 10000)).WillOnce(Return(true));
+    EXPECT_CALL(
+        runtime.snapshot_,
+        featureEnabled("foo",
+                       testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0)), 5))
+        .WillOnce(Return(true));
     EXPECT_TRUE(FilterUtility::shouldShadow(policy, runtime, 5));
   }
   // Use default value instead of runtime key.


### PR DESCRIPTION
Previously in the case that the default was 0, the fractional
percent variant of runtime lookup was not used. This uses that
variant in all cases while retaining default behavior. This leads
to the expected behavior.

Risk Level: Low
Testing: Fixed tests
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
