### PR TITLE
Update OutOfOrder test to use new addDefaultHeaders interface

### DIFF
--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -1997,7 +1997,8 @@ TEST_F(HttpFilterTest, OutOfOrder) {
       cluster_name: "ext_proc_server"
   )EOF");
 
-  HttpTestUtility::addDefaultHeaders(request_headers_, "POST");
+  HttpTestUtility::addDefaultHeaders(request_headers_);
+  request_headers_.setMethod("POST");
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_FALSE(last_request_.async_mode());


### PR DESCRIPTION
The addDefaultHeaders function takes a bool as its second argument.
If we want to set the method, we need to do that on the requestHeaders
object itself.

This seems to have been forgotten in
82b1f66df20d9577a24ea632f149481ba2f99edd.

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

Risk Level: N/A
Testing: bazel test //test/extensions/filters/http/ext_proc:filter_test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
