### PR TITLE
fuzz test: Prevent use of negative durations.

### DIFF
--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -153,7 +153,7 @@ void UberFilterFuzzer::checkInvalidInputForFuzzer(const std::string& filter_name
     }
     if (config.codec_type() == envoy::extensions::filters::network::http_connection_manager::v3::
                                    HttpConnectionManager::HTTP2) {
-      // Sanitiy check on connection_keepalive interval and timeout.
+      // Sanity check on connection_keepalive interval and timeout.
       try {
         PROTOBUF_GET_MS_REQUIRED(config.http2_protocol_options().connection_keepalive(), interval);
       } catch (const DurationUtil::OutOfRangeException& e) {

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -151,6 +151,26 @@ void UberFilterFuzzer::checkInvalidInputForFuzzer(const std::string& filter_name
           "http_conn_manager trying to use Quiche which we won't fuzz here. Config:\n{}",
           config.DebugString()));
     }
+    if (config.codec_type() == envoy::extensions::filters::network::http_connection_manager::v3::
+                                   HttpConnectionManager::HTTP2) {
+      // Sanitiy check on connection_keepalive interval and timeout.
+      try {
+        PROTOBUF_GET_MS_REQUIRED(config.http2_protocol_options().connection_keepalive(), interval);
+      } catch (const DurationUtil::OutOfRangeException& e) {
+        throw EnvoyException(
+            absl::StrCat("In http2_protocol_options.connection_keepalive interval shall not be "
+                         "negative. Exception {}",
+                         e.what()));
+      }
+      try {
+        PROTOBUF_GET_MS_REQUIRED(config.http2_protocol_options().connection_keepalive(), timeout);
+      } catch (const DurationUtil::OutOfRangeException& e) {
+        throw EnvoyException(
+            absl::StrCat("In http2_protocol_options.connection_keepalive timeout shall not be "
+                         "negative. Exception {}",
+                         e.what()));
+      }
+    }
   } else if (filter_name == NetworkFilterNames::get().EnvoyMobileHttpConnectionManager) {
     envoy::extensions::filters::network::http_connection_manager::v3::
         EnvoyMobileHttpConnectionManager& config =


### PR DESCRIPTION
Commit Message: fuzz test: Prevent use of negative durations.
Additional Description:
In network_readfilter_fuzz_test ensure that timeout and intervall of
http2_protocol_options.connection_keepalive are
both positive.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
