### PR TITLE
test: deflake MultiplexedUpstreamIntegrationTest.UpstreamCachesZeroRttKeys

### DIFF
--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -702,7 +702,6 @@ TEST_P(MultiplexedUpstreamIntegrationTest, UpstreamCachesZeroRttKeys) {
 
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();
-
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response->waitForEndStream());
   upstream_request_.reset();
@@ -712,6 +711,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, UpstreamCachesZeroRttKeys) {
   fake_upstream_connection_.reset();
 
   EXPECT_EQ(0u, test_server_->counter("cluster.cluster_0.upstream_cx_connect_with_0_rtt")->value());
+  test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_destroy", 1);
 
   default_request_headers_.addCopy("second_request", "1");
   auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -702,6 +702,7 @@ TEST_P(MultiplexedUpstreamIntegrationTest, UpstreamCachesZeroRttKeys) {
 
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();
+
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response->waitForEndStream());
   upstream_request_.reset();


### PR DESCRIPTION
Commit Message: the test closes the upstream connection between two requests to test upstream caches 0-RTT keys. But because the upstream connection is closed by the fake upstream, there is a race in Envoy between closing the corresponding upstream connection and picking an existing upstream connection for the 2nd request. If the latter wins the race, the 2nd request will reuse the old upstream connection and then fail. This change fixes the race by checking cluster stats `upstream_cx_destroy` in Envoy before sending the 2nd request to ensure the Envoy also has closed the upstream connection.

Risk Level: low, test only
Testing: the test is no longer flaky
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a