### PR TITLE
Increase crash integration test sharding as it takes a long time under

### DIFF
--- a/test/extensions/filters/http/kill_request/BUILD
+++ b/test/extensions/filters/http/kill_request/BUILD
@@ -55,7 +55,7 @@ envoy_cc_test(
     name = "crash_integration_test",
     size = "large",
     srcs = ["crash_integration_test.cc"],
-    shard_count = 2,
+    shard_count = 16,  # This is really slow on coverage.
     deps = [
         "//source/extensions/filters/http/kill_request:kill_request_config",
         "//test/integration:http_protocol_integration_lib",


### PR DESCRIPTION
coverage.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Increase crash integration test sharding as it takes a long time under coverage.
Additional Description: Ironically, I think automatic deflaking kept this one hidden from us as it'd occasionally pass from those retired attempts.
Risk Level: low
Testing: ran
Docs Changes: NA
Release Notes: NA
Platform Specific Features:
[Optional Runtime guard:]
Fixes #20444
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
