### PR TITLE
router: add support for virtual cluster based on virtual host headers

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -36,6 +36,7 @@ Minor Behavior Changes
 * network: add a new ConnectionEvent ``ConnectedZeroRtt`` which may be raised by QUIC connections to allow early data to be sent before the handshake finishes. This event is ignored at callsites which is only reachable for TCP connections in the Envoy core code. Any extensions which depend on ConnectionEvent enum value should audit their usage of it to make sure this new event is handled appropriately.
 * perf: ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
 * ratelimit: the :ref:`header_value_match <envoy_v3_api_msg_config.route.v3.ratelimit.action.HeaderValueMatch>` support custom descriptor_key.
+* router: added support for configuring virtual clusters based on virtual host headers.
 * router: record upstream request timeouts for all the cases and not just for those requests which are awaiting headers. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` to false.
 * runtime: deprecated runtime flags set via configuration files or xDS will now ENVOY_BUG, rather than silently resulting in unexpected behavior on the data plane by no longer applying removed code paths.
 * runtime: removed global runtime as Envoy default. This behavioral change can be reverted by setting runtime guard ``envoy.restart_features.no_runtime_singleton`` to false.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -908,9 +908,12 @@ public:
   /**
    * Determine whether a specific request path belongs to a virtual cluster for use in stats, etc.
    * @param headers supplies the request headers.
+   * @param stream_info holds additional information about the request.
    * @return the virtual cluster or nullptr if there is no match.
    */
-  virtual const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const PURE;
+  virtual const VirtualCluster*
+  virtualCluster(const Http::HeaderMap& headers,
+                 const StreamInfo::StreamInfo& stream_info) const PURE;
 
   /**
    * @return const VirtualHost& the virtual host that owns the route.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -257,7 +257,8 @@ private:
     absl::optional<std::chrono::milliseconds> grpcTimeoutOffset() const override {
       return absl::nullopt;
     }
-    const Router::VirtualCluster* virtualCluster(const Http::HeaderMap&) const override {
+    const Router::VirtualCluster* virtualCluster(const Http::HeaderMap&,
+                                                 const StreamInfo::StreamInfo&) const override {
       return nullptr;
     }
     const Router::TlsContextMatchCriteria* tlsContextMatchCriteria() const override {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -23,6 +23,7 @@
 #include "source/common/common/matchers.h"
 #include "source/common/config/metadata.h"
 #include "source/common/http/hash_policy.h"
+#include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
 #include "source/common/matcher/matcher.h"
 #include "source/common/router/config_utility.h"
@@ -533,6 +534,8 @@ public:
   void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
                               const StreamInfo::StreamInfo& stream_info,
                               bool insert_envoy_original_path) const override;
+  const VirtualCluster* virtualCluster(const Http::HeaderMap& headers,
+                                       const StreamInfo::StreamInfo& stream_info) const override;
   Http::HeaderTransforms requestHeaderTransforms(const StreamInfo::StreamInfo& stream_info,
                                                  bool do_formatting = true) const override;
   void finalizeResponseHeaders(Http::ResponseHeaderMap& headers,
@@ -557,9 +560,6 @@ public:
   }
   uint32_t retryShadowBufferLimit() const override { return retry_shadow_buffer_limit_; }
   const std::vector<ShadowPolicyPtr>& shadowPolicies() const override { return shadow_policies_; }
-  const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
-    return vhost_.virtualClusterFromEntries(headers);
-  }
   std::chrono::milliseconds timeout() const override { return timeout_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   bool usingNewTimeouts() const override { return using_new_timeouts_; }
@@ -729,8 +729,9 @@ private:
       return parent_->tlsContextMatchCriteria();
     }
 
-    const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
-      return parent_->virtualCluster(headers);
+    const VirtualCluster* virtualCluster(const Http::HeaderMap& headers,
+                                         const StreamInfo::StreamInfo& stream_info) const override {
+      return parent_->virtualCluster(headers, stream_info);
     }
 
     const std::multimap<std::string, std::string>& opaqueConfig() const override {

--- a/source/common/router/delegating_route_impl.cc
+++ b/source/common/router/delegating_route_impl.cc
@@ -120,8 +120,10 @@ absl::optional<std::chrono::milliseconds> DelegatingRouteEntry::grpcTimeoutOffse
   return base_route_->routeEntry()->grpcTimeoutOffset();
 }
 
-const VirtualCluster* DelegatingRouteEntry::virtualCluster(const Http::HeaderMap& headers) const {
-  return base_route_->routeEntry()->virtualCluster(headers);
+const VirtualCluster*
+DelegatingRouteEntry::virtualCluster(const Http::HeaderMap& headers,
+                                     const StreamInfo::StreamInfo& stream_info) const {
+  return base_route_->routeEntry()->virtualCluster(headers, stream_info);
 }
 
 const VirtualHost& DelegatingRouteEntry::virtualHost() const {

--- a/source/common/router/delegating_route_impl.h
+++ b/source/common/router/delegating_route_impl.h
@@ -95,7 +95,8 @@ public:
   absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const override;
   absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override;
   absl::optional<std::chrono::milliseconds> grpcTimeoutOffset() const override;
-  const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override;
+  const VirtualCluster* virtualCluster(const Http::HeaderMap& headers,
+                                       const StreamInfo::StreamInfo& stream_info) const override;
   const VirtualHost& virtualHost() const override;
   bool autoHostRewrite() const override;
   bool appendXfh() const override;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -651,16 +651,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
-  // Inject the active span's tracing context into the request headers.
-  callbacks_->activeSpan().injectContext(headers);
-
-  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
-                                       !config_.suppress_envoy_headers_);
-  // Set up stat prefixes, etc.
-  request_vcluster_ = route_entry_->virtualCluster(headers);
-  if (request_vcluster_ != nullptr) {
-    callbacks_->streamInfo().setVirtualClusterName(request_vcluster_->name());
-  }
   FilterUtility::setUpstreamScheme(
       headers, callbacks_->streamInfo().downstreamAddressProvider().sslConnection() != nullptr);
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -461,11 +461,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   cluster_ = cluster->info();
 
-  // Set up stat prefixes, etc.
-  request_vcluster_ = route_entry_->virtualCluster(headers);
-  if (request_vcluster_ != nullptr) {
-    callbacks_->streamInfo().setVirtualClusterName(request_vcluster_->name());
-  }
   ENVOY_STREAM_LOG(debug, "cluster '{}' match for URL '{}'", *callbacks_,
                    route_entry_->clusterName(), headers.getPathValue());
 
@@ -649,8 +644,16 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
+  // Inject the active span's tracing context into the request headers.
+  callbacks_->activeSpan().injectContext(headers);
+
   route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
                                        !config_.suppress_envoy_headers_);
+  // Set up stat prefixes, etc.
+  request_vcluster_ = route_entry_->virtualCluster(headers);
+  if (request_vcluster_ != nullptr) {
+    callbacks_->streamInfo().setVirtualClusterName(request_vcluster_->name());
+  }
   FilterUtility::setUpstreamScheme(
       headers, callbacks_->streamInfo().downstreamAddressProvider().sslConnection() != nullptr);
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -462,9 +462,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   cluster_ = cluster->info();
 
   // Set up stat prefixes, etc.
-  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
-                                       !config_.suppress_envoy_headers_);
-  request_vcluster_ = route_entry_->virtualCluster(headers);
+  request_vcluster_ = route_entry_->virtualCluster(headers, callbacks_->streamInfo());
   if (request_vcluster_ != nullptr) {
     callbacks_->streamInfo().setVirtualClusterName(request_vcluster_->name());
   }
@@ -651,6 +649,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   callbacks_->streamInfo().setAttemptCount(attempt_count_);
 
+  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
+                                       !config_.suppress_envoy_headers_);
   FilterUtility::setUpstreamScheme(
       headers, callbacks_->streamInfo().downstreamAddressProvider().sslConnection() != nullptr);
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -461,6 +461,13 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
   cluster_ = cluster->info();
 
+  // Set up stat prefixes, etc.
+  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
+                                       !config_.suppress_envoy_headers_);
+  request_vcluster_ = route_entry_->virtualCluster(headers);
+  if (request_vcluster_ != nullptr) {
+    callbacks_->streamInfo().setVirtualClusterName(request_vcluster_->name());
+  }
   ENVOY_STREAM_LOG(debug, "cluster '{}' match for URL '{}'", *callbacks_,
                    route_entry_->clusterName(), headers.getPathValue());
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -990,6 +990,8 @@ TEST_F(HttpConnectionManagerImplTest, DelegatingRouteEntryAllCalls) {
                                                                {":path", "/new_endpoint/foo"},
                                                                {":method", "GET"},
                                                                {"x-forwarded-proto", "http"}};
+        NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+
         EXPECT_EQ(default_route->routeEntry()->currentUrlPathAfterRewrite(test_req_headers),
                   delegating_route_foo->routeEntry()->currentUrlPathAfterRewrite(test_req_headers));
 
@@ -1052,7 +1054,6 @@ TEST_F(HttpConnectionManagerImplTest, DelegatingRouteEntryAllCalls) {
                   delegating_route_foo->routeEntry()->maxGrpcTimeout());
         EXPECT_EQ(default_route->routeEntry()->grpcTimeoutOffset(),
                   delegating_route_foo->routeEntry()->grpcTimeoutOffset());
-        NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
         EXPECT_EQ(
             default_route->routeEntry()->virtualCluster(test_req_headers, stream_info),
             delegating_route_foo->routeEntry()->virtualCluster(test_req_headers, stream_info));
@@ -1099,7 +1100,6 @@ TEST_F(HttpConnectionManagerImplTest, DelegatingRouteEntryAllCalls) {
                   delegating_route_foo->routeEntry()->routeName());
 
         // Coverage for finalizeRequestHeaders
-        NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
         delegating_route_foo->routeEntry()->finalizeRequestHeaders(test_req_headers, stream_info,
                                                                    true);
         EXPECT_EQ("/new_endpoint/foo", test_req_headers.get_(Http::Headers::get().Path));

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1052,8 +1052,10 @@ TEST_F(HttpConnectionManagerImplTest, DelegatingRouteEntryAllCalls) {
                   delegating_route_foo->routeEntry()->maxGrpcTimeout());
         EXPECT_EQ(default_route->routeEntry()->grpcTimeoutOffset(),
                   delegating_route_foo->routeEntry()->grpcTimeoutOffset());
-        EXPECT_EQ(default_route->routeEntry()->virtualCluster(test_req_headers),
-                  delegating_route_foo->routeEntry()->virtualCluster(test_req_headers));
+        NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+        EXPECT_EQ(
+            default_route->routeEntry()->virtualCluster(test_req_headers, stream_info),
+            delegating_route_foo->routeEntry()->virtualCluster(test_req_headers, stream_info));
 
         EXPECT_EQ(default_route->routeEntry()->virtualHost().corsPolicy(),
                   delegating_route_foo->routeEntry()->virtualHost().corsPolicy());

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -176,7 +176,8 @@ protected:
   }
 
   std::string virtualClusterName(const RouteEntry* route, Http::TestRequestHeaderMapImpl& headers) {
-    Stats::StatName name = route->virtualCluster(headers)->statName();
+    NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+    Stats::StatName name = route->virtualCluster(headers, stream_info)->statName();
     return factory_context_.scope().symbolTable().toString(name);
   }
 
@@ -3111,7 +3112,7 @@ virtual_hosts:
     route->routeEntry()->rateLimitPolicy();
     route->routeEntry()->retryPolicy();
     route->routeEntry()->shadowPolicies();
-    route->routeEntry()->virtualCluster(headers);
+    route->routeEntry()->virtualCluster(headers, stream_info);
     route->routeEntry()->virtualHost();
     route->routeEntry()->virtualHost().rateLimitPolicy();
     route->routeEntry()->pathMatchCriterion();

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -678,7 +678,7 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "sni.lyft.com"}
+                                                 {":authority", "sni.lyft.com"},
                                                  {matching_header, "true"}};
 
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -697,8 +697,8 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response2.get());
 
-  test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 2);
-  test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 0);
+  test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
+  test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 1);
 }
 
 // Make sure virtual cluster stats are charged to the virtual cluster based on header specified in

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -671,12 +671,6 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
           headers->set_name(matching_header);
           headers->set_present_match(true);
         }
-        {
-          envoy::config::core::v3::HeaderValueOption* header =
-              virtual_host->mutable_request_headers_to_add()->Add();
-          header->mutable_header()->set_key(matching_header);
-          header->mutable_header()->set_value("value");
-        }
       });
   initialize();
 
@@ -686,8 +680,7 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
                                                  {":scheme", "http"},
                                                  {":authority", "sni.lyft.com"}};
 
-  auto response =
-      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
@@ -734,8 +727,7 @@ void HttpIntegrationTest::testRouterVirtualClustersOnVirtualHostHeader() {
                                                  {":scheme", "http"},
                                                  {":authority", "sni.lyft.com"}};
 
-  auto response =
-      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -680,14 +680,13 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
                                                  {":scheme", "http"},
                                                  {":authority", "sni.lyft.com"}};
 
-  auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
   test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 0);
 
-  auto response2 =
-      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response2 = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response2.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -678,7 +678,8 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
-                                                 {":authority", "sni.lyft.com"}};
+                                                 {":authority", "sni.lyft.com"}
+                                                 {matching_header, "true"}};
 
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -723,7 +723,8 @@ void HttpIntegrationTest::testRouterVirtualClustersOnVirtualHostHeader() {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -686,7 +686,8 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
   test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 0);
 
-  auto response2 = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response2 = 
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response2.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
@@ -721,10 +722,6 @@ void HttpIntegrationTest::testRouterVirtualClustersOnVirtualHostHeader() {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
-                                                 {":path", "/test/long/url"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "sni.lyft.com"}};
 
   auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -672,10 +672,10 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
           headers->set_present_match(true);
         }
         {
-                envoy::config::core::v3::HeaderValueOption* header =
-          virtual_host->mutable_request_headers_to_add()->Add();
-      header->mutable_header()->set_key(matching_header);
-      header->mutable_header()->set_value("value");
+          envoy::config::core::v3::HeaderValueOption* header =
+              virtual_host->mutable_request_headers_to_add()->Add();
+          header->mutable_header()->set_key(matching_header);
+          header->mutable_header()->set_value("value");
         }
       });
   initialize();
@@ -686,7 +686,8 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
                                                  {":scheme", "http"},
                                                  {":authority", "sni.lyft.com"}};
 
-  auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
@@ -700,7 +701,8 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 0);
 }
 
-// Make sure virtual cluster stats are charged to the virtual cluster based on header specified in virtual host.
+// Make sure virtual cluster stats are charged to the virtual cluster based on header specified in
+// virtual host.
 void HttpIntegrationTest::testRouterVirtualClustersOnVirtualHostHeader() {
   const std::string matching_header = "x-use-test-vcluster";
   config_helper_.addConfigModifier(
@@ -718,10 +720,10 @@ void HttpIntegrationTest::testRouterVirtualClustersOnVirtualHostHeader() {
           headers->set_present_match(true);
         }
         {
-                envoy::config::core::v3::HeaderValueOption* header =
-          virtual_host->mutable_request_headers_to_add()->Add();
-      header->mutable_header()->set_key(matching_header);
-      header->mutable_header()->set_value("value");
+          envoy::config::core::v3::HeaderValueOption* header =
+              virtual_host->mutable_request_headers_to_add()->Add();
+          header->mutable_header()->set_key(matching_header);
+          header->mutable_header()->set_value("value");
         }
       });
   initialize();
@@ -732,7 +734,8 @@ void HttpIntegrationTest::testRouterVirtualClustersOnVirtualHostHeader() {
                                                  {":scheme", "http"},
                                                  {":authority", "sni.lyft.com"}};
 
-  auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response.get());
 
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -686,7 +686,7 @@ void HttpIntegrationTest::testRouterVirtualClusters() {
   test_server_->waitForCounterEq("vhost.integration.vcluster.test_vcluster.upstream_rq_total", 1);
   test_server_->waitForCounterEq("vhost.integration.vcluster.other.upstream_rq_total", 0);
 
-  auto response2 = 
+  auto response2 =
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   checkSimpleRequestSuccess(0, 0, response2.get());
 

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -211,6 +211,7 @@ protected:
   void testRouterNotFound();
   void testRouterNotFoundWithBody();
   void testRouterVirtualClusters();
+  void testRouterVirtualClustersOnVirtualHostHeader();
   void testRouterUpstreamProtocolError(const std::string&, const std::string&);
 
   void testRouterRequestAndResponseWithBody(

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -74,7 +74,9 @@ TEST_P(DownstreamProtocolIntegrationTest, RouterNotFound) { testRouterNotFound()
 
 TEST_P(ProtocolIntegrationTest, RouterVirtualClusters) { testRouterVirtualClusters(); }
 
-TEST_P(ProtocolIntegrationTest, RouterVirtualClustersOnVirtualHost) { testRouterVirtualClustersOnVirtualHostHeader();}
+TEST_P(ProtocolIntegrationTest, RouterVirtualClustersOnVirtualHost) {
+  testRouterVirtualClustersOnVirtualHostHeader();
+}
 
 // Change the default route to be restrictive, and send a POST to an alternate route.
 TEST_P(DownstreamProtocolIntegrationTest, RouterNotFoundBodyNoBuffer) {

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -74,6 +74,8 @@ TEST_P(DownstreamProtocolIntegrationTest, RouterNotFound) { testRouterNotFound()
 
 TEST_P(ProtocolIntegrationTest, RouterVirtualClusters) { testRouterVirtualClusters(); }
 
+TEST_P(ProtocolIntegrationTest, RouterVirtualClustersOnVirtualHost) { testRouterVirtualClustersOnVirtualHostHeader();}
+
 // Change the default route to be restrictive, and send a POST to an alternate route.
 TEST_P(DownstreamProtocolIntegrationTest, RouterNotFoundBodyNoBuffer) {
   testRouterNotFoundWithBody();

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -104,7 +104,7 @@ MockRouteEntry::MockRouteEntry() {
       .WillByDefault(Return(std::numeric_limits<uint32_t>::max()));
   ON_CALL(*this, shadowPolicies()).WillByDefault(ReturnRef(shadow_policies_));
   ON_CALL(*this, timeout()).WillByDefault(Return(std::chrono::milliseconds(10)));
-  ON_CALL(*this, virtualCluster(_)).WillByDefault(Return(&virtual_cluster_));
+  ON_CALL(*this, virtualCluster(_, _)).WillByDefault(Return(&virtual_cluster_));
   ON_CALL(*this, virtualHost()).WillByDefault(ReturnRef(virtual_host_));
   ON_CALL(*this, includeVirtualHostRateLimits()).WillByDefault(Return(true));
   ON_CALL(*this, pathMatchCriterion()).WillByDefault(ReturnRef(path_match_criterion_));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -379,7 +379,8 @@ public:
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderOffset, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxGrpcTimeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutOffset, (), (const));
-  MOCK_METHOD(const VirtualCluster*, virtualCluster, (const Http::HeaderMap& headers), (const));
+  MOCK_METHOD(const VirtualCluster*, virtualCluster,
+              (const Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info), (const));
   MOCK_METHOD(const VirtualHost&, virtualHost, (), (const));
   MOCK_METHOD(bool, autoHostRewrite, (), (const));
   MOCK_METHOD(bool, appendXfh, (), (const));

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -335,7 +335,7 @@ bool RouterCheckTool::compareVirtualCluster(
   std::string actual = "";
   if (has_virtual_cluster) {
     Stats::StatName stat_name =
-        tool_config.route_->routeEntry()->virtualCluster(*tool_config.request_headers_)->statName();
+        tool_config.route_->routeEntry()->virtualCluster(*tool_config.request_headers_, stream_info)->statName();
     actual = tool_config.symbolTable().toString(stat_name);
   }
   const bool matches =

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -334,8 +334,9 @@ bool RouterCheckTool::compareVirtualCluster(
                              *tool_config.request_headers_, stream_info) != nullptr;
   std::string actual = "";
   if (has_virtual_cluster) {
-    Stats::StatName stat_name =
-        tool_config.route_->routeEntry()->virtualCluster(*tool_config.request_headers_, stream_info)->statName();
+    Stats::StatName stat_name = tool_config.route_->routeEntry()
+                                    ->virtualCluster(*tool_config.request_headers_, stream_info)
+                                    ->statName();
     actual = tool_config.symbolTable().toString(stat_name);
   }
   const bool matches =

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -120,7 +120,8 @@ private:
   bool compareCluster(ToolConfig& tool_config,
                       const envoy::RouterCheckToolSchema::ValidationAssert& expected,
                       envoy::RouterCheckToolSchema::ValidationFailure& failure);
-  bool compareVirtualCluster(ToolConfig& tool_config,
+  bool compareVirtualCluster(const Envoy::StreamInfo::StreamInfoImpl stream_info,
+                             ToolConfig& tool_config,
                              const envoy::RouterCheckToolSchema::ValidationAssert& expected,
                              envoy::RouterCheckToolSchema::ValidationFailure& failure);
   bool compareVirtualHost(ToolConfig& tool_config,


### PR DESCRIPTION

Commit Message: add support for virtual cluster based on virtual host headers
Additional Description: Currently virtual cluster is determined based on downstream headers. But we have a usecase to generate stats based on the headers added in virtual host. This PR enables that.
Risk Level: Low
Testing: Added integration test
Docs Changes: N/A
Release Notes: Added

