### PR TITLE
fuzz test: Fix fuzzer tracking of allocs.

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5605149941301248
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-5605149941301248
@@ -1,0 +1,1 @@
+actions {   reserve_commit {     reserve_length: 51201     commit_length: 65535   } } actions {   read: 7 } 

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -315,8 +315,9 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
       for (uint32_t i = 0; i < reservation.numSlices(); ++i) {
         ::memset(reservation.slices()[i].mem_, insert_value, reservation.slices()[i].len_);
       }
-      const uint32_t target_length =
-          std::min<uint32_t>(reservation.length(), action.reserve_commit().commit_length());
+      const uint32_t target_length = clampSize(
+          std::min<uint32_t>(reservation.length(), action.reserve_commit().commit_length()),
+          reserve_length);
       reservation.commit(target_length);
     }
     break;


### PR DESCRIPTION
Commit Message: fuzz test: Fix fuzzer tracking of allocs.
Additional Description:
Fix tracking the reserved size for the (fuzzer's shadow) StringBuffer
when reserveCommitting a slice larger than 16kB.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
