### PR TITLE
upate filter config provider to return reference wrapper of filter factory cb

### DIFF
--- a/envoy/config/extension_config_provider.h
+++ b/envoy/config/extension_config_provider.h
@@ -32,7 +32,7 @@ public:
    * callback is the latest version of the extension configuration, and should
    * generally apply only to new requests and connections.
    */
-  virtual absl::optional<FactoryCallback> config() PURE;
+  virtual absl::optional<std::reference_wrapper<FactoryCallback>> config() PURE;
 };
 
 class DynamicExtensionConfigProviderBase {

--- a/envoy/config/extension_config_provider.h
+++ b/envoy/config/extension_config_provider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/optref.h"
 #include "envoy/common/pure.h"
 
 #include "source/common/protobuf/protobuf.h"
@@ -32,7 +33,7 @@ public:
    * callback is the latest version of the extension configuration, and should
    * generally apply only to new requests and connections.
    */
-  virtual absl::optional<std::reference_wrapper<FactoryCallback>> config() PURE;
+  virtual OptRef<FactoryCallback> config() PURE;
 };
 
 class DynamicExtensionConfigProviderBase {

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -94,7 +94,12 @@ public:
 
   // Config::ExtensionConfigProvider
   const std::string& name() override { return DynamicFilterConfigProviderImplBase::name(); }
-  absl::optional<FactoryCb> config() override { return tls_->config_; }
+  absl::optional<std::reference_wrapper<FactoryCb>> config() override {
+    if (auto& optional_config = tls_->config_; optional_config.has_value()) {
+      return std::ref<FactoryCb>(optional_config.value());
+    }
+    return absl::nullopt;
+  }
 
   // Config::DynamicExtensionConfigProviderBase
   void onConfigUpdate(const Protobuf::Message& message, const std::string&,
@@ -269,7 +274,9 @@ public:
 
   // Config::ExtensionConfigProvider
   const std::string& name() override { return filter_config_name_; }
-  absl::optional<FactoryCb> config() override { return config_; }
+  absl::optional<std::reference_wrapper<FactoryCb>> config() override {
+    return std::ref<FactoryCb>(config_);
+  }
 
 private:
   FactoryCb config_;

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -94,11 +94,11 @@ public:
 
   // Config::ExtensionConfigProvider
   const std::string& name() override { return DynamicFilterConfigProviderImplBase::name(); }
-  absl::optional<std::reference_wrapper<FactoryCb>> config() override {
+  OptRef<FactoryCb> config() override {
     if (auto& optional_config = tls_->config_; optional_config.has_value()) {
-      return std::ref<FactoryCb>(optional_config.value());
+      return optional_config.value();
     }
-    return absl::nullopt;
+    return {};
   }
 
   // Config::DynamicExtensionConfigProviderBase
@@ -274,9 +274,7 @@ public:
 
   // Config::ExtensionConfigProvider
   const std::string& name() override { return filter_config_name_; }
-  absl::optional<std::reference_wrapper<FactoryCb>> config() override {
-    return std::ref<FactoryCb>(config_);
-  }
+  OptRef<FactoryCb> config() override { return config_; }
 
 private:
   FactoryCb config_;


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>

Commit Message: upate filter config provider to return reference wrapper of filter factory cb
Additional Description:

In the previous ecds implementation, we will always create a temp copy of `FactoryCb` which results in uncessary memory allocations and atomic operations (copy and destroy shared pointer in the `FactoryCb`).


Risk Level: Low.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.