### PR TITLE
test: Add oghttp2 and wrapped-nghttp2 coverage to codec_impl_fuzz_test.cc

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -95,6 +95,7 @@ envoy_cc_fuzz_test(
         "//test/fuzz:utility_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -23,6 +23,7 @@
 #include "test/fuzz/utility.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 
@@ -516,7 +517,7 @@ using HttpStreamPtr = std::unique_ptr<HttpStream>;
 
 namespace {
 
-enum class HttpVersion { Http1, Http2 };
+enum class HttpVersion { Http1, Http2Nghttp2, Http2WrappedNghttp2, Http2Oghttp2 };
 
 void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersion http_version) {
   Stats::IsolatedStoreImpl stats_store;
@@ -537,12 +538,33 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
 
   HttpStream::ConnectionContext connection_context(&conn_manager_config, server_connection,
                                                    client_connection);
+  TestScopedRuntime scoped_runtime;
 
   Http1::CodecStats::AtomicPtr http1_stats;
   Http2::CodecStats::AtomicPtr http2_stats;
   ClientConnectionPtr client;
   ServerConnectionPtr server;
-  const bool http2 = http_version == HttpVersion::Http2;
+  bool http2 = false;
+
+  switch (http_version) {
+  case HttpVersion::Http1:
+    break;
+  case HttpVersion::Http2Nghttp2:
+    http2 = true;
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.http2_new_codec_wrapper", "false"}});
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.http2_use_oghttp2", "false"}});
+    break;
+  case HttpVersion::Http2WrappedNghttp2:
+    http2 = true;
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.http2_new_codec_wrapper", "true"}});
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.http2_use_oghttp2", "false"}});
+    break;
+  case HttpVersion::Http2Oghttp2:
+    http2 = true;
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.http2_new_codec_wrapper", "true"}});
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.http2_use_oghttp2", "true"}});
+    break;
+  }
 
   if (http2) {
     client = std::make_unique<Http2::ClientConnectionImpl>(
@@ -742,7 +764,9 @@ DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
     // Validate input early.
     TestUtility::validate(input);
     codecFuzz(input, HttpVersion::Http1);
-    codecFuzz(input, HttpVersion::Http2);
+    codecFuzz(input, HttpVersion::Http2Nghttp2);
+    codecFuzz(input, HttpVersion::Http2WrappedNghttp2);
+    codecFuzz(input, HttpVersion::Http2Oghttp2);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
   }


### PR DESCRIPTION
Signed-off-by: Dianna Hu <diannahu@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: This PR updates codec_impl_fuzz_test.cc's HttpVersion to include oghttp2 and wrapped-nghttp2, then enables the appropriate runtime config in testing.
Additional Description: Other examples of the three HTTP/2 codec variations and associated runtime config enablement can be found at https://github.com/envoyproxy/envoy/search?q=setupHttp2Overrides. However, I chose not to use a dedicated method here because setup occurs at only one place. This PR is an identical respin of envoyproxy#20811, except that the unrelated commits are removed.
Risk Level: Low
Testing: bazel test //test/common/http:codec_impl_fuzz_test --config=libc++
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
