### PR TITLE
fuzz test: Validate fuzz input to local rate limit

### DIFF
--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_corpus/clusterfuzz-testcase-minimized-local_ratelimit_fuzz_test-5036107325112320
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_corpus/clusterfuzz-testcase-minimized-local_ratelimit_fuzz_test-5036107325112320
@@ -1,0 +1,13 @@
+config {
+  stat_prefix: "...............................................,"
+  token_bucket {
+    max_tokens: 5
+    fill_interval {
+      nanos: 2
+    }
+  }
+}
+actions {
+  refill {
+  }
+}


### PR DESCRIPTION
Commit Message: fuzz test: Validate fuzzed input to local rate limit
Additional Description: 
Input to the local_ratelimit_fuzz_test must not accept fill_intervals
less than 50ms. Added better checking of input.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>