### PR TITLE
use variant replace StatusOr for getJsonStringFromMessage

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -521,7 +521,7 @@ std::string MessageUtil::getYamlStringFromMessage(const Protobuf::Message& messa
   return out.c_str();
 }
 
-StatusOr<std::string>
+ProtoStatusOr<std::string>
 MessageUtil::getJsonStringFromMessage(const Protobuf::Message& message, const bool pretty_print,
                                       const bool always_print_primitive_fields) {
   Protobuf::util::JsonPrintOptions json_options;

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -496,11 +496,12 @@ std::string MessageUtil::getYamlStringFromMessage(const Protobuf::Message& messa
                                                   const bool always_print_primitive_fields) {
 
   auto json_or_error = getJsonStringFromMessage(message, false, always_print_primitive_fields);
-  if (!json_or_error.ok()) {
-    throw EnvoyException(json_or_error.status().ToString());
+  if (absl::holds_alternative<ProtobufUtil::Status>(json_or_error)) {
+    ASSERT(!absl::get<ProtobufUtil::Status>(json_or_error).ok());
+    throw EnvoyException(absl::get<ProtobufUtil::Status>(json_or_error).ToString());
   }
   YAML::Node node;
-  TRY_ASSERT_MAIN_THREAD { node = YAML::Load(json_or_error.value()); }
+  TRY_ASSERT_MAIN_THREAD { node = YAML::Load(absl::get<std::string>(json_or_error)); }
   END_TRY
   catch (YAML::ParserException& e) {
     throw EnvoyException(e.what());
@@ -520,7 +521,7 @@ std::string MessageUtil::getYamlStringFromMessage(const Protobuf::Message& messa
   return out.c_str();
 }
 
-ProtobufUtil::StatusOr<std::string>
+absl::variant<std::string, ProtobufUtil::Status>
 MessageUtil::getJsonStringFromMessage(const Protobuf::Message& message, const bool pretty_print,
                                       const bool always_print_primitive_fields) {
   Protobuf::util::JsonPrintOptions json_options;
@@ -549,9 +550,10 @@ std::string MessageUtil::getJsonStringFromMessageOrError(const Protobuf::Message
                                                          bool always_print_primitive_fields) {
   auto json_or_error =
       getJsonStringFromMessage(message, pretty_print, always_print_primitive_fields);
-  return json_or_error.ok() ? std::move(json_or_error).value()
-                            : fmt::format("Failed to convert protobuf message to JSON string: {}",
-                                          json_or_error.status().ToString());
+  return absl::holds_alternative<std::string>(json_or_error)
+             ? absl::get<std::string>(std::move(json_or_error))
+             : fmt::format("Failed to convert protobuf message to JSON string: {}",
+                           absl::get<ProtobufUtil::Status>(json_or_error).ToString());
 }
 
 void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message) {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -470,10 +470,10 @@ public:
    * @param pretty_print whether the returned JSON should be formatted.
    * @param always_print_primitive_fields whether to include primitive fields set to their default
    * values, e.g. an int32 set to 0 or a bool set to false.
-   * @return ProtobufUtil::StatusOr<std::string> of formatted JSON object, or an error status if
-   * conversion fails.
+   * @return absl::variant<std::string, ProtobufUtil::Status> of formatted JSON object, or an error
+   * status if conversion fails.
    */
-  static ProtobufUtil::StatusOr<std::string>
+  static absl::variant<std::string, ProtobufUtil::Status>
   getJsonStringFromMessage(const Protobuf::Message& message, bool pretty_print = false,
                            bool always_print_primitive_fields = false);
 
@@ -492,8 +492,9 @@ public:
                                                    bool always_print_primitive_fields = false) {
     auto json_or_error =
         getJsonStringFromMessage(message, pretty_print, always_print_primitive_fields);
-    RELEASE_ASSERT(json_or_error.ok(), json_or_error.status().ToString());
-    return std::move(json_or_error).value();
+    RELEASE_ASSERT(absl::holds_alternative<std::string>(json_or_error),
+                   absl::get<ProtobufUtil::Status>(json_or_error).ToString());
+    return absl::get<std::string>(std::move(json_or_error));
   }
 
   /**

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -221,15 +221,15 @@ public:
 
 // Move semantics friendly StatusOr that will used to replace ProtoBufUtil::StatusOr temporary to
 // achieve better performance.
-template <typename T, typename Status = ProtobufUtil::Status> class StatusOr {
+template <typename T, typename Status = ProtobufUtil::Status> class ProtoStatusOr {
 public:
-  StatusOr(T&& value) : value_(std::move(value)), status_(Status()) {}
-  StatusOr(ProtobufUtil::Status&& status) : value_(T()), status_(std::move(status)) {
+  ProtoStatusOr(T&& value) : value_(std::move(value)), status_(Status()) {}
+  ProtoStatusOr(ProtobufUtil::Status&& status) : value_(T()), status_(std::move(status)) {
     ASSERT(!status.ok());
   }
 
-  StatusOr(const T& value) : value_(value), status_(Status()) {}
-  StatusOr(const ProtobufUtil::Status& status) : value_(T()), status_(status) {
+  ProtoStatusOr(const T& value) : value_(value), status_(Status()) {}
+  ProtoStatusOr(const ProtobufUtil::Status& status) : value_(T()), status_(status) {
     ASSERT(!status.ok());
   }
 
@@ -499,11 +499,12 @@ public:
    * @param pretty_print whether the returned JSON should be formatted.
    * @param always_print_primitive_fields whether to include primitive fields set to their default
    * values, e.g. an int32 set to 0 or a bool set to false.
-   * @return StatusOr<std::string> of formatted JSON object, or an error status if conversion fails.
+   * @return ProtoStatusOr<std::string> of formatted JSON object, or an error status if conversion
+   * fails.
    */
-  static StatusOr<std::string> getJsonStringFromMessage(const Protobuf::Message& message,
-                                                        bool pretty_print = false,
-                                                        bool always_print_primitive_fields = false);
+  static ProtoStatusOr<std::string>
+  getJsonStringFromMessage(const Protobuf::Message& message, bool pretty_print = false,
+                           bool always_print_primitive_fields = false);
 
   /**
    * Extract JSON as string from a google.protobuf.Message, crashing if the conversion to JSON

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -287,9 +287,8 @@ TEST_F(ProtobufUtilityTest, JsonConvertAnyUnknownMessageType) {
   source_any.set_type_url("type.googleapis.com/bad.type.url");
   source_any.set_value("asdf");
   auto json_or_status = MessageUtil::getJsonStringFromMessage(source_any, true);
-  EXPECT_FALSE(absl::holds_alternative<std::string>(json_or_status));
-  EXPECT_THAT(absl::get<ProtobufUtil::Status>(json_or_status).ToString(),
-              testing::HasSubstr("bad.type.url"));
+  EXPECT_FALSE(json_or_status.ok());
+  EXPECT_THAT(json_or_status.status().ToString(), testing::HasSubstr("bad.type.url"));
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertKnownGoodMessage) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -286,9 +286,9 @@ TEST_F(ProtobufUtilityTest, JsonConvertAnyUnknownMessageType) {
   ProtobufWkt::Any source_any;
   source_any.set_type_url("type.googleapis.com/bad.type.url");
   source_any.set_value("asdf");
-  auto json_or_status = MessageUtil::getJsonStringFromMessage(source_any, true);
-  EXPECT_FALSE(json_or_status.ok());
-  EXPECT_THAT(json_or_status.status().ToString(), testing::HasSubstr("bad.type.url"));
+  auto status = MessageUtil::getJsonStringFromMessage(source_any, true).status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.ToString(), testing::HasSubstr("bad.type.url"));
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertKnownGoodMessage) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -286,9 +286,10 @@ TEST_F(ProtobufUtilityTest, JsonConvertAnyUnknownMessageType) {
   ProtobufWkt::Any source_any;
   source_any.set_type_url("type.googleapis.com/bad.type.url");
   source_any.set_value("asdf");
-  auto status = MessageUtil::getJsonStringFromMessage(source_any, true).status();
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.ToString(), testing::HasSubstr("bad.type.url"));
+  auto json_or_status = MessageUtil::getJsonStringFromMessage(source_any, true);
+  EXPECT_FALSE(absl::holds_alternative<std::string>(json_or_status));
+  EXPECT_THAT(absl::get<ProtobufUtil::Status>(json_or_status).ToString(),
+              testing::HasSubstr("bad.type.url"));
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertKnownGoodMessage) {


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>

Commit Message: use variant replace StatusOr for getJsonStringFromMessage
Additional Description: Using `absl::variant` replace `StatusOr` as the return type of `getJsonStringMessage`. Because `absl::variant` is more friendly to the move semantics. By this way, we can reduce uncessary string copies.
Risk Level: Low.
Testing: Unit.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.