### PR TITLE
vcl: stop readv if slice not full after read

### DIFF
--- a/contrib/vcl/source/vcl_io_handle.cc
+++ b/contrib/vcl/source/vcl_io_handle.cc
@@ -183,7 +183,7 @@ Api::IoCallUint64Result VclIoHandle::readv(uint64_t max_length, Buffer::RawSlice
       break;
     }
     num_bytes_read += rv;
-    if (num_bytes_read == max_length) {
+    if (static_cast<size_t>(rv) < slice_length || num_bytes_read == max_length) {
       break;
     }
   }


### PR DESCRIPTION
Signed-off-by: Florin Coras <fcoras@cisco.com>

Commit Message: stop reading from vcl if previous read did not fill current slice
Risk Level: low
Testing: n/a
Docs Changes: n/a
