### PR TITLE
skywalking: inject peer IP address into span's peer field

### DIFF
--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -99,7 +99,7 @@ public:
    * stream.
    * @param stream_info stream info
    */
-  virtual void setStreamInfoIntoSpan(const StreamInfo::StreamInfo& stream_info) PURE;
+  virtual void setStreamInfo(const StreamInfo::StreamInfo& stream_info) PURE;
 };
 
 /**

--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -93,6 +93,13 @@ public:
    * @return trace ID as a hex string
    */
   virtual std::string getTraceIdAsHex() const PURE;
+
+  /**
+   * To set some fields in Span exclude tags, which needs additional info related with current
+   * stream.
+   * @param stream_info stream info
+   */
+  virtual void setStreamInfoIntoSpan(const StreamInfo::StreamInfo& stream_info) PURE;
 };
 
 /**

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -218,7 +218,7 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span,
   span.setTag(Tracing::Tags::get().ResponseSize, std::to_string(stream_info.bytesSent()));
 
   setCommonTags(span, response_headers, response_trailers, stream_info, tracing_config);
-  span.setStreamInfoIntoSpan(stream_info);
+  span.setStreamInfo(stream_info);
 
   span.finishSpan();
 }

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -218,6 +218,7 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span,
   span.setTag(Tracing::Tags::get().ResponseSize, std::to_string(stream_info.bytesSent()));
 
   setCommonTags(span, response_headers, response_trailers, stream_info, tracing_config);
+  span.setStreamInfoIntoSpan(stream_info);
 
   span.finishSpan();
 }

--- a/source/common/tracing/null_span_impl.h
+++ b/source/common/tracing/null_span_impl.h
@@ -26,6 +26,8 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override {}
+
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }

--- a/source/common/tracing/null_span_impl.h
+++ b/source/common/tracing/null_span_impl.h
@@ -26,7 +26,7 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
-  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override {}
+  void setStreamInfo(const StreamInfo::StreamInfo&) override {}
 
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -46,7 +46,7 @@ public:
 
   // TODO: This method is unimplemented for OpenTracing.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
-  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
+  void setStreamInfo(const StreamInfo::StreamInfo&) override{};
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -46,6 +46,7 @@ public:
 
   // TODO: This method is unimplemented for OpenTracing.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -79,7 +79,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; };
 
   std::string getTraceIdAsHex() const override;
-  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
+  void setStreamInfo(const StreamInfo::StreamInfo&) override{};
 
 private:
   ::opencensus::trace::Span span_;

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -79,6 +79,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; };
 
   std::string getTraceIdAsHex() const override;
+  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
 
 private:
   ::opencensus::trace::Span span_;

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -39,6 +39,12 @@ void Span::setSampled(bool do_sample) {
 
 void Span::log(SystemTime, const std::string& event) { span_entity_->addLog(EMPTY_STRING, event); }
 
+void Span::setStreamInfoIntoSpan(const StreamInfo::StreamInfo& stream_info) {
+  if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
+    span_entity_->setPeer(stream_info.upstreamInfo()->upstreamHost()->address()->asString());
+  }
+}
+
 void Span::finishSpan() {
   span_entity_->endSpan();
   parent_tracer_.sendSegment(tracing_context_);

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -39,7 +39,7 @@ void Span::setSampled(bool do_sample) {
 
 void Span::log(SystemTime, const std::string& event) { span_entity_->addLog(EMPTY_STRING, event); }
 
-void Span::setStreamInfoIntoSpan(const StreamInfo::StreamInfo& stream_info) {
+void Span::setStreamInfo(const StreamInfo::StreamInfo& stream_info) {
   if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
     span_entity_->setPeer(stream_info.upstreamInfo()->upstreamHost()->address()->asString());
   }

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -73,7 +73,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
-  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo& stream_info) override;
+  void setStreamInfo(const StreamInfo::StreamInfo& stream_info) override;
 
   const TracingContextPtr tracingContext() { return tracing_context_; }
   const TracingSpanPtr spanEntity() { return span_entity_; }

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -73,6 +73,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo& stream_info) override;
 
   const TracingContextPtr tracingContext() { return tracing_context_; }
   const TracingSpanPtr spanEntity() { return span_entity_; }

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -207,7 +207,7 @@ public:
   // TODO: This method is unimplemented for X-Ray.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
-  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
+  void setStreamInfo(const StreamInfo::StreamInfo&) override{};
 
   /**
    * Creates a child span.

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -207,6 +207,8 @@ public:
   // TODO: This method is unimplemented for X-Ray.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
+  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
+
   /**
    * Creates a child span.
    * In X-Ray terms this creates a sub-segment and sets its parent ID to the current span's ID.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -85,6 +85,8 @@ public:
   // TODO: This method is unimplemented for Zipkin.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
+  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
+
   /**
    * @return a reference to the Zipkin::Span object.
    */

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -85,7 +85,7 @@ public:
   // TODO: This method is unimplemented for Zipkin.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
-  void setStreamInfoIntoSpan(const StreamInfo::StreamInfo&) override{};
+  void setStreamInfo(const StreamInfo::StreamInfo&) override{};
 
   /**
    * @return a reference to the Zipkin::Span object.

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -154,6 +154,7 @@ TEST_F(HttpConnManFinalizerImplTest, OriginalAndLongPath) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("GET")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -185,6 +186,7 @@ TEST_F(HttpConnManFinalizerImplTest, NoGeneratedId) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("GET")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -215,6 +217,7 @@ TEST_F(HttpConnManFinalizerImplTest, Connect) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("CONNECT")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -258,6 +261,7 @@ metadata:
   kind: { host: {} }
   metadata_key: { key: m.host, path: [ {key: not-found } ] })EOF",
                         false, ""}});
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
@@ -299,6 +303,8 @@ TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
   EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastDownstreamTxByteSent));
 
   EXPECT_CALL(config, verbose).WillOnce(Return(true));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
 
@@ -320,6 +326,7 @@ TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseSize), Eq("11")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
@@ -361,6 +368,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -380,6 +388,7 @@ TEST_F(HttpConnManFinalizerImplTest, UnixDomainSocketPeerAddressTag) {
   EXPECT_CALL(span, setTag(_, _)).Times(AnyNumber());
   EXPECT_CALL(span,
               setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(remote_address->logicalName())));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -498,6 +507,7 @@ metadata:
   kind: { host: {} }
   metadata_key: { key: m.host, path: [ { key: not-found } ] })EOF",
         false, ""}});
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, nullptr, nullptr, stream_info,
                                             config);
@@ -551,6 +561,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -600,6 +611,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -657,6 +669,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("permission denied")));
   }
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -713,6 +726,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("permission denied")));
   }
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
+  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -154,7 +154,7 @@ TEST_F(HttpConnManFinalizerImplTest, OriginalAndLongPath) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("GET")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -186,7 +186,7 @@ TEST_F(HttpConnManFinalizerImplTest, NoGeneratedId) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("GET")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -217,7 +217,7 @@ TEST_F(HttpConnManFinalizerImplTest, Connect) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("CONNECT")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -261,7 +261,7 @@ metadata:
   kind: { host: {} }
   metadata_key: { key: m.host, path: [ {key: not-found } ] })EOF",
                         false, ""}});
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
@@ -303,7 +303,7 @@ TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
   EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastDownstreamTxByteSent));
 
   EXPECT_CALL(config, verbose).WillOnce(Return(true));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
@@ -326,7 +326,7 @@ TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseSize), Eq("11")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
@@ -368,7 +368,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -388,7 +388,7 @@ TEST_F(HttpConnManFinalizerImplTest, UnixDomainSocketPeerAddressTag) {
   EXPECT_CALL(span, setTag(_, _)).Times(AnyNumber());
   EXPECT_CALL(span,
               setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(remote_address->logicalName())));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -507,7 +507,7 @@ metadata:
   kind: { host: {} }
   metadata_key: { key: m.host, path: [ { key: not-found } ] })EOF",
         false, ""}});
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, nullptr, nullptr, stream_info,
                                             config);
@@ -561,7 +561,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -611,7 +611,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -669,7 +669,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("permission denied")));
   }
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -726,7 +726,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcMessage), Eq("permission denied")));
   }
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
-  EXPECT_CALL(span, setStreamInfoIntoSpan(_));
+  EXPECT_CALL(span, setStreamInfo(_));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -758,6 +758,7 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
       null_tracer.startSpan(config, request_headers, stream_info, {Reason::Sampling, true});
   EXPECT_TRUE(dynamic_cast<NullSpan*>(span_ptr.get()) != nullptr);
 
+  span_ptr->setStreamInfo(stream_info); // nothing to do
   span_ptr->setOperation("foo");
   span_ptr->setTag("foo", "bar");
   span_ptr->setBaggage("key", "value");

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -121,8 +121,8 @@ TEST(OpenCensusTracerTest, Span) {
     // injectContext is tested in another unit test.
     Tracing::SpanPtr child = span->spawnChild(config, "child_span", start_time);
     child->finishSpan();
-    span->setSampled(false);                  // Abandon tracer.
-    span->setStreamInfoIntoSpan(stream_info); // Nothing to do
+    span->setSampled(false);          // Abandon tracer.
+    span->setStreamInfo(stream_info); // Nothing to do
     span->finishSpan();
 
     // Baggage methods are a noop in opencensus and won't affect events.

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -110,6 +110,7 @@ TEST(OpenCensusTracerTest, Span) {
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
   const std::string operation_name{"my_operation_1"};
   SystemTime start_time;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   {
     Tracing::SpanPtr span = driver->startSpan(config, request_headers, operation_name, start_time,
@@ -120,7 +121,8 @@ TEST(OpenCensusTracerTest, Span) {
     // injectContext is tested in another unit test.
     Tracing::SpanPtr child = span->spawnChild(config, "child_span", start_time);
     child->finishSpan();
-    span->setSampled(false); // Abandon tracer.
+    span->setSampled(false);                  // Abandon tracer.
+    span->setStreamInfoIntoSpan(stream_info); // Nothing to do
     span->finishSpan();
 
     // Baggage methods are a noop in opencensus and won't affect events.

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -67,6 +67,7 @@ protected:
   SkyWalkingTracerStats tracing_stats_{
       SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))};
   TracerPtr tracer_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 };
 
 // Test that the basic functionality of Tracer is working, including creating Span, using Span to
@@ -145,8 +146,10 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
 
     EXPECT_EQ("TestChild", first_child_span->spanEntity()->operationName());
 
+    first_child_span->setStreamInfoIntoSpan(stream_info_);
     first_child_span->finishSpan();
     EXPECT_NE(0, first_child_span->spanEntity()->endTime());
+    EXPECT_EQ("10.0.0.1:443", first_child_span->spanEntity()->peer());
 
     Http::TestRequestHeaderMapImpl first_child_headers{{":authority", "test.com"}};
 

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -146,7 +146,7 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
 
     EXPECT_EQ("TestChild", first_child_span->spanEntity()->operationName());
 
-    first_child_span->setStreamInfoIntoSpan(stream_info_);
+    first_child_span->setStreamInfo(stream_info_);
     first_child_span->finishSpan();
     EXPECT_NE(0, first_child_span->spanEntity()->endTime());
     EXPECT_EQ("10.0.0.1:443", first_child_span->spanEntity()->peer());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -640,7 +640,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
 
   ZipkinSpanPtr zipkin_span(dynamic_cast<ZipkinSpan*>(span.release()));
   zipkin_span->setTag("key", "value");
-  zipkin_span->setStreamInfoIntoSpan(stream_info_); // Nothing to do
+  zipkin_span->setStreamInfo(stream_info_); // Nothing to do
 
   Span& zipkin_zipkin_span = zipkin_span->span();
   EXPECT_EQ(1ULL, zipkin_zipkin_span.binaryAnnotations().size());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -640,6 +640,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
 
   ZipkinSpanPtr zipkin_span(dynamic_cast<ZipkinSpan*>(span.release()));
   zipkin_span->setTag("key", "value");
+  zipkin_span->setStreamInfoIntoSpan(stream_info_); // Nothing to do
 
   Span& zipkin_zipkin_span = zipkin_span->span();
   EXPECT_EQ(1ULL, zipkin_zipkin_span.binaryAnnotations().size());

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -41,7 +41,7 @@ public:
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
   MOCK_METHOD(std::string, getTraceIdAsHex, (), (const));
-
+  MOCK_METHOD(void, setStreamInfoIntoSpan, (const StreamInfo::StreamInfo& stream_info));
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {
     return SpanPtr{spawnChild_(config, name, start_time)};

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -41,7 +41,7 @@ public:
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
   MOCK_METHOD(std::string, getTraceIdAsHex, (), (const));
-  MOCK_METHOD(void, setStreamInfoIntoSpan, (const StreamInfo::StreamInfo& stream_info));
+  MOCK_METHOD(void, setStreamInfo, (const StreamInfo::StreamInfo& stream_info));
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {
     return SpanPtr{spawnChild_(config, name, start_time)};


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: skywalking: inject peer IP address into span's peer field
Additional Description:
Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
