### PR TITLE
Revert "clarify xds docs on resource deletion"

### DIFF
--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -498,20 +498,18 @@ twice. Clients should NACK responses that contain multiple instances of the same
 Deleting Resources
 ^^^^^^^^^^^^^^^^^^
 
-Wildcard Resource Types
-"""""""""""""""""""""""
 In the incremental protocol variants, the server signals the client that a resource should be
 deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.removed_resources>`
 field of the response. This tells the client to remove the resource from its local cache.
 
-In the SotW protocol variants, the criteria for deleting is more complex. If a previously seen resource
-is not present in a new response, that indicates that the resource has been removed, and the client must
-delete it; a response containing no resources means to delete all resources of that type.
-
-Other Resource Types
-""""""""""""""""""""
-In both SotW and incremental protocol variants, deletions are indicated implicitly by parent resources being
-changed to no longer refer to a child resource. For example, when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
+In the SotW protocol variants, the criteria for deleting resources is more complex. For
+:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource types,
+if a previously seen resource is not present in a new response, that indicates that the resource
+has been removed, and the client must delete it; a response containing no resources means to delete
+all resources of that type. However, for other resource types, the API provides no mechanism for
+the server to tell the client that resources have been deleted; instead, deletions are indicated
+implicitly by parent resources being changed to no longer refer to a child resource. For example,
+when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
 that was previously pointing to :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A,
 if no other :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` is pointing to :ref:`RouteConfiguration
 <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A, then the client may delete A. For those resource types,


### PR DESCRIPTION
Reverts envoyproxy/envoy#20523.

The change made in that PR was incorrect.  The incremental protocol variant does explicitly delete resources of all types, not just LDS and CDS.