### PR TITLE
Remove QuicheMemSliceImpl(Envoy::Buffer::Instance) constructor.

### DIFF
--- a/source/common/quic/platform/quiche_mem_slice_impl.cc
+++ b/source/common/quic/platform/quiche_mem_slice_impl.cc
@@ -30,12 +30,6 @@ QuicheMemSliceImpl::QuicheMemSliceImpl(quiche::QuicheBuffer buffer) {
   ASSERT(this->length() == length);
 }
 
-QuicheMemSliceImpl::QuicheMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t length) {
-  ASSERT(firstSliceLength(buffer) == length);
-  single_slice_buffer_.move(buffer, length);
-  ASSERT(single_slice_buffer_.getRawSlices().size() == 1);
-}
-
 QuicheMemSliceImpl::QuicheMemSliceImpl(std::unique_ptr<char[]> buffer, size_t length)
     : fragment_(std::make_unique<Envoy::Buffer::BufferFragmentImpl>(
           buffer.release(), length,

--- a/source/common/quic/platform/quiche_mem_slice_impl.h
+++ b/source/common/quic/platform/quiche_mem_slice_impl.h
@@ -29,11 +29,6 @@ public:
   QuicheMemSliceImpl(quiche::QuicheBuffer buffer);
   QuicheMemSliceImpl(std::unique_ptr<char[]> buffer, size_t length);
 
-  // Constructs a QuicheMemSliceImpl from a Buffer::Instance with first |length| bytes in it.
-  // Data will be moved from |buffer| to this mem slice.
-  // Prerequisite: |buffer| has at least |length| bytes of data and not empty.
-  explicit QuicheMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t length);
-
   QuicheMemSliceImpl(const QuicheMemSliceImpl& other) = delete;
   // Move constructors. |other| will not hold a reference to the data buffer
   // after this call completes.


### PR DESCRIPTION
Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
