### PR TITLE
fix APT gpg key

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,9 @@ ENV BUILD_DIR=/build
 ENV ENVOY_STDLIB=libstdc++
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update \
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware-archive-keyring.gpg >/dev/null \
+  && ls /etc/apt/trusted.gpg.d \
+  && apt-get -y update \
   && apt-get -y install --no-install-recommends libpython2.7 net-tools psmisc vim 2>&1 \
   # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
   && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zhangkaiamm@gmail.com>

when use devcontainer of VSCODE, it will be come out with an error with "GPG key " error.

![image](https://user-images.githubusercontent.com/20178386/163741195-566f9065-2d70-4d82-804a-e82414b1eb1a.png)

So, this PR is to aim to fix this error.

How to see this error?

```
docker run -ti --rm gcr.io/envoy-ci/envoy-build:81a93046060dbe5620d5b3aa92632090a9ee4da6 sh
apt-get update 
```

Then you will see error as below.

![image](https://user-images.githubusercontent.com/20178386/163763959-fc7a56e5-a955-4673-af18-ab5daa1808f4.png)

Why did this error occur?

```bash
cd /etc/apt
ls ls trusted.gpg.d
```
![image](https://user-images.githubusercontent.com/20178386/163764139-4ee7930f-f04e-42ef-b7ad-86f29ee0bf59.png)

Really, the gpg key not existed!

The repo was there.

```
#  cat /etc/apt/sources.list
```

![image](https://user-images.githubusercontent.com/20178386/163764223-56fcb01e-9286-4a57-963e-095b343bb518.png)

So, we should add the gpg key to the trusted directory.

```
wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware-archive-keyring.gpg >/dev/null
```

Then, it would be work well.


```
apt-get update 
```

![image](https://user-images.githubusercontent.com/20178386/163764436-9fe54db1-150d-441e-bfb7-9a4aaee3e692.png)
