### PR TITLE
docs: add an example with TCP Keep-alive for socket_option

### DIFF
--- a/api/envoy/config/core/v3/socket_option.proto
+++ b/api/envoy/config/core/v3/socket_option.proto
@@ -16,6 +16,26 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Generic socket option message. This would be used to set socket options that
 // might not exist in upstream kernels or precompiled Envoy binaries.
+//
+// For example:
+//
+// .. code-block:: json
+//
+//  {
+//    "description": "support tcp keep alive",
+//    "state": 0,
+//    "level": 1,
+//    "name": 9,
+//    "int_value": 1,
+//  }
+//
+// 1 means SOL_SOCKET and 9 means SO_KEEPALIVE on Linux.
+// With the above configuration, `TCP Keep-Alives <https://www.freesoft.org/CIE/RFC/1122/114.htm>`_
+// can be enabled in socket with Linux, which can be used in
+// :ref:`listener's<envoy_v3_api_field_config.listener.v3.Listener.socket_options>` or
+// :ref:`admin's <envoy_v3_api_field_config.bootstrap.v3.Admin.socket_options>` socket_options etc.
+//
+// It should be noted that the name or level may have different values on different platforms.
 // [#next-free-field: 7]
 message SocketOption {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.SocketOption";


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs: add an example with TCP Keep-alive for socket_option
Additional Description: Add docs for https://github.com/envoyproxy/envoy/issues/21042
Risk Level: N/A
Testing: N/A
Docs Changes: Yes, for socket option
Release Notes: N/A
Platform Specific Features: N/A
