### PR TITLE
Add EXPECT_OK and IsOk to test_common/status_utility.h

### DIFF
--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -287,6 +287,14 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test(
+    name = "status_utility_test",
+    srcs = ["status_utility_test.cc"],
+    deps = [
+        ":status_utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "simulated_time_system_test",
     srcs = ["simulated_time_system_test.cc"],
     deps = [

--- a/test/test_common/status_utility.h
+++ b/test/test_common/status_utility.h
@@ -62,14 +62,41 @@ public:
   void DescribeNegationTo(::std::ostream* os) const { *os << "is not OK"; }
 };
 
+// Check that an absl::Status or absl::StatusOr is OK.
+//
+// For example:
+//
+// StatusOr<int> statusor(absl::InvalidArgumentError("bad argument!"));
+// EXPECT_THAT(statusor, IsOk());  // fails!
+//
 // NOLINTNEXTLINE(readability-identifier-naming)
 inline ::testing::PolymorphicMatcher<IsOkMatcher> IsOk() {
   return ::testing::MakePolymorphicMatcher(IsOkMatcher());
 }
 
 #ifndef EXPECT_OK
+// Fails if an absl::Status or absl::StatusOr is not OK.
+//
+// For example:
+//
+// StatusOr<int> statusor(absl::InvalidArgumentError("bad argument!"));
+// EXPECT_OK(statusor);  // fails!
+// absl::Status status{absl::OkStatus()};
+// EXPECT_OK(status);  // passes!
 #define EXPECT_OK(v) EXPECT_THAT((v), ::Envoy::StatusHelpers::IsOk())
 #endif // EXPECT_OK
+
+#ifndef ASSERT_OK
+// Asserts if an absl::Status or absl::StatusOr is not OK.
+//
+// For example:
+//
+// StatusOr<int> statusor(absl::InvalidArgumentError("bad argument!"));
+// ASSERT_OK(statusor);  // asserts!
+// absl::Status status{absl::OkStatus()};
+// ASSERT_OK(status);  // passes!
+#define ASSERT_OK(v) ASSERT_THAT((v), ::Envoy::StatusHelpers::IsOk())
+#endif // ASSERT_OK
 
 } // namespace StatusHelpers
 } // namespace Envoy

--- a/test/test_common/status_utility.h
+++ b/test/test_common/status_utility.h
@@ -53,8 +53,9 @@ public:
 
   template <typename T>
   // NOLINTNEXTLINE(readability-identifier-naming)
-  bool MatchAndExplain(absl::StatusOr<T> statusor, ::testing::MatchResultListener* listener) const {
-    return MatchAndExplain(statusor.status(), listener);
+  bool MatchAndExplain(absl::StatusOr<T> status_or,
+                       ::testing::MatchResultListener* listener) const {
+    return MatchAndExplain(status_or.status(), listener);
   }
   // NOLINTNEXTLINE(readability-identifier-naming)
   void DescribeTo(::std::ostream* os) const { *os << "is OK"; }
@@ -66,8 +67,8 @@ public:
 //
 // For example:
 //
-// StatusOr<int> statusor(absl::InvalidArgumentError("bad argument!"));
-// EXPECT_THAT(statusor, IsOk());  // fails!
+// StatusOr<int> status_or(absl::InvalidArgumentError("bad argument!"));
+// EXPECT_THAT(status_or, IsOk());  // fails!
 //
 // NOLINTNEXTLINE(readability-identifier-naming)
 inline ::testing::PolymorphicMatcher<IsOkMatcher> IsOk() {
@@ -79,8 +80,8 @@ inline ::testing::PolymorphicMatcher<IsOkMatcher> IsOk() {
 //
 // For example:
 //
-// StatusOr<int> statusor(absl::InvalidArgumentError("bad argument!"));
-// EXPECT_OK(statusor);  // fails!
+// StatusOr<int> status_or(absl::InvalidArgumentError("bad argument!"));
+// EXPECT_OK(status_or);  // fails!
 // absl::Status status{absl::OkStatus()};
 // EXPECT_OK(status);  // passes!
 #define EXPECT_OK(v) EXPECT_THAT((v), ::Envoy::StatusHelpers::IsOk())
@@ -91,8 +92,8 @@ inline ::testing::PolymorphicMatcher<IsOkMatcher> IsOk() {
 //
 // For example:
 //
-// StatusOr<int> statusor(absl::InvalidArgumentError("bad argument!"));
-// ASSERT_OK(statusor);  // asserts!
+// StatusOr<int> status_or(absl::InvalidArgumentError("bad argument!"));
+// ASSERT_OK(status_or);  // asserts!
 // absl::Status status{absl::OkStatus()};
 // ASSERT_OK(status);  // passes!
 #define ASSERT_OK(v) ASSERT_THAT((v), ::Envoy::StatusHelpers::IsOk())

--- a/test/test_common/status_utility_test.cc
+++ b/test/test_common/status_utility_test.cc
@@ -1,0 +1,48 @@
+#include "test/test_common/status_utility.h"
+
+namespace Envoy {
+namespace StatusHelpers {
+
+TEST(StatusUtilityTest, ExpectOkForStatus) {
+  absl::Status status;
+  EXPECT_OK(status);
+}
+
+TEST(StatusUtilityTest, ExpectOkForStatusOr) {
+  absl::StatusOr<int> status_or = 5;
+  EXPECT_OK(status_or);
+}
+
+TEST(StatusUtilityTest, IsOkFailureForStatus) {
+  ::testing::StringMatchResultListener listener;
+  ::testing::ExplainMatchResult(IsOk(), absl::FailedPreconditionError("whatever"), &listener);
+  EXPECT_EQ("status is FAILED_PRECONDITION: whatever", listener.str());
+}
+
+TEST(StatusUtilityTest, IsOkFailureForStatusOr) {
+  ::testing::StringMatchResultListener listener;
+  ::testing::ExplainMatchResult(
+      IsOk(), absl::StatusOr<int>{absl::FailedPreconditionError("whatever")}, &listener);
+  EXPECT_EQ("status is FAILED_PRECONDITION: whatever", listener.str());
+}
+
+TEST(StatusUtilityTest, IsOkAndHoldsSuccess) {
+  absl::StatusOr<int> five = 5;
+  EXPECT_THAT(five, IsOkAndHolds(5));
+}
+
+TEST(StatusUtilityTest, IsOkAndHoldsFailureByValue) {
+  ::testing::StringMatchResultListener listener;
+  ::testing::ExplainMatchResult(IsOkAndHolds(5), absl::StatusOr<int>{6}, &listener);
+  EXPECT_EQ("which has wrong value: 6", listener.str());
+}
+
+TEST(StatusUtilityTest, IsOkAndHoldsFailureByCode) {
+  ::testing::StringMatchResultListener listener;
+  ::testing::ExplainMatchResult(
+      IsOkAndHolds(5), absl::StatusOr<int>{absl::FailedPreconditionError("oh no")}, &listener);
+  EXPECT_EQ("which has unexpected status: FAILED_PRECONDITION: oh no", listener.str());
+}
+
+} // namespace StatusHelpers
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: Add EXPECT_OK and IsOk to test_common/status_utility.h
Additional Description: Test helper functions.
Risk Level: None, just test helper functions.
Testing: Included tests for the tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
