### PR TITLE
api: Add validate to required member.

### DIFF
--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -110,7 +110,7 @@ message ComparisonFilter {
   Op op = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Value to compare against.
-  core.v3.RuntimeUInt32 value = 2;
+  core.v3.RuntimeUInt32 value = 2 [(validate.rules).message = {required: true}];
 }
 
 // Filters on HTTP response/status code.


### PR DESCRIPTION
Commit Message: api: Add validate to required member.
Additional Description:
ComparisonFilter's value now marked as required in validate to ensure valid
input to fuzz tests.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
API Considerations: Add a validate rule to the value a binary operation compares against. Not ensuring that the value exists without giving a reasonable default is questionable. Therefore this patch adds a validate rule to at least flag the missing value.