### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # v3
+        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 
+        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -9,8 +9,6 @@ jobs:
   CodeQL-Build:
 
     permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -2,9 +2,16 @@ on:
   schedule:
   - cron: '0 12 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false
 

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -2,9 +2,6 @@ on:
   schedule:
   - cron: '0 12 * * 4'
 
-permissions:
-  contents: read
-
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -8,9 +8,16 @@ on:
     - 'dependabot/**'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false
 

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -8,7 +8,6 @@ on:
     - 'dependabot/**'
   pull_request:
 
-
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -8,15 +8,11 @@ on:
     - 'dependabot/**'
   pull_request:
 
-permissions:
-  contents: read
 
 jobs:
   CodeQL-Build:
 
     permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -3,8 +3,6 @@ on:
   schedule:
   - cron: '0 5 * * 1,2,3,4,5'
 
-permissions:
-  contents: read
 
 jobs:
   pr_notifier:
@@ -15,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
     - name: Set up Python 3.8
-      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # v3
+      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 
       with:
         python-version: '3.8'
         architecture: 'x64'

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -3,6 +3,9 @@ on:
   schedule:
   - cron: '0 5 * * 1,2,3,4,5'
 
+permissions:
+  contents: read
+
 jobs:
   pr_notifier:
     name: PR Notifier
@@ -12,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # v3
       with:
         python-version: '3.8'
         architecture: 'x64'

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -3,7 +3,6 @@ on:
   schedule:
   - cron: '0 5 * * 1,2,3,4,5'
 
-
 jobs:
   pr_notifier:
     name: PR Notifier
@@ -13,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
     - name: Set up Python 3.8
-      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 
+      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
       with:
         python-version: '3.8'
         architecture: 'x64'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,9 +3,6 @@ on:
   schedule:
   - cron: '0 */4 * * *'
 
-permissions:
-  contents: read
-
 jobs:
   prune_stale:
     permissions:
@@ -17,7 +14,7 @@ jobs:
 
     steps:
     - name: Prune Stale
-      uses: actions/stale@428b0ed64d74596742200dc98805bb90f39ef9f0 # v5
+      uses: actions/stale@428b0ed64d74596742200dc98805bb90f39ef9f0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Different amounts of days for issues/PRs are not currently supported but there is a PR

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,15 +3,21 @@ on:
   schedule:
   - cron: '0 */4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   prune_stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     name: Prune Stale
     runs-on: ubuntu-latest
     if: github.repository == 'envoyproxy/envoy'
 
     steps:
     - name: Prune Stale
-      uses: actions/stale@v5
+      uses: actions/stale@428b0ed64d74596742200dc98805bb90f39ef9f0 # v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Different amounts of days for issues/PRs are not currently supported but there is a PR


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

- Also included permissions for actions to reduce the attack vector.

GitHub's own repository pin's their `checkout` actions by SHA and doesn't use the version tag https://github.com/github/docs/blob/ea7f218c91ecbae9a700a8702b51a7d2736e0d2c/.github/workflows/docs-review-collect.yml#L23

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
