### PR TITLE
Add quoting strings to YAML from proto message gen.

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -516,6 +516,7 @@ std::string MessageUtil::getYamlStringFromMessage(const Protobuf::Message& messa
     blockFormat(node);
   }
   YAML::Emitter out;
+  out.SetStringFormat(YAML::EMITTER_MANIP::DoubleQuoted);
   out << node;
   return out.c_str();
 }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -516,7 +516,9 @@ std::string MessageUtil::getYamlStringFromMessage(const Protobuf::Message& messa
     blockFormat(node);
   }
   YAML::Emitter out;
-  out.SetStringFormat(YAML::EMITTER_MANIP::DoubleQuoted);
+  if (!node.IsScalar()) {
+    out.SetStringFormat(YAML::EMITTER_MANIP::DoubleQuoted);
+  }
   out << node;
   return out.c_str();
 }

--- a/test/common/json/json_corpus/clusterfuzz-testcase-minimized-json_fuzz_test-4779322450903040.fuzz
+++ b/test/common/json/json_corpus/clusterfuzz-testcase-minimized-json_fuzz_test-4779322450903040.fuzz
@@ -1,0 +1,5 @@
+    {
+      "eescr%i`tors": [
+        [{"wMMMl": "", "TMMMMVators": "", "TMMMMVatl": "", "VMMMMMMMMe": "Z_r---6932+-1"}]
+      ]
+   } 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1599,13 +1599,15 @@ TEST_F(ProtobufUtilityTest, YamlLoadFromStringFail) {
 TEST_F(ProtobufUtilityTest, GetFlowYamlStringFromMessage) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   bootstrap.set_flags_path("foo");
-  EXPECT_EQ("{flags_path: foo}", MessageUtil::getYamlStringFromMessage(bootstrap, false, false));
+  EXPECT_EQ("{\"flags_path\": \"foo\"}",
+            MessageUtil::getYamlStringFromMessage(bootstrap, false, false));
 }
 
 TEST_F(ProtobufUtilityTest, GetBlockYamlStringFromMessage) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   bootstrap.set_flags_path("foo");
-  EXPECT_EQ("flags_path: foo", MessageUtil::getYamlStringFromMessage(bootstrap, true, false));
+  EXPECT_EQ("\"flags_path\": \"foo\"",
+            MessageUtil::getYamlStringFromMessage(bootstrap, true, false));
 }
 
 TEST_F(ProtobufUtilityTest, GetBlockYamlStringFromRecursiveMessage) {
@@ -1615,12 +1617,12 @@ TEST_F(ProtobufUtilityTest, GetBlockYamlStringFromRecursiveMessage) {
   bootstrap.mutable_static_resources()->add_listeners()->set_name("http");
 
   const std::string expected_yaml = R"EOF(
-node:
+"node":
   {}
-static_resources:
-  listeners:
-    - name: http
-flags_path: foo)EOF";
+"static_resources":
+  "listeners":
+    - "name": "http"
+"flags_path": "foo")EOF";
   EXPECT_EQ(expected_yaml, "\n" + MessageUtil::getYamlStringFromMessage(bootstrap, true, false));
 }
 


### PR DESCRIPTION
Commit Message: Add quoting strings to YAML from proto message gen.
Additional Description:
Some strings in a protobuf message may not be valid in YAML,
like strings containing tabs. Quoting these strings on protobuf
message to YAML as string conversion fixes missunderstandings
of YAML parsers and therefore fuzz-tests.
Risk Level: None
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
