### PR TITLE
bazel: enable rules_foreign_cc vendored tools

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,10 +21,10 @@ build --tool_java_runtime_version=remotejdk_11
 build --platform_mappings=bazel/platform_mappings
 
 # Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
-build --action_env=CC
-build --action_env=CXX
-build --action_env=LLVM_CONFIG
-build --action_env=PATH
+build --action_env=CC --host_action_env=CC
+build --action_env=CXX --host_action_env=CXX
+build --action_env=LLVM_CONFIG --host_action_env=LLVM_CONFIG
+build --action_env=PATH --host_action_env=PATH
 
 build --enable_platform_specific_config
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -52,12 +52,8 @@ for how to update or override dependencies.
     ```console
     sudo apt-get install \
        autoconf \
-       automake \
-       cmake \
        curl \
        libtool \
-       make \
-       ninja-build \
        patch \
        python3-pip \
        unzip \
@@ -69,13 +65,11 @@ for how to update or override dependencies.
     ```console
     dnf install \
         aspell-en \
-        cmake \
         libatomic \
         libstdc++ \
         libstdc++-static \
         libtool \
         lld \
-        ninja-build \
         patch \
         python3-pip
     ```
@@ -105,7 +99,7 @@ for how to update or override dependencies.
     ### macOS
     On macOS, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):
     ```console
-    brew install coreutils wget cmake libtool go bazel automake ninja clang-format autoconf aspell
+    brew install coreutils wget libtool go bazel clang-format autoconf aspell
     ```
     _notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`
 
@@ -201,15 +195,6 @@ for how to update or override dependencies.
     ```
 
     The Windows SDK contains header files and libraries you need when building Windows applications. Bazel always uses the latest, but you can specify a different version by setting the environment variable `BAZEL_WINSDK_FULL_VERSION`. See [bazel/windows](https://docs.bazel.build/versions/master/windows.html)
-
-    Ensure `CMake` and `ninja` binaries are on the PATH. The versions packaged with VC++ Build
-    Tools are sufficient in most cases, but are 32 bit binaries. These flavors will not run in
-    the project's GCP CI remote build environment, so 64 bit builds from the CMake and ninja
-    projects are used instead.
-    ```cmd
-    set PATH=%USERPROFILE%\VSBT2019\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;%PATH%
-    set PATH=%USERPROFILE%\VSBT2019\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%PATH%
-    ```
 
     [MSYS2 shell](https://msys2.github.io/): Install to a path with no spaces, e.g. C:\msys64.
 

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -15,8 +15,7 @@ load("@emsdk//:emscripten_deps.bzl", "emscripten_deps")
 GO_VERSION = "1.17.5"
 
 def envoy_dependency_imports(go_version = GO_VERSION):
-    # TODO: allow building of tools for easier onboarding
-    rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
+    rules_foreign_cc_dependencies()
     go_rules_dependencies()
     go_register_toolchains(go_version)
     gazelle_dependencies()

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -15,10 +15,10 @@ export PATH
 RT_LIBRARY_PATH="$(dirname "$(find "$(llvm-config --libdir)" -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)")"
 
 echo "# Generated file, do not edit. If you want to disable clang, just delete this file.
-build:clang --action_env='PATH=${PATH}'
-build:clang --action_env=CC=clang
-build:clang --action_env=CXX=clang++
-build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
+build:clang --action_env='PATH=${PATH}' --host_action_env='PATH=${PATH}'
+build:clang --action_env=CC=clang --host_action_env=CC=clang
+build:clang --action_env=CXX=clang++ --host_action_env=CXX=clang++
+build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config' --host_action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --linkopt='-L$(llvm-config --libdir)'
 build:clang --linkopt='-Wl,-rpath,$(llvm-config --libdir)'


### PR DESCRIPTION
This makes it so you don't have to have cmake, make, or ninja installed,
or worry about version issues between them.

Since 0.1.0 rules_foreign_cc has supported vendoring these tools https://github.com/bazelbuild/rules_foreign_cc/releases/tag/0.1.0 and it builds them with cross platform scripts for bootstrapping.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>