### PR TITLE
test: Fix clang-tidy and pre for upgrade of absl and protobuf

### DIFF
--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -284,7 +284,7 @@ void FilterChainManagerImpl::addFilterChains(
       std::vector<std::string> server_names;
       // Reject partial wildcards, we don't match on them.
       for (const auto& server_name : filter_chain_match.server_names()) {
-        if (server_name.find('*') != std::string::npos && !isWildcardServerName(server_name)) {
+        if (absl::StrContains(server_name, '*') && !isWildcardServerName(server_name)) {
           throw EnvoyException(
               fmt::format("error adding listener '{}': partial wildcards are not supported in "
                           "\"server_names\"",

--- a/test/test_common/status_utility_test.cc
+++ b/test/test_common/status_utility_test.cc
@@ -134,7 +134,7 @@ TEST(StatusUtilityTest, IsOkAndHoldsFailureByCode) {
   ::testing::StringMatchResultListener listener;
   ::testing::ExplainMatchResult(
       IsOkAndHolds(5), absl::StatusOr<int>{absl::FailedPreconditionError("oh no")}, &listener);
-  EXPECT_EQ("which has unexpected status: FAILED_PRECONDITION: oh no", listener.str());
+  EXPECT_THAT(listener.str(), HasSubstr("which has unexpected status: FAILED_PRECONDITION: oh no"));
 }
 
 } // namespace StatusHelpers

--- a/test/tools/router_check/coverage.cc
+++ b/test/tools/router_check/coverage.cc
@@ -99,8 +99,10 @@ void Coverage::printMissingTests(const std::set<std::string>& all_route_names,
   for (const auto& host : route_config_.virtual_hosts()) {
     for (const auto& route : host.routes()) {
       if (missing_route_names.find(route.name()) != missing_route_names.end()) {
-        std::cout << "Missing test for host: " << host.name()
-                  << ", route: " << route.match().DebugString() << std::endl;
+        std::string route_text;
+        Protobuf::TextFormat::PrintToString(route.match(), &route_text);
+        std::cout << "Missing test for host: " << host.name() << ", route: " << route_text
+                  << std::endl;
       }
     }
   }


### PR DESCRIPTION
Additional Description:
Small clean-ups for clang-tidy complaints and prep for upgrade of absl and protobuf

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>

