### PR TITLE
WiP stats: use RefcountPtr rather than shared_ptr for Scopes, and fix wasm not to need weak ptrs.

### DIFF
--- a/envoy/stats/refcount_ptr.h
+++ b/envoy/stats/refcount_ptr.h
@@ -159,5 +159,15 @@ struct RefcountHelper {
   std::atomic<uint32_t> ref_count_{0};
 };
 
+class RefcountImpl {
+ public:
+  void incRefCount() const { refcount_.incRefCount(); }
+  bool decRefCount() const { return refcount_.decRefCount(); }
+  uint32_t use_count() const { return refcount_.use_count(); }
+
+ private:
+  mutable RefcountHelper refcount_;
+};
+
 } // namespace Stats
 } // namespace Envoy

--- a/envoy/stats/refcount_ptr.h
+++ b/envoy/stats/refcount_ptr.h
@@ -160,12 +160,12 @@ struct RefcountHelper {
 };
 
 class RefcountImpl {
- public:
+public:
   void incRefCount() const { refcount_.incRefCount(); }
   bool decRefCount() const { return refcount_.decRefCount(); }
   uint32_t use_count() const { return refcount_.use_count(); }
 
- private:
+private:
   mutable RefcountHelper refcount_;
 };
 

--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -25,9 +25,7 @@ using CounterOptConstRef = absl::optional<std::reference_wrapper<const Counter>>
 using GaugeOptConstRef = absl::optional<std::reference_wrapper<const Gauge>>;
 using HistogramOptConstRef = absl::optional<std::reference_wrapper<const Histogram>>;
 using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextReadout>>;
-//using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ConstScopeSharedPtr = RefcountPtr<const Scope>;
-//using ScopeSharedPtr = std::shared_ptr<Scope>;
 
 using ScopeSharedPtr = RefcountPtr<Scope>;
 
@@ -66,10 +64,8 @@ public:
   virtual ~Scope() = default;
 
   /** @return a shared_ptr for this */
-  //ScopeSharedPtr getShared() { return shared_from_this(); }
   ScopeSharedPtr getShared() { return ScopeSharedPtr(this); }
   /** @return a const shared_ptr for this */
-  //ConstScopeSharedPtr getConstShared() const { return shared_from_this(); }
   ConstScopeSharedPtr getConstShared() const { return ConstScopeSharedPtr(this); }
 
   /**

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -35,7 +35,7 @@ IsolatedStoreImpl::IsolatedStoreImpl(SymbolTable& symbol_table)
       }),
       null_counter_(new NullCounterImpl(symbol_table)),
       null_gauge_(new NullGaugeImpl(symbol_table)),
-      default_scope_(std::make_shared<ScopePrefixer>("", *this)) {}
+      default_scope_(new ScopePrefixer("", *this)) {}
 
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 
@@ -45,7 +45,7 @@ ScopeSharedPtr IsolatedStoreImpl::createScope(const std::string& name) {
 }
 
 ScopeSharedPtr IsolatedStoreImpl::scopeFromStatName(StatName name) {
-  ScopeSharedPtr scope = std::make_shared<ScopePrefixer>(name, *this);
+  ScopeSharedPtr scope(new ScopePrefixer(name, *this));
   scopes_.push_back(scope);
   return scope;
 }

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -34,8 +34,7 @@ IsolatedStoreImpl::IsolatedStoreImpl(SymbolTable& symbol_table)
         return alloc_.makeTextReadout(name, name, StatNameTagVector{});
       }),
       null_counter_(new NullCounterImpl(symbol_table)),
-      null_gauge_(new NullGaugeImpl(symbol_table)),
-      default_scope_(new ScopePrefixer("", *this)) {}
+      null_gauge_(new NullGaugeImpl(symbol_table)), default_scope_(new ScopePrefixer("", *this)) {}
 
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 

--- a/source/common/stats/scope_prefixer.cc
+++ b/source/common/stats/scope_prefixer.cc
@@ -18,7 +18,6 @@ ScopePrefixer::~ScopePrefixer() { prefix_.free(symbolTable()); }
 
 ScopeSharedPtr ScopePrefixer::scopeFromStatName(StatName name) {
   SymbolTable::StoragePtr joined = symbolTable().join({prefix_.statName(), name});
-  //return std::make_shared<ScopePrefixer>(StatName(joined.get()), scope_);
   return ScopeSharedPtr(new ScopePrefixer(StatName(joined.get()), scope_));
 }
 

--- a/source/common/stats/scope_prefixer.cc
+++ b/source/common/stats/scope_prefixer.cc
@@ -18,7 +18,8 @@ ScopePrefixer::~ScopePrefixer() { prefix_.free(symbolTable()); }
 
 ScopeSharedPtr ScopePrefixer::scopeFromStatName(StatName name) {
   SymbolTable::StoragePtr joined = symbolTable().join({prefix_.statName(), name});
-  return std::make_shared<ScopePrefixer>(StatName(joined.get()), scope_);
+  //return std::make_shared<ScopePrefixer>(StatName(joined.get()), scope_);
+  return ScopeSharedPtr(new ScopePrefixer(StatName(joined.get()), scope_));
 }
 
 ScopeSharedPtr ScopePrefixer::createScope(const std::string& name) {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -149,9 +149,10 @@ ScopeSharedPtr ThreadLocalStoreImpl::createScope(const std::string& name) {
 }
 
 ScopeSharedPtr ThreadLocalStoreImpl::scopeFromStatName(StatName name) {
-  auto new_scope = std::make_shared<ScopeImpl>(*this, name);
+  auto scope_impl = new ScopeImpl(*this, name);
+  ScopeSharedPtr new_scope(scope_impl);
   Thread::LockGuard lock(lock_);
-  scopes_.emplace(new_scope.get());
+  scopes_.emplace(scope_impl);
   return new_scope;
 }
 

--- a/source/extensions/common/wasm/stats_handler.cc
+++ b/source/extensions/common/wasm/stats_handler.cc
@@ -9,18 +9,13 @@ namespace Extensions {
 namespace Common {
 namespace Wasm {
 
-Stats::ScopeSharedPtr CreateStatsHandler::lockAndCreateStats(const Stats::ScopeSharedPtr& scope) {
+void CreateStatsHandler::lockAndCreateStats(const Stats::ScopeSharedPtr& scope) {
   absl::MutexLock l(&mutex_);
-  Stats::ScopeSharedPtr lock = scope_;
-  //if (!(lock = scope_.lock())) {
   if (scope_ == nullptr) {
     resetStats();
-    createStats(scope);
-    scope_ = scope; //ScopeWeakPtr(scope);
-    return scope;
+    scope_ = scope;
   }
   createStats(scope);
-  return lock;
 }
 
 void CreateStatsHandler::resetStatsForTesting() {

--- a/source/extensions/common/wasm/stats_handler.cc
+++ b/source/extensions/common/wasm/stats_handler.cc
@@ -11,11 +11,12 @@ namespace Wasm {
 
 Stats::ScopeSharedPtr CreateStatsHandler::lockAndCreateStats(const Stats::ScopeSharedPtr& scope) {
   absl::MutexLock l(&mutex_);
-  Stats::ScopeSharedPtr lock;
-  if (!(lock = scope_.lock())) {
+  Stats::ScopeSharedPtr lock = scope_;
+  //if (!(lock = scope_.lock())) {
+  if (scope_ == nullptr) {
     resetStats();
     createStats(scope);
-    scope_ = ScopeWeakPtr(scope);
+    scope_ = scope; //ScopeWeakPtr(scope);
     return scope;
   }
   createStats(scope);
@@ -60,7 +61,10 @@ void CreateStatsHandler::createStats(const Stats::ScopeSharedPtr& scope) {
   }
 }
 
-void CreateStatsHandler::resetStats() { create_wasm_stats_.reset(); }
+void CreateStatsHandler::resetStats() {
+  create_wasm_stats_.reset();
+  scope_.reset();
+}
 
 CreateStatsHandler& getCreateStatsHandler() { MUTABLE_CONSTRUCT_ON_FIRST_USE(CreateStatsHandler); }
 

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -39,8 +39,6 @@ struct LifecycleStats {
   LIFECYCLE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-//using ScopeWeakPtr = std::weak_ptr<Stats::Scope>;
-
 enum class WasmEvent : int {
   Ok,
   RemoteLoadCacheHit,
@@ -75,13 +73,12 @@ public:
   // happens the stats must be recreated. This hook verifies the Scope of any existing stats and if
   // necessary recreates the stats with the newly provided scope.
   // This call takes out the mutex_ and calls createStats and possibly resetStats().
-  Stats::ScopeSharedPtr lockAndCreateStats(const Stats::ScopeSharedPtr& scope);
+  void lockAndCreateStats(const Stats::ScopeSharedPtr& scope);
 
   void resetStatsForTesting();
 
 protected:
   absl::Mutex mutex_;
-  //ScopeWeakPtr scope_;
   Stats::ScopeSharedPtr scope_ ABSL_GUARDED_BY(mutex_);
   std::unique_ptr<CreateWasmStats> create_wasm_stats_;
 };

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -39,7 +39,7 @@ struct LifecycleStats {
   LIFECYCLE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-using ScopeWeakPtr = std::weak_ptr<Stats::Scope>;
+//using ScopeWeakPtr = std::weak_ptr<Stats::Scope>;
 
 enum class WasmEvent : int {
   Ok,
@@ -81,7 +81,8 @@ public:
 
 protected:
   absl::Mutex mutex_;
-  ScopeWeakPtr scope_;
+  //ScopeWeakPtr scope_;
+  Stats::ScopeSharedPtr scope_ ABSL_GUARDED_BY(mutex_);
   std::unique_ptr<CreateWasmStats> create_wasm_stats_;
 };
 

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -17,8 +17,6 @@ using proxy_wasm::Word;
 
 namespace Envoy {
 
-//using ScopeWeakPtr = std::weak_ptr<Stats::Scope>;
-
 namespace Extensions {
 namespace Common {
 namespace Wasm {
@@ -329,7 +327,7 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
     if (!code_cache) {
       code_cache = new std::remove_reference<decltype(*code_cache)>::type;
     }
-    Stats::ScopeSharedPtr create_wasm_stats_scope = stats_handler.lockAndCreateStats(scope);
+    stats_handler.lockAndCreateStats(scope);
     // Remove entries older than CODE_CACHE_SECONDS_CACHING_TTL except for our target.
     for (auto it = code_cache->begin(); it != code_cache->end();) {
       if (now - it->second.use_time > std::chrono::seconds(CODE_CACHE_SECONDS_CACHING_TTL) &&
@@ -394,7 +392,7 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
         getWasmHandleFactory(config, scope, api, cluster_manager, dispatcher, lifecycle_notifier),
         getWasmHandleCloneFactory(dispatcher, create_root_context_for_testing),
         config.config().vm_config().allow_precompiled());
-    Stats::ScopeSharedPtr create_wasm_stats_scope = stats_handler.lockAndCreateStats(scope);
+    stats_handler.lockAndCreateStats(scope);
     stats_handler.onEvent(toWasmEvent(wasm));
     if (!wasm || wasm->wasm()->isFailed()) {
       ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::wasm), trace,
@@ -415,7 +413,7 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
         auto& e = (*code_cache)[vm_config.code().remote().sha256()];
         e.in_progress = false;
         e.code = code;
-        Stats::ScopeSharedPtr create_wasm_stats_scope = stats_handler.lockAndCreateStats(scope);
+        stats_handler.lockAndCreateStats(scope);
         if (code.empty()) {
           stats_handler.onEvent(WasmEvent::RemoteLoadCacheFetchFailure);
         } else {

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -17,7 +17,7 @@ using proxy_wasm::Word;
 
 namespace Envoy {
 
-using ScopeWeakPtr = std::weak_ptr<Stats::Scope>;
+//using ScopeWeakPtr = std::weak_ptr<Stats::Scope>;
 
 namespace Extensions {
 namespace Common {

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -40,12 +40,12 @@ InstanceImpl::InstanceImpl(
     Common::Redis::Client::ClientFactory& client_factory, ThreadLocal::SlotAllocator& tls,
     const envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::ConnPoolSettings&
         config,
-    Api::Api& api, Stats::ScopeSharedPtr&& stats_scope,
+    Api::Api& api, const Stats::ScopeSharedPtr& stats_scope,
     const Common::Redis::RedisCommandStatsSharedPtr& redis_command_stats,
     Extensions::Common::Redis::ClusterRefreshManagerSharedPtr refresh_manager)
     : cluster_name_(cluster_name), cm_(cm), client_factory_(client_factory),
       tls_(tls.allocateSlot()), config_(new Common::Redis::Client::ConfigImpl(config)), api_(api),
-      stats_scope_(std::move(stats_scope)),
+      stats_scope_(stats_scope),
       redis_command_stats_(redis_command_stats), redis_cluster_stats_{REDIS_CLUSTER_STATS(
                                                      POOL_COUNTER(*stats_scope_))},
       refresh_manager_(std::move(refresh_manager)) {}

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -59,7 +59,7 @@ public:
       Common::Redis::Client::ClientFactory& client_factory, ThreadLocal::SlotAllocator& tls,
       const envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::ConnPoolSettings&
           config,
-      Api::Api& api, Stats::ScopeSharedPtr&& stats_scope,
+      Api::Api& api, const Stats::ScopeSharedPtr& stats_scope,
       const Common::Redis::RedisCommandStatsSharedPtr& redis_command_stats,
       Extensions::Common::Redis::ClusterRefreshManagerSharedPtr refresh_manager);
   // RedisProxy::ConnPool::Instance

--- a/test/extensions/bootstrap/wasm/wasm_integration_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_integration_test.cc
@@ -16,6 +16,10 @@ public:
   WasmIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4) {}
 
+  ~WasmIntegrationTest() {
+    Common::Wasm::clearCodeCacheForTesting();
+  }
+
   void createUpstreams() override {
     HttpIntegrationTest::createUpstreams();
     addFakeUpstream(Http::CodecType::HTTP1);

--- a/test/extensions/bootstrap/wasm/wasm_integration_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_integration_test.cc
@@ -16,9 +16,7 @@ public:
   WasmIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4) {}
 
-  ~WasmIntegrationTest() {
-    Common::Wasm::clearCodeCacheForTesting();
-  }
+  ~WasmIntegrationTest() { Common::Wasm::clearCodeCacheForTesting(); }
 
   void createUpstreams() override {
     HttpIntegrationTest::createUpstreams();

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -82,13 +82,9 @@ public:
 
 class WasmCommonTest : public testing::TestWithParam<std::tuple<std::string, std::string>> {
 public:
-  WasmCommonTest() {
-    Logger::Registry::getLog(Logger::Id::wasm).set_level(spdlog::level::debug);
-  }
+  WasmCommonTest() { Logger::Registry::getLog(Logger::Id::wasm).set_level(spdlog::level::debug); }
 
-  ~WasmCommonTest() override {
-    clearCodeCacheForTesting();
-  }
+  ~WasmCommonTest() override { clearCodeCacheForTesting(); }
 
   Stats::IsolatedStoreImpl stats_store_;
 };
@@ -644,12 +640,12 @@ TEST_P(WasmCommonTest, VmCache) {
 
   ServerLifecycleNotifier::StageCallbackWithCompletion lifecycle_callback;
   EXPECT_CALL(lifecycle_notifier, registerCallback2(_, _))
-          .WillRepeatedly(
-              Invoke([&](ServerLifecycleNotifier::Stage,
-                         StageCallbackWithCompletion callback) -> ServerLifecycleNotifier::HandlePtr {
-                lifecycle_callback = callback;
-                return nullptr;
-              }));
+      .WillRepeatedly(
+          Invoke([&](ServerLifecycleNotifier::Stage,
+                     StageCallbackWithCompletion callback) -> ServerLifecycleNotifier::HandlePtr {
+            lifecycle_callback = callback;
+            return nullptr;
+          }));
 
   auto vm_config = plugin_config.mutable_vm_config();
   vm_config->set_runtime(absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam())));
@@ -1288,10 +1284,7 @@ class WasmCommonContextTest : public Common::Wasm::WasmTestBase<
                                   testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmCommonContextTest() = default;
-  ~WasmCommonContextTest() override {
-    clearCodeCacheForTesting();
-  }
-
+  ~WasmCommonContextTest() override { clearCodeCacheForTesting(); }
 
   void setup(const std::string& code, std::string vm_configuration, std::string root_id = "") {
     setRootId(root_id);

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -82,10 +82,15 @@ public:
 
 class WasmCommonTest : public testing::TestWithParam<std::tuple<std::string, std::string>> {
 public:
-  void SetUp() override { // NOLINT(readability-identifier-naming)
+  WasmCommonTest() {
     Logger::Registry::getLog(Logger::Id::wasm).set_level(spdlog::level::debug);
+  }
+
+  ~WasmCommonTest() override {
     clearCodeCacheForTesting();
   }
+
+  Stats::IsolatedStoreImpl stats_store_;
 };
 
 INSTANTIATE_TEST_SUITE_P(Runtimes, WasmCommonTest,
@@ -93,11 +98,10 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmCommonTest,
                          Envoy::Extensions::Common::Wasm::wasmTestParamsToString);
 
 TEST_P(WasmCommonTest, WasmFailState) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
 
   envoy::extensions::wasm::v3::PluginConfig plugin_config;
@@ -157,11 +161,10 @@ TEST_P(WasmCommonTest, WasmFailState) {
 }
 
 TEST_P(WasmCommonTest, Logging) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "logging";
   auto plugin_configuration = "configure-test";
@@ -238,11 +241,10 @@ TEST_P(WasmCommonTest, BadSignature) {
   if (std::get<0>(GetParam()) != "v8") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/common/wasm/test_data/bad_signature_cpp.wasm"));
@@ -266,11 +268,10 @@ TEST_P(WasmCommonTest, Segv) {
   if (std::get<0>(GetParam()) != "v8") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "segv";
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -309,11 +310,10 @@ TEST_P(WasmCommonTest, DivByZero) {
   if (std::get<0>(GetParam()) != "v8") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "divbyzero";
 
@@ -344,11 +344,10 @@ TEST_P(WasmCommonTest, DivByZero) {
 }
 
 TEST_P(WasmCommonTest, IntrinsicGlobals) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "globals";
 
@@ -386,11 +385,10 @@ TEST_P(WasmCommonTest, IntrinsicGlobals) {
 }
 
 TEST_P(WasmCommonTest, Utilities) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
 
   auto vm_configuration = "utilities";
@@ -455,11 +453,10 @@ TEST_P(WasmCommonTest, Stats) {
   // We set logger level to critical here to gain more coverage.
   Logger::Registry::getLog(Logger::Id::wasm).set_level(spdlog::level::critical);
 
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "stats";
 
@@ -502,11 +499,10 @@ TEST_P(WasmCommonTest, Stats) {
 }
 
 TEST_P(WasmCommonTest, Foreign) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "foreign";
 
@@ -542,11 +538,10 @@ TEST_P(WasmCommonTest, Foreign) {
 }
 
 TEST_P(WasmCommonTest, OnForeign) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "on_foreign";
 
@@ -590,11 +585,10 @@ TEST_P(WasmCommonTest, WASI) {
     // This test has no meaning unless it is invoked by actual Wasm code
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "WASI";
 
@@ -631,14 +625,13 @@ TEST_P(WasmCommonTest, WASI) {
 }
 
 TEST_P(WasmCommonTest, VmCache) {
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Init::MockManager> init_manager;
   NiceMock<Server::MockServerLifecycleNotifier2> lifecycle_notifier;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "vm_cache";
   auto plugin_configuration = "done";
@@ -651,12 +644,12 @@ TEST_P(WasmCommonTest, VmCache) {
 
   ServerLifecycleNotifier::StageCallbackWithCompletion lifecycle_callback;
   EXPECT_CALL(lifecycle_notifier, registerCallback2(_, _))
-      .WillRepeatedly(
-          Invoke([&](ServerLifecycleNotifier::Stage,
-                     StageCallbackWithCompletion callback) -> ServerLifecycleNotifier::HandlePtr {
-            lifecycle_callback = callback;
-            return nullptr;
-          }));
+          .WillRepeatedly(
+              Invoke([&](ServerLifecycleNotifier::Stage,
+                         StageCallbackWithCompletion callback) -> ServerLifecycleNotifier::HandlePtr {
+                lifecycle_callback = callback;
+                return nullptr;
+              }));
 
   auto vm_config = plugin_config.mutable_vm_config();
   vm_config->set_runtime(absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam())));
@@ -724,21 +717,21 @@ TEST_P(WasmCommonTest, VmCache) {
   dispatcher->clearDeferredDeleteList();
 
   proxy_wasm::clearWasmCachesForTesting();
+  clearCodeCacheForTesting();
 }
 
 TEST_P(WasmCommonTest, RemoteCode) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Init::MockManager> init_manager;
   NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
   Init::ExpectableWatcherImpl init_watcher;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "vm_cache";
   auto plugin_configuration = "done";
@@ -838,21 +831,21 @@ TEST_P(WasmCommonTest, RemoteCode) {
   plugin.reset();
   dispatcher->run(Event::Dispatcher::RunType::NonBlock);
   dispatcher->clearDeferredDeleteList();
+  clearCodeCacheForTesting();
 }
 
 TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Init::MockManager> init_manager;
   NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
   Init::ExpectableWatcherImpl init_watcher;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "vm_cache";
   auto plugin_configuration = "done";
@@ -966,11 +959,10 @@ TEST_P(WasmCommonTest, RestrictCapabilities) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "restrict_all";
 
@@ -1020,11 +1012,10 @@ TEST_P(WasmCommonTest, AllowOnVmStart) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "allow_on_vm_start";
 
@@ -1076,11 +1067,10 @@ TEST_P(WasmCommonTest, AllowLog) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "allow_log";
 
@@ -1129,11 +1119,10 @@ TEST_P(WasmCommonTest, AllowWASI) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "allow_wasi";
 
@@ -1182,11 +1171,10 @@ TEST_P(WasmCommonTest, AllowOnContextCreate) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "allow_on_context_create";
 
@@ -1237,11 +1225,10 @@ TEST_P(WasmCommonTest, ThreadLocalCopyRetainsEnforcement) {
   if (std::get<0>(GetParam()) == "null") {
     return;
   }
-  Stats::IsolatedStoreImpl stats_store;
-  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  Api::ApiPtr api = Api::createApiForTest(stats_store_);
   Upstream::MockClusterManager cluster_manager;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
-  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  auto scope = stats_store_.createScope("wasm.");
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto vm_configuration = "thread_local_copy";
 
@@ -1301,6 +1288,10 @@ class WasmCommonContextTest : public Common::Wasm::WasmTestBase<
                                   testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmCommonContextTest() = default;
+  ~WasmCommonContextTest() override {
+    clearCodeCacheForTesting();
+  }
+
 
   void setup(const std::string& code, std::string vm_configuration, std::string root_id = "") {
     setRootId(root_id);

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -56,7 +56,9 @@ class WasmHttpFilterTest : public Common::Wasm::WasmHttpFilterTestBase<
                                testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmHttpFilterTest() = default;
-  ~WasmHttpFilterTest() override = default;
+  ~WasmHttpFilterTest() override {
+    Common::Wasm::clearCodeCacheForTesting();
+  }
 
   CreateContextFn createContextFn() {
     return [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -56,9 +56,7 @@ class WasmHttpFilterTest : public Common::Wasm::WasmHttpFilterTestBase<
                                testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmHttpFilterTest() = default;
-  ~WasmHttpFilterTest() override {
-    Common::Wasm::clearCodeCacheForTesting();
-  }
+  ~WasmHttpFilterTest() override { Common::Wasm::clearCodeCacheForTesting(); }
 
   CreateContextFn createContextFn() {
     return [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -57,11 +57,8 @@ public:
       cm_.initializeThreadLocalClusters({"fake_cluster"});
     }
 
-    std::unique_ptr<NiceMock<Stats::MockStore>> store =
-        std::make_unique<NiceMock<Stats::MockStore>>();
-
     upstream_cx_drained_.value_ = 0;
-    ON_CALL(*store, counter(Eq("upstream_cx_drained")))
+    ON_CALL(*store_, counter(Eq("upstream_cx_drained")))
         .WillByDefault(ReturnRef(upstream_cx_drained_));
     ON_CALL(upstream_cx_drained_, value()).WillByDefault(Invoke([&]() -> uint64_t {
       return upstream_cx_drained_.value_;
@@ -71,7 +68,7 @@ public:
     }));
 
     max_upstream_unknown_connections_reached_.value_ = 0;
-    ON_CALL(*store, counter(Eq("max_upstream_unknown_connections_reached")))
+    ON_CALL(*store_, counter(Eq("max_upstream_unknown_connections_reached")))
         .WillByDefault(ReturnRef(max_upstream_unknown_connections_reached_));
     ON_CALL(max_upstream_unknown_connections_reached_, value())
         .WillByDefault(
@@ -83,12 +80,12 @@ public:
     cluster_refresh_manager_ =
         std::make_shared<NiceMock<Extensions::Common::Redis::MockClusterRefreshManager>>();
     auto redis_command_stats =
-        Common::Redis::RedisCommandStats::createRedisCommandStats(store->symbolTable());
+        Common::Redis::RedisCommandStats::createRedisCommandStats(store_->symbolTable());
     std::shared_ptr<InstanceImpl> conn_pool_impl = std::make_shared<InstanceImpl>(
         cluster_name_, cm_, *this, tls_,
         Common::Redis::Client::createConnPoolSettings(20, hashtagging, true, max_unknown_conns,
                                                       read_policy_),
-        api_, std::move(store), redis_command_stats, cluster_refresh_manager_);
+        api_, scope_, redis_command_stats, cluster_refresh_manager_);
     conn_pool_impl->init();
     // Set the authentication password for this connection pool.
     conn_pool_impl->tls_->getTyped<InstanceImpl::ThreadLocalPool>().auth_username_ = auth_username_;
@@ -294,6 +291,8 @@ public:
   const std::string cluster_name_{"fake_cluster"};
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<ThreadLocal::MockInstance> tls_;
+  NiceMock<Stats::MockStore>* store_{new NiceMock<Stats::MockStore>};
+  Stats::ScopeSharedPtr scope_{Stats::ScopeSharedPtr(store_)};
   std::shared_ptr<InstanceImpl> conn_pool_;
   Upstream::ClusterUpdateCallbacks* update_callbacks_{};
   Common::Redis::Client::MockClient* client_{};
@@ -1222,16 +1221,14 @@ TEST_F(RedisConnPoolImplTest, AskRedirectionFailure) {
 TEST_F(RedisConnPoolImplTest, MakeRequestAndRedirectFollowedByDelete) {
   cm_.initializeThreadLocalClusters({"fake_cluster"});
   tls_.defer_delete_ = true;
-  std::unique_ptr<NiceMock<Stats::MockStore>> store =
-      std::make_unique<NiceMock<Stats::MockStore>>();
   cluster_refresh_manager_ =
       std::make_shared<NiceMock<Extensions::Common::Redis::MockClusterRefreshManager>>();
   auto redis_command_stats =
-      Common::Redis::RedisCommandStats::createRedisCommandStats(store->symbolTable());
+      Common::Redis::RedisCommandStats::createRedisCommandStats(store_->symbolTable());
   conn_pool_ = std::make_shared<InstanceImpl>(
       cluster_name_, cm_, *this, tls_,
       Common::Redis::Client::createConnPoolSettings(20, true, true, 100, read_policy_), api_,
-      std::move(store), redis_command_stats, cluster_refresh_manager_);
+      scope_, redis_command_stats, cluster_refresh_manager_);
   conn_pool_->init();
 
   auto& local_pool = threadLocalPool();

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -81,11 +81,11 @@ public:
         std::make_shared<NiceMock<Extensions::Common::Redis::MockClusterRefreshManager>>();
     auto redis_command_stats =
         Common::Redis::RedisCommandStats::createRedisCommandStats(store_->symbolTable());
-    std::shared_ptr<InstanceImpl> conn_pool_impl = std::make_shared<InstanceImpl>(
-        cluster_name_, cm_, *this, tls_,
-        Common::Redis::Client::createConnPoolSettings(20, hashtagging, true, max_unknown_conns,
-                                                      read_policy_),
-        api_, scope_, redis_command_stats, cluster_refresh_manager_);
+    std::shared_ptr<InstanceImpl> conn_pool_impl =
+        std::make_shared<InstanceImpl>(cluster_name_, cm_, *this, tls_,
+                                       Common::Redis::Client::createConnPoolSettings(
+                                           20, hashtagging, true, max_unknown_conns, read_policy_),
+                                       api_, scope_, redis_command_stats, cluster_refresh_manager_);
     conn_pool_impl->init();
     // Set the authentication password for this connection pool.
     conn_pool_impl->tls_->getTyped<InstanceImpl::ThreadLocalPool>().auth_username_ = auth_username_;

--- a/test/extensions/filters/network/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/network/wasm/wasm_filter_test.cc
@@ -45,7 +45,9 @@ class WasmNetworkFilterTest : public Extensions::Common::Wasm::WasmNetworkFilter
                                   testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmNetworkFilterTest() = default;
-  ~WasmNetworkFilterTest() override = default;
+  ~WasmNetworkFilterTest() override {
+    Common::Wasm::clearCodeCacheForTesting();
+  }
 
   void setupConfig(const std::string& code, std::string root_id = "",
                    std::string vm_configuration = "", bool fail_open = false,

--- a/test/extensions/filters/network/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/network/wasm/wasm_filter_test.cc
@@ -45,9 +45,7 @@ class WasmNetworkFilterTest : public Extensions::Common::Wasm::WasmNetworkFilter
                                   testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmNetworkFilterTest() = default;
-  ~WasmNetworkFilterTest() override {
-    Common::Wasm::clearCodeCacheForTesting();
-  }
+  ~WasmNetworkFilterTest() override { Common::Wasm::clearCodeCacheForTesting(); }
 
   void setupConfig(const std::string& code, std::string root_id = "",
                    std::string vm_configuration = "", bool fail_open = false,

--- a/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
+++ b/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
@@ -35,9 +35,7 @@ class WasmCommonContextTest : public Common::Wasm::WasmTestBase<
                                   testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmCommonContextTest() = default;
-  ~WasmCommonContextTest() {
-    clearCodeCacheForTesting();
-  }
+  ~WasmCommonContextTest() { clearCodeCacheForTesting(); }
 
   void setup(const std::string& code, std::string root_id = "") {
     setRootId(root_id);

--- a/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
+++ b/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
@@ -35,6 +35,9 @@ class WasmCommonContextTest : public Common::Wasm::WasmTestBase<
                                   testing::TestWithParam<std::tuple<std::string, std::string>>> {
 public:
   WasmCommonContextTest() = default;
+  ~WasmCommonContextTest() {
+    clearCodeCacheForTesting();
+  }
 
   void setup(const std::string& code, std::string root_id = "") {
     setRootId(root_id);


### PR DESCRIPTION
Commit Message: Experimental PR to drop weak_ptr usage from wasm. Not sure if this is helpful.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
