### PR TITLE
Add HasStatus, HasStatusCode and HasStatusMessage matchers to status_utility.h

### DIFF
--- a/test/test_common/status_utility.h
+++ b/test/test_common/status_utility.h
@@ -39,29 +39,79 @@ MATCHER_P(StatusIs, expected_code, "") {
   return true;
 }
 
-class IsOkMatcher {
+// A polymorphic matcher class for matching absl::Status or absl::StatusOr.
+// Not intended for direct use, see HasStatus, HasStatusCode, HasStatusMessage and IsOk
+// below.
+class StatusMatcher {
 public:
-  template <typename StatusT>
+  StatusMatcher(::testing::Matcher<absl::Status> matcher) : matcher_(matcher) {}
+
   // NOLINTNEXTLINE(readability-identifier-naming)
-  bool MatchAndExplain(StatusT status, ::testing::MatchResultListener* listener) const {
-    if (status.ok()) {
-      return true;
-    }
-    *listener << "status is " << status;
-    return false;
+  bool MatchAndExplain(absl::Status status, ::testing::MatchResultListener* listener) const {
+    return matcher_.MatchAndExplain(status, listener);
   }
 
   template <typename T>
   // NOLINTNEXTLINE(readability-identifier-naming)
   bool MatchAndExplain(absl::StatusOr<T> status_or,
                        ::testing::MatchResultListener* listener) const {
-    return MatchAndExplain(status_or.status(), listener);
+    return ::testing::ExplainMatchResult(
+        ::testing::Property("status", &absl::StatusOr<T>::status, matcher_), status_or, listener);
   }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void DescribeTo(::std::ostream* os) const { *os << "is OK"; }
+  void DescribeTo(::std::ostream* os) const { matcher_.DescribeTo(os); }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void DescribeNegationTo(::std::ostream* os) const { *os << "is not OK"; }
+  void DescribeNegationTo(::std::ostream* os) const {
+    *os << "not ";
+    matcher_.DescribeTo(os);
+  }
+
+private:
+  ::testing::Matcher<absl::Status> matcher_;
 };
+
+// Match status code in an absl::StatusOr or absl::Status, allowing arbitrary matchers,
+// e.g.
+// EXPECT_THAT(some_status_or, HasStatusCode(AnyOf(absl::StatusCode::kOk,
+//                                                 absl::StatusCode::kInvalidArgument)));
+template <typename InnerMatcher>
+// NOLINTNEXTLINE(readability-identifier-naming)
+::testing::PolymorphicMatcher<StatusMatcher> HasStatusCode(InnerMatcher m) {
+  return ::testing::MakePolymorphicMatcher(StatusMatcher(::testing::SafeMatcherCast<absl::Status>(
+      ::testing::Property("code", &absl::Status::code, m))));
+}
+
+// Match status message in an absl::StatusOr or absl::Status, allowing arbitrary matchers,
+// e.g.
+// EXPECT_THAT(some_status_or, HasStatusMessage(HasSubstr("cheese")));
+template <typename InnerMatcher>
+// NOLINTNEXTLINE(readability-identifier-naming)
+::testing::PolymorphicMatcher<StatusMatcher> HasStatusMessage(InnerMatcher m) {
+  return ::testing::MakePolymorphicMatcher(StatusMatcher(::testing::SafeMatcherCast<absl::Status>(
+      ::testing::Property("message", &absl::Status::message, m))));
+}
+
+// Match the status of an absl::StatusOr or absl::Status, e.g.
+// EXPECT_THAT(some_status_or, HasStatus(absl::InvalidArgumentError("oh no")));
+// One may also use a Status matcher, but see the other HasStatus below for a
+// more readable version of that.
+template <typename InnerMatcher>
+// NOLINTNEXTLINE(readability-identifier-naming)
+::testing::PolymorphicMatcher<StatusMatcher> HasStatus(InnerMatcher m) {
+  return ::testing::MakePolymorphicMatcher(
+      StatusMatcher(::testing::SafeMatcherCast<absl::Status>(m)));
+}
+
+// Match the code and message of an absl::StatusOr or absl::Status, e.g.
+// EXPECT_THAT(some_status_or, HasStatus(absl::StatusCode::kInvalidArgument, HasSubstr("cheese")));
+template <typename InnerMatcherCode, typename InnerMatcherMessage>
+// NOLINTNEXTLINE(readability-identifier-naming)
+::testing::PolymorphicMatcher<StatusMatcher> HasStatus(InnerMatcherCode code_matcher,
+                                                       InnerMatcherMessage message_matcher) {
+  return ::testing::MakePolymorphicMatcher(StatusMatcher(::testing::SafeMatcherCast<absl::Status>(
+      AllOf(::testing::Property("code", &absl::Status::code, code_matcher),
+            ::testing::Property("message", &absl::Status::message, message_matcher)))));
+}
 
 // Check that an absl::Status or absl::StatusOr is OK.
 //
@@ -71,8 +121,8 @@ public:
 // EXPECT_THAT(status_or, IsOk());  // fails!
 //
 // NOLINTNEXTLINE(readability-identifier-naming)
-inline ::testing::PolymorphicMatcher<IsOkMatcher> IsOk() {
-  return ::testing::MakePolymorphicMatcher(IsOkMatcher());
+inline ::testing::PolymorphicMatcher<StatusMatcher> IsOk() {
+  return HasStatusCode(absl::StatusCode::kOk);
 }
 
 #ifndef EXPECT_OK


### PR DESCRIPTION
Signed-off-by: Raven Black <ravenblack@dropbox.com>

Commit Message: Add HasStatus, HasStatusCode and HasStatusMessage matchers to status_utility.h
Additional Description: The current set of matchers hinders readability of tests that validate error statuses. These new functions will improve that. Also added better validation in the matcher tests, that simulates the full EXPECT_THAT output, making it easier to see that the matcher output contains all the important information (validating only the result_listener implies the output is blank for a simple equality matcher, for example).
Risk Level: None, test-only.
Testing: Excessive coverage.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a