### PR TITLE
[test case fix]: fix resource competition in access_log_manager_impl_test.

### DIFF
--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -442,9 +442,7 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
     }
   }
   waitForCounterEq("filesystem.reopen_failed", 1);
-  EXPECT_EQ(0UL,
-            store_.gauge("filesystem.write_total_buffered", Stats::Gauge::ImportMode::Accumulate)
-                .value());
+  waitForGaugeEq("filesystem.write_total_buffered",0);
 }
 
 TEST_F(AccessLogManagerImplTest, BigDataChunkShouldBeFlushedWithoutTimer) {

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -442,7 +442,7 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
     }
   }
   waitForCounterEq("filesystem.reopen_failed", 1);
-  waitForGaugeEq("filesystem.write_total_buffered",0);
+  waitForGaugeEq("filesystem.write_total_buffered", 0);
 }
 
 TEST_F(AccessLogManagerImplTest, BigDataChunkShouldBeFlushedWithoutTimer) {


### PR DESCRIPTION
Signed-off-by: Guang Yang <pyrl247@gmail.com>

Fixes https://github.com/envoyproxy/envoy/issues/20084

Commit Message:
Fix resource Competition in access_log_manager_impl_test.
"filesystem.write_total_buffered" sub in another thread after file_lock_ unlock, so we need to wait it.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
