### PR TITLE
bazel: test remove java flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,8 +16,6 @@ build --color=yes
 build --workspace_status_command="bash bazel/get_workspace_status"
 build --incompatible_strict_action_env
 build --host_force_python=PY3
-build --java_runtime_version=remotejdk_11
-build --tool_java_runtime_version=remotejdk_11
 build --platform_mappings=bazel/platform_mappings
 # silence absl logspam.
 build --copt=-DABSL_MIN_LOG_LEVEL=4


### PR DESCRIPTION
It seems like these break with newer bazel versions, so I'm interested
to see why there needed originally.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>