### PR TITLE
thrift proxy: minor api docs update for new trds feature

### DIFF
--- a/api/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
@@ -24,7 +24,11 @@ message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.thrift_proxy.v2alpha1.RouteConfiguration";
 
-  // The name of the route configuration. Reserved for future use in asynchronous route discovery.
+  // The name of the route configuration. This name is used in asynchronous route discovery.
+  // For example, it might match
+  // :ref:`route_config_name
+  // <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.Trds.route_config_name>` in
+  // :ref:`envoy_v3_api_msg_extensions.filters.network.thrift_proxy.v3.Trds`.
   string name = 1;
 
   // The list of routes that will be matched, in order, against incoming requests. The first route


### PR DESCRIPTION
Commit Message: thrift proxy: minor api docs update for new trds feature
Additional Description: Asynchronous route discovery was supported but the comment of `name` field in the thrift `RouteConfiguration` havn't updated.
I dicovered this minor issue occationally when I was trying to implement dubbo rds. So I created this minor PR.

Risk Level: None. Docs only update.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
