### PR TITLE
cluster: add new config to restore original dst address from :authority header

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -479,7 +479,7 @@ message Cluster {
     //
     // .. attention::
     //
-    //   The header isn't sanitized by default, so enabling this feature allows HTTP clients to
+    //   This header isn't sanitized by default, so enabling this feature allows HTTP clients to
     //   route traffic to arbitrary hosts and/or ports, which may have serious security
     //   consequences.
     //

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -489,12 +489,8 @@ message Cluster {
     bool use_http_header = 1;
 
     // The http header to override destination address if :ref:`use_http_header <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.use_http_header>`.
-    // is set to true. If no field is specified, :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>`
-    // will be used.
-    oneof http_header_name {
-      // Use the ``:authority`` header to override original dst address.
-      bool use_http_authority = 2;
-    }
+    // is set to true. If the value is empty, :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>` will be used.
+    string http_header_name = 2;
   }
 
   // Common configuration for all load balancer implementations.

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -474,13 +474,12 @@ message Cluster {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.Cluster.OriginalDstLbConfig";
 
-    // When true, :ref:`x-envoy-original-dst-host
-    // <config_http_conn_man_headers_x-envoy-original-dst-host>` can be used to override destination
-    // address.
+    // When true, a HTTP header can be used to override the original dst address. The default header is
+    // :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>`.
     //
     // .. attention::
     //
-    //   This header isn't sanitized by default, so enabling this feature allows HTTP clients to
+    //   The header isn't sanitized by default, so enabling this feature allows HTTP clients to
     //   route traffic to arbitrary hosts and/or ports, which may have serious security
     //   consequences.
     //
@@ -488,6 +487,14 @@ message Cluster {
     //
     //   If the header appears multiple times only the first value is used.
     bool use_http_header = 1;
+
+    // The http header to override destination address if :ref:`use_http_header <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.use_http_header>`.
+    // is set to true. If no field is specified, :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>`
+    // will be used.
+    oneof http_header_name {
+      // Use the ``:authority`` header to override original dst address.
+      bool use_http_authority = 2;
+    }
   }
 
   // Common configuration for all load balancer implementations.

--- a/configs/encapsulate_in_http1_connect.yaml
+++ b/configs/encapsulate_in_http1_connect.yaml
@@ -1,8 +1,13 @@
-# This configuration takes incoming data on port 10000 and encapsulates it in a CONNECT
-# request which is sent upstream port 10001.
+# This configuration takes incoming data on port 10000,10002 and encapsulates it in a CONNECT
+# request which is sent upstream port 10001. The difference is that if the data was from port
+# 10002, Envoy adds a "foo: bar" header in the CONNECT request.
+# Seeing this "foo: bar" header, another Envoy running with the configuration ``terminate_http1_connect.yaml``
+# will terminate the CONNECT request and establish tcp connection to 127.0.0.1:10003.
+#
 # It can be used to test TCP tunneling as described in
 # https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades
-# and running `curl -x 127.0.0.1:10000 https://www.google.com`
+# and running `curl -x 127.0.0.1:10000 https://www.google.com`,
+# or running `curl -H "Host: the-hosted-domain-on-port-10003"  http://127.0.0.1:10002
 
 admin:
   address:
@@ -41,11 +46,12 @@ static_resources:
           stat_prefix: tcp_stats
           cluster: "cluster_0"
           tunneling_config:
+            # The upstream request content would be ``CONNECT 127.0.0.1:10003 HTTP/1.1``.
             hostname: 127.0.0.1:10003
             headers_to_add:
             - header:
-                key: to-original-dst
-                value: "true"
+                key: foo
+                value: bar
   clusters:
   - name: cluster_0
     connect_timeout: 5s

--- a/configs/encapsulate_in_http1_connect.yaml
+++ b/configs/encapsulate_in_http1_connect.yaml
@@ -27,6 +27,25 @@ static_resources:
           cluster: "cluster_0"
           tunneling_config:
             hostname: host.com:443
+  - name: listener_1
+    address:
+      socket_address:
+        protocol: TCP
+        address: 127.0.0.1
+        port_value: 10002
+    filter_chains:
+    - filters:
+      - name: tcp
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: tcp_stats
+          cluster: "cluster_0"
+          tunneling_config:
+            hostname: 127.0.0.1:10003
+            headers_to_add:
+            - header:
+                key: to-original-dst
+                value: "true"
   clusters:
   - name: cluster_0
     connect_timeout: 5s

--- a/configs/terminate_http1_connect.yaml
+++ b/configs/terminate_http1_connect.yaml
@@ -32,6 +32,19 @@ static_resources:
               - match:
                   connect_matcher:
                     {}
+                  headers:
+                    - name: to-original-dst
+                      string_match:
+                        exact: "true"
+                route:
+                  cluster: local_original_dst
+                  upgrade_configs:
+                  - upgrade_type: CONNECT
+                    connect_config:
+                      {}
+              - match:
+                  connect_matcher:
+                    {}
                 route:
                   cluster: service_google
                   upgrade_configs:
@@ -59,3 +72,10 @@ static_resources:
               socket_address:
                 address: www.google.com
                 port_value: 443
+  - name: local_original_dst
+    connect_timeout: 0.25s
+    type: ORIGINAL_DST
+    lb_policy: CLUSTER_PROVIDED
+    original_dst_lb_config:
+      use_http_header: true
+      use_http_authority: true

--- a/configs/terminate_http1_connect.yaml
+++ b/configs/terminate_http1_connect.yaml
@@ -1,7 +1,10 @@
 # This configuration terminates a CONNECT request and sends the CONNECT payload upstream.
 # It can be used to test TCP tunneling as described in
 # https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/upgrades
-# or used to test CONNECT directly, by running `curl -k -v -x 127.0.0.1:10001 https://www.google.com`
+# or used to test CONNECT to domain such as www.google.com, by running `curl -k -v -x 127.0.0.1:10001 https://www.google.com.
+#
+# To test the CONNECT to tcp address 127.0.0.1:10003, run
+# `curl -k -v -x 127.0.0.1:10001 --proxy-header "foo: bar" https://127.0.0.1:10003`.
 admin:
   address:
     socket_address:
@@ -33,9 +36,9 @@ static_resources:
                   connect_matcher:
                     {}
                   headers:
-                    - name: to-original-dst
+                    - name: foo
                       string_match:
-                        exact: "true"
+                        exact: bar
                 route:
                   cluster: local_original_dst
                   upgrade_configs:
@@ -78,4 +81,4 @@ static_resources:
     lb_policy: CLUSTER_PROVIDED
     original_dst_lb_config:
       use_http_header: true
-      use_http_authority: true
+      http_header_name: ":authority"

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -96,6 +96,7 @@ New Features
 * access_log: make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
 * admin: :http:post:`/logging` now accepts ``/logging?paths=name1:level1,name2:level2,...`` to change multiple log levels at once.
 * cluster: added support for per host limits in :ref:`circuit breakers settings <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers>`. Currently only  :ref:`max_connections <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.max_connections>` is supported.
+* cluster: added support to restore original destination address from host header via :ref:`use_http_authority <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.use_http_authority>`.
 * cluster: support :ref:`override host status restriction <envoy_v3_api_field_config.cluster.v3.Cluster.CommonLbConfig.override_host_status>`.
 * config: added new file based xDS configuration via :ref:`path_config_source <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`.
   :ref:`watched_directory <envoy_v3_api_field_config.core.v3.PathConfigSource.watched_directory>` can

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -96,7 +96,7 @@ New Features
 * access_log: make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
 * admin: :http:post:`/logging` now accepts ``/logging?paths=name1:level1,name2:level2,...`` to change multiple log levels at once.
 * cluster: added support for per host limits in :ref:`circuit breakers settings <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers>`. Currently only  :ref:`max_connections <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.max_connections>` is supported.
-* cluster: added support to restore original destination address from host header via :ref:`use_http_authority <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.use_http_authority>`.
+* cluster: added support to restore original destination address from any desired header via setting :ref:`http_header_name <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.http_header_name>`.
 * cluster: support :ref:`override host status restriction <envoy_v3_api_field_config.cluster.v3.Cluster.CommonLbConfig.override_host_status>`.
 * config: added new file based xDS configuration via :ref:`path_config_source <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`.
   :ref:`watched_directory <envoy_v3_api_field_config.core.v3.PathConfigSource.watched_directory>` can

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -117,8 +117,9 @@ OriginalDstCluster::LoadBalancer::createFromLbConfig(
     return nullptr;
   }
   return std::make_unique<OriginalDstCluster::LoadBalancer::OriginalHostProvider>(
-      stats, config->has_use_http_authority() ? Http::Headers::get().Host
-                                              : Http::Headers::get().EnvoyOriginalDstHost);
+      stats, config->http_header_name().empty()
+                 ? Http::Headers::get().EnvoyOriginalDstHost
+                 : Http::LowerCaseString(config->http_header_name()));
 }
 
 OriginalDstCluster::OriginalDstCluster(

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -81,7 +81,7 @@ public:
 
     private:
       ClusterStats& stats_;
-      const Http::LowerCaseString& header_name_;
+      const Http::LowerCaseString header_name_;
     };
 
     static std::unique_ptr<OriginalHostProvider> createFromLbConfig(

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -569,6 +569,65 @@ TEST_F(OriginalDstClusterTest, UseHttpHeaderEnabled) {
       2, TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
 }
 
+// Verify original dst cluster can read from HTTP host header. The corner cases are tested in
+// `UseHttpHeaderEnabled`.
+TEST_F(OriginalDstClusterTest, UseHttpAuthorityHeader) {
+  std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 1.250s
+    type: ORIGINAL_DST
+    lb_policy: CLUSTER_PROVIDED
+    original_dst_lb_config:
+      use_http_header: true
+      use_http_authority: true
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_, _));
+  setupFromYaml(yaml);
+
+  OriginalDstCluster::LoadBalancer lb(cluster_);
+  Event::PostCb post_cb;
+
+  // HTTP header override by ``:authority``.
+  TestLoadBalancerContext lb_context1(nullptr, Http::Headers::get().Host.get(), "127.0.0.1:6666");
+  lb_context1.downstream_headers_->setCopy(Http::Headers::get().EnvoyOriginalDstHost,
+                                           "127.0.0.1:5555");
+
+  EXPECT_CALL(membership_updated_, ready());
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
+  HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
+  post_cb();
+  ASSERT_NE(host1, nullptr);
+  EXPECT_EQ("127.0.0.1:6666", host1->address()->asString());
+}
+
+// Verify clearing ``use_http_header`` disables override from ``:authority``.
+TEST_F(OriginalDstClusterTest, DoNotReadFromHttpAuthorityHeaderUnlessSetUseHttpHeader) {
+  std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 1.250s
+    type: ORIGINAL_DST
+    lb_policy: CLUSTER_PROVIDED
+    original_dst_lb_config:
+      use_http_authority: true
+  )EOF";
+
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*cleanup_timer_, enableTimer(_, _));
+  setupFromYaml(yaml);
+
+  OriginalDstCluster::LoadBalancer lb(cluster_);
+
+  // HTTP ``:authority`` header override is ignored.
+  TestLoadBalancerContext lb_context1(nullptr, Http::Headers::get().Host.get(), "127.0.0.1:6666");
+
+  EXPECT_CALL(membership_updated_, ready()).Times(0);
+  EXPECT_CALL(dispatcher_, post(_)).Times(0);
+  HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
+  ASSERT_EQ(host1, nullptr);
+}
+
 TEST_F(OriginalDstClusterTest, UseHttpHeaderDisabled) {
   std::string yaml = R"EOF(
     name: name


### PR DESCRIPTION
Commit Message:
Add an option in OriginalDstCluster type to override the original dst address by 
host header in load downstream load balance context.

Note that the :authority header is offered in HTTP CONNECT request. 

For example, if a HTTP request is `CONNECT 127.0.0.1:443 HTTP/1.1`
Envoy HTTP conn manager sets :authority to `127.0.0.1:443`. A TCP connection will
be established to this address via an original_dst cluster setting `use_http_authority`.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>
Additional Description:
Risk Level: LOW
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]  part of #16503
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
