### PR TITLE
Check msg length in mongo proxy

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.cc
@@ -355,6 +355,11 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
   }
 
   data.drain(sizeof(int32_t));
+  if (message_length < Message::MessageHeaderSize) {
+    ENVOY_LOG(error, "message size {} less than min. message size {}", message_length,
+              Message::MessageHeaderSize);
+    return false;
+  }
   int32_t request_id = Bson::BufferHelper::removeInt32(data);
   int32_t response_to = Bson::BufferHelper::removeInt32(data);
   Message::OpCode op_code = static_cast<Message::OpCode>(Bson::BufferHelper::removeInt32(data));

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.cc
@@ -356,7 +356,7 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
 
   data.drain(sizeof(int32_t));
   if (message_length < Message::MessageHeaderSize) {
-    ENVOY_LOG(error, "message size {} less than min. message size {}", message_length,
+    ENVOY_LOG(debug, "message size {} less than min. message size {}", message_length,
               Message::MessageHeaderSize);
     return false;
   }

--- a/test/extensions/filters/network/common/fuzz/network_writefilter_corpus/mongodb_proxy_2
+++ b/test/extensions/filters/network/common/fuzz/network_writefilter_corpus/mongodb_proxy_2
@@ -1,0 +1,12 @@
+config {
+  name: "envoy.filters.network.mongo_proxy"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.network.mongo_proxy.v3.MongoProxy"
+    value: "\n\001<"
+  }
+}
+actions {
+  on_write {
+    data: "\016\000\000\000[\000zxid\000)\324\007\000\000D@de$t._eett$_s.\000\024)....\016\001\005\000\000\000\000"
+  }
+}


### PR DESCRIPTION
Commit Message: mongodb_proxy: Enhance sanity check before accessing message header.
Additional Description:
Fuzz tests showed an issue where bytes are read beyond the message end. This patch adds a corpus showing an assert because of the issue and a patch to fix it. Please comment, whether the log-message and return is appropriate here or if an exception should be thrown.
Risk Level: medium
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
