### PR TITLE
fuzz test: Limit the size of json input.

### DIFF
--- a/test/common/json/json_fuzz_test.cc
+++ b/test/common/json/json_fuzz_test.cc
@@ -12,6 +12,11 @@ namespace Fuzz {
 // We fuzz nlohmann/JSON and protobuf and compare their results, since RapidJSON is deprecated and
 // has known limitations. See https://github.com/envoyproxy/envoy/issues/4705.
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
+  // protect against overly large JSON files
+  if (len > 64 * 1024) {
+    return;
+  }
+
   std::string json_string{reinterpret_cast<const char*>(buf), len};
 
   // Load via Protobuf JSON parsing, if we can.

--- a/test/common/json/json_fuzz_test.cc
+++ b/test/common/json/json_fuzz_test.cc
@@ -8,12 +8,15 @@
 namespace Envoy {
 namespace Fuzz {
 
+static const size_t MaxInputSize = 64 * 1024;
+
 // We have multiple third party JSON parsers in Envoy, nlohmann/JSON, RapidJSON and Protobuf.
 // We fuzz nlohmann/JSON and protobuf and compare their results, since RapidJSON is deprecated and
 // has known limitations. See https://github.com/envoyproxy/envoy/issues/4705.
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   // protect against overly large JSON files
-  if (len > 64 * 1024) {
+  if (len > kMaxInputSize) {
+    ENVOY_LOG_MISC(debug, "Buffer length is over {}KiB, skipping test.", MaxInputSize / 1024);
     return;
   }
 

--- a/test/common/json/json_fuzz_test.cc
+++ b/test/common/json/json_fuzz_test.cc
@@ -15,7 +15,7 @@ static const size_t MaxInputSize = 64 * 1024;
 // has known limitations. See https://github.com/envoyproxy/envoy/issues/4705.
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   // protect against overly large JSON files
-  if (len > kMaxInputSize) {
+  if (len > MaxInputSize) {
     ENVOY_LOG_MISC(debug, "Buffer length is over {}KiB, skipping test.", MaxInputSize / 1024);
     return;
   }


### PR DESCRIPTION
Commit Message: fuzz test: Limit the size of json input.
Additional Description:
There is no added benefit in allowing the fuzzer to generate arbitrary
big json input for the configuration.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
