### PR TITLE
test: deflake TSAN test failure with giant payload in multiplex_integration_test

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -228,7 +228,7 @@ bool waitForWithDispatcherRun(Event::TestTimeSystem& time_system, absl::Mutex& l
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
   while (bound.withinBound()) {
-    // Wake up every certain period to run the client dispatcher.
+    // Wake up periodically to run the client dispatcher.
     if (time_system.waitFor(lock, absl::Condition(&condition), 5ms * TSAN_TIMEOUT_FACTOR)) {
       return true;
     }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -228,8 +228,8 @@ bool waitForWithDispatcherRun(Event::TestTimeSystem& time_system, absl::Mutex& l
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock) {
   Event::TestTimeSystem::RealTimeBound bound(timeout);
   while (bound.withinBound()) {
-    // Wake up every 5ms to run the client dispatcher.
-    if (time_system.waitFor(lock, absl::Condition(&condition), 5ms)) {
+    // Wake up every certain period to run the client dispatcher.
+    if (time_system.waitFor(lock, absl::Condition(&condition), 5ms * TSAN_TIMEOUT_FACTOR)) {
       return true;
     }
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -571,8 +571,9 @@ void HttpIntegrationTest::checkSimpleRequestSuccess(uint64_t expected_request_si
 void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
     uint64_t request_size, uint64_t response_size, bool big_header, bool set_content_length_header,
     ConnectionCreationFunction* create_connection, std::chrono::milliseconds timeout) {
-#if defined(ENVOY_CONFIG_COVERAGE)
-  // https://github.com/envoyproxy/envoy/issues/19595
+#ifdef ENVOY_CONFIG_COVERAGE
+  // Avoid excessive logging at UDP packet level, which causes log spamming, as well as worse
+  // contention: https://github.com/envoyproxy/envoy/issues/19595
   ENVOY_LOG_MISC(warn, "manually lowering logs to error");
   LogLevelSetter save_levels(spdlog::level::err);
 #endif
@@ -595,8 +596,9 @@ void HttpIntegrationTest::testGiantRequestAndResponse(uint64_t request_size, uin
                                                       bool set_content_length_header,
                                                       std::chrono::milliseconds timeout) {
   autonomous_upstream_ = true;
-#if defined(ENVOY_CONFIG_COVERAGE)
-  // https://github.com/envoyproxy/envoy/issues/19595
+#ifdef ENVOY_CONFIG_COVERAGE
+  // Avoid excessive logging at UDP packet level, which causes log spamming, as well as worse
+  // contention: https://github.com/envoyproxy/envoy/issues/19595
   ENVOY_LOG_MISC(warn, "manually lowering logs to error");
   LogLevelSetter save_levels(spdlog::level::err);
 #endif

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -591,6 +591,43 @@ void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
   checkSimpleRequestSuccess(request_size, response_size, response.get());
 }
 
+void HttpIntegrationTest::testGiantRequestAndResponse(uint64_t request_size, uint64_t response_size,
+                                                      bool set_content_length_header,
+                                                      std::chrono::milliseconds timeout) {
+  autonomous_upstream_ = true;
+#if defined(ENVOY_CONFIG_COVERAGE)
+  // https://github.com/envoyproxy/envoy/issues/19595
+  ENVOY_LOG_MISC(warn, "manually lowering logs to error");
+  LogLevelSetter save_levels(spdlog::level::err);
+#endif
+  initialize();
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"},
+      {":path", "/test/long/url"},
+      {":authority", "sni.lyft.com"},
+      {":scheme", "http"},
+      {AutonomousStream::RESPONSE_SIZE_BYTES, std::to_string(response_size)},
+      {AutonomousStream::EXPECT_REQUEST_SIZE_BYTES, std::to_string(request_size)},
+      {AutonomousStream::NO_TRAILERS, "0"}};
+  auto response_headers =
+      std::make_unique<Http::TestResponseHeaderMapImpl>(default_response_headers_);
+  if (set_content_length_header) {
+    request_headers.setContentLength(request_size);
+    response_headers->setContentLength(response_size);
+  }
+  reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
+      ->setResponseHeaders(std::move(response_headers));
+
+  auto response = codec_client_->makeRequestWithBody(request_headers, request_size);
+
+  // Wait for the response to be read by the codec client.
+  RELEASE_ASSERT(response->waitForEndStream(timeout), "unexpected timeout");
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ(response_size, response->body().size());
+}
+
 void HttpIntegrationTest::testRouterUpstreamProtocolError(const std::string& expected_code,
                                                           const std::string& expected_flag) {
   useAccessLog("%RESPONSE_CODE% %RESPONSE_FLAGS%");

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -274,6 +274,12 @@ protected:
                     bool response_trailers_present);
   // Test /drain_listener from admin portal.
   void testAdminDrain(Http::CodecClient::Type admin_request_type);
+
+  // Test sending and receiving large request and response bodies with autonomous upstream.
+  void testGiantRequestAndResponse(
+      uint64_t request_size, uint64_t response_size, bool set_content_length_header,
+      std::chrono::milliseconds timeout = 2 * TestUtility::DefaultTimeout * TSAN_TIMEOUT_FACTOR);
+
   Http::CodecClient::Type downstreamProtocol() const { return downstream_protocol_; }
   std::string downstreamProtocolStatsRoot() const;
   // Return the upstream protocol part of the stats root.

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -28,6 +28,7 @@ struct HttpProtocolTestParams {
 // TEST_P(MyTest, TestInstance) {
 // ....
 // }
+// TODO(#20996) consider switching to SimulatedTimeSystem instead of using real time.
 class HttpProtocolIntegrationTest : public testing::TestWithParam<HttpProtocolTestParams>,
                                     public HttpIntegrationTest {
 public:

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -43,6 +43,8 @@ public:
   void simultaneousRequest(int32_t request1_bytes, int32_t request2_bytes);
 };
 
+constexpr uint32_t GiantPayoadSizeByte = 10 * 1024 * 1024;
+
 INSTANTIATE_TEST_SUITE_P(IpVersions, MultiplexedIntegrationTest,
                          testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
                              {Http::CodecType::HTTP2, Http::CodecType::HTTP3},
@@ -57,20 +59,20 @@ TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithGiantBodyNoBuffer
   ENVOY_LOG_MISC(warn, "manually lowering logs to error");
   LogLevelSetter save_levels(spdlog::level::err);
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
-  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, false);
+  testGiantRequestAndResponse(GiantPayoadSizeByte, GiantPayoadSizeByte, false);
 }
 
 TEST_P(MultiplexedIntegrationTest, FlowControlOnAndGiantBody) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(1024, 1024); // Set buffer limits upstream and downstream
-  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, false);
+  testGiantRequestAndResponse(GiantPayoadSizeByte, GiantPayoadSizeByte, false);
 }
 
 TEST_P(MultiplexedIntegrationTest, LargeFlowControlOnAndGiantBody) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(128 * 1024,
                                  128 * 1024); // Set buffer limits upstream and downstream.
-  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, false);
+  testGiantRequestAndResponse(GiantPayoadSizeByte, GiantPayoadSizeByte, false);
 }
 
 TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithBodyAndContentLengthNoBuffer) {
@@ -79,20 +81,20 @@ TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithBodyAndContentLen
 
 TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithGiantBodyAndContentLengthNoBuffer) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
-  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, true);
+  testGiantRequestAndResponse(GiantPayoadSizeByte, GiantPayoadSizeByte, true);
 }
 
 TEST_P(MultiplexedIntegrationTest, FlowControlOnAndGiantBodyWithContentLength) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(1024, 1024); // Set buffer limits upstream and downstream.
-  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, true);
+  testGiantRequestAndResponse(GiantPayoadSizeByte, GiantPayoadSizeByte, true);
 }
 
 TEST_P(MultiplexedIntegrationTest, LargeFlowControlOnAndGiantBodyWithContentLength) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(128 * 1024,
                                  128 * 1024); // Set buffer limits upstream and downstream.
-  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, true);
+  testGiantRequestAndResponse(GiantPayoadSizeByte, GiantPayoadSizeByte, true);
 }
 
 TEST_P(MultiplexedIntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -57,23 +57,20 @@ TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithGiantBodyNoBuffer
   ENVOY_LOG_MISC(warn, "manually lowering logs to error");
   LogLevelSetter save_levels(spdlog::level::err);
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
-  testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, false, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, false);
 }
 
 TEST_P(MultiplexedIntegrationTest, FlowControlOnAndGiantBody) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
-  config_helper_.setBufferLimits(1024, 1024); // Set buffer limits upstream and downstream.
-  testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, false, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+  config_helper_.setBufferLimits(1024, 1024); // Set buffer limits upstream and downstream
+  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, false);
 }
 
 TEST_P(MultiplexedIntegrationTest, LargeFlowControlOnAndGiantBody) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(128 * 1024,
                                  128 * 1024); // Set buffer limits upstream and downstream.
-  testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, false, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, false);
 }
 
 TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithBodyAndContentLengthNoBuffer) {
@@ -82,23 +79,20 @@ TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithBodyAndContentLen
 
 TEST_P(MultiplexedIntegrationTest, RouterRequestAndResponseWithGiantBodyAndContentLengthNoBuffer) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
-  testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, true, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, true);
 }
 
 TEST_P(MultiplexedIntegrationTest, FlowControlOnAndGiantBodyWithContentLength) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(1024, 1024); // Set buffer limits upstream and downstream.
-  testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, true, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, true);
 }
 
 TEST_P(MultiplexedIntegrationTest, LargeFlowControlOnAndGiantBodyWithContentLength) {
   config_helper_.addConfigModifier(ConfigHelper::adjustUpstreamTimeoutForTsan);
   config_helper_.setBufferLimits(128 * 1024,
                                  128 * 1024); // Set buffer limits upstream and downstream.
-  testRouterRequestAndResponseWithBody(10 * 1024 * 1024, 10 * 1024 * 1024, false, true, nullptr,
-                                       TSAN_TIMEOUT_FACTOR * TestUtility::DefaultTimeout);
+  testGiantRequestAndResponse(10 * 1024 * 1024, 10 * 1024 * 1024, true);
 }
 
 TEST_P(MultiplexedIntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: some tests with giant request/response payload in multiplex_integration_tests.cc have been flaky at FakeHttpConnection::waitForNewStream() under TSAN because of the contention between the main test thread and the fake upstream thread. This contention exists in all tests that uses non-autonomous fake upstream, but more severe in tests with large payload because their clients have more IO events to handle while holding the mutex.

This change modifies two things to mitigate the synchronization cost:
1. Change large payload tests to use autonomous fake upstream, so that the synchronization between the main test thread and the fake upstream thread can be eliminated.
2. Adjust the timeout of waitForWithDispatcherRun() to respect TSAN_TIMEOUT_FACTOR, so that the main test thread doesn't too aggressively acquire the mutex.

Risk Level: low, test only
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A