### PR TITLE
router: inject tracing context in the upstream request

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -652,9 +652,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
-  // Inject the active span's tracing context into the request headers.
-  callbacks_->activeSpan().injectContext(headers);
-
   route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
                                        !config_.suppress_envoy_headers_);
   FilterUtility::setUpstreamScheme(

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -486,6 +486,10 @@ void UpstreamRequest::onPoolReady(
 
   if (span_ != nullptr) {
     span_->injectContext(*parent_.downstreamHeaders());
+  } else {
+    // No independent child span for current upstream request then inject the parent span's tracing
+    // context into the request headers.
+    parent_.callbacks()->activeSpan().injectContext(*parent_.downstreamHeaders());
   }
 
   upstreamTiming().onFirstUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -489,6 +489,7 @@ void UpstreamRequest::onPoolReady(
   } else {
     // No independent child span for current upstream request then inject the parent span's tracing
     // context into the request headers.
+    // The injectContext() of the parent span may be called repeatedly when the request is retried.
     parent_.callbacks()->activeSpan().injectContext(*parent_.downstreamHeaders());
   }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -412,7 +412,6 @@ TEST_F(RouterTest, Http1Upstream) {
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.route_->route_entry_, finalizeRequestHeaders(_, _, true));
-  EXPECT_CALL(span_, injectContext(_));
   router_.decodeHeaders(headers, true);
   EXPECT_EQ("10", headers.get_("x-envoy-expected-rq-timeout-ms"));
 
@@ -432,7 +431,6 @@ TEST_F(RouterTest, Http2Upstream) {
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  EXPECT_CALL(span_, injectContext(_));
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
@@ -739,7 +737,6 @@ TEST_F(RouterTest, MaintenanceMode) {
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow));
-  EXPECT_CALL(span_, injectContext(_)).Times(0);
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -4556,7 +4553,6 @@ TEST_F(RouterTest, DirectResponse) {
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
-  EXPECT_CALL(span_, injectContext(_)).Times(0);
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, true);
@@ -4606,7 +4602,6 @@ TEST_F(RouterTest, DirectResponseWithLocation) {
   Http::TestResponseHeaderMapImpl response_headers{{":status", "201"},
                                                    {"location", "http://host/"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
-  EXPECT_CALL(span_, injectContext(_)).Times(0);
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, true);
@@ -4630,7 +4625,6 @@ TEST_F(RouterTest, DirectResponseWithoutLocation) {
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
-  EXPECT_CALL(span_, injectContext(_)).Times(0);
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, true);
@@ -5653,7 +5647,6 @@ TEST_F(RouterTest, ApplicationProtocols) {
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  EXPECT_CALL(span_, injectContext(_));
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.


### PR DESCRIPTION
Commit Message: router: inject tracing context in the upstream request
Additional Description: 

Move tracing context injecting to upstream request. We can reduce some unnecessary injectings by this way. And in the future, we can provide some more upstream infos (for example, upstream host) to `injectContext` call.

Risk Level: Low.
Testing: Unit.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.