### PR TITLE
Disable test for failing filters in filter_fuzz_test

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -6,6 +6,8 @@
 #include "test/extensions/filters/http/common/fuzz/uber_filter.h"
 #include "test/fuzz/fuzz_runner.h"
 
+#include <vector>
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -19,8 +21,20 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& i
         // applied only when libprotobuf-mutator calls mutate on an input, and *not* during fuzz
         // target execution. Replaying a corpus through the fuzzer will not be affected by the
         // post-processor mutation.
-        static const std::vector<absl::string_view> filter_names = Registry::FactoryRegistry<
+        static const std::vector<absl::string_view> registered_names = Registry::FactoryRegistry<
             Server::Configuration::NamedHttpFilterConfigFactory>::registeredNames();
+        // Exclude filters that don't work with this test. See #20737
+        absl::flat_hash_set<absl::string_view> exclusion_list = {
+            "envoy.ext_proc", "envoy.filters.http.alternate_protocols_cache",
+            "envoy.filters.http.composite", "envoy.filters.http.ext_proc"};
+        std::vector<absl::string_view> filter_names;
+        filter_names.reserve(registered_names.size());
+        std::for_each(registered_names.begin(), registered_names.end(),
+                      [&](const absl::string_view& filter) {
+                        if (exclusion_list.count(filter) == 0) {
+                          filter_names.push_back(filter);
+                        }
+                      });
         static const auto factories = Registry::FactoryRegistry<
             Server::Configuration::NamedHttpFilterConfigFactory>::factories();
         // Choose a valid filter name.

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -6,8 +6,6 @@
 #include "test/extensions/filters/http/common/fuzz/uber_filter.h"
 #include "test/fuzz/fuzz_runner.h"
 
-#include <vector>
-
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {


### PR DESCRIPTION
Signed-off-by: Pradeep Rao <pcrao@google.com>

Commit Message:
Disable failing filters in filter_fuzz_test as a temporary fix for #20737
Additional Description:
Risk Level: Low
Testing:
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA

