### PR TITLE
access log: add GRPC_STATUS_NUMBER format operator

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -569,6 +569,9 @@ The following command operators are supported:
 %GRPC_STATUS%
   gRPC status code which is easy to interpret with text message corresponding with number.
 
+%GRPC_STATUS_NUMBER%
+  gRPC status code.
+
 .. _config_access_log_format_req:
 
 %REQ(X?Y):Z%

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -12,7 +12,6 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
-* access_log: add GRPC_STATUS_NUMBER format command operator.
 * access_log: log all header values in the grpc access log.
 * build: ``VERSION`` and ``API_VERSION`` have been renamed to ``VERSION.txt`` and ``API_VERSION.txt`` respectively to avoid conflicts with the C++ ``<version>`` header.
 * config: type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` to false.
@@ -100,6 +99,7 @@ Removed Config or Runtime
 
 New Features
 ------------
+* access_log: added new access_log command operator ``%GRPC_STATUS_NUMBER%``.
 * access_log: added new access_log command operator ``%ENVIRONMENT(X):Z%``.
 * access_log: added TCP proxy upstream and downstream byte logging. This can be accessed through the ``%DOWNSTREAM_WIRE_BYTES_SENT%``, ``%DOWNSTREAM_WIRE_BYTES_RECEIVED%``, ``%UPSTREAM_WIRE_BYTES_SENT%``, and ``%UPSTREAM_WIRE_BYTES_RECEIVED%`` access_log command operatrors.
 * access_log: make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -12,6 +12,7 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* access_log: add GRPC_STATUS_NUMBER format command operator
 * access_log: log all header values in the grpc access log.
 * build: ``VERSION`` and ``API_VERSION`` have been renamed to ``VERSION.txt`` and ``API_VERSION.txt`` respectively to avoid conflicts with the C++ ``<version>`` header.
 * config: type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` to false.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -12,7 +12,7 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
-* access_log: add GRPC_STATUS_NUMBER format command operator
+* access_log: add GRPC_STATUS_NUMBER format command operator.
 * access_log: log all header values in the grpc access log.
 * build: ``VERSION`` and ``API_VERSION`` have been renamed to ``VERSION.txt`` and ``API_VERSION.txt`` respectively to avoid conflicts with the C++ ``<version>`` header.
 * config: type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` to false.

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -375,8 +375,7 @@ SubstitutionFormatParser::getKnownFormatters() {
        {"GRPC_STATUS_NUMBER",
         {CommandSyntaxChecker::COMMAND_ONLY,
          [](const std::string&, const absl::optional<size_t>&) {
-           return std::make_unique<GrpcStatusFormatter>("grpc-status", "",
-                                                        absl::optional<size_t>(),
+           return std::make_unique<GrpcStatusFormatter>("grpc-status", "", absl::optional<size_t>(),
                                                         true);
          }}},
        {"REQUEST_HEADERS_BYTES",

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -372,6 +372,13 @@ SubstitutionFormatParser::getKnownFormatters() {
            return std::make_unique<GrpcStatusFormatter>("grpc-status", "",
                                                         absl::optional<size_t>());
          }}},
+       {"GRPC_STATUS_NUMBER",
+        {CommandSyntaxChecker::COMMAND_ONLY,
+         [](const std::string&, const absl::optional<size_t>&) {
+           return std::make_unique<GrpcStatusFormatter>("grpc-status", "",
+                                                        absl::optional<size_t>(),
+                                                        true);
+         }}},
        {"REQUEST_HEADERS_BYTES",
         {CommandSyntaxChecker::COMMAND_ONLY,
          [](const std::string&, absl::optional<size_t>&) {
@@ -1565,8 +1572,8 @@ HeadersByteSizeFormatter::formatValue(const Http::RequestHeaderMap& request_head
 
 GrpcStatusFormatter::GrpcStatusFormatter(const std::string& main_header,
                                          const std::string& alternative_header,
-                                         absl::optional<size_t> max_length)
-    : HeaderFormatter(main_header, alternative_header, max_length) {}
+                                         absl::optional<size_t> max_length, bool format_as_number)
+    : HeaderFormatter(main_header, alternative_header, max_length), format_as_number_(format_as_number) {}
 
 absl::optional<std::string>
 GrpcStatusFormatter::format(const Http::RequestHeaderMap&,
@@ -1577,6 +1584,9 @@ GrpcStatusFormatter::format(const Http::RequestHeaderMap&,
       Grpc::Common::getGrpcStatus(response_trailers, response_headers, info, true);
   if (!grpc_status.has_value()) {
     return absl::nullopt;
+  }
+  if (format_as_number_) {
+    return std::to_string(grpc_status.value());
   }
   const auto grpc_status_message = Grpc::Utility::grpcStatusToString(grpc_status.value());
   if (grpc_status_message == EMPTY_STRING || grpc_status_message == "InvalidCode") {
@@ -1594,6 +1604,9 @@ GrpcStatusFormatter::formatValue(const Http::RequestHeaderMap&,
       Grpc::Common::getGrpcStatus(response_trailers, response_headers, info, true);
   if (!grpc_status.has_value()) {
     return unspecifiedValue();
+  }
+  if (format_as_number_) {
+    return ValueUtil::numberValue(grpc_status.value());
   }
   const auto grpc_status_message = Grpc::Utility::grpcStatusToString(grpc_status.value());
   if (grpc_status_message == EMPTY_STRING || grpc_status_message == "InvalidCode") {

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1573,7 +1573,8 @@ HeadersByteSizeFormatter::formatValue(const Http::RequestHeaderMap& request_head
 GrpcStatusFormatter::GrpcStatusFormatter(const std::string& main_header,
                                          const std::string& alternative_header,
                                          absl::optional<size_t> max_length, bool format_as_number)
-    : HeaderFormatter(main_header, alternative_header, max_length), format_as_number_(format_as_number) {}
+    : HeaderFormatter(main_header, alternative_header, max_length),
+      format_as_number_(format_as_number) {}
 
 absl::optional<std::string>
 GrpcStatusFormatter::format(const Http::RequestHeaderMap&,

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -400,7 +400,7 @@ public:
 class GrpcStatusFormatter : public FormatterProvider, HeaderFormatter {
 public:
   GrpcStatusFormatter(const std::string& main_header, const std::string& alternative_header,
-                      absl::optional<size_t> max_length);
+                      absl::optional<size_t> max_length, bool format_as_number = false);
 
   // FormatterProvider
   absl::optional<std::string> format(const Http::RequestHeaderMap&,
@@ -411,6 +411,8 @@ public:
   ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
                                  const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&,
                                  absl::string_view) const override;
+private:
+  bool format_as_number_;
 };
 
 /**

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -413,7 +413,7 @@ public:
                                  absl::string_view) const override;
 
 private:
-  bool format_as_number_;
+  const bool format_as_number_;
 };
 
 /**

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -411,6 +411,7 @@ public:
   ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
                                  const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&,
                                  absl::string_view) const override;
+
 private:
   bool format_as_number_;
 };

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1094,7 +1094,7 @@ typed_config:
   path: /dev/null
   log_format:
     text_format_source:
-      inline_string: "%GRPC_STATUS%\n"
+      inline_string: "%GRPC_STATUS% %GRPC_STATUS_NUMBER%\n"
   )EOF";
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
@@ -1102,7 +1102,7 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
     response_trailers_.addCopy(Http::Headers::get().GrpcStatus, "0");
     log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
-    EXPECT_EQ("OK\n", output_);
+    EXPECT_EQ("OK 0\n", output_);
     response_trailers_.remove(Http::Headers::get().GrpcStatus);
   }
   {
@@ -1110,7 +1110,7 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
     response_headers_.addCopy(Http::Headers::get().GrpcStatus, "1");
     log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
-    EXPECT_EQ("Canceled\n", output_);
+    EXPECT_EQ("Canceled 1\n", output_);
     response_headers_.remove(Http::Headers::get().GrpcStatus);
   }
   {
@@ -1118,7 +1118,7 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
     response_headers_.addCopy(Http::Headers::get().GrpcStatus, "-1");
     log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
-    EXPECT_EQ("-1\n", output_);
+    EXPECT_EQ("-1 -1\n", output_);
     response_headers_.remove(Http::Headers::get().GrpcStatus);
   }
 }

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1968,7 +1968,7 @@ TEST(SubstitutionFormatterTest, GrpcStatusNumberFormatterTest) {
   for (size_t i = 0; i < grpcStatuses; ++i) {
     response_trailer = Http::TestResponseTrailerMapImpl{{"grpc-status", std::to_string(i)}};
     EXPECT_EQ(std::to_string(i), formatter.format(request_header, response_header, response_trailer,
-                                                 stream_info, body));
+                                                  stream_info, body));
     EXPECT_THAT(
         formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
         ProtoEq(ValueUtil::numberValue(i)));

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1955,6 +1955,64 @@ TEST(SubstitutionFormatterTest, GrpcStatusFormatterTest) {
   }
 }
 
+TEST(SubstitutionFormatterTest, GrpcStatusNumberFormatterTest) {
+  GrpcStatusFormatter formatter("grpc-status", "", absl::optional<size_t>(), true);
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Http::TestRequestHeaderMapImpl request_header;
+  Http::TestResponseHeaderMapImpl response_header;
+  Http::TestResponseTrailerMapImpl response_trailer;
+  std::string body;
+
+  const int grpcStatuses = static_cast<int>(Grpc::Status::WellKnownGrpcStatus::MaximumKnown) + 1;
+
+  for (size_t i = 0; i < grpcStatuses; ++i) {
+    response_trailer = Http::TestResponseTrailerMapImpl{{"grpc-status", std::to_string(i)}};
+    EXPECT_EQ(std::to_string(i), formatter.format(request_header, response_header, response_trailer,
+                                                 stream_info, body));
+    EXPECT_THAT(
+        formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
+        ProtoEq(ValueUtil::numberValue(i)));
+  }
+  {
+    response_trailer = Http::TestResponseTrailerMapImpl{{"not-a-grpc-status", "13"}};
+    EXPECT_EQ(absl::nullopt, formatter.format(request_header, response_header, response_trailer,
+                                              stream_info, body));
+    EXPECT_THAT(
+        formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
+        ProtoEq(ValueUtil::nullValue()));
+  }
+  {
+    response_trailer = Http::TestResponseTrailerMapImpl{{"grpc-status", "-1"}};
+    EXPECT_EQ("-1", formatter.format(request_header, response_header, response_trailer, stream_info,
+                                     body));
+    EXPECT_THAT(
+        formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
+        ProtoEq(ValueUtil::numberValue(-1)));
+    response_trailer = Http::TestResponseTrailerMapImpl{{"grpc-status", "42738"}};
+    EXPECT_EQ("42738", formatter.format(request_header, response_header, response_trailer,
+                                        stream_info, body));
+    EXPECT_THAT(
+        formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
+        ProtoEq(ValueUtil::numberValue(42738)));
+    response_trailer.clear();
+  }
+  {
+    response_header = Http::TestResponseHeaderMapImpl{{"grpc-status", "-1"}};
+    EXPECT_EQ("-1", formatter.format(request_header, response_header, response_trailer, stream_info,
+                                     body));
+    EXPECT_THAT(
+        formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
+        ProtoEq(ValueUtil::numberValue(-1)));
+    response_header = Http::TestResponseHeaderMapImpl{{"grpc-status", "42738"}};
+    EXPECT_EQ("42738", formatter.format(request_header, response_header, response_trailer,
+                                        stream_info, body));
+    EXPECT_THAT(
+        formatter.formatValue(request_header, response_header, response_trailer, stream_info, body),
+        ProtoEq(ValueUtil::numberValue(42738)));
+    response_header.clear();
+  }
+}
+
 void verifyStructOutput(ProtobufWkt::Struct output,
                         absl::node_hash_map<std::string, std::string> expected_map) {
   for (const auto& pair : expected_map) {


### PR DESCRIPTION
Similar to https://github.com/envoyproxy/envoy/issues/9352 but number format. Useful because `grpc-status` may appear in either the headers or in the trailers and there's no alternative to coalesce the value into a single access log field.

Appreciate feedback regarding C++ and testing. The change is simple enough, but I'm not particularly familiar with C++.

Risk Level: Low
Testing: Unit tests
Docs Changes: Required
Release Notes: Required
