### PR TITLE
repo: Use python toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,10 @@ load("//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
 
 envoy_dependencies_extra()
 
+load("//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+
+envoy_python_dependencies()
+
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()

--- a/bazel/python_dependencies.bzl
+++ b/bazel/python_dependencies.bzl
@@ -1,0 +1,25 @@
+load("@rules_python//python:pip.bzl", "pip_install", "pip_parse")
+load("@python3_10//:defs.bzl", "interpreter")
+
+def envoy_python_dependencies():
+    pip_parse(
+        name = "base_pip3",
+        python_interpreter_target = interpreter,
+        requirements_lock = "@envoy//tools/base:requirements.txt",
+        extra_pip_args = ["--require-hashes"],
+    )
+
+    # These need to use `pip_install`
+    pip_install(
+        # Note: dev requirements do *not* check hashes
+        python_interpreter_target = interpreter,
+        name = "dev_pip3",
+        requirements = "@envoy//tools/dev:requirements.txt",
+    )
+
+    pip_install(
+        name = "fuzzing_pip3",
+        python_interpreter_target = interpreter,
+        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+        extra_pip_args = ["--require-hashes"],
+    )

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -1,31 +1,18 @@
 load("@emsdk//:deps.bzl", emsdk_deps = "deps")
-load("@rules_python//python:pip.bzl", "pip_install", "pip_parse")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 load("@proxy_wasm_cpp_host//bazel/cargo/wasmtime:crates.bzl", "wasmtime_fetch_remote_crates")
 load("//bazel/external/cargo:crates.bzl", "raze_fetch_remote_crates")
 
-# Python dependencies.
-def _python_deps():
-    pip_parse(
-        name = "base_pip3",
-        requirements_lock = "@envoy//tools/base:requirements.txt",
-        extra_pip_args = ["--require-hashes"],
-    )
-
-    # These need to use `pip_install`
-    pip_install(
-        # Note: dev requirements do *not* check hashes
-        name = "dev_pip3",
-        requirements = "@envoy//tools/dev:requirements.txt",
-    )
-    pip_install(
-        name = "fuzzing_pip3",
-        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
-        extra_pip_args = ["--require-hashes"],
-    )
+# Python version for `rules_python`
+PYTHON_VERSION = "3.10.2"
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().
-def envoy_dependencies_extra():
-    _python_deps()
+def envoy_dependencies_extra(python_version=PYTHON_VERSION):
     emsdk_deps()
     raze_fetch_remote_crates()
     wasmtime_fetch_remote_crates()
+    # Registers underscored Python minor version - eg `python3_10`
+    python_register_toolchains(
+        name = "python%s" % ("_".join(python_version.split(".")[:-1])),
+        python_version = python_version,
+    )

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -7,10 +7,11 @@ load("//bazel/external/cargo:crates.bzl", "raze_fetch_remote_crates")
 PYTHON_VERSION = "3.10.2"
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().
-def envoy_dependencies_extra(python_version=PYTHON_VERSION):
+def envoy_dependencies_extra(python_version = PYTHON_VERSION):
     emsdk_deps()
     raze_fetch_remote_crates()
     wasmtime_fetch_remote_crates()
+
     # Registers underscored Python minor version - eg `python3_10`
     python_register_toolchains(
         name = "python%s" % ("_".join(python_version.split(".")[:-1])),

--- a/ci/WORKSPACE.filter.example
+++ b/ci/WORKSPACE.filter.example
@@ -21,6 +21,10 @@ load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
 
 envoy_dependencies_extra()
 
+load("@envoy//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+
+envoy_python_dependencies()
+
 load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

Also bumps `rules_python` -> 0.8.0 (Fix #20431 ) 

In order to get this to work and to accommodate the 3 stages of loading required (register toolchains, register pipsets, install pipsets) i have had to move things around a little and add a `python_dependencies.bzl` file

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
