### PR TITLE
access_logs: propagate UPSTREAM_TRANSPORT_FAILURE_REASON

### DIFF
--- a/envoy/tcp/upstream.h
+++ b/envoy/tcp/upstream.h
@@ -82,6 +82,7 @@ public:
    *             if no host was involved in the failure (for example overflow).
    */
   virtual void onGenericPoolFailure(ConnectionPool::PoolFailureReason reason,
+                                    absl::string_view failure_reason,
                                     Upstream::HostDescriptionConstSharedPtr host) PURE;
 };
 

--- a/envoy/tcp/upstream.h
+++ b/envoy/tcp/upstream.h
@@ -78,6 +78,8 @@ public:
    * Called to indicate a failure for GenericConnPool::newStream to establish a stream.
    *
    * @param reason supplies the failure reason.
+   * @param failure_reason failure reason string (Note: it is expected that the caller will provide
+   * matching `reason` and `failure_reason`).
    * @param host supplies the description of the host that caused the failure. This may be nullptr
    *             if no host was involved in the failure (for example overflow).
    */

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1440,6 +1440,9 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                                                    .get()
                                                    .upstreamTransportFailureReason();
                                     }
+                                    if (result) {
+                                      std::replace(result->begin(), result->end(), ' ', '_');
+                                    }
                                     return result;
                                   });
                             }}},

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -406,6 +406,8 @@ void UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason reason,
     reset_reason = Http::StreamResetReason::ConnectionFailure;
   }
 
+  stream_info_.upstreamInfo()->setUpstreamTransportFailureReason(transport_failure_reason);
+
   // Mimic an upstream reset.
   onUpstreamHostSelected(host);
   onResetStream(reset_reason, transport_failure_reason);

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -317,7 +317,6 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
   awaiting_headers_ = false;
   if (!calling_encode_headers_) {
     stream_info_.setResponseFlag(Filter::streamResetReasonToResponseFlag(reason));
-    stream_info_.upstreamInfo()->setUpstreamTransportFailureReason(transport_failure_reason);
     parent_.onUpstreamReset(reason, transport_failure_reason, *this);
   } else {
     deferred_reset_reason_ = reason;
@@ -406,6 +405,8 @@ void UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason reason,
   case ConnectionPool::PoolFailureReason::Timeout:
     reset_reason = Http::StreamResetReason::ConnectionFailure;
   }
+
+  stream_info_.upstreamInfo()->setUpstreamTransportFailureReason(transport_failure_reason);
 
   // Mimic an upstream reset.
   onUpstreamHostSelected(host);

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -317,6 +317,7 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
   awaiting_headers_ = false;
   if (!calling_encode_headers_) {
     stream_info_.setResponseFlag(Filter::streamResetReasonToResponseFlag(reason));
+    stream_info_.upstreamInfo()->setUpstreamTransportFailureReason(transport_failure_reason);
     parent_.onUpstreamReset(reason, transport_failure_reason, *this);
   } else {
     deferred_reset_reason_ = reason;
@@ -405,8 +406,6 @@ void UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason reason,
   case ConnectionPool::PoolFailureReason::Timeout:
     reset_reason = Http::StreamResetReason::ConnectionFailure;
   }
-
-  stream_info_.upstreamInfo()->setUpstreamTransportFailureReason(transport_failure_reason);
 
   // Mimic an upstream reset.
   onUpstreamHostSelected(host);

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -480,10 +480,12 @@ bool Filter::maybeTunnel(Upstream::ThreadLocalCluster& cluster) {
 }
 
 void Filter::onGenericPoolFailure(ConnectionPool::PoolFailureReason reason,
+                                  absl::string_view failure_reason,
                                   Upstream::HostDescriptionConstSharedPtr host) {
   generic_conn_pool_.reset();
   read_callbacks_->upstreamHost(host);
   getStreamInfo().upstreamInfo()->setUpstreamHost(host);
+  getStreamInfo().upstreamInfo()->setUpstreamTransportFailureReason(failure_reason);
 
   switch (reason) {
   case ConnectionPool::PoolFailureReason::Overflow:

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -343,6 +343,7 @@ public:
                           const Network::Address::InstanceConstSharedPtr& local_address,
                           Ssl::ConnectionInfoConstSharedPtr ssl_info) override;
   void onGenericPoolFailure(ConnectionPool::PoolFailureReason reason,
+                            absl::string_view failure_reason,
                             Upstream::HostDescriptionConstSharedPtr host) override;
 
   // Upstream::LoadBalancerContext

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -173,10 +173,11 @@ void TcpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
   }
 }
 
-void TcpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason, absl::string_view,
+void TcpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                                absl::string_view failure_reason,
                                 Upstream::HostDescriptionConstSharedPtr host) {
   upstream_handle_ = nullptr;
-  callbacks_->onGenericPoolFailure(reason, host);
+  callbacks_->onGenericPoolFailure(reason, failure_reason, host);
 }
 
 void TcpConnPool::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
@@ -233,10 +234,11 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
   }
 }
 
-void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason, absl::string_view,
+void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                                 absl::string_view failure_reason,
                                  Upstream::HostDescriptionConstSharedPtr host) {
   upstream_handle_ = nullptr;
-  callbacks_->onGenericPoolFailure(reason, host);
+  callbacks_->onGenericPoolFailure(reason, failure_reason, host);
 }
 
 void HttpConnPool::onPoolReady(Http::RequestEncoder& request_encoder,

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -77,7 +77,7 @@ public:
     virtual void onFailure() {
       ASSERT(conn_pool_ != nullptr);
       conn_pool_->callbacks_->onGenericPoolFailure(
-          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, host_);
+          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "",  host_);
     }
 
   protected:

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -77,8 +77,7 @@ public:
     virtual void onFailure() {
       ASSERT(conn_pool_ != nullptr);
       conn_pool_->callbacks_->onGenericPoolFailure(
-          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "remote_connection_failure",
-          host_);
+          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "", host_);
     }
 
   protected:

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -77,7 +77,8 @@ public:
     virtual void onFailure() {
       ASSERT(conn_pool_ != nullptr);
       conn_pool_->callbacks_->onGenericPoolFailure(
-          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "", host_);
+          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "remote_connection_failure",
+          host_);
     }
 
   protected:

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -77,7 +77,7 @@ public:
     virtual void onFailure() {
       ASSERT(conn_pool_ != nullptr);
       conn_pool_->callbacks_->onGenericPoolFailure(
-          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "",  host_);
+          ConnectionPool::PoolFailureReason::RemoteConnectionFailure, "", host_);
     }
 
   protected:

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -810,11 +810,11 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string upstream_transport_failure_reason = "SSL error";
     stream_info.upstreamInfo()->setUpstreamTransportFailureReason(
         upstream_transport_failure_reason);
-    EXPECT_EQ("SSL error", upstream_format.format(request_headers, response_headers,
+    EXPECT_EQ("SSL_error", upstream_format.format(request_headers, response_headers,
                                                   response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
                                             stream_info, body),
-                ProtoEq(ValueUtil::stringValue("SSL error")));
+                ProtoEq(ValueUtil::stringValue("SSL_error")));
   }
   {
     StreamInfoFormatter upstream_format("UPSTREAM_TRANSPORT_FAILURE_REASON");

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1322,7 +1322,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailureStreamInfoAccessLog) {
                                   "test_transport_failure");
 
   EXPECT_EQ(filter_->getStreamInfo().upstreamInfo()->upstreamTransportFailureReason(),
-            "test_failure");
+            "test_transport_failure");
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "test_transport_failure");

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1312,6 +1312,22 @@ TEST_F(TcpProxyTest, OdcdsClusterMissingCauseConnectionClose) {
   std::invoke(*cluster_discovery_callback, Upstream::ClusterDiscoveryStatus::Missing);
 }
 
+// Test that upstream transport failure message is reflected in access logs.
+TEST_F(TcpProxyTest, UpstreamConnectFailureStreamInfoAccessLog) {
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
+
+  setup(1, accessLogConfig("%UPSTREAM_TRANSPORT_FAILURE_REASON%"));
+
+  raiseEventUpstreamConnectFailed(0, ConnectionPool::PoolFailureReason::LocalConnectionFailure,
+                                  "test_transport_failure");
+
+  EXPECT_EQ(filter_->getStreamInfo().upstreamInfo()->upstreamTransportFailureReason(),
+            "test_failure");
+
+  filter_.reset();
+  EXPECT_EQ(access_log_data_, "test_transport_failure");
+}
+
 } // namespace
 } // namespace TcpProxy
 } // namespace Envoy

--- a/test/common/tcp_proxy/tcp_proxy_test_base.h
+++ b/test/common/tcp_proxy/tcp_proxy_test_base.h
@@ -133,9 +133,12 @@ public:
                       upstream_hosts_.at(conn_index));
   }
 
-  void raiseEventUpstreamConnectFailed(uint32_t conn_index,
-                                       ConnectionPool::PoolFailureReason reason) {
-    conn_pool_callbacks_.at(conn_index)->onPoolFailure(reason, "", upstream_hosts_.at(conn_index));
+  void raiseEventUpstreamConnectFailed(
+      uint32_t conn_index, ConnectionPool::PoolFailureReason reason,
+      absl::optional<absl::string_view> failure_message = absl::nullopt) {
+    conn_pool_callbacks_.at(conn_index)
+        ->onPoolFailure(reason, failure_message ? *failure_message : "",
+                        upstream_hosts_.at(conn_index));
   }
 
   Tcp::ConnectionPool::Cancellable* onNewConnection(Tcp::ConnectionPool::Cancellable* connection) {

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -576,7 +576,10 @@ TEST_P(TcpProxyIntegrationTest, AccessLogUpstreamConnectFailure) {
   test_server_.reset();
   auto log_result = waitForAccessLog(access_log_path);
 
-  EXPECT_THAT(log_result, testing::StartsWith("delayed connect error:"));
+  std::string expected_transport_failure = "delayed connect error:";
+  std::replace(expected_transport_failure.begin(), expected_transport_failure.end(), ' ', '_');
+
+  EXPECT_THAT(log_result, testing::StartsWith(expected_transport_failure));
 }
 
 // Make sure no bytes are logged when no data is sent.

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -567,13 +567,10 @@ TEST_P(TcpProxyIntegrationTest, AccessLogUpstreamConnectFailure) {
   initialize();
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
-  ASSERT_TRUE(tcp_client->write("test", false));
 
   tcp_client->waitForDisconnect();
-  FakeRawConnectionPtr fake_upstream_connection;
 
   // Guarantee client is done writing to the log.
-  test_server_.reset();
   auto log_result = waitForAccessLog(access_log_path);
 
   EXPECT_THAT(log_result, testing::StartsWith("delayed_connect_error:"));

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -527,6 +527,58 @@ TEST_P(TcpProxyIntegrationTest, AccessLogBytesMeter) {
                                        ip_port_regex, ip_regex)));
 }
 
+// Verifies that access log value for `UPSTREAM_TRANSPORT_FAILURE_REASON` matches the failure
+// message when there is an upstream transport failure.
+TEST_P(TcpProxyIntegrationTest, AccessLogUpstreamConnectFailure) {
+  std::string access_log_path = TestEnvironment::temporaryPath(
+      fmt::format("access_log{}{}.txt", version_ == Network::Address::IpVersion::v4 ? "v4" : "v6",
+                  TestUtility::uniqueFilename()));
+  useListenerAccessLog();
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+    auto* filter_chain = listener->mutable_filter_chains(0);
+    auto* config_blob = filter_chain->mutable_filters(0)->mutable_typed_config();
+
+    ASSERT_TRUE(config_blob->Is<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>());
+    auto tcp_proxy_config =
+        MessageUtil::anyConvert<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+            *config_blob);
+
+    auto* access_log = tcp_proxy_config.add_access_log();
+    access_log->set_name("accesslog");
+    envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
+    access_log_config.set_path(access_log_path);
+    access_log_config.mutable_log_format()->mutable_text_format_source()->set_inline_string(
+        "%UPSTREAM_TRANSPORT_FAILURE_REASON%");
+    access_log->mutable_typed_config()->PackFrom(access_log_config);
+    config_blob->PackFrom(tcp_proxy_config);
+  });
+
+  // Ensure we dont get an upstream connection.
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+    auto* lb_endpoint =
+        cluster->mutable_load_assignment()->mutable_endpoints(0)->mutable_lb_endpoints(0);
+    lb_endpoint->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_port_value(1);
+  });
+
+  config_helper_.skipPortUsageValidation();
+  enableHalfClose(false);
+  initialize();
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
+  ASSERT_TRUE(tcp_client->write("test", false));
+
+  tcp_client->waitForDisconnect();
+  FakeRawConnectionPtr fake_upstream_connection;
+
+  // Guarantee client is done writing to the log.
+  test_server_.reset();
+  auto log_result = waitForAccessLog(access_log_path);
+
+  EXPECT_THAT(log_result, testing::StartsWith("delayed connect error:"));
+}
+
 // Make sure no bytes are logged when no data is sent.
 TEST_P(TcpProxyIntegrationTest, TcpProxyNoDataBytesMeter) {
   setupByteMeterAccessLog();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -554,7 +554,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLogUpstreamConnectFailure) {
     config_blob->PackFrom(tcp_proxy_config);
   });
 
-  // Ensure we dont get an upstream connection.
+  // Ensure we don't get an upstream connection.
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
     auto* lb_endpoint =

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -576,10 +576,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLogUpstreamConnectFailure) {
   test_server_.reset();
   auto log_result = waitForAccessLog(access_log_path);
 
-  std::string expected_transport_failure = "delayed connect error:";
-  std::replace(expected_transport_failure.begin(), expected_transport_failure.end(), ' ', '_');
-
-  EXPECT_THAT(log_result, testing::StartsWith(expected_transport_failure));
+  EXPECT_THAT(log_result, testing::StartsWith("delayed_connect_error:"));
 }
 
 // Make sure no bytes are logged when no data is sent.


### PR DESCRIPTION
Description:
 Currently the access log tag `UPSTREAM_TRANSPORT_FAILURE_REASON` does not work as intended. The
 failure string is not propagated all the way to the logs. This change fixes the issue.

Risk Level: Low
Testing: Unit tests, manual tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None