### PR TITLE
fix zstd compile error

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -553,6 +553,7 @@ envoy_cmake(
     build_data = ["@com_github_facebook_zstd//:all"],
     cache_entries = {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_LIBDIR": "lib",
         "ZSTD_BUILD_SHARED": "off",
         "ZSTD_BUILD_STATIC": "on",
     },


### PR DESCRIPTION
When compile envoy on RedHat based OS like Fedra, zstd will compile error with complaining: external/envoy/bazel/foreign_cc/BUILD:551:12: output 'external/envoy/bazel/foreign_cc/zstd/lib/libzstd.a' was not created
This is because on RedHat based OS, CMAKE_INSTALL_LIBDIR default is set to lib64, so it will generate object in external/envoy/bazel/foreign_cc/zstd/lib64/libzstd.a

Add the cmake compile flag `CMAKE_INSTALL_LIBDIR: lib` to fix this.

Signed-off-by: Felix Du <durd07@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: fix zstd compile error
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
