### PR TITLE
Conn manager fuzz test improve

### DIFF
--- a/test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-5183159447322624.fuzz
+++ b/test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-5183159447322624.fuzz
@@ -1,0 +1,105 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    status: HEADER_STOP_ALL_ITERATION_AND_BUFFER
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":path"
+        value: "//"
+      }
+    }
+    status: HEADER_STOP_ALL_ITERATION_AND_BUFFER
+  }
+}
+actions {
+  stream_action {
+    stream_id: 5
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "/"
+        value: "//"
+      }
+      headers {
+        key: "//"
+        value: "http"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    status: HEADER_STOP_ALL_ITERATION_AND_BUFFER
+  }
+}
+actions {
+  stream_action {
+    stream_id: 5
+    request {
+      continue_decoding {
+      }
+    }
+  }
+}
+actions {
+  new_suream {
+  }
+}
+actions {
+}
+actions {
+  stream_action {
+    request {
+      continue_decoding {
+      }
+    }
+  }
+}
+actions {
+}
+actions {
+  stream_action {
+    stream_id: 5
+    request {
+      continue_decoding {
+      }
+    }
+  }
+}
+actions {
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+        decoder_filter_callback_action {
+          add_decoded_data {
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+forward_client_cert: APPEND_FORWARD

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -400,6 +400,7 @@ public:
         fakeOnData();
         FUZZ_ASSERT(testing::Mock::VerifyAndClearExpectations(config_.codec_));
         state = data_action.end_stream() ? StreamState::Closed : StreamState::PendingDataOrTrailers;
+        decoding_done_ = false;
       }
       break;
     }
@@ -423,17 +424,19 @@ public:
         fakeOnData();
         FUZZ_ASSERT(testing::Mock::VerifyAndClearExpectations(config_.codec_));
         state = StreamState::Closed;
+        decoding_done_ = false;
       }
       break;
     }
     case test::common::http::RequestAction::kContinueDecoding: {
-      if (header_status_ == FilterHeadersStatus::StopAllIterationAndBuffer ||
-          header_status_ == FilterHeadersStatus::StopAllIterationAndWatermark ||
-          (header_status_ == FilterHeadersStatus::StopIteration &&
-           (data_status_ == FilterDataStatus::StopIterationAndBuffer ||
-            data_status_ == FilterDataStatus::StopIterationAndWatermark ||
-            data_status_ == FilterDataStatus::StopIterationNoBuffer))) {
+      if (!decoding_done_ && (header_status_ == FilterHeadersStatus::StopAllIterationAndBuffer ||
+                              header_status_ == FilterHeadersStatus::StopAllIterationAndWatermark ||
+                              (header_status_ == FilterHeadersStatus::StopIteration &&
+                               (data_status_ == FilterDataStatus::StopIterationAndBuffer ||
+                                data_status_ == FilterDataStatus::StopIterationAndWatermark ||
+                                data_status_ == FilterDataStatus::StopIterationNoBuffer)))) {
         decoder_filter_->callbacks_->continueDecoding();
+        decoding_done_ = true;
       }
       break;
     }
@@ -542,6 +545,7 @@ public:
   StreamState response_state_;
   absl::optional<Http::FilterHeadersStatus> header_status_;
   absl::optional<Http::FilterDataStatus> data_status_;
+  bool decoding_done_{};
 };
 
 using FuzzStreamPtr = std::unique_ptr<FuzzStream>;


### PR DESCRIPTION
Commit Message: Improve state handling in conn manager fuzz test
Additional Description:
The fuzzer tends to repeat actions, but a decoding done already cannot
be repeated or an assert is hit.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
