### PR TITLE
ext_proc: Fix flaky test by improving integration framework

### DIFF
--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -12,6 +12,10 @@ ExternalProcessorClientImpl::ExternalProcessorClientImpl(
     const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope)
     : client_manager_(client_manager), grpc_service_(grpc_service), scope_(scope) {}
 
+ExternalProcessorClientImpl::~ExternalProcessorClientImpl() {
+  ENVOY_LOG(trace, "~ExternalProcessorClientImpl");
+}
+
 ExternalProcessorStreamPtr
 ExternalProcessorClientImpl::start(ExternalProcessorCallbacks& callbacks,
                                    const StreamInfo::StreamInfo& stream_info) {
@@ -34,6 +38,10 @@ ExternalProcessorStreamImpl::ExternalProcessorStreamImpl(
   stream_ = client_.start(*descriptor, *this, options);
 }
 
+ExternalProcessorStreamImpl::~ExternalProcessorStreamImpl() {
+  ENVOY_LOG(trace, "~ExternalProcessorStreamImpl");
+}
+
 void ExternalProcessorStreamImpl::send(envoy::service::ext_proc::v3::ProcessingRequest&& request,
                                        bool end_stream) {
   stream_.sendMessage(std::move(request), end_stream);
@@ -51,6 +59,7 @@ bool ExternalProcessorStreamImpl::close() {
 }
 
 void ExternalProcessorStreamImpl::onReceiveMessage(ProcessingResponsePtr&& response) {
+  ENVOY_LOG(trace, "Received message");
   callbacks_.onReceiveMessage(std::move(response));
 }
 

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -21,11 +21,13 @@ namespace ExternalProcessing {
 
 using ProcessingResponsePtr = std::unique_ptr<ProcessingResponse>;
 
-class ExternalProcessorClientImpl : public ExternalProcessorClient {
+class ExternalProcessorClientImpl : public ExternalProcessorClient,
+                                    public Logger::Loggable<Logger::Id::ext_proc> {
 public:
   ExternalProcessorClientImpl(Grpc::AsyncClientManager& client_manager,
                               const envoy::config::core::v3::GrpcService& grpc_service,
                               Stats::Scope& scope);
+  ~ExternalProcessorClientImpl() override;
 
   ExternalProcessorStreamPtr start(ExternalProcessorCallbacks& callbacks,
                                    const StreamInfo::StreamInfo& stream_info) override;
@@ -43,6 +45,8 @@ public:
   ExternalProcessorStreamImpl(Grpc::AsyncClient<ProcessingRequest, ProcessingResponse>&& client,
                               ExternalProcessorCallbacks& callbacks,
                               const StreamInfo::StreamInfo& stream_info);
+  ~ExternalProcessorStreamImpl() override;
+
   void send(ProcessingRequest&& request, bool end_stream) override;
   // Close the stream. This is idempotent and will return true if we
   // actually closed it.

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -68,6 +68,8 @@ void FilterConfigPerRoute::merge(const FilterConfigPerRoute& src) {
   processing_mode_ = src.processing_mode_;
 }
 
+Filter::~Filter() { ENVOY_LOG(trace, "~Filter"); }
+
 void Filter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
   Http::PassThroughFilter::setDecoderFilterCallbacks(callbacks);
   decoding_state_.setDecoderFilterCallbacks(callbacks);

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -116,6 +116,7 @@ public:
       : config_(config), client_(std::move(client)), stats_(config->stats()),
         decoding_state_(*this, config->processingMode()),
         encoding_state_(*this, config->processingMode()) {}
+  ~Filter() override;
 
   const FilterConfig& config() const { return *config_; }
 

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -76,14 +76,26 @@ private:
     IntegrationCodecClient& parent_;
   };
 
+  struct CodecClientCallbacks : public Http::CodecClientCallbacks {
+    CodecClientCallbacks(IntegrationCodecClient& parent) : parent_(parent) {}
+
+    // Http::CodecClientCallbacks
+    void onStreamDestroy() override { parent_.stream_gone_ = true; }
+    void onStreamReset(Http::StreamResetReason) override { parent_.stream_gone_ = true; }
+
+    IntegrationCodecClient& parent_;
+  };
+
   void flushWrite();
 
   Event::Dispatcher& dispatcher_;
   ConnectionCallbacks callbacks_;
   CodecCallbacks codec_callbacks_;
+  CodecClientCallbacks codec_client_callbacks_;
   bool connected_{};
   bool disconnected_{};
   bool saw_goaway_{};
+  bool stream_gone_{};
   Network::ConnectionEvent last_connection_event_;
 };
 


### PR DESCRIPTION
Commit Message: HTTP integration tests: Ensure that the integration test's fake client doesn't try to send
chunks on a stream that has already been reset.
Additional Description: Fixes a flaky test in ext_proc
Risk Level: Low
Testing: Tested locally with many iterations
Docs Changes:
Release Notes:
Platform Specific Features:
Signed-off-by: Greg Brail <gbrail@users.noreply.github.com>

Fixes https://github.com/envoyproxy/envoy/issues/20586
