### PR TITLE
fuzz test: Force server_fuzz_test to end event loop.

### DIFF
--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -140,6 +140,10 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v3::Bootstrap& input) {
     ENVOY_LOG_MISC(debug, "Controlled EnvoyException exit: {}", ex.what());
     return;
   }
+  // Ensure the event loop gets at least one event to end the test.
+  auto end_timer =
+      server->dispatcher().createTimer([]() { ENVOY_LOG_MISC(trace, "server timer fired"); });
+  end_timer->enableTimer(std::chrono::milliseconds(5000));
   // If we were successful, run any pending events on the main thread's dispatcher loop. These might
   // be, for example, pending DNS resolution callbacks. If they generate exceptions, we want to
   // explode and fail the test, hence we do this outside of the try-catch above.


### PR DESCRIPTION
Commit Message: fuzz test: Force server_fuzz_test to end event loop.
Additional Description:
When a fuzz input does not produce any events in the main event loop,
server_fuzz_test will run forever. Enforce an event (closing event loop)
after 5 seconds.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
