### PR TITLE
Limit num endpoints in config fuzz test

### DIFF
--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -21,7 +21,11 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v3::Bootstrap& input) {
   envoy::config::bootstrap::v3::Bootstrap sanitizedInput(input);
   // TODO(asraa): QUIC is not enabled in production code yet, so remove references for HTTP3.
   // Tracked at https://github.com/envoyproxy/envoy/issues/9513.
-  for (auto& cluster : *sanitizedInput.mutable_static_resources()->mutable_clusters()) {
+  for (::envoy::config::cluster::v3::Cluster& cluster :
+       *sanitizedInput.mutable_static_resources()->mutable_clusters()) {
+    if (cluster.load_assignment().endpoints_size() > 10) {
+      return;
+    }
     for (auto& health_check : *cluster.mutable_health_checks()) {
       if (health_check.http_health_check().codec_client_type() ==
           envoy::type::v3::CodecClientType::HTTP3) {

--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -19,13 +19,17 @@ namespace {
 // mode (quits upon validation of the given config)
 DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v3::Bootstrap& input) {
   envoy::config::bootstrap::v3::Bootstrap sanitizedInput(input);
-  // TODO(asraa): QUIC is not enabled in production code yet, so remove references for HTTP3.
-  // Tracked at https://github.com/envoyproxy/envoy/issues/9513.
   for (::envoy::config::cluster::v3::Cluster& cluster :
        *sanitizedInput.mutable_static_resources()->mutable_clusters()) {
     if (cluster.load_assignment().endpoints_size() > 10) {
+      ENVOY_LOG_MISC(debug,
+                     "Rejecting input with more the 10 endpoints to keep runtime acceptable. "
+                     "Current #endpoints: {}",
+                     cluster.load_assignment().endpoints_size());
       return;
     }
+    // TODO(asraa): QUIC is not enabled in production code yet, so remove references for HTTP3.
+    // Tracked at https://github.com/envoyproxy/envoy/issues/9513.
     for (auto& health_check : *cluster.mutable_health_checks()) {
       if (health_check.http_health_check().codec_client_type() ==
           envoy::type::v3::CodecClientType::HTTP3) {


### PR DESCRIPTION
Commit Message: Limit the number of endpoints in config_fuzz_test.
Additional Description:
A config_fuzz_test having more than 10 endpoints configured takes a
significant amount of time to run, which leads to a timeout in when
more then 1 minute is needed. Limiting the number of endpoints to 10
still allows the fuzzer to generate a sufficiently complex config.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
