### PR TITLE
network: declare factory for default client connection factory

### DIFF
--- a/source/common/network/default_client_connection_factory.h
+++ b/source/common/network/default_client_connection_factory.h
@@ -4,6 +4,8 @@
 #include "envoy/network/client_connection_factory.h"
 #include "envoy/network/connection.h"
 
+#include "envoy/registry/registry.h"
+
 namespace Envoy {
 
 namespace Network {
@@ -27,6 +29,8 @@ public:
                          Network::TransportSocketPtr&& transport_socket,
                          const Network::ConnectionSocket::OptionsSharedPtr& options) override;
 };
+
+DECLARE_FACTORY(DefaultClientConnectioFactory);
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/default_client_connection_factory.h
+++ b/source/common/network/default_client_connection_factory.h
@@ -30,7 +30,7 @@ public:
                          const Network::ConnectionSocket::OptionsSharedPtr& options) override;
 };
 
-DECLARE_FACTORY(DefaultClientConnectioFactory);
+DECLARE_FACTORY(DefaultClientConnectionFactory);
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/default_client_connection_factory.h
+++ b/source/common/network/default_client_connection_factory.h
@@ -3,7 +3,6 @@
 #include "envoy/common/pure.h"
 #include "envoy/network/client_connection_factory.h"
 #include "envoy/network/connection.h"
-
 #include "envoy/registry/registry.h"
 
 namespace Envoy {


### PR DESCRIPTION
The change to use a default factory broke Envoy Mobile as the static init pattern doesn't work unless the TU is considered actively used. This adds the factory declaration to the header, allowing EM to call the forceRegister* function to ensure that this class is registered.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
