### PR TITLE
io_uring: skip tests if unsupported

### DIFF
--- a/source/common/io/io_uring_impl.cc
+++ b/source/common/io/io_uring_impl.cc
@@ -5,6 +5,18 @@
 namespace Envoy {
 namespace Io {
 
+bool isIoUringSupported() {
+  struct io_uring_params p {};
+  struct io_uring ring;
+
+  bool is_supported = io_uring_queue_init_params(2, &ring, &p) == 0;
+  if (is_supported) {
+    io_uring_queue_exit(&ring);
+  }
+
+  return is_supported;
+}
+
 IoUringFactoryImpl::IoUringFactoryImpl(uint32_t io_uring_size, bool use_submission_queue_polling,
                                        ThreadLocal::SlotAllocator& tls)
     : io_uring_size_(io_uring_size), use_submission_queue_polling_(use_submission_queue_polling),

--- a/source/common/io/io_uring_impl.h
+++ b/source/common/io/io_uring_impl.h
@@ -9,6 +9,8 @@
 namespace Envoy {
 namespace Io {
 
+bool isIoUringSupported();
+
 class IoUringImpl : public IoUring, public ThreadLocal::ThreadLocalObject {
 public:
   IoUringImpl(uint32_t io_uring_size, bool use_submission_queue_polling);

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -12,12 +12,27 @@ namespace {
 
 class IoUringBaseTest : public ::testing::Test {
 public:
-  IoUringBaseTest() : api_(Api::createApiForTest()), factory_(2, false, context_.threadLocal()) {
-    factory_.onServerInitialized();
+  IoUringBaseTest() : api_(Api::createApiForTest()) {
+    if (isIoUringSupported()) {
+      factory_ = std::make_unique<IoUringFactoryImpl>(2, false, context_.threadLocal());
+      factory_->onServerInitialized();
+    } else {
+      should_skip_ = true;
+    }
+  }
+
+  void SetUp() override {
+    if (should_skip_) {
+      GTEST_SKIP();
+    }
   }
 
   void TearDown() override {
-    auto& uring = factory_.getOrCreate();
+    if (should_skip_) {
+      return;
+    }
+
+    auto& uring = factory_->getOrCreate();
     if (uring.isEventfdRegistered()) {
       uring.unregisterEventfd();
     }
@@ -25,7 +40,8 @@ public:
 
   Api::ApiPtr api_;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context_;
-  IoUringFactoryImpl factory_;
+  std::unique_ptr<IoUringFactoryImpl> factory_{};
+  bool should_skip_{};
 };
 
 class IoUringImplParamTest
@@ -58,7 +74,7 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   SET_SOCKET_INVALID(fd);
   auto dispatcher = api_->allocateDispatcher("test_thread");
 
-  auto& uring = factory_.getOrCreate();
+  auto& uring = factory_->getOrCreate();
 
   os_fd_t event_fd = uring.registerEventfd();
   const Event::FileTriggerType trigger = Event::PlatformDefaultTriggerType;
@@ -91,7 +107,10 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
 
 class IoUringImplTest : public IoUringBaseTest {
 protected:
-  void SetUp() override { test_dir_ = TestEnvironment::temporaryDirectory(); }
+  void SetUp() override {
+    IoUringBaseTest::SetUp();
+    test_dir_ = TestEnvironment::temporaryDirectory();
+  }
 
   void TearDown() override {
     TestEnvironment::removePath(test_dir_);
@@ -102,13 +121,13 @@ protected:
 };
 
 TEST_F(IoUringImplTest, Instantiate) {
-  auto& uring1 = factory_.getOrCreate();
-  auto& uring2 = factory_.getOrCreate();
+  auto& uring1 = factory_->getOrCreate();
+  auto& uring2 = factory_->getOrCreate();
   EXPECT_EQ(&uring1, &uring2);
 }
 
 TEST_F(IoUringImplTest, RegisterEventfd) {
-  auto& uring = factory_.getOrCreate();
+  auto& uring = factory_->getOrCreate();
 
   EXPECT_FALSE(uring.isEventfdRegistered());
   uring.registerEventfd();
@@ -131,7 +150,7 @@ TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
   iov.iov_base = buffer;
   iov.iov_len = 4096;
 
-  auto& uring = factory_.getOrCreate();
+  auto& uring = factory_->getOrCreate();
   os_fd_t event_fd = uring.registerEventfd();
 
   const Event::FileTriggerType trigger = Event::PlatformDefaultTriggerType;
@@ -180,7 +199,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   iov3.iov_base = buffer3;
   iov3.iov_len = 2;
 
-  auto& uring = factory_.getOrCreate();
+  auto& uring = factory_->getOrCreate();
 
   os_fd_t event_fd = uring.registerEventfd();
   const Event::FileTriggerType trigger = Event::PlatformDefaultTriggerType;

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -10,9 +10,9 @@ namespace Envoy {
 namespace Io {
 namespace {
 
-class IoUringBaseTest : public ::testing::Test {
+class IoUringImplTest : public ::testing::Test {
 public:
-  IoUringBaseTest() : api_(Api::createApiForTest()) {
+  IoUringImplTest() : api_(Api::createApiForTest()) {
     if (isIoUringSupported()) {
       factory_ = std::make_unique<IoUringFactoryImpl>(2, false, context_.threadLocal());
       factory_->onServerInitialized();
@@ -45,7 +45,7 @@ public:
 };
 
 class IoUringImplParamTest
-    : public IoUringBaseTest,
+    : public IoUringImplTest,
       public testing::WithParamInterface<std::function<IoUringResult(IoUring&, os_fd_t)>> {};
 
 INSTANTIATE_TEST_SUITE_P(InvalidPrepareMethodParamsTest, IoUringImplParamTest,
@@ -105,21 +105,6 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   EXPECT_EQ(completions_nr, 2);
 }
 
-class IoUringImplTest : public IoUringBaseTest {
-protected:
-  void SetUp() override {
-    IoUringBaseTest::SetUp();
-    test_dir_ = TestEnvironment::temporaryDirectory();
-  }
-
-  void TearDown() override {
-    TestEnvironment::removePath(test_dir_);
-    IoUringBaseTest::TearDown();
-  }
-
-  std::string test_dir_;
-};
-
 TEST_F(IoUringImplTest, Instantiate) {
   auto& uring1 = factory_->getOrCreate();
   auto& uring2 = factory_->getOrCreate();
@@ -138,8 +123,10 @@ TEST_F(IoUringImplTest, RegisterEventfd) {
 }
 
 TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
+  std::string test_dir = TestEnvironment::temporaryDirectory();
+  TestEnvironment::createPath(test_dir);
   std::string test_file = TestEnvironment::writeStringToFileForTest(
-      absl::StrCat(test_dir_, "prepare_readv"), "test text", true);
+      absl::StrCat(test_dir, "/prepare_readv"), "test text", true);
   os_fd_t fd = open(test_file.c_str(), O_RDONLY);
   ASSERT_TRUE(fd >= 0);
 
@@ -176,11 +163,14 @@ TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
   EXPECT_EQ(completions_nr, 1);
   // The file's content is in the read buffer now.
   EXPECT_STREQ(static_cast<char*>(iov.iov_base), "test text");
+  TestEnvironment::removePath(test_dir);
 }
 
 TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
+  std::string test_dir = TestEnvironment::temporaryDirectory();
+  TestEnvironment::createPath(test_dir);
   std::string test_file = TestEnvironment::writeStringToFileForTest(
-      absl::StrCat(test_dir_, "prepare_readv"), "abcdefhg", true);
+      absl::StrCat(test_dir, "/prepare_readv_overflow"), "abcdefhg", true);
   os_fd_t fd = open(test_file.c_str(), O_RDONLY);
   ASSERT_TRUE(fd >= 0);
 
@@ -254,6 +244,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   dispatcher->run(Event::Dispatcher::RunType::NonBlock);
   // Check the completion callback was called actually.
   EXPECT_EQ(completions_nr, 3);
+  TestEnvironment::removePath(test_dir);
 }
 
 } // namespace

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -14,6 +14,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/filesystem/posix:95.5"
 "source/common/http:96.3"
 "source/common/http/http2:96.4"
+"source/common/io:98.0"
 "source/common/json:89.8"
 "source/common/matcher:92.0"
 "source/common/network:94.4" # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV


### PR DESCRIPTION
Commit Message: io_uring: skip tests if unsupported

Risk Level: low
Testing: run unittests on machines where io_uring supported and not (MS WSL).
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: no features added
Fixes #20763 