### PR TITLE
test: moving the tls inspector test to the extension directory

### DIFF
--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -35,7 +35,7 @@ envoy_proto_library(
     name = "tls_inspector_fuzz_test_proto",
     srcs = ["tls_inspector_fuzz_test.proto"],
     deps = [
-        "//test/extensions/filters/listener/common/fuzz:tls_inspector_fuzzer_proto",
+        "//test/extensions/filters/listener/common/fuzz:listener_filter_fuzzer_proto",
         "@envoy_api//envoy/extensions/filters/listener/tls_inspector/v3:pkg",
     ],
 )
@@ -47,7 +47,7 @@ envoy_cc_fuzz_test(
     deps = [
         ":tls_inspector_fuzz_test_proto_cc_proto",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
-        "//test/extensions/filters/listener/common/fuzz:tls_inspector_fuzzer_lib",
+        "//test/extensions/filters/listener/common/fuzz:listener_filter_fuzzer_lib",
     ],
 )
 

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -35,7 +35,7 @@ envoy_proto_library(
     name = "tls_inspector_fuzz_test_proto",
     srcs = ["tls_inspector_fuzz_test.proto"],
     deps = [
-        "//test/extensions/filters/listener/common/fuzz:listener_filter_fuzzer_proto",
+        "//test/extensions/filters/listener/common/fuzz:tls_inspector_fuzzer_proto",
         "@envoy_api//envoy/extensions/filters/listener/tls_inspector/v3:pkg",
     ],
 )
@@ -47,7 +47,7 @@ envoy_cc_fuzz_test(
     deps = [
         ":tls_inspector_fuzz_test_proto_cc_proto",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
-        "//test/extensions/filters/listener/common/fuzz:listener_filter_fuzzer_lib",
+        "//test/extensions/filters/listener/common/fuzz:tls_inspector_fuzzer_lib",
     ],
 )
 
@@ -83,5 +83,36 @@ envoy_cc_library(
     external_deps = ["ssl"],
     deps = [
         "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "tls_inspector_integration_test",
+    srcs = [
+        "tls_inspector_integration_test.cc",
+    ],
+    data = [
+        "//test/config/integration/certs",
+    ],
+    deps = [
+        "//source/common/config:api_version_lib",
+        "//source/common/event:dispatcher_includes",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:utility_lib",
+        "//source/extensions/access_loggers/file:config",
+        "//source/extensions/filters/listener/tls_inspector:config",
+        "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
+        "//source/extensions/filters/network/echo:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//source/extensions/transport_sockets/tls:context_config_lib",
+        "//source/extensions/transport_sockets/tls:context_lib",
+        "//test/integration:integration_lib",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/secret:secret_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
     ],
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1703,37 +1703,6 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-    name = "listener_filter_integration_test",
-    srcs = [
-        "listener_filter_integration_test.cc",
-    ],
-    data = [
-        "//test/config/integration/certs",
-    ],
-    deps = [
-        ":integration_lib",
-        "//source/common/config:api_version_lib",
-        "//source/common/event:dispatcher_includes",
-        "//source/common/event:dispatcher_lib",
-        "//source/common/network:utility_lib",
-        "//source/extensions/access_loggers/file:config",
-        "//source/extensions/filters/listener/tls_inspector:config",
-        "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
-        "//source/extensions/filters/network/echo:config",
-        "//source/extensions/transport_sockets/tls:config",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
-        "//source/extensions/transport_sockets/tls:context_lib",
-        "//test/mocks/runtime:runtime_mocks",
-        "//test/mocks/secret:secret_mocks",
-        "//test/test_common:utility_lib",
-        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
-    ],
-)
-
-envoy_cc_test(
     name = "cx_limit_integration_test",
     srcs = ["cx_limit_integration_test.cc"],
     deps = [


### PR DESCRIPTION
Part of https://github.com/envoyproxy/envoy/issues/9953
