### PR TITLE
contrib-sipproxy: Fix the issue when teardown

### DIFF
--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -61,7 +61,7 @@ class TrafficRoutingAssistantHandler : public TrafficRoutingAssistant::RequestCa
                                        public Logger::Loggable<Logger::Id::filter> {
 public:
   TrafficRoutingAssistantHandler(
-      ConnectionManager& parent,
+      ConnectionManager& parent, Event::Dispatcher& dispatcher,
       const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
 

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -45,7 +45,6 @@ RouteConstSharedPtr GeneralRouteEntryImpl::matches(MessageMetadata& metadata) co
   absl::string_view header = "";
   // Default is route
   HeaderType type = HeaderType::Route;
-  absl::string_view domain = "";
 
   if (domain_.empty()) {
     return nullptr;
@@ -85,7 +84,7 @@ RouteConstSharedPtr GeneralRouteEntryImpl::matches(MessageMetadata& metadata) co
     return clusterEntry(metadata);
   }
 
-  domain = metadata.getDomainFromHeaderParameter(header, parameter_);
+  auto domain = metadata.getDomainFromHeaderParameter(header, parameter_);
 
   if (domain_ == domain) {
     ENVOY_LOG(trace, "Route matched with header: {}, parameter: {} and domain: {}", header_,

--- a/contrib/sip_proxy/filters/network/source/tra/BUILD
+++ b/contrib/sip_proxy/filters/network/source/tra/BUILD
@@ -20,6 +20,7 @@ envoy_cc_contrib_extension(
         "//envoy/server:filter_config_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:linked_object",
         "//source/common/common:minimal_logger_lib",
         "//source/common/grpc:typed_async_client_lib",
         "//source/common/http:headers_lib",

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -48,11 +48,6 @@ public:
   virtual ~Client() = default;
 
   virtual void setRequestCallbacks(RequestCallbacks& callbacks) PURE;
-
-  virtual void cancel() PURE;
-
-  virtual void closeStream() PURE;
-
   virtual void createTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
       Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -21,41 +21,25 @@ namespace SipProxy {
 namespace TrafficRoutingAssistant {
 
 GrpcClientImpl::GrpcClientImpl(const Grpc::RawAsyncClientSharedPtr& async_client,
+                               Event::Dispatcher& dispatcher,
                                const absl::optional<std::chrono::milliseconds>& timeout)
-    : async_client_(async_client), timeout_(timeout) {}
+    : async_client_(async_client), dispatcher_(dispatcher), timeout_(timeout) {}
 
 GrpcClientImpl::~GrpcClientImpl() {
-  // Avoid to call virtual functions during destruction
-  // error: Call to virtual method 'GrpcClientImpl::cancel' during destruction bypasses virtual
-  // dispatch [clang-analyzer-optin.cplusplus.VirtualCall,-warnings-as-errors]
-  if (request_) {
-    request_->cancel();
+  while (!request_callbacks_.empty()) {
+    request_callbacks_.front()->request_->cancel();
+    request_callbacks_.front()->cleanup();
   }
 
-  if (stream_ != nullptr) {
-    stream_.resetStream();
+  while (!stream_callbacks_.empty()) {
+    stream_callbacks_.front()->stream_.resetStream();
+    stream_callbacks_.front()->cleanup();
   }
 }
 
 void GrpcClientImpl::setRequestCallbacks(RequestCallbacks& callbacks) {
   // ASSERT(callbacks_ == nullptr);
   callbacks_ = &callbacks;
-}
-
-void GrpcClientImpl::cancel() {
-  ASSERT(callbacks_ != nullptr);
-  if (request_) {
-    request_->cancel();
-    request_ = nullptr;
-  }
-  // callbacks_ = nullptr;
-}
-
-void GrpcClientImpl::closeStream() {
-  ASSERT(callbacks_ != nullptr);
-  if (stream_ != nullptr) {
-    stream_.closeStream();
-  }
 }
 
 void GrpcClientImpl::createTrafficRoutingAssistant(
@@ -71,10 +55,13 @@ void GrpcClientImpl::createTrafficRoutingAssistant(
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Create");
-  request_ =
-      async_client_->send(service_method, request, *this, parent_span,
+
+  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
+  callback->request_ =
+      async_client_->send(service_method, request, *callback, parent_span,
                           Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
                               Http::AsyncClient::ParentContext{&stream_info}));
+  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
 }
 
 void GrpcClientImpl::updateTrafficRoutingAssistant(
@@ -89,10 +76,12 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Update");
-  request_ =
-      async_client_->send(service_method, request, *this, parent_span,
+  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
+  callback->request_ =
+      async_client_->send(service_method, request, *callback, parent_span,
                           Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
                               Http::AsyncClient::ParentContext{&stream_info}));
+  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
 }
 
 void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
@@ -106,10 +95,12 @@ void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Retrieve");
-  request_ =
-      async_client_->send(service_method, request, *this, parent_span,
+  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
+  callback->request_ =
+      async_client_->send(service_method, request, *callback, parent_span,
                           Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
                               Http::AsyncClient::ParentContext{&stream_info}));
+  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
 }
 
 void GrpcClientImpl::deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
@@ -122,10 +113,12 @@ void GrpcClientImpl::deleteTrafficRoutingAssistant(const std::string& type, cons
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Delete");
-  request_ =
-      async_client_->send(service_method, request, *this, parent_span,
+  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
+  callback->request_ =
+      async_client_->send(service_method, request, *callback, parent_span,
                           Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
                               Http::AsyncClient::ParentContext{&stream_info}));
+  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
 }
 
 void GrpcClientImpl::subscribeTrafficRoutingAssistant(const std::string& type,
@@ -139,11 +132,12 @@ void GrpcClientImpl::subscribeTrafficRoutingAssistant(const std::string& type,
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Subscribe");
-  //"contrib.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Subscribe");
-  stream_ = async_client_->start(service_method, *this,
-                                 Http::AsyncClient::StreamOptions().setParentContext(
-                                     Http::AsyncClient::ParentContext{&stream_info}));
-  stream_.sendMessage(request, false);
+  std::unique_ptr<AsyncStreamCallbacks> callback = std::make_unique<AsyncStreamCallbacks>(*this);
+  callback->stream_ = async_client_->start(service_method, *callback,
+                                           Http::AsyncClient::StreamOptions().setParentContext(
+                                               Http::AsyncClient::ParentContext{&stream_info}));
+  callback->stream_.sendMessage(request, false);
+  LinkedList::moveIntoList(std::move(callback), stream_callbacks_);
 }
 
 void GrpcClientImpl::onSuccess(
@@ -182,7 +176,7 @@ void GrpcClientImpl::onReceiveMessage(
   // callbacks_ = nullptr;
 }
 
-ClientPtr traClient(Server::Configuration::FactoryContext& context,
+ClientPtr traClient(Event::Dispatcher& dispatcher, Server::Configuration::FactoryContext& context,
                     const envoy::config::core::v3::GrpcService& grpc_service,
                     const std::chrono::milliseconds timeout) {
   // TODO(ramaraochavali): register client to singleton when GrpcClientImpl supports concurrent
@@ -190,7 +184,7 @@ ClientPtr traClient(Server::Configuration::FactoryContext& context,
   return std::make_unique<SipProxy::TrafficRoutingAssistant::GrpcClientImpl>(
       context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
           grpc_service, context.scope(), true, Grpc::CacheOption::CacheWhenRuntimeEnabled),
-      timeout);
+      dispatcher, timeout);
 }
 
 } // namespace TrafficRoutingAssistant

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -91,10 +91,10 @@ MockRoute::~MockRoute() = default;
 MockConnectionManager::~MockConnectionManager() = default;
 
 MockTrafficRoutingAssistantHandler::MockTrafficRoutingAssistantHandler(
-    ConnectionManager& parent,
+    ConnectionManager& parent, Event::Dispatcher& dispatcher,
     const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
     Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info)
-    : TrafficRoutingAssistantHandler(parent, config, context, stream_info) {
+    : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {
   ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _))
       .WillByDefault(
           Invoke([&](const std::string&, const std::string&, SipFilters::DecoderFilterCallbacks&,

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -187,7 +187,7 @@ public:
 class MockTrafficRoutingAssistantHandler : public TrafficRoutingAssistantHandler {
 public:
   MockTrafficRoutingAssistantHandler(
-      ConnectionManager& parent,
+      ConnectionManager& parent, Event::Dispatcher& dispatcher,
       const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
@@ -223,10 +223,10 @@ public:
 class MockTrafficRoutingAssistantHandlerDeep : public TrafficRoutingAssistantHandler {
 public:
   MockTrafficRoutingAssistantHandlerDeep(
-      ConnectionManager& parent,
+      ConnectionManager& parent, Event::Dispatcher& dispatcher,
       const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info)
-      : TrafficRoutingAssistantHandler(parent, config, context, stream_info) {}
+      : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {}
   MOCK_METHOD(TrafficRoutingAssistant::ClientPtr&, traClient, (), (override));
 };
 

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -119,7 +119,8 @@ public:
 
     EXPECT_CALL(*filter_, settings()).WillRepeatedly(Return(sip_settings_));
     tra_handler_ = std::make_shared<NiceMock<SipProxy::MockTrafficRoutingAssistantHandler>>(
-        *filter_, sip_proxy_config_.settings().tra_service_config(), context_, stream_info);
+        *filter_, dispatcher_, sip_proxy_config_.settings().tra_service_config(), context_,
+        stream_info);
   }
 
   void initializeRouter() {


### PR DESCRIPTION
When their are more than one TRA subscribe actions, stream_ maybe
overwrited which cause the last connection can't be resetted gracefully.
so introduce a list of stream_callbacks and request_callbacks.

Signed-off-by: Felix Du <durd07@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: contrib-sipproxy: Fix the coredump when teardown
Additional Description: When their are more than one TRA subscribe actions, stream_ maybe                                                                                                                               overwrited which cause the last connection can't be resetted gracefully.                                                                                                                        so introduce a list of stream_callbacks and request_callbacks to fix it.  
Risk Level: Low
Testing: unit test/integrated test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
