### PR TITLE
skywalking: use header's path for entry/exit span's operation name

### DIFF
--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -45,9 +45,8 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
 }
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
-                                   Tracing::TraceContext& trace_context,
-                                   const std::string& operation_name, Envoy::SystemTime start_time,
-                                   const Tracing::Decision decision) {
+                                   Tracing::TraceContext& trace_context, const std::string&,
+                                   Envoy::SystemTime start_time, const Tracing::Decision decision) {
   auto& tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer();
   TracingContextPtr tracing_context;
   // TODO(shikugawa): support extension span header.
@@ -71,7 +70,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
     }
   }
 
-  return tracer.startSpan(config, start_time, operation_name, tracing_context, nullptr);
+  return tracer.startSpan(config, start_time, trace_context.path(), tracing_context, nullptr);
 }
 
 void Driver::loadConfig(const envoy::config::trace::v3::ClientConfig& client_config,

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -54,6 +54,8 @@ void Span::injectContext(Tracing::TraceContext& trace_context) {
   if (sw8_header.has_value()) {
     trace_context.setByReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
   }
+
+  // span_entity_->setOperationName(trace_context.path());
 }
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& name, SystemTime) {


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: skywalking: use header's path for entry/exit span's operation name
Additional Description: In Apache SkyWalking, we have a usecase to use pathname in downstream header as child span's name. This feature adds a option to achieve this requirement.
Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: Required
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

cc @wu-sheng
