### PR TITLE
Add mem_slice_test and time_utils_test targets.

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -4802,17 +4802,34 @@ envoy_cc_library(
 
 envoy_cc_test_library(
     name = "quiche_common_platform_test",
-    srcs = [
-        "quiche/common/platform/api/quiche_mem_slice_test.cc",
-        "quiche/common/platform/api/quiche_time_utils_test.cc",
-    ],
     hdrs = ["quiche/common/platform/api/quiche_test.h"],
+    repository = "@envoy",
+    tags = ["nofips"],
+    deps = ["@envoy//test/common/quic/platform:quiche_test_impl_lib"],
+)
+
+envoy_cc_test(
+    name = "quiche_common_mem_slice_test",
+    srcs = ["quiche/common/platform/api/quiche_mem_slice_test.cc"],
+    copts = quiche_copts,
     repository = "@envoy",
     tags = ["nofips"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_platform",
-        "@envoy//test/common/quic/platform:quiche_test_impl_lib",
+        ":quiche_common_platform_test",
+    ],
+)
+
+envoy_cc_test(
+    name = "quiche_common_time_utils_test",
+    srcs = ["quiche/common/platform/api/quiche_time_utils_test.cc"],
+    copts = quiche_copts,
+    repository = "@envoy",
+    tags = ["nofips"],
+    deps = [
+        ":quiche_common_platform",
+        ":quiche_common_platform_test",
     ],
 )
 


### PR DESCRIPTION
Add quiche_common_mem_slice_test and quiche_common_time_utils_test build
targets of envoy_cc_test kind.  Previously quiche_mem_slice_test.cc and
quiche_time_utils_test.cc were part of quiche_common_platform_test,
which is a envoy_cc_test_library (as opposed to a envoy_cc_test),
therefore these tests were not actually ran.

I verified that no other envoy_cc_test_library rules in this
build file have source files matching ".*_test.cc" using the following
command:

  bazel query 'attr("srcs", "_test.cc", \
      attr(generator_function, envoy_cc_test_library, \
      @com_github_google_quiche//...))'

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add mem_slice_test and time_utils_test targets.
Additional Description:
Risk Level: low (test-only)
Testing: n/a (test-only)
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
