### PR TITLE
http: the first step towards alpn having intelligent initial streams.

### DIFF
--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -199,7 +199,7 @@ void MultiplexedActiveClientBase::onStreamReset(Http::StreamResetReason reason) 
   }
 }
 
-uint64_t maxStreamsPerConnection(uint64_t max_streams_config) {
+uint64_t MultiplexedActiveClientBase::maxStreamsPerConnection(uint64_t max_streams_config) {
   return (max_streams_config != 0) ? max_streams_config : DEFAULT_MAX_STREAMS;
 }
 

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -190,6 +190,8 @@ public:
   MultiplexedActiveClientBase(HttpConnPoolImplBase& parent, uint32_t max_concurrent_streams,
                               Stats::Counter& cx_total, Upstream::Host::CreateConnectionData& data);
   ~MultiplexedActiveClientBase() override = default;
+  // Caps max streams per connection below 2^31 to prevent overflow.
+  static uint64_t maxStreamsPerConnection(uint64_t max_streams_config);
 
   // ConnPoolImpl::ActiveClient
   bool closingWithIncompleteStream() const override;

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -4,14 +4,25 @@
 #include "source/common/http/http1/conn_pool.h"
 #include "source/common/http/http2/conn_pool.h"
 #include "source/common/http/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/common/tcp/conn_pool.h"
 
 namespace Envoy {
 namespace Http {
 
 Envoy::ConnectionPool::ActiveClientPtr HttpConnPoolImplMixed::instantiateActiveClient() {
-  return std::make_unique<Tcp::ActiveTcpClient>(*this,
-                                                Envoy::ConnectionPool::ConnPoolImplBase::host(), 1);
+  uint32_t initial_streams = 1;
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
+    // For now, use the hard-coded setting. Eventually use the cached setting if available.
+    initial_streams = host()->cluster().http2Options().max_concurrent_streams().value();
+    auto max_requests = MultiplexedActiveClientBase::maxStreamsPerConnection(
+        host()->cluster().maxRequestsPerConnection());
+    if (max_requests < initial_streams) {
+      initial_streams = max_requests;
+    }
+  }
+  return std::make_unique<Tcp::ActiveTcpClient>(
+      *this, Envoy::ConnectionPool::ConnPoolImplBase::host(), initial_streams);
 }
 
 CodecClientPtr
@@ -47,6 +58,14 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
     }
   }
 
+  uint32_t old_effective_limit = client.effectiveConcurrentStreamLimit();
+  if (protocol_ == Http::Protocol::Http11 && client.concurrent_stream_limit_ != 1) {
+    // The estimates were all based on assuming HTTP/2 would be negotiated. Adjust down.
+    uint32_t delta = client.concurrent_stream_limit_ - 1;
+    client.concurrent_stream_limit_ = 1;
+    decrConnectingAndConnectedStreamCapacity(delta, client);
+  }
+
   Upstream::Host::CreateConnectionData data{std::move(tcp_client->connection_),
                                             client.real_host_description_};
   // As this connection comes from the tcp connection pool, it will be
@@ -70,9 +89,9 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
   // The global capacity is not adjusted in onConnectionEvent, so simply update
   // it to reflect any difference between the TCP stream limits and HTTP/2
   // stream limits.
-  if (new_client->effectiveConcurrentStreamLimit() > 1) {
+  if (new_client->effectiveConcurrentStreamLimit() > old_effective_limit) {
     state_.incrConnectingAndConnectedStreamCapacity(new_client->effectiveConcurrentStreamLimit() -
-                                                    1);
+                                                    old_effective_limit);
   }
   new_client->setState(ActiveClient::State::Connecting);
   LinkedList::moveIntoList(std::move(new_client), owningList(new_client->state()));

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -30,6 +30,7 @@
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_allow_adding_content_type_in_local_replies);
+RUNTIME_GUARD(envoy_reloadable_features_allow_concurrency_for_alpn_pool);
 RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_inline_write);
 RUNTIME_GUARD(envoy_reloadable_features_append_or_truncate);
 RUNTIME_GUARD(envoy_reloadable_features_append_to_accept_content_encoding_only_once);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -30,7 +30,6 @@
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_allow_adding_content_type_in_local_replies);
-RUNTIME_GUARD(envoy_reloadable_features_allow_concurrency_for_alpn_pool);
 RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_inline_write);
 RUNTIME_GUARD(envoy_reloadable_features_append_or_truncate);
 RUNTIME_GUARD(envoy_reloadable_features_append_to_accept_content_encoding_only_once);
@@ -74,6 +73,8 @@ RUNTIME_GUARD(envoy_restart_features_use_apple_api_for_dns_lookups);
 // Begin false flags. These should come with a TODO to flip true.
 // Sentinel and test flag.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_test_feature_false);
+// TODO(alyssawilk) flip true once H2 caching is on by default.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_allow_concurrency_for_alpn_pool);
 // TODO(alyssawilk, junr03) flip (and add release notes + docs) these after Lyft tests
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_allow_multiple_dns_addresses);
 // TODO(adisuissa) reset to true to enable unified mux by default

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -78,7 +78,11 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
                                                           : Http::Utility::AlpnNames::get().Http2);
   }
   EXPECT_CALL(*connection, nextProtocol()).WillOnce(Return(next_protocol));
-  EXPECT_EQ(536870912, state_.connecting_and_connected_stream_capacity_);
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
+    EXPECT_EQ(536870912, state_.connecting_and_connected_stream_capacity_);
+  } else {
+    EXPECT_EQ(1, state_.connecting_and_connected_stream_capacity_);
+  }
 
   connection->raiseEvent(Network::ConnectionEvent::Connected);
   if (!protocol.has_value()) {

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -78,6 +78,7 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
                                                           : Http::Utility::AlpnNames::get().Http2);
   }
   EXPECT_CALL(*connection, nextProtocol()).WillOnce(Return(next_protocol));
+  EXPECT_EQ(536870912, state_.connecting_and_connected_stream_capacity_);
 
   connection->raiseEvent(Network::ConnectionEvent::Connected);
   if (!protocol.has_value()) {

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -126,7 +126,7 @@ common_tls_context:
   if (upstream_config.upstream_protocol_ != Http::CodecType::HTTP3) {
     auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
         tls_context, factory_context_);
-    static Stats::Scope* upstream_stats_store = new Stats::IsolatedStoreImpl();
+    static Stats::Scope* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
         std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
   } else {


### PR DESCRIPTION
Risk Level: low (off by default)
Testing: unit + integration
Docs Changes: n/a
Release Notes: n/a
Runtime guard: envoy.reloadable_features.allow_concurrency_for_alpn_pool
Part of https://github.com/envoyproxy/envoy/issues/20696 part of https://github.com/envoyproxy/envoy/issues/15947 
