### PR TITLE
[test] Add fake-runtime for fake-upstream implementation

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -727,6 +727,16 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test_library(
+    name = "fake_runtime_loader_lib",
+    hdrs = [
+        "fake_runtime_loader.h",
+    ],
+    deps = [
+        "//envoy/runtime:runtime_interface",
+    ],
+)
+
+envoy_cc_test_library(
     name = "fake_upstream_lib",
     srcs = [
         "fake_upstream.cc",
@@ -735,6 +745,7 @@ envoy_cc_test_library(
         "fake_upstream.h",
     ],
     deps = [
+        ":fake_runtime_loader_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//source/server:listener_manager_lib",
         "//envoy/api:api_interface",

--- a/test/integration/fake_runtime_loader.h
+++ b/test/integration/fake_runtime_loader.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "envoy/runtime/runtime.h"
+
+namespace Envoy {
+
+/**
+ * A fake Runtime Loader that implements some of the functionality of
+ * the runtime loader. This is only meant to be used by FakeUpstream,
+ * and doesn't share any runtime feature values with Envoy's runtime
+ * (see source/common/runtime/runtime_features.h).
+ */
+class FakeRuntimeLoader : public Runtime::Loader {
+public:
+  FakeRuntimeLoader() = default;
+  ~FakeRuntimeLoader() override = default;
+
+  void initialize(Upstream::ClusterManager&) override { snapshot_.clear(); }
+
+  const Runtime::Snapshot& snapshot() override { return snapshot_; }
+
+  Runtime::SnapshotConstSharedPtr threadsafeSnapshot() override {
+    return std::make_shared<const FakeSnapshot>(snapshot_);
+  }
+
+  void mergeValues(const absl::node_hash_map<std::string, std::string>&) override {
+    PANIC("unimplemented");
+  }
+
+  void startRtdsSubscriptions(ReadyCallback) override { PANIC("unimplemented"); }
+
+  Stats::Scope& getRootScope() override { PANIC("not implemented"); }
+
+  void countDeprecatedFeatureUse() const override {}
+
+  class FakeSnapshot : public Runtime::Snapshot {
+  public:
+    FakeSnapshot() = default;
+    FakeSnapshot(const FakeSnapshot& other) { entry_map_ = other.entry_map_; }
+    ~FakeSnapshot() = default;
+
+    bool deprecatedFeatureEnabled(absl::string_view key, bool default_enabled) const override {
+      return getBoolean(key, default_enabled);
+    }
+
+    bool runtimeFeatureEnabled(absl::string_view key) const override {
+      return getBoolean(key, false);
+    }
+
+    bool featureEnabled(absl::string_view key, uint64_t default_value) const override {
+      return getBoolean(key, default_value);
+    }
+
+    bool featureEnabled(absl::string_view key, uint64_t default_value,
+                        uint64_t random_value) const override {
+      return featureEnabled(key, default_value, random_value, 100);
+    }
+
+    bool featureEnabled(absl::string_view key, uint64_t default_value, uint64_t random_value,
+                        uint64_t num_buckets) const override {
+      return random_value % num_buckets < std::min(getInteger(key, default_value), num_buckets);
+    }
+
+    bool featureEnabled(absl::string_view,
+                        const envoy::type::v3::FractionalPercent&) const override {
+      PANIC("not implemented");
+    };
+
+    bool featureEnabled(absl::string_view, const envoy::type::v3::FractionalPercent&,
+                        uint64_t) const override {
+      PANIC("not implemented");
+    }
+
+    Runtime::Snapshot::ConstStringOptRef get(absl::string_view key) const override {
+      if (auto map_it = entry_map_.find(key); map_it != entry_map_.end()) {
+        return map_it->second.raw_string_value_;
+      }
+      return absl::nullopt;
+    }
+
+    uint64_t getInteger(absl::string_view key, uint64_t default_value) const override {
+      if (auto map_it = entry_map_.find(key); map_it != entry_map_.end()) {
+        auto value = map_it->second.uint_value_;
+        if (value.has_value()) {
+          return value.value();
+        }
+      }
+      return default_value;
+    }
+
+    double getDouble(absl::string_view key, double default_value) const override {
+      if (auto map_it = entry_map_.find(key); map_it != entry_map_.end()) {
+        auto value = map_it->second.double_value_;
+        if (value.has_value()) {
+          return value.value();
+        }
+      }
+      return default_value;
+    }
+
+    bool getBoolean(absl::string_view key, bool default_value) const override {
+      if (auto map_it = entry_map_.find(key); map_it != entry_map_.end()) {
+        auto value = map_it->second.bool_value_;
+        if (value.has_value()) {
+          return value.value();
+        }
+      }
+      return default_value;
+    }
+
+    const std::vector<Runtime::Snapshot::OverrideLayerConstPtr>& getLayers() const override {
+      // TODO - Panic
+      return empty_layers_;
+    }
+
+    // Clears the current snapshot.
+    void clear() { entry_map_.clear(); }
+
+  private:
+    Runtime::Snapshot::EntryMap entry_map_;
+    std::vector<Runtime::Snapshot::OverrideLayerConstPtr> empty_layers_;
+  };
+
+private:
+  FakeSnapshot snapshot_;
+};
+
+} // namespace Envoy

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -43,8 +43,8 @@
 
 #include "source/server/active_raw_udp_listener_config.h"
 
+#include "test/integration/fake_runtime_loader.h"
 #include "test/mocks/common.h"
-#include "test/mocks/runtime/mocks.h"
 #include "test/test_common/test_time_system.h"
 #include "test/test_common/utility.h"
 
@@ -852,7 +852,7 @@ private:
   Event::DispatcherPtr dispatcher_;
   Network::ConnectionHandlerPtr handler_;
   std::list<SharedConnectionWrapperPtr> new_connections_ ABSL_GUARDED_BY(lock_);
-  testing::NiceMock<Runtime::MockLoader> runtime_;
+  FakeRuntimeLoader runtime_;
 
   // When a QueuedConnectionWrapper is popped from new_connections_, ownership is transferred to
   // consumed_connections_. This allows later the Connection destruction (when the FakeUpstream is


### PR DESCRIPTION
Commit Message: Add fake-runtime for fake-upstream implementation
Additional Description:
Recent change (#19907) used a RuntimeMock as part of the FakeUpstream.
This caused the H1-fuzz integration test when used in persistent mode to become flaky, as the googletest framework (gmock) and the static allocation of the persistent fuzzer conflicted.
This PR introduces a fake-runtime, that the FakeUpstream can use.
Note that the fake-runtime doesn't share the same runtime settings as the Envoy runtime-features.

Risk Level: Low (tests only)
Testing: Fixed integration tests.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
Fixes #20382

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
