### PR TITLE
ci: add contrib target

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -115,6 +115,8 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.debug.server_only` &mdash; build Envoy static binary under `-c dbg`.
 * `bazel.dev` &mdash; build Envoy static binary and run tests under `-c fastbuild` with clang.
 * `bazel.dev <test>` &mdash; build Envoy static binary and run a specified test or test dir under `-c fastbuild` with clang.
+* `bazel.dev.contrib` &mdash; build Envoy static binary with contrib and run tests under `-c fastbuild` with clang.
+* `bazel.dev.contrib <test>` &mdash; build Envoy static binary with contrib and run a specified test or test dir under `-c fastbuild` with clang.
 * `bazel.release` &mdash; build Envoy static binary and run tests under `-c opt` with clang.
 * `bazel.release <test>` &mdash; build Envoy static binary and run a specified test or test dir under `-c opt` with clang.
 * `bazel.release.server_only` &mdash; build Envoy static binary under `-c opt` with clang.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -325,6 +325,16 @@ elif [[ "$CI_TARGET" == "bazel.dev" ]]; then
   echo "Testing ${TEST_TARGETS[*]}"
   bazel test "${BAZEL_BUILD_OPTIONS[@]}" -c fastbuild "${TEST_TARGETS[@]}"
   exit 0
+elif [[ "$CI_TARGET" == "bazel.dev.contrib" ]]; then
+  setup_clang_toolchain
+  # This doesn't go into CI but is available for developer convenience.
+  echo "bazel fastbuild build with tests..."
+  echo "Building..."
+  bazel_contrib_binary_build fastbuild
+
+  echo "Testing ${TEST_TARGETS[*]}"
+  bazel test "${BAZEL_BUILD_OPTIONS[@]}" -c fastbuild "${TEST_TARGETS[@]}"
+  exit 0
 elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
   # Right now, none of the available compile-time options conflict with each other. If this
   # changes, this build type may need to be broken up.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -328,7 +328,7 @@ elif [[ "$CI_TARGET" == "bazel.dev" ]]; then
 elif [[ "$CI_TARGET" == "bazel.dev.contrib" ]]; then
   setup_clang_toolchain
   # This doesn't go into CI but is available for developer convenience.
-  echo "bazel fastbuild build with tests..."
+  echo "bazel fastbuild build with contrib extensions and tests..."
   echo "Building..."
   bazel_contrib_binary_build fastbuild
 


### PR DESCRIPTION
Signed-off-by: Loong Dai <loong.dai@intel.com>

Now only `bazel.release` cover contrib, add this target will help developers.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
