### PR TITLE
alpn: latching h2 streams (off by default)

### DIFF
--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -265,6 +265,8 @@ public:
 
   /**
    * Returns the default SNI for transport sockets created by this factory.
+   * This will return an empty string view if the transport sockets created are
+   * not client-side TLS sockets.
    */
   virtual absl::string_view defaultServerNameIndication() const PURE;
 

--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -264,6 +264,11 @@ public:
   virtual bool supportsAlpn() const { return false; }
 
   /**
+   * Returns the default SNI for transport sockets created by this factory.
+   */
+  virtual absl::string_view defaultServerNameIndication() const PURE;
+
+  /**
    * @param key supplies a vector of bytes to which the option should append hash key data that will
    *        be used to separate connections based on the option. Any data already in the key vector
    *        must not be modified.

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -143,6 +143,7 @@ envoy_cc_library(
     hdrs = ["mixed_conn_pool.h"],
     deps = [
         ":conn_pool_base_lib",
+        ":http_server_properties_cache",
         "//source/common/http/http1:conn_pool_lib",
         "//source/common/http/http2:conn_pool_lib",
         "//source/common/tcp:conn_pool_lib",

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -23,10 +23,7 @@ std::string getSni(const Network::TransportSocketOptionsConstSharedPtr& options,
   if (options && options->serverNameOverride().has_value()) {
     return options->serverNameOverride().value();
   }
-  auto* quic_socket_factory =
-      dynamic_cast<Quic::QuicClientTransportSocketFactory*>(&transport_socket_factory);
-  ASSERT(quic_socket_factory != nullptr);
-  return quic_socket_factory->clientContextConfig().serverNameIndication();
+  return std::string(transport_socket_factory.defaultServerNameIndication());
 }
 
 } // namespace
@@ -268,7 +265,8 @@ absl::optional<ConnectivityGrid::PoolIterator> ConnectivityGrid::createNextPool(
         makeOptRefFromPtr<Http3::PoolConnectResultCallback>(this), quic_info_);
   } else {
     pool = std::make_unique<HttpConnPoolImplMixed>(dispatcher_, random_generator_, host_, priority_,
-                                                   options_, transport_socket_options_, state_);
+                                                   options_, transport_socket_options_, state_,
+                                                   origin_, alternate_protocols_);
   }
 
   setupPool(*pool);

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -15,6 +15,13 @@ Envoy::ConnectionPool::ActiveClientPtr HttpConnPoolImplMixed::instantiateActiveC
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
     // For now, use the hard-coded setting. Eventually use the cached setting if available.
     initial_streams = host()->cluster().http2Options().max_concurrent_streams().value();
+    if (http_server_properties_cache_ && origin_.has_value()) {
+      uint32_t cached_concurrency =
+          http_server_properties_cache_->getConcurrentStreams(origin_.value());
+      if (cached_concurrency != 0 && cached_concurrency < initial_streams) {
+        initial_streams = cached_concurrency;
+      }
+    }
     auto max_requests = MultiplexedActiveClientBase::maxStreamsPerConnection(
         host()->cluster().maxRequestsPerConnection());
     if (max_requests < initial_streams) {
@@ -64,6 +71,9 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
     uint32_t delta = client.concurrent_stream_limit_ - 1;
     client.concurrent_stream_limit_ = 1;
     decrConnectingAndConnectedStreamCapacity(delta, client);
+    if (http_server_properties_cache_ && origin_.has_value()) {
+      http_server_properties_cache_->setConcurrentStreams(origin_.value(), 1);
+    }
   }
 
   Upstream::Host::CreateConnectionData data{std::move(tcp_client->connection_),

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -12,11 +12,9 @@ namespace Http {
 
 Envoy::ConnectionPool::ActiveClientPtr HttpConnPoolImplMixed::instantiateActiveClient() {
   uint32_t initial_streams = 1;
-  std::cerr << "initial is one\n";
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
     // For now, use the hard-coded setting. Eventually use the cached setting if available.
     initial_streams = host()->cluster().http2Options().max_concurrent_streams().value();
-    std::cerr << "initiadl is " << initial_streams << "\n";
     if (http_server_properties_cache_ && origin_.has_value()) {
       uint32_t cached_concurrency =
           http_server_properties_cache_->getConcurrentStreams(origin_.value());
@@ -25,13 +23,11 @@ Envoy::ConnectionPool::ActiveClientPtr HttpConnPoolImplMixed::instantiateActiveC
         // configured max_concurrent_streams as Envoy should never send more
         // than max_concurrent_streams at once.
         initial_streams = cached_concurrency;
-        std::cerr << "initiaial is " << initial_streams << "\n";
       }
     }
     auto max_requests = MultiplexedActiveClientBase::maxStreamsPerConnection(
         host()->cluster().maxRequestsPerConnection());
     if (max_requests < initial_streams) {
-      std::cerr << "ianitiaial is " << initial_streams << "\n";
       initial_streams = max_requests;
     }
   }

--- a/source/common/http/mixed_conn_pool.h
+++ b/source/common/http/mixed_conn_pool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/http/http_server_properties_cache.h"
+
 #include "source/common/http/conn_pool_base.h"
 
 namespace Envoy {
@@ -13,10 +15,13 @@ public:
       Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
       const Network::ConnectionSocket::OptionsSharedPtr& options,
       const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
-      Upstream::ClusterConnectivityState& state)
+      Upstream::ClusterConnectivityState& state,
+      absl::optional<HttpServerPropertiesCache::Origin> origin,
+      Http::HttpServerPropertiesCacheSharedPtr http_server_properties_cache)
       : HttpConnPoolImplBase(std::move(host), std::move(priority), dispatcher, options,
                              transport_socket_options, random_generator, state,
-                             {Protocol::Http2, Protocol::Http11}) {}
+                             {Protocol::Http2, Protocol::Http11}),
+        http_server_properties_cache_(http_server_properties_cache), origin_(origin) {}
 
   Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override;
   CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;
@@ -29,6 +34,8 @@ public:
 private:
   // Default to HTTP/1, as servers which don't support ALPN are probably HTTP/1 only.
   Http::Protocol protocol_ = Protocol::Http11;
+  Http::HttpServerPropertiesCacheSharedPtr http_server_properties_cache_;
+  absl::optional<HttpServerPropertiesCache::Origin> origin_;
 };
 
 } // namespace Http

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -39,6 +39,7 @@ public:
   TransportSocketPtr
   createTransportSocket(TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  absl::string_view defaultServerNameIndication() const override { return ""; }
 };
 
 } // namespace Network

--- a/source/common/quic/quic_transport_socket_factory.h
+++ b/source/common/quic/quic_transport_socket_factory.h
@@ -87,6 +87,7 @@ public:
   }
 
   bool earlyDataEnabled() const { return enable_early_data_; }
+  absl::string_view defaultServerNameIndication() const override { return ""; }
 
 protected:
   void onSecretUpdated() override { stats_.context_config_update_by_sds_.inc(); }
@@ -103,6 +104,9 @@ public:
       Server::Configuration::TransportSocketFactoryContext& factory_context);
 
   void initialize() override {}
+  absl::string_view defaultServerNameIndication() const override {
+    return clientContextConfig().serverNameIndication();
+  }
 
   // As documented above for QuicTransportSocketFactoryBase, the actual HTTP/3
   // code does not create transport sockets.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1825,6 +1825,18 @@ ClusterManagerPtr ProdClusterManagerFactory::clusterManagerFromProto(
       http_context_, grpc_context_, router_context_, server_)};
 }
 
+absl::optional<Http::HttpServerPropertiesCache::Origin>
+getOrigin(const Network::TransportSocketOptionsConstSharedPtr& options, HostConstSharedPtr host) {
+  std::string sni(host->transportSocketFactory().defaultServerNameIndication());
+  if (options && options->serverNameOverride().has_value()) {
+    sni = options->serverNameOverride().value();
+  }
+  if (sni.empty()) {
+    return absl::nullopt;
+  }
+  return {{"https", sni, host->address()->ip()->port()}};
+}
+
 Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     Event::Dispatcher& dispatcher, HostConstSharedPtr host, ResourcePriority priority,
     std::vector<Http::Protocol>& protocols,
@@ -1833,15 +1845,18 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     const Network::ConnectionSocket::OptionsSharedPtr& options,
     const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
     TimeSource& source, ClusterConnectivityState& state, Http::PersistentQuicInfoPtr& quic_info) {
+  Http::HttpServerPropertiesCacheSharedPtr alternate_protocols_cache{};
+
+  if (alternate_protocol_options.has_value()) {
+    alternate_protocols_cache = alternate_protocols_cache_manager_->getCache(
+        alternate_protocol_options.value(), dispatcher);
+  }
   if (protocols.size() == 3 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http3", 100)) {
     ASSERT(contains(protocols,
                     {Http::Protocol::Http11, Http::Protocol::Http2, Http::Protocol::Http3}));
     ASSERT(alternate_protocol_options.has_value());
 #ifdef ENVOY_ENABLE_QUIC
-    Http::HttpServerPropertiesCacheSharedPtr alternate_protocols_cache =
-        alternate_protocols_cache_manager_->getCache(alternate_protocol_options.value(),
-                                                     dispatcher);
     Envoy::Http::ConnectivityGrid::ConnectivityOptions coptions{protocols};
     if (quic_info == nullptr) {
       quic_info = Quic::createPersistentQuicInfoForCluster(dispatcher, host->cluster());
@@ -1857,10 +1872,22 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
 #endif
   }
   if (protocols.size() >= 2) {
+    absl::optional<Http::HttpServerPropertiesCache::Origin> origin =
+        getOrigin(transport_socket_options, host);
+    ENVOY_BUG(origin.has_value(), "Unable to determine origin for host ");
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
+      envoy::config::core::v3::AlternateProtocolsCacheOptions default_options;
+      default_options.set_name(host->cluster().name());
+      alternate_protocols_cache =
+          alternate_protocols_cache_manager_->getCache(default_options, dispatcher);
+    }
+
     ASSERT(contains(protocols, {Http::Protocol::Http11, Http::Protocol::Http2}));
     return std::make_unique<Http::HttpConnPoolImplMixed>(
         dispatcher, context_.api().randomGenerator(), host, priority, options,
-        transport_socket_options, state);
+        transport_socket_options, state, getOrigin(transport_socket_options, host),
+        alternate_protocols_cache);
   }
   if (protocols.size() == 1 && protocols[0] == Http::Protocol::Http2 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http2", 100)) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1851,6 +1851,8 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     alternate_protocols_cache = alternate_protocols_cache_manager_->getCache(
         alternate_protocol_options.value(), dispatcher);
   }
+  absl::optional<Http::HttpServerPropertiesCache::Origin> origin =
+      getOrigin(transport_socket_options, host);
   if (protocols.size() == 3 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http3", 100)) {
     ASSERT(contains(protocols,
@@ -1872,8 +1874,6 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
 #endif
   }
   if (protocols.size() >= 2) {
-    absl::optional<Http::HttpServerPropertiesCache::Origin> origin =
-        getOrigin(transport_socket_options, host);
     ENVOY_BUG(origin.has_value(), "Unable to determine origin for host ");
     if (Runtime::runtimeFeatureEnabled(
             "envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
@@ -1886,8 +1886,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     ASSERT(contains(protocols, {Http::Protocol::Http11, Http::Protocol::Http2}));
     return std::make_unique<Http::HttpConnPoolImplMixed>(
         dispatcher, context_.api().randomGenerator(), host, priority, options,
-        transport_socket_options, state, getOrigin(transport_socket_options, host),
-        alternate_protocols_cache);
+        transport_socket_options, state, origin, alternate_protocols_cache);
   }
   if (protocols.size() == 1 && protocols[0] == Http::Protocol::Http2 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http2", 100)) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -77,7 +77,7 @@ bool contains(const std::vector<Http::Protocol>& protocols,
 
 absl::optional<Http::HttpServerPropertiesCache::Origin>
 getOrigin(const Network::TransportSocketOptionsConstSharedPtr& options, HostConstSharedPtr host) {
-  std::string sni = host->transportSocketFactory().defaultServerNameIndication();
+  std::string sni = std::string(host->transportSocketFactory().defaultServerNameIndication());
   if (options && options->serverNameOverride().has_value()) {
     sni = options->serverNameOverride().value();
   }

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -135,6 +135,7 @@ public:
   TsiSocketFactory(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator);
 
   bool implementsSecureTransport() const override;
+  absl::string_view defaultServerNameIndication() const override { return ""; }
 
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;

--- a/source/extensions/transport_sockets/common/passthrough.h
+++ b/source/extensions/transport_sockets/common/passthrough.h
@@ -21,6 +21,9 @@ public:
     return transport_socket_factory_->implementsSecureTransport();
   }
   bool supportsAlpn() const override { return transport_socket_factory_->supportsAlpn(); }
+  absl::string_view defaultServerNameIndication() const override {
+    return transport_socket_factory_->defaultServerNameIndication();
+  }
 
 protected:
   // The wrapped factory.

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -82,6 +82,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override { return false; }
+  absl::string_view defaultServerNameIndication() const override { return ""; }
 
 private:
   Network::TransportSocketFactoryPtr raw_socket_factory_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -110,6 +110,9 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  absl::string_view defaultServerNameIndication() const override {
+    return config().serverNameIndication();
+  }
   bool supportsAlpn() const override { return true; }
 
   // Secret::SecretCallbacks
@@ -141,6 +144,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  absl::string_view defaultServerNameIndication() const override { return ""; }
 
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -415,11 +415,13 @@ envoy_cc_test(
         "//test/mocks:common_lib",
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/http:http_server_properties_cache_mocks",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:connection_mocks",
         "//test/mocks/router:router_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -7,11 +7,13 @@
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/http_server_properties_cache.h"
 #include "test/mocks/http/stream_decoder.h"
 #include "test/mocks/network/connection.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -26,10 +28,12 @@ namespace {
 class ConnPoolImplForTest : public Event::TestUsingSimulatedTime, public HttpConnPoolImplMixed {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::ClusterConnectivityState& state,
-                      Random::RandomGenerator& random, Upstream::ClusterInfoConstSharedPtr cluster)
-      : HttpConnPoolImplMixed(dispatcher, random,
-                              Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
-                              Upstream::ResourcePriority::Default, nullptr, nullptr, state) {}
+                      Random::RandomGenerator& random, Upstream::ClusterInfoConstSharedPtr cluster,
+                      HttpServerPropertiesCache::Origin origin,
+                      HttpServerPropertiesCacheSharedPtr cache)
+      : HttpConnPoolImplMixed(
+            dispatcher, random, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000", simTime()),
+            Upstream::ResourcePriority::Default, nullptr, nullptr, state, origin, cache) {}
 };
 
 /**
@@ -39,7 +43,19 @@ class MixedConnPoolImplTest : public testing::Test {
 public:
   MixedConnPoolImplTest()
       : upstream_ready_cb_(new NiceMock<Event::MockSchedulableCallback>(&dispatcher_)),
-        conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, state_, random_, cluster_)) {}
+        cache_(std::make_shared<NiceMock<MockHttpServerPropertiesCache>>()),
+        mock_cache_(*(dynamic_cast<MockHttpServerPropertiesCache*>(cache_.get()))),
+        conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, state_, random_, cluster_,
+                                                         origin_, cache_)) {
+    {
+      if (Runtime::runtimeFeatureEnabled(
+              "envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
+        expected_capacity_ = 536870912;
+      } else {
+        expected_capacity_ = 1;
+      }
+    }
+  }
 
   ~MixedConnPoolImplTest() override {
     EXPECT_EQ("", TestUtility::nonZeroedGauges(cluster_->stats_store_.gauges()));
@@ -49,12 +65,16 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   NiceMock<Event::MockSchedulableCallback>* upstream_ready_cb_;
+  Http::HttpServerPropertiesCacheSharedPtr cache_;
+  MockHttpServerPropertiesCache& mock_cache_;
+  HttpServerPropertiesCache::Origin origin_{"https", "hostname.com", 443};
   std::unique_ptr<ConnPoolImplForTest> conn_pool_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Event::MockSchedulableCallback>* mock_upstream_ready_cb_;
 
   void testAlpnHandshake(absl::optional<Protocol> protocol);
+  uint32_t expected_capacity_;
 };
 
 TEST_F(MixedConnPoolImplTest, AlpnTest) {
@@ -78,11 +98,7 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
                                                           : Http::Utility::AlpnNames::get().Http2);
   }
   EXPECT_CALL(*connection, nextProtocol()).WillOnce(Return(next_protocol));
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
-    EXPECT_EQ(536870912, state_.connecting_and_connected_stream_capacity_);
-  } else {
-    EXPECT_EQ(1, state_.connecting_and_connected_stream_capacity_);
-  }
+  EXPECT_EQ(expected_capacity_, state_.connecting_and_connected_stream_capacity_);
 
   connection->raiseEvent(Network::ConnectionEvent::Connected);
   if (!protocol.has_value()) {
@@ -98,6 +114,16 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
 }
 
 TEST_F(MixedConnPoolImplTest, BasicNoAlpnHandshake) { testAlpnHandshake({}); }
+
+TEST_F(MixedConnPoolImplTest, HandshakeWithCachedLimit) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "true"}});
+
+  expected_capacity_ = 5;
+  EXPECT_CALL(mock_cache_, getConcurrentStreams(_)).WillOnce(Return(5));
+  testAlpnHandshake({});
+}
 
 TEST_F(MixedConnPoolImplTest, Http1AlpnHandshake) { testAlpnHandshake(Protocol::Http11); }
 

--- a/test/common/http/mixed_conn_pool_test.cc
+++ b/test/common/http/mixed_conn_pool_test.cc
@@ -46,16 +46,7 @@ public:
         cache_(std::make_shared<NiceMock<MockHttpServerPropertiesCache>>()),
         mock_cache_(*(dynamic_cast<MockHttpServerPropertiesCache*>(cache_.get()))),
         conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, state_, random_, cluster_,
-                                                         origin_, cache_)) {
-    {
-      if (Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
-        expected_capacity_ = 536870912;
-      } else {
-        expected_capacity_ = 1;
-      }
-    }
-  }
+                                                         origin_, cache_)) {}
 
   ~MixedConnPoolImplTest() override {
     EXPECT_EQ("", TestUtility::nonZeroedGauges(cluster_->stats_store_.gauges()));
@@ -74,7 +65,9 @@ public:
   NiceMock<Event::MockSchedulableCallback>* mock_upstream_ready_cb_;
 
   void testAlpnHandshake(absl::optional<Protocol> protocol);
-  uint32_t expected_capacity_;
+  TestScopedRuntime scoped_runtime;
+  // The default capacity for HTTP/2 streams.
+  uint32_t expected_capacity_{536870912};
 };
 
 TEST_F(MixedConnPoolImplTest, AlpnTest) {
@@ -113,10 +106,12 @@ void MixedConnPoolImplTest::testAlpnHandshake(absl::optional<Protocol> protocol)
   conn_pool_.reset();
 }
 
-TEST_F(MixedConnPoolImplTest, BasicNoAlpnHandshake) { testAlpnHandshake({}); }
+TEST_F(MixedConnPoolImplTest, BasicNoAlpnHandshake) {
+  expected_capacity_ = 1; // The old code assumes HTTP/1.1
+  testAlpnHandshake({});
+}
 
 TEST_F(MixedConnPoolImplTest, HandshakeWithCachedLimit) {
-  TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "true"}});
 
@@ -125,9 +120,41 @@ TEST_F(MixedConnPoolImplTest, HandshakeWithCachedLimit) {
   testAlpnHandshake({});
 }
 
-TEST_F(MixedConnPoolImplTest, Http1AlpnHandshake) { testAlpnHandshake(Protocol::Http11); }
+TEST_F(MixedConnPoolImplTest, HandshakeWithCachedLimitCapped) {
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "true"}});
 
-TEST_F(MixedConnPoolImplTest, Http2AlpnHandshake) { testAlpnHandshake(Protocol::Http2); }
+  EXPECT_CALL(mock_cache_, getConcurrentStreams(_))
+      .WillOnce(Return(std::numeric_limits<uint32_t>::max()));
+  testAlpnHandshake({});
+}
+
+TEST_F(MixedConnPoolImplTest, Http1AlpnHandshakeOld) {
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "false"}});
+
+  expected_capacity_ = 1; // The old code assumes HTTP/1.1
+  testAlpnHandshake(Protocol::Http11);
+}
+
+TEST_F(MixedConnPoolImplTest, Http2AlpnHandshakeOld) {
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "false"}});
+  expected_capacity_ = 1; // The old code assumes HTTP/1.1
+  testAlpnHandshake(Protocol::Http2);
+}
+
+TEST_F(MixedConnPoolImplTest, Http1AlpnHandshake) {
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "true"}});
+  testAlpnHandshake(Protocol::Http11);
+}
+
+TEST_F(MixedConnPoolImplTest, Http2AlpnHandshake) {
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_concurrency_for_alpn_pool", "true"}});
+  testAlpnHandshake(Protocol::Http2);
+}
 
 } // namespace
 } // namespace Http

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -32,6 +32,7 @@ class FakeTransportSocketFactory : public Network::TransportSocketFactory {
 public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(bool, supportsAlpn, (), (const));
+  MOCK_METHOD(absl::string_view, defaultServerNameIndication, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsConstSharedPtr), (const));
   MOCK_METHOD(void, hashKey, (std::vector<uint8_t>&, Network::TransportSocketOptionsConstSharedPtr),
@@ -57,6 +58,7 @@ public:
               (Network::TransportSocketOptionsConstSharedPtr), (const));
   MOCK_METHOD(void, hashKey, (std::vector<uint8_t>&, Network::TransportSocketOptionsConstSharedPtr),
               (const));
+  MOCK_METHOD(absl::string_view, defaultServerNameIndication, (), (const));
 
   Network::TransportSocketFactoryPtr
   createTransportSocketFactory(const Protobuf::Message& proto,

--- a/test/integration/alpn_integration_test.cc
+++ b/test/integration/alpn_integration_test.cc
@@ -136,6 +136,34 @@ TEST_P(AlpnIntegrationTest, Http1New) {
   codec_client2->close();
 }
 
+TEST_P(AlpnIntegrationTest, Http1RememberLimits) {
+  setUpstreamProtocol(Http::CodecType::HTTP1);
+  autonomous_upstream_ = true;
+  protocols_ = {Http::CodecType::HTTP1, Http::CodecType::HTTP1};
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_concurrency_for_alpn_pool",
+                                    "true");
+  initialize();
+
+  // Send a request and response, then close the connection.
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  default_request_headers_.addCopy(AutonomousStream::CLOSE_AFTER_RESPONSE, "yes");
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_destroy", 1);
+  test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_total", 1);
+  {
+    absl::MutexLock l(&fake_upstreams_[0]->lock_);
+    IntegrationCodecClientPtr codec_client1 = makeHttpConnection(lookupPort("http"));
+    auto response1 = codec_client1->makeHeaderOnlyRequest(default_request_headers_);
+    IntegrationCodecClientPtr codec_client2 = makeHttpConnection(lookupPort("http"));
+    auto response2 = codec_client2->makeHeaderOnlyRequest(default_request_headers_);
+    // Envoy should attempt to establish 2 new connections, one for each stream.
+    test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_total", 3);
+    codec_client1->close();
+    codec_client2->close();
+  }
+}
+
 TEST_P(AlpnIntegrationTest, Mixed) {
   protocols_ = {Http::CodecType::HTTP1, Http::CodecType::HTTP2};
   initialize();

--- a/test/integration/alpn_integration_test.cc
+++ b/test/integration/alpn_integration_test.cc
@@ -152,7 +152,7 @@ TEST_P(AlpnIntegrationTest, Http1RememberLimits) {
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_destroy", 1);
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_total", 1);
   {
-    absl::MutexLock l(&fake_upstreams_[0]->lock_);
+    absl::MutexLock l(&fake_upstreams_[0]->lock());
     IntegrationCodecClientPtr codec_client1 = makeHttpConnection(lookupPort("http"));
     auto response1 = codec_client1->makeHeaderOnlyRequest(default_request_headers_);
     IntegrationCodecClientPtr codec_client2 = makeHttpConnection(lookupPort("http"));

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -645,7 +645,6 @@ public:
     return std::make_unique<FakeRawConnection>(shared_connection, time_system);
   }
 
-  absl::Mutex lock_;
   // Wait for one of the upstreams to receive a connection
   ABSL_MUST_USE_RESULT
   static testing::AssertionResult
@@ -706,6 +705,7 @@ public:
   const envoy::config::core::v3::Http3ProtocolOptions& http3Options() { return http3_options_; }
 
   Event::DispatcherPtr& dispatcher() { return dispatcher_; }
+  absl::Mutex& lock() { return lock_; }
 
 protected:
   Stats::IsolatedStoreImpl stats_store_;
@@ -849,6 +849,7 @@ private:
   ConditionalInitializer server_initialized_;
   // Guards any objects which can be altered both in the upstream thread and the
   // main test thread.
+  absl::Mutex lock_;
   Thread::ThreadPtr thread_;
   Api::ApiPtr api_;
   Event::TestTimeSystem& time_system_;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -645,6 +645,7 @@ public:
     return std::make_unique<FakeRawConnection>(shared_connection, time_system);
   }
 
+  absl::Mutex lock_;
   // Wait for one of the upstreams to receive a connection
   ABSL_MUST_USE_RESULT
   static testing::AssertionResult
@@ -848,7 +849,6 @@ private:
   ConditionalInitializer server_initialized_;
   // Guards any objects which can be altered both in the upstream thread and the
   // main test thread.
-  absl::Mutex lock_;
   Thread::ThreadPtr thread_;
   Api::ApiPtr api_;
   Event::TestTimeSystem& time_system_;

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -40,6 +40,7 @@ public:
 
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(bool, supportsAlpn, (), (const));
+  MOCK_METHOD(absl::string_view, defaultServerNameIndication, (), (const));
   MOCK_METHOD(TransportSocketPtr, createTransportSocket, (TransportSocketOptionsConstSharedPtr),
               (const));
   MOCK_METHOD(void, hashKey,


### PR DESCRIPTION
Commit Message: having the ALPN pool cache initial muxed stream limits
Risk Level: low (off by default)
Testing: new unit, integration tests
Docs Changes: n/a
Part of https://github.com/envoyproxy/envoy/issues/20696