### PR TITLE
lb fuzz test: Limit choice_count.

### DIFF
--- a/test/common/upstream/least_request_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/least_request_load_balancer_fuzz_test.cc
@@ -45,7 +45,11 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::LeastRequestLoadBalancerTestCa
     ENVOY_LOG_MISC(debug, "ProtoValidationException: {}", e.what());
     return;
   }
-
+  if (input.least_request_lb_config().has_choice_count() &&
+      input.least_request_lb_config().choice_count().value() > 10000) {
+    ENVOY_LOG_MISC(debug, "a choice count greater than 10,000 has no added value");
+    return;
+  }
   const test::common::upstream::ZoneAwareLoadBalancerTestCase& zone_aware_load_balancer_test_case =
       input.zone_aware_load_balancer_test_case();
 

--- a/test/common/upstream/least_request_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/least_request_load_balancer_fuzz_test.cc
@@ -8,6 +8,8 @@
 namespace Envoy {
 namespace Upstream {
 
+static const u_int32_t MaxChoiceCountForTest = 150;
+
 // Least Request takes into account both weights (handled in ZoneAwareLoadBalancerFuzzBase), and
 // requests active as well
 void setRequestsActiveForStaticHosts(NiceMock<MockPrioritySet>& priority_set,
@@ -46,8 +48,9 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::LeastRequestLoadBalancerTestCa
     return;
   }
   if (input.least_request_lb_config().has_choice_count() &&
-      input.least_request_lb_config().choice_count().value() > 10000) {
-    ENVOY_LOG_MISC(debug, "a choice count greater than 10,000 has no added value");
+      input.least_request_lb_config().choice_count().value() > MaxChoiceCountForTest) {
+    ENVOY_LOG_MISC(debug, "a choice count greater than {} has no added value",
+                   MaxChoiceCountForTest);
     return;
   }
   const test::common::upstream::ZoneAwareLoadBalancerTestCase& zone_aware_load_balancer_test_case =

--- a/test/common/upstream/least_request_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/least_request_load_balancer_fuzz_test.cc
@@ -8,7 +8,7 @@
 namespace Envoy {
 namespace Upstream {
 
-static const u_int32_t MaxChoiceCountForTest = 150;
+static const uint32_t MaxChoiceCountForTest = 150;
 
 // Least Request takes into account both weights (handled in ZoneAwareLoadBalancerFuzzBase), and
 // requests active as well


### PR DESCRIPTION
Commit Message: lb fuzz test: Limit choice_count.
Additional Description:
Limit the choice_count to a reasonable number. Allowing any number has
no added value.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
