### PR TITLE
get factories by type for filters route config

### DIFF
--- a/envoy/config/typed_config.h
+++ b/envoy/config/typed_config.h
@@ -32,6 +32,12 @@ public:
    * @return configuration proto full name, or empty for untyped factories.
    */
   virtual std::string configType() { return ""; }
+
+  /**
+   * @return All full names of configuration protos used by the factories except the name
+   * returned by configType().
+   */
+  virtual std::set<std::string> otherTypes() { return {}; }
 };
 
 /**

--- a/envoy/registry/registry.h
+++ b/envoy/registry/registry.h
@@ -334,22 +334,26 @@ private:
         continue;
       }
 
-      // Skip untyped factories.
-      std::string config_type = factory->configType();
-      if (config_type.empty()) {
-        continue;
-      }
+      std::set<std::string> config_types = factory->otherTypes();
+      config_types.insert(factory->configType());
 
-      // Register config types in the mapping.
-      auto it = mapping->find(config_type);
-      if (it != mapping->end() && it->second != factory) {
-        // Mark double-registered types with a nullptr.
-        // See issue https://github.com/envoyproxy/envoy/issues/9643.
-        ENVOY_LOG(warn, "Double registration for type: '{}' by '{}' and '{}'", config_type,
-                  factory->name(), it->second ? it->second->name() : "");
-        it->second = nullptr;
-      } else {
-        mapping->emplace(std::make_pair(config_type, factory));
+      for (const std::string& config_type : config_types) {
+        // Skip untyped factories.
+        if (config_type.empty()) {
+          continue;
+        }
+
+        // Register config types in the mapping.
+        auto it = mapping->find(config_type);
+        if (it != mapping->end() && it->second != factory) {
+          // Mark double-registered types with a nullptr.
+          // See issue https://github.com/envoyproxy/envoy/issues/9643.
+          ENVOY_LOG(warn, "Double registration for type: '{}' by '{}' and '{}'", config_type,
+                    factory->name(), it->second ? it->second->name() : "");
+          it->second = nullptr;
+        } else {
+          mapping->emplace(std::make_pair(config_type, factory));
+        }
       }
     }
 

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -231,6 +231,18 @@ public:
     return std::make_unique<
         envoy::extensions::filters::common::dependency::v3::MatchingRequirements>();
   }
+
+  std::set<std::string> otherTypes() override {
+    auto route_message = createEmptyRouteConfigProto();
+    if (route_message == nullptr) {
+      return {};
+    }
+    const std::string route_type_url = route_message->GetDescriptor()->full_name();
+    if (route_type_url == configType()) {
+      return {};
+    }
+    return {route_type_url};
+  }
 };
 
 } // namespace Configuration

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -8499,13 +8499,14 @@ virtual_hosts:
       - match: { prefix: "/" }
         route: { cluster: baz }
     typed_per_filter_config:
-      unknown.filter:
-        "@type": type.googleapis.com/google.protobuf.Timestamp
+      filter.unknown:
+        "@type": type.googleapis.com/google.protobuf.BoolValue
 )EOF";
 
   EXPECT_THROW_WITH_MESSAGE(
       TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      "Didn't find a registered implementation for name: 'unknown.filter'");
+      "Didn't find a registered implementation for 'filter.unknown' with type URL: "
+      "'google.protobuf.BoolValue'");
 }
 
 TEST_F(PerFilterConfigsTest, DefaultFilterImplementationAnyWithCheckPerVirtualHost) {
@@ -8600,14 +8601,13 @@ virtual_hosts:
         route: { cluster: baz }
     typed_per_filter_config:
       filter.unknown:
-        "@type": type.googleapis.com/google.protobuf.Struct
-        value:
-          seconds: 123
+        "@type": type.googleapis.com/google.protobuf.BoolValue
 )EOF";
 
   EXPECT_THROW_WITH_MESSAGE(
-      TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
-      EnvoyException, "Didn't find a registered implementation for name: 'filter.unknown'");
+      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
+      "Didn't find a registered implementation for 'filter.unknown' with type URL: "
+      "'google.protobuf.BoolValue'");
 }
 
 TEST_F(PerFilterConfigsTest, PerVirtualHostWithOptionalUnknownFilter) {
@@ -8620,9 +8620,7 @@ virtual_hosts:
         route: { cluster: baz }
     typed_per_filter_config:
       filter.unknown:
-        "@type": type.googleapis.com/google.protobuf.Struct
-        value:
-          seconds: 123
+        "@type": type.googleapis.com/google.protobuf.BoolValue
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
@@ -8641,14 +8639,13 @@ virtual_hosts:
         route: { cluster: baz }
         typed_per_filter_config:
           filter.unknown:
-            "@type": type.googleapis.com/google.protobuf.Struct
-            value:
-              seconds: 123
+            "@type": type.googleapis.com/google.protobuf.BoolValue
 )EOF";
 
   EXPECT_THROW_WITH_MESSAGE(
-      TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
-      EnvoyException, "Didn't find a registered implementation for name: 'filter.unknown'");
+      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
+      "Didn't find a registered implementation for 'filter.unknown' with type URL: "
+      "'google.protobuf.BoolValue'");
 }
 
 TEST_F(PerFilterConfigsTest, PerRouteWithOptionalUnknownFilter) {
@@ -8661,9 +8658,7 @@ virtual_hosts:
         route: { cluster: baz }
         typed_per_filter_config:
           filter.unknown:
-            "@type": type.googleapis.com/google.protobuf.Struct
-            value:
-              seconds: 123
+            "@type": type.googleapis.com/google.protobuf.BoolValue
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
@@ -8687,7 +8682,7 @@ virtual_hosts:
               seconds: 123
     typed_per_filter_config:
       test.filter:
-        "@type": type.googleapis.com/google.protobuf.Struct
+        "@type": type.googleapis.com/google.protobuf.Timestamp
         value:
           seconds: 456
 )EOF";
@@ -8713,7 +8708,7 @@ virtual_hosts:
               seconds: 123
     typed_per_filter_config:
       test.filter:
-        "@type": type.googleapis.com/google.protobuf.Struct
+        "@type": type.googleapis.com/google.protobuf.Timestamp
         value:
           seconds: 456
 )EOF";

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -171,7 +171,9 @@ http_filters:
       RouteConfigProviderUtil::create(parseHttpConnectionManagerFromYaml(config_yaml),
                                       server_factory_context_, validation_visitor_,
                                       outer_init_manager_, "foo.", *route_config_provider_manager_),
-      EnvoyException, "Didn't find a registered implementation for name: 'filter.unknown'");
+      EnvoyException,
+      "Didn't find a registered implementation for 'filter.unknown' with type URL: "
+      "'google.protobuf.Struct'");
 }
 
 TEST_F(RdsImplTest, RdsAndStaticWithOptionalUnknownFilterPerVirtualHostConfig) {
@@ -346,7 +348,9 @@ TEST_F(RdsImplTest, UnknownFacotryForPerVirtualHostTypedConfig) {
   EXPECT_CALL(init_watcher_, ready());
   EXPECT_THROW_WITH_MESSAGE(
       rds_callbacks_->onConfigUpdate(decoded_resources.refvec_, response1.version_info()),
-      EnvoyException, "Didn't find a registered implementation for name: 'filter.unknown'");
+      EnvoyException,
+      "Didn't find a registered implementation for 'filter.unknown' with type URL: "
+      "'google.protobuf.Struct'");
 }
 
 // validate the optional unknown factory will be ignored for per virtualhost typed config.
@@ -461,7 +465,9 @@ TEST_F(RdsImplTest, UnknownFacotryForPerRouteTypedConfig) {
   EXPECT_CALL(init_watcher_, ready());
   EXPECT_THROW_WITH_MESSAGE(
       rds_callbacks_->onConfigUpdate(decoded_resources.refvec_, response1.version_info()),
-      EnvoyException, "Didn't find a registered implementation for name: 'filter.unknown'");
+      EnvoyException,
+      "Didn't find a registered implementation for 'filter.unknown' with type URL: "
+      "'google.protobuf.Struct'");
 }
 
 // validate the optional unknown factory will be ignored for per route typed config.

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -511,7 +511,8 @@ key:
 )EOF";
 
   EXPECT_THROW_WITH_MESSAGE(pushRdsConfig({"foo_routes"}, "111", route_config_tmpl), EnvoyException,
-                            "Didn't find a registered implementation for name: 'filter.unknown'");
+                            "Didn't find a registered implementation for 'filter.unknown' with "
+                            "type URL: 'google.protobuf.Struct'");
 }
 
 // Test ignoring the optional unknown factory in the per-virtualhost typed config.


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>

Commit Message: get factories by type for filters route config
Additional Description:

Now, most of extensions/filters factories are searched by the proto configuration full names. Only the route config of http filters will get http filter factories by the filter name. 
This PR try to get http filter factories by types when we initializing http filter route configs.

(By this way, the keys of `typed_per_filter_config` are needn't to be http filter name. 

Risk Level: Mid.
Testing: Waiting.
Docs Changes: Waiting.
Release Notes: Waiting.
Platform Specific Features: N/A.