### PR TITLE
bazel: add temporary rules_rust patch

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -127,7 +127,10 @@ def _go_deps(skip_targets):
         external_http_archive("bazel_gazelle")
 
 def _rust_deps():
-    external_http_archive("rules_rust")
+    external_http_archive(
+        "rules_rust",
+        patches = ["@envoy//bazel:rules_rust.patch"],
+    )
 
 def envoy_dependencies(skip_targets = []):
     # Add a binding for repository variables.

--- a/bazel/rules_rust.patch
+++ b/bazel/rules_rust.patch
@@ -1,0 +1,18 @@
+# https://github.com/bazelbuild/rules_rust/pull/1259
+
+--- rust/platform/triple_mappings.bzl
++++ rust/platform/triple_mappings.bzl
+@@ -269,6 +269,13 @@ def triple_to_constraint_set(target_triple):
+             "@rules_rust//rust/platform/os:unknown",
+         ]
+ 
++    # Workaround for https://github.com/bazelbuild/bazel/issues/14982
++    if target_triple in ("armv7-linux-androideabi", "thumbv7neon-linux-androideabi"):
++        return [
++            "@platforms//cpu:arm",
++            "@platforms//os:android",
++        ]
++
+     triple_struct = triple(target_triple)
+ 
+     constraint_set = []


### PR DESCRIPTION
This enables building rust that targets android devices until the
upstream PR is released. It shouldn't affect any other configuration
since it's scoped to the triple.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>