### PR TITLE
json: add hand-rolled json sanitizer

### DIFF
--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -34,3 +34,18 @@ envoy_cc_library(
         "//source/common/runtime:runtime_features_lib",
     ],
 )
+
+envoy_cc_library(
+    name = "json_sanitizer_lib",
+    srcs = ["json_sanitizer.cc"],
+    hdrs = ["json_sanitizer.h"],
+    external_deps = [
+        "json",
+    ],
+    deps = [
+        "//envoy/json:json_object_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/protobuf:utility_lib",
+    ],
+)

--- a/source/common/json/json_sanitizer.cc
+++ b/source/common/json/json_sanitizer.cc
@@ -1,0 +1,75 @@
+#include "source/common/json/json_sanitizer.h"
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
+namespace Envoy {
+namespace Json {
+
+JsonSanitizer::JsonSanitizer() {
+  // Single-char escape sequences for common control characters.
+  auto control_char = [this](char escape, absl::string_view letter) {
+    char_escapes_[static_cast<uint32_t>(escape)] =
+        std::make_unique<std::string>(absl::StrCat("\\", letter));
+  };
+  control_char('\b', "b");
+  control_char('\f', "f");
+  control_char('\n', "n");
+  control_char('\r', "r");
+  control_char('\t', "t");
+  control_char('\\', "\\");
+  control_char('\"', "\"");
+
+  // Low characters (0-31) not listed above are encoded as unicode 4-digit hex, plus
+  // a few other specific ones.
+  auto unicode_escape = [this](uint32_t index) {
+    if (char_escapes_[index] == nullptr) {
+      char_escapes_[index] = std::make_unique<std::string>(absl::StrFormat("\\u%04x", index));
+    }
+  };
+  unicode_escape('<');
+  unicode_escape('>');
+  unicode_escape(127);
+
+  // Control-characters below 32.
+  for (uint32_t i = 0; i < ' '; ++i) {
+    unicode_escape(i);
+  }
+}
+
+absl::string_view JsonSanitizer::sanitize(std::string& buffer, absl::string_view str) const {
+  size_t last_escape = absl::string_view::npos;
+  for (uint32_t i = 0, n = str.size(); i < n; ++i) {
+    uint32_t index = static_cast<uint32_t>(static_cast<uint8_t>(str[i]));
+    const std::string* escape = char_escapes_[index].get();
+    if (escape != nullptr) {
+      if (last_escape == absl::string_view::npos) {
+        // We only initialize buffer when we first learn we need to add an
+        // escape-sequence to the sanitized string.
+        last_escape = i;
+        if (i == 0) {
+          buffer = *escape;
+        } else {
+          buffer = absl::StrCat(str.substr(0, i), *escape);
+        }
+      } else {
+        absl::StrAppend(&buffer, str.substr(last_escape + 1, i - last_escape), *escape);
+      }
+    }
+  }
+
+  // If no escape-sequence was needed, we just return the input.
+  if (last_escape == absl::string_view::npos) {
+    return str;
+  }
+
+  // Otherwise we append on any unescaped chunk at the end of the input, and
+  // return buffer as the result.
+  if (last_escape < str.size() - 1) {
+    absl::StrAppend(&buffer, str.substr(last_escape + 1, str.size() - last_escape));
+  }
+  return buffer;
+}
+
+} // namespace Json
+} // namespace Envoy

--- a/source/common/json/json_sanitizer.h
+++ b/source/common/json/json_sanitizer.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Json {
+
+// Hand-rolled JSON sanitizer that has exactly the same behavior as serializing
+// through protobufs, but is more than 10x faster. From
+// test/common/json/json_sanitizer_speed_test.cc:
+//
+// ---------------------------------------------------------------------
+// Benchmark                           Time             CPU   Iterations
+// ---------------------------------------------------------------------
+// BM_ProtoEncoderNoEscape          1100 ns         1100 ns       636735
+// BM_JsonSanitizerNoEscape         18.1 ns         18.1 ns     38671848
+// BM_ProtoEncoderWithEscape        1376 ns         1375 ns       507137
+// BM_JsonSanitizerWithEscape       94.5 ns         94.5 ns      7402468
+//
+class JsonSanitizer {
+public:
+  // Constructing the sanitizer fills in a table with all escape-sequences,
+  // indexed by character. To make this perform well, you should instantiate the
+  // sanitizer in a context that lives across a large number of sanitizations.
+  JsonSanitizer();
+
+  /**
+   * Sanitizes a string so it is suitable for JSON. The buffer is
+   * used if any of the characters in str need to be escaped.
+   *
+   * @param buffer a string in which an escaped string can be written, if needed
+   * @param str the string to be translated
+   * @return the translated string_view.
+   */
+  absl::string_view sanitize(std::string& buffer, absl::string_view str) const;
+
+private:
+  // Character-indexed array of translation strings. If an entry is nullptr then
+  // the character does not require substitution. This strategy is dependent on
+  // the property of UTF-8 where all two-byte characters have the high-order bit
+  // set for both bytes, and don't require escaping for JSON. Thus we can
+  // consider each character in isolation for escaping.
+  std::unique_ptr<std::string> char_escapes_[256];
+};
+
+} // namespace Json
+} // namespace Envoy

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
@@ -34,5 +35,23 @@ envoy_cc_test(
         "//source/common/json:json_loader_lib",
         "//source/common/stats:isolated_store_lib",
         "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "json_sanitizer_test",
+    srcs = ["json_sanitizer_test.cc"],
+    deps = [
+        "//source/common/json:json_sanitizer_lib",
+        "//source/common/protobuf:utility_lib",
+    ],
+)
+
+envoy_cc_benchmark_binary(
+    name = "json_sanitizer_speed_test",
+    srcs = ["json_sanitizer_speed_test.cc"],
+    deps = [
+        "//source/common/json:json_sanitizer_lib",
+        "//source/common/protobuf:utility_lib",
     ],
 )

--- a/test/common/json/json_sanitizer_speed_test.cc
+++ b/test/common/json/json_sanitizer_speed_test.cc
@@ -1,0 +1,53 @@
+#include "source/common/json/json_sanitizer.h"
+#include "source/common/protobuf/utility.h"
+
+#include "benchmark/benchmark.h"
+
+// NOLINT(namespace-envoy)
+
+constexpr absl::string_view pass_through_encoding = "Now is the time for all good men";
+constexpr absl::string_view escaped_encoding = "Now <is the \"time\"> for all good men";
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_ProtoEncoderNoEscape(benchmark::State& state) {
+  const std::string str = std::string(pass_through_encoding);
+
+  for (auto _ : state) { // NOLINT
+    Envoy::MessageUtil::getJsonStringFromMessageOrDie(Envoy::ValueUtil::stringValue(str), false,
+                                                      true);
+  }
+}
+BENCHMARK(BM_ProtoEncoderNoEscape);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_JsonSanitizerNoEscape(benchmark::State& state) {
+  Envoy::Json::JsonSanitizer sanitizer;
+  std::string buffer;
+
+  for (auto _ : state) { // NOLINT
+    sanitizer.sanitize(buffer, pass_through_encoding);
+  }
+}
+BENCHMARK(BM_JsonSanitizerNoEscape);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_ProtoEncoderWithEscape(benchmark::State& state) {
+  const std::string str = std::string(escaped_encoding);
+
+  for (auto _ : state) { // NOLINT
+    Envoy::MessageUtil::getJsonStringFromMessageOrDie(Envoy::ValueUtil::stringValue(str), false,
+                                                      true);
+  }
+}
+BENCHMARK(BM_ProtoEncoderWithEscape);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_JsonSanitizerWithEscape(benchmark::State& state) {
+  Envoy::Json::JsonSanitizer sanitizer;
+  std::string buffer;
+
+  for (auto _ : state) { // NOLINT
+    sanitizer.sanitize(buffer, escaped_encoding);
+  }
+}
+BENCHMARK(BM_JsonSanitizerWithEscape);

--- a/test/common/json/json_sanitizer_test.cc
+++ b/test/common/json/json_sanitizer_test.cc
@@ -1,0 +1,93 @@
+#include "source/common/json/json_sanitizer.h"
+#include "source/common/protobuf/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Json {
+namespace {
+
+class JsonSanitizerTest : public testing::Test {
+protected:
+  absl::string_view sanitize(absl::string_view str) {
+    absl::string_view hand_sanitized = sanitizer_.sanitize(buffer_, str);
+    std::string proto_sanitized = MessageUtil::getJsonStringFromMessageOrDie(
+        ValueUtil::stringValue(std::string(str)), false, true);
+    EXPECT_EQ(proto_sanitized, absl::StrCat("\"", hand_sanitized, "\"")) << "str=" << str;
+    return hand_sanitized;
+  }
+
+  void expectUnchanged(absl::string_view str) { EXPECT_EQ(str, sanitize(str)); }
+
+  JsonSanitizer sanitizer_;
+  std::string buffer_;
+};
+
+TEST_F(JsonSanitizerTest, Empty) { expectUnchanged(""); }
+
+TEST_F(JsonSanitizerTest, NoEscape) {
+  expectUnchanged("abcdefghijklmnopqrstuvwxyz");
+  expectUnchanged("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  expectUnchanged("1234567890");
+  expectUnchanged(" `~!@#$%^&*()_+-={}|[]");
+}
+
+TEST_F(JsonSanitizerTest, SlashChars) {
+  EXPECT_EQ("\\b", sanitize("\b"));
+  EXPECT_EQ("\\f", sanitize("\f"));
+  EXPECT_EQ("\\n", sanitize("\n"));
+  EXPECT_EQ("\\r", sanitize("\r"));
+  EXPECT_EQ("\\t", sanitize("\t"));
+  EXPECT_EQ("\\\\", sanitize("\\"));
+  EXPECT_EQ("\\\"", sanitize("\""));
+}
+
+TEST_F(JsonSanitizerTest, ControlChars) {
+  EXPECT_EQ("\\u0001", sanitize("\001"));
+  EXPECT_EQ("\\u0002", sanitize("\002"));
+  EXPECT_EQ("\\b", sanitize("\010"));
+  EXPECT_EQ("\\t", sanitize("\011"));
+  EXPECT_EQ("\\n", sanitize("\012"));
+  EXPECT_EQ("\\u000b", sanitize("\013"));
+  EXPECT_EQ("\\f", sanitize("\014"));
+  EXPECT_EQ("\\r", sanitize("\015"));
+  EXPECT_EQ("\\u000e", sanitize("\016"));
+  EXPECT_EQ("\\u000f", sanitize("\017"));
+  EXPECT_EQ("\\u0010", sanitize("\020"));
+  EXPECT_EQ("\\u003c", sanitize("<"));
+  EXPECT_EQ("\\u003e", sanitize(">"));
+}
+
+TEST_F(JsonSanitizerTest, SevenBitAscii) {
+  // Cover all the 7-bit ascii values, calling sanitize so that it checks
+  // our hand-rolled sanitizer vs protobuf. We ignore the return-value of
+  // sanitize(); we are just calling for it to test against protobuf.
+  for (uint32_t i = 0; i < 128; ++i) {
+    char c = i;
+    sanitize(absl::string_view(&c, 1));
+  }
+}
+
+TEST_F(JsonSanitizerTest, Utf8) {
+  // reference; https://www.charset.org/utf-8
+  auto unicode = [](std::vector<uint8_t> chars) -> std::string {
+    return std::string(reinterpret_cast<const char*>(&chars[0]), chars.size());
+  };
+
+  expectUnchanged(unicode({0xc2, 0xa2})); // Cent.
+  expectUnchanged(unicode({0xc2, 0xa9})); // Copyright.
+  expectUnchanged(unicode({0xc3, 0xa0})); // 'a' with accent grave.
+}
+
+TEST_F(JsonSanitizerTest, Interspersed) {
+  EXPECT_EQ("a\\bc", sanitize("a\bc"));
+  EXPECT_EQ("a\\b\\fc", sanitize("a\b\fc"));
+  EXPECT_EQ("\\bac", sanitize("\bac"));
+  EXPECT_EQ("\\b\\fac", sanitize("\b\fac"));
+  EXPECT_EQ("ac\\b", sanitize("ac\b"));
+  EXPECT_EQ("ac\\b", sanitize("ac\b"));
+}
+
+} // namespace
+} // namespace Json
+} // namespace Envoy

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1099,6 +1099,7 @@ rver
 rxhash
 sandboxed
 sanitization
+sanitizations
 sanitizer
 satisfiable
 scalability


### PR DESCRIPTION
Commit Message: Creates a hand-coded json string sanitizer, functionally equivalent to creating a protobuf and serializing to JSON, but more than 10x faster.
```
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_ProtoEncoderNoEscape          1100 ns         1100 ns       636735
BM_JsonSanitizerNoEscape         18.1 ns         18.1 ns     38671848
BM_ProtoEncoderWithEscape        1376 ns         1375 ns       507137
BM_JsonSanitizerWithEscape       94.5 ns         94.5 ns      7402468
```
Additional Description: This is intended to be adapted into the JSON renderer introduced in https://github.com/envoyproxy/envoy/pull/19693
Risk Level: low
Testing: Just the new unit-test and benchmark
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

