### PR TITLE
remote address action support prefix len

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1726,7 +1726,7 @@ message VirtualCluster {
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RateLimit";
 
-  // [#next-free-field: 10]
+  // [#next-free-field: 11]
   message Action {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RateLimit.Action";

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1807,15 +1807,18 @@ message RateLimit {
     //
     //   ("masked_remote_address", "<masked address from x-forwarded-for>")
     message MaskedRemoteAddress {
-      // Length of prefix mask len(e.g. 0, 32), enable rate limit base on cidr format.
+      // Length of prefix mask len for IPv4 (e.g. 0, 32), enable rate limit base on cidr format.
       // Defaults to 32 when unset.
       // For example, trusted address from x-forwarded-for is `192.168.1.1`,
-      // the descriptor entry is ("remote_address", "192.168.1.1");
-      // if mask len is 24, the descriptor entry is ("remote_address", "192.168.1.0/24").
+      // the descriptor entry is ("masked_remote_address", "192.168.1.1/32");
+      // if mask len is 24, the descriptor entry is ("masked_remote_address", "192.168.1.0/24").
       google.protobuf.UInt32Value v4_prefix_mask_len = 1 [(validate.rules).uint32 = {lte: 32}];
 
-      // Length of prefix mask len for ipv6(e.g. 0, 128), enable rate limit base on cidr format.
+      // Length of prefix mask len for IPv6 (e.g. 0, 128), enable rate limit base on cidr format.
       // Defaults to 128 when unset.
+      // For example, trusted address from x-forwarded-for is `2001:abcd:ef01:2345:6789:abcd:ef01:234`,
+      // the descriptor entry is ("masked_remote_address", "2001:abcd:ef01:2345:6789:abcd:ef01:234/128");
+      // if mask len is 64, the descriptor entry is ("masked_remote_address", "2001:abcd:ef01:2345::/64").
       google.protobuf.UInt32Value v6_prefix_mask_len = 2 [(validate.rules).uint32 = {lte: 128}];
     }
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1799,8 +1799,16 @@ message RateLimit {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.route.RateLimit.Action.RemoteAddress";
 
-      // Length of prefix, e.g. 0, 32. Defaults to -1 when unset.
-      google.protobuf.UInt32Value prefix_len = 1 [(validate.rules).uint32 = {lte: 128}];
+      // Length of prefix mask len(e.g. 0, 32), enable rate limit base on cidr format.
+      // Defaults to 32 when unset.
+      // For example, trusted address from x-forwarded-for is `192.168.1.1`,
+      // the descriptor entry is ("remote_address", "192.168.1.1");
+      // if mask len is 24, the descriptor entry is ("remote_address", "192.168.1.0/24").
+      google.protobuf.UInt32Value v4_prefix_mask_len = 1 [(validate.rules).uint32 = {lte: 32}];
+
+      // Length of prefix mask len for ipv6(e.g. 0, 128), enable rate limit base on cidr format.
+      // Defaults to 128 when unset.
+      google.protobuf.UInt32Value v6_prefix_mask_len = 2 [(validate.rules).uint32 = {lte: 128}];
     }
 
     // The following descriptor entry is appended to the descriptor:

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1798,7 +1798,15 @@ message RateLimit {
     message RemoteAddress {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.route.RateLimit.Action.RemoteAddress";
+    }
 
+    // The following descriptor entry is appended to the descriptor and is populated using the
+    // masked address from :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>`:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("masked_remote_address", "<masked address from x-forwarded-for>")
+    message MaskedRemoteAddress {
       // Length of prefix mask len(e.g. 0, 32), enable rate limit base on cidr format.
       // Defaults to 32 when unset.
       // For example, trusted address from x-forwarded-for is `192.168.1.1`,
@@ -1945,6 +1953,9 @@ message RateLimit {
       // Rate limit descriptor extension. See the rate limit descriptor extensions documentation.
       // [#extension-category: envoy.rate_limit_descriptors]
       core.v3.TypedExtensionConfig extension = 9;
+
+      // Rate limit on masked remote address.
+      MaskedRemoteAddress masked_remote_address = 10;
     }
   }
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1798,6 +1798,9 @@ message RateLimit {
     message RemoteAddress {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.route.RateLimit.Action.RemoteAddress";
+
+      // Length of prefix, e.g. 0, 32. Defaults to -1 when unset.
+      google.protobuf.UInt32Value prefix_len = 1 [(validate.rules).uint32 = {lte: 128}];
     }
 
     // The following descriptor entry is appended to the descriptor:

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1807,14 +1807,14 @@ message RateLimit {
     //
     //   ("masked_remote_address", "<masked address from x-forwarded-for>")
     message MaskedRemoteAddress {
-      // Length of prefix mask len for IPv4 (e.g. 0, 32), enable rate limit base on cidr format.
+      // Length of prefix mask len for IPv4 (e.g. 0, 32).
       // Defaults to 32 when unset.
       // For example, trusted address from x-forwarded-for is `192.168.1.1`,
       // the descriptor entry is ("masked_remote_address", "192.168.1.1/32");
       // if mask len is 24, the descriptor entry is ("masked_remote_address", "192.168.1.0/24").
       google.protobuf.UInt32Value v4_prefix_mask_len = 1 [(validate.rules).uint32 = {lte: 32}];
 
-      // Length of prefix mask len for IPv6 (e.g. 0, 128), enable rate limit base on cidr format.
+      // Length of prefix mask len for IPv6 (e.g. 0, 128).
       // Defaults to 128 when unset.
       // For example, trusted address from x-forwarded-for is `2001:abcd:ef01:2345:6789:abcd:ef01:234`,
       // the descriptor entry is ("masked_remote_address", "2001:abcd:ef01:2345:6789:abcd:ef01:234/128");

--- a/changelogs/1.23.0.yaml
+++ b/changelogs/1.23.0.yaml
@@ -78,5 +78,8 @@ new_features:
 - area: build
   change: |
     enabled building arm64 envoy-distroless and envoy-tools :ref:`docker images <install_binaries>`.
+- area: ratelimit
+  change: |
+    added support for masked_remote_address :ref:`masked_remote_address <envoy_v3_api_field_config.route.v3.RateLimit.Action.masked_remote_address>`.
 
 deprecated:

--- a/changelogs/1.23.0.yaml
+++ b/changelogs/1.23.0.yaml
@@ -80,6 +80,6 @@ new_features:
     enabled building arm64 envoy-distroless and envoy-tools :ref:`docker images <install_binaries>`.
 - area: ratelimit
   change: |
-    added support for masked_remote_address :ref:`masked_remote_address <envoy_v3_api_field_config.route.v3.RateLimit.Action.masked_remote_address>`.
+    added support for :ref:`masked_remote_address <envoy_v3_api_field_config.route.v3.RateLimit.Action.masked_remote_address>`.
 
 deprecated:

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -337,6 +337,7 @@ envoy_cc_library(
         "//source/common/config:metadata_lib",
         "//source/common/config:utility_lib",
         "//source/common/http:header_utility_lib",
+        "//source/common/network:cidr_range_lib",
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -109,13 +109,20 @@ bool RemoteAddressAction::populateDescriptor(RateLimit::DescriptorEntry& descrip
     return false;
   }
 
-  if (prefix_len_ == RemoteAddressAction::PREFIX_LEN_UNSET) {
+  uint32_t mask_len = v4_prefix_mask_len_;
+  uint32_t default_mask_len = RemoteAddressAction::V4_PREFIX_LEN_UNSET;
+  if (remote_address->ip()->version() == Network::Address::IpVersion::v6) {
+    mask_len = v6_prefix_mask_len_;
+    default_mask_len = RemoteAddressAction::V6_PREFIX_LEN_UNSET;
+  }
+
+  if (mask_len == default_mask_len) {
     descriptor_entry = {"remote_address", remote_address->ip()->addressAsString()};
     return true;
   }
 
   Network::Address::CidrRange cidr_entry =
-      Network::Address::CidrRange::create(remote_address->ip()->addressAsString(), prefix_len_);
+      Network::Address::CidrRange::create(remote_address->ip()->addressAsString(), mask_len);
   descriptor_entry = {"remote_address", cidr_entry.asString()};
 
   return true;

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -129,9 +129,10 @@ bool MaskedRemoteAddressAction::populateDescriptor(RateLimit::DescriptorEntry& d
     mask_len = v6_prefix_mask_len_;
   }
 
+  // TODO: increase the efficiency, avoid string transform back and forth
   Network::Address::CidrRange cidr_entry =
       Network::Address::CidrRange::create(remote_address->ip()->addressAsString(), mask_len);
-  descriptor_entry = {"remote_address", cidr_entry.asString()};
+  descriptor_entry = {"masked_remote_address", cidr_entry.asString()};
 
   return true;
 }

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -109,7 +109,15 @@ bool RemoteAddressAction::populateDescriptor(RateLimit::DescriptorEntry& descrip
     return false;
   }
 
-  descriptor_entry = {"remote_address", remote_address->ip()->addressAsString()};
+  if (prefix_len_ == RemoteAddressAction::PREFIX_LEN_UNSET) {
+    descriptor_entry = {"remote_address", remote_address->ip()->addressAsString()};
+    return true;
+  }
+
+  Network::Address::CidrRange cidr_entry =
+      Network::Address::CidrRange::create(remote_address->ip()->addressAsString(), prefix_len_);
+  descriptor_entry = {"remote_address", cidr_entry.asString()};
+
   return true;
 }
 
@@ -195,7 +203,7 @@ RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(
       actions_.emplace_back(new RequestHeadersAction(action.request_headers()));
       break;
     case envoy::config::route::v3::RateLimit::Action::ActionSpecifierCase::kRemoteAddress:
-      actions_.emplace_back(new RemoteAddressAction());
+      actions_.emplace_back(new RemoteAddressAction(action.remote_address()));
       break;
     case envoy::config::route::v3::RateLimit::Action::ActionSpecifierCase::kGenericKey:
       actions_.emplace_back(new GenericKeyAction(action.generic_key()));

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -125,15 +125,8 @@ bool MaskedRemoteAddressAction::populateDescriptor(RateLimit::DescriptorEntry& d
   }
 
   uint32_t mask_len = v4_prefix_mask_len_;
-  uint32_t default_mask_len = MaskedRemoteAddressAction::V4_PREFIX_LEN_UNSET;
   if (remote_address->ip()->version() == Network::Address::IpVersion::v6) {
     mask_len = v6_prefix_mask_len_;
-    default_mask_len = MaskedRemoteAddressAction::V6_PREFIX_LEN_UNSET;
-  }
-
-  if (mask_len == default_mask_len) {
-    descriptor_entry = {"remote_address", remote_address->ip()->addressAsString()};
-    return true;
   }
 
   Network::Address::CidrRange cidr_entry =

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -13,6 +13,8 @@
 
 #include "source/common/config/metadata.h"
 #include "source/common/http/header_utility.h"
+#include "source/common/network/cidr_range.h"
+#include "source/common/protobuf/utility.h"
 
 #include "absl/types/optional.h"
 
@@ -86,11 +88,18 @@ private:
  */
 class RemoteAddressAction : public RateLimit::DescriptorProducer {
 public:
+  RemoteAddressAction(const envoy::config::route::v3::RateLimit::Action::RemoteAddress& action)
+      : prefix_len_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, prefix_len, PREFIX_LEN_UNSET)) {}
+
   // Ratelimit::DescriptorProducer
   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,
                           const std::string& local_service_cluster,
                           const Http::RequestHeaderMap& headers,
                           const StreamInfo::StreamInfo& info) const override;
+
+private:
+  const uint32_t prefix_len_;
+  static const uint32_t PREFIX_LEN_UNSET = -1;
 };
 
 /**

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -102,10 +102,8 @@ class MaskedRemoteAddressAction : public RateLimit::DescriptorProducer {
 public:
   MaskedRemoteAddressAction(
       const envoy::config::route::v3::RateLimit::Action::MaskedRemoteAddress& action)
-      : v4_prefix_mask_len_(
-            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, 32)),
-        v6_prefix_mask_len_(
-            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v6_prefix_mask_len, 128)) {}
+      : v4_prefix_mask_len_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, 32)),
+        v6_prefix_mask_len_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v6_prefix_mask_len, 128)) {}
 
   // Ratelimit::DescriptorProducer
   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -100,7 +100,8 @@ public:
  */
 class MaskedRemoteAddressAction : public RateLimit::DescriptorProducer {
 public:
-  MaskedRemoteAddressAction(const envoy::config::route::v3::RateLimit::Action::MaskedRemoteAddress& action)
+  MaskedRemoteAddressAction(
+      const envoy::config::route::v3::RateLimit::Action::MaskedRemoteAddress& action)
       : v4_prefix_mask_len_(
             PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, V4_PREFIX_LEN_UNSET)),
         v6_prefix_mask_len_(

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -88,7 +88,19 @@ private:
  */
 class RemoteAddressAction : public RateLimit::DescriptorProducer {
 public:
-  RemoteAddressAction(const envoy::config::route::v3::RateLimit::Action::RemoteAddress& action)
+  // Ratelimit::DescriptorProducer
+  bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,
+                          const std::string& local_service_cluster,
+                          const Http::RequestHeaderMap& headers,
+                          const StreamInfo::StreamInfo& info) const override;
+};
+
+/**
+ * Action for masked remote address rate limiting.
+ */
+class MaskedRemoteAddressAction : public RateLimit::DescriptorProducer {
+public:
+  MaskedRemoteAddressAction(const envoy::config::route::v3::RateLimit::Action::MaskedRemoteAddress& action)
       : v4_prefix_mask_len_(
             PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, V4_PREFIX_LEN_UNSET)),
         v6_prefix_mask_len_(

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -89,7 +89,10 @@ private:
 class RemoteAddressAction : public RateLimit::DescriptorProducer {
 public:
   RemoteAddressAction(const envoy::config::route::v3::RateLimit::Action::RemoteAddress& action)
-      : prefix_len_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, prefix_len, PREFIX_LEN_UNSET)) {}
+      : v4_prefix_mask_len_(
+            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, V4_PREFIX_LEN_UNSET)),
+        v6_prefix_mask_len_(
+            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v6_prefix_mask_len, V6_PREFIX_LEN_UNSET)) {}
 
   // Ratelimit::DescriptorProducer
   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,
@@ -98,8 +101,10 @@ public:
                           const StreamInfo::StreamInfo& info) const override;
 
 private:
-  const uint32_t prefix_len_;
-  static const uint32_t PREFIX_LEN_UNSET = -1;
+  const uint32_t v4_prefix_mask_len_;
+  const uint32_t v6_prefix_mask_len_;
+  static const uint32_t V4_PREFIX_LEN_UNSET = 32;
+  static const uint32_t V6_PREFIX_LEN_UNSET = 128;
 };
 
 /**

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -103,9 +103,9 @@ public:
   MaskedRemoteAddressAction(
       const envoy::config::route::v3::RateLimit::Action::MaskedRemoteAddress& action)
       : v4_prefix_mask_len_(
-            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, V4_PREFIX_LEN_UNSET)),
+            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v4_prefix_mask_len, 32)),
         v6_prefix_mask_len_(
-            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v6_prefix_mask_len, V6_PREFIX_LEN_UNSET)) {}
+            PROTOBUF_GET_WRAPPED_OR_DEFAULT(action, v6_prefix_mask_len, 128)) {}
 
   // Ratelimit::DescriptorProducer
   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,
@@ -116,8 +116,6 @@ public:
 private:
   const uint32_t v4_prefix_mask_len_;
   const uint32_t v6_prefix_mask_len_;
-  static const uint32_t V4_PREFIX_LEN_UNSET = 32;
-  static const uint32_t V6_PREFIX_LEN_UNSET = 128;
 };
 
 /**

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -371,11 +371,12 @@ actions:
 
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
-  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.1/32"}}}}),
-              testing::ContainerEq(descriptors_));
   EXPECT_THAT(
-      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"masked_remote_address", "10.0.0.1/32"}}}}),
-      testing::ContainerEq(local_descriptors_));
+      std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.1/32"}}}}),
+      testing::ContainerEq(descriptors_));
+  EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
+                  {{{{"masked_remote_address", "10.0.0.1/32"}}}}),
+              testing::ContainerEq(local_descriptors_));
 }
 
 TEST_F(RateLimitPolicyEntryTest, MaskedRemoteAddressIpv4) {
@@ -389,11 +390,12 @@ actions:
 
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
-  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
-              testing::ContainerEq(descriptors_));
   EXPECT_THAT(
-      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
-      testing::ContainerEq(local_descriptors_));
+      std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
+      testing::ContainerEq(descriptors_));
+  EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
+                  {{{{"masked_remote_address", "10.0.0.0/16"}}}}),
+              testing::ContainerEq(local_descriptors_));
 }
 
 TEST_F(RateLimitPolicyEntryIpv6Test, MaskedRemoteAddressIpv6Default) {

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -340,10 +340,10 @@ actions:
               testing::ContainerEq(local_descriptors_));
 }
 
-TEST_F(RateLimitPolicyEntryTest, RemoteAddressWithPrefixLen) {
+TEST_F(RateLimitPolicyEntryTest, MaskedRemoteAddressIpv4) {
   const std::string yaml = R"EOF(
 actions:
-- remote_address:
+- masked_remote_address:
     v4_prefix_mask_len: 16
   )EOF";
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -310,6 +310,27 @@ public:
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
 };
 
+class RateLimitPolicyEntryIpv6Test : public testing::Test {
+public:
+  void setupTest(const std::string& yaml) {
+    rate_limit_entry_ = std::make_unique<RateLimitPolicyEntryImpl>(
+        parseRateLimitFromV3Yaml(yaml), ProtobufMessage::getStrictValidationVisitor());
+    descriptors_.clear();
+    local_descriptors_.clear();
+    stream_info_.downstream_connection_info_provider_->setRemoteAddress(default_remote_address_);
+    ON_CALL(Const(stream_info_), route()).WillByDefault(testing::Return(route_));
+  }
+
+  std::unique_ptr<RateLimitPolicyEntryImpl> rate_limit_entry_;
+  Http::TestRequestHeaderMapImpl header_;
+  std::shared_ptr<MockRoute> route_{new NiceMock<MockRoute>()};
+  std::vector<Envoy::RateLimit::Descriptor> descriptors_;
+  std::vector<Envoy::RateLimit::LocalDescriptor> local_descriptors_;
+  Network::Address::InstanceConstSharedPtr default_remote_address_{
+      new Network::Address::Ipv6Instance("2001:abcd:ef01:2345:6789:abcd:ef01:234")};
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
+};
+
 TEST_F(RateLimitPolicyEntryTest, RateLimitPolicyEntryMembers) {
   const std::string yaml = R"EOF(
 stage: 2
@@ -355,6 +376,24 @@ actions:
               testing::ContainerEq(descriptors_));
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"remote_address", "10.0.0.0/16"}}}}),
+      testing::ContainerEq(local_descriptors_));
+}
+
+TEST_F(RateLimitPolicyEntryIpv6Test, MaskedRemoteAddressIpv6) {
+  const std::string yaml = R"EOF(
+actions:
+- masked_remote_address:
+    v6_prefix_mask_len: 64
+  )EOF";
+
+  setupTest(yaml);
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
+  rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
+              testing::ContainerEq(descriptors_));
+  EXPECT_THAT(
+      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
       testing::ContainerEq(local_descriptors_));
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -344,7 +344,7 @@ TEST_F(RateLimitPolicyEntryTest, RemoteAddressWithPrefixLen) {
   const std::string yaml = R"EOF(
 actions:
 - remote_address:
-    prefix_len: 16
+    v4_prefix_mask_len: 16
   )EOF";
 
   setupTest(yaml);

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -361,6 +361,23 @@ actions:
               testing::ContainerEq(local_descriptors_));
 }
 
+TEST_F(RateLimitPolicyEntryTest, MaskedRemoteAddressIpv4Default) {
+  const std::string yaml = R"EOF(
+actions:
+- masked_remote_address: {}
+  )EOF";
+
+  setupTest(yaml);
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
+  rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.1/32"}}}}),
+              testing::ContainerEq(descriptors_));
+  EXPECT_THAT(
+      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"masked_remote_address", "10.0.0.1/32"}}}}),
+      testing::ContainerEq(local_descriptors_));
+}
+
 TEST_F(RateLimitPolicyEntryTest, MaskedRemoteAddressIpv4) {
   const std::string yaml = R"EOF(
 actions:
@@ -372,11 +389,29 @@ actions:
 
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
-  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.0/16"}}}}),
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
               testing::ContainerEq(descriptors_));
   EXPECT_THAT(
-      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"remote_address", "10.0.0.0/16"}}}}),
+      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"masked_remote_address", "10.0.0.0/16"}}}}),
       testing::ContainerEq(local_descriptors_));
+}
+
+TEST_F(RateLimitPolicyEntryIpv6Test, MaskedRemoteAddressIpv6Default) {
+  const std::string yaml = R"EOF(
+actions:
+- masked_remote_address: {}
+  )EOF";
+
+  setupTest(yaml);
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
+  rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
+                  {{{{"masked_remote_address", "2001:abcd:ef01:2345:6789:abcd:ef01:234/128"}}}}),
+              testing::ContainerEq(descriptors_));
+  EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
+                  {{{{"masked_remote_address", "2001:abcd:ef01:2345:6789:abcd:ef01:234/128"}}}}),
+              testing::ContainerEq(local_descriptors_));
 }
 
 TEST_F(RateLimitPolicyEntryIpv6Test, MaskedRemoteAddressIpv6) {
@@ -391,10 +426,10 @@ actions:
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
-                  {{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
+                  {{{{"masked_remote_address", "2001:abcd:ef01:2345::/64"}}}}),
               testing::ContainerEq(descriptors_));
   EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
-                  {{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
+                  {{{{"masked_remote_address", "2001:abcd:ef01:2345::/64"}}}}),
               testing::ContainerEq(local_descriptors_));
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -390,11 +390,12 @@ actions:
 
   rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
   rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
-  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
+                  {{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
               testing::ContainerEq(descriptors_));
-  EXPECT_THAT(
-      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
-      testing::ContainerEq(local_descriptors_));
+  EXPECT_THAT(std::vector<Envoy::RateLimit::LocalDescriptor>(
+                  {{{{"remote_address", "2001:abcd:ef01:2345::/64"}}}}),
+              testing::ContainerEq(local_descriptors_));
 }
 
 // Verify no descriptor is emitted if remote is a pipe.

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -340,6 +340,24 @@ actions:
               testing::ContainerEq(local_descriptors_));
 }
 
+TEST_F(RateLimitPolicyEntryTest, RemoteAddressWithPrefixLen) {
+  const std::string yaml = R"EOF(
+actions:
+- remote_address:
+    prefix_len: 16
+  )EOF";
+
+  setupTest(yaml);
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
+  rate_limit_entry_->populateLocalDescriptors(local_descriptors_, "", header_, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.0/16"}}}}),
+              testing::ContainerEq(descriptors_));
+  EXPECT_THAT(
+      std::vector<Envoy::RateLimit::LocalDescriptor>({{{{"remote_address", "10.0.0.0/16"}}}}),
+      testing::ContainerEq(local_descriptors_));
+}
+
 // Verify no descriptor is emitted if remote is a pipe.
 TEST_F(RateLimitPolicyEntryTest, PipeAddress) {
   const std::string yaml = R"EOF(


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

make `RemoteAddressAction` support prefix len`

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/20433
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
