### PR TITLE
chore: remove useless comment for tls key log

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -131,8 +131,6 @@ message TlsKeyLog {
   // The path to save the TLS key log.
   string path = 1 [(validate.rules).string = {min_len: 1}];
 
-  // At least one of src or dst must be specified, or the config will be rejected as invalid.
-
   // The local IP address that will be used to filter the connection which should save the TLS key log
   // If it is not set, any local IP address  will be matched.
   repeated config.core.v3.CidrRange local_address_range = 2;

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -114,6 +114,12 @@ public:
     keylog_local_negative_ = false;
     keylog_remote_negative_ = false;
   }
+  void setNeitherLocalNorRemoteFilter() {
+    keylog_remote_ = false;
+    keylog_local_ = false;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = false;
+  }
   void setNegative() {
     keylog_local_ = true;
     keylog_remote_ = true;
@@ -982,6 +988,21 @@ TEST_P(SslKeyLogTest, SetRemoteFilter) {
 TEST_P(SslKeyLogTest, SetLocalAndRemoteFilter) {
   setLogPath();
   setBothLocalAndRemoteFilter();
+  initialize();
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+  codec_client_ = makeHttpConnection(creator());
+  const Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  auto result = codec_client_->startRequest(request_headers);
+  codec_client_->close();
+  logCheck();
+}
+
+TEST_P(SslKeyLogTest, SetNeitherLocalNorRemoteFilter) {
+  setLogPath();
+  setNeitherLocalNorRemoteFilter();
   initialize();
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: remove useless comment for tls key log
Additional Description: [This comment](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L134) is useless now. It should be [useful during this commit](https://github.com/envoyproxy/envoy/pull/19182/commits/d70fcc4aef9df89bcd1b83c84576796272731f67#r791849206), and [should be remove after this discussion](https://github.com/envoyproxy/envoy/pull/19182/commits/7d806e0c9ecfde5db69be6bbc3e81d121cfcbaf6#r818131121).
Risk Level: Low
Testing: Testing with neither `local_address_range` nor `remote_address_range`
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
