### PR TITLE
open-telemetry access logs resource support literal custom tag

### DIFF
--- a/source/extensions/access_loggers/open_telemetry/BUILD
+++ b/source/extensions/access_loggers/open_telemetry/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/grpc:typed_async_client_lib",
         "//source/common/protobuf",
+        "//source/common/tracing:custom_tag_lib",
         "//source/extensions/access_loggers/common:grpc_access_logger",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/open_telemetry/v3:pkg_cc_proto",

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -57,7 +57,8 @@ void GrpcAccessLoggerImpl::initMessageRoot(
   // TODO: support other type
   for (const auto& custom_tag : config.custom_tags()) {
     if (custom_tag.type_case() == envoy::type::tracing::v3::CustomTag::TypeCase::kLiteral) {
-      *resource->add_attributes() = getStringKeyValue(std::string(custom_tag.tag()), custom_tag.literal().value());
+      *resource->add_attributes() =
+          getStringKeyValue(std::string(custom_tag.tag()), custom_tag.literal().value());
     }
   }
 }

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
@@ -41,7 +41,9 @@ public:
       Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope);
 
 private:
-  void initMessageRoot(const std::string& log_name, const LocalInfo::LocalInfo& local_info);
+  void initMessageRoot(
+      const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
+      const LocalInfo::LocalInfo& local_info);
   // Extensions::AccessLoggers::GrpcCommon::GrpcAccessLogger
   void addEntry(opentelemetry::proto::logs::v1::LogRecord&& entry) override;
   // Non used addEntry method (the above is used for both TCP and HTTP).

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -201,7 +201,7 @@ literal:
   value: test_host_name
   )EOF";
   TestUtility::loadFromYaml(tag_yaml, tag);
-  config.add_custom_tags(tag)
+  config.add_custom_tags(tag);
 
   GrpcAccessLoggerSharedPtr logger =
       logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -201,7 +201,7 @@ literal:
   value: test_host_name
   )EOF";
   TestUtility::loadFromYaml(tag_yaml, tag);
-  config.add_custom_tags(tag);
+  *config.add_custom_tags() = tag;
 
   GrpcAccessLoggerSharedPtr logger =
       logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -201,7 +201,7 @@ literal:
   value: test_host_name
   )EOF";
   TestUtility::loadFromYaml(tag_yaml, tag);
-  config.mutable_common_config()->add_custom_tags() = tag;
+  config.add_custom_tags(tag)
 
   GrpcAccessLoggerSharedPtr logger =
       logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

Hi, I'm trying out build up a demo with istio, otel-collector and loki, arch looks like:
![image](https://user-images.githubusercontent.com/4354057/163948746-b2c77baa-2e99-4867-b52a-61f3d8c6ba8b.png)

this PR allow users set literal custom tag in open-telemetry resource labels, such as cluster name, host name, pod name, namespace etc.

BTW, I did not use `CustomTagUtility::createCustomTag`, because I think it's hard to support all custom tag here(maybe someone can guide me how to support the other types).


with the following config:
```yaml
- name: envoy.access_loggers.open_telemetry
  typedConfig:
    "@type": type.googleapis.com/envoy.extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig
    body:
      stringValue: |
        [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%
    commonConfig:
      grpcService:
        envoyGrpc:
          clusterName: otel-collector
      logName: otel_envoy_accesslog
      transportApiVersion: V3
      customTags:
        - tag: "deploy_type"
          literal: 
            value: "binary"
```
otel-collector output:
```console
2022-04-19T14:18:55.546+0800	DEBUG	loggingexporter/logging_exporter.go:79	ResourceLog #0
Resource SchemaURL: 
Resource labels:
     -> log_name: STRING(otel_envoy_accesslog)
     -> zone_name: STRING()
     -> cluster_name: STRING()
     -> node_name: STRING()
     -> deploy_type: STRING(binary)
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
Timestamp: 2022-04-19 06:18:55.046335 +0000 UTC
Severity: 
ShortName: 
Body: [2022-04-19T06:18:55.046Z] "GET / HTTP/1.1" 200 - direct_response - "-" 0 13 0 - "-" "curl/7.68.0" "55db93d0-9313-416a-9b0b-5a59e7efa7d8" "localhost:10000" "-" - - 127.0.0.1:10000 127.0.0.1:57668 - -

Trace ID: 
Span ID: 
Flags: 0
```
