### PR TITLE
regex: restoring regex behavior prior to runtime load

### DIFF
--- a/source/common/common/regex.cc
+++ b/source/common/common/regex.cc
@@ -17,7 +17,7 @@ CompiledGoogleReMatcher::CompiledGoogleReMatcher(const std::string& regex,
     throw EnvoyException(regex_.error());
   }
 
-  if (do_program_size_check) {
+  if (do_program_size_check && Runtime::isRuntimeInitialized()) {
     const uint32_t regex_program_size = static_cast<uint32_t>(regex_.ProgramSize());
     const uint32_t max_program_size_error_level =
         Runtime::getInteger("re2.max_program_size.error_level", 100);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -33,6 +33,7 @@ RUNTIME_GUARD(envoy_reloadable_features_allow_adding_content_type_in_local_repli
 RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_inline_write);
 RUNTIME_GUARD(envoy_reloadable_features_append_or_truncate);
 RUNTIME_GUARD(envoy_reloadable_features_append_to_accept_content_encoding_only_once);
+RUNTIME_GUARD(envoy_reloadable_features_conn_pool_delete_when_idle);
 RUNTIME_GUARD(envoy_reloadable_features_conn_pool_new_stream_with_early_data_and_http3);
 RUNTIME_GUARD(envoy_reloadable_features_correctly_validate_alpn);
 RUNTIME_GUARD(envoy_reloadable_features_deprecate_global_ints);
@@ -61,6 +62,7 @@ RUNTIME_GUARD(envoy_reloadable_features_top_level_ecds_stats);
 RUNTIME_GUARD(envoy_reloadable_features_udp_listener_updates_filter_chain_in_place);
 RUNTIME_GUARD(envoy_reloadable_features_update_expected_rq_timeout_on_retry);
 RUNTIME_GUARD(envoy_reloadable_features_update_grpc_response_error_tag);
+RUNTIME_GUARD(envoy_reloadable_features_validate_connect);
 RUNTIME_GUARD(envoy_restart_features_explicit_wildcard_resource);
 RUNTIME_GUARD(envoy_restart_features_no_runtime_singleton);
 RUNTIME_GUARD(envoy_restart_features_use_apple_api_for_dns_lookups);
@@ -82,6 +84,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_thrift_connection_draining);
 // TODO(birenroy) flip after a burn-in period
 // Requires envoy_reloadable_features_http2_new_codec_wrapper to be enabled.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
+// Used to track if runtime is initialized.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 
 // Block of non-boolean flags. These are deprecated. Do not add more.
 ABSL_FLAG(uint64_t, envoy_headermap_lazy_map_min_size, 3, "");  // NOLINT
@@ -172,6 +176,14 @@ uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
   }
   IS_ENVOY_BUG(absl::StrCat("requested an unsupported integer ", feature));
   return default_value;
+}
+
+void runtimeIsInitialized() {
+  maybeSetRuntimeGuard("envoy.reloadable_features.runtime_initialized", true);
+}
+
+bool isRuntimeInitialized() {
+  return runtimeFeatureEnabled("envoy.reloadable_features.runtime_initialized");
 }
 
 void maybeSetRuntimeGuard(absl::string_view name, bool value) {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -178,7 +178,7 @@ uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
   return default_value;
 }
 
-void runtimeIsInitialized() {
+void markRuntimeInitialized() {
   maybeSetRuntimeGuard("envoy.reloadable_features.runtime_initialized", true);
 }
 

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -18,6 +18,9 @@ bool isRuntimeFeature(absl::string_view feature);
 bool runtimeFeatureEnabled(absl::string_view feature);
 uint64_t getInteger(absl::string_view feature, uint64_t default_value);
 
+void runtimeIsInitialized();
+bool isRuntimeInitialized();
+
 void maybeSetRuntimeGuard(absl::string_view name, bool value);
 
 void maybeSetDeprecatedInts(absl::string_view name, uint32_t value);

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -18,7 +18,7 @@ bool isRuntimeFeature(absl::string_view feature);
 bool runtimeFeatureEnabled(absl::string_view feature);
 uint64_t getInteger(absl::string_view feature, uint64_t default_value);
 
-void runtimeIsInitialized();
+void markRuntimeInitialized();
 bool isRuntimeInitialized();
 
 void maybeSetRuntimeGuard(absl::string_view name, bool value);

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -65,6 +65,7 @@ void refreshReloadableFlags(const Snapshot::EntryMap& flag_map) {
       maybeSetDeprecatedInts(it.first, it.second.uint_value_.value());
     }
   }
+  runtimeIsInitialized();
 }
 
 } // namespace

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -65,7 +65,7 @@ void refreshReloadableFlags(const Snapshot::EntryMap& flag_map) {
       maybeSetDeprecatedInts(it.first, it.second.uint_value_.value());
     }
   }
-  runtimeIsInitialized();
+  markRuntimeInitialized();
 }
 
 } // namespace

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -54,6 +54,9 @@ TEST_P(StatsIntegrationTest, WithoutDefaultTagExtractors) {
   EXPECT_EQ(counter->tags().size(), 0);
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/pull/21069 making
+// sure that the default error_level limits are not applied before runtime is
+// created. As described by the linked issue, this simply bypasses regex size checks.
 TEST_P(StatsIntegrationTest, WithLargeRegex) {
   config_helper_.addRuntimeOverride("re2.max_program_size.error_level", "1000");
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -58,6 +58,7 @@ TEST_P(StatsIntegrationTest, WithoutDefaultTagExtractors) {
 // sure that the default error_level limits are not applied before runtime is
 // created. As described by the linked issue, this simply bypasses regex size checks.
 TEST_P(StatsIntegrationTest, WithLargeRegex) {
+  // This limit of 1000 will be ignored.
   config_helper_.addRuntimeOverride("re2.max_program_size.error_level", "1000");
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     auto pattern = bootstrap.mutable_stats_config()

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -54,6 +54,22 @@ TEST_P(StatsIntegrationTest, WithoutDefaultTagExtractors) {
   EXPECT_EQ(counter->tags().size(), 0);
 }
 
+TEST_P(StatsIntegrationTest, WithLargeRegex) {
+  config_helper_.addRuntimeOverride("re2.max_program_size.error_level", "1000");
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto pattern = bootstrap.mutable_stats_config()
+                       ->mutable_stats_matcher()
+                       ->mutable_inclusion_list()
+                       ->add_patterns();
+    pattern->mutable_safe_regex()->mutable_google_re2();
+    pattern->mutable_safe_regex()->set_regex(
+        "cluster.(metadata-cluster|iam-cluster|service-control-cluster|backend-cluster-sample-"
+        "backend-s3fctubhaq-uc.a.run.app_443).upstream_rq_(reset|timeout|[1-5]xx)|listener.*");
+  });
+  use_lds_ = false;
+  initialize();
+}
+
 TEST_P(StatsIntegrationTest, WithDefaultTagExtractors) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     bootstrap.mutable_stats_config()->mutable_use_all_default_tags()->set_value(true);


### PR DESCRIPTION
Fixes an issue where a runtime value was applied before it was set.
Re-introduces an issue where that runtime guard may never actually be applied.

Risk Level: low 
Testing: new integration test
Release Notes: 
Part of https://github.com/envoyproxy/envoy/issues/21056
