### PR TITLE
compressor filter: support zstd benchmark

### DIFF
--- a/test/extensions/filters/http/compressor/BUILD
+++ b/test/extensions/filters/http/compressor/BUILD
@@ -79,6 +79,7 @@ envoy_cc_benchmark_binary(
         "//envoy/compression/compressor:compressor_factory_interface",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/compression/gzip/compressor:compressor_lib",
+        "//source/extensions/compression/zstd/compressor:config",
         "//source/extensions/filters/http/compressor:compressor_filter_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/protobuf:protobuf_mocks",

--- a/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
@@ -394,17 +394,14 @@ static std::vector<CompressionParams> zstd_compression_params = {
     // level7 + default
     {7, 0, 0, 0},
 
-    // level1 + default
+    // level8 + default
     {8, 0, 0, 0},
 
-    // level8 + default
+    // level9 + default
     {9, 0, 0, 0},
 
-    // level9 + default
-    {10, 0, 0, 0},
-
     // level10 + default
-    {1, 0, 0, 0},
+    {10, 0, 0, 0},
 
     // level11 + default
     {11, 0, 0, 0},

--- a/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
@@ -284,12 +284,13 @@ static std::vector<CompressionParams> gzip_compression_params = {
     // Best + Standard + High window + High mem level
     {Z_BEST_COMPRESSION, Z_DEFAULT_STRATEGY, 15, 9}};
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressFullWithGzip(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = gzip_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(1, 122880);
     compressWith(CompressorLibs::Gzip, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -299,12 +300,13 @@ BENCHMARK(compressFullWithGzip)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks16384WithGzip(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = gzip_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(7, 16384);
     compressWith(CompressorLibs::Gzip, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -314,12 +316,13 @@ BENCHMARK(compressChunks16384WithGzip)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks8192WithGzip(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = gzip_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(15, 8192);
     compressWith(CompressorLibs::Gzip, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -329,12 +332,13 @@ BENCHMARK(compressChunks8192WithGzip)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks4096WithGzip(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = gzip_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(30, 4096);
     compressWith(CompressorLibs::Gzip, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -344,12 +348,13 @@ BENCHMARK(compressChunks4096WithGzip)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks1024WithGzip(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = gzip_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(120, 1024);
     compressWith(CompressorLibs::Gzip, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -429,13 +434,14 @@ static std::vector<CompressionParams> zstd_compression_params = {
     // level22 + default
     {22, 0, 0, 0}};
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressFullWithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
   Envoy::Extensions::HttpFilters::Compressor::Result res;
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(1, 122880);
     res = compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -445,13 +451,14 @@ BENCHMARK(compressFullWithZstd)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks16384WithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
   Envoy::Extensions::HttpFilters::Compressor::Result res;
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(7, 16384);
     res = compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -461,12 +468,13 @@ BENCHMARK(compressChunks16384WithZstd)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks8192WithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(15, 8192);
     compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -476,12 +484,13 @@ BENCHMARK(compressChunks8192WithZstd)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks4096WithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(30, 4096);
     compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
   }
@@ -491,12 +500,13 @@ BENCHMARK(compressChunks4096WithZstd)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void compressChunks1024WithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(120, 1024);
     compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
   }

--- a/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
@@ -447,11 +447,10 @@ static void compressFullWithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
-  Envoy::Extensions::HttpFilters::Compressor::Result res;
 
   for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(1, 122880);
-    res = compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
+    compressWith(CompressorLibs::Zstd, std::move(chunks), params, decoder_callbacks, state);
   }
 }
 BENCHMARK(compressFullWithZstd)
@@ -464,7 +463,6 @@ static void compressChunks16384WithZstd(benchmark::State& state) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   const auto idx = state.range(0);
   const auto& params = zstd_compression_params[idx];
-  Envoy::Extensions::HttpFilters::Compressor::Result res;
 
   for (auto _ : state) { // NOLINT
     std::vector<Buffer::OwnedImpl> chunks = generateChunks(7, 16384);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: support zstd benchmark
Additional Description:
```
2022-04-24T13:45:31+08:00
Running ./bazel-bin/test/extensions/filters/http/compressor/compressor_filter_speed_test
Run on (112 X 3500.57 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x56)
  L1 Instruction 32 KiB (x56)
  L2 Unified 1280 KiB (x56)
  L3 Unified 43008 KiB (x2)
Load Average: 10.64, 5.78, 5.70
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
...
compressFullWithZstd/0/manual_time               2.62 ms         3.18 ms          272
compressFullWithZstd/1/manual_time               2.75 ms         3.31 ms          252
compressFullWithZstd/2/manual_time               6.62 ms         7.18 ms          106
compressFullWithZstd/3/manual_time               6.65 ms         7.23 ms          107
compressFullWithZstd/4/manual_time               10.7 ms         11.3 ms           68
compressFullWithZstd/5/manual_time               11.1 ms         11.6 ms           63
compressFullWithZstd/6/manual_time               11.3 ms         11.8 ms           61
compressFullWithZstd/7/manual_time               12.0 ms         12.6 ms           59
compressFullWithZstd/8/manual_time               12.1 ms         12.6 ms           57
compressFullWithZstd/9/manual_time               13.3 ms         13.9 ms           51
compressFullWithZstd/10/manual_time              2.61 ms         3.17 ms          272
compressFullWithZstd/11/manual_time              16.3 ms         16.9 ms           44
compressFullWithZstd/12/manual_time              19.5 ms         20.2 ms           33
compressFullWithZstd/13/manual_time              11.8 ms         12.4 ms           55
compressFullWithZstd/14/manual_time              13.7 ms         14.3 ms           51
compressFullWithZstd/15/manual_time              15.9 ms         16.5 ms           38
compressFullWithZstd/16/manual_time              22.7 ms         23.3 ms           32
compressFullWithZstd/17/manual_time              33.2 ms         33.9 ms           21
compressFullWithZstd/18/manual_time              44.5 ms         45.2 ms           16
compressFullWithZstd/19/manual_time              91.4 ms         92.8 ms            6
compressFullWithZstd/20/manual_time               108 ms          110 ms            5
compressFullWithZstd/21/manual_time               112 ms          113 ms            5
compressChunks16384WithZstd/0/manual_time        2.52 ms         3.09 ms          282
compressChunks16384WithZstd/1/manual_time        2.63 ms         3.21 ms          269
compressChunks16384WithZstd/2/manual_time        6.19 ms         6.87 ms          113
compressChunks16384WithZstd/3/manual_time        6.24 ms         6.84 ms          114
compressChunks16384WithZstd/4/manual_time        9.63 ms         10.3 ms           73
compressChunks16384WithZstd/5/manual_time        10.5 ms         11.1 ms           68
compressChunks16384WithZstd/6/manual_time        10.6 ms         11.2 ms           67
compressChunks16384WithZstd/7/manual_time        11.2 ms         11.8 ms           62
compressChunks16384WithZstd/8/manual_time        11.4 ms         12.0 ms           57
compressChunks16384WithZstd/9/manual_time        12.6 ms         13.2 ms           57
compressChunks16384WithZstd/10/manual_time       2.55 ms         3.13 ms          282
compressChunks16384WithZstd/11/manual_time       15.8 ms         16.5 ms           44
compressChunks16384WithZstd/12/manual_time       18.8 ms         19.5 ms           34
compressChunks16384WithZstd/13/manual_time       11.4 ms         12.0 ms           51
compressChunks16384WithZstd/14/manual_time       13.3 ms         13.9 ms           50
compressChunks16384WithZstd/15/manual_time       14.6 ms         15.3 ms           40
compressChunks16384WithZstd/16/manual_time       20.0 ms         20.6 ms           34
compressChunks16384WithZstd/17/manual_time       30.5 ms         31.2 ms           22
compressChunks16384WithZstd/18/manual_time       42.7 ms         43.5 ms           16
compressChunks16384WithZstd/19/manual_time       86.8 ms         88.2 ms            7
compressChunks16384WithZstd/20/manual_time       91.4 ms         92.2 ms            7
compressChunks16384WithZstd/21/manual_time        128 ms          131 ms            4
...
```
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
