### PR TITLE
tools: allow overriding the bazel target to use in tools/gen_compilation_database.py

### DIFF
--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -17,12 +17,12 @@ def generate_compilation_database(args):
         "--remote_download_outputs=all",
     ]
 
-    subprocess.check_call(["bazel", "build"] + bazel_options + [
+    subprocess.check_call([args.bazel, "build"] + bazel_options + [
         "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
         "--output_groups=compdb_files,header_files"
     ] + args.bazel_targets)
 
-    execroot = subprocess.check_output(["bazel", "info", "execution_root"]
+    execroot = subprocess.check_output([bazel.args, "info", "execution_root"]
                                        + bazel_options).decode().strip()
 
     db_entries = []
@@ -111,6 +111,7 @@ if __name__ == "__main__":
     parser.add_argument('--include_headers', action='store_true')
     parser.add_argument('--vscode', action='store_true')
     parser.add_argument('--include_all', action='store_true')
+    parser.add_argument('--bazel', default='bazel')
     parser.add_argument(
         'bazel_targets',
         nargs='*',

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -22,7 +22,7 @@ def generate_compilation_database(args):
         "--output_groups=compdb_files,header_files"
     ] + args.bazel_targets)
 
-    execroot = subprocess.check_output([bazel.args, "info", "execution_root"]
+    execroot = subprocess.check_output([args.bazel, "info", "execution_root"]
                                        + bazel_options).decode().strip()
 
     db_entries = []


### PR DESCRIPTION
Commit Message: tools: allow overriding the bazel target to use in tools/gen_compilation_database.py
Additional Description: This allows submodules that consume Envoy to override the bazel binary to use, e.g. Envoy Mobile's bazelw wrapper.
Risk Level: Low, tools only
Testing: Manual testing
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
