### PR TITLE
Refactor libcurl metadata fetcher to accept RequestMessage as argument

### DIFF
--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -29,7 +29,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/crypto:utility_lib",
-        "//source/common/http:headers_lib",
+        "//source/common/http:message_lib",
         "//source/common/singleton:const_singleton",
     ],
 )
@@ -47,6 +47,7 @@ envoy_cc_library(
     external_deps = ["abseil_time"],
     deps = [
         ":credentials_provider_interface",
+        ":utility_lib",
         "//envoy/api:api_interface",
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",
@@ -61,6 +62,7 @@ envoy_cc_library(
     hdrs = ["utility.h"],
     external_deps = ["curl"],
     deps = [
+        "//envoy/http:message_interface",
         "//source/common/common:empty_string",
         "//source/common/common:matchers_lib",
         "//source/common/common:utility_lib",

--- a/source/extensions/common/aws/credentials_provider.h
+++ b/source/extensions/common/aws/credentials_provider.h
@@ -21,9 +21,10 @@ namespace Aws {
  */
 class Credentials {
 public:
-  Credentials(absl::string_view access_key_id = absl::string_view(),
-              absl::string_view secret_access_key = absl::string_view(),
-              absl::string_view session_token = absl::string_view()) {
+  explicit Credentials(absl::string_view access_key_id = absl::string_view(),
+                       absl::string_view secret_access_key = absl::string_view(),
+                       absl::string_view session_token = absl::string_view()) {
+    // TODO(suniltheta): Move credential expiration date in here
     if (!access_key_id.empty()) {
       access_key_id_ = std::string(access_key_id);
       if (!secret_access_key.empty()) {

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -74,7 +74,6 @@ void InstanceProfileCredentialsProvider::refresh() {
 
   // First discover the Role of this instance
   Http::RequestMessageImpl message;
-  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
   message.headers().setMethod(Http::Headers::get().MethodValues.Get);
   message.headers().setHost(EC2_METADATA_HOST);
   message.headers().setPath(SECURITY_CREDENTIALS_PATH);
@@ -87,7 +86,7 @@ void InstanceProfileCredentialsProvider::refresh() {
 }
 
 void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
-    const std::string& instance_role, bool async /*default = false*/) {
+    const std::string& instance_role) {
   if (instance_role.empty()) {
     return;
   }
@@ -107,21 +106,16 @@ void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
 
   // Then fetch and parse the credentials
   Http::RequestMessageImpl message;
-  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
   message.headers().setMethod(Http::Headers::get().MethodValues.Get);
   message.headers().setHost(EC2_METADATA_HOST);
   message.headers().setPath(credential_path);
 
-  if (!async) {
-    const auto credential_document = metadata_fetcher_(message);
-    if (!credential_document) {
-      ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
-      return;
-    }
-    extractCredentials(credential_document.value());
-  } else {
-    // TODO(suniltheta) async call using http_async_client
+  const auto credential_document = metadata_fetcher_(message);
+  if (!credential_document) {
+    ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
+    return;
   }
+  extractCredentials(credential_document.value());
 }
 
 void InstanceProfileCredentialsProvider::extractCredentials(
@@ -164,7 +158,6 @@ void TaskRoleCredentialsProvider::refresh() {
   Http::Utility::extractHostPathFromUri(credential_uri_, host, path);
 
   Http::RequestMessageImpl message;
-  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
   message.headers().setMethod(Http::Headers::get().MethodValues.Get);
   message.headers().setHost(host);
   message.headers().setPath(path);

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -3,8 +3,10 @@
 #include "envoy/common/exception.h"
 
 #include "source/common/common/lock_guard.h"
+#include "source/common/http/message_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/json/json_loader.h"
+#include "source/extensions/common/aws/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -71,20 +73,30 @@ void InstanceProfileCredentialsProvider::refresh() {
   ENVOY_LOG(debug, "Getting AWS credentials from the instance metadata");
 
   // First discover the Role of this instance
-  const auto instance_role_string =
-      metadata_fetcher_(EC2_METADATA_HOST, SECURITY_CREDENTIALS_PATH, "");
+  Http::RequestMessageImpl message;
+  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
+  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
+  message.headers().setHost(EC2_METADATA_HOST);
+  message.headers().setPath(SECURITY_CREDENTIALS_PATH);
+  const auto instance_role_string = metadata_fetcher_(message);
   if (!instance_role_string) {
     ENVOY_LOG(error, "Could not retrieve credentials listing from the instance metadata");
     return;
   }
+  fetchCredentialFromInstanceRole(instance_role_string.value());
+}
 
-  const auto instance_role_list =
-      StringUtil::splitToken(StringUtil::trim(instance_role_string.value()), "\n");
+void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
+    const std::string& instance_role, bool async /*default = false*/) {
+  if (instance_role.empty()) {
+    return;
+  }
+  const auto instance_role_list = StringUtil::splitToken(StringUtil::trim(instance_role), "\n");
   if (instance_role_list.empty()) {
     ENVOY_LOG(error, "No AWS credentials were found in the instance metadata");
     return;
   }
-  ENVOY_LOG(debug, "AWS credentials list:\n{}", instance_role_string.value());
+  ENVOY_LOG(debug, "AWS credentials list:\n{}", instance_role);
 
   // Only one Role can be associated with an instance:
   // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
@@ -94,15 +106,32 @@ void InstanceProfileCredentialsProvider::refresh() {
   ENVOY_LOG(debug, "AWS credentials path: {}", credential_path);
 
   // Then fetch and parse the credentials
-  const auto credential_document = metadata_fetcher_(EC2_METADATA_HOST, credential_path, "");
-  if (!credential_document) {
-    ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
+  Http::RequestMessageImpl message;
+  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
+  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
+  message.headers().setHost(EC2_METADATA_HOST);
+  message.headers().setPath(credential_path);
+
+  if (!async) {
+    const auto credential_document = metadata_fetcher_(message);
+    if (!credential_document) {
+      ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
+      return;
+    }
+    extractCredentials(credential_document.value());
+  } else {
+    // TODO(suniltheta) async call using http_async_client
+  }
+}
+
+void InstanceProfileCredentialsProvider::extractCredentials(
+    const std::string& credential_document_value) {
+  if (credential_document_value.empty()) {
     return;
   }
-
   Json::ObjectSharedPtr document_json;
   try {
-    document_json = Json::Factory::loadFromString(credential_document.value());
+    document_json = Json::Factory::loadFromString(credential_document_value);
   } catch (EnvoyException& e) {
     ENVOY_LOG(error, "Could not parse AWS credentials document: {}", e.what());
     return;
@@ -133,17 +162,28 @@ void TaskRoleCredentialsProvider::refresh() {
   absl::string_view host;
   absl::string_view path;
   Http::Utility::extractHostPathFromUri(credential_uri_, host, path);
-  const auto credential_document =
-      metadata_fetcher_(std::string(host.data(), host.size()),
-                        std::string(path.data(), path.size()), authorization_token_);
+
+  Http::RequestMessageImpl message;
+  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
+  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
+  message.headers().setHost(host);
+  message.headers().setPath(path);
+  message.headers().setCopy(Http::CustomHeaders::get().Authorization, authorization_token_);
+  const auto credential_document = metadata_fetcher_(message);
   if (!credential_document) {
     ENVOY_LOG(error, "Could not load AWS credentials document from the task role");
     return;
   }
+  extractCredentials(credential_document.value());
+}
 
+void TaskRoleCredentialsProvider::extractCredentials(const std::string& credential_document_value) {
+  if (credential_document_value.empty()) {
+    return;
+  }
   Json::ObjectSharedPtr document_json;
   try {
-    document_json = Json::Factory::loadFromString(credential_document.value());
+    document_json = Json::Factory::loadFromString(credential_document_value);
   } catch (EnvoyException& e) {
     ENVOY_LOG(error, "Could not parse AWS credentials document from the task role: {}", e.what());
     return;

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -69,10 +69,7 @@ private:
   bool needsRefresh() override;
   void refresh() override;
   void extractCredentials(const std::string& credential_document_value);
-  void fetchCredentialFromInstanceRole(const std::string& instance_role, bool async = false);
-  void fetchCredentialFromInstanceRoleAsync(const std::string& instance_role) {
-    fetchCredentialFromInstanceRole(instance_role, true);
-  }
+  void fetchCredentialFromInstanceRole(const std::string& instance_role);
 };
 
 /**

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -4,6 +4,7 @@
 
 #include "envoy/api/api.h"
 #include "envoy/event/timer.h"
+#include "envoy/http/message.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
@@ -31,8 +32,7 @@ public:
 class MetadataCredentialsProviderBase : public CredentialsProvider,
                                         public Logger::Loggable<Logger::Id::aws> {
 public:
-  using MetadataFetcher = std::function<absl::optional<std::string>(
-      const std::string& host, const std::string& path, const std::string& auth_token)>;
+  using MetadataFetcher = std::function<absl::optional<std::string>(Http::RequestMessage&)>;
 
   MetadataCredentialsProviderBase(Api::Api& api, const MetadataFetcher& metadata_fetcher)
       : api_(api), metadata_fetcher_(metadata_fetcher) {}
@@ -68,6 +68,11 @@ public:
 private:
   bool needsRefresh() override;
   void refresh() override;
+  void extractCredentials(const std::string& credential_document_value);
+  void fetchCredentialFromInstanceRole(const std::string& instance_role, bool async = false);
+  void fetchCredentialFromInstanceRoleAsync(const std::string& instance_role) {
+    fetchCredentialFromInstanceRole(instance_role, true);
+  }
 };
 
 /**
@@ -90,6 +95,7 @@ private:
 
   bool needsRefresh() override;
   void refresh() override;
+  void extractCredentials(const std::string& credential_document_value);
 };
 
 /**

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -48,7 +48,7 @@ using AwsSigV4HeaderExclusionVector = std::vector<envoy::type::matcher::v3::Stri
  * Implementation of the Signature V4 signing process.
  * See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
  */
-class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::http> {
+class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::aws> {
 public:
   SignerImpl(absl::string_view service_name, absl::string_view region,
              const CredentialsProviderSharedPtr& credentials_provider, TimeSource& time_source,

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -223,19 +223,18 @@ static size_t curlCallback(char* ptr, size_t, size_t nmemb, void* data) {
   return nmemb;
 }
 
-absl::optional<std::string> Utility::metadataFetcher(const std::string& host,
-                                                     const std::string& path,
-                                                     const std::string& auth_token) {
+absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message) {
   static const size_t MAX_RETRIES = 4;
   static const std::chrono::milliseconds RETRY_DELAY{1000};
   static const std::chrono::seconds TIMEOUT{5};
 
   CURL* const curl = curl_easy_init();
-  if (!curl) {
-    return absl::nullopt;
-  };
+  RELEASE_ASSERT(curl != nullptr, "");
+  const auto host = message.headers().getHostValue();
+  const auto path = message.headers().getPathValue();
+  const auto scheme = message.headers().getSchemeValue();
 
-  const std::string url = fmt::format("http://{}/{}", host, path);
+  const std::string url = fmt::format("{}://{}{}", scheme, host, path);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, TIMEOUT.count());
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
@@ -246,9 +245,17 @@ absl::optional<std::string> Utility::metadataFetcher(const std::string& host,
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlCallback);
 
   struct curl_slist* headers = nullptr;
-  if (!auth_token.empty()) {
-    const std::string auth = fmt::format("Authorization: {}", auth_token);
-    headers = curl_slist_append(headers, auth.c_str());
+  message.headers().iterate([&headers](const Http::HeaderEntry& entry) -> Http::HeaderMap::Iterate {
+    // Skip pseudo-headers
+    if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
+      return Http::HeaderMap::Iterate::Continue;
+    }
+    const std::string header =
+        fmt::format("{}: {}", entry.key().getStringView(), entry.value().getStringView());
+    headers = curl_slist_append(headers, header.c_str());
+    return Http::HeaderMap::Iterate::Continue;
+  });
+  if (headers != nullptr) {
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
 

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -229,12 +229,14 @@ absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message
   static const std::chrono::seconds TIMEOUT{5};
 
   CURL* const curl = curl_easy_init();
-  RELEASE_ASSERT(curl != nullptr, "");
+  if (!curl) {
+    return absl::nullopt;
+  };
+
   const auto host = message.headers().getHostValue();
   const auto path = message.headers().getPathValue();
-  const auto scheme = message.headers().getSchemeValue();
 
-  const std::string url = fmt::format("{}://{}{}", scheme, host, path);
+  const std::string url = fmt::format("http://{}{}", host, path);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, TIMEOUT.count());
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);

--- a/source/extensions/common/aws/utility.h
+++ b/source/extensions/common/aws/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/http/message.h"
+
 #include "source/common/common/matchers.h"
 #include "source/common/http/headers.h"
 
@@ -81,9 +83,7 @@ public:
   /**
    * Fetch AWS instance or task metadata.
    *
-   * @param host host or ip address of the metadata endpoint.
-   * @param path path of the metadata document.
-   * @auth_token authentication token to pass in the request, empty string indicates no auth.
+   * @param message An HTTP request.
    * @return Metadata document or nullopt in case if unable to fetch it.
    *
    * @note In case of an error, function will log ENVOY_LOG_MISC(debug) message.
@@ -91,8 +91,7 @@ public:
    * @note This is not main loop safe method as it is blocking. It is intended to be used from the
    * gRPC auth plugins that are able to schedule blocking plugins on a different thread.
    */
-  static absl::optional<std::string>
-  metadataFetcher(const std::string& host, const std::string& path, const std::string& auth_token);
+  static absl::optional<std::string> fetchMetadata(Http::RequestMessage& message);
 };
 
 } // namespace Aws

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -37,15 +37,16 @@ Http::FilterFactoryCb AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
     const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
 
-  auto credentials_provider =
-      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-          context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
-
   const auto arn = parseArn(proto_config.arn());
   if (!arn) {
     throw EnvoyException(fmt::format("aws_lambda_filter: Invalid ARN: {}", proto_config.arn()));
   }
   const std::string region = arn->region();
+
+  auto credentials_provider =
+      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
+          context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
+
   auto signer = std::make_shared<Extensions::Common::Aws::SignerImpl>(
       service_name, region, std::move(credentials_provider),
       context.mainThreadDispatcher().timeSource(),

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-          context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
+          context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
   const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
       config.match_excluded_headers().begin(), config.match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -45,7 +45,7 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
             const envoy::config::grpc_credential::v3::AwsIamConfig&>(
             *config_message, ProtobufMessage::getNullValidationVisitor());
         auto credentials_provider = std::make_shared<Common::Aws::DefaultCredentialsProviderChain>(
-            api, Common::Aws::Utility::metadataFetcher);
+            api, Common::Aws::Utility::fetchMetadata);
         auto signer = std::make_unique<Common::Aws::SignerImpl>(
             config.service_name(), getRegion(config), credentials_provider, api.timeSource(),
             // TODO: extend API to allow specifying header exclusion. ref:

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -424,9 +424,8 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-    // No request trailer O(1) headers.
-  }
-  {
+      // No request trailer O(1) headers.
+  } {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -425,7 +425,8 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
   }
   {
       // No request trailer O(1) headers.
-  } {
+  }
+  {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -82,7 +82,7 @@ TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
   const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
                                      lookupPort("listener_0"));
   auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
-      {":path", "/"}, {":authority", authority}, {":scheme", "http"}, {":method", "GET"}}};
+      {":path", "/"}, {":authority", authority}, {":method", "GET"}}};
   Http::RequestMessageImpl message(std::move(headers));
   const auto response = Utility::fetchMetadata(message);
 
@@ -99,7 +99,6 @@ TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
   auto headers = Http::RequestHeaderMapPtr{
       new Http::TestRequestHeaderMapImpl{{":path", "/"},
                                          {":authority", authority},
-                                         {":scheme", "http"},
                                          {":method", "GET"},
                                          {"authorization", "AUTH_TOKEN"}}};
   Http::RequestMessageImpl message(std::move(headers));
@@ -118,7 +117,6 @@ TEST_F(AwsMetadataIntegrationTestSuccess, Redirect) {
   auto headers = Http::RequestHeaderMapPtr{
       new Http::TestRequestHeaderMapImpl{{":path", "/redirect"},
                                          {":authority", authority},
-                                         {":scheme", "http"},
                                          {":method", "GET"},
                                          {"authorization", "AUTH_TOKEN"}}};
   Http::RequestMessageImpl message(std::move(headers));
@@ -146,7 +144,6 @@ TEST_F(AwsMetadataIntegrationTestFailure, Failure) {
   auto headers = Http::RequestHeaderMapPtr{
       new Http::TestRequestHeaderMapImpl{{":path", "/"},
                                          {":authority", authority},
-                                         {":scheme", "http"},
                                          {":method", "GET"},
                                          {"authorization", "AUTH_TOKEN"}}};
 
@@ -175,7 +172,7 @@ TEST_F(AwsMetadataIntegrationTestTimeout, Timeout) {
   const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
                                      lookupPort("listener_0"));
   auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
-      {":path", "/"}, {":authority", authority}, {":scheme", "http"}, {":method", "GET"}}};
+      {":path", "/"}, {":authority", authority}, {":method", "GET"}}};
   Http::RequestMessageImpl message(std::move(headers));
 
   const auto start_time = timeSystem().monotonicTime();

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -79,9 +79,12 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
+      {":path", "/"}, {":authority", authority}, {":scheme", "http"}, {":method", "GET"}}};
+  Http::RequestMessageImpl message(std::move(headers));
+  const auto response = Utility::fetchMetadata(message);
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE", *response);
@@ -91,9 +94,16 @@ TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
 }
 
 TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "", "AUTH_TOKEN");
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{
+      new Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                         {":authority", authority},
+                                         {":scheme", "http"},
+                                         {":method", "GET"},
+                                         {"authorization", "AUTH_TOKEN"}}};
+  Http::RequestMessageImpl message(std::move(headers));
+  const auto response = Utility::fetchMetadata(message);
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -103,9 +113,16 @@ TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
 }
 
 TEST_F(AwsMetadataIntegrationTestSuccess, Redirect) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "redirect", "AUTH_TOKEN");
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{
+      new Http::TestRequestHeaderMapImpl{{":path", "/redirect"},
+                                         {":authority", authority},
+                                         {":scheme", "http"},
+                                         {":method", "GET"},
+                                         {"authorization", "AUTH_TOKEN"}}};
+  Http::RequestMessageImpl message(std::move(headers));
+  const auto response = Utility::fetchMetadata(message);
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -124,11 +141,18 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestFailure, Failure) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{
+      new Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                         {":authority", authority},
+                                         {":scheme", "http"},
+                                         {":method", "GET"},
+                                         {"authorization", "AUTH_TOKEN"}}};
 
+  Http::RequestMessageImpl message(std::move(headers));
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::fetchMetadata(message);
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
@@ -148,16 +172,19 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestTimeout, Timeout) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
+      {":path", "/"}, {":authority", authority}, {":scheme", "http"}, {":method", "GET"}}};
+  Http::RequestMessageImpl message(std::move(headers));
 
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::fetchMetadata(message);
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
 
-  // We do now check http.metadata_test.downstream_rq_completed value here because it's
+  // We do not check http.metadata_test.downstream_rq_completed value here because it's
   // behavior is different between Linux and Mac when Curl disconnects on timeout. On Mac it is
   // incremented, while on Linux it is not.
 

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -101,29 +101,27 @@ public:
   InstanceProfileCredentialsProviderTest()
       : api_(Api::createApiForTest(time_system_)),
         provider_(*api_, [this](Http::RequestMessage& message) -> absl::optional<std::string> {
-          return this->fetcher_.fetch(message);
+          return this->fetch_metadata_.fetch(message);
         }) {}
 
   void expectCredentialListing(const absl::optional<std::string>& listing) {
     Http::TestRequestHeaderMapImpl headers{{":path", "/latest/meta-data/iam/security-credentials"},
                                            {":authority", "169.254.169.254:80"},
-                                           {":scheme", "http"},
                                            {":method", "GET"}};
-    EXPECT_CALL(fetcher_, fetch(MessageMatches(headers))).WillOnce(Return(listing));
+    EXPECT_CALL(fetch_metadata_, fetch(MessageMatches(headers))).WillOnce(Return(listing));
   }
 
   void expectDocument(const absl::optional<std::string>& document) {
     Http::TestRequestHeaderMapImpl headers{
         {":path", "/latest/meta-data/iam/security-credentials/doc1"},
         {":authority", "169.254.169.254:80"},
-        {":scheme", "http"},
         {":method", "GET"}};
-    EXPECT_CALL(fetcher_, fetch(MessageMatches(headers))).WillOnce(Return(document));
+    EXPECT_CALL(fetch_metadata_, fetch(MessageMatches(headers))).WillOnce(Return(document));
   }
 
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
-  NiceMock<MockFetchMetadataer> fetcher_;
+  NiceMock<MockFetchMetadata> fetch_metadata_;
   InstanceProfileCredentialsProvider provider_;
 };
 
@@ -233,7 +231,7 @@ public:
         provider_(
             *api_,
             [this](Http::RequestMessage& message) -> absl::optional<std::string> {
-              return this->fetcher_.fetch(message);
+              return this->fetch_metadata_.fetch(message);
             },
             "169.254.170.2:80/path/to/doc", "auth_token") {
     // Tue Jan  2 03:04:05 UTC 2018
@@ -243,15 +241,14 @@ public:
   void expectDocument(const absl::optional<std::string>& document) {
     Http::TestRequestHeaderMapImpl headers{{":path", "/path/to/doc"},
                                            {":authority", "169.254.170.2:80"},
-                                           {":scheme", "http"},
                                            {":method", "GET"},
                                            {"authorization", "auth_token"}};
-    EXPECT_CALL(fetcher_, fetch(MessageMatches(headers))).WillOnce(Return(document));
+    EXPECT_CALL(fetch_metadata_, fetch(MessageMatches(headers))).WillOnce(Return(document));
   }
 
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
-  NiceMock<MockFetchMetadataer> fetcher_;
+  NiceMock<MockFetchMetadata> fetch_metadata_;
   TaskRoleCredentialsProvider provider_;
 };
 

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -62,35 +62,72 @@ TEST_F(EvironmentCredentialsProviderTest, NoSessionToken) {
   EXPECT_FALSE(credentials.sessionToken().has_value());
 }
 
+class MessageMatcher : public testing::MatcherInterface<Http::RequestMessage&> {
+public:
+  explicit MessageMatcher(const Http::TestRequestHeaderMapImpl& expected_headers)
+      : expected_headers_(expected_headers) {}
+
+  bool MatchAndExplain(Http::RequestMessage& message,
+                       testing::MatchResultListener* result_listener) const override {
+    const bool equal = TestUtility::headerMapEqualIgnoreOrder(message.headers(), expected_headers_);
+    if (!equal) {
+      *result_listener << "\n"
+                       << TestUtility::addLeftAndRightPadding("Expected header map:") << "\n"
+                       << expected_headers_
+                       << TestUtility::addLeftAndRightPadding("is not equal to actual header map:")
+                       << "\n"
+                       << message.headers()
+                       << TestUtility::addLeftAndRightPadding("") // line full of padding
+                       << "\n";
+    }
+    return equal;
+  }
+
+  void DescribeTo(::std::ostream* os) const override { *os << "Message matches"; }
+
+  void DescribeNegationTo(::std::ostream* os) const override { *os << "Message does not match"; }
+
+private:
+  const Http::TestRequestHeaderMapImpl expected_headers_;
+};
+
+testing::Matcher<Http::RequestMessage&>
+MessageMatches(const Http::TestRequestHeaderMapImpl& expected_headers) {
+  return testing::MakeMatcher(new MessageMatcher(expected_headers));
+}
+
 class InstanceProfileCredentialsProviderTest : public testing::Test {
 public:
   InstanceProfileCredentialsProviderTest()
       : api_(Api::createApiForTest(time_system_)),
-        provider_(*api_,
-                  [this](const std::string& host, const std::string& path,
-                         const std::string& auth_token) -> absl::optional<std::string> {
-                    return this->fetcher_.fetch(host, path, auth_token);
-                  }) {}
+        provider_(*api_, [this](Http::RequestMessage& message) -> absl::optional<std::string> {
+          return this->fetcher_.fetch(message);
+        }) {}
 
   void expectCredentialListing(const absl::optional<std::string>& listing) {
-    EXPECT_CALL(fetcher_,
-                fetch("169.254.169.254:80", "/latest/meta-data/iam/security-credentials", _))
-        .WillOnce(Return(listing));
+    Http::TestRequestHeaderMapImpl headers{{":path", "/latest/meta-data/iam/security-credentials"},
+                                           {":authority", "169.254.169.254:80"},
+                                           {":scheme", "http"},
+                                           {":method", "GET"}};
+    EXPECT_CALL(fetcher_, fetch(MessageMatches(headers))).WillOnce(Return(listing));
   }
 
   void expectDocument(const absl::optional<std::string>& document) {
-    EXPECT_CALL(fetcher_,
-                fetch("169.254.169.254:80", "/latest/meta-data/iam/security-credentials/doc1", _))
-        .WillOnce(Return(document));
+    Http::TestRequestHeaderMapImpl headers{
+        {":path", "/latest/meta-data/iam/security-credentials/doc1"},
+        {":authority", "169.254.169.254:80"},
+        {":scheme", "http"},
+        {":method", "GET"}};
+    EXPECT_CALL(fetcher_, fetch(MessageMatches(headers))).WillOnce(Return(document));
   }
 
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
-  NiceMock<MockMetadataFetcher> fetcher_;
+  NiceMock<MockFetchMetadataer> fetcher_;
   InstanceProfileCredentialsProvider provider_;
 };
 
-TEST_F(InstanceProfileCredentialsProviderTest, FailedCredentailListing) {
+TEST_F(InstanceProfileCredentialsProviderTest, FailedCredentialListing) {
   expectCredentialListing(absl::optional<std::string>());
   const auto credentials = provider_.getCredentials();
   EXPECT_FALSE(credentials.accessKeyId().has_value());
@@ -195,9 +232,8 @@ public:
       : api_(Api::createApiForTest(time_system_)),
         provider_(
             *api_,
-            [this](const std::string& host, const std::string& path,
-                   const absl::optional<std::string>& auth_token) -> absl::optional<std::string> {
-              return this->fetcher_.fetch(host, path, auth_token);
+            [this](Http::RequestMessage& message) -> absl::optional<std::string> {
+              return this->fetcher_.fetch(message);
             },
             "169.254.170.2:80/path/to/doc", "auth_token") {
     // Tue Jan  2 03:04:05 UTC 2018
@@ -205,12 +241,17 @@ public:
   }
 
   void expectDocument(const absl::optional<std::string>& document) {
-    EXPECT_CALL(fetcher_, fetch("169.254.170.2:80", "/path/to/doc", _)).WillOnce(Return(document));
+    Http::TestRequestHeaderMapImpl headers{{":path", "/path/to/doc"},
+                                           {":authority", "169.254.170.2:80"},
+                                           {":scheme", "http"},
+                                           {":method", "GET"},
+                                           {"authorization", "auth_token"}};
+    EXPECT_CALL(fetcher_, fetch(MessageMatches(headers))).WillOnce(Return(document));
   }
 
   Event::SimulatedTimeSystem time_system_;
   Api::ApiPtr api_;
-  NiceMock<MockMetadataFetcher> fetcher_;
+  NiceMock<MockFetchMetadataer> fetcher_;
   TaskRoleCredentialsProvider provider_;
 };
 

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -29,21 +29,16 @@ public:
   MOCK_METHOD(void, signUnsignedPayload, (Http::RequestHeaderMap&));
 };
 
-class MockMetadataFetcher {
+class MockFetchMetadataer {
 public:
-  virtual ~MockMetadataFetcher() = default;
+  virtual ~MockFetchMetadataer() = default;
 
-  MOCK_METHOD(absl::optional<std::string>, fetch,
-              (const std::string&, const std::string&, const absl::optional<std::string>&),
-              (const));
+  MOCK_METHOD(absl::optional<std::string>, fetch, (Http::RequestMessage&), (const));
 };
 
 class DummyMetadataFetcher {
 public:
-  absl::optional<std::string> operator()(const std::string&, const std::string&,
-                                         const absl::optional<std::string>&) {
-    return absl::nullopt;
-  }
+  absl::optional<std::string> operator()(Http::RequestMessage&) { return absl::nullopt; }
 };
 
 } // namespace Aws

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -29,9 +29,9 @@ public:
   MOCK_METHOD(void, signUnsignedPayload, (Http::RequestHeaderMap&));
 };
 
-class MockFetchMetadataer {
+class MockFetchMetadata {
 public:
-  virtual ~MockFetchMetadataer() = default;
+  virtual ~MockFetchMetadata() = default;
 
   MOCK_METHOD(absl::optional<std::string>, fetch, (Http::RequestMessage&), (const));
 };


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

**Commit Message:** Refactor libcurl metadata fetcher to accept RequestMessage as argument
**Additional Description:** This is the first commit in the overall effort to remove dependency on libcurl for AWS extensions #11816. This doesn't have much functional change but more of refactoring necessary to introduce a new class MetadataFetcher which will inherit from `Http::AsyncClient::Callbacks`.
Risk Level: Low
Testing:
Docs Changes: NA
Release Notes: NA
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
