### PR TITLE
build: Add bazel option for enabling Universal Header Validator

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -430,6 +430,16 @@ config_setting(
     values = {"define": "wasm=disabled"},
 )
 
+# This config setting enables Universal Header Validator and disables
+# HTTP header compliance checks in codecs.
+# This setting is temporary to transition header validation into UHV without
+# impacting production builds of Envoy.
+# This setting is enabled for the bazel.compile_time_options CI target.
+config_setting(
+    name = "uhv_enabled",
+    values = {"define": "uhv=enabled"},
+)
+
 # Alias pointing to the selected version of BoringSSL:
 # - BoringSSL FIPS from @boringssl_fips//:ssl,
 # - non-FIPS BoringSSL from @boringssl//:ssl.

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -118,6 +118,9 @@ def envoy_copts(repository, test = False):
                # APPLE_USE_RFC_3542 is needed to support IPV6_PKTINFO in MAC OS.
                repository + "//bazel:apple": ["-D__APPLE_USE_RFC_3542"],
                "//conditions:default": [],
+           }) + select({
+               repository + "//bazel:uhv_enabled": ["-DENVOY_ENABLE_UHV"],
+               "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
            envoy_select_enable_http3(["-DENVOY_ENABLE_QUIC"], repository) + \
            _envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -348,6 +348,7 @@ elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
     "--define" "deprecated_features=disabled"
     "--define" "tcmalloc=gperftools"
     "--define" "zlib=ng"
+    "--define" "uhv=enabled"
     "--@envoy//bazel:http3=False"
     "--@envoy//source/extensions/filters/http/kill_request:enabled"
     "--test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true")


### PR DESCRIPTION
Additional Description: 
This config setting enables Universal Header Validator and disables HTTP header compliance checks in codecs.
This setting is temporary to transition header validation into UHV without impacting production builds of Envoy.
This setting is enabled for the bazel.compile_time_options CI target.

Risk Level: Low, build options for compile_time_options CI target
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Part of #20261

Signed-off-by: Yan Avlasov <yavlasov@google.com>

