### PR TITLE
bazel: Add rustc source files

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -23,7 +23,7 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     apple_rules_dependencies()
     pip_dependencies()
     rules_rust_dependencies()
-    rust_register_toolchains()
+    rust_register_toolchains(include_rustc_srcs = True)
     upb_deps()
     antlr_dependencies(472)
     proxy_wasm_rust_sdk_dependencies()


### PR DESCRIPTION
This is required to support rust analyzer for IDEs

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>