### PR TITLE
make sendLocalReply support gRPC error details

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -22,6 +22,7 @@
 #include "source/common/common/scope_tracked_object_stack.h"
 
 #include "absl/types/optional.h"
+#include "google/rpc/status.pb.h"
 
 namespace Envoy {
 namespace Http {
@@ -420,8 +421,8 @@ public:
   /**
    * Attempts to create a locally generated response using the provided response_code and body_text
    * parameters. If the request was a gRPC request the local reply will be encoded as a gRPC
-   * response with a 200 HTTP response code and grpc-status and grpc-message headers mapped from the
-   * provided parameters.
+   * response with a 200 HTTP response code and grpc-status, grpc-message and
+   * grpc-status-details-bin headers mapped from the provided parameters.
    *
    * If a response has already started (e.g. if the router calls sendSendLocalReply after encoding
    * headers) this will either ship the reply directly to the downstream codec, or reset the stream.
@@ -432,11 +433,16 @@ public:
    * @param modify_headers supplies an optional callback function that can modify the
    *                       response headers.
    * @param grpc_status the gRPC status code to override the httpToGrpcStatus mapping with.
+   * @param grpc_error_details the gRPC status error details. It will be seralized and encoded in
+   * grpc-status-details-bin header. Please be aware, inside `grpc_error_details`, only the
+   * `details` field will be effective and the `code`/`message` fields will be overwritten by the
+   * provided parameters.
    * @param details a string detailing why this local reply was sent.
    */
   virtual void sendLocalReply(Code response_code, absl::string_view body_text,
                               std::function<void(ResponseHeaderMap& headers)> modify_headers,
                               const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                              std::unique_ptr<::google::rpc::Status> grpc_error_details,
                               absl::string_view details) PURE;
 
   /**
@@ -856,8 +862,8 @@ public:
   /**
    * Attempts to create a locally generated response using the provided response_code and body_text
    * parameters. If the request was a gRPC request the local reply will be encoded as a gRPC
-   * response with a 200 HTTP response code and grpc-status and grpc-message headers mapped from the
-   * provided parameters.
+   * response with a 200 HTTP response code and grpc-status, grpc-message and
+   * grpc-status-details-bin headers mapped from the provided parameters.
    *
    * If a response has already started (e.g. if the router calls sendSendLocalReply after encoding
    * headers) this will either ship the reply directly to the downstream codec, or reset the stream.
@@ -868,11 +874,16 @@ public:
    * @param modify_headers supplies an optional callback function that can modify the
    *                       response headers.
    * @param grpc_status the gRPC status code to override the httpToGrpcStatus mapping with.
+   * @param grpc_error_details the gRPC status error details. It will be seralized and encoded in
+   * grpc-status-details-bin header. Please be aware, inside `grpc_error_details`, only the
+   * `details` field will be effective and the `code`/`message` fields will be overwritten by the
+   * provided parameters.
    * @param details a string detailing why this local reply was sent.
    */
   virtual void sendLocalReply(Code response_code, absl::string_view body_text,
                               std::function<void(ResponseHeaderMap& headers)> modify_headers,
                               const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                              std::unique_ptr<::google::rpc::Status> grpc_error_details,
                               absl::string_view details) PURE;
   /**
    * Adds new metadata to be encoded.

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -876,8 +876,8 @@ public:
    * @param grpc_status the gRPC status code to override the httpToGrpcStatus mapping with.
    * @param grpc_error_details the gRPC status error details. It will be seralized and encoded in
    * grpc-status-details-bin header. Please be aware, inside `grpc_error_details`, only the
-   * `details` field will be effective and the `code`/`message` fields will be overwritten by the
-   * provided parameters.
+   * `details` field will be effective and the `code`/`message` fields will be overwritten by other
+   * provided parameters in this function.
    * @param details a string detailing why this local reply was sent.
    */
   virtual void sendLocalReply(Code response_code, absl::string_view body_text,

--- a/envoy/http/header_map.h
+++ b/envoy/http/header_map.h
@@ -373,8 +373,9 @@ private:
 /**
  * Default O(1) response headers and trailers.
  */
-#define INLINE_RESP_STRING_HEADERS_TRAILERS(HEADER_FUNC) HEADER_FUNC(GrpcMessage)
-
+#define INLINE_RESP_STRING_HEADERS_TRAILERS(HEADER_FUNC)                                           \
+  HEADER_FUNC(GrpcMessage)                                                                         \
+  HEADER_FUNC(GrpcStatusDetailsBin)
 #define INLINE_RESP_NUMERIC_HEADERS_TRAILERS(HEADER_FUNC) HEADER_FUNC(GrpcStatus)
 
 #define INLINE_RESP_HEADERS_TRAILERS(HEADER_FUNC)                                                  \

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -453,6 +453,7 @@ envoy_cc_library(
         "//envoy/http:query_params_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:base64_lib",
         "//source/common/common:empty_string",
         "//source/common/common:enum_to_int",
         "//source/common/common:utility_lib",

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -360,6 +360,7 @@ private:
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      std::unique_ptr<::google::rpc::Status> grpc_error_details,
                       absl::string_view details) override {
     if (encoded_response_headers_) {
       resetStream();
@@ -378,7 +379,8 @@ private:
                                  [this](Buffer::Instance& data, bool end_stream) -> void {
                                    encodeData(data, end_stream);
                                  }},
-        Utility::LocalReplyData{is_grpc_request_, code, body, grpc_status, is_head_request_});
+        Utility::LocalReplyData{is_grpc_request_, code, body, grpc_status,
+                                std::move(grpc_error_details), is_head_request_});
   }
   // The async client won't pause if sending 1xx headers so simply swallow any.
   void encode1xxHeaders(ResponseHeaderMapPtr&&) override {}

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -195,7 +195,8 @@ private:
                         const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                         absl::string_view details) override {
-      return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, details);
+      return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, nullptr,
+                                            details);
     }
 
     // Tracing::TracingConfig

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -397,8 +397,10 @@ void ActiveStreamDecoderFilter::modifyDecodingBuffer(
 void ActiveStreamDecoderFilter::sendLocalReply(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
-  parent_.sendLocalReply(code, body, modify_headers, grpc_status, details);
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+    std::unique_ptr<::google::rpc::Status> grpc_error_details, absl::string_view details) {
+  parent_.sendLocalReply(code, body, modify_headers, grpc_status, std::move(grpc_error_details),
+                         details);
 }
 
 void ActiveStreamDecoderFilter::encode1xxHeaders(ResponseHeaderMapPtr&& headers) {
@@ -455,7 +457,8 @@ void ActiveStreamDecoderFilter::requestDataTooLarge() {
   } else {
     parent_.filter_manager_callbacks_.onRequestDataTooLarge();
     sendLocalReply(Code::PayloadTooLarge, CodeUtility::toString(Code::PayloadTooLarge), nullptr,
-                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().RequestPayloadTooLarge);
+                   absl::nullopt, nullptr,
+                   StreamInfo::ResponseCodeDetails::get().RequestPayloadTooLarge);
   }
 }
 
@@ -758,7 +761,7 @@ void FilterManager::addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::In
     decodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
   } else {
     IS_ENVOY_BUG("Invalid request data");
-    sendLocalReply(Http::Code::BadGateway, "Filter error", nullptr, absl::nullopt,
+    sendLocalReply(Http::Code::BadGateway, "Filter error", nullptr, absl::nullopt, nullptr,
                    StreamInfo::ResponseCodeDetails::get().FilterAddedInvalidRequestData);
   }
 }
@@ -898,7 +901,8 @@ void FilterManager::onLocalReply(StreamFilterBase::LocalReplyData& data) {
 void FilterManager::sendLocalReply(
     Code code, absl::string_view body,
     const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+    std::unique_ptr<::google::rpc::Status> grpc_error_details, absl::string_view details) {
   ASSERT(!state_.under_on_local_reply_);
   const bool is_head_request = state_.is_head_request_;
   const bool is_grpc_request = state_.is_grpc_request_;
@@ -927,7 +931,7 @@ void FilterManager::sendLocalReply(
   if (!filter_manager_callbacks_.responseHeaders().has_value()) {
     // If the response has not started at all, send the response through the filter chain.
     sendLocalReplyViaFilterChain(is_grpc_request, code, body, modify_headers, is_head_request,
-                                 grpc_status, details);
+                                 grpc_status, std::move(grpc_error_details), details);
   } else if (!state_.non_100_response_headers_encoded_) {
     ENVOY_STREAM_LOG(debug, "Sending local reply with details {} directly to the encoder", *this,
                      details);
@@ -937,7 +941,8 @@ void FilterManager::sendLocalReply(
     // state machine screwed up, bypass the filter chain and send the local
     // reply directly to the codec.
     //
-    sendDirectLocalReply(code, body, modify_headers, state_.is_head_request_, grpc_status);
+    sendDirectLocalReply(code, body, modify_headers, state_.is_head_request_, grpc_status,
+                         std::move(grpc_error_details));
   } else {
     // If we land in this branch, response headers have already been sent to the client.
     // All we can do at this point is reset the stream.
@@ -952,7 +957,8 @@ void FilterManager::sendLocalReply(
 void FilterManager::sendLocalReplyViaFilterChain(
     bool is_grpc_request, Code code, absl::string_view body,
     const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+    std::unique_ptr<::google::rpc::Status> grpc_error_details, absl::string_view details) {
   ENVOY_STREAM_LOG(debug, "Sending local reply with details {}", *this, details);
   ASSERT(!filter_manager_callbacks_.responseHeaders().has_value());
   // For early error handling, do a best-effort attempt to create a filter chain
@@ -990,13 +996,15 @@ void FilterManager::sendLocalReplyViaFilterChain(
             encodeData(nullptr, data, end_stream,
                        FilterManager::FilterIterationStartState::CanStartFromCurrent);
           }},
-      Utility::LocalReplyData{is_grpc_request, code, body, grpc_status, is_head_request});
+      Utility::LocalReplyData{is_grpc_request, code, body, grpc_status,
+                              std::move(grpc_error_details), is_head_request});
 }
 
 void FilterManager::sendDirectLocalReply(
     Code code, absl::string_view body,
     const std::function<void(ResponseHeaderMap&)>& modify_headers, bool is_head_request,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status) {
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+    std::unique_ptr<::google::rpc::Status> grpc_error_details) {
   // Make sure we won't end up with nested watermark calls from the body buffer.
   state_.encoder_filters_streaming_ = true;
   Http::Utility::sendLocalReply(
@@ -1035,7 +1043,8 @@ void FilterManager::sendDirectLocalReply(
             }
             maybeEndEncode(end_stream);
           }},
-      Utility::LocalReplyData{state_.is_grpc_request_, code, body, grpc_status, is_head_request});
+      Utility::LocalReplyData{state_.is_grpc_request_, code, body, grpc_status,
+                              std::move(grpc_error_details), is_head_request});
 }
 
 void FilterManager::encode1xxHeaders(ActiveStreamEncoderFilter* filter,
@@ -1157,7 +1166,7 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
   if (!status.ok()) {
     // If the check failed, then we reply with BadGateway, and stop the further processing.
     sendLocalReply(
-        Http::Code::BadGateway, status.message(), nullptr, absl::nullopt,
+        Http::Code::BadGateway, status.message(), nullptr, absl::nullopt, nullptr,
         absl::StrCat(StreamInfo::ResponseCodeDetails::get().FilterRemovedRequiredResponseHeaders,
                      "{", StringUtil::replaceAllEmptySpace(status.message()), "}"));
     return;
@@ -1238,7 +1247,7 @@ void FilterManager::addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::In
     encodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
   } else {
     IS_ENVOY_BUG("Invalid response data");
-    sendLocalReply(Http::Code::BadGateway, "Filter error", nullptr, absl::nullopt,
+    sendLocalReply(Http::Code::BadGateway, "Filter error", nullptr, absl::nullopt, nullptr,
                    StreamInfo::ResponseCodeDetails::get().FilterAddedInvalidResponseData);
   }
 }
@@ -1642,8 +1651,10 @@ void ActiveStreamEncoderFilter::modifyEncodingBuffer(
 void ActiveStreamEncoderFilter::sendLocalReply(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
-  parent_.sendLocalReply(code, body, modify_headers, grpc_status, details);
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+    std::unique_ptr<::google::rpc::Status> grpc_error_details, absl::string_view details) {
+  parent_.sendLocalReply(code, body, modify_headers, grpc_status, std::move(grpc_error_details),
+                         details);
 }
 
 Http1StreamEncoderOptionsOptRef ActiveStreamEncoderFilter::http1StreamEncoderOptions() {
@@ -1661,9 +1672,10 @@ void ActiveStreamEncoderFilter::responseDataTooLarge() {
 
     // In this case, sendLocalReply will either send a response directly to the encoder, or
     // reset the stream.
-    parent_.sendLocalReply(
-        Http::Code::InternalServerError, CodeUtility::toString(Http::Code::InternalServerError),
-        nullptr, absl::nullopt, StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
+    parent_.sendLocalReply(Http::Code::InternalServerError,
+                           CodeUtility::toString(Http::Code::InternalServerError), nullptr,
+                           absl::nullopt, nullptr,
+                           StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
   }
 }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -258,6 +258,7 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      std::unique_ptr<::google::rpc::Status> grpc_error_details,
                       absl::string_view details) override;
   void encode1xxHeaders(ResponseHeaderMapPtr&& headers) override;
   ResponseHeaderMapOptRef informationalHeaders() const override;
@@ -352,6 +353,7 @@ struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      std::unique_ptr<::google::rpc::Status> grpc_error_details,
                       absl::string_view details) override;
   Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
 
@@ -853,6 +855,7 @@ public:
   void sendLocalReply(Code code, absl::string_view body,
                       const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      std::unique_ptr<::google::rpc::Status> grpc_error_details,
                       absl::string_view details);
   /**
    * Sends a local reply by constructing a response and passing it through all the encoder
@@ -861,7 +864,8 @@ public:
   void sendLocalReplyViaFilterChain(
       bool is_grpc_request, Code code, absl::string_view body,
       const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
-      const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details);
+      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+      std::unique_ptr<::google::rpc::Status> grpc_error_details, absl::string_view details);
 
   /**
    * Sends a local reply by constructing a response and skipping the encoder filters. The
@@ -870,7 +874,8 @@ public:
   void sendDirectLocalReply(Code code, absl::string_view body,
                             const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                             bool is_head_request,
-                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status);
+                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                            std::unique_ptr<::google::rpc::Status> grpc_error_details);
 
   // Possibly increases buffer_limit_ to the value of limit.
   void setBufferLimit(uint32_t limit);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -595,7 +595,7 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
     response_headers->setReferenceContentType(Headers::get().ContentTypeValues.Grpc);
 
     if (response_headers->getGrpcStatusValue().empty()) {
-      auto final_grpc_status_code =
+      const auto final_grpc_status_code =
           enumToInt(local_reply_data.grpc_status_
                         ? local_reply_data.grpc_status_.value()
                         : Grpc::Utility::httpToGrpcStatus(enumToInt(response_code)));
@@ -621,7 +621,8 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
       }
     }
     if (local_reply_data.grpc_error_details_) {
-      auto status_detail_str = local_reply_data.grpc_error_details_->SerializeAsString();
+      const std::string status_detail_str =
+          local_reply_data.grpc_error_details_->SerializeAsString();
       response_headers->setGrpcStatusDetailsBin(
           ::Envoy::Base64::encode(status_detail_str.data(), status_detail_str.size(), false));
     }

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -375,6 +375,10 @@ struct LocalReplyData {
   absl::string_view body_text_;
   // gRPC status code to override the httpToGrpcStatus mapping with.
   const absl::optional<Grpc::Status::GrpcStatus> grpc_status_;
+
+  // Supplies gRPC status error details.
+  std::unique_ptr<::google::rpc::Status> grpc_error_details_;
+
   // Tells if this is a response to a HEAD request.
   bool is_head_request_ = false;
 };

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -523,7 +523,7 @@ void UpstreamRequest::onPoolReady(
         absl::StrCat(StreamInfo::ResponseCodeDetails::get().FilterRemovedRequiredRequestHeaders,
                      "{", StringUtil::replaceAllEmptySpace(status.message()), "}");
     parent_.callbacks()->sendLocalReply(Http::Code::ServiceUnavailable, status.message(), nullptr,
-                                        absl::nullopt, details);
+                                        absl::nullopt, nullptr, details);
     return;
   }
 

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -468,7 +468,7 @@ void FaultFilter::abortWithStatus(Http::Code http_status_code,
   recordAbortsInjectedStats();
   decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FaultInjected);
   decoder_callbacks_->sendLocalReply(http_status_code, "fault filter abort", nullptr, grpc_status,
-                                     RcDetails::get().FaultAbort);
+                                     nullptr, RcDetails::get().FaultAbort);
 }
 
 bool FaultFilter::matchesTargetUpstreamCluster() {

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -462,7 +462,8 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
     ENVOY_LOG(debug, "Request is rejected due to strict rejection policy.");
     error_ = true;
     decoder_callbacks_->sendLocalReply(
-        static_cast<Http::Code>(http_code), status.message().ToString(), nullptr, absl::nullopt,
+        static_cast<Http::Code>(http_code), std::string(status.message()), nullptr, absl::nullopt,
+        nullptr,
         absl::StrCat(RcDetails::get().GrpcTranscodeFailedEarly, "{",
                      StringUtil::replaceAllEmptySpace(MessageUtil::codeEnumToString(status.code())),
                      "}"));
@@ -482,7 +483,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
           "Transcoding of query arguments of HttpBody request is not done (unexpected state)");
       error_ = true;
       decoder_callbacks_->sendLocalReply(
-          Http::Code::BadRequest, "Bad request", nullptr, absl::nullopt,
+          Http::Code::BadRequest, "Bad request", nullptr, absl::nullopt, nullptr,
           absl::StrCat(RcDetails::get().GrpcTranscodeFailedEarly, "{BAD_REQUEST}"));
       return Http::FilterHeadersStatus::StopIteration;
     }
@@ -744,7 +745,7 @@ bool JsonTranscoderFilter::checkIfTranscoderFailed(const std::string& details) {
     decoder_callbacks_->sendLocalReply(
         Http::Code::BadRequest,
         absl::string_view(request_status.message().data(), request_status.message().size()),
-        nullptr, absl::nullopt,
+        nullptr, absl::nullopt, nullptr,
         absl::StrCat(
             details, "{",
             StringUtil::replaceAllEmptySpace(MessageUtil::codeEnumToString(request_status.code())),
@@ -905,7 +906,7 @@ bool JsonTranscoderFilter::decoderBufferLimitReached(uint64_t buffer_length) {
         Http::Code::PayloadTooLarge,
         "Request rejected because the transcoder's internal buffer size exceeds the configured "
         "limit.",
-        nullptr, absl::nullopt,
+        nullptr, absl::nullopt, nullptr,
         absl::StrCat(RcDetails::get().GrpcTranscodeFailed, "{request_buffer_size_limit_reached}"));
     return true;
   }
@@ -923,7 +924,7 @@ bool JsonTranscoderFilter::encoderBufferLimitReached(uint64_t buffer_length) {
         Http::Code::InternalServerError,
         "Response not transcoded because the transcoder's internal buffer size exceeds the "
         "configured limit.",
-        nullptr, absl::nullopt,
+        nullptr, absl::nullopt, nullptr,
         absl::StrCat(RcDetails::get().GrpcTranscodeFailed, "{response_buffer_size_limit_reached}"));
     return true;
   }

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -206,9 +206,9 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool en
     }
     if (available % 4 != 0) {
       // Client end stream with invalid base64. Note, base64 padding is mandatory.
-      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
-                                         "Bad gRPC-web request, invalid base64 data.", nullptr,
-                                         absl::nullopt, RcDetails::get().GrpcDecodeFailedDueToSize);
+      decoder_callbacks_->sendLocalReply(
+          Http::Code::BadRequest, "Bad gRPC-web request, invalid base64 data.", nullptr,
+          absl::nullopt, nullptr, RcDetails::get().GrpcDecodeFailedDueToSize);
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }
   } else if (available < 4) {
@@ -223,9 +223,9 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool en
                   decoding_buffer_.length()));
   if (decoded.empty()) {
     // Error happened when decoding base64.
-    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
-                                       "Bad gRPC-web request, invalid base64 data.", nullptr,
-                                       absl::nullopt, RcDetails::get().GrpcDecodeFailedDueToData);
+    decoder_callbacks_->sendLocalReply(
+        Http::Code::BadRequest, "Bad gRPC-web request, invalid base64 data.", nullptr,
+        absl::nullopt, nullptr, RcDetails::get().GrpcDecodeFailedDueToData);
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -181,7 +181,7 @@ void HealthCheckFilter::onComplete() {
           headers.setEnvoyDegraded("");
         }
       },
-      absl::nullopt, *details);
+      absl::nullopt, nullptr, *details);
 }
 
 } // namespace HealthCheck

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -74,9 +74,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     if (!error_msg.empty()) {
       stats_.denied_.inc();
       state_ = Responded;
-      decoder_callbacks_->sendLocalReply(Http::Code::Forbidden,
-                                         absl::StrCat("Failed JWT authentication: ", error_msg),
-                                         nullptr, absl::nullopt, generateRcDetails(error_msg));
+      decoder_callbacks_->sendLocalReply(
+          Http::Code::Forbidden, absl::StrCat("Failed JWT authentication: ", error_msg), nullptr,
+          absl::nullopt, nullptr, generateRcDetails(error_msg));
       return Http::FilterHeadersStatus::StopIteration;
     }
   } else {
@@ -128,7 +128,7 @@ void Filter::onComplete(const Status& status) {
           }
           headers.setCopy(Http::Headers::get().WWWAuthenticate, value);
         },
-        absl::nullopt, generateRcDetails(::google::jwt_verify::getStatusString(status)));
+        absl::nullopt, nullptr, generateRcDetails(::google::jwt_verify::getStatusString(status)));
     return;
   }
   stats_.allowed_.inc();

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -89,7 +89,7 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoFilterConfigFound);
     decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError, EMPTY_STRING, nullptr,
-                                       absl::nullopt, EMPTY_STRING);
+                                       absl::nullopt, nullptr, EMPTY_STRING);
     return Http::FilterHeadersStatus::StopIteration;
   }
 };

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -103,10 +103,12 @@ envoy_cc_test(
     srcs = ["filter_manager_test.cc"],
     deps = [
         "//source/common/http:filter_manager_lib",
+        "//source/common/protobuf",
         "//test/mocks/event:event_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/local_reply:local_reply_mocks",
         "//test/mocks/network:network_mocks",
+        "@com_google_googleapis//google/rpc:error_details_cc_proto",
     ],
 )
 
@@ -378,10 +380,12 @@ envoy_cc_test(
         "//source/common/http:header_map_lib",
         "//source/common/http:utility_lib",
         "//source/common/network:address_lib",
+        "//source/common/protobuf",
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
+        "@com_google_googleapis//google/rpc:error_details_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -1534,7 +1534,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterHeadReply) {
   EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
         decoder_filters_[0]->callbacks_->sendLocalReply(Code::BadRequest, "Bad request", nullptr,
-                                                        absl::nullopt, "");
+                                                        absl::nullopt, nullptr, "");
         return FilterHeadersStatus::StopIteration;
       }));
 
@@ -1564,7 +1564,7 @@ TEST_F(HttpConnectionManagerImplTest, ResetWithStoppedFilter) {
   EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
         decoder_filters_[0]->callbacks_->sendLocalReply(Code::BadRequest, "Bad request", nullptr,
-                                                        absl::nullopt, "");
+                                                        absl::nullopt, nullptr, "");
         return FilterHeadersStatus::StopIteration;
       }));
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -164,7 +164,7 @@ void Http1ServerConnectionImplTest::expect400(Protocol p, bool allow_absolute_ur
         return decoder;
       }));
 
-  EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(p, codec_->protocol());
@@ -264,7 +264,7 @@ void Http1ServerConnectionImplTest::testTrailersExceedLimit(std::string trailer_
   EXPECT_TRUE(status.ok());
   buffer = Buffer::OwnedImpl(trailer_string);
   if (enable_trailers) {
-    EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+    EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
     status = codec_->dispatch(buffer);
     EXPECT_TRUE(isCodecProtocolError(status));
     EXPECT_EQ(status.message(), error_message);
@@ -293,7 +293,7 @@ void Http1ServerConnectionImplTest::testRequestHeadersExceedLimit(std::string he
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(status.ok());
   buffer = Buffer::OwnedImpl(header_string + "\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), error_message);
@@ -350,7 +350,7 @@ void Http1ServerConnectionImplTest::testServerAllowChunkedContentLength(uint32_t
   } else {
     EXPECT_CALL(decoder, decodeHeaders_(_, _)).Times(0);
     EXPECT_CALL(decoder, decodeData(_, _)).Times(0);
-    EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _));
+    EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _, _));
   }
 
   Buffer::OwnedImpl buffer(
@@ -406,7 +406,7 @@ TEST_F(Http1ServerConnectionImplTest, IdentityEncodingNoChunked) {
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\ntransfer-encoding: identity\r\n\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
@@ -421,7 +421,7 @@ TEST_F(Http1ServerConnectionImplTest, UnsupportedEncoding) {
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\ntransfer-encoding: gzip\r\n\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
@@ -629,7 +629,7 @@ TEST_F(Http1ServerConnectionImplTest, InvalidChunkHeader) {
                            "6\r\nHello \r\n"
                            "invalid\r\nWorl");
 
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_CHUNK_SIZE");
@@ -646,7 +646,7 @@ TEST_F(Http1ServerConnectionImplTest, IdentityAndChunkedBody) {
   Buffer::OwnedImpl buffer("POST / HTTP/1.1\r\ntransfer-encoding: "
                            "identity,chunked\r\n\r\nb\r\nHello World\r\n0\r\n\r\n");
 
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
@@ -925,7 +925,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
                            "body\r\n0\r\n"
                            "badtrailer\r\n\r\n");
 
-  EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
 }
@@ -1009,7 +1009,7 @@ TEST_F(Http1ServerConnectionImplTest, BadRequestNoStream) {
         return decoder;
       }));
   // Check that before any headers are parsed, requests do not look like HEAD or gRPC requests.
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
 
   Buffer::OwnedImpl buffer("bad");
   auto status = codec_->dispatch(buffer);
@@ -1025,7 +1025,7 @@ TEST_F(Http1ServerConnectionImplTest, RejectInvalidMethod) {
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("BAD / HTTP/1.1\r\nHost: foo\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
 }
@@ -1041,7 +1041,7 @@ TEST_F(Http1ServerConnectionImplTest, BadRequestStartedStream) {
   EXPECT_TRUE(status.ok());
 
   Buffer::OwnedImpl buffer2("g");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
 }
@@ -1129,7 +1129,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderInvalidCharsRejection) {
       }));
   Buffer::OwnedImpl buffer(
       absl::StrCat("GET / HTTP/1.1\r\nHOST: h.com\r\nfoo: ", std::string(1, 3), "\r\n"));
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: header value contains invalid chars");
@@ -1198,7 +1198,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreCauseRequestReject
       }));
 
   Buffer::OwnedImpl buffer(absl::StrCat("GET / HTTP/1.1\r\nHOST: h.com\r\nfoo_bar: bar\r\n\r\n"));
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: header name contains underscores");
@@ -1217,7 +1217,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderInvalidAuthority) {
         return decoder;
       }));
   Buffer::OwnedImpl buffer(absl::StrCat("GET / HTTP/1.1\r\nHOST: h.\"com\r\n\r\n"));
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(),
@@ -1240,7 +1240,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderMutateEmbeddedNul) {
 
     Buffer::OwnedImpl buffer(
         absl::StrCat(example_input.substr(0, n), std::string(1, '\0'), example_input.substr(n)));
-    EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+    EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
     auto status = codec_->dispatch(buffer);
     EXPECT_FALSE(status.ok());
     EXPECT_TRUE(isCodecProtocolError(status));
@@ -1913,7 +1913,7 @@ TEST_F(Http1ServerConnectionImplTest, ConnectRequestAbsoluteURLNotallowed) {
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("CONNECT http://host:80 HTTP/1.1\r\n\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
 }
@@ -1942,7 +1942,7 @@ TEST_F(Http1ServerConnectionImplTest, ConnectRequestWithTEChunked) {
 
   // Per https://tools.ietf.org/html/rfc7231#section-4.3.6 CONNECT with body has no defined
   // semantics: Envoy will reject chunked CONNECT requests.
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   Buffer::OwnedImpl buffer(
       "CONNECT host:80 HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n12345abcd");
   auto status = codec_->dispatch(buffer);
@@ -1960,7 +1960,7 @@ TEST_F(Http1ServerConnectionImplTest, ConnectRequestWithNonZeroContentLength) {
   // Make sure we avoid the deferred_end_stream_headers_ optimization for
   // requests-with-no-body.
   Buffer::OwnedImpl buffer("CONNECT host:80 HTTP/1.1\r\ncontent-length: 1\r\n\r\nabcd");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported content length");
@@ -2909,7 +2909,7 @@ TEST_F(Http1ServerConnectionImplTest, LargeRequestHeadersSplitRejected) {
   }
   // the 60th 1kb header should induce overflow
   buffer = Buffer::OwnedImpl(fmt::format("big: {}\r\n", long_string));
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "headers size exceeds limit");
@@ -2939,7 +2939,7 @@ TEST_F(Http1ServerConnectionImplTest, LargeRequestHeadersSplitRejectedMaxConfigu
   }
   // the 128th 64kb header should induce overflow
   buffer = Buffer::OwnedImpl(fmt::format("big: {}\r\n", long_string));
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "headers size exceeds limit");
@@ -2969,7 +2969,7 @@ TEST_F(Http1ServerConnectionImplTest, ManyRequestHeadersSplitRejected) {
 
   // The final 101th header should induce overflow.
   buffer = Buffer::OwnedImpl("header101:\r\n\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _, _));
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "headers count exceeds limit");

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -964,7 +964,7 @@ TEST(HttpUtility, SendLocalGrpcReplyWithErrorDetails) {
         expected.set_message("this-is-message");
         // The gRPC status error details is from sendLocalReply's `grpc_error_details` arg.
         *expected.mutable_details()->Add() = a;
-        Envoy::Protobuf::util::MessageDifferencer::Equals(got, expected);
+        EXPECT_TRUE(Envoy::Protobuf::util::MessageDifferencer::Equals(got, expected));
       }));
 
   Utility::sendLocalReply(is_reset, callbacks,

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -318,7 +318,7 @@ TEST_F(RouterTest, MissingRequiredHeaders) {
   EXPECT_CALL(
       callbacks_,
       sendLocalReply(Http::Code::ServiceUnavailable,
-                     testing::Eq("missing required header: :method"), _, _,
+                     testing::Eq("missing required header: :method"), _, _, _,
                      "filter_removed_required_request_headers{missing_required_header:_:method}"))
       .WillOnce(InvokeWithoutArgs([] {}));
   router_.decodeHeaders(headers, true);
@@ -3481,7 +3481,7 @@ TEST_F(RouterTest, RetryUpstreamResetResponseStarted) {
   // Normally, sendLocalReply will actually send the reply, but in this case the
   // HCM will detect the headers have already been sent and not route through
   // the encoder again.
-  EXPECT_CALL(callbacks_, sendLocalReply(_, _, _, _, _)).WillOnce(InvokeWithoutArgs([] {}));
+  EXPECT_CALL(callbacks_, sendLocalReply(_, _, _, _, _, _)).WillOnce(InvokeWithoutArgs([] {}));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
   // For normal HTTP, once we have a 200 we consider this a success, even if a
   // later reset occurs.

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -248,7 +248,7 @@ TEST_F(AdaptiveConcurrencyFilterTest, DecodeHeadersTestBlock) {
   Http::TestRequestHeaderMapImpl request_headers;
 
   EXPECT_CALL(*controller_, forwardingDecision()).WillOnce(Return(RequestForwardingAction::Block));
-  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::ServiceUnavailable, _, _, _, _));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::ServiceUnavailable, _, _, _, _, _));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, true));
 }

--- a/test/extensions/filters/http/cdn_loop/filter_test.cc
+++ b/test/extensions/filters/http/cdn_loop/filter_test.cc
@@ -41,7 +41,7 @@ TEST(CdnLoopFilterTest, OtherCdnsInHeader) {
 
 TEST(CdnLoopFilterTest, LoopDetected) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _));
+  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _, _));
   CdnLoopFilter filter("cdn", 0);
   filter.setDecoderFilterCallbacks(decoder_callbacks);
 
@@ -52,7 +52,7 @@ TEST(CdnLoopFilterTest, LoopDetected) {
 
 TEST(CdnLoopFilterTest, MultipleTransitsAllowed) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _));
+  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, - < _));
   CdnLoopFilter filter("cdn", 3);
   filter.setDecoderFilterCallbacks(decoder_callbacks);
 
@@ -101,7 +101,7 @@ TEST(CdnLoopFilterTest, MultipleHeadersAllowed) {
 
 TEST(CdnLoopFilterTest, UnparseableHeader) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadRequest, _, _, _, _));
+  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadRequest, _, _, _, _, _));
   CdnLoopFilter filter("cdn", 0);
   filter.setDecoderFilterCallbacks(decoder_callbacks);
 

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -39,14 +39,15 @@ UberFilterFuzzer::UberFilterFuzzer()
       .WillByDefault(
           Invoke([&](AccessLog::InstanceSharedPtr handler) -> void { access_logger_ = handler; }));
   // This handles stopping execution after a direct response is sent.
-  ON_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _))
+  ON_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _, _))
       .WillByDefault(
           Invoke([this](Http::Code code, absl::string_view body,
                         std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                         absl::string_view details) {
             enabled_ = false;
-            decoder_callbacks_.sendLocalReply_(code, body, modify_headers, grpc_status, details);
+            decoder_callbacks_.sendLocalReply_(code, body, modify_headers, grpc_status, nullptr,
+                                               details);
           }));
   ON_CALL(encoder_callbacks_, addEncodedTrailers())
       .WillByDefault(testing::ReturnRef(encoded_trailers_));

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -163,7 +163,7 @@ TEST_F(ProxyFilterTest, CacheOverflow) {
       .WillOnce(Return(
           MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Overflow, nullptr, absl::nullopt}));
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable, Eq("DNS cache overflow"),
-                                         _, _, Eq("dns_cache_overflow")));
+                                         _, _, _, Eq("dns_cache_overflow")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -201,7 +201,7 @@ TEST_F(ProxyFilterTest, CircuitBreakerOverflow) {
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_());
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable,
                                          Eq("Dynamic forward proxy pending request overflow"), _, _,
-                                         Eq("dynamic_forward_proxy_pending_request_overflow")));
+                                         _, Eq("dynamic_forward_proxy_pending_request_overflow")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -241,7 +241,7 @@ TEST_F(ProxyFilterTest, CircuitBreakerOverflowWithDnsCacheResourceManager) {
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_());
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable,
                                          Eq("Dynamic forward proxy pending request overflow"), _, _,
-                                         Eq("dynamic_forward_proxy_pending_request_overflow")));
+                                         _, Eq("dynamic_forward_proxy_pending_request_overflow")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -522,7 +522,7 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, IgnoreFilterStateMetadataNullAddre
 
   EXPECT_CALL(*host_info, address());
   EXPECT_CALL(callbacks_,
-              sendLocalReply(Http::Code::ServiceUnavailable, Eq("DNS resolution failure"), _, _,
+              sendLocalReply(Http::Code::ServiceUnavailable, Eq("DNS resolution failure"), _, _, _,
                              Eq("dns_resolution_failure")));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks_, encodeData(_, true));

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -417,8 +417,9 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 
   Http::TestResponseHeaderMapImpl immediate_response_headers;
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadRequest, "Bad request", _,
-                                                 Eq(absl::nullopt), "Got_a_bad_request"))
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest, "Bad request", _, Eq(absl::nullopt),
+                             Eq(nullptr), "Got_a_bad_request"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -490,7 +491,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyOnResponse) {
 
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadRequest, "Bad request", _,
-                                                 Eq(absl::nullopt), "Got_a_bad_request"))
+                                                 Eq(absl::nullopt), _, "Got_a_bad_request"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,

--- a/test/extensions/filters/http/ext_proc/ordering_test.cc
+++ b/test/extensions/filters/http/ext_proc/ordering_test.cc
@@ -543,7 +543,7 @@ TEST_F(OrderingTest, ImmediateResponseOnRequest) {
   EXPECT_CALL(*request_timer, enabled()).Times(AnyNumber());
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   EXPECT_CALL(*request_timer, disableTimer());
   sendImmediateResponse500();
   // The rest of the filter isn't necessarily called after this.
@@ -567,7 +567,7 @@ TEST_F(OrderingTest, ImmediateResponseOnResponse) {
   EXPECT_CALL(*response_timer, enabled()).Times(AnyNumber());
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendResponseHeaders(true);
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   EXPECT_CALL(*response_timer, disableTimer());
   sendImmediateResponse500();
   Buffer::OwnedImpl resp_body("Hello!");
@@ -688,7 +688,7 @@ TEST_F(OrderingTest, ExtraAfterImmediateResponse) {
 
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   sendImmediateResponse500();
   // Extra messages sent after immediate response shouldn't affect anything
   sendRequestHeadersReply();
@@ -706,7 +706,7 @@ TEST_F(OrderingTest, GrpcErrorInline) {
   EXPECT_CALL(*request_timer, enableTimer(kMessageTimeout, nullptr));
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   EXPECT_CALL(*request_timer, enabled()).WillOnce(Return(true));
   EXPECT_CALL(*request_timer, disableTimer());
   sendGrpcError();
@@ -750,7 +750,7 @@ TEST_F(OrderingTest, GrpcErrorOutOfLine) {
   EXPECT_CALL(*request_timer, disableTimer());
   sendRequestHeadersReply();
 
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   EXPECT_CALL(*request_timer, enabled()).WillOnce(Return(false));
   sendGrpcError();
 }
@@ -833,7 +833,7 @@ TEST_F(OrderingTest, TimeoutOnResponseBody) {
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(resp_body, true));
 
   // Now, fire the timeout, which will end everything
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   response_timer->invokeCallback();
 }
 
@@ -867,7 +867,7 @@ TEST_F(OrderingTest, TimeoutOnRequestBody) {
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_body, true));
 
   // Now fire the timeout and expect a 500 error
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   request_timer->invokeCallback();
 }
 
@@ -875,7 +875,7 @@ TEST_F(OrderingTest, TimeoutOnRequestBody) {
 TEST_F(FastFailOrderingTest, GrpcErrorOnStartRequestHeaders) {
   initialize(absl::nullopt);
   HttpTestUtility::addDefaultHeaders(request_headers_);
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, true));
 }
 
@@ -901,7 +901,7 @@ TEST_F(FastFailOrderingTest, GrpcErrorOnStartRequestBody) {
   Buffer::OwnedImpl req_body("Hello!");
   Buffer::OwnedImpl buffered_body;
   expectBufferedRequest(buffered_body);
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _, _));
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_body, true));
 }
 

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -67,7 +67,7 @@ TEST_F(ReverseBridgeTest, InvalidGrpcRequest) {
     // We should remove the first five bytes.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("abc", 3);
-    EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _));
+    EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _, _));
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _)).WillOnce(Invoke([](auto& headers, auto) {
       EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Status, "200"));
       EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().GrpcStatus, "2"));
@@ -550,7 +550,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestBadResponseNoContentType) {
       sendLocalReply(
           Http::Code::OK,
           "envoy reverse bridge: upstream responded with no content-type header, status code 400",
-          _, absl::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Unknown)), _));
+          _, absl::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Unknown)), _,
+          _));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->encodeHeaders(headers, false));
 }
@@ -593,13 +594,14 @@ TEST_F(ReverseBridgeTest, GrpcRequestBadResponse) {
 
   Http::TestResponseHeaderMapImpl headers(
       {{":status", "400"}, {"content-type", "application/json"}});
-  EXPECT_CALL(
-      decoder_callbacks_,
-      sendLocalReply(
-          Http::Code::OK,
-          "envoy reverse bridge: upstream responded with unsupported "
-          "content-type application/json, status code 400",
-          _, absl::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Unknown)), _));
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(
+                  Http::Code::OK,
+                  "envoy reverse bridge: upstream responded with unsupported "
+                  "content-type application/json, status code 400",
+                  _,
+                  absl::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Unknown)),
+                  _, _));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->encodeHeaders(headers, false));
 }
@@ -916,7 +918,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcStreamResponseNoContentLength) {
       decoder_callbacks_,
       sendLocalReply(
           Http::Code::OK, "envoy reverse bridge: upstream did not set content length", _,
-          absl::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _));
+          absl::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _,
+          _));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->encodeHeaders(headers, false));
 }

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1914,7 +1914,7 @@ TEST_P(WasmHttpFilterTest, PanicOnRequestHeaders) {
               sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
                              testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
                              testing::Eq("wasm_fail_stream")));
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _, _)).Times(0);
 
   // Create in-VM context.
   filter().onCreate();
@@ -1937,7 +1937,7 @@ TEST_P(WasmHttpFilterTest, PanicOnRequestBody) {
               sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
                              testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
                              testing::Eq("wasm_fail_stream")));
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _, _)).Times(0);
 
   // Create in-VM context.
   filter().onCreate();
@@ -1959,7 +1959,7 @@ TEST_P(WasmHttpFilterTest, PanicOnRequestTrailers) {
               sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
                              testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
                              testing::Eq("wasm_fail_stream")));
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _, _)).Times(0);
 
   // Create in-VM context.
   filter().onCreate();
@@ -1979,7 +1979,7 @@ TEST_P(WasmHttpFilterTest, PanicOnResponseHeaders) {
               sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
                              testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
                              testing::Eq("wasm_fail_stream")));
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _, _)).Times(0);
 
   // Create in-VM context.
   filter().onCreate();
@@ -2000,7 +2000,7 @@ TEST_P(WasmHttpFilterTest, PanicOnResponseBody) {
               sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
                              testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
                              testing::Eq("wasm_fail_stream")));
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _, _)).Times(0);
 
   // Create in-VM context.
   filter().onCreate();
@@ -2020,7 +2020,7 @@ TEST_P(WasmHttpFilterTest, PanicOnResponseTrailers) {
               sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
                              testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
                              testing::Eq("wasm_fail_stream")));
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(_, _, _, _, _, _)).Times(0);
 
   // Create in-VM context.
   filter().onCreate();

--- a/test/integration/filters/invalid_header_filter.cc
+++ b/test/integration/filters/invalid_header_filter.cc
@@ -29,7 +29,7 @@ public:
       headers.removeHost();
     }
     if (!headers.get(Http::LowerCaseString("send-reply")).empty()) {
-      decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt,
+      decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt, nullptr,
                                          "invalid_header_filter_ready");
       return Http::FilterHeadersStatus::StopIteration;
     }

--- a/test/integration/filters/local_reply_during_encoding_filter.cc
+++ b/test/integration/filters/local_reply_during_encoding_filter.cc
@@ -17,7 +17,7 @@ public:
 
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
     encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError, "", nullptr, absl::nullopt,
-                                       "");
+                                       nullptr, "");
     return Http::FilterHeadersStatus::StopIteration;
   }
 };

--- a/test/integration/filters/local_reply_with_metadata_filter.cc
+++ b/test/integration/filters/local_reply_with_metadata_filter.cc
@@ -19,7 +19,7 @@ public:
     Http::MetadataMap metadata_map = {{"headers", "headers"}, {"duplicate", "duplicate"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     decoder_callbacks_->addDecodedMetadata().emplace_back(std::move(metadata_map_ptr));
-    decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt,
+    decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "", nullptr, absl::nullopt, nullptr,
                                        "local_reply_with_metadata_filter_is_ready");
     return Http::FilterHeadersStatus::StopIteration;
   }

--- a/test/integration/filters/on_local_reply_filter.cc
+++ b/test/integration/filters/on_local_reply_filter.cc
@@ -20,14 +20,14 @@ public:
       dual_reply_ = true;
     }
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "original_reply", nullptr,
-                                       absl::nullopt, "original_reply");
+                                       absl::nullopt, nullptr, "original_reply");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
     if (dual_reply_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "second_reply", nullptr,
-                                         absl::nullopt, "second_reply");
+                                         absl::nullopt, nullptr, "second_reply");
       return Http::FilterHeadersStatus::StopIteration;
     }
     return Http::FilterHeadersStatus::Continue;

--- a/test/integration/filters/process_context_filter.cc
+++ b/test/integration/filters/process_context_filter.cc
@@ -24,11 +24,11 @@ public:
     if (!process_object_.isHealthy()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,
                                          "ProcessObjectForFilter is unhealthy", nullptr,
-                                         absl::nullopt, "");
+                                         absl::nullopt, nullptr, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
     decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "ProcessObjectForFilter is healthy",
-                                       nullptr, absl::nullopt, "");
+                                       nullptr, absl::nullopt, nullptr, "");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -34,7 +34,7 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
     if (absl::StartsWith(headers.Path()->value().getStringView(), config_->prefix_)) {
       decoder_callbacks_->sendLocalReply(static_cast<Http::Code>(config_->code_), config_->body_,
-                                         nullptr, absl::nullopt, "");
+                                         nullptr, absl::nullopt, nullptr, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
     return Http::FilterHeadersStatus::Continue;

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -76,12 +76,14 @@ MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
   ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
-  ON_CALL(*this, sendLocalReply(_, _, _, _, _))
+  ON_CALL(*this, sendLocalReply(_, _, _, _, _, _))
       .WillByDefault(Invoke([this](Code code, absl::string_view body,
                                    std::function<void(ResponseHeaderMap & headers)> modify_headers,
                                    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                                   std::unique_ptr<::google::rpc::Status> grpc_error_details,
                                    absl::string_view details) {
-        sendLocalReply_(code, body, modify_headers, grpc_status, details);
+        sendLocalReply_(code, body, modify_headers, grpc_status, std::move(grpc_error_details),
+                        details);
       }));
   ON_CALL(*this, routeConfig())
       .WillByDefault(Return(absl::optional<Router::ConfigConstSharedPtr>()));
@@ -93,7 +95,8 @@ MockStreamDecoderFilterCallbacks::~MockStreamDecoderFilterCallbacks() = default;
 void MockStreamDecoderFilterCallbacks::sendLocalReply_(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+    std::unique_ptr<::google::rpc::Status> grpc_error_details, absl::string_view details) {
   Utility::sendLocalReply(
       stream_destroyed_,
       Utility::EncodeFunctions{
@@ -107,7 +110,8 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
           [this](Buffer::Instance& data, bool end_stream) -> void {
             encodeData(data, end_stream);
           }},
-      Utility::LocalReplyData{is_grpc_request_, code, body, grpc_status, is_head_request_});
+      Utility::LocalReplyData{is_grpc_request_, code, body, grpc_status,
+                              std::move(grpc_error_details), is_head_request_});
 }
 
 MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -229,6 +229,7 @@ public:
   void sendLocalReply_(Code code, absl::string_view body,
                        std::function<void(ResponseHeaderMap& headers)> modify_headers,
                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                       std::unique_ptr<::google::rpc::Status> grpc_error_details,
                        absl::string_view details);
 
   void encode1xxHeaders(ResponseHeaderMapPtr&& headers) override { encode1xxHeaders_(*headers); }
@@ -267,6 +268,7 @@ public:
               (Code code, absl::string_view body,
                std::function<void(ResponseHeaderMap& headers)> modify_headers,
                const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+               std::unique_ptr<::google::rpc::Status> grpc_error_details,
                absl::string_view details));
   MOCK_METHOD(Buffer::BufferMemoryAccountSharedPtr, account, (), (const));
   MOCK_METHOD(void, setUpstreamOverrideHost, (absl::string_view host));
@@ -323,6 +325,7 @@ public:
               (Code code, absl::string_view body,
                std::function<void(ResponseHeaderMap& headers)> modify_headers,
                const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+               std::unique_ptr<::google::rpc::Status> grpc_error_details,
                absl::string_view details));
   MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
 


### PR DESCRIPTION
Signed-off-by: Xuyang Tao <taoxuy@google.com>

Commit Message: Make filter's sendLocalReply support gRPC error details. gRPC [error details](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto#L46) is the canonical place for gRPC to send additional error details. Currently Envoy filter's local reply doesn't support and this change is to make that happen.
Risk Level:low
Testing:add unit tests 
Docs Changes:
Release Notes:
Platform Specific Features:
