### PR TITLE
bazel: add ios_sim_arm64 CPU

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -524,6 +524,11 @@ config_setting(
 )
 
 config_setting(
+    name = "ios_sim_arm64",
+    values = {"cpu": "ios_sim_arm64"},
+)
+
+config_setting(
     name = "ios_arm64e",
     values = {"cpu": "ios_arm64e"},
 )
@@ -576,6 +581,7 @@ selects.config_setting_group(
         ":ios_armv7",
         ":ios_armv7s",
         ":ios_i386",
+        ":ios_sim_arm64",
         ":ios_x86_64",
     ],
 )
@@ -610,6 +616,7 @@ selects.config_setting_group(
         ":ios_armv7",
         ":ios_armv7s",
         ":ios_i386",
+        ":ios_sim_arm64",
         ":linux_aarch64",
         ":linux_mips64",
         ":linux_ppc",
@@ -706,7 +713,7 @@ platform(
 )
 
 platform(
-    name = "ios_sim_arm64",
+    name = "ios_sim_arm64_platform",  # TODO(keith): Resolve duplicate name issue
     constraint_values = [
         "@platforms//cpu:arm64",
         "@platforms//os:ios",

--- a/bazel/platform_mappings
+++ b/bazel/platform_mappings
@@ -29,7 +29,7 @@ flags:
 
   --cpu=ios_sim_arm64
   --apple_platform_type=ios
-    @envoy//bazel:ios_sim_arm64
+    @envoy//bazel:ios_sim_arm64_platform
 
   --cpu=ios_arm64
   --apple_platform_type=ios


### PR DESCRIPTION
This allows us to build envoy mobile for the M1 simulator architecture,
and get the correct apple conditionals

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>