### PR TITLE
test: fixing timeout

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -258,7 +258,7 @@ TEST_P(ConnectTerminationIntegrationTest, IgnoreH11HostField) {
       "",
       "':authority', 'www.foo.com:443'\n"
       "':method', 'CONNECT'",
-      sendRawHttpAndWaitForResponse(lookupPort("http"), full_request.c_str(), &response, false););
+      sendRawHttpAndWaitForResponse(lookupPort("http"), full_request.c_str(), &response, true););
 }
 
 // For this class, forward the CONNECT request upstream


### PR DESCRIPTION
we had a connect test which was doing sendRawHttpAndWaitForResponse, which generally waits for a completely framed response, and the while point of CONNECT proxying is the "body" isn't ever complete.  Setting disconnect_after_headers_complete = true means the test finishes up after the headers are sent rather than waiting for a body which will never arrive.