### PR TITLE
clarify xds docs on resource deletion

### DIFF
--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -499,7 +499,7 @@ Deleting Resources
 ^^^^^^^^^^^^^^^^^^
 
 Wildcard Resource Types
-^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""
 In the incremental protocol variants, the server signals the client that a resource should be
 deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.removed_resources>`
 field of the response. This tells the client to remove the resource from its local cache.
@@ -509,7 +509,7 @@ is not present in a new response, that indicates that the resource has been remo
 delete it; a response containing no resources means to delete all resources of that type.
 
 Other Resource Types
-^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""
 In both SotW and incremental protocol variants, deletions are indicated implicitly by parent resources being
 changed to no longer refer to a child resource. For example, when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
 that was previously pointing to :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A,

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -505,9 +505,8 @@ deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3
 field of the response. This tells the client to remove the resource from its local cache.
 
 In the SotW protocol variants, the criteria for deleting is more complex. If a previously seen resource
-is not present in a new response, that indicates that the resource
-has been removed, and the client must delete it; a response containing no resources means to delete
-all resources of that type. 
+is not present in a new response, that indicates that the resource has been removed, and the client must
+delete it; a response containing no resources means to delete all resources of that type. 
 
 Other Resource Types
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -500,14 +500,17 @@ Deleting Resources
 
 In the incremental protocol variants, the server signals the client that a resource should be
 deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.removed_resources>`
-field of the response. This tells the client to remove the resource from its local cache.
+field of the response for wildcard resource types like 
+:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`.
+This tells the client to remove the resource from its local cache.
 
-In the SotW protocol variants, the criteria for deleting resources is more complex. For
-:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource types,
+In the SotW protocol variants, the criteria for deleting resources is more complex. For wildcard resource types like
+:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`
 if a previously seen resource is not present in a new response, that indicates that the resource
 has been removed, and the client must delete it; a response containing no resources means to delete
-all resources of that type. However, for other resource types, the API provides no mechanism for
-the server to tell the client that resources have been deleted; instead, deletions are indicated
+all resources of that type. 
+
+For other resource types, in both SotW and incremental protocol variants, deletions are indicated
 implicitly by parent resources being changed to no longer refer to a child resource. For example,
 when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
 that was previously pointing to :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A,

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -511,9 +511,8 @@ all resources of that type.
 
 Other Resource Types
 ^^^^^^^^^^^^^^^^^^^^
-In both SotW and incremental protocol variants, deletions are indicated
-implicitly by parent resources being changed to no longer refer to a child resource. For example,
-when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
+In both SotW and incremental protocol variants, deletions are indicated implicitly by parent resources being
+changed to no longer refer to a child resource. For example, when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
 that was previously pointing to :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A,
 if no other :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` is pointing to :ref:`RouteConfiguration
 <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A, then the client may delete A. For those resource types,

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -506,7 +506,7 @@ field of the response. This tells the client to remove the resource from its loc
 
 In the SotW protocol variants, the criteria for deleting is more complex. If a previously seen resource
 is not present in a new response, that indicates that the resource has been removed, and the client must
-delete it; a response containing no resources means to delete all resources of that type. 
+delete it; a response containing no resources means to delete all resources of that type.
 
 Other Resource Types
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -498,19 +498,20 @@ twice. Clients should NACK responses that contain multiple instances of the same
 Deleting Resources
 ^^^^^^^^^^^^^^^^^^
 
+Wildcard Resource Types
+^^^^^^^^^^^^^^^^^^^^^^^
 In the incremental protocol variants, the server signals the client that a resource should be
 deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.removed_resources>`
-field of the response for wildcard resource types like
-:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`.
-This tells the client to remove the resource from its local cache.
+field of the response. This tells the client to remove the resource from its local cache.
 
-In the SotW protocol variants, the criteria for deleting resources is more complex. For wildcard resource types like
-:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`
-if a previously seen resource is not present in a new response, that indicates that the resource
+In the SotW protocol variants, the criteria for deleting is more complex. If a previously seen resource
+is not present in a new response, that indicates that the resource
 has been removed, and the client must delete it; a response containing no resources means to delete
 all resources of that type. 
 
-For other resource types, in both SotW and incremental protocol variants, deletions are indicated
+Other Resource Types
+^^^^^^^^^^^^^^^^^^^^
+In both SotW and incremental protocol variants, deletions are indicated
 implicitly by parent resources being changed to no longer refer to a child resource. For example,
 when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
 that was previously pointing to :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A,

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -500,7 +500,7 @@ Deleting Resources
 
 In the incremental protocol variants, the server signals the client that a resource should be
 deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.removed_resources>`
-field of the response for wildcard resource types like 
+field of the response for wildcard resource types like
 :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`.
 This tells the client to remove the resource from its local cache.
 


### PR DESCRIPTION
Commit Message: clarify xds docs on resource deletion
Additional Description: Resource deletion for non wildcard resource types like eds and rds will only happen on parent resource deletion for both Sotw and Incremental variants. This PR clarifies it in doc.
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes:N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
