### PR TITLE
test: switching one more wait to not infinitely time out for failures

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1049,6 +1049,12 @@ void ConfigHelper::setConnectTimeout(std::chrono::milliseconds timeout) {
   connect_timeout_set_ = true;
 }
 
+void ConfigHelper::disableDelayClose() {
+  addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.mutable_delayed_close_timeout()->set_nanos(0); });
+}
+
 void ConfigHelper::setDownstreamMaxRequestsPerConnection(uint64_t max_requests_per_connection) {
   addConfigModifier(
       [max_requests_per_connection](

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -246,6 +246,10 @@ public:
   // Set the connect timeout on upstream connections.
   void setConnectTimeout(std::chrono::milliseconds timeout);
 
+  // Disable delay close. This is especially useful for tests doing raw TCP for
+  // HTTP/1.1 which functionally frame by connection close.
+  void disableDelayClose();
+
   // Set the max_requests_per_connection for downstream through the HttpConnectionManager.
   void setDownstreamMaxRequestsPerConnection(uint64_t max_requests_per_connection);
 

--- a/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
+++ b/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
@@ -43,7 +43,7 @@ TEST_P(DirectResponseIntegrationTest, DirectResponseOnConnection) {
         response.append(data.toString());
         conn.close(Network::ConnectionCloseType::FlushWrite);
       });
-  connection->run();
+  ASSERT_TRUE(connection->run());
   EXPECT_EQ("hello, world!\n", response);
   EXPECT_THAT(waitForAccessLog(listener_access_log_name_),
               testing::HasSubstr(StreamInfo::ResponseCodeDetails::get().DirectResponse));

--- a/test/extensions/filters/network/echo/echo_integration_test.cc
+++ b/test/extensions/filters/network/echo/echo_integration_test.cc
@@ -43,7 +43,7 @@ TEST_P(EchoIntegrationTest, Hello) {
         response.append(data.toString());
         conn.close(Network::ConnectionCloseType::FlushWrite);
       });
-  connection->run();
+  ASSERT_TRUE(connection->run());
   EXPECT_EQ("hello", response);
 }
 
@@ -90,7 +90,7 @@ filter_chains:
         response.append(data.toString());
         conn.close(Network::ConnectionCloseType::FlushWrite);
       });
-  connection->run();
+  ASSERT_TRUE(connection->run());
   EXPECT_EQ("hello", response);
 
   // Remove the listener.

--- a/test/extensions/stats_sinks/hystrix/hystrix_integration_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_integration_test.cc
@@ -34,7 +34,7 @@ TEST_P(HystrixIntegrationTest, NoChunkEncoding) {
             conn.close(Network::ConnectionCloseType::NoFlush);
           }
         });
-    connection->run();
+    ASSERT_TRUE(connection->run());
     EXPECT_THAT(response, StartsWith("HTTP/1.1 200 OK\r\n"));
     // Make sure that the response is not actually chunk encoded, but it does have the hystrix flush
     // trailer.

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -333,7 +333,7 @@ protected:
 
     // Drive the connection until we get a response.
     while (response.empty()) {
-      connection->run(Event::Dispatcher::RunType::NonBlock);
+      EXPECT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
     }
     EXPECT_THAT(response, testing::HasSubstr("HTTP/1.1 200 OK\r\n"));
 

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -446,7 +446,10 @@ void BaseIntegrationTest::sendRawHttpAndWaitForResponse(
       },
       std::move(transport_socket));
 
-  connection->run();
+  if (connection->run() != testing::AssertionSuccess()) {
+    FAIL() << "Failed to get expected response within the time bound\n"
+           << "received " << *response << "\n";
+  }
 }
 
 void BaseIntegrationTest::useListenerAccessLog(absl::string_view format) {

--- a/test/integration/command_formatter_extension_integration_test.cc
+++ b/test/integration/command_formatter_extension_integration_test.cc
@@ -17,6 +17,7 @@ public:
 };
 
 TEST_F(CommandFormatterExtensionIntegrationTest, BasicExtension) {
+  autonomous_upstream_ = true;
   TestCommandFactory factory;
   Registry::InjectFactory<CommandParserFactory> command_register(factory);
   std::vector<envoy::config::core::v3::TypedExtensionConfig> formatters;

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -533,13 +533,13 @@ TEST_P(HttpTimeoutIntegrationTest, RequestHeaderTimeout) {
       });
 
   while (!connection_driver->allBytesSent()) {
-    connection_driver->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection_driver->run(Event::Dispatcher::RunType::NonBlock));
   }
   test_server_->waitForGaugeGe("http.config_test.downstream_rq_active", 1);
   ASSERT_FALSE(connection_driver->closed());
 
   timeSystem().advanceTimeWait(std::chrono::milliseconds(1001));
-  connection_driver->run();
+  ASSERT_TRUE(connection_driver->run());
 
   // The upstream should send a 40x response and send a local reply.
   EXPECT_TRUE(connection_driver->closed());

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -12,6 +12,7 @@ namespace {
 class IdleTimeoutIntegrationTest : public HttpProtocolIntegrationTest {
 public:
   void initialize() override {
+    config_helper_.disableDelayClose();
     useAccessLog("%RESPONSE_CODE_DETAILS%");
     config_helper_.addConfigModifier(
         [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -717,6 +717,7 @@ TEST_P(IntegrationTest, UpstreamDisconnectWithTwoRequests) {
 }
 
 TEST_P(IntegrationTest, TestSmuggling) {
+  config_helper_.disableDelayClose();
   initialize();
 
   // Make sure the http parser rejects having content-length and transfer-encoding: chunked
@@ -1106,13 +1107,13 @@ TEST_P(IntegrationTest, Pipeline) {
       });
   // First response should be success.
   while (response.find("200") == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
   EXPECT_THAT(response, StartsWith("HTTP/1.1 200 OK\r\n"));
 
   // Second response should be 400 (no host)
   while (response.find("400") == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 400 Bad Request\r\n"));
   connection->close();
@@ -1155,14 +1156,14 @@ TEST_P(IntegrationTest, PipelineWithTrailers) {
   // First response should be success.
   size_t pos;
   while ((pos = response.find("200")) == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
   EXPECT_THAT(response, StartsWith("HTTP/1.1 200 OK\r\n"));
   while (response.find("200", pos + 1) == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
   while (response.find("400") == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
 
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 400 Bad Request\r\n"));
@@ -1188,12 +1189,12 @@ TEST_P(IntegrationTest, PipelineInline) {
       });
 
   while (response.find("400") == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
   EXPECT_THAT(response, StartsWith("HTTP/1.1 400 Bad Request\r\n"));
 
   while (response.find("426") == std::string::npos) {
-    connection->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(connection->run(Event::Dispatcher::RunType::NonBlock));
   }
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 426 Upgrade Required\r\n"));
   connection->close();

--- a/test/integration/original_ip_detection_integration_test.cc
+++ b/test/integration/original_ip_detection_integration_test.cc
@@ -18,6 +18,7 @@ public:
   OriginalIPDetectionIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
 
   void runTest(const std::string& ip) {
+    autonomous_upstream_ = true;
     useAccessLog("%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%");
     config_helper_.addConfigModifier(
         [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3466,6 +3466,7 @@ TEST_P(ProtocolIntegrationTest, UpstreamDisconnectBeforeResponseCompleteWireByte
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, BadRequest) {
+  config_helper_.disableDelayClose();
   // we only care about upstream protocol.
   if (downstreamProtocol() != Http::CodecType::HTTP1) {
     return;

--- a/test/integration/socket_interface_integration_test.cc
+++ b/test/integration/socket_interface_integration_test.cc
@@ -61,7 +61,7 @@ TEST_P(SocketInterfaceIntegrationTest, Basic) {
         response.append(data.toString());
         conn.close(Network::ConnectionCloseType::FlushWrite);
       });
-  connection->run();
+  ASSERT_TRUE(connection->run());
   EXPECT_EQ("hello", response);
 }
 

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -267,12 +267,14 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, DoWriteCallback write_re
     : dispatcher_(dispatcher), remaining_bytes_to_send_(0) {
   api_ = Api::createApiForTest(stats_store_);
   Event::GlobalTimeSystem time_system;
-  callbacks_ = std::make_unique<ConnectionCallbacks>([this, write_request_callback]() {
-    Buffer::OwnedImpl buffer;
-    const bool close_after = write_request_callback(buffer);
-    remaining_bytes_to_send_ += buffer.length();
-    client_->write(buffer, close_after);
-  });
+  callbacks_ = std::make_unique<ConnectionCallbacks>(
+      [this, write_request_callback]() {
+        Buffer::OwnedImpl buffer;
+        const bool close_after = write_request_callback(buffer);
+        remaining_bytes_to_send_ += buffer.length();
+        client_->write(buffer, close_after);
+      },
+      dispatcher);
 
   if (transport_socket == nullptr) {
     transport_socket = Network::Test::createRawBufferSocket();
@@ -307,7 +309,19 @@ void RawConnectionDriver::waitForConnection() {
   }
 }
 
-void RawConnectionDriver::run(Event::Dispatcher::RunType run_type) { dispatcher_.run(run_type); }
+testing::AssertionResult RawConnectionDriver::run(Event::Dispatcher::RunType run_type,
+                                                  std::chrono::milliseconds timeout) {
+  Event::TimerPtr timeout_timer = dispatcher_.createTimer([this]() -> void { dispatcher_.exit(); });
+  timeout_timer->enableTimer(timeout);
+
+  dispatcher_.run(run_type);
+
+  if (timeout_timer->enabled()) {
+    timeout_timer->disableTimer();
+    return testing::AssertionSuccess();
+  }
+  return testing::AssertionFailure();
+}
 
 void RawConnectionDriver::close() { client_->close(Network::ConnectionCloseType::FlushWrite); }
 

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -19,6 +19,7 @@
 
 #include "test/test_common/printers.h"
 #include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -85,7 +86,9 @@ public:
                       Network::TransportSocketPtr transport_socket = nullptr);
   ~RawConnectionDriver();
   const Network::Connection& connection() { return *client_; }
-  void run(Event::Dispatcher::RunType run_type = Event::Dispatcher::RunType::Block);
+  testing::AssertionResult
+  run(Event::Dispatcher::RunType run_type = Event::Dispatcher::RunType::Block,
+      std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
   void close();
   Network::ConnectionEvent lastConnectionEvent() const {
     return callbacks_->last_connection_event_;
@@ -115,7 +118,8 @@ private:
   struct ConnectionCallbacks : public Network::ConnectionCallbacks {
     using WriteCb = std::function<void()>;
 
-    ConnectionCallbacks(WriteCb write_cb) : write_cb_(write_cb) {}
+    ConnectionCallbacks(WriteCb write_cb, Event::Dispatcher& dispatcher)
+        : write_cb_(write_cb), dispatcher_(dispatcher) {}
     bool connected() const { return connected_; }
     bool closed() const { return closed_; }
 
@@ -124,11 +128,15 @@ private:
       if (!connected_ && event == Network::ConnectionEvent::Connected) {
         write_cb_();
       }
-
       last_connection_event_ = event;
+
       closed_ |= (event == Network::ConnectionEvent::RemoteClose ||
                   event == Network::ConnectionEvent::LocalClose);
       connected_ |= (event == Network::ConnectionEvent::Connected);
+
+      if (closed_) {
+        dispatcher_.exit();
+      }
     }
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override { write_cb_(); }
@@ -137,6 +145,7 @@ private:
 
   private:
     WriteCb write_cb_;
+    Event::Dispatcher& dispatcher_;
     bool connected_{false};
     bool closed_{false};
   };

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -220,7 +220,7 @@ TEST_P(LdsInplaceUpdateTcpProxyIntegrationTest, ReloadConfigDeletingFilterChain)
 
   ASSERT_TRUE(fake_upstream_connection_0->write("world"));
   while (response_0.find("world") == std::string::npos) {
-    client_conn_0->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(client_conn_0->run(Event::Dispatcher::RunType::NonBlock));
   }
   client_conn_0->close();
   while (!client_conn_0->closed()) {
@@ -266,7 +266,7 @@ TEST_P(LdsInplaceUpdateTcpProxyIntegrationTest, ReloadConfigAddingFilterChain) {
 
   ASSERT_TRUE(fake_upstream_connection_2->write("world2"));
   while (response_2.find("world2") == std::string::npos) {
-    client_conn_2->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(client_conn_2->run(Event::Dispatcher::RunType::NonBlock));
   }
   client_conn_2->close();
   while (!client_conn_2->closed()) {
@@ -279,7 +279,7 @@ TEST_P(LdsInplaceUpdateTcpProxyIntegrationTest, ReloadConfigAddingFilterChain) {
 
   ASSERT_TRUE(fake_upstream_connection_0->write("world"));
   while (response_0.find("world") == std::string::npos) {
-    client_conn_0->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(client_conn_0->run(Event::Dispatcher::RunType::NonBlock));
   }
   client_conn_0->close();
   while (!client_conn_0->closed()) {
@@ -550,6 +550,7 @@ INSTANTIATE_TEST_SUITE_P(Protocols, LdsIntegrationTest,
 
 // Sample test making sure our config framework correctly reloads listeners.
 TEST_P(LdsIntegrationTest, ReloadConfig) {
+  config_helper_.disableDelayClose();
   autonomous_upstream_ = true;
   initialize();
   // Given we're using LDS in this test, initialize() will not complete until
@@ -669,7 +670,7 @@ TEST_P(LdsStsIntegrationTest, TcpListenerRemoveFilterChainCalledAfterListenerIsR
 
   ASSERT_TRUE(fake_upstream_connection_0->write("world"));
   while (response_0.find("world") == std::string::npos) {
-    client_conn_0->run(Event::Dispatcher::RunType::NonBlock);
+    ASSERT_TRUE(client_conn_0->run(Event::Dispatcher::RunType::NonBlock));
   }
   client_conn_0->close();
   while (!client_conn_0->closed()) {


### PR DESCRIPTION
Follow up on https://github.com/envoyproxy/envoy/pull/20468 to future-proof against slow tests, by adding a default timeout to the raw connection driver
This caught a whole bunch of tests which were waiting 15s for delay close.

Risk Level: n/a (test only)
Testing: CI