### PR TITLE
xray: use HTTP X-Forwarded-For header value inside xray span

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -61,6 +61,7 @@ Bug Fixes
 * xray: fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header ``x-amzn-trace-id``.
 * xray: fix the AWS X-Ray tracer extension to annotate a child span with ``type=subsegment`` to correctly relate subsegments to a parent segment. Previously a subsegment would be treated as an independent segment.
 * xray: fix the AWS X-Ray tracer extension to reuse the trace ID already present in the header ``x-amzn-trace-id`` instead of creating a new one.
+* xray: fix the AWS X-Ray tracer extension to set the HTTP X-Forwarded-For header value as client_ip in the segment data.
 
 Removed Config or Runtime
 -------------------------

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -123,7 +123,8 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config& config, const std::stri
 
 Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& operation_name,
                                    Envoy::SystemTime start_time,
-                                   const absl::optional<XRayHeader>& xray_header) {
+                                   const absl::optional<XRayHeader>& xray_header,
+                                   const absl::optional<absl::string_view> client_ip) {
 
   auto span_ptr = std::make_unique<XRay::Span>(time_source_, random_, *daemon_broker_);
   span_ptr->setName(segment_name_);
@@ -134,6 +135,12 @@ Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::str
   span_ptr->setStartTime(start_time);
   span_ptr->setOrigin(origin_);
   span_ptr->setAwsMetadata(aws_metadata_);
+  if (client_ip) {
+    span_ptr->addToHttpRequestAnnotations(SpanClientIp,
+                                          ValueUtil::stringValue(std::string(*client_ip)));
+    // The `client_ip` is the address specified in the HTTP X-Forwarded-For header.
+    span_ptr->addToHttpRequestAnnotations(SpanXForwardedFor, ValueUtil::boolValue(true));
+  }
 
   if (xray_header) {
     // There's a previous span that this span should be based-on.
@@ -155,19 +162,8 @@ Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::str
   return span_ptr;
 }
 
-XRay::SpanPtr Tracer::createNonSampledSpan(const Tracing::Config& config,
-                                           const std::string& operation_name,
-                                           Envoy::SystemTime start_time,
-                                           const absl::optional<XRayHeader>& xray_header) const {
+XRay::SpanPtr Tracer::createNonSampledSpan(const absl::optional<XRayHeader>& xray_header) const {
   auto span_ptr = std::make_unique<XRay::Span>(time_source_, random_, *daemon_broker_);
-  span_ptr->setName(segment_name_);
-  span_ptr->setOperation(operation_name);
-  span_ptr->setDirection(Tracing::HttpTracerUtility::toString(config.operationName()));
-  // Even though we have a TimeSource member in the tracer, we assume the start_time argument has a
-  // more precise value than calling the systemTime() at this point in time.
-  span_ptr->setStartTime(start_time);
-  span_ptr->setOrigin(origin_);
-  span_ptr->setAwsMetadata(aws_metadata_);
   if (xray_header) {
     // There's a previous span that this span should be based-on.
     span_ptr->setParentId(xray_header->parent_id_);
@@ -185,20 +181,18 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
   constexpr auto SpanContentLength = "content_length";
   constexpr auto SpanMethod = "method";
   constexpr auto SpanUrl = "url";
-  constexpr auto SpanClientIp = "client_ip";
-  constexpr auto SpanXForwardedFor = "x_forwarded_for";
 
   if (name.empty() || value.empty()) {
     return;
   }
 
   if (name == Tracing::Tags::get().HttpUrl) {
-    http_request_annotations_.emplace(SpanUrl, ValueUtil::stringValue(std::string(value)));
+    addToHttpRequestAnnotations(SpanUrl, ValueUtil::stringValue(std::string(value)));
   } else if (name == Tracing::Tags::get().HttpMethod) {
-    http_request_annotations_.emplace(SpanMethod, ValueUtil::stringValue(std::string(value)));
+    addToHttpRequestAnnotations(SpanMethod, ValueUtil::stringValue(std::string(value)));
   } else if (name == Tracing::Tags::get().UserAgent) {
-    http_request_annotations_.emplace(Tracing::Tags::get().UserAgent,
-                                      ValueUtil::stringValue(std::string(value)));
+    addToHttpRequestAnnotations(Tracing::Tags::get().UserAgent,
+                                ValueUtil::stringValue(std::string(value)));
   } else if (name == Tracing::Tags::get().HttpStatusCode) {
     uint64_t status_code;
     if (!absl::SimpleAtoi(value, &status_code)) {
@@ -207,20 +201,22 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
       return;
     }
     setResponseStatusCode(status_code);
-    http_response_annotations_.emplace(Tracing::Tags::get().Status,
-                                       ValueUtil::numberValue(status_code));
+    addToHttpResponseAnnotations(Tracing::Tags::get().Status, ValueUtil::numberValue(status_code));
   } else if (name == Tracing::Tags::get().ResponseSize) {
     uint64_t response_size;
     if (!absl::SimpleAtoi(value, &response_size)) {
       ENVOY_LOG(debug, "{} must be a number, given: {}", Tracing::Tags::get().ResponseSize, value);
       return;
     }
-    http_response_annotations_.emplace(SpanContentLength, ValueUtil::numberValue(response_size));
+    addToHttpResponseAnnotations(SpanContentLength, ValueUtil::numberValue(response_size));
   } else if (name == Tracing::Tags::get().PeerAddress) {
-    http_request_annotations_.emplace(SpanClientIp, ValueUtil::stringValue(std::string(value)));
-    // In this case, PeerAddress refers to the client's actual IP address, not
-    // the address specified in the HTTP X-Forwarded-For header.
-    http_request_annotations_.emplace(SpanXForwardedFor, ValueUtil::boolValue(false));
+    // Use PeerAddress if client_ip is not already set from the header.
+    if (!hasKeyInHttpRequestAnnotations(SpanClientIp)) {
+      addToHttpRequestAnnotations(SpanClientIp, ValueUtil::stringValue(std::string(value)));
+      // In this case, PeerAddress refers to the client's actual IP address, not
+      // the address specified in the HTTP X-Forwarded-For header.
+      addToHttpRequestAnnotations(SpanXForwardedFor, ValueUtil::boolValue(false));
+    }
   } else if (name == Tracing::Tags::get().Error && value == Tracing::Tags::get().True) {
     setServerError();
   } else {

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -121,7 +121,7 @@ public:
   /*
    * Adds to the http request annotation field of the Span.
    */
-  void addToHttpRequestAnnotations(absl::string_view key, ProtobufWkt::Value value) {
+  void addToHttpRequestAnnotations(absl::string_view key, const ProtobufWkt::Value& value) {
     http_request_annotations_.emplace(std::string(key), value);
   }
 
@@ -135,7 +135,7 @@ public:
   /*
    * Adds to the http response annotation field of the Span.
    */
-  void addToHttpResponseAnnotations(absl::string_view key, ProtobufWkt::Value value) {
+  void addToHttpResponseAnnotations(absl::string_view key, const ProtobufWkt::Value& value) {
     http_response_annotations_.emplace(std::string(key), value);
   }
 

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -25,7 +25,10 @@ namespace Extensions {
 namespace Tracers {
 namespace XRay {
 
-constexpr auto XRayTraceHeader = "x-amzn-trace-id";
+constexpr absl::string_view SpanClientIp = "client_ip";
+constexpr absl::string_view SpanXForwardedFor = "x_forwarded_for";
+constexpr absl::string_view XForwardedForHeader = "x-forwarded-for";
+constexpr absl::string_view XRayTraceHeader = "x-amzn-trace-id";
 constexpr absl::string_view Subsegment = "subsegment";
 
 class Span : public Tracing::Span, Logger::Loggable<Logger::Id::config> {
@@ -113,6 +116,27 @@ public:
    */
   void setAwsMetadata(const absl::flat_hash_map<std::string, ProtobufWkt::Value>& aws_metadata) {
     aws_metadata_ = aws_metadata;
+  }
+
+  /*
+   * Adds to the http request annotation field of the Span.
+   */
+  void addToHttpRequestAnnotations(absl::string_view key, ProtobufWkt::Value value) {
+    http_request_annotations_.emplace(std::string(key), value);
+  }
+
+  /*
+   * Check if key is set in http request annotation field of a Span.
+   */
+  bool hasKeyInHttpRequestAnnotations(absl::string_view key) {
+    return http_request_annotations_.find(key) != http_request_annotations_.end();
+  }
+
+  /*
+   * Adds to the http response annotation field of the Span.
+   */
+  void addToHttpResponseAnnotations(absl::string_view key, ProtobufWkt::Value value) {
+    http_response_annotations_.emplace(std::string(key), value);
   }
 
   /**
@@ -252,16 +276,15 @@ public:
    */
   Tracing::SpanPtr startSpan(const Tracing::Config&, const std::string& operation_name,
                              Envoy::SystemTime start_time,
-                             const absl::optional<XRayHeader>& xray_header);
+                             const absl::optional<XRayHeader>& xray_header,
+                             const absl::optional<absl::string_view> client_ip);
   /**
    * Creates a Span that is marked as not-sampled.
    * This is useful when the sampling decision is done in Envoy's X-Ray and we want to avoid
    * overruling that decision in the upstream service in case that service itself uses X-Ray for
    * tracing. Also at the same time if X-Ray header is set then preserve its value.
    */
-  XRay::SpanPtr createNonSampledSpan(const Tracing::Config&, const std::string& operation_name,
-                                     Envoy::SystemTime start_time,
-                                     const absl::optional<XRayHeader>& xray_header) const;
+  XRay::SpanPtr createNonSampledSpan(const absl::optional<XRayHeader>& xray_header) const;
 
 private:
   const std::string segment_name_;

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -107,15 +107,15 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
   if (should_trace.value()) {
     return tracer->startSpan(config, operation_name, start_time,
                              header.has_value() ? absl::optional<XRayHeader>(xray_header)
-                                                : absl::nullopt);
+                                                : absl::nullopt,
+                             trace_context.getByKey(XForwardedForHeader));
   }
 
-  // instead of returning nullptr, we return a Span that is marked as not-sampled.
+  // Instead of returning nullptr, we return a Span that is marked as not-sampled.
   // This is important to communicate that information to upstream services (see injectContext()).
   // Otherwise, the upstream service can decide to sample the request regardless and we end up with
   // more samples than we asked for.
-  return tracer->createNonSampledSpan(config, operation_name, start_time,
-                                      header.has_value() ? absl::optional<XRayHeader>(xray_header)
+  return tracer->createNonSampledSpan(header.has_value() ? absl::optional<XRayHeader>(xray_header)
                                                          : absl::nullopt);
 }
 

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -119,13 +119,65 @@ TEST_F(XRayTracerTest, SerializeSpanTest) {
   Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
                 std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, expected_->operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
   span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
   span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
   span->setTag(Tracing::Tags::get().HttpStatusCode, absl::StrFormat("%d", expected_status_code));
   span->setTag(Tracing::Tags::get().ResponseSize, absl::StrFormat("%d", expected_content_length));
   span->setTag(Tracing::Tags::get().PeerAddress, expected_client_ip);
+  span->setTag(Tracing::Tags::get().UpstreamAddress, expected_upstream_address);
+  span->finishSpan();
+}
+
+TEST_F(XRayTracerTest, SerializeSpanTestXForwardedForSet) {
+  constexpr uint32_t expected_status_code = 202;
+  constexpr uint32_t expected_content_length = 1337;
+  constexpr absl::string_view expected_client_ip = "190.0.0.100";
+  constexpr absl::string_view unexpected_client_ip = "10.0.0.100";
+  constexpr bool expected_x_forwarded_for = true;
+  constexpr absl::string_view expected_upstream_address = "10.0.0.200";
+
+  auto on_send = [&](const std::string& json) {
+    ASSERT_FALSE(json.empty());
+    daemon::Segment s;
+    MessageUtil::loadFromJson(json, s, ProtobufMessage::getNullValidationVisitor());
+    TestUtility::validate(s);
+    commonAsserts(s);
+    EXPECT_FALSE(s.trace_id().empty());
+    EXPECT_FALSE(s.id().empty());
+    EXPECT_EQ(2, s.annotations().size());
+    EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_FALSE(s.fault());    /*server error*/
+    EXPECT_FALSE(s.error());    /*client error*/
+    EXPECT_FALSE(s.throttle()); /*request throttled*/
+    EXPECT_EQ(expected_status_code,
+              s.http().response().fields().at(Tracing::Tags::get().Status).number_value());
+    EXPECT_EQ(expected_content_length,
+              s.http().response().fields().at("content_length").number_value());
+    EXPECT_EQ(expected_client_ip,
+              s.http().request().fields().at("client_ip").string_value().c_str());
+    EXPECT_EQ(expected_x_forwarded_for,
+              s.http().request().fields().at("x_forwarded_for").bool_value());
+    EXPECT_EQ(expected_upstream_address,
+              s.annotations().at(Tracing::Tags::get().UpstreamAddress).c_str());
+  };
+
+  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Egress));
+  EXPECT_CALL(*broker_, send(_)).WillOnce(Invoke(on_send));
+  aws_metadata_.insert({"key", ValueUtil::stringValue(expected_->aws_key_value)});
+  Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
+                std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
+  auto span = tracer.startSpan(config_, expected_->operation_name,
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               expected_client_ip /*client_ip from x-forwarded-for header*/);
+  span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
+  span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
+  span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
+  span->setTag(Tracing::Tags::get().HttpStatusCode, absl::StrFormat("%d", expected_status_code));
+  span->setTag(Tracing::Tags::get().ResponseSize, absl::StrFormat("%d", expected_content_length));
+  span->setTag(Tracing::Tags::get().PeerAddress, unexpected_client_ip);
   span->setTag(Tracing::Tags::get().UpstreamAddress, expected_upstream_address);
   span->finishSpan();
 }
@@ -156,7 +208,8 @@ TEST_F(XRayTracerTest, SerializeSpanTestServerError) {
   Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
                 std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, expected_->operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
   span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
   span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
@@ -191,7 +244,8 @@ TEST_F(XRayTracerTest, SerializeSpanTestClientError) {
   Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
                 std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, expected_->operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
   span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
   span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
@@ -225,7 +279,8 @@ TEST_F(XRayTracerTest, SerializeSpanTestClientErrorWithThrottle) {
   Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
                 std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, expected_->operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
   span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
   span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
@@ -253,7 +308,8 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithEmptyValue) {
   Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
                 std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, expected_->operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
   span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
   span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
@@ -286,7 +342,8 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithStatusCodeNotANumber) {
   Tracer tracer{expected_->span_name, expected_->origin_name, aws_metadata_,
                 std::move(broker_),   server_.timeSource(),   server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, expected_->operation_name,
-                               server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   span->setTag(Tracing::Tags::get().HttpMethod, expected_->http_method);
   span->setTag(Tracing::Tags::get().HttpUrl, expected_->http_url);
   span->setTag(Tracing::Tags::get().UserAgent, expected_->user_agent);
@@ -297,22 +354,16 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithStatusCodeNotANumber) {
 }
 
 TEST_F(XRayTracerTest, NonSampledSpansNotSerialized) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Egress));
   Tracer tracer{"" /*span name*/,   "" /*origin*/,        aws_metadata_,
                 std::move(broker_), server_.timeSource(), server_.api().randomGenerator()};
-  auto span =
-      tracer.createNonSampledSpan(config_, "egress" /*operation name*/,
-                                  server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
   span->finishSpan();
 }
 
 TEST_F(XRayTracerTest, BaggageNotImplemented) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   Tracer tracer{"" /*span name*/,   "" /*origin*/,        aws_metadata_,
                 std::move(broker_), server_.timeSource(), server_.api().randomGenerator()};
-  auto span =
-      tracer.createNonSampledSpan(config_, "ingress" /*operation name*/,
-                                  server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
   span->setBaggage("baggage_key", "baggage_value");
   span->finishSpan();
 
@@ -321,24 +372,18 @@ TEST_F(XRayTracerTest, BaggageNotImplemented) {
 }
 
 TEST_F(XRayTracerTest, LogNotImplemented) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   Tracer tracer{"" /*span name*/,   "" /*origin*/,        aws_metadata_,
                 std::move(broker_), server_.timeSource(), server_.api().randomGenerator()};
-  auto span =
-      tracer.createNonSampledSpan(config_, "ingress" /*operation name*/,
-                                  server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
   span->log(SystemTime{std::chrono::duration<int, std::milli>(100)}, "dummy log value");
   span->finishSpan();
   // Nothing to assert here as log is a dummy function
 }
 
 TEST_F(XRayTracerTest, GetTraceId) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   Tracer tracer{"" /*span name*/,   "" /*origin*/,        aws_metadata_,
                 std::move(broker_), server_.timeSource(), server_.api().randomGenerator()};
-  auto span =
-      tracer.createNonSampledSpan(config_, "ingress" /*operation name*/,
-                                  server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
   span->finishSpan();
 
   // This method is unimplemented and a noop.
@@ -354,7 +399,8 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
   // Span id taken from random generator
   EXPECT_CALL(server_.api_.random_, random()).WillOnce(Return(999));
   auto parent_span = tracer.startSpan(config_, expected_->operation_name,
-                                      server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+                                      server_.timeSource().systemTime(), absl::nullopt /*headers*/,
+                                      absl::nullopt /*client_ip from x-forwarded-for header*/);
 
   const XRay::Span* xray_parent_span = static_cast<XRay::Span*>(parent_span.get());
   auto on_send = [&](const std::string& json) {
@@ -393,7 +439,8 @@ TEST_F(XRayTracerTest, UseExistingHeaderInformation) {
                 std::move(broker_),
                 server_.timeSource(),
                 server_.api().randomGenerator()};
-  auto span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(), xray_header);
+  auto span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(), xray_header,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
 
   const XRay::Span* xray_span = static_cast<XRay::Span*>(span.get());
   EXPECT_STREQ(xray_header.trace_id_.c_str(), xray_span->traceId().c_str());
@@ -416,9 +463,10 @@ TEST_F(XRayTracerTest, DontStartSpanOnNonSampledSpans) {
                 server_.timeSource(),
                 server_.api().randomGenerator()};
   Tracing::SpanPtr span;
-  EXPECT_ENVOY_BUG(
-      span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(), xray_header),
-      "unexpected code path hit");
+  EXPECT_ENVOY_BUG(span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(),
+                                           xray_header,
+                                           absl::nullopt /*client_ip from x-forwarded-for header*/),
+                   "unexpected code path hit");
 }
 
 TEST_F(XRayTracerTest, UnknownSpanStillSampled) {
@@ -435,7 +483,8 @@ TEST_F(XRayTracerTest, UnknownSpanStillSampled) {
                 std::move(broker_),
                 server_.timeSource(),
                 server_.api().randomGenerator()};
-  auto span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(), xray_header);
+  auto span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(), xray_header,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
 
   const XRay::Span* xray_span = static_cast<XRay::Span*>(span.get());
   EXPECT_STREQ(xray_header.trace_id_.c_str(), xray_span->traceId().c_str());
@@ -456,7 +505,8 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
                 server_.timeSource(),
                 server_.api().randomGenerator()};
   auto span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(),
-                               absl::nullopt /*headers*/);
+                               absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
   Http::TestRequestHeaderMapImpl request_headers;
   span->injectContext(request_headers);
   auto header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
@@ -467,7 +517,6 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
 }
 
 TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   constexpr absl::string_view span_name = "my span";
   Tracer tracer{span_name,
                 "",
@@ -475,9 +524,7 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
                 std::move(broker_),
                 server_.timeSource(),
                 server_.api().randomGenerator()};
-  auto span =
-      tracer.createNonSampledSpan(config_, "ingress" /*operation name*/,
-                                  server_.timeSource().systemTime(), absl::nullopt /*headers*/);
+  auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
   Http::TestRequestHeaderMapImpl request_headers;
   span->injectContext(request_headers);
   auto header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
@@ -488,7 +535,6 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
 }
 
 TEST_F(XRayTracerTest, TraceIDFormatTest) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   constexpr absl::string_view span_name = "my span";
   Tracer tracer{span_name,
                 "",
@@ -496,10 +542,8 @@ TEST_F(XRayTracerTest, TraceIDFormatTest) {
                 std::move(broker_),
                 server_.timeSource(),
                 server_.api().randomGenerator()};
-  auto span = tracer.createNonSampledSpan(
-      config_, "ingress" /*operation name*/, server_.timeSource().systemTime(),
-      absl::nullopt /*headers*/); // startSpan and createNonSampledSpan use the
-                                  // same logic to create a trace ID
+  // startSpan and createNonSampledSpan use the same logic to create a trace ID
+  auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
   XRay::Span* xray_span = span.get();
   std::vector<std::string> parts = absl::StrSplit(xray_span->traceId(), absl::ByChar('-'));
   EXPECT_EQ(3, parts.size());
@@ -509,7 +553,6 @@ TEST_F(XRayTracerTest, TraceIDFormatTest) {
 }
 
 TEST_F(XRayTracerTest, UseExistingHeaderInformationNonSampled) {
-  ON_CALL(config_, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   XRayHeader xray_header;
   xray_header.trace_id_ = "a";
   xray_header.parent_id_ = "b";
@@ -521,8 +564,7 @@ TEST_F(XRayTracerTest, UseExistingHeaderInformationNonSampled) {
                 std::move(broker_),
                 server_.timeSource(),
                 server_.api().randomGenerator()};
-  auto span = tracer.createNonSampledSpan(config_, "ingress", server_.timeSource().systemTime(),
-                                          xray_header);
+  auto span = tracer.createNonSampledSpan(xray_header);
 
   const XRay::Span* xray_span = static_cast<XRay::Span*>(span.get());
   EXPECT_STREQ(xray_header.trace_id_.c_str(), xray_span->traceId().c_str());
@@ -547,7 +589,8 @@ TEST_P(XRayDaemonTest, VerifyUdpPacketContents) {
                 aws_metadata,        std::make_unique<DaemonBrokerImpl>(daemon_endpoint),
                 server.timeSource(), server.api().randomGenerator()};
   auto span = tracer.startSpan(config_, "ingress" /*operation name*/,
-                               server.timeSource().systemTime(), absl::nullopt /*headers*/);
+                               server.timeSource().systemTime(), absl::nullopt /*headers*/,
+                               absl::nullopt /*client_ip from x-forwarded-for header*/);
 
   span->setTag(Tracing::Tags::get().HttpStatusCode, "202");
   span->finishSpan();

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -31,7 +31,7 @@ public:
 };
 
 TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
-  request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;Sampled=0");
+  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=0");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
@@ -47,7 +47,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
 }
 
 TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
-  request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;Sampled=1");
+  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=1");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
@@ -61,7 +61,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
 }
 
 TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
-  request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;Sampled=");
+  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
@@ -79,7 +79,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
 }
 
 TEST_F(XRayDriverTest, XRayTraceHeaderWithoutSamplingDecision) {
-  request_headers_.addCopy(XRayTraceHeader, "Root=1-272793;Parent=5398ad8;");
+  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;");
   // sampling rules with default fixed_target = 0 & rate = 0
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", R"EOF(
 {
@@ -119,6 +119,39 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
   // b) there are no sampling rules passed, so the default rules apply (1 req/sec and 5% after that
   // within that second)
   ASSERT_NE(span, nullptr);
+}
+
+TEST_F(XRayDriverTest, XForwardedForHeaderSet) {
+  request_headers_.addCopy(std::string(XForwardedForHeader), "191.251.191.251");
+  XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
+                           "" /*origin*/, aws_metadata_};
+  Driver driver(config, context_);
+
+  Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
+  Envoy::SystemTime start_time;
+  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+                               tracing_decision);
+
+  ASSERT_NE(span, nullptr);
+  auto* xray_span = static_cast<XRay::Span*>(span.get());
+  ASSERT_TRUE(xray_span->hasKeyInHttpRequestAnnotations(SpanXForwardedFor));
+  ASSERT_TRUE(xray_span->hasKeyInHttpRequestAnnotations(SpanClientIp));
+}
+
+TEST_F(XRayDriverTest, XForwardedForHeaderNotSet) {
+  XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
+                           "" /*origin*/, aws_metadata_};
+  Driver driver(config, context_);
+
+  Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
+  Envoy::SystemTime start_time;
+  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+                               tracing_decision);
+
+  ASSERT_NE(span, nullptr);
+  auto* xray_span = static_cast<XRay::Span*>(span.get());
+  ASSERT_FALSE(xray_span->hasKeyInHttpRequestAnnotations(SpanXForwardedFor));
+  ASSERT_FALSE(xray_span->hasKeyInHttpRequestAnnotations(SpanClientIp));
 }
 
 } // namespace


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: xray: use HTTP X-Forwarded-For header value inside xray span
Additional Description:
Risk Level: Low
Testing: Unit Test
Docs Changes: NA
Release Notes: yes
Platform Specific Features:
Fixes: https://github.com/aws/aws-app-mesh-roadmap/issues/395