### PR TITLE
GCP Authentication Filter: Implement response path

### DIFF
--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
@@ -78,8 +78,7 @@ void GcpAuthnFilter::onComplete(const Http::ResponseMessage* response) {
       // Modify the request header to include the ID token in an `Authorization: Bearer ID_TOKEN`
       // header.
       std::string id_token = absl::StrCat("Bearer ", response->bodyAsString());
-      request_header_map_->addCopy(Envoy::Http::LowerCaseString(authorizationHeaderKey()),
-                                   id_token);
+      request_header_map_->addCopy(authorizationHeaderKey(), id_token);
     }
     decoder_callbacks_->continueDecoding();
   }

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
@@ -78,7 +78,7 @@ void GcpAuthnFilter::onComplete(const Http::ResponseMessage* response) {
       // Modify the request header to include the ID token in an `Authorization: Bearer ID_TOKEN`
       // header.
       std::string id_token = absl::StrCat("Bearer ", response->bodyAsString());
-      request_header_map_->addCopy(Envoy::Http::LowerCaseString(AuthorizationHeaderKey()),
+      request_header_map_->addCopy(Envoy::Http::LowerCaseString(authorizationHeaderKey()),
                                    id_token);
     }
     decoder_callbacks_->continueDecoding();

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
@@ -17,8 +17,11 @@ namespace GcpAuthn {
 
 inline constexpr absl::string_view FilterName = "envoy.filters.http.gcp_authn";
 inline constexpr absl::string_view AudienceKey = "audience_key";
-inline const std::string& authorizationHeaderKey() {
-  CONSTRUCT_ON_FIRST_USE(std::string, "Authorization");
+// inline const std::string& authorizationHeaderKey() {
+//   CONSTRUCT_ON_FIRST_USE(std::string, "Authorization");
+// }
+inline const Envoy::Http::LowerCaseString& authorizationHeaderKey() {
+  CONSTRUCT_ON_FIRST_USE(Envoy::Http::LowerCaseString, "Authorization");
 }
 /**
  * All stats for the gcp authentication filter. @see stats_macros.h

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
@@ -17,6 +17,9 @@ namespace GcpAuthn {
 
 inline constexpr absl::string_view FilterName = "envoy.filters.http.gcp_authn";
 inline constexpr absl::string_view AudienceKey = "audience_key";
+inline const std::string& AuthorizationHeaderKey() {
+  CONSTRUCT_ON_FIRST_USE(std::string, "Authorization");
+}
 /**
  * All stats for the gcp authentication filter. @see stats_macros.h
  */
@@ -70,6 +73,8 @@ private:
   Server::Configuration::FactoryContext& context_;
   std::unique_ptr<GcpAuthnClient> client_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
+  // The pointer to request headers for header manipulation later.
+  Envoy::Http::RequestHeaderMap* request_header_map_ = nullptr;
 
   bool initiating_call_{};
   State state_{State::NotStarted};

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
@@ -17,9 +17,6 @@ namespace GcpAuthn {
 
 inline constexpr absl::string_view FilterName = "envoy.filters.http.gcp_authn";
 inline constexpr absl::string_view AudienceKey = "audience_key";
-// inline const std::string& authorizationHeaderKey() {
-//   CONSTRUCT_ON_FIRST_USE(std::string, "Authorization");
-// }
 inline const Envoy::Http::LowerCaseString& authorizationHeaderKey() {
   CONSTRUCT_ON_FIRST_USE(Envoy::Http::LowerCaseString, "Authorization");
 }

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
@@ -17,7 +17,7 @@ namespace GcpAuthn {
 
 inline constexpr absl::string_view FilterName = "envoy.filters.http.gcp_authn";
 inline constexpr absl::string_view AudienceKey = "audience_key";
-inline const std::string& AuthorizationHeaderKey() {
+inline const std::string& authorizationHeaderKey() {
   CONSTRUCT_ON_FIRST_USE(std::string, "Authorization");
 }
 /**

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
@@ -127,14 +127,14 @@ public:
     // field).
     if (with_audience) {
       ASSERT_FALSE(upstream_request_->headers()
-                       .get(Envoy::Http::LowerCaseString(AuthorizationHeaderKey()))
+                       .get(Envoy::Http::LowerCaseString(authorizationHeaderKey()))
                        .empty());
       // The expected ID token is in format of `Bearer ID_TOKEN`
       std::string id_token = absl::StrCat("Bearer ", MockTokenString);
       // Verify the request header modification: the token returned from authentication server
       // has been added to the request header that is sent to destination upstream.
       EXPECT_EQ(upstream_request_->headers()
-                    .get(Envoy::Http::LowerCaseString(AuthorizationHeaderKey()))[0]
+                    .get(Envoy::Http::LowerCaseString(authorizationHeaderKey()))[0]
                     ->value()
                     .getStringView(),
                 id_token);

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
@@ -126,18 +126,14 @@ public:
     // The authorization header is only added when the configuration is valid (e.g., with audience
     // field).
     if (with_audience) {
-      ASSERT_FALSE(upstream_request_->headers()
-                       .get(Envoy::Http::LowerCaseString(authorizationHeaderKey()))
-                       .empty());
+      ASSERT_FALSE(upstream_request_->headers().get(authorizationHeaderKey()).empty());
       // The expected ID token is in format of `Bearer ID_TOKEN`
       std::string id_token = absl::StrCat("Bearer ", MockTokenString);
       // Verify the request header modification: the token returned from authentication server
       // has been added to the request header that is sent to destination upstream.
-      EXPECT_EQ(upstream_request_->headers()
-                    .get(Envoy::Http::LowerCaseString(authorizationHeaderKey()))[0]
-                    ->value()
-                    .getStringView(),
-                id_token);
+      EXPECT_EQ(
+          upstream_request_->headers().get(authorizationHeaderKey())[0]->value().getStringView(),
+          id_token);
     }
 
     EXPECT_EQ(0U, upstream_request_->bodyLength());

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
@@ -20,6 +20,8 @@ namespace {
 constexpr absl::string_view AudienceValue = "http://test.com";
 constexpr absl::string_view Url = "http://metadata.google.internal/computeMetadata/v1/instance/"
                                   "service-accounts/default/identity?audience=[AUDIENCE]";
+constexpr absl::string_view MockedTokenString =
+    "eyJhbGciOiJSUzI1NiIsImtpZCI6ImYxMzM4Y2EyNjgzNTg2M2Y2NzE0MDhmNDE3MzhhN2I0OWU3NDBmYzAiLCJ0eXAiO";
 
 class GcpAuthnFilterIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                       public HttpIntegrationTest {
@@ -96,13 +98,16 @@ public:
     // fake upstream successfully from http async client.
     EXPECT_EQ(request_->headers().Host()->value(), std::string(host));
     EXPECT_EQ(request_->headers().Path()->value(), std::string(path));
+    // Send response headers with end_stream false because we want to add response body next.
+    request_->encodeHeaders(default_response_headers_, false);
+    // Send response data with end_stream true.
+    request_->encodeData(MockedTokenString, true);
     result = request_->waitForEndStream(*dispatcher_);
     RELEASE_ASSERT(result, result.message());
-    request_->encodeHeaders(default_response_headers_, true);
   }
 
   // First cluster (i.e., cluster_0) is destination upstream cluster
-  void sendRequestToFirstClusterAndValidateResponse() {
+  void sendRequestToFirstClusterAndValidateResponse(bool with_audience = true) {
     // Send the request to cluster `cluster_0`;
     AssertionResult result =
         fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
@@ -118,6 +123,23 @@ public:
 
     // Verify the proxied request was received upstream, as expected.
     EXPECT_TRUE(upstream_request_->complete());
+    // The authorization header is only added when the configuration is valid (e.g., with audience
+    // field).
+    if (with_audience) {
+      ASSERT_FALSE(upstream_request_->headers()
+                       .get(Envoy::Http::LowerCaseString(AuthorizationHeaderKey()))
+                       .empty());
+      // The expected ID token is in format of `Bearer ID_TOKEN`
+      std::string id_token = absl::StrCat("Bearer ", MockedTokenString);
+      // Verify the request header modification that the token returned from authentication server
+      // has been added to the request sent to destination upstream.
+      EXPECT_EQ(upstream_request_->headers()
+                    .get(Envoy::Http::LowerCaseString(AuthorizationHeaderKey()))[0]
+                    ->value()
+                    .getStringView(),
+                id_token);
+    }
+
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     // Verify the proxied response was received downstream, as expected.
     EXPECT_TRUE(response_->complete());
@@ -173,7 +195,7 @@ TEST_P(GcpAuthnFilterIntegrationTest, BasicflowWithoutAudience) {
                                                          std::chrono::milliseconds(200)));
 
   // Send the request to cluster `cluster_0` and validate the response.
-  sendRequestToFirstClusterAndValidateResponse();
+  sendRequestToFirstClusterAndValidateResponse(/*with_audience=*/false);
 
   // Verify request has been routed to `cluster_0` but not `gcp_authn` cluster.
   EXPECT_GE(test_server_->counter("cluster.gcp_authn.upstream_cx_total")->value(), 0);


### PR DESCRIPTION
- Implement the response path
   On the response path, once the token is returned from authentication server,  we need to include it  in an `Authorization: Bearer ID_TOKEN` header and add the header into the request which is sent from calling service to the receiving service.

- Add the test coverage in integration test to verify the request header modification mentioned above 

Signed-off-by: Tianyu Xia [tyxia@google.com](mailto:tyxia@google.com)
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
