### PR TITLE
build: silencing info logspam.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,8 +23,6 @@ build --platform_mappings=bazel/platform_mappings
 build --copt=-DABSL_MIN_LOG_LEVEL=4
 build --ui_event_filters=-info
 
-test --ui_event_filters=-info
-
 # Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
 build --action_env=CC --host_action_env=CC
 build --action_env=CXX --host_action_env=CXX

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,9 @@ build --tool_java_runtime_version=remotejdk_11
 build --platform_mappings=bazel/platform_mappings
 # silence absl logspam.
 build --copt=-DABSL_MIN_LOG_LEVEL=4
+build --ui_event_filters=-info
+
+test --ui_event_filters=-info
 
 # Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
 build --action_env=CC --host_action_env=CC


### PR DESCRIPTION
To be reverted if it makes CI debug harder, but in the interim makes CI logs and build logs MUCH easier to read.