### PR TITLE
bazel: disable wasm on macOS for now

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,6 +96,7 @@ build:macos --cxxopt=-std=c++17
 build:macos --action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
 build:macos --host_action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
 build:macos --define tcmalloc=disabled
+build:macos --define wasm=disabled
 
 # macOS ASAN/UBSAN
 build:macos-asan --config=asan


### PR DESCRIPTION
On M1 macs this fails with a linker error that I'm attempting to fix
here https://chromium-review.googlesource.com/c/v8/v8/+/3589296

We could also take that as a patch but it would probably be nice to get
input upstream on the fix first.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>