### PR TITLE
Limit xray-fuzz input to reasonable size.

### DIFF
--- a/test/extensions/tracers/xray/fuzz_test.cc
+++ b/test/extensions/tracers/xray/fuzz_test.cc
@@ -1,3 +1,4 @@
+#include "source/common/common/logger.h"
 #include "source/extensions/tracers/xray/util.h"
 
 #include "test/fuzz/fuzz_runner.h"
@@ -12,9 +13,19 @@ namespace XRay {
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   absl::string_view pattern, input;
   if (len > 1) {
-    pattern = absl::string_view(reinterpret_cast<const char*>(buf), len / 2);
-    input = absl::string_view(reinterpret_cast<const char*>(buf + len / 2), len - len / 2);
-    wildcardMatch(pattern, input);
+    // The input to wildcardMatch usually is http_method hostname url
+    // Limit the size of the input for all of these to 4 kBytes to reduce runtime when running
+    // fuzzer with asan.
+    constexpr size_t inputlimit = 4096;
+    if (len <= inputlimit) {
+      pattern = absl::string_view(reinterpret_cast<const char*>(buf), len / 2);
+      input = absl::string_view(reinterpret_cast<const char*>(buf + len / 2), len - len / 2);
+      wildcardMatch(pattern, input);
+    } else {
+      ENVOY_LOG_MISC(debug, "Input size of {} bytes exceeds limit of {} bytes, rejecting", len,
+                     inputlimit);
+      return;
+    }
   } else { // buf is a single byte, use it for both pattern and input
     absl::string_view sv(reinterpret_cast<const char*>(buf), len);
     wildcardMatch(sv, "hello");


### PR DESCRIPTION
Commit Message: Limit xray-fuzz input to reasonable size.
Additional Description:
The fuzzer's input size is now limited to 4k to prevent timeouts
due to asan overhead.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
