### PR TITLE
stateful session: allow empty filter config

### DIFF
--- a/api/envoy/extensions/filters/http/stateful_session/v3/stateful_session.proto
+++ b/api/envoy/extensions/filters/http/stateful_session/v3/stateful_session.proto
@@ -22,8 +22,7 @@ message StatefulSession {
   // get address of the upstream host to which the session is assigned.
   //
   // [#extension-category: envoy.http.stateful_session]
-  config.core.v3.TypedExtensionConfig session_state = 1
-      [(validate.rules).message = {required: true}];
+  config.core.v3.TypedExtensionConfig session_state = 1;
 }
 
 message StatefulSessionPerRoute {

--- a/source/extensions/filters/http/stateful_session/config.cc
+++ b/source/extensions/filters/http/stateful_session/config.cc
@@ -15,8 +15,7 @@ Http::FilterFactoryCb StatefulSessionFactoryConfig::createFilterFactoryFromProto
   auto filter_config(std::make_shared<StatefulSessionConfig>(proto_config, context));
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(
-        Http::StreamFilterSharedPtr{new StatefulSession(filter_config.get())});
+    callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new StatefulSession(filter_config)});
   };
 }
 

--- a/source/extensions/filters/http/stateful_session/stateful_session.h
+++ b/source/extensions/filters/http/stateful_session/stateful_session.h
@@ -55,7 +55,7 @@ using PerRouteStatefulSessionConfigSharedPtr = std::shared_ptr<PerRouteStatefulS
 class StatefulSession : public Http::PassThroughFilter,
                         public Logger::Loggable<Logger::Id::filter> {
 public:
-  StatefulSession(const StatefulSessionConfig* config) : config_(config) {}
+  StatefulSession(StatefulSessionConfigSharedPtr config) : config_(std::move(config)) {}
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
@@ -68,7 +68,7 @@ public:
 private:
   Http::SessionStatePtr session_state_;
 
-  const StatefulSessionConfig* config_{nullptr};
+  StatefulSessionConfigSharedPtr config_{};
 };
 
 } // namespace StatefulSession

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -40,7 +40,7 @@ stateful_session:
     typed_config: {}
 )EOF";
 
-constexpr absl::string_view EmptyRouteYaml = R"EOF(
+constexpr absl::string_view EmptyStatefulSessionRouteYaml = R"EOF(
 stateful_session: {}
 )EOF";
 
@@ -59,7 +59,8 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
   TestUtility::loadFromYamlAndValidate(std::string(RouteConfigYaml), proto_route_config);
   TestUtility::loadFromYamlAndValidate(std::string(DisableYaml), disabled_config);
   TestUtility::loadFromYamlAndValidate(std::string(NotExistYaml), not_exist_config);
-  TestUtility::loadFromYamlAndValidate(std::string(EmptyRouteYaml), empty_proto_route_config);
+  TestUtility::loadFromYamlAndValidate(std::string(EmptyStatefulSessionRouteYaml),
+                                       empty_proto_route_config);
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -40,6 +40,10 @@ stateful_session:
     typed_config: {}
 )EOF";
 
+constexpr absl::string_view EmptyRouteYaml = R"EOF(
+stateful_session: {}
+)EOF";
+
 TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
   testing::NiceMock<Http::MockSessionStateFactoryConfig> config_factory;
   Registry::InjectFactory<Http::SessionStateFactoryConfig> registration(config_factory);
@@ -48,11 +52,14 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
   PerRouteProtoConfig proto_route_config;
   PerRouteProtoConfig disabled_config;
   PerRouteProtoConfig not_exist_config;
+  ProtoConfig empty_proto_config;
+  PerRouteProtoConfig empty_proto_route_config;
 
   TestUtility::loadFromYamlAndValidate(std::string(ConfigYaml), proto_config);
   TestUtility::loadFromYamlAndValidate(std::string(RouteConfigYaml), proto_route_config);
   TestUtility::loadFromYamlAndValidate(std::string(DisableYaml), disabled_config);
   TestUtility::loadFromYamlAndValidate(std::string(NotExistYaml), not_exist_config);
+  TestUtility::loadFromYamlAndValidate(std::string(EmptyRouteYaml), empty_proto_route_config);
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
@@ -72,6 +79,10 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
                                               context.messageValidationVisitor()),
       EnvoyException,
       "Didn't find a registered implementation for name: 'envoy.http.stateful_session.not_exist'");
+
+  EXPECT_NO_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context));
+  EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
+                                                          context.messageValidationVisitor()));
 }
 
 } // namespace

--- a/test/extensions/filters/http/stateful_session/stateful_session_test.cc
+++ b/test/extensions/filters/http/stateful_session/stateful_session_test.cc
@@ -35,7 +35,7 @@ public:
 
     config_ = std::make_shared<StatefulSessionConfig>(proto_config, context_);
 
-    filter_ = std::make_shared<StatefulSession>(config_.get());
+    filter_ = std::make_shared<StatefulSession>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
 
@@ -204,6 +204,17 @@ TEST_F(StatefulSessionTest, NullSessionState) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
+}
+
+TEST(EmpytProtoConfigTest, EmpytProtoConfigTest) {
+  ProtoConfig empty_proto_config;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  StatefulSessionConfig config(empty_proto_config, server_context);
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":path", "/"}, {":method", "GET"}, {":authority", "test.com"}};
+  EXPECT_EQ(nullptr, config.createSessionState(request_headers));
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>

Commit Message: stateful session: allow empty filter config
Additional Description:

Now, empty filter config is not allowed for the stateful session filter. However, some users may like to enable stateful session in only specific routes. For example, #20658.

This PR will loosen restrictions on proto API of stateful session.

Risk Level: Low.
Testing: Unit. Added.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
