### PR TITLE
test: fixing up hostnames

### DIFF
--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -107,7 +107,9 @@ namespace {
 class ConnectivityGridTest : public Event::TestUsingSimulatedTime, public testing::Test {
 public:
   ConnectivityGridTest()
-      : options_({Http::Protocol::Http11, Http::Protocol::Http2, Http::Protocol::Http3}),
+      : transport_socket_options_(
+            std::make_shared<Network::TransportSocketOptionsImpl>("hostname")),
+        options_({Http::Protocol::Http11, Http::Protocol::Http2, Http::Protocol::Http3}),
         alternate_protocols_(std::make_shared<AlternateProtocolsCacheImpl>(simTime(), nullptr, 10)),
         quic_stat_names_(store_.symbolTable()) {}
 

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -112,8 +112,9 @@ TEST_P(FilterIntegrationTest, AltSvc) {
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
 
   Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
-      {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
+      {":method", "POST"},       {":path", "/test/long/url"},
+      {":scheme", "http"},       {":authority", "sni.lyft.com"},
+      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
   int port = fake_upstreams_[1]->localAddress()->ip()->port();
   std::string alt_svc = absl::StrCat("h3=\":", port, "\"; ma=86400");
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"alt-svc", alt_svc}};
@@ -150,7 +151,7 @@ TEST_P(FilterIntegrationTest, H3PostHandshakeFailoverToTcp) {
       {":method", "POST"},
       {":path", "/test/long/url"},
       {":scheme", "http"},
-      {":authority", "host"},
+      {":authority", "sni.lyft.com"},
       {"x-lyft-user-id", "123"},
       {"x-forwarded-for", "10.0.0.1"},
       {"x-envoy-retry-on", "http3-post-connect-failure"}};

--- a/test/extensions/filters/http/on_demand/on_demand_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/on_demand_integration_test.cc
@@ -61,7 +61,7 @@ key:
   auto response = codec_client_->makeHeaderOnlyRequest(
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/meh"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=foo"}});
   createRdsStream("foo_route1");
@@ -119,7 +119,7 @@ key:
   auto response = codec_client_->makeHeaderOnlyRequest(
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/meh"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=bar"}});
   ASSERT_TRUE(response->waitForEndStream());
@@ -169,7 +169,7 @@ key:
   auto response = codec_client_->makeHeaderOnlyRequest(
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/neh"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=foo"}});
   ASSERT_TRUE(response->waitForEndStream());
@@ -225,7 +225,7 @@ key:
   auto response = codec_client_->makeHeaderOnlyRequest(
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/neh"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=bar"}});
   ASSERT_TRUE(response->waitForEndStream());
@@ -283,7 +283,7 @@ key:
     sendRequestAndVerifyResponse(
         Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                        {":path", "/meh"},
-                                       {":authority", "host"},
+                                       {":authority", "sni.lyft.com"},
                                        {":scheme", "http"},
                                        {"Addr", fmt::format("x-foo-key={}", scope_key)}},
         456, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", scope_key}}, 123, 0);
@@ -323,7 +323,7 @@ key:
   auto response = codec_client_->makeHeaderOnlyRequest(
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/meh"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=foo"}});
   test_server_->waitForCounterGe("http.config_test.rds.foo_route1.update_attempt", 1);

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -743,8 +743,9 @@ TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
   const uint64_t first_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
   codec_client_ = makeHttpConnection(creator());
   Http::TestRequestHeaderMapImpl post_request_headers{
-      {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
-      {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
+      {":method", "POST"},       {":path", "/test/long/url"},
+      {":scheme", "http"},       {":authority", "sni.lyft.com"},
+      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
   auto response =
       sendRequestAndWaitForResponse(post_request_headers, 128, default_response_headers_, 256);
   EXPECT_TRUE(upstream_request_->complete());
@@ -783,8 +784,9 @@ TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
   const uint64_t second_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
   codec_client_ = makeHttpConnection(creator());
   Http::TestRequestHeaderMapImpl get_request_headers{
-      {":method", "GET"},     {":path", "/test/long/url"}, {":scheme", "http"},
-      {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
+      {":method", "GET"},        {":path", "/test/long/url"},
+      {":scheme", "http"},       {":authority", "sni.lyft.com"},
+      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
   response =
       sendRequestAndWaitForResponse(get_request_headers, 128, default_response_headers_, 256);
   EXPECT_TRUE(upstream_request_->complete());
@@ -819,8 +821,10 @@ TEST_P(SslTapIntegrationTest, TruncationWithMultipleDataFrames) {
 
   const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
   codec_client_ = makeHttpConnection(creator());
-  const Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                       {":path", "/test/long/url"},
+                                                       {":scheme", "http"},
+                                                       {":authority", "sni.lyft.com"}};
   auto result = codec_client_->startRequest(request_headers);
   auto response = std::move(result.second);
   Buffer::OwnedImpl data1("one");
@@ -866,7 +870,7 @@ TEST_P(SslTapIntegrationTest, RequestWithTextProto) {
   TestUtility::loadFromFile(fmt::format("{}_{}.pb_text", path_prefix_, id), trace, *api_);
   // Test some obvious properties.
   EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
-                               "POST /test/long/url HTTP/1.1"));
+                               "GET /test/long/url HTTP/1.1"));
   EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
                                "HTTP/1.1 200 OK"));
   EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
@@ -896,7 +900,7 @@ TEST_P(SslTapIntegrationTest, RequestWithJsonBodyAsStringUpstreamTap) {
   TestUtility::loadFromFile(fmt::format("{}_{}.json", path_prefix_, id), trace, *api_);
 
   // Test some obvious properties.
-  EXPECT_EQ(trace.socket_buffered_trace().events(0).write().data().as_string(), "POST");
+  EXPECT_EQ(trace.socket_buffered_trace().events(0).write().data().as_string(), "GET ");
   EXPECT_EQ(trace.socket_buffered_trace().events(1).read().data().as_string(), "HTTP/");
   EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
   EXPECT_TRUE(trace.socket_buffered_trace().write_truncated());
@@ -935,7 +939,7 @@ TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTap) {
   EXPECT_TRUE(traces[0].socket_streamed_trace_segment().connection().has_remote_address());
 
   // Verify truncated request/response data.
-  EXPECT_EQ(traces[1].socket_streamed_trace_segment().event().write().data().as_bytes(), "POST");
+  EXPECT_EQ(traces[1].socket_streamed_trace_segment().event().write().data().as_bytes(), "GET ");
   EXPECT_TRUE(traces[1].socket_streamed_trace_segment().event().write().data().truncated());
   EXPECT_EQ(traces[2].socket_streamed_trace_segment().event().read().data().as_bytes(), "HTTP/");
   EXPECT_TRUE(traces[2].socket_streamed_trace_segment().event().read().data().truncated());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -562,19 +562,15 @@ void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
   initialize();
   codec_client_ = makeHttpConnection(
       create_connection ? ((*create_connection)()) : makeClientConnection((lookupPort("http"))));
-  Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
-      {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   if (set_content_length_header) {
-    request_headers.setContentLength(request_size);
-    response_headers.setContentLength(response_size);
+    default_request_headers_.setContentLength(request_size);
+    default_response_headers_.setContentLength(response_size);
   }
   if (big_header) {
-    request_headers.addCopy("big", std::string(4096, 'a'));
+    default_request_headers_.addCopy("big", std::string(4096, 'a'));
   }
-  auto response = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
-                                                response_size, 0, timeout);
+  auto response = sendRequestAndWaitForResponse(
+      default_request_headers_, request_size, default_response_headers_, response_size, 0, timeout);
   checkSimpleRequestSuccess(request_size, response_size, response.get());
 }
 
@@ -586,15 +582,14 @@ void HttpIntegrationTest::testRouterUpstreamProtocolError(const std::string& exp
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":authority", "host"}});
+      {":method", "GET"}, {":path", "/test/long/url"}, {":authority", "sni.lyft.com"}});
   auto response = std::move(encoder_decoder.second);
 
   FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
-  // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
-  // be fixed.
   std::string data;
-  ASSERT_TRUE(fake_upstream_connection->waitForData(187, &data));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(
+      FakeRawConnection::waitForInexactMatch("\r\n\r\n"), &data));
   ASSERT_TRUE(fake_upstream_connection->write("bad protocol data!"));
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
   ASSERT_TRUE(codec_client_->waitForDisconnect());
@@ -617,12 +612,11 @@ HttpIntegrationTest::makeHeaderOnlyRequest(ConnectionCreationFunction* create_co
   }
   codec_client_ = makeHttpConnection(
       create_connection ? ((*create_connection)()) : makeClientConnection((lookupPort("http"))));
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                 {":path", path},
-                                                 {":scheme", "http"},
-                                                 {":authority", authority},
-                                                 {"x-lyft-user-id", "123"}};
-  return sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0,
+  if (!authority.empty()) {
+    default_request_headers_.setHost(authority);
+  }
+  default_request_headers_.setPath(path);
+  return sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0,
                                        upstream_index);
 }
 
@@ -684,7 +678,7 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "host"},
+                                                 {":authority", "sni.lyft.com"},
                                                  {matching_header, "true"}};
 
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
@@ -693,12 +687,8 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
   test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 0);
 
-  Http::TestRequestHeaderMapImpl request_headers2{{":method", "POST"},
-                                                  {":path", "/test/long/url"},
-                                                  {":scheme", "http"},
-                                                  {":authority", "host"}};
-
-  auto response2 = sendRequestAndWaitForResponse(request_headers2, 0, default_response_headers_, 0);
+  auto response2 =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response2.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
@@ -870,7 +860,7 @@ void HttpIntegrationTest::testRetry() {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024);
@@ -899,7 +889,7 @@ void HttpIntegrationTest::testRetry() {
 // Tests that the x-envoy-attempt-count header is properly set on the upstream request
 // and updated after the request is retried.
 void HttpIntegrationTest::testRetryAttemptCountHeader() {
-  auto host = config_helper_.createVirtualHost("host", "/test_retry");
+  auto host = config_helper_.createVirtualHost("sni.lyft.com", "/test_retry");
   host.set_include_request_attempt_count(true);
   host.set_include_attempt_count_in_response(true);
   config_helper_.addVirtualHost(host);
@@ -910,7 +900,7 @@ void HttpIntegrationTest::testRetryAttemptCountHeader() {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test_retry"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024);
@@ -949,7 +939,7 @@ void HttpIntegrationTest::testGrpcRetry() {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-grpc-on", "cancelled"}});
   request_encoder_ = &encoder_decoder.first;
@@ -994,7 +984,7 @@ void HttpIntegrationTest::testEnvoyHandling1xx(bool additional_continue_from_ups
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/dynamo/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"expect", "100-continue"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
@@ -1065,7 +1055,7 @@ void HttpIntegrationTest::testEnvoyProxying1xx(bool continue_before_upstream_com
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                                                  {":path", "/dynamo/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"expect", "100-continue"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
@@ -1174,7 +1164,7 @@ void HttpIntegrationTest::testLargeRequestUrl(uint32_t url_size, uint32_t max_he
   Http::TestRequestHeaderMapImpl big_headers{{":method", "GET"},
                                              {":path", "/" + std::string(url_size * 1024, 'a')},
                                              {":scheme", "http"},
-                                             {":authority", "host"}};
+                                             {":authority", "sni.lyft.com"}};
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1217,8 +1207,10 @@ void HttpIntegrationTest::testLargeRequestHeaders(uint32_t size, uint32_t count,
   setMaxRequestHeadersKb(max_size);
   setMaxRequestHeadersCount(max_count);
 
-  Http::TestRequestHeaderMapImpl big_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl big_headers{{":method", "GET"},
+                                             {":path", "/test/long/url"},
+                                             {":scheme", "http"},
+                                             {":authority", "sni.lyft.com"}};
 
   // Already added four headers.
   for (unsigned int i = 0; i < count; i++) {
@@ -1311,7 +1303,7 @@ void HttpIntegrationTest::testManyRequestHeaders(std::chrono::milliseconds time)
       {{Http::Headers::get().Method, "GET"},
        {Http::Headers::get().Path, "/test/long/url"},
        {Http::Headers::get().Scheme, "http"},
-       {Http::Headers::get().Host, "host"}});
+       {Http::Headers::get().Host, "sni.lyft.com"}});
 
   for (int i = 0; i < 10000; i++) {
     big_headers->addCopy(Http::LowerCaseString(std::to_string(i)), std::string(0, 'a'));
@@ -1335,7 +1327,7 @@ void HttpIntegrationTest::testDownstreamResetBeforeResponseComplete() {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"cookie", "a=b"},
                                                                  {"cookie", "c=d"}});
   request_encoder_ = &encoder_decoder.first;
@@ -1382,7 +1374,7 @@ void HttpIntegrationTest::testTrailers(uint64_t request_size, uint64_t response_
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, request_size, false);
@@ -1419,7 +1411,7 @@ void HttpIntegrationTest::testAdminDrain(Http::CodecType admin_request_type) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "HEAD"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "host"}};
+                                                 {":authority", "sni.lyft.com"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest(0);
 
@@ -1466,22 +1458,14 @@ void HttpIntegrationTest::simultaneousRequest(uint32_t request1_bytes, uint32_t 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Start request 1
-  auto encoder_decoder1 =
-      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"}});
+  auto encoder_decoder1 = codec_client_->startRequest(default_request_headers_);
   Http::RequestEncoder* encoder1 = &encoder_decoder1.first;
   auto response1 = std::move(encoder_decoder1.second);
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request1));
 
   // Start request 2
-  auto encoder_decoder2 =
-      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"}});
+  auto encoder_decoder2 = codec_client_->startRequest(default_request_headers_);
   Http::RequestEncoder* encoder2 = &encoder_decoder2.first;
   auto response2 = std::move(encoder_decoder2.second);
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request2));

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -207,7 +207,7 @@ protected:
   IntegrationStreamDecoderPtr makeHeaderOnlyRequest(ConnectionCreationFunction* create_connection,
                                                     int upstream_index,
                                                     const std::string& path = "/test/long/url",
-                                                    const std::string& authority = "host");
+                                                    const std::string& overwrite_authority = "");
   void testRouterNotFound();
   void testRouterNotFoundWithBody();
   void testRouterVirtualClusters();
@@ -220,7 +220,7 @@ protected:
   void testRouterHeaderOnlyRequestAndResponse(ConnectionCreationFunction* creator = nullptr,
                                               int upstream_index = 0,
                                               const std::string& path = "/test/long/url",
-                                              const std::string& authority = "host");
+                                              const std::string& overwrite_authority = "");
 
   // Disconnect tests
   void testRouterUpstreamDisconnectBeforeRequestComplete();
@@ -288,8 +288,10 @@ protected:
   Http::RequestEncoder* request_encoder_{nullptr};
   // The response headers sent by sendRequestAndWaitForResponse() by default.
   Http::TestResponseHeaderMapImpl default_response_headers_{{":status", "200"}};
-  Http::TestRequestHeaderMapImpl default_request_headers_{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl default_request_headers_{{":method", "GET"},
+                                                          {":path", "/test/long/url"},
+                                                          {":scheme", "http"},
+                                                          {":authority", "sni.lyft.com"}};
   // The codec type for the client-to-Envoy connection
   Http::CodecType downstream_protocol_{Http::CodecType::HTTP1};
   std::string access_log_name_;

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -124,7 +124,7 @@ void MultiplexedUpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) 
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -196,7 +196,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, BidirectionalStreamingReset) {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -255,7 +255,7 @@ void MultiplexedUpstreamIntegrationTest::manySimultaneousRequests(uint32_t reque
         {":method", "POST"},
         {":path", "/test/long/url"},
         {":scheme", "http"},
-        {":authority", "host"},
+        {":authority", "sni.lyft.com"},
         {AutonomousStream::RESPONSE_SIZE_BYTES, std::to_string(response_bytes[i])},
         {AutonomousStream::EXPECT_REQUEST_SIZE_BYTES, std::to_string(request_bytes)}};
     if (i % 2 == 0) {
@@ -371,7 +371,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, UpstreamConnectionCloseWithManyStream
         codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                    {":path", "/test/long/url"},
                                                                    {":scheme", "http"},
-                                                                   {":authority", "host"}});
+                                                                   {":authority", "sni.lyft.com"}});
     encoders.push_back(&encoder_decoder.first);
     responses.push_back(std::move(encoder_decoder.second));
 
@@ -457,7 +457,7 @@ typed_config:
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"te", "trailers"}});
   auto downstream_request = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
@@ -566,7 +566,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, NoInitialStreams) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"},
                                      {"x-envoy-upstream-rq-per-try-timeout-ms", "100"},
@@ -605,7 +605,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, MultipleRequestsLowStreamLimit) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {AutonomousStream::NO_END_STREAM, "true"}});
   // Wait until the response is sent to ensure the SETTINGS frame has been read
   // by Envoy.
@@ -679,7 +679,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, EarlyDataRejected) {
   Http::TestRequestHeaderMapImpl request{{":method", "GET"},
                                          {":path", "/test/long/url"},
                                          {":scheme", "http"},
-                                         {":authority", "host"},
+                                         {":authority", "sni.lyft.com"},
                                          {"Early-Data", "1"}};
   auto response2 = codec_client_->makeHeaderOnlyRequest(request);
   waitForNextUpstreamRequest(0);

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -83,14 +83,14 @@ TEST_P(DownstreamProtocolIntegrationTest, RouterNotFoundBodyNoBuffer) {
 TEST_P(DownstreamProtocolIntegrationTest, RouterClusterNotFound404) {
   config_helper_.addConfigModifier(&setDoNotValidateRouteConfig);
   config_helper_.addConfigModifier(configureProxyStatus());
-  auto host = config_helper_.createVirtualHost("foo.com", "/unknown", "unknown_cluster");
+  auto host = config_helper_.createVirtualHost("foo.lyft.com", "/unknown", "unknown_cluster");
   host.mutable_routes(0)->mutable_route()->set_cluster_not_found_response_code(
       envoy::config::route::v3::RouteAction::NOT_FOUND);
   config_helper_.addVirtualHost(host);
   initialize();
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/unknown", "", downstream_protocol_, version_, "foo.com");
+      lookupPort("http"), "GET", "/unknown", "", downstream_protocol_, version_, "foo.lyft.com");
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("404", response->headers().getStatusValue());
   EXPECT_EQ(response->headers().getProxyStatusValue(),
@@ -99,7 +99,7 @@ TEST_P(DownstreamProtocolIntegrationTest, RouterClusterNotFound404) {
 
 TEST_P(DownstreamProtocolIntegrationTest, TestHostWhitespacee) {
   config_helper_.addConfigModifier(&setDoNotValidateRouteConfig);
-  auto host = config_helper_.createVirtualHost("foo.com", "/unknown", "unknown_cluster");
+  auto host = config_helper_.createVirtualHost("foo.lyft.com", "/unknown", "unknown_cluster");
   host.mutable_routes(0)->mutable_route()->set_cluster_not_found_response_code(
       envoy::config::route::v3::RouteAction::NOT_FOUND);
   config_helper_.addVirtualHost(host);
@@ -107,7 +107,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TestHostWhitespacee) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
-      {":method", "GET"}, {":authority", " foo.com "}, {":path", "/unknown"}});
+      {":method", "GET"}, {":authority", " foo.lyft.com "}, {":path", "/unknown"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -126,14 +126,14 @@ TEST_P(DownstreamProtocolIntegrationTest, TestHostWhitespacee) {
 // Add a route that uses unknown cluster (expect 503 Service Unavailable).
 TEST_P(DownstreamProtocolIntegrationTest, RouterClusterNotFound503) {
   config_helper_.addConfigModifier(&setDoNotValidateRouteConfig);
-  auto host = config_helper_.createVirtualHost("foo.com", "/unknown", "unknown_cluster");
+  auto host = config_helper_.createVirtualHost("foo.lyft.com", "/unknown", "unknown_cluster");
   host.mutable_routes(0)->mutable_route()->set_cluster_not_found_response_code(
       envoy::config::route::v3::RouteAction::SERVICE_UNAVAILABLE);
   config_helper_.addVirtualHost(host);
   initialize();
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/unknown", "", downstream_protocol_, version_, "foo.com");
+      lookupPort("http"), "GET", "/unknown", "", downstream_protocol_, version_, "foo.lyft.com");
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().getStatusValue());
 }
@@ -355,7 +355,7 @@ TEST_P(ProtocolIntegrationTest, ResponseWithHostHeader) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"}});
+                                     {":authority", "sni.lyft.com"}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(
       Http::TestResponseHeaderMapImpl{{":status", "200"}, {"host", "host"}}, true);
@@ -375,7 +375,7 @@ TEST_P(ProtocolIntegrationTest, Upstream304ResponseWithContentLength) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"if-none-match", "\"1234567890\""}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "304"},
@@ -396,7 +396,7 @@ TEST_P(ProtocolIntegrationTest, Upstream304ResponseWithContentLength) {
       Http::TestRequestHeaderMapImpl{{":method", "HEAD"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"if-none-match", "\"1234567890\""}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "304"},
@@ -421,7 +421,7 @@ TEST_P(ProtocolIntegrationTest, 304ResponseWithoutContentLength) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"if-none-match", "\"1234567890\""}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(
@@ -443,7 +443,7 @@ TEST_P(ProtocolIntegrationTest, 304HeadResponseWithoutContentLength) {
       Http::TestRequestHeaderMapImpl{{":method", "HEAD"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"if-none-match", "\"1234567890\""}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(
@@ -463,7 +463,7 @@ TEST_P(ProtocolIntegrationTest, 200HeadResponseWithContentLength) {
       Http::TestRequestHeaderMapImpl{{":method", "HEAD"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"if-none-match", "\"1234567890\""}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(
@@ -495,7 +495,7 @@ TEST_P(DownstreamProtocolIntegrationTest, DownstreamRequestWithFaultyFilter) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"remove-method", "yes"}});
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
@@ -507,7 +507,7 @@ TEST_P(DownstreamProtocolIntegrationTest, DownstreamRequestWithFaultyFilter) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"remove-path", "yes"}});
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
@@ -559,7 +559,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReply) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"remove-method", "yes"},
                                      {"send-reply", "yes"}});
   ASSERT_TRUE(response->waitForEndStream());
@@ -581,13 +581,13 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyDownstreamByte
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"remove-method", "yes"},
                                      {"send-reply", "yes"}});
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(90, 80, 71, 46),
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(90, 88, 71, 54),
                                        BytesCountExpectation(0, 58, 0, 58),
                                        BytesCountExpectation(7, 10, 7, 8));
 }
@@ -605,7 +605,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyUpstreamBytesC
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"remove-method", "yes"},
                                      {"send-reply", "yes"}});
   ASSERT_TRUE(response->waitForEndStream());
@@ -624,14 +624,14 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyWithBody) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Missing method
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                                                        {":path", "/test/long/url"},
-                                                                        {":scheme", "http"},
-                                                                        {":authority", "host"},
-                                                                        {"remove-method", "yes"},
-                                                                        {"send-reply", "yes"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"remove-method", "yes"},
+                                     {"send-reply", "yes"}},
+      1024);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
@@ -647,18 +647,18 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyWithBodyBytesC
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Missing method
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                                                        {":path", "/test/long/url"},
-                                                                        {":scheme", "http"},
-                                                                        {":authority", "host"},
-                                                                        {"remove-method", "yes"},
-                                                                        {"send-reply", "yes"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"remove-method", "yes"},
+                                     {"send-reply", "yes"}},
+      1024);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(109, 1144, 90, 73),
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(109, 1152, 90, 81),
                                        BytesCountExpectation(0, 58, 0, 58),
                                        BytesCountExpectation(7, 10, 7, 8));
 }
@@ -676,7 +676,7 @@ TEST_P(ProtocolIntegrationTest, LongHeaderValueWithSpaces) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"longrequestvalue", long_header_value_with_inner_lws}});
   waitForNextUpstreamRequest();
   EXPECT_EQ(long_header_value_with_inner_lws, upstream_request_->headers()
@@ -714,7 +714,7 @@ TEST_P(ProtocolIntegrationTest, Retry) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024);
@@ -768,8 +768,8 @@ TEST_P(ProtocolIntegrationTest, Retry) {
   // The two requests are sent with https scheme rather than http for QUIC downstream.
   const size_t quic_https_extra_bytes = (downstreamProtocol() == Http::CodecType::HTTP3 ? 2u : 0u);
   expectUpstreamBytesSentAndReceived(
-      BytesCountExpectation(2550 + quic_https_extra_bytes, 635, 414 + quic_https_extra_bytes, 54),
-      BytesCountExpectation(2262, 548, 184, 27), BytesCountExpectation(2204, 520, 150, 6));
+      BytesCountExpectation(2566 + quic_https_extra_bytes, 635, 430 + quic_https_extra_bytes, 54),
+      BytesCountExpectation(2262, 548, 196, 27), BytesCountExpectation(2204, 520, 150, 6));
 }
 
 TEST_P(ProtocolIntegrationTest, RetryStreaming) {
@@ -779,7 +779,7 @@ TEST_P(ProtocolIntegrationTest, RetryStreaming) {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"x-forwarded-for", "10.0.0.1"},
                                                                  {"x-envoy-retry-on", "5xx"}});
   auto& encoder = encoder_decoder.first;
@@ -836,7 +836,7 @@ TEST_P(ProtocolIntegrationTest, RetryStreamingReset) {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"x-forwarded-for", "10.0.0.1"},
                                                                  {"x-envoy-retry-on", "5xx"}});
   auto& encoder = encoder_decoder.first;
@@ -909,7 +909,7 @@ TEST_P(ProtocolIntegrationTest, RetryStreamingCancelDueToBufferOverflow) {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"x-forwarded-for", "10.0.0.1"},
                                                                  {"x-envoy-retry-on", "5xx"}});
   auto& encoder = encoder_decoder.first;
@@ -949,7 +949,7 @@ TEST_P(ProtocolIntegrationTest, RetryStreamingCancelDueToBufferOverflow) {
 // Tests that the x-envoy-attempt-count header is properly set on the upstream request and the
 // downstream response, and updated after the request is retried.
 TEST_P(DownstreamProtocolIntegrationTest, RetryAttemptCountHeader) {
-  auto host = config_helper_.createVirtualHost("host", "/test_retry");
+  auto host = config_helper_.createVirtualHost("sni.lyft.com", "/test_retry");
   host.set_include_request_attempt_count(true);
   host.set_include_attempt_count_in_response(true);
   config_helper_.addVirtualHost(host);
@@ -959,7 +959,7 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryAttemptCountHeader) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test_retry"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024);
@@ -1002,7 +1002,7 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryPriority) {
   Registry::InjectFactory<Upstream::RetryPriorityFactory> inject_factory(factory);
 
   // Add route with custom retry policy
-  auto host = config_helper_.createVirtualHost("host", "/test_retry");
+  auto host = config_helper_.createVirtualHost("sni.lyft.com", "/test_retry");
   host.set_include_request_attempt_count(true);
   auto retry_policy = host.mutable_routes(0)->mutable_route()->mutable_retry_policy();
   retry_policy->mutable_retry_priority()->set_name(factory.name());
@@ -1030,7 +1030,7 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryPriority) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test_retry"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024);
@@ -1073,7 +1073,7 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryHostPredicateFilter) {
   Registry::InjectFactory<Upstream::RetryHostPredicateFactory> inject_factory(predicate_factory);
 
   // Add route with custom retry policy
-  auto host = config_helper_.createVirtualHost("host", "/test_retry");
+  auto host = config_helper_.createVirtualHost("sni.lyft.com", "/test_retry");
   host.set_include_request_attempt_count(true);
   auto retry_policy = host.mutable_routes(0)->mutable_route()->mutable_retry_policy();
   retry_policy->add_retry_host_predicate()->set_name(predicate_factory.name());
@@ -1096,7 +1096,7 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryHostPredicateFilter) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test_retry"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024);
@@ -1138,7 +1138,7 @@ TEST_P(ProtocolIntegrationTest, RetryHittingBufferLimit) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024 * 65);
@@ -1156,7 +1156,7 @@ TEST_P(ProtocolIntegrationTest, RetryHittingBufferLimit) {
 
 // Very similar set-up to RetryHittingBufferLimits but using the route specific cap.
 TEST_P(ProtocolIntegrationTest, RetryHittingRouteLimits) {
-  auto host = config_helper_.createVirtualHost("nobody.com", "/");
+  auto host = config_helper_.createVirtualHost("routelimit.lyft.com", "/");
   host.mutable_per_request_buffer_limit_bytes()->set_value(0);
   config_helper_.addVirtualHost(host);
   initialize();
@@ -1166,7 +1166,7 @@ TEST_P(ProtocolIntegrationTest, RetryHittingRouteLimits) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/"},
                                      {":scheme", "http"},
-                                     {":authority", "nobody.com"},
+                                     {":authority", "routelimit.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1);
@@ -1196,7 +1196,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/dynamo/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024 * 65);
@@ -1371,9 +1371,13 @@ TEST_P(ProtocolIntegrationTest, MaxStreamDurationWithRetryPolicy) {
     ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
                                      protocol_options);
   });
-  Http::TestRequestHeaderMapImpl retriable_header = Http::TestRequestHeaderMapImpl{
-      {":method", "POST"},    {":path", "/test/long/url"},     {":scheme", "http"},
-      {":authority", "host"}, {"x-forwarded-for", "10.0.0.1"}, {"x-envoy-retry-on", "5xx"}};
+  Http::TestRequestHeaderMapImpl retriable_header =
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}};
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1416,9 +1420,13 @@ TEST_P(ProtocolIntegrationTest, MaxStreamDurationWithRetryPolicyWhenRetryUpstrea
     ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
                                      protocol_options);
   });
-  Http::TestRequestHeaderMapImpl retriable_header = Http::TestRequestHeaderMapImpl{
-      {":method", "POST"},    {":path", "/test/long/url"},     {":scheme", "http"},
-      {":authority", "host"}, {"x-forwarded-for", "10.0.0.1"}, {"x-envoy-retry-on", "5xx"}};
+  Http::TestRequestHeaderMapImpl retriable_header =
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}};
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1469,7 +1477,7 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresDropped) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"foo_bar", "baz"}});
   waitForNextUpstreamRequest();
 
@@ -1508,7 +1516,7 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresRemainByDefault) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"foo_bar", "baz"}});
   waitForNextUpstreamRequest();
 
@@ -1536,7 +1544,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"foo_bar", "baz"}});
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
@@ -1560,7 +1568,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "host"},
+                                                 {":authority", "sni.lyft.com"},
                                                  {"content-length", "0"}};
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 
@@ -1704,7 +1712,7 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeCookieParsingConcatenated) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "host"},
+                                                 {":authority", "sni.lyft.com"},
                                                  {"content-length", "0"}};
   std::vector<std::string> cookie_pieces;
   cookie_pieces.reserve(7000);
@@ -1736,7 +1744,7 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeCookieParsingMany) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "host"},
+                                                 {":authority", "sni.lyft.com"},
                                                  {"content-length", "0"}};
   for (int i = 0; i < 2000; i++) {
     request_headers.addCopy("cookie", fmt::sprintf("a%x=b", i));
@@ -1755,7 +1763,7 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidContentLength) {
   auto encoder_decoder =
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"content-length", "-1"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -1793,7 +1801,7 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidContentLengthAllowed) {
   auto encoder_decoder =
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"content-length", "-1"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -1819,7 +1827,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MultipleContentLengths) {
   auto encoder_decoder =
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"content-length", "3,2"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -1852,7 +1860,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MultipleContentLengthsAllowed) {
   auto encoder_decoder =
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"content-length", "3,2"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -1884,7 +1892,7 @@ name: local-reply-during-encode
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"}});
+                                     {":authority", "sni.lyft.com"}});
 
   // Wait for the upstream request and begin sending a response with end_stream = false.
   waitForNextUpstreamRequest();
@@ -2067,7 +2075,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   codec_client_->sendTrailers(*request_encoder_, *request_trailers);
@@ -2102,7 +2110,7 @@ TEST_P(ProtocolIntegrationTest, LargeRequestMethod) {
   const Http::TestRequestHeaderMapImpl request_headers{{":method", long_method},
                                                        {":path", "/test/long/url"},
                                                        {":scheme", "http"},
-                                                       {":authority", "host"}};
+                                                       {":authority", "sni.lyft.com"}};
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -2373,9 +2381,10 @@ TEST_P(ProtocolIntegrationTest, MultipleCookiesAndSetCookies) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},  {":path", "/dynamo/url"},
-                                                 {":scheme", "http"}, {":authority", "host"},
-                                                 {"cookie", "a=b"},   {"cookie", "c=d"}};
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"},  {":path", "/dynamo/url"},
+      {":scheme", "http"}, {":authority", "sni.lyft.com"},
+      {"cookie", "a=b"},   {"cookie", "c=d"}};
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "200"}, {"set-cookie", "foo"}, {"set-cookie", "bar"}};
 
@@ -2416,7 +2425,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TestDelayedConnectionTeardownTimeoutTr
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
                                                                  {":scheme", "http"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -2696,8 +2705,8 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidAuthority) {
 TEST_P(DownstreamProtocolIntegrationTest, ConnectIsBlocked) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder = codec_client_->startRequest(
-      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}, {":authority", "host.com:80"}});
+  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "CONNECT"}, {":authority", "sni.lyft.com.com:80"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -2719,11 +2728,11 @@ TEST_P(DownstreamProtocolIntegrationTest, ExtendedConnectIsBlocked) {
   }
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder =
-      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "CONNECT"},
-                                                                 {":protocol", "bytestream"},
-                                                                 {":path", "/"},
-                                                                 {":authority", "host.com:80"}});
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"},
+                                     {":protocol", "bytestream"},
+                                     {":path", "/"},
+                                     {":authority", "sni.lyft.com.com:80"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -2751,7 +2760,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}, {":authority", "host"}});
+      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}, {":authority", "sni.lyft.com"}});
 
   ASSERT_TRUE(response->waitForReset());
   EXPECT_FALSE(codec_client_->disconnected());
@@ -2819,7 +2828,7 @@ TEST_P(ProtocolIntegrationTest, EnableStripTrailingHostDot) {
         auto* route_config = hcm.mutable_route_config();
         auto* virtual_host = route_config->mutable_virtual_hosts(0);
         virtual_host->clear_domains();
-        virtual_host->add_domains("host");
+        virtual_host->add_domains("sni.lyft.com");
       });
 
   initialize();
@@ -2828,7 +2837,7 @@ TEST_P(ProtocolIntegrationTest, EnableStripTrailingHostDot) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host."}});
+                                     {":authority", "sni.lyft.com."}});
   waitForNextUpstreamRequest();
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
@@ -2848,7 +2857,7 @@ TEST_P(DownstreamProtocolIntegrationTest, DisableStripTrailingHostDot) {
         auto* route_config = hcm.mutable_route_config();
         auto* virtual_host = route_config->mutable_virtual_hosts(0);
         virtual_host->clear_domains();
-        virtual_host->add_domains("host");
+        virtual_host->add_domains("sni.lyft.com");
       });
 
   initialize();
@@ -2857,7 +2866,7 @@ TEST_P(DownstreamProtocolIntegrationTest, DisableStripTrailingHostDot) {
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host."}});
+                                     {":authority", "sni.lyft.com."}});
   // Expect local reply as request host fails to match configured domains.
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
@@ -2914,7 +2923,7 @@ TEST_P(ProtocolIntegrationTest, ReqRespSizeStats) {
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"}, {":path", "/found"}, {":scheme", "http"}, {":authority", "foo.com"}};
+      {":method", "GET"}, {":path", "/found"}, {":scheme", "http"}, {":authority", "foo.lyft.com"}};
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 0, 0,
                                                 TestUtility::DefaultTimeout);
@@ -3072,7 +3081,7 @@ TEST_P(DownstreamProtocolIntegrationTest, OverflowDecoderBufferFromDecodeData) {
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":scheme", "http"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   auto request_encoder = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -3114,7 +3123,7 @@ TEST_P(DownstreamProtocolIntegrationTest, OverflowDecoderBufferFromDecodeDataCon
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":scheme", "http"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   auto request_encoder = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -3150,7 +3159,7 @@ TEST_P(DownstreamProtocolIntegrationTest,
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":scheme", "http"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   auto request_encoder = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -3198,7 +3207,7 @@ TEST_P(DownstreamProtocolIntegrationTest, OverflowDecoderBufferFromDecodeTrailer
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":scheme", "http"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"}});
+                                                                 {":authority", "sni.lyft.com"}});
   auto request_encoder = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -3235,7 +3244,7 @@ TEST_P(ProtocolIntegrationTest, ResetLargeResponseUponReceivingHeaders) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"content-length", "10"},
                                      {"response_size_bytes", absl::StrCat(response_size)}});
   auto& encoder = encoder_decoder.first;
@@ -3256,9 +3265,9 @@ TEST_P(ProtocolIntegrationTest, HeaderOnlyBytesCountUpstream) {
   useAccessLog("%UPSTREAM_WIRE_BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% "
                "%UPSTREAM_HEADER_BYTES_SENT% %UPSTREAM_HEADER_BYTES_RECEIVED%");
   testRouterRequestAndResponseWithBody(0, 0, false);
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(251, 38, 219, 18),
-                                     BytesCountExpectation(168, 13, 168, 13),
-                                     BytesCountExpectation(153, 5, 155, 3));
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(167, 38, 136, 18),
+                                     BytesCountExpectation(120, 13, 120, 13),
+                                     BytesCountExpectation(116, 5, 116, 3));
 }
 
 TEST_P(ProtocolIntegrationTest, HeaderOnlyBytesCountDownstream) {
@@ -3268,9 +3277,9 @@ TEST_P(ProtocolIntegrationTest, HeaderOnlyBytesCountDownstream) {
   useAccessLog("%DOWNSTREAM_WIRE_BYTES_SENT% %DOWNSTREAM_WIRE_BYTES_RECEIVED% "
                "%DOWNSTREAM_HEADER_BYTES_SENT% %DOWNSTREAM_HEADER_BYTES_RECEIVED%");
   testRouterRequestAndResponseWithBody(0, 0, false);
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(124, 111, 105, 75),
-                                       BytesCountExpectation(68, 64, 68, 64),
-                                       BytesCountExpectation(8, 10, 8, 8));
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(124, 51, 105, 19),
+                                       BytesCountExpectation(68, 34, 68, 34),
+                                       BytesCountExpectation(8, 10, 8, 6));
 }
 
 TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountUpstream) {
@@ -3281,9 +3290,9 @@ TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountUpstream) {
   useAccessLog("%UPSTREAM_WIRE_BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% "
                "%UPSTREAM_HEADER_BYTES_SENT% %UPSTREAM_HEADER_BYTES_RECEIVED%");
   testRouterRequestAndResponseWithBody(100, 100, false);
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(371, 158, 228, 27),
-                                     BytesCountExpectation(277, 122, 168, 13),
-                                     BytesCountExpectation(256, 109, 153, 3));
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(306, 158, 164, 27),
+                                     BytesCountExpectation(229, 122, 120, 13),
+                                     BytesCountExpectation(219, 109, 116, 3));
 }
 
 TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountDownstream) {
@@ -3294,9 +3303,9 @@ TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountDownstream) {
   useAccessLog("%DOWNSTREAM_WIRE_BYTES_SENT% %DOWNSTREAM_WIRE_BYTES_RECEIVED% "
                "%DOWNSTREAM_HEADER_BYTES_SENT% %DOWNSTREAM_HEADER_BYTES_RECEIVED%");
   testRouterRequestAndResponseWithBody(100, 100, false);
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(244, 231, 114, 84),
-                                       BytesCountExpectation(177, 173, 68, 64),
-                                       BytesCountExpectation(111, 113, 8, 8));
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(244, 190, 114, 46),
+                                       BytesCountExpectation(177, 173, 68, 34),
+                                       BytesCountExpectation(111, 113, 8, 6));
 }
 
 TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountReuseDownstream) {
@@ -3317,15 +3326,15 @@ TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountReuseDownstream) {
   auto response_one = sendRequestAndWaitForResponse(default_request_headers_, request_size,
                                                     default_response_headers_, response_size, 0);
   checkSimpleRequestSuccess(request_size, response_size, response_one.get());
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(244, 182, 114, 38),
-                                       BytesCountExpectation(177, 137, 68, 28),
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(244, 190, 114, 46),
+                                       BytesCountExpectation(177, 137, 68, 34),
                                        BytesCountExpectation(111, 137, 8, 6), 0);
 
   // Reuse connection, send the second request on the connection.
   auto response_two = sendRequestAndWaitForResponse(default_request_headers_, request_size,
                                                     default_response_headers_, response_size, 0);
   checkSimpleRequestSuccess(request_size, response_size, response_two.get());
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(244, 182, 114, 38),
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(244, 190, 114, 46),
                                        BytesCountExpectation(148, 137, 15, 27),
                                        BytesCountExpectation(111, 137, 8, 6), 1);
 }
@@ -3348,15 +3357,15 @@ TEST_P(ProtocolIntegrationTest, HeaderAndBodyWireBytesCountReuseUpstream) {
   // Send to the same upstream from the two clients.
   auto response_one = sendRequestAndWaitForResponse(default_request_headers_, request_size,
                                                     default_response_headers_, response_size, 0);
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(298, 158, 156, 27),
-                                     BytesCountExpectation(223, 122, 114, 13),
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(306, 158, 164, 27),
+                                     BytesCountExpectation(223, 122, 120, 13),
                                      BytesCountExpectation(223, 108, 114, 3), 0);
 
   // Swap clients so the other connection is used to send the request.
   std::swap(codec_client_, second_client);
   auto response_two = sendRequestAndWaitForResponse(default_request_headers_, request_size,
                                                     default_response_headers_, response_size, 0);
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(298, 158, 156, 27),
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(306, 158, 164, 27),
                                      BytesCountExpectation(167, 119, 58, 10),
                                      BytesCountExpectation(114, 108, 11, 3), 1);
   second_client->close();
@@ -3374,7 +3383,7 @@ TEST_P(ProtocolIntegrationTest, TrailersWireBytesCountUpstream) {
 
   testTrailers(10, 20, true, true);
 
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(248, 120, 196, 67),
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(256, 120, 204, 67),
                                      BytesCountExpectation(172, 81, 154, 52),
                                      BytesCountExpectation(154, 33, 142, 7));
 }
@@ -3391,7 +3400,7 @@ TEST_P(ProtocolIntegrationTest, TrailersWireBytesCountDownstream) {
 
   testTrailers(10, 20, true, true);
 
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(206, 132, 156, 76),
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(206, 140, 156, 84),
                                        BytesCountExpectation(136, 86, 107, 67),
                                        BytesCountExpectation(36, 26, 14, 10));
 }
@@ -3406,9 +3415,9 @@ TEST_P(ProtocolIntegrationTest, DownstreamDisconnectBeforeRequestCompleteWireByt
 
   testRouterDownstreamDisconnectBeforeRequestComplete(nullptr);
 
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(187, 0, 156, 0),
-                                     BytesCountExpectation(114, 0, 114, 0),
-                                     BytesCountExpectation(114, 0, 114, 0));
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(195, 0, 164, 0),
+                                     BytesCountExpectation(120, 0, 120, 0),
+                                     BytesCountExpectation(120, 0, 120, 0));
 }
 
 TEST_P(ProtocolIntegrationTest, DownstreamDisconnectBeforeRequestCompleteWireBytesCountDownstream) {
@@ -3421,8 +3430,8 @@ TEST_P(ProtocolIntegrationTest, DownstreamDisconnectBeforeRequestCompleteWireByt
 
   testRouterDownstreamDisconnectBeforeRequestComplete(nullptr);
 
-  expectDownstreamBytesSentAndReceived(BytesCountExpectation(0, 71, 0, 38),
-                                       BytesCountExpectation(0, 28, 0, 28),
+  expectDownstreamBytesSentAndReceived(BytesCountExpectation(0, 79, 0, 46),
+                                       BytesCountExpectation(0, 34, 0, 34),
                                        BytesCountExpectation(0, 8, 0, 6));
 }
 
@@ -3436,9 +3445,9 @@ TEST_P(ProtocolIntegrationTest, UpstreamDisconnectBeforeRequestCompleteWireBytes
 
   testRouterUpstreamDisconnectBeforeRequestComplete();
 
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(187, 0, 156, 0),
-                                     BytesCountExpectation(114, 0, 114, 0),
-                                     BytesCountExpectation(114, 0, 114, 0));
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(195, 0, 164, 0),
+                                     BytesCountExpectation(120, 0, 120, 0),
+                                     BytesCountExpectation(120, 0, 120, 0));
 }
 
 TEST_P(ProtocolIntegrationTest, UpstreamDisconnectBeforeResponseCompleteWireBytesCountUpstream) {
@@ -3451,8 +3460,8 @@ TEST_P(ProtocolIntegrationTest, UpstreamDisconnectBeforeResponseCompleteWireByte
 
   testRouterUpstreamDisconnectBeforeResponseComplete();
 
-  expectUpstreamBytesSentAndReceived(BytesCountExpectation(159, 47, 128, 27),
-                                     BytesCountExpectation(113, 13, 113, 13),
+  expectUpstreamBytesSentAndReceived(BytesCountExpectation(167, 47, 136, 27),
+                                     BytesCountExpectation(120, 13, 120, 13),
                                      BytesCountExpectation(113, 5, 113, 3));
 }
 
@@ -3481,11 +3490,9 @@ TEST_P(DownstreamProtocolIntegrationTest, PathWithFragmentRejectedByDefault) {
   initialize();
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                 {":path", "/some/path#fragment"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "foo.com"}};
-  IntegrationStreamDecoderPtr response = codec_client_->makeRequestWithBody(request_headers, 10);
+  default_request_headers_.setPath("/some/path#fragment");
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeRequestWithBody(default_request_headers_, 10);
   ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());
@@ -3497,11 +3504,8 @@ TEST_P(ProtocolIntegrationTest, FragmentStrippedFromPathWithOverride) {
   initialize();
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                 {":path", "/some/path?p1=v1#fragment"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "foo.com"}};
-  Http::TestRequestHeaderMapImpl expected_request_headers{request_headers};
+  default_request_headers_.setPath("/some/path?p1=v1#fragment");
+  Http::TestRequestHeaderMapImpl expected_request_headers{default_request_headers_};
   expected_request_headers.setPath("/some/path?p1=v1");
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   auto response = sendRequestAndWaitForResponse(expected_request_headers, 0, response_headers, 0, 0,
@@ -3566,13 +3570,13 @@ TEST_P(ProtocolIntegrationTest, BufferContinue) {
 TEST_P(DownstreamProtocolIntegrationTest, ContentLengthSmallerThanPayload) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                                                        {":path", "/test/long/url"},
-                                                                        {":scheme", "http"},
-                                                                        {":authority", "host"},
-                                                                        {"content-length", "123"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"content-length", "123"}},
+      1024);
   if (downstreamProtocol() == Http::CodecType::HTTP1) {
     waitForNextUpstreamRequest();
     // HTTP/1.x requests get the payload length from Content-Length header. The remaining bytes is
@@ -3599,13 +3603,13 @@ TEST_P(DownstreamProtocolIntegrationTest, ContentLengthLargerThanPayload) {
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                                                        {":path", "/test/long/url"},
-                                                                        {":scheme", "http"},
-                                                                        {":authority", "host"},
-                                                                        {"content-length", "1025"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"content-length", "1025"}},
+      1024);
 
   // Inconsistency in content-length header and the actually body length should be treated as a
   // stream error.
@@ -3764,7 +3768,7 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidReqestHeaderName) {
   auto encoder_decoder =
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},
-                                                                 {":authority", "host"},
+                                                                 {":authority", "sni.lyft.com"},
                                                                  {"foo\nname", "foo_value"}});
   auto response = std::move(encoder_decoder.second);
 

--- a/test/integration/vhds.h
+++ b/test/integration/vhds.h
@@ -160,7 +160,7 @@ public:
 
   envoy::config::route::v3::VirtualHost buildVirtualHost() {
     return TestUtility::parseYaml<envoy::config::route::v3::VirtualHost>(
-        virtualHostYaml("my_route/vhost_0", "host"));
+        virtualHostYaml("my_route/vhost_0", "sni.lyft.com"));
   }
 
   std::vector<envoy::config::route::v3::VirtualHost> buildVirtualHost1() {

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -139,7 +139,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, VhdsIntegrationTest,
                          UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS);
 
 TEST_P(VhdsIntegrationTest, RdsUpdateWithoutVHDSChangesDoesNotRestartVHDS) {
-  testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/", "host");
+  testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/", "sni.lyft.com");
   cleanupUpstreamAndDownstream();
   ASSERT_TRUE(codec_client_->waitForDisconnect());
 
@@ -150,7 +150,7 @@ TEST_P(VhdsIntegrationTest, RdsUpdateWithoutVHDSChangesDoesNotRestartVHDS) {
       "2");
 
   // Confirm vhost_0 that was originally configured via VHDS is reachable
-  testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/", "host");
+  testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/", "sni.lyft.com");
   cleanupUpstreamAndDownstream();
   ASSERT_TRUE(codec_client_->waitForDisconnect());
 }

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -62,6 +62,7 @@ public:
   MOCK_METHOD(std::string, ciphersuiteString, (), (const));
   MOCK_METHOD(const std::string&, tlsVersion, (), (const));
   MOCK_METHOD(const std::string&, alpn, (), (const));
+  MOCK_METHOD(const std::string&, sni, (), (const));
 };
 
 class MockClientContext : public ClientContext {


### PR DESCRIPTION
Upcoming https://github.com/envoyproxy/envoy/pull/20436 fixes QUIC to use auto_sni when it's configured.
The Envoy integration tests use auto_sni by default, but this causes problems for HTTP/3 which validates that the sni hostname (currently "host" for most test) matches the certificate (*.lyft.com for most tests).

Changing the tests independently of the fix PR per request.