### PR TITLE
router: fix default mirror when runtime key not specified

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -342,12 +342,16 @@ CorsPolicyImpl::CorsPolicyImpl(const envoy::config::route::v3::CorsPolicy& confi
 }
 
 ShadowPolicyImpl::ShadowPolicyImpl(const RequestMirrorPolicy& config) {
-
   cluster_ = config.cluster();
 
   if (config.has_runtime_fraction()) {
     runtime_key_ = config.runtime_fraction().runtime_key();
     default_value_ = config.runtime_fraction().default_value();
+  } else {
+    // If there is no runtime fraction specified, the default is 100% sampled. By leaving
+    // runtime_key_ empty and forcing the default to 100% this will yield the expected behavior.
+    default_value_.set_numerator(100);
+    default_value_.set_denominator(envoy::type::v3::FractionalPercent::HUNDRED);
   }
   trace_sampled_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, trace_sampled, true);
 }

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -103,14 +103,11 @@ bool FilterUtility::shouldShadow(const ShadowPolicy& policy, Runtime::Loader& ru
     return false;
   }
 
-  if (!policy.runtimeKey().empty()) {
-    // The default is 0/100, which means that the default for a key set but no default value
-    // explicitly set is 0% mirrored.
-    return runtime.snapshot().featureEnabled(policy.runtimeKey(), policy.defaultValue(),
-                                             stable_random);
-  }
-
-  return true;
+  // The policy's default value is set correctly regardless of whether there is a runtime key
+  // or not, thus this call is sufficient for all cases (100% if no runtime set, otherwise
+  // using the default value within the runtime fractional percent setting).
+  return runtime.snapshot().featureEnabled(policy.runtimeKey(), policy.defaultValue(),
+                                           stable_random);
 }
 
 FilterUtility::TimeoutData

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4388,11 +4388,31 @@ TEST_F(RouterTest, CrossSchemeRedirectAllowedByPolicy) {
   router_.onDestroy();
 }
 
+namespace {
+
+std::unique_ptr<ShadowPolicyImpl>
+makeShadowPolicy(std::string cluster = "", absl::optional<std::string> runtime_key = absl::nullopt,
+                 absl::optional<envoy::type::v3::FractionalPercent> default_value = absl::nullopt,
+                 bool trace_sampled = true) {
+  envoy::config::route::v3::RouteAction::RequestMirrorPolicy policy;
+  policy.set_cluster(cluster);
+  if (runtime_key.has_value()) {
+    policy.mutable_runtime_fraction()->set_runtime_key(runtime_key.value());
+  }
+  if (default_value.has_value()) {
+    *policy.mutable_runtime_fraction()->mutable_default_value() = default_value.value();
+  }
+  policy.mutable_trace_sampled()->set_value(trace_sampled);
+
+  return std::make_unique<ShadowPolicyImpl>(policy);
+}
+
+} // namespace
+
 TEST_F(RouterTest, Shadow) {
-  ShadowPolicyPtr policy = std::make_unique<TestShadowPolicy>("foo", "bar");
+  ShadowPolicyPtr policy = makeShadowPolicy("foo", "bar");
   callbacks_.route_->route_entry_.shadow_policies_.push_back(std::move(policy));
-  policy = std::make_unique<TestShadowPolicy>("fizz", "buzz", envoy::type::v3::FractionalPercent(),
-                                              false);
+  policy = makeShadowPolicy("fizz", "buzz", envoy::type::v3::FractionalPercent(), false);
   callbacks_.route_->route_entry_.shadow_policies_.push_back(std::move(policy));
   ON_CALL(callbacks_, streamId()).WillByDefault(Return(43));
 
@@ -5389,55 +5409,56 @@ TEST(RouterFilterUtilityTest, SetUpstreamScheme) {
 
 TEST(RouterFilterUtilityTest, ShouldShadow) {
   {
-    TestShadowPolicy policy;
+    auto policy = makeShadowPolicy();
     NiceMock<Runtime::MockLoader> runtime;
     EXPECT_CALL(
         runtime.snapshot_,
         featureEnabled(_, testing::Matcher<const envoy::type::v3::FractionalPercent&>(_), _))
         .Times(0);
-    EXPECT_FALSE(FilterUtility::shouldShadow(policy, runtime, 5));
+    EXPECT_FALSE(FilterUtility::shouldShadow(*policy, runtime, 5));
   }
   {
-    TestShadowPolicy policy("cluster");
+    auto policy = makeShadowPolicy("cluster");
     NiceMock<Runtime::MockLoader> runtime;
     EXPECT_CALL(
         runtime.snapshot_,
-        featureEnabled(_, testing::Matcher<const envoy::type::v3::FractionalPercent&>(_), _))
-        .Times(0);
-    EXPECT_TRUE(FilterUtility::shouldShadow(policy, runtime, 5));
+        featureEnabled(
+            "", testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100)), _))
+        .WillOnce(Return(true));
+    EXPECT_TRUE(FilterUtility::shouldShadow(*policy, runtime, 5));
   }
   {
-    TestShadowPolicy policy("cluster", "foo");
+    auto policy = makeShadowPolicy("cluster", "foo");
     NiceMock<Runtime::MockLoader> runtime;
     EXPECT_CALL(
         runtime.snapshot_,
         featureEnabled("foo",
                        testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0)), 5))
         .WillOnce(Return(false));
-    EXPECT_FALSE(FilterUtility::shouldShadow(policy, runtime, 5));
+    EXPECT_FALSE(FilterUtility::shouldShadow(*policy, runtime, 5));
   }
   {
-    TestShadowPolicy policy("cluster", "foo");
+    auto policy = makeShadowPolicy("cluster", "foo");
     NiceMock<Runtime::MockLoader> runtime;
     EXPECT_CALL(
         runtime.snapshot_,
         featureEnabled("foo",
                        testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(0)), 5))
         .WillOnce(Return(true));
-    EXPECT_TRUE(FilterUtility::shouldShadow(policy, runtime, 5));
+    EXPECT_TRUE(FilterUtility::shouldShadow(*policy, runtime, 5));
   }
   // Use default value instead of runtime key.
   {
     envoy::type::v3::FractionalPercent fractional_percent;
     fractional_percent.set_numerator(5);
-    fractional_percent.set_denominator(envoy::type::v3::FractionalPercent::TEN_THOUSAND);
-    TestShadowPolicy policy("cluster", "foo", fractional_percent);
+    fractional_percent.set_denominator(envoy::type::v3::FractionalPercent::HUNDRED);
+    auto policy = makeShadowPolicy("cluster", absl::nullopt, fractional_percent);
     NiceMock<Runtime::MockLoader> runtime;
-    EXPECT_CALL(
-        runtime.snapshot_,
-        featureEnabled("foo", testing::Matcher<const envoy::type::v3::FractionalPercent&>(_), 3))
+    EXPECT_CALL(runtime.snapshot_,
+                featureEnabled(
+                    "", testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(5)), 3))
         .WillOnce(Return(true));
-    EXPECT_TRUE(FilterUtility::shouldShadow(policy, runtime, 3));
+    EXPECT_TRUE(FilterUtility::shouldShadow(*policy, runtime, 3));
   }
 }
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -232,24 +232,6 @@ public:
   std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>> rate_limit_policy_entry_;
 };
 
-class TestShadowPolicy : public ShadowPolicy {
-public:
-  TestShadowPolicy(absl::string_view cluster = "", absl::string_view runtime_key = "",
-                   envoy::type::v3::FractionalPercent default_value = {}, bool trace_sampled = true)
-      : cluster_(cluster), runtime_key_(runtime_key), default_value_(default_value),
-        trace_sampled_(trace_sampled) {}
-  // Router::ShadowPolicy
-  const std::string& cluster() const override { return cluster_; }
-  const std::string& runtimeKey() const override { return runtime_key_; }
-  const envoy::type::v3::FractionalPercent& defaultValue() const override { return default_value_; }
-  bool traceSampled() const override { return trace_sampled_; }
-
-  std::string cluster_;
-  std::string runtime_key_;
-  envoy::type::v3::FractionalPercent default_value_;
-  bool trace_sampled_;
-};
-
 class MockShadowWriter : public ShadowWriter {
 public:
   MockShadowWriter();


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/20424 had a regression
when runtimey key was not set but the default was set to not zero.

This change further cleans up the logic to make it more clear
as well as fixes the regression. Tests now use more of the
production code to protect against future regressions.

Risk Level: Low
Testing: Updated tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
