### PR TITLE
Refactor sendLocalReply interface to have a struct to configure gRPC reply

### DIFF
--- a/envoy/grpc/BUILD
+++ b/envoy/grpc/BUILD
@@ -58,4 +58,5 @@ envoy_cc_library(
 envoy_cc_library(
     name = "status",
     hdrs = ["status.h"],
+    deps = ["@com_google_googleapis//google/rpc:status_cc_proto"],
 )

--- a/envoy/grpc/status.h
+++ b/envoy/grpc/status.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 #include <memory>
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -55,14 +55,13 @@ public:
     InvalidCode = -1,
   };
 
-
   /**
    * The gRPC status option for gRPC local reply.
    */
   struct LocalReplyGrpcStatusOption {
     // gRPC status code to override the httpToGrpcStatus mapping with.
-    const std::optional<GrpcStatus> status_code_;
-    LocalReplyGrpcStatusOption(GrpcStatus status_code): status_code_(status_code){}
+    const absl::optional<GrpcStatus> status_code_;
+    LocalReplyGrpcStatusOption(GrpcStatus status_code) : status_code_(status_code) {}
   };
 
   using LocalReplyGrpcStatusOptionPtr = std::unique_ptr<LocalReplyGrpcStatusOption>;

--- a/envoy/grpc/status.h
+++ b/envoy/grpc/status.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
+#include <memory>
 
 namespace Envoy {
 namespace Grpc {
@@ -52,6 +54,18 @@ public:
     // was invalid.
     InvalidCode = -1,
   };
+
+
+  /**
+   * The gRPC status option for gRPC local reply.
+   */
+  struct LocalReplyGrpcStatusOption {
+    // gRPC status code to override the httpToGrpcStatus mapping with.
+    const std::optional<GrpcStatus> status_code_;
+    LocalReplyGrpcStatusOption(GrpcStatus status_code): status_code_(status_code){}
+  };
+
+  using LocalReplyGrpcStatusOptionPtr = std::unique_ptr<LocalReplyGrpcStatusOption>;
 };
 
 } // namespace Grpc

--- a/envoy/grpc/status.h
+++ b/envoy/grpc/status.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include "absl/types/optional.h"
+#include "google/rpc/status.pb.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -59,9 +60,14 @@ public:
    * The gRPC status option for gRPC local reply.
    */
   struct LocalReplyGrpcStatusOption {
-    // gRPC status code to override the httpToGrpcStatus mapping with.
+
+    // Supplies gRPC status code to override the httpToGrpcStatus mapping with.
     const absl::optional<GrpcStatus> status_code_;
-    LocalReplyGrpcStatusOption(GrpcStatus status_code) : status_code_(status_code) {}
+
+    // Supplies gRPC status error details.
+    std::unique_ptr<::google::rpc::Status> error_details_;
+
+    LocalReplyGrpcStatusOption(GrpcStatus status_code, std::unique_ptr<::google::rpc::Status> error_details) : status_code_(status_code), error_details_(std::move(error_details)) {}
   };
 
   using LocalReplyGrpcStatusOptionPtr = std::unique_ptr<LocalReplyGrpcStatusOption>;

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -220,7 +220,7 @@ public:
    */
   virtual void sendLocalReply(Code code, absl::string_view body,
                               const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                              const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                              Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                               absl::string_view details) PURE;
 
   /**

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -436,7 +436,7 @@ public:
    */
   virtual void sendLocalReply(Code response_code, absl::string_view body_text,
                               std::function<void(ResponseHeaderMap& headers)> modify_headers,
-                              const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                              Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                               absl::string_view details) PURE;
 
   /**
@@ -872,7 +872,7 @@ public:
    */
   virtual void sendLocalReply(Code response_code, absl::string_view body_text,
                               std::function<void(ResponseHeaderMap& headers)> modify_headers,
-                              const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                              Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                               absl::string_view details) PURE;
   /**
    * Adds new metadata to be encoded.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -378,7 +378,8 @@ private:
                                  [this](Buffer::Instance& data, bool end_stream) -> void {
                                    encodeData(data, end_stream);
                                  }},
-        Utility::LocalReplyData{is_grpc_request_, code, body, std::move(grpc_status), is_head_request_});
+        Utility::LocalReplyData{is_grpc_request_, code, body, std::move(grpc_status),
+                                is_head_request_});
   }
   // The async client won't pause if sending 1xx headers so simply swallow any.
   void encode1xxHeaders(ResponseHeaderMapPtr&&) override {}

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -359,7 +359,7 @@ private:
   void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {}
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
-                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                       absl::string_view details) override {
     if (encoded_response_headers_) {
       resetStream();
@@ -378,7 +378,7 @@ private:
                                  [this](Buffer::Instance& data, bool end_stream) -> void {
                                    encodeData(data, end_stream);
                                  }},
-        Utility::LocalReplyData{is_grpc_request_, code, body, grpc_status, is_head_request_});
+        Utility::LocalReplyData{is_grpc_request_, code, body, std::move(grpc_status), is_head_request_});
   }
   // The async client won't pause if sending 1xx headers so simply swallow any.
   void encode1xxHeaders(ResponseHeaderMapPtr&&) override {}

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -809,7 +809,8 @@ void ConnectionManagerImpl::ActiveStream::onStreamMaxDurationReached() {
   connection_manager_.stats_.named_.downstream_rq_max_duration_reached_.inc();
   sendLocalReply(Http::Utility::maybeRequestTimeoutCode(filter_manager_.remoteDecodeComplete()),
                  "downstream duration timeout", nullptr,
-std::make_unique<Envoy::Grpc::Status::LocalReplyGrpcStatusOption>(Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded),
+                 std::make_unique<Envoy::Grpc::Status::LocalReplyGrpcStatusOption>(
+                     Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded),
                  StreamInfo::ResponseCodeDetails::get().MaxDurationTimeout);
 }
 
@@ -1031,8 +1032,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
       const auto& reject_request_params = mutate_result.reject_request.value();
       connection_manager_.stats_.named_.downstream_rq_rejected_via_ip_detection_.inc();
       sendLocalReply(reject_request_params.response_code, reject_request_params.body, nullptr,
-                     nullptr,
-                     StreamInfo::ResponseCodeDetails::get().OriginalIPDetectionFailed);
+                     nullptr, StreamInfo::ResponseCodeDetails::get().OriginalIPDetectionFailed);
       return;
     }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -810,7 +810,7 @@ void ConnectionManagerImpl::ActiveStream::onStreamMaxDurationReached() {
   sendLocalReply(Http::Utility::maybeRequestTimeoutCode(filter_manager_.remoteDecodeComplete()),
                  "downstream duration timeout", nullptr,
                  std::make_unique<Envoy::Grpc::Status::LocalReplyGrpcStatusOption>(
-                     Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded),
+                     Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded, nullptr),
                  StreamInfo::ResponseCodeDetails::get().MaxDurationTimeout);
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -193,9 +193,9 @@ private:
     StreamInfo::StreamInfo& streamInfo() override { return filter_manager_.streamInfo(); }
     void sendLocalReply(Code code, absl::string_view body,
                         const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                        Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                         absl::string_view details) override {
-      return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, details);
+      return filter_manager_.sendLocalReply(code, body, modify_headers, std::move(grpc_status), details);
     }
 
     // Tracing::TracingConfig

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -195,7 +195,8 @@ private:
                         const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                         Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                         absl::string_view details) override {
-      return filter_manager_.sendLocalReply(code, body, modify_headers, std::move(grpc_status), details);
+      return filter_manager_.sendLocalReply(code, body, modify_headers, std::move(grpc_status),
+                                            details);
     }
 
     // Tracing::TracingConfig

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -760,7 +760,7 @@ void FilterManager::addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::In
     decodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
   } else {
     IS_ENVOY_BUG("Invalid request data");
-    sendLocalReply(Http::Code::BadGateway, "Filter error", nullptr,nullptr,
+    sendLocalReply(Http::Code::BadGateway, "Filter error", nullptr, nullptr,
                    StreamInfo::ResponseCodeDetails::get().FilterAddedInvalidRequestData);
   }
 }
@@ -939,7 +939,8 @@ void FilterManager::sendLocalReply(
     // state machine screwed up, bypass the filter chain and send the local
     // reply directly to the codec.
     //
-    sendDirectLocalReply(code, body, modify_headers, state_.is_head_request_, std::move(grpc_status));
+    sendDirectLocalReply(code, body, modify_headers, state_.is_head_request_,
+                         std::move(grpc_status));
   } else {
     // If we land in this branch, response headers have already been sent to the client.
     // All we can do at this point is reset the stream.
@@ -992,7 +993,8 @@ void FilterManager::sendLocalReplyViaFilterChain(
             encodeData(nullptr, data, end_stream,
                        FilterManager::FilterIterationStartState::CanStartFromCurrent);
           }},
-      Utility::LocalReplyData{is_grpc_request, code, body, std::move(grpc_status), is_head_request});
+      Utility::LocalReplyData{is_grpc_request, code, body, std::move(grpc_status),
+                              is_head_request});
 }
 
 void FilterManager::sendDirectLocalReply(
@@ -1037,7 +1039,8 @@ void FilterManager::sendDirectLocalReply(
             }
             maybeEndEncode(end_stream);
           }},
-      Utility::LocalReplyData{state_.is_grpc_request_, code, body, std::move(grpc_status), is_head_request});
+      Utility::LocalReplyData{state_.is_grpc_request_, code, body, std::move(grpc_status),
+                              is_head_request});
 }
 
 void FilterManager::encode1xxHeaders(ActiveStreamEncoderFilter* filter,
@@ -1663,9 +1666,9 @@ void ActiveStreamEncoderFilter::responseDataTooLarge() {
 
     // In this case, sendLocalReply will either send a response directly to the encoder, or
     // reset the stream.
-    parent_.sendLocalReply(
-        Http::Code::InternalServerError, CodeUtility::toString(Http::Code::InternalServerError),
-        nullptr, nullptr, StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
+    parent_.sendLocalReply(Http::Code::InternalServerError,
+                           CodeUtility::toString(Http::Code::InternalServerError), nullptr, nullptr,
+                           StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
   }
 }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -257,8 +257,9 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
 
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
-                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                       absl::string_view details) override;
+
   void encode1xxHeaders(ResponseHeaderMapPtr&& headers) override;
   ResponseHeaderMapOptRef informationalHeaders() const override;
   void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
@@ -351,7 +352,7 @@ struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
   void modifyEncodingBuffer(std::function<void(Buffer::Instance&)> callback) override;
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
-                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                       absl::string_view details) override;
   Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
 
@@ -852,7 +853,7 @@ public:
 
   void sendLocalReply(Code code, absl::string_view body,
                       const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status,
                       absl::string_view details);
   /**
    * Sends a local reply by constructing a response and passing it through all the encoder
@@ -861,7 +862,7 @@ public:
   void sendLocalReplyViaFilterChain(
       bool is_grpc_request, Code code, absl::string_view body,
       const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
-      const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details);
+      Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status, absl::string_view details);
 
   /**
    * Sends a local reply by constructing a response and skipping the encoder filters. The
@@ -870,7 +871,7 @@ public:
   void sendDirectLocalReply(Code code, absl::string_view body,
                             const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                             bool is_head_request,
-                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status);
+                            Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status);
 
   // Possibly increases buffer_limit_ to the value of limit.
   void setBufferLimit(uint32_t limit);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1217,7 +1217,7 @@ Status ServerConnectionImpl::sendProtocolError(absl::string_view details) {
   active_request_->response_encoder_.setDetails(details);
   if (!active_request_->response_encoder_.startedResponse()) {
     active_request_->request_decoder_->sendLocalReply(
-        error_code_, CodeUtility::toString(error_code_), nullptr, absl::nullopt, details);
+        error_code_, CodeUtility::toString(error_code_), nullptr, nullptr, details);
   }
   return okStatus();
 }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -594,10 +594,12 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
     response_headers->setReferenceContentType(Headers::get().ContentTypeValues.Grpc);
 
     if (response_headers->getGrpcStatusValue().empty()) {
-      response_headers->setGrpcStatus(std::to_string(
-          enumToInt(local_reply_data.grpc_status_
-                        ? local_reply_data.grpc_status_.value()
-                        : Grpc::Utility::httpToGrpcStatus(enumToInt(response_code)))));
+      if (local_reply_data.grpc_status_ && local_reply_data.grpc_status_->status_code_) {
+        response_headers->setGrpcStatus(local_reply_data.grpc_status_->status_code_.value());
+      } else {
+         response_headers->setGrpcStatus(Grpc::Utility::httpToGrpcStatus(enumToInt(response_code)));
+      }
+
     }
 
     if (!body_text.empty() && !local_reply_data.is_head_request_) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -597,9 +597,8 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
       if (local_reply_data.grpc_status_ && local_reply_data.grpc_status_->status_code_) {
         response_headers->setGrpcStatus(local_reply_data.grpc_status_->status_code_.value());
       } else {
-         response_headers->setGrpcStatus(Grpc::Utility::httpToGrpcStatus(enumToInt(response_code)));
+        response_headers->setGrpcStatus(Grpc::Utility::httpToGrpcStatus(enumToInt(response_code)));
       }
-
     }
 
     if (!body_text.empty() && !local_reply_data.is_head_request_) {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -373,8 +373,8 @@ struct LocalReplyData {
   Code response_code_;
   // Supplies the optional body text which is returned.
   absl::string_view body_text_;
-  // gRPC status code to override the httpToGrpcStatus mapping with.
-  const absl::optional<Grpc::Status::GrpcStatus> grpc_status_;
+
+  Grpc::Status::LocalReplyGrpcStatusOptionPtr grpc_status_;
   // Tells if this is a response to a HEAD request.
   bool is_head_request_ = false;
 };

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -401,7 +401,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     ENVOY_STREAM_LOG(debug, "no route match for URL '{}'", *callbacks_, headers.getPathValue());
 
     callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
-    callbacks_->sendLocalReply(Http::Code::NotFound, "", modify_headers, absl::nullopt,
+    callbacks_->sendLocalReply(Http::Code::NotFound, "", modify_headers, nullptr,
                                StreamInfo::ResponseCodeDetails::get().RouteNotFound);
     return Http::FilterHeadersStatus::StopIteration;
   }
@@ -429,7 +429,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
           }
           direct_response->finalizeResponseHeaders(response_headers, callbacks_->streamInfo());
         },
-        absl::nullopt, StreamInfo::ResponseCodeDetails::get().DirectResponse);
+        nullptr,StreamInfo::ResponseCodeDetails::get().DirectResponse);
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -455,7 +455,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
     callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoClusterFound);
     callbacks_->sendLocalReply(route_entry_->clusterNotFoundResponseCode(), "", modify_headers,
-                               absl::nullopt,
+                               nullptr,
                                StreamInfo::ResponseCodeDetails::get().ClusterNotFound);
     return Http::FilterHeadersStatus::StopIteration;
   }
@@ -481,7 +481,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         const std::string details =
             absl::StrCat(StreamInfo::ResponseCodeDetails::get().InvalidEnvoyRequestHeaders, "{",
                          StringUtil::replaceAllEmptySpace(res.entry_->key().getStringView()), "}");
-        callbacks_->sendLocalReply(Http::Code::BadRequest, body, nullptr, absl::nullopt, details);
+        callbacks_->sendLocalReply(Http::Code::BadRequest, body, nullptr, nullptr,details);
         return Http::FilterHeadersStatus::StopIteration;
       }
     }
@@ -508,7 +508,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
           // Note: append_cluster_info does not respect suppress_envoy_headers.
           modify_headers(headers);
         },
-        absl::nullopt, StreamInfo::ResponseCodeDetails::get().MaintenanceMode);
+        nullptr,StreamInfo::ResponseCodeDetails::get().MaintenanceMode);
     cluster_->stats().upstream_rq_maintenance_mode_.inc();
     return Http::FilterHeadersStatus::StopIteration;
   }
@@ -606,7 +606,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
           debug_config->not_forwarded_header_.value_or(Http::Headers::get().EnvoyNotForwarded),
           "true");
     };
-    callbacks_->sendLocalReply(Http::Code::NoContent, "", modify_headers, absl::nullopt, "");
+    callbacks_->sendLocalReply(Http::Code::NoContent, "", modify_headers, nullptr,"");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -728,7 +728,7 @@ void Filter::sendNoHealthyUpstreamResponse() {
   callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream);
   chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, false);
   callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "no healthy upstream", modify_headers_,
-                             absl::nullopt,
+                             nullptr,
                              StreamInfo::ResponseCodeDetails::get().NoHealthyUpstream);
 }
 
@@ -761,7 +761,7 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
       cleanup();
       callbacks_->sendLocalReply(
           Http::Code::InsufficientStorage, "exceeded request buffer limit while retrying upstream",
-          modify_headers_, absl::nullopt,
+          modify_headers_, nullptr,
           StreamInfo::ResponseCodeDetails::get().RequestPayloadExceededRetryBufferLimit);
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }
@@ -1048,7 +1048,7 @@ void Filter::onStreamMaxDurationReached(UpstreamRequest& upstream_request) {
   // sendLocalReply may instead reset the stream if downstream_response_started_ is true.
   callbacks_->sendLocalReply(
       Http::Utility::maybeRequestTimeoutCode(downstream_decode_complete),
-      "upstream max stream duration reached", modify_headers_, absl::nullopt,
+      "upstream max stream duration reached", modify_headers_, nullptr,
       StreamInfo::ResponseCodeDetails::get().UpstreamMaxStreamDurationReached);
 }
 
@@ -1114,7 +1114,7 @@ void Filter::onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_
         }
         modify_headers_(headers);
       },
-      absl::nullopt, details);
+      nullptr,details);
 }
 
 bool Filter::maybeRetryReset(Http::StreamResetReason reset_reason,

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -429,7 +429,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
           }
           direct_response->finalizeResponseHeaders(response_headers, callbacks_->streamInfo());
         },
-        nullptr,StreamInfo::ResponseCodeDetails::get().DirectResponse);
+        nullptr, StreamInfo::ResponseCodeDetails::get().DirectResponse);
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -455,8 +455,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
     callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoClusterFound);
     callbacks_->sendLocalReply(route_entry_->clusterNotFoundResponseCode(), "", modify_headers,
-                               nullptr,
-                               StreamInfo::ResponseCodeDetails::get().ClusterNotFound);
+                               nullptr, StreamInfo::ResponseCodeDetails::get().ClusterNotFound);
     return Http::FilterHeadersStatus::StopIteration;
   }
   cluster_ = cluster->info();
@@ -481,7 +480,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         const std::string details =
             absl::StrCat(StreamInfo::ResponseCodeDetails::get().InvalidEnvoyRequestHeaders, "{",
                          StringUtil::replaceAllEmptySpace(res.entry_->key().getStringView()), "}");
-        callbacks_->sendLocalReply(Http::Code::BadRequest, body, nullptr, nullptr,details);
+        callbacks_->sendLocalReply(Http::Code::BadRequest, body, nullptr, nullptr, details);
         return Http::FilterHeadersStatus::StopIteration;
       }
     }
@@ -508,7 +507,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
           // Note: append_cluster_info does not respect suppress_envoy_headers.
           modify_headers(headers);
         },
-        nullptr,StreamInfo::ResponseCodeDetails::get().MaintenanceMode);
+        nullptr, StreamInfo::ResponseCodeDetails::get().MaintenanceMode);
     cluster_->stats().upstream_rq_maintenance_mode_.inc();
     return Http::FilterHeadersStatus::StopIteration;
   }
@@ -606,7 +605,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
           debug_config->not_forwarded_header_.value_or(Http::Headers::get().EnvoyNotForwarded),
           "true");
     };
-    callbacks_->sendLocalReply(Http::Code::NoContent, "", modify_headers, nullptr,"");
+    callbacks_->sendLocalReply(Http::Code::NoContent, "", modify_headers, nullptr, "");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -728,8 +727,7 @@ void Filter::sendNoHealthyUpstreamResponse() {
   callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream);
   chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, false);
   callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "no healthy upstream", modify_headers_,
-                             nullptr,
-                             StreamInfo::ResponseCodeDetails::get().NoHealthyUpstream);
+                             nullptr, StreamInfo::ResponseCodeDetails::get().NoHealthyUpstream);
 }
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
@@ -1114,7 +1112,7 @@ void Filter::onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_
         }
         modify_headers_(headers);
       },
-      nullptr,details);
+      nullptr, details);
 }
 
 bool Filter::maybeRetryReset(Http::StreamResetReason reset_reason,

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -523,7 +523,7 @@ void UpstreamRequest::onPoolReady(
         absl::StrCat(StreamInfo::ResponseCodeDetails::get().FilterRemovedRequiredRequestHeaders,
                      "{", StringUtil::replaceAllEmptySpace(status.message()), "}");
     parent_.callbacks()->sendLocalReply(Http::Code::ServiceUnavailable, status.message(), nullptr,
-                                        absl::nullopt, details);
+                                        nullptr, details);
     return;
   }
 

--- a/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter.cc
@@ -37,7 +37,7 @@ Http::FilterHeadersStatus AdaptiveConcurrencyFilter::decodeHeaders(Http::Request
 
   if (controller_->forwardingDecision() == Controller::RequestForwardingAction::Block) {
     decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "reached concurrency limit",
-                                       nullptr, absl::nullopt, "reached_concurrency_limit");
+                                       nullptr, nullptr, "reached_concurrency_limit");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/source/extensions/filters/http/admission_control/admission_control.cc
+++ b/source/extensions/filters/http/admission_control/admission_control.cc
@@ -98,7 +98,7 @@ Http::FilterHeadersStatus AdmissionControlFilter::decodeHeaders(Http::RequestHea
     record_request_ = false;
 
     stats_.rq_rejected_.inc();
-    decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "", nullptr, absl::nullopt,
+    decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, "", nullptr, nullptr,
                                        "denied_by_admission_control");
     return Http::FilterHeadersStatus::StopIteration;
   }

--- a/source/extensions/filters/http/cdn_loop/filter.cc
+++ b/source/extensions/filters/http/cdn_loop/filter.cc
@@ -34,11 +34,11 @@ Http::FilterHeadersStatus CdnLoopFilter::decodeHeaders(Http::RequestHeaderMap& h
             countCdnLoopOccurrences(header_entry->value().getStringView(), cdn_id_);
         !count.ok()) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, ParseErrorMessage, nullptr,
-                                         absl::nullopt, ParseErrorDetails);
+                                         nullptr, ParseErrorDetails);
       return Http::FilterHeadersStatus::StopIteration;
     } else if (*count > max_allowed_occurrences_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadGateway, LoopDetectedMessage, nullptr,
-                                         absl::nullopt, LoopDetectedDetails);
+                                         nullptr, LoopDetectedDetails);
       return Http::FilterHeadersStatus::StopIteration;
     }
   }

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -120,7 +120,7 @@ Http::FilterHeadersStatus CsrfFilter::decodeHeaders(Http::RequestHeaderMap& head
     return Http::FilterHeadersStatus::Continue;
   }
 
-  callbacks_->sendLocalReply(Http::Code::Forbidden, "Invalid origin", nullptr, absl::nullopt,
+  callbacks_->sendLocalReply(Http::Code::Forbidden, "Invalid origin", nullptr, nullptr,
                              RcDetails::get().OriginMismatch);
   return Http::FilterHeadersStatus::StopIteration;
 }

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -89,7 +89,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
       decoder_callbacks_->streamInfo().setResponseFlag(
           StreamInfo::ResponseFlag::UnauthorizedExternalService);
       decoder_callbacks_->sendLocalReply(
-          config_->statusOnError(), EMPTY_STRING, nullptr, absl::nullopt,
+          config_->statusOnError(), EMPTY_STRING, nullptr, nullptr,
           Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzError);
       return Http::FilterHeadersStatus::StopIteration;
     }
@@ -406,7 +406,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
       decoder_callbacks_->streamInfo().setResponseFlag(
           StreamInfo::ResponseFlag::UnauthorizedExternalService);
       decoder_callbacks_->sendLocalReply(
-          config_->statusOnError(), EMPTY_STRING, nullptr, absl::nullopt,
+          config_->statusOnError(), EMPTY_STRING, nullptr, nullptr,
           Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzError);
     }
     break;

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -462,7 +462,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
     ENVOY_LOG(debug, "Request is rejected due to strict rejection policy.");
     error_ = true;
     decoder_callbacks_->sendLocalReply(
-        static_cast<Http::Code>(http_code), status.message().ToString(), nullptr, absl::nullopt,
+        static_cast<Http::Code>(http_code), status.message().ToString(), nullptr, nullptr,
         absl::StrCat(RcDetails::get().GrpcTranscodeFailedEarly, "{",
                      StringUtil::replaceAllEmptySpace(MessageUtil::codeEnumToString(status.code())),
                      "}"));
@@ -482,7 +482,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
           "Transcoding of query arguments of HttpBody request is not done (unexpected state)");
       error_ = true;
       decoder_callbacks_->sendLocalReply(
-          Http::Code::BadRequest, "Bad request", nullptr, absl::nullopt,
+          Http::Code::BadRequest, "Bad request", nullptr, nullptr,
           absl::StrCat(RcDetails::get().GrpcTranscodeFailedEarly, "{BAD_REQUEST}"));
       return Http::FilterHeadersStatus::StopIteration;
     }

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -515,7 +515,7 @@ void OAuth2Filter::finishFlow() {
 void OAuth2Filter::sendUnauthorizedResponse() {
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(Http::Code::Unauthorized, UnauthorizedBodyMessage, nullptr,
-                                     absl::nullopt, EMPTY_STRING);
+                                     nullptr, EMPTY_STRING);
 }
 
 } // namespace Oauth2

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -216,7 +216,7 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
       state_ = State::Responded;
       callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError);
       callbacks_->sendLocalReply(Http::Code::InternalServerError, response_body, nullptr,
-                                 absl::nullopt, RcDetails::get().RateLimitError);
+                                 nullptr, RcDetails::get().RateLimitError);
     }
   } else if (!initiating_call_) {
     appendRequestHeaders(req_headers_to_add);

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -215,8 +215,8 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
     } else {
       state_ = State::Responded;
       callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError);
-      callbacks_->sendLocalReply(Http::Code::InternalServerError, response_body, nullptr,
-                                 nullptr, RcDetails::get().RateLimitError);
+      callbacks_->sendLocalReply(Http::Code::InternalServerError, response_body, nullptr, nullptr,
+                                 RcDetails::get().RateLimitError);
     }
   } else if (!initiating_call_) {
     appendRequestHeaders(req_headers_to_add);

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -111,8 +111,7 @@ RoleBasedAccessControlFilter::decodeHeaders(Http::RequestHeaderMap& headers, boo
       return Http::FilterHeadersStatus::Continue;
     } else {
       ENVOY_LOG(debug, "enforced denied, matched policy {}", log_policy_id);
-      callbacks_->sendLocalReply(Http::Code::Forbidden, "RBAC: access denied", nullptr,
-                                 nullptr,
+      callbacks_->sendLocalReply(Http::Code::Forbidden, "RBAC: access denied", nullptr, nullptr,
                                  Filters::Common::RBAC::responseDetail(log_policy_id));
       config_->stats().denied_.inc();
       return Http::FilterHeadersStatus::StopIteration;

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -112,7 +112,7 @@ RoleBasedAccessControlFilter::decodeHeaders(Http::RequestHeaderMap& headers, boo
     } else {
       ENVOY_LOG(debug, "enforced denied, matched policy {}", log_policy_id);
       callbacks_->sendLocalReply(Http::Code::Forbidden, "RBAC: access denied", nullptr,
-                                 absl::nullopt,
+                                 nullptr,
                                  Filters::Common::RBAC::responseDetail(log_policy_id));
       config_->stats().denied_.inc();
       return Http::FilterHeadersStatus::StopIteration;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -89,7 +89,7 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoFilterConfigFound);
     decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError, EMPTY_STRING, nullptr,
-                                       absl::nullopt, EMPTY_STRING);
+                                       nullptr, EMPTY_STRING);
     return Http::FilterHeadersStatus::StopIteration;
   }
 };

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -1534,7 +1534,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterHeadReply) {
   EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
         decoder_filters_[0]->callbacks_->sendLocalReply(Code::BadRequest, "Bad request", nullptr,
-                                                        absl::nullopt, "");
+                                                        nullptr, "");
         return FilterHeadersStatus::StopIteration;
       }));
 
@@ -1564,7 +1564,7 @@ TEST_F(HttpConnectionManagerImplTest, ResetWithStoppedFilter) {
   EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
         decoder_filters_[0]->callbacks_->sendLocalReply(Code::BadRequest, "Bad request", nullptr,
-                                                        absl::nullopt, "");
+                                                        nullptr, "");
         return FilterHeadersStatus::StopIteration;
       }));
 

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -478,8 +478,8 @@ TEST_F(FilterManagerTest, OnLocalReply) {
       .WillOnce(Return(LocalErrorStatus::ContinueAndResetStream));
   EXPECT_CALL(*encoder_filter, onLocalReply(_));
   EXPECT_CALL(filter_manager_callbacks_, resetStream());
-  decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr,
-                                             nullptr, "details");
+  decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr, nullptr,
+                                             "details");
 
   // The reason for the response (in this case the reset) will still be tracked
   // but as no response is sent the response code will remain absent.
@@ -540,8 +540,8 @@ TEST_F(FilterManagerTest, MultipleOnLocalReply) {
     // iteration.
     EXPECT_CALL(dispatcher_, trackedObjectStackIsEmpty()).Times(0);
 
-    decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr,
-                                               nullptr, "details");
+    decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr, nullptr,
+                                               "details");
   }
 
   // The final details should be details2.

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -114,7 +114,7 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringEncodingGrpcClassiciation) {
   EXPECT_CALL(*encoder_filter, encodeHeaders(_, true))
       .WillRepeatedly(Invoke([&](auto&, bool) -> FilterHeadersStatus {
         encoder_filter->encoder_callbacks_->sendLocalReply(Code::InternalServerError, "", nullptr,
-                                                           absl::nullopt, "");
+                                                           nullptr, "");
         return FilterHeadersStatus::StopIteration;
       }));
 
@@ -479,7 +479,7 @@ TEST_F(FilterManagerTest, OnLocalReply) {
   EXPECT_CALL(*encoder_filter, onLocalReply(_));
   EXPECT_CALL(filter_manager_callbacks_, resetStream());
   decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr,
-                                             absl::nullopt, "details");
+                                             nullptr, "details");
 
   // The reason for the response (in this case the reset) will still be tracked
   // but as no response is sent the response code will remain absent.
@@ -528,7 +528,7 @@ TEST_F(FilterManagerTest, MultipleOnLocalReply) {
     EXPECT_CALL(*encoder_filter, encodeHeaders(_, _))
         .WillOnce(Invoke([&](ResponseHeaderMap&, bool) -> FilterHeadersStatus {
           decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body2", nullptr,
-                                                     absl::nullopt, "details2");
+                                                     nullptr, "details2");
           return FilterHeadersStatus::StopIteration;
         }));
 
@@ -541,7 +541,7 @@ TEST_F(FilterManagerTest, MultipleOnLocalReply) {
     EXPECT_CALL(dispatcher_, trackedObjectStackIsEmpty()).Times(0);
 
     decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr,
-                                               absl::nullopt, "details");
+                                               nullptr, "details");
   }
 
   // The final details should be details2.

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -418,7 +418,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
 
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadRequest, "Bad request", _,
-                                                 Eq(absl::nullopt), "Got_a_bad_request"))
+                                                 Eq(nullptr), "Got_a_bad_request"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -490,7 +490,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyOnResponse) {
 
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadRequest, "Bad request", _,
-                                                 Eq(absl::nullopt), "Got_a_bad_request"))
+                                                 Eq(nullptr), "Got_a_bad_request"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -1547,7 +1547,7 @@ TEST_F(HttpFilterTest, PostAndFail) {
   // Oh no! The remote server had a failure!
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, "", _,
-                                                 Eq(absl::nullopt), "ext_proc_error_gRPC_error_13"))
+                                                 Eq(nullptr), "ext_proc_error_gRPC_error_13"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -1604,7 +1604,7 @@ TEST_F(HttpFilterTest, PostAndFailOnResponse) {
   // Oh no! The remote server had a failure!
   Http::TestResponseHeaderMapImpl immediate_response_headers;
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, "", _,
-                                                 Eq(absl::nullopt), "ext_proc_error_gRPC_error_13"))
+                                                 Eq(nullptr), "ext_proc_error_gRPC_error_13"))
       .WillOnce(Invoke([&immediate_response_headers](
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,

--- a/test/integration/filters/eds_ready_filter.cc
+++ b/test/integration/filters/eds_ready_filter.cc
@@ -23,16 +23,16 @@ public:
     Stats::GaugeOptConstRef gauge = root_scope_.findGauge(stat_name_.statName());
     if (!gauge.has_value()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,
-                                         "Couldn't find stat", nullptr, absl::nullopt, "");
+                                         "Couldn't find stat", nullptr, nullptr. "");
       return Http::FilterHeadersStatus::StopIteration;
     }
     if (gauge->get().value() == 0) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError, "EDS not ready",
-                                         nullptr, absl::nullopt, "");
+                                         nullptr, nullptr, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
     decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "EDS is ready", nullptr,
-                                       absl::nullopt, "");
+                                       nullptr, "");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/test/integration/filters/eds_ready_filter.cc
+++ b/test/integration/filters/eds_ready_filter.cc
@@ -23,7 +23,7 @@ public:
     Stats::GaugeOptConstRef gauge = root_scope_.findGauge(stat_name_.statName());
     if (!gauge.has_value()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,
-                                         "Couldn't find stat", nullptr, nullptr. "");
+                                         "Couldn't find stat", nullptr, nullptr."");
       return Http::FilterHeadersStatus::StopIteration;
     }
     if (gauge->get().value() == 0) {
@@ -31,8 +31,7 @@ public:
                                          nullptr, nullptr, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
-    decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "EDS is ready", nullptr,
-                                       nullptr, "");
+    decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "EDS is ready", nullptr, nullptr, "");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/test/integration/filters/on_local_reply_filter.cc
+++ b/test/integration/filters/on_local_reply_filter.cc
@@ -20,14 +20,14 @@ public:
       dual_reply_ = true;
     }
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "original_reply", nullptr,
-                                       absl::nullopt, "original_reply");
+                                       nullptr, "original_reply");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
     if (dual_reply_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "second_reply", nullptr,
-                                         absl::nullopt, "second_reply");
+                                         nullptr, "second_reply");
       return Http::FilterHeadersStatus::StopIteration;
     }
     return Http::FilterHeadersStatus::Continue;

--- a/test/integration/filters/on_local_reply_filter.cc
+++ b/test/integration/filters/on_local_reply_filter.cc
@@ -19,15 +19,15 @@ public:
     if (!request_headers.get(Http::LowerCaseString("dual-local-reply")).empty()) {
       dual_reply_ = true;
     }
-    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "original_reply", nullptr,
-                                       nullptr, "original_reply");
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "original_reply", nullptr, nullptr,
+                                       "original_reply");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
     if (dual_reply_) {
-      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "second_reply", nullptr,
-                                         nullptr, "second_reply");
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "second_reply", nullptr, nullptr,
+                                         "second_reply");
       return Http::FilterHeadersStatus::StopIteration;
     }
     return Http::FilterHeadersStatus::Continue;

--- a/test/integration/filters/process_context_filter.cc
+++ b/test/integration/filters/process_context_filter.cc
@@ -28,7 +28,7 @@ public:
       return Http::FilterHeadersStatus::StopIteration;
     }
     decoder_callbacks_->sendLocalReply(Envoy::Http::Code::OK, "ProcessObjectForFilter is healthy",
-                                       nullptr, absl::nullopt, "");
+                                       nullptr, nullptr, "");
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -34,7 +34,7 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
     if (absl::StartsWith(headers.Path()->value().getStringView(), config_->prefix_)) {
       decoder_callbacks_->sendLocalReply(static_cast<Http::Code>(config_->code_), config_->body_,
-                                         nullptr, absl::nullopt, "");
+                                         nullptr, nullptr, "");
       return Http::FilterHeadersStatus::StopIteration;
     }
     return Http::FilterHeadersStatus::Continue;


### PR DESCRIPTION
Commit Message: this PR is to make all the gRPC related arguments into one struct so that it would be easier to add more in the future like PR https://github.com/envoyproxy/envoy/pull/20620. Make it as a unique_ptr to enforce non-copy move as we are gonna add gRPC error details, causing non-trivial copy.

Risk Level: low
Testing: no need
Docs Changes: WIP
Release Notes: WIP
Platform Specific Features:
[Optional Runtime guard:] 
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
