### PR TITLE
filter: remove legacy mock function for DecoderFilter

### DIFF
--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -85,7 +85,6 @@ public:
   // SipProxy::SipFilters::DecoderFilter
   MOCK_METHOD(void, onDestroy, ());
   MOCK_METHOD(void, setDecoderFilterCallbacks, (DecoderFilterCallbacks & callbacks));
-  MOCK_METHOD(void, resetUpstreamConnection, ());
   MOCK_METHOD(bool, passthroughSupported, (), (const));
 
   // SipProxy::DecoderEventHandler

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -211,7 +211,6 @@ public:
   // ThriftProxy::ThriftFilters::DecoderFilter
   MOCK_METHOD(void, onDestroy, ());
   MOCK_METHOD(void, setDecoderFilterCallbacks, (DecoderFilterCallbacks & callbacks));
-  MOCK_METHOD(void, resetUpstreamConnection, ());
   MOCK_METHOD(bool, passthroughSupported, (), (const));
 
   // ThriftProxy::DecoderEventHandler


### PR DESCRIPTION
Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>

Commit Message:
`resetUpstreamConnection` should be a removed method of `DecoderFilter`.

