### PR TITLE
docs: add WASM runtime build instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -710,10 +710,10 @@ Note not all extensions can be disabled.
 
 To enable a specific WebAssembly (Wasm) engine, you'll need to pass `--define wasm=[wasm_engine]`, e.g. `--define wasm=wasmtime` to enable the [wasmtime](https://wasmtime.dev/) engine. Supported engines are:
 
-* v8 (the default included engine)
-* wavm
-* wasmtime
-* wavr
+* `v8` (the default included engine)
+* `wamr`
+* `wasmtime`
+* `wavm`
 
 If you're building from a custom build repository, the parameters need to prefixed with `@envoy`, for example
 `--@envoy//source/extensions/filters/http/kill_request:enabled`.
@@ -998,4 +998,3 @@ Adding the following parameter to Bazel everytime or persist them in `.bazelrc`.
 ```
 --remote_http_cache=http://127.0.0.1:28080/
 ```
-

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -708,6 +708,8 @@ The extensions enabled by default can be disabled by adding the following parame
 `envoy.wasm.runtime.v8` extension, add `--//source/extensions/wasm_runtime/v8:enabled=false`.
 Note not all extensions can be disabled.
 
+To enable a specific wasm runtime, you'll need to pass `--define wasm=[wasm_runtime]`, e.g. `--define wasm=wasmtime` to enable the [wasmtime](https://wasmtime.dev/) runtime. The list of runtimes available can be found in the [bazel/BUILD](https://github.com/envoyproxy/envoy/blob/0a587f23b21ab34b28d9c53428af259b3f7b0970/bazel/BUILD#L407-L430) file. 
+
 If you're building from a custom build repository, the parameters need to prefixed with `@envoy`, for example
 `--@envoy//source/extensions/filters/http/kill_request:enabled`.
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -708,7 +708,12 @@ The extensions enabled by default can be disabled by adding the following parame
 `envoy.wasm.runtime.v8` extension, add `--//source/extensions/wasm_runtime/v8:enabled=false`.
 Note not all extensions can be disabled.
 
-To enable a specific wasm runtime, you'll need to pass `--define wasm=[wasm_runtime]`, e.g. `--define wasm=wasmtime` to enable the [wasmtime](https://wasmtime.dev/) runtime. The list of runtimes available can be found in the [bazel/BUILD](https://github.com/envoyproxy/envoy/blob/0a587f23b21ab34b28d9c53428af259b3f7b0970/bazel/BUILD#L407-L430) file. 
+To enable a specific WebAssembly (Wasm) engine, you'll need to pass `--define wasm=[wasm_engine]`, e.g. `--define wasm=wasmtime` to enable the [wasmtime](https://wasmtime.dev/) engine. Supported engines are:
+
+* v8 (the default included engine)
+* wavm
+* wasmtime
+* wavr
 
 If you're building from a custom build repository, the parameters need to prefixed with `@envoy`, for example
 `--@envoy//source/extensions/filters/http/kill_request:enabled`.
@@ -993,3 +998,4 @@ Adding the following parameter to Bazel everytime or persist them in `.bazelrc`.
 ```
 --remote_http_cache=http://127.0.0.1:28080/
 ```
+

--- a/external
+++ b/external
@@ -1,0 +1,1 @@
+bazel-out/../../../external

--- a/external
+++ b/external
@@ -1,1 +1,0 @@
-bazel-out/../../../external


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs: add WASM runtime build instructions
Additional Description: This adds the specific language for enabling an optional WASM runtime for envoy to the bazel build instructions
Risk Level: low
Testing: n/a
Docs Changes: this is only a change to docs
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
