### PR TITLE
bazel: add mobile rust toolchains

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -23,7 +23,19 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     apple_rules_dependencies()
     pip_dependencies()
     rules_rust_dependencies()
-    rust_register_toolchains(include_rustc_srcs = True)
+    rust_register_toolchains(
+        include_rustc_srcs = True,
+        extra_target_triples = [
+            "aarch64-apple-ios",
+            "aarch64-linux-android",
+            "armv7-linux-androideabi",
+            "i686-linux-android",
+            "wasm32-unknown-unknown",
+            "wasm32-wasi",
+            "x86_64-apple-ios",
+            "x86_64-linux-android",
+        ],
+    )
     upb_deps()
     antlr_dependencies(472)
     proxy_wasm_rust_sdk_dependencies()


### PR DESCRIPTION
This is preliminary work for getting rust working in envoy mobile. This
should be minimal overhead in the case you're not actually building rust
for mobile. If it becomes an issue we can inject this from the consumers
of `envoy_dependency_imports`.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>