### PR TITLE
build: export wasm null VM library

### DIFF
--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -66,11 +66,8 @@ envoy_cc_library(
             "-DWASM_USE_CEL_PARSER",
         ],
     }),
-    visibility = [
-        "//source/extensions:__subpackages__",
-        "//test/extensions:__subpackages__",
-        "//test/test_common:__subpackages__",
-    ],
+    # Export an implementation of "null-VM" interfaces in proxy-wasm.
+    visibility = ["//visibility:public"],
     deps = [
         ":wasm_hdr",
         ":wasm_runtime_factory_interface",

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1126,6 +1126,7 @@ if __name__ == "__main__":
         # https://github.com/envoyproxy/envoy/issues/9953
         # PLEASE DO NOT ADD FILES TO THIS LIST WITHOUT SENIOR MAINTAINER APPROVAL
         exclude_list = (
+            "':(exclude)source/extensions/common/wasm/BUILD' "
             "':(exclude)source/extensions/filters/http/buffer/BUILD' "
             "':(exclude)source/extensions/filters/network/common/BUILD' ")
         command = (


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Revert to public visibility. Otherwise, we can't link the library and make null VM extension tests executable.
Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none