### PR TITLE
Update googleurl to the latest version.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,6 +44,9 @@ build --action_env=CXX
 build --action_env=LLVM_CONFIG
 build --action_env=PATH
 
+# Disable ICU linking for googleurl.
+build --@com_googlesource_googleurl//build_config:system_icu=0
+
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled
 build:sanitizer --linkopt -ldl

--- a/bazel/external/googleurl.patch
+++ b/bazel/external/googleurl.patch
@@ -112,39 +112,3 @@ index b5fe925..31aa81e 100644
  template <typename T>
  struct pointer_traits<::gurl_base::CheckedContiguousIterator<T>> {
 
-# TODO(dio): Consider to remove the following patch when we have IDN-free optional build for URL
-# library from the upstream Chromium project. This is tracked in:
-# https://github.com/envoyproxy/envoy/issues/14743.
-
-diff --git a/url/BUILD b/url/BUILD
-index f2ec8da..df69661 100644
---- a/url/BUILD
-+++ b/url/BUILD
-@@ -52,3 +52,27 @@ cc_library(
-         "//polyfills",
-     ] + build_config.icuuc_deps,
- )
-+
-+cc_library(
-+    name = "envoy_url",
-+    srcs = [
-+       "url_canon.cc",
-+       "url_canon_internal.cc",
-+       "url_canon_path.cc",
-+       "url_canon_stdstring.cc",
-+    ],
-+    hdrs = [
-+       "third_party/mozilla/url_parse.h",
-+       "url_canon.h",
-+       "url_canon_internal.h",
-+       "url_canon_stdstring.h",
-+       "url_parse_internal.h",
-+    ],
-+    copts = build_config.default_copts,
-+    visibility = ["//visibility:public"],
-+    deps = [
-+       "//base",
-+       "//base/strings",
-+       "//polyfills",
-+    ]
-+)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -872,13 +872,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Chrome URL parsing library",
         project_desc = "Chrome URL parsing library",
         project_url = "https://quiche.googlesource.com/googleurl",
-        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/561705e0066ff11e6cb97b8092f1547835beeb92.tar.gz.
-        version = "561705e0066ff11e6cb97b8092f1547835beeb92",
-        sha256 = "7ce00768fea1fa4c7bf658942f13e41c9ba30e9cff931a6cda2f9fd02289f673",
+        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/9fa1882a31bb16d8a4ca01dc4a13cfb4bd491e9d.tar.gz.
+        version = "9fa1882a31bb16d8a4ca01dc4a13cfb4bd491e9d",
+        sha256 = "8f0ef03baa1146bab93f44e52dd16fcee41147ba361a2a7853921924d0045b93",
         urls = ["https://storage.googleapis.com/quiche-envoy-integration/googleurl_{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
         extensions = [],
-        release_date = "2021-08-31",
+        release_date = "2022-03-30",
         cpe = "N/A",
     ),
     com_google_cel_cpp = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -872,13 +872,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Chrome URL parsing library",
         project_desc = "Chrome URL parsing library",
         project_url = "https://quiche.googlesource.com/googleurl",
-        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/9fa1882a31bb16d8a4ca01dc4a13cfb4bd491e9d.tar.gz.
-        version = "9fa1882a31bb16d8a4ca01dc4a13cfb4bd491e9d",
-        sha256 = "8f0ef03baa1146bab93f44e52dd16fcee41147ba361a2a7853921924d0045b93",
+        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/9cdb1f4d1a365ebdbcbf179dadf7f8aa5ee802e7.tar.gz.
+        version = "9cdb1f4d1a365ebdbcbf179dadf7f8aa5ee802e7",
+        sha256 = "a1bc96169d34dcc1406ffb750deef3bc8718bd1f9069a2878838e1bd905de989",
         urls = ["https://storage.googleapis.com/quiche-envoy-integration/googleurl_{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
         extensions = [],
-        release_date = "2022-03-30",
+        release_date = "2022-04-04",
         cpe = "N/A",
     ),
     com_google_cel_cpp = dict(

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -503,7 +503,7 @@ envoy_cc_library(
         "//envoy/http:header_map_interface",
         "//source/common/common:logger_lib",
         "//source/common/runtime:runtime_features_lib",
-        "@com_googlesource_googleurl//url:envoy_url",
+        "@com_googlesource_googleurl//url",
     ],
 )
 


### PR DESCRIPTION
A newer version of googleurl also supports building without ICU, so we
can remove the patch that created an Envoy-specific build target.

Signed-off-by: Victor Vasiliev <vasilvv@google.com>

Risk Level: Low
Testing: Dependency change; should be covered by existing tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #14743