### PR TITLE
listener: fix tls inspector's maxReadBytes() return type

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -80,7 +80,7 @@ public:
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;
   Network::FilterStatus onData(Network::ListenerFilterBuffer& buffer) override;
-  uint64_t maxReadBytes() const override { return config_->maxClientHelloSize(); }
+  size_t maxReadBytes() const override { return config_->maxClientHelloSize(); }
 
 private:
   ParseState parseClientHello(const void* data, size_t len);


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: listener: fix tls inspector's maxReadBytes() return type
Additional Description:
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: no
