### PR TITLE
ci: remove unused variable (NFC)

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -88,9 +88,6 @@ trap cleanup EXIT
 
 [[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=("--nocache_test_results")
 
-# TODO(phlax): deprecate/remove this - i believe it was made redundant here:
-#   https://github.com/envoyproxy/envoy/commit/3ebedeb708a23062332a6fcdf33b462b7070adba#diff-2fa22a1337effee365a51e6844be0ab3
-export BAZEL_QUERY_OPTIONS="${BAZEL_OPTIONS[*]}"
 # Use https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_repository_cache_hardlinks
 # to save disk space.
 BAZEL_BUILD_OPTIONS=(


### PR DESCRIPTION
The last consumer of this was removed in the linked commit

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>