### PR TITLE
http2: update nghttp2 callback status in onStreamClose callback.

### DIFF
--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -649,10 +649,10 @@ private:
   virtual int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) PURE;
   int onInvalidFrame(int32_t stream_id, int error_code);
   // Pass through invoking with the actual stream.
-  int onStreamClose(int32_t stream_id, uint32_t error_code);
+  Status onStreamClose(int32_t stream_id, uint32_t error_code);
   // Should be invoked directly in buffered onStreamClose scenarios
   // where nghttp2 might have already forgotten about the stream.
-  int onStreamClose(StreamImpl* stream, uint32_t error_code);
+  Status onStreamClose(StreamImpl* stream, uint32_t error_code);
   int onMetadataReceived(int32_t stream_id, const uint8_t* data, size_t len);
   int onMetadataFrameComplete(int32_t stream_id, bool end_metadata);
   // Called iff use_new_codec_wrapper_ is false.


### PR DESCRIPTION
Signed-off-by: Michael Warres <mpw@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: update nghttp2 callback status in onStreamClose callback.
Additional Description: Avoids triggering an assertion failure in the case of an H2 GOAWAY followed by WINDOW_UPDATE.
Risk Level: Low.
Testing: Added integration test
Docs Changes: N/A
Release Notes: none
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
