### PR TITLE
[1.21] Backport #20408 cryptomb: remove PKCS1_5 padding support.

### DIFF
--- a/contrib/cryptomb/private_key_providers/test/ops_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/ops_test.cc
@@ -133,34 +133,13 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaSigning) {
 }
 
 TEST_F(CryptoMbProviderRsaTest, TestRsaPkcs1Signing) {
-  // Initialize connections.
-  TestCallbacks cbs[CryptoMbQueue::MULTIBUFF_BATCH];
-  std::vector<std::unique_ptr<CryptoMbPrivateKeyConnection>> connections;
-  for (auto& cb : cbs) {
-    connections.push_back(std::make_unique<CryptoMbPrivateKeyConnection>(
-        cb, *dispatcher_, bssl::UpRef(pkey_), queue_));
-  }
+  // PKCS #1 v1.5 is not supported.
+  TestCallbacks cb;
+  CryptoMbPrivateKeyConnection op(cb, *dispatcher_, bssl::UpRef(pkey_), queue_);
 
-  // Create MULTIBUFF_BATCH amount of signing operations.
-  for (uint32_t i = 0; i < CryptoMbQueue::MULTIBUFF_BATCH; i++) {
-    // Create request.
-    res_ = rsaPrivateKeySignForTest(connections[i].get(), nullptr, nullptr, max_out_len_,
-                                    SSL_SIGN_RSA_PKCS1_SHA256, in_, in_len_);
-    EXPECT_EQ(res_, ssl_private_key_retry);
-
-    // No processing done after first requests.
-    // After the last request, the status is set only from the event loop which is not run. This
-    // should still be "retry", the cryptographic result is present anyway.
-    res_ = privateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
-    EXPECT_EQ(res_, ssl_private_key_retry);
-  }
-
-  // Timeout does not have to be triggered when queue is at maximum size.
-  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
-  EXPECT_EQ(res_, ssl_private_key_success);
-  EXPECT_NE(out_len_, 0);
+  res_ = rsaPrivateKeySignForTest(&op, nullptr, nullptr, max_out_len_, SSL_SIGN_RSA_PKCS1_SHA256,
+                                  in_, in_len_);
+  EXPECT_EQ(res_, ssl_private_key_failure);
 }
 
 TEST_F(CryptoMbProviderRsaTest, TestRsaPssSigning) {
@@ -279,7 +258,7 @@ TEST_F(CryptoMbProviderRsaTest, TestRSATimer) {
 
   // Successful operation with timer.
   CryptoMbPrivateKeyConnection op0(cbs[0], *dispatcher_, bssl::UpRef(pkey_), queue_);
-  res_ = rsaPrivateKeySignForTest(&op0, nullptr, nullptr, max_out_len_, SSL_SIGN_RSA_PKCS1_SHA256,
+  res_ = rsaPrivateKeySignForTest(&op0, nullptr, nullptr, max_out_len_, SSL_SIGN_RSA_PSS_SHA256,
                                   in_, in_len_);
   EXPECT_EQ(res_, ssl_private_key_retry);
 
@@ -300,7 +279,7 @@ TEST_F(CryptoMbProviderRsaTest, TestRSATimer) {
 
   CryptoMbPrivateKeyConnection op1(cbs[1], *dispatcher_, bssl::UpRef(pkey_), queue_);
 
-  res_ = rsaPrivateKeySignForTest(&op1, nullptr, nullptr, max_out_len_, SSL_SIGN_RSA_PKCS1_SHA256,
+  res_ = rsaPrivateKeySignForTest(&op1, nullptr, nullptr, max_out_len_, SSL_SIGN_RSA_PSS_SHA256,
                                   in_, in_len_);
   EXPECT_EQ(res_, ssl_private_key_retry);
 
@@ -329,7 +308,7 @@ TEST_F(CryptoMbProviderRsaTest, TestRSAQueueSizeStatistics) {
     // Create correct amount of signing operations for current index.
     for (uint32_t j = 0; j < i; j++) {
       res_ = rsaPrivateKeySignForTest(connections[j].get(), nullptr, nullptr, max_out_len_,
-                                      SSL_SIGN_RSA_PKCS1_SHA256, in_, in_len_);
+                                      SSL_SIGN_RSA_PSS_SHA256, in_, in_len_);
       EXPECT_EQ(res_, ssl_private_key_retry);
     }
 
@@ -352,7 +331,7 @@ TEST_F(CryptoMbProviderRsaTest, TestRSAQueueSizeStatistics) {
   // Create an amount of signing operations equal to maximum queue size.
   for (uint32_t j = 0; j < CryptoMbQueue::MULTIBUFF_BATCH; j++) {
     res_ = rsaPrivateKeySignForTest(connections[j].get(), nullptr, nullptr, max_out_len_,
-                                    SSL_SIGN_RSA_PKCS1_SHA256, in_, in_len_);
+                                    SSL_SIGN_RSA_PSS_SHA256, in_, in_len_);
     EXPECT_EQ(res_, ssl_private_key_retry);
   }
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -10,6 +10,7 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* cryptomb: remove RSA PKCS1 v1.5 padding support.
 * perf: ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
 
 Bug Fixes


### PR DESCRIPTION
Backport: cryptomb: remove PKCS1_5 padding support (https://github.com/envoyproxy/envoy/pull/20408)

Additional Description: Drop RSA signing PKCS1 v1.5 padding support (which wasn't functional).
Risk Level: low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: CryptoMB extension works on 3rd Gen Intel Xeon Scalable processors.
