### PR TITLE
stats: update comment and add reference to issue for removing Stats::ScopePtr

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -27,14 +27,12 @@ using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextR
 using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
 
-// TODO(jmarantz): In the initial transformation to store Scope as shared_ptr,
-// we don't change all the references, as that would result in an unreviewable
-// PR that combines a small number of semantic changes and a large number of
-// files with trivial changes. Furthermore, code that depends on the Envoy stats
-// infrastructure that's not in this repo will stop compiling when we remove
-// ScopePtr. We should fully remove this alias in a future PR and change all the
-// references, once known consumers that might break from this change have a
-// chance to do the global replace in their own repos.
+// TODO(#20911): Until 2022, scopes were generally captured by the creator
+// as unique_ptr<Scope>. This has changed to std::shared_ptr<Scope>, and to
+// make this transition work we made ScopePtr an alias for ScopeSharedPtr. All
+// references in the Envoy repo are now removed, but there remain references
+// in external repos, so we'll leave this alias until we have some confidence
+// that external repos are cleaned up.
 using ScopePtr ABSL_DEPRECATED("Use ScopeSharedPtr() instead.") = ScopeSharedPtr;
 
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;


### PR DESCRIPTION
Commit Message: Adds a reference to the issue for removing Stats::ScopePtr once all external refs are cleaned
Additional Description:
Risk Level: low
Testing: none
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

