### PR TITLE
bazel: move shared action_env above enable_platform_specific_config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,12 @@ build --java_runtime_version=remotejdk_11
 build --tool_java_runtime_version=remotejdk_11
 build --platform_mappings=bazel/platform_mappings
 
+# Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
+build --action_env=CC
+build --action_env=CXX
+build --action_env=LLVM_CONFIG
+build --action_env=PATH
+
 build --enable_platform_specific_config
 
 # Allow tags to influence execution requirements
@@ -38,12 +44,6 @@ build:linux --action_env=BAZEL_LINKOPTS=-lm
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1
-
-# Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
-build --action_env=CC
-build --action_env=CXX
-build --action_env=LLVM_CONFIG
-build --action_env=PATH
 
 # Disable ICU linking for googleurl.
 build --@com_googlesource_googleurl//build_config:system_icu=0


### PR DESCRIPTION
This fixes an issue where the PATH wasn't actually set to what we tried
to force as the default on macOS. I'm not sure if this is a bazel bug or
not, but either way it's surprising behavior.

https://github.com/bazelbuild/bazel/issues/15270

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>