### PR TITLE
bazel: Add googleurl patch for android

### DIFF
--- a/bazel/external/googleurl.patch
+++ b/bazel/external/googleurl.patch
@@ -112,3 +112,18 @@ index b5fe925..31aa81e 100644
  template <typename T>
  struct pointer_traits<::gurl_base::CheckedContiguousIterator<T>> {
 
+# TODO(keith): Remove once https://quiche-review.googlesource.com/c/googleurl/+/10980 lands
+
+diff --git a/base/compiler_specific.h b/base/compiler_specific.h
+index 3a85453..a329de2 100644
+--- a/base/compiler_specific.h
++++ b/base/compiler_specific.h
+@@ -382,7 +382,7 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
+ #define CONSTINIT
+ #endif
+ 
+-#if defined(__clang__)
++#if defined(__clang__) && HAS_CPP_ATTRIBUTE(gsl::Pointer)
+ #define GSL_OWNER [[gsl::Owner]]
+ #define GSL_POINTER [[gsl::Pointer]]
+ #else


### PR DESCRIPTION
The [recent update](https://github.com/envoyproxy/envoy/commit/74a32f3aa0a5b7ba118ba99cb0a3d61a24a900b2) broke Android builds because the clang shipped with the NDK version we use doesn't support these attributes.

I've submitted this upstream as well https://quiche-review.googlesource.com/c/googleurl/+/10961

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>