### PR TITLE
ci: remove no-op bazel option

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -93,7 +93,6 @@ trap cleanup EXIT
 BAZEL_BUILD_OPTIONS=(
   "${BAZEL_OPTIONS[@]}"
   "--verbose_failures"
-  "--show_task_finish"
   "--experimental_generate_json_trace_profile"
   "--test_output=errors"
   "--noshow_progress"

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -23,7 +23,6 @@ BUILD_CONFIG="$(dirname "$(realpath "$0")")"/osx-build-config
 # is resolved.
 BAZEL_BUILD_OPTIONS=(
     "--curses=no"
-    --show_task_finish
     --verbose_failures
     "--test_output=all"
     "--flaky_test_attempts=integration@2"

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -47,7 +47,6 @@ export TEST_TMPDIR=${BUILD_DIR}/tmp
 BAZEL_STARTUP_OPTIONS+=("--output_base=${TEST_TMPDIR/\/c/c:}")
 BAZEL_BUILD_OPTIONS=(
     -c opt
-    --show_task_finish
     --verbose_failures
     "--test_output=errors"
     "--repository_cache=${BUILD_DIR/\/c/c:}/repository_cache"


### PR DESCRIPTION
This flag was removed from newer versions of bazel and apparently hasn't
done anything since 2019

https://github.com/bazelbuild/bazel/commit/2e48994ab8202796324df3c93ff9441a44b5ba4d

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>