### PR TITLE
stats: add lint error for using Stats::ScopePtr, and mark that nickname as deprecated

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -35,7 +35,7 @@ using ScopeSharedPtr = std::shared_ptr<Scope>;
 // ScopePtr. We should fully remove this alias in a future PR and change all the
 // references, once known consumers that might break from this change have a
 // chance to do the global replace in their own repos.
-using ScopePtr [[deprecated("Use ScopeSharedPtr() instead.")]] = ScopeSharedPtr;
+using ScopePtr ABSL_DEPRECATED("Use ScopeSharedPtr() instead.") = ScopeSharedPtr;
 
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 

--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -35,7 +35,7 @@ using ScopeSharedPtr = std::shared_ptr<Scope>;
 // ScopePtr. We should fully remove this alias in a future PR and change all the
 // references, once known consumers that might break from this change have a
 // chance to do the global replace in their own repos.
-using ScopePtr = ScopeSharedPtr;
+using ScopePtr [[deprecated("Use ScopeSharedPtr() instead.")]] = ScopeSharedPtr;
 
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -206,6 +206,7 @@ CODE_CONVENTION_REPLACEMENTS = {
     # Times(1) noise.
     ".Times(1).WillOnce": ".WillOnce",
     ".Times(1).WillRepeatedly": ".WillOnce",
+    "Stats::ScopePtr": "Stats::ScopeSharedPtr",
 }
 
 UNSORTED_FLAGS = {

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -308,6 +308,8 @@ def run_checks():
         "term absl::make_unique< should be replaced with standard library term std::make_unique<")
     errors += check_and_fix_error(
         "code_conventions.cc", "term .Times(1); should be replaced with preferred term ;")
+    errors += check_and_fix_error(
+        "code_conventions.cc", "term Stats::ScopePtr should be replaced with preferred term Stats::ScopeSharedPtr")
 
     errors += check_file_expecting_ok("real_time_source_override.cc")
     errors += check_file_expecting_ok("duration_value_zero.cc")

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -309,7 +309,8 @@ def run_checks():
     errors += check_and_fix_error(
         "code_conventions.cc", "term .Times(1); should be replaced with preferred term ;")
     errors += check_and_fix_error(
-        "code_conventions.cc", "term Stats::ScopePtr should be replaced with preferred term Stats::ScopeSharedPtr")
+        "code_conventions.cc",
+        "term Stats::ScopePtr should be replaced with preferred term Stats::ScopeSharedPtr")
 
     errors += check_file_expecting_ok("real_time_source_override.cc")
     errors += check_file_expecting_ok("duration_value_zero.cc")

--- a/tools/testdata/check_format/code_conventions.cc
+++ b/tools/testdata/check_format/code_conventions.cc
@@ -6,6 +6,7 @@ void foo() {
     .Times(1);
   EXPECT_CALL(a, b).Times(1).WillRepeatedly(foo);
   EXPECT_CALL(a, b).Times(1).WillOnce(foo);
+  Stats::ScopePtr scope;
 }
 
 }

--- a/tools/testdata/check_format/code_conventions.cc.gold
+++ b/tools/testdata/check_format/code_conventions.cc.gold
@@ -5,6 +5,7 @@ void foo() {
   EXPECT_CALL(a, b);
   EXPECT_CALL(a, b).WillOnce(foo);
   EXPECT_CALL(a, b).WillOnce(foo);
+  Stats::ScopeSharedPtr scope;
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Prevent further in-repo uses of Stats::ScopePtr with a lint error. Attempt to discourage out-of-repo uses of Stats::ScopePtr with a `deprecated` flag, though that doesn't seem to cause any warning in *our* build  or clang-tidy when I change a reference in the code. See #19468 for the change to suppress deprecation warnings. 
Additional Description:
Risk Level: low
Testing: //test/common/stats/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

