### PR TITLE
switch to using json sanitizer for admin counters, gauges, and text-readouts

### DIFF
--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -117,6 +117,7 @@ envoy_cc_library(
         ":utils_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/html:utility_lib",
+        "//source/common/json:json_sanitizer_lib",
         "//source/common/stats:histogram_lib",
     ],
 )

--- a/source/server/admin/stats_render.cc
+++ b/source/server/admin/stats_render.cc
@@ -98,8 +98,8 @@ StatsJsonRender::StatsJsonRender(Http::ResponseHeaderMap& response_headers,
 // buffer once we exceed JsonStatsFlushCount stats.
 void StatsJsonRender::generate(Buffer::Instance& response, const std::string& name,
                                uint64_t value) {
-  response.addFragments({delim_, JsonNameTag, Json::sanitize(name_buffer_, name),
-      JsonValueTag, std::to_string(value), JsonCloseBrace});
+  response.addFragments({delim_, JsonNameTag, Json::sanitize(name_buffer_, name), JsonValueTag,
+                         std::to_string(value), JsonCloseBrace});
   delim_ = ",";
 }
 
@@ -107,8 +107,8 @@ void StatsJsonRender::generate(Buffer::Instance& response, const std::string& na
 // buffer once we exceed JsonStatsFlushCount stats.
 void StatsJsonRender::generate(Buffer::Instance& response, const std::string& name,
                                const std::string& value) {
-  response.addFragments({delim_, JsonNameTag, Json::sanitize(name_buffer_, name),
-      JsonValueTagQuote, Json::sanitize(value_buffer_, value), JsonQuoteCloseBrace});
+  response.addFragments({delim_, JsonNameTag, Json::sanitize(name_buffer_, name), JsonValueTagQuote,
+                         Json::sanitize(value_buffer_, value), JsonQuoteCloseBrace});
   delim_ = ",";
 }
 

--- a/source/server/admin/stats_render.cc
+++ b/source/server/admin/stats_render.cc
@@ -4,11 +4,6 @@
 #include "source/common/json/json_sanitizer.h"
 #include "source/common/stats/histogram_impl.h"
 
-namespace {
-// This value found by iterating in stats_handler_speed_test.cc, maximizing the
-// performance of the Json tests, and then rounding to a power of 2.
-constexpr uint64_t JsonStatsFlushCount = 64;
-} // namespace
 namespace Envoy {
 
 using ProtoMap = Protobuf::Map<std::string, ProtobufWkt::Value>;

--- a/source/server/admin/stats_render.h
+++ b/source/server/admin/stats_render.h
@@ -83,7 +83,7 @@ private:
   ProtobufWkt::Struct histograms_obj_container_;
   std::unique_ptr<ProtobufWkt::ListValue> histogram_array_;
   bool found_used_histogram_{false};
-  absl::string_view delim_;
+  absl::string_view delim_{""};
   const Utility::HistogramBucketsMode histogram_buckets_mode_;
   std::string name_buffer_;  // Used for Json::sanitize for names.
   std::string value_buffer_; // Used for Json::sanitize for text-readout values.

--- a/source/server/admin/stats_render.h
+++ b/source/server/admin/stats_render.h
@@ -67,22 +67,12 @@ public:
   void finalize(Buffer::Instance& response) override;
 
 private:
-  // Collects a scalar metric (text-readout, counter, or gauge) into an array of
-  // stats, so they can all be serialized in one shot when a threshold is
-  // reached. Serializing each one individually results in much worse
-  // performance (see stats_handler_speed_test.cc).
-  template <class Value>
-  void addScalar(Buffer::Instance& response, const std::string& name, const Value& value);
-
-  // Adds a JSON stat to our buffer, flushing to response every JsonStatsFlushCount stats.
-  void addJson(Buffer::Instance& response, const ProtobufWkt::Value& json);
-
   // Flushes all stats that were buffered in addJson() above.
   void flushStats(Buffer::Instance& response);
 
   // Adds a json fragment of scalar stats to the response buffer, including a
   // "," delimiter if this is not the first fragment.
-  void addStatAsRenderedJson(Buffer::Instance& response, absl::string_view json);
+  void addJson(Buffer::Instance& response, absl::string_view json);
 
   // Summarizes the buckets in the specified histogram, collecting JSON objects.
   // Note, we do not flush this buffer to the network when it grows large, and
@@ -103,6 +93,8 @@ private:
   bool found_used_histogram_{false};
   bool first_{true};
   const Utility::HistogramBucketsMode histogram_buckets_mode_;
+  std::string name_buffer_;  // Used for Json::sanitize for names.
+  std::string value_buffer_; // Used for Json::sanitize for text-readout values.
 };
 
 } // namespace Server

--- a/source/server/admin/stats_render.h
+++ b/source/server/admin/stats_render.h
@@ -67,13 +67,6 @@ public:
   void finalize(Buffer::Instance& response) override;
 
 private:
-  // Flushes all stats that were buffered in addJson() above.
-  void flushStats(Buffer::Instance& response);
-
-  // Adds a json fragment of scalar stats to the response buffer, including a
-  // "," delimiter if this is not the first fragment.
-  void addJson(Buffer::Instance& response, absl::string_view json);
-
   // Summarizes the buckets in the specified histogram, collecting JSON objects.
   // Note, we do not flush this buffer to the network when it grows large, and
   // if this becomes an issue it should be possible to do, noting that we are
@@ -86,12 +79,11 @@ private:
                       const std::vector<uint64_t>& interval_buckets,
                       const std::vector<uint64_t>& cumulative_buckets);
 
-  std::vector<ProtobufWkt::Value> stats_array_;
   ProtobufWkt::Struct histograms_obj_;
   ProtobufWkt::Struct histograms_obj_container_;
   std::unique_ptr<ProtobufWkt::ListValue> histogram_array_;
   bool found_used_histogram_{false};
-  bool first_{true};
+  absl::string_view delim_{""};
   const Utility::HistogramBucketsMode histogram_buckets_mode_;
   std::string name_buffer_;  // Used for Json::sanitize for names.
   std::string value_buffer_; // Used for Json::sanitize for text-readout values.

--- a/source/server/admin/stats_render.h
+++ b/source/server/admin/stats_render.h
@@ -83,7 +83,7 @@ private:
   ProtobufWkt::Struct histograms_obj_container_;
   std::unique_ptr<ProtobufWkt::ListValue> histogram_array_;
   bool found_used_histogram_{false};
-  absl::string_view delim_{""};
+  absl::string_view delim_;
   const Utility::HistogramBucketsMode histogram_buckets_mode_;
   std::string name_buffer_;  // Used for Json::sanitize for names.
   std::string value_buffer_; // Used for Json::sanitize for text-readout values.

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -424,9 +424,8 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-    // No request trailer O(1) headers.
-  }
-  {
+      // No request trailer O(1) headers.
+  } {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -424,8 +424,9 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-      // No request trailer O(1) headers.
-  } {
+    // No request trailer O(1) headers.
+  }
+  {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)


### PR DESCRIPTION
Commit Message: Uses the new Json::sanitizer from #20637 to generate counters, gauges, and text-readouts in response to admin endpoint `/stats?format=json`, resulting in a 5.6x speedup for AllCountersJson, and making JSON output only around 10% slower than text output.

Additional Description:
Before:
```
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
BM_AllCountersText             454 ms          453 ms            2
BM_UsedCountersText           35.8 ms         35.8 ms           20
BM_FilteredCountersText       1806 ms         1805 ms            1
BM_AllCountersJson            2824 ms         2823 ms            1
BM_UsedCountersJson           61.8 ms         61.8 ms           11
BM_FilteredCountersJson       1798 ms         1798 ms            1
```
after
```
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
BM_AllCountersText             458 ms          458 ms            2
BM_UsedCountersText           36.1 ms         36.1 ms           19
BM_FilteredCountersText       1790 ms         1790 ms            1
BM_AllCountersJson             496 ms          496 ms            2
BM_UsedCountersJson           36.4 ms         36.4 ms           19
BM_FilteredCountersJson       1789 ms         1789 ms            1
```

Risk Level: low -- Json::sanitizer is new, but based on nlohmann, and is differentially fuzzed vs protobuf serialization
Testing: //test/server/admin/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

