### PR TITLE
delta-xds: fix wildcard resource versions

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -68,6 +68,7 @@ Bug Fixes
 * upstream: cluster slow start config add ``min_weight_percent`` field to avoid too big EDF deadline which cause slow start endpoints receiving no traffic, default 10%. This fix is releted to `issue#19526 <https://github.com/envoyproxy/envoy/issues/19526>`_.
 * upstream: fix stack overflow when a cluster with large number of idle connections is removed.
 * xds: fix a crash that occurs when Envoy receives a discovery response without ``control_plane`` field.
+* xds: fix the wildcard resource versions that are sent upon reconnection when using delta-xds mode.
 * xray: fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header ``x-amzn-trace-id``.
 * xray: fix the AWS X-Ray tracer extension to annotate a child span with ``type=subsegment`` to correctly relate subsegments to a parent segment. Previously a subsegment would be treated as an independent segment.
 * xray: fix the AWS X-Ray tracer extension to reuse the trace ID already present in the header ``x-amzn-trace-id`` instead of creating a new one.

--- a/source/common/config/new_delta_subscription_state.cc
+++ b/source/common/config/new_delta_subscription_state.cc
@@ -78,7 +78,7 @@ void NewDeltaSubscriptionState::updateSubscriptionInterest(
         // won't be a wildcard resource then. If r is Wildcard itself, then it never has a version
         // attached to it, so it will not be moved to ambiguous category.
         if (!it->second.isWaitingForServer()) {
-          ambiguous_resource_state_.insert({it->first, it->second.version()});
+          ambiguous_resource_state_.insert_or_assign(it->first, it->second.version());
         }
         requested_resource_state_.erase(it);
         actually_erased = true;
@@ -375,7 +375,7 @@ void NewDeltaSubscriptionState::addResourceStateFromServer(
     ASSERT(!ambiguous_resource_state_.contains(resource.name()));
   } else {
     // It is a resource that is a part of our wildcard request.
-    wildcard_resource_state_.insert({resource.name(), resource.version()});
+    wildcard_resource_state_.insert_or_assign(resource.name(), resource.version());
     // The resource could be ambiguous before, but now the ambiguity
     // is resolved.
     ambiguous_resource_state_.erase(resource.name());

--- a/source/common/config/xds_mux/delta_subscription_state.cc
+++ b/source/common/config/xds_mux/delta_subscription_state.cc
@@ -61,7 +61,7 @@ void DeltaSubscriptionState::updateSubscriptionInterest(
         // won't be a wildcard resource then. If r is Wildcard itself, then it never has a version
         // attached to it, so it will not be moved to ambiguous category.
         if (!it->second.isWaitingForServer()) {
-          ambiguous_resource_state_.insert({it->first, it->second.version()});
+          ambiguous_resource_state_.insert_or_assign(it->first, it->second.version());
         }
         requested_resource_state_.erase(it);
         actually_erased = true;
@@ -317,7 +317,7 @@ void DeltaSubscriptionState::addResourceStateFromServer(
     ASSERT(!ambiguous_resource_state_.contains(resource.name()));
   } else {
     // It is a resource that is a part of our wildcard request.
-    wildcard_resource_state_.insert({resource.name(), resource.version()});
+    wildcard_resource_state_.insert_or_assign(resource.name(), resource.version());
     // The resource could be ambiguous before, but now the ambiguity
     // is resolved.
     ambiguous_resource_state_.erase(resource.name());


### PR DESCRIPTION
Commit Message: delta-xds fix wildcard resource versions
Additional Description: Fixing a bug in delta-xDS where the versions of the wildcard resources are not updated, and may result in wasted passing of resources, and usage of stale resources.
Risk Level: Low
Testing: Added a unit test.
Docs Changes: N/A
Release Notes:
Platform Specific Features: N/A
Fixes #Issue: #20699

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
