### PR TITLE
Minor improvements to QuicheMemSliceImpl.

### DIFF
--- a/source/common/quic/platform/quiche_mem_slice_impl.cc
+++ b/source/common/quic/platform/quiche_mem_slice_impl.cc
@@ -12,13 +12,19 @@
 
 namespace quiche {
 
+namespace {
+
+size_t firstSliceLength(const Envoy::Buffer::Instance& buffer) { return buffer.frontSlice().len_; }
+
+} // namespace
+
 QuicheMemSliceImpl::QuicheMemSliceImpl(quiche::QuicheBuffer buffer) {
   size_t length = buffer.size();
   quiche::QuicheUniqueBufferPtr buffer_ptr = buffer.Release();
   fragment_ = std::make_unique<Envoy::Buffer::BufferFragmentImpl>(
       buffer_ptr.get(), length,
       // TODO(danzh) change the buffer fragment constructor to take the lambda by move instead
-      // of copy, so that the ownership of |buffer| can be transferred to lambda via capture
+      // of copy, so that the ownership of `buffer` can be transferred to lambda via capture
       // here and below to unify and simplify the constructor implementations.
       [allocator = buffer_ptr.get_deleter().allocator()](const void* p, size_t,
                                                          const Envoy::Buffer::BufferFragmentImpl*) {
@@ -53,10 +59,6 @@ QuicheMemSliceImpl::~QuicheMemSliceImpl() {
 
 const char* QuicheMemSliceImpl::data() const {
   return reinterpret_cast<const char*>(single_slice_buffer_.frontSlice().mem_);
-}
-
-size_t QuicheMemSliceImpl::firstSliceLength(Envoy::Buffer::Instance& buffer) {
-  return buffer.frontSlice().len_;
 }
 
 } // namespace quiche

--- a/source/common/quic/platform/quiche_mem_slice_impl.h
+++ b/source/common/quic/platform/quiche_mem_slice_impl.h
@@ -25,17 +25,19 @@ public:
 
   ~QuicheMemSliceImpl();
 
-  // Constructs a QuicheMemSliceImpl by taking ownership of the memory in |buffer|.
+  // Constructs a QuicheMemSliceImpl by taking ownership of the memory in `buffer`.
   QuicheMemSliceImpl(quiche::QuicheBuffer buffer);
   QuicheMemSliceImpl(std::unique_ptr<char[]> buffer, size_t length);
 
-  // Constructs a QuicheMemSliceImpl from a Buffer::Instance with first |length| bytes in it.
-  // Data will be moved from |buffer| to this mem slice.
-  // Prerequisite: |buffer| has at least |length| bytes of data and not empty.
+  // Prerequisite: `buffer` must be non-empty, and its first slice must have
+  // length `length`.
+  // Constructs a QuicheMemSliceImpl, copies `length` bytes into it from
+  // `buffer`, and drains `length` bytes of `buffer`, effectively consuming its
+  // first slice.
   explicit QuicheMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t length);
 
   QuicheMemSliceImpl(const QuicheMemSliceImpl& other) = delete;
-  // Move constructors. |other| will not hold a reference to the data buffer
+  // Move constructors. `other` will not hold a reference to the data buffer
   // after this call completes.
   QuicheMemSliceImpl(QuicheMemSliceImpl&& other) noexcept { *this = std::move(other); }
 
@@ -65,12 +67,13 @@ public:
   size_t length() const { return single_slice_buffer_.length(); }
   bool empty() const { return length() == 0; }
 
-  Envoy::Buffer::OwnedImpl& getSingleSliceBuffer() { return single_slice_buffer_; }
-
 private:
-  size_t firstSliceLength(Envoy::Buffer::Instance& buffer);
-
+  // Owns data of this buffer if `single_slice_buffer_` has a slice that does
+  // not own data. `nullptr` otherwise.
   std::unique_ptr<Envoy::Buffer::BufferFragmentImpl> fragment_;
+
+  // A buffer that holds zero or one slice.
+  // The slice might or might not own its data.
   Envoy::Buffer::OwnedImpl single_slice_buffer_;
 };
 


### PR DESCRIPTION
Remove unused getSingleSliceBuffer().

Move firstSliceLength() private method (which should have been static)
to anonymous namespace, make its argument const.

Fix comment for QuicheMemSliceImpl(Envoy::Buffer::Instance&)
constructor: data is not "moved" but copied and consumed, and first
slice must have `length`.

Add comment for private members.

Backtick-quote symbols in comments in accordance with latest
trends.

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Minor improvements to QuicheMemSliceImpl.
Additional Description:
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
