### PR TITLE
HTTP3: Set the interface name when an HTTP/3 client creates a socket to upstream

### DIFF
--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -87,6 +87,11 @@ void EnvoyQuicClientConnection::setUpConnectionSocket(Network::ConnectionSocket&
       ENVOY_CONN_LOG(error, "Fail to apply listening options", *this);
       connection_socket.close();
     }
+    const auto maybe_interface_name = connection_socket.connectionInfoProvider().interfaceName();
+    if (maybe_interface_name.has_value()) {
+      ENVOY_CONN_LOG_EVENT(debug, "conn_interface", "connected on local interface '{}'", *this,
+                           maybe_interface_name.value());
+    }
   }
   if (!connection_socket.ioHandle().isOpen()) {
     CloseConnection(quic::QUIC_CONNECTION_CANCELLED, "Fail to set up connection socket.",

--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -89,7 +89,7 @@ void EnvoyQuicClientConnection::setUpConnectionSocket(Network::ConnectionSocket&
     }
     const auto maybe_interface_name = connection_socket.connectionInfoProvider().interfaceName();
     if (maybe_interface_name.has_value()) {
-      ENVOY_CONN_LOG_EVENT(debug, "conn_interface", "connected on local interface '{}'", *this,
+      ENVOY_CONN_LOG_EVENT(debug, "conn_interface", "registered with local interface '{}'", *this,
                            maybe_interface_name.value());
     }
   }

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -154,6 +154,7 @@ createConnectionSocket(const Network::Address::InstanceConstSharedPtr& peer_addr
     ENVOY_LOG_MISC(error, "Fail to apply post-bind options");
     connection_socket->close();
   }
+  connection_socket->connectionInfoProvider().maybeSetInterfaceName(connection_socket->ioHandle());
   return connection_socket;
 }
 

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -2,6 +2,7 @@
 
 #include "source/common/quic/client_connection_factory_impl.h"
 #include "source/common/quic/quic_transport_socket_factory.h"
+#include "source/common/api/os_sys_calls_impl.h"
 
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
@@ -14,10 +15,12 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/mocks/api/mocks.h"
 
 #include "quiche/quic/core/crypto/quic_client_session_cache.h"
 
 using testing::Return;
+using testing::AnyNumber;
 
 namespace Envoy {
 namespace Quic {
@@ -71,6 +74,7 @@ protected:
   std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config_;
   Stats::IsolatedStoreImpl store_;
   QuicStatNames quic_stat_names_{store_.symbolTable()};
+  Api::OsSysCallsImpl os_sys_calls_actual_;
 };
 
 TEST_P(QuicNetworkConnectionTest, BufferLimits) {
@@ -93,6 +97,7 @@ TEST_P(QuicNetworkConnectionTest, BufferLimits) {
 }
 
 TEST_P(QuicNetworkConnectionTest, Srtt) {
+  Api::MockOsSysCalls os_sys_calls;
   initialize();
 
   Http::MockAlternateProtocolsCache rtt_cache;
@@ -107,7 +112,15 @@ TEST_P(QuicNetworkConnectionTest, Srtt) {
       dispatcher_, test_address_, test_address_, quic_stat_names_, rtt_cache, store_);
 
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
-
+  EXPECT_CALL(os_sys_calls, supportsGetifaddrs())
+      .Times(AnyNumber())
+      .WillRepeatedly(
+          Invoke([this]() -> bool { return os_sys_calls_actual_.supportsGetifaddrs(); }));
+  EXPECT_CALL(os_sys_calls, getifaddrs(_))
+      .Times(AnyNumber())
+      .WillRepeatedly(Invoke([this](Api::InterfaceAddressVector& vector) -> Api::SysCallIntResult {
+        return os_sys_calls_actual_.getifaddrs(vector);
+      }));
   EXPECT_EQ(session->config()->GetInitialRoundTripTimeUsToSend(), 5);
   session->Initialize();
   client_connection->connect();

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -1,10 +1,11 @@
 #include <chrono>
 
+#include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/quic/client_connection_factory_impl.h"
 #include "source/common/quic/quic_transport_socket_factory.h"
-#include "source/common/api/os_sys_calls_impl.h"
 
 #include "test/common/upstream/utility.h"
+#include "test/mocks/api/mocks.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/alternate_protocols_cache.h"
@@ -15,12 +16,11 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/simulated_time_system.h"
-#include "test/mocks/api/mocks.h"
 
 #include "quiche/quic/core/crypto/quic_client_session_cache.h"
 
-using testing::Return;
 using testing::AnyNumber;
+using testing::Return;
 
 namespace Envoy {
 namespace Quic {

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -104,14 +104,6 @@ TEST_P(QuicNetworkConnectionTest, Srtt) {
   PersistentQuicInfoImpl info{dispatcher_, 45};
 
   EXPECT_CALL(rtt_cache, getSrtt).WillOnce(Return(std::chrono::microseconds(5)));
-
-  const int port = 30;
-  std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
-      info, crypto_config_,
-      quic::QuicServerId{factory_->clientContextConfig().serverNameIndication(), port, false},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, rtt_cache, store_);
-
-  EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   EXPECT_CALL(os_sys_calls, supportsGetifaddrs())
       .Times(AnyNumber())
       .WillRepeatedly(
@@ -121,6 +113,15 @@ TEST_P(QuicNetworkConnectionTest, Srtt) {
       .WillRepeatedly(Invoke([this](Api::InterfaceAddressVector& vector) -> Api::SysCallIntResult {
         return os_sys_calls_actual_.getifaddrs(vector);
       }));
+
+  const int port = 30;
+  std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
+      info, crypto_config_,
+      quic::QuicServerId{factory_->clientContextConfig().serverNameIndication(), port, false},
+      dispatcher_, test_address_, test_address_, quic_stat_names_, rtt_cache, store_);
+
+  EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
+
   EXPECT_EQ(session->config()->GetInitialRoundTripTimeUsToSend(), 5);
   session->Initialize();
   client_connection->connect();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: try to get the interface name when H3 client creating a socket to upstream
Additional Description: this is a following work of #19336, and replacing the previous PR #20644  
Risk Level: midum
Testing: yes
Docs Changes: None
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #20209 
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
