### PR TITLE
docs: delete useless section in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -143,7 +143,6 @@ extensions/filters/common/original_src @snowp @klarose
 /*/extensions/filters/http/aws_lambda @mattklein123 @marcomagdy @lavignes @tonya11en
 /*/extensions/filters/http/buffer @alyssawilk @mattklein123
 /*/extensions/transport_sockets/raw_buffer @alyssawilk @mattklein123
-# Compression
 # Watchdog Extensions
 /*/extensions/watchdog/profile_action @kbaichoo @antoniovicente
 # Core upstream code


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: delete useless section in CODEOWNERS
Additional Description: the section is useless since compression part has moved in this commit: https://github.com/envoyproxy/envoy/commit/fa385b2e9e8b269ad2a1c4723da9aac6b4bd4866#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR194
Risk Level: n/a (docs)
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
