### PR TITLE
Add two QUICHE platform APIs.

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -4755,7 +4755,7 @@ envoy_cc_test(
 )
 
 envoy_cc_library(
-    name = "quiche_common_platform_lower_case_string_lib",
+    name = "quiche_common_platform_lower_case_string",
     hdrs = ["quiche/common/platform/api/quiche_lower_case_string.h"],
     repository = "@envoy",
     tags = ["nofips"],
@@ -4763,7 +4763,7 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "quiche_common_platform_header_policy_lib",
+    name = "quiche_common_platform_header_policy",
     hdrs = ["quiche/common/platform/api/quiche_header_policy.h"],
     repository = "@envoy",
     tags = ["nofips"],

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -4753,3 +4753,24 @@ envoy_cc_test(
         ":quic_platform",
     ],
 )
+
+envoy_cc_library(
+    name = "quiche_common_platform_lower_case_string_lib",
+    hdrs = ["quiche/common/platform/api/quiche_lower_case_string.h"],
+    repository = "@envoy",
+    tags = ["nofips"],
+    deps = ["@envoy//source/common/quic/platform:quiche_lower_case_string_impl_lib"],
+)
+
+envoy_cc_library(
+    name = "quiche_common_platform_header_policy_lib",
+    hdrs = ["quiche/common/platform/api/quiche_header_policy.h"],
+    repository = "@envoy",
+    tags = ["nofips"],
+    deps = [":quiche_common_platform_default_quiche_platform_impl_header_policy_impl_lib"],
+)
+
+envoy_quiche_platform_impl_cc_library(
+    name = "quiche_common_platform_default_quiche_platform_impl_header_policy_impl_lib",
+    hdrs = ["quiche/common/platform/default/quiche_platform_impl/quiche_header_policy_impl.h"],
+)

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -172,3 +172,10 @@ envoy_quiche_platform_impl_cc_library(
         "@com_github_google_quiche//:quiche_common_buffer_allocator_lib",
     ],
 )
+
+envoy_quiche_platform_impl_cc_library(
+    name = "quiche_lower_case_string_impl_lib",
+    hdrs = ["quiche_lower_case_string_impl.h"],
+    tags = ["nofips"],
+    deps = ["//envoy/http:header_map_interface"],
+)

--- a/source/common/quic/platform/quiche_lower_case_string_impl.h
+++ b/source/common/quic/platform/quiche_lower_case_string_impl.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "envoy/http/header_map.h"
+
+namespace quiche {
+
+using QuicheLowerCaseStringImpl = Http::LowerCaseString;
+
+}

--- a/source/common/quic/platform/quiche_lower_case_string_impl.h
+++ b/source/common/quic/platform/quiche_lower_case_string_impl.h
@@ -10,6 +10,6 @@
 
 namespace quiche {
 
-using QuicheLowerCaseStringImpl = Http::LowerCaseString;
+using QuicheLowerCaseStringImpl = Envoy::Http::LowerCaseString;
 
 }


### PR DESCRIPTION
Add a build target for platform/api/quiche_header_policy.h, and another
one for the default implementation bundled in QUICHE.

Add a build target for platform/api/quiche_lower_case_string.h, and add
an implementation that defines it as an alias to Http::LowerCaseString.

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add two QUICHE platform APIs.
Additional Description: Add some unused build targets.
Risk Level: low
Testing: These APIs are part of the QUICHE third party library and do not have tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
