### PR TITLE
matching: avoid template specialization in favor of uniform types

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -1002,6 +1002,14 @@ public:
   virtual ResponseHeaderMapOptConstRef responseHeaders() const PURE;
   virtual ResponseTrailerMapOptConstRef responseTrailers() const PURE;
   virtual const Network::ConnectionInfoProvider& connectionInfoProvider() const PURE;
+
+  const Network::Address::Instance& localAddress() const {
+    return *connectionInfoProvider().localAddress();
+  }
+
+  const Network::Address::Instance& remoteAddress() const {
+    return *connectionInfoProvider().remoteAddress();
+  }
 };
 
 /**

--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -550,6 +550,12 @@ public:
   const ConnectionInfoProvider& connectionInfoProvider() const {
     return socket().connectionInfoProvider();
   }
+
+  const Address::Instance& localAddress() const { return *connectionInfoProvider().localAddress(); }
+
+  const Address::Instance& remoteAddress() const {
+    return *connectionInfoProvider().remoteAddress();
+  }
 };
 
 /**

--- a/source/common/network/matching/inputs.cc
+++ b/source/common/network/matching/inputs.cc
@@ -9,49 +9,6 @@ namespace Envoy {
 namespace Network {
 namespace Matching {
 
-template <>
-Matcher::DataInputGetResult
-DestinationIPInput<UdpMatchingData>::get(const UdpMatchingData& data) const {
-  const auto& address = data.localAddress();
-  if (address.type() != Network::Address::Type::Ip) {
-    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
-  }
-  return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-          address.ip()->addressAsString()};
-}
-
-template <>
-Matcher::DataInputGetResult
-DestinationPortInput<UdpMatchingData>::get(const UdpMatchingData& data) const {
-  const auto& address = data.localAddress();
-  if (address.type() != Network::Address::Type::Ip) {
-    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
-  }
-  return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-          absl::StrCat(address.ip()->port())};
-}
-
-template <>
-Matcher::DataInputGetResult SourceIPInput<UdpMatchingData>::get(const UdpMatchingData& data) const {
-  const auto& address = data.remoteAddress();
-  if (address.type() != Network::Address::Type::Ip) {
-    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
-  }
-  return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-          address.ip()->addressAsString()};
-}
-
-template <>
-Matcher::DataInputGetResult
-SourcePortInput<UdpMatchingData>::get(const UdpMatchingData& data) const {
-  const auto& address = data.remoteAddress();
-  if (address.type() != Network::Address::Type::Ip) {
-    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
-  }
-  return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-          absl::StrCat(address.ip()->port())};
-}
-
 Matcher::DataInputGetResult TransportProtocolInput::get(const MatchingData& data) const {
   const auto transport_protocol = data.socket().detectedTransportProtocol();
   if (!transport_protocol.empty()) {

--- a/source/common/network/matching/inputs.h
+++ b/source/common/network/matching/inputs.h
@@ -35,18 +35,15 @@ template <class MatchingDataType>
 class DestinationIPInput : public Matcher::DataInput<MatchingDataType> {
 public:
   Matcher::DataInputGetResult get(const MatchingDataType& data) const override {
-    const auto& address = data.connectionInfoProvider().localAddress();
-    if (address->type() != Network::Address::Type::Ip) {
+    const auto& address = data.localAddress();
+
+    if (address.type() != Network::Address::Type::Ip) {
       return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
     }
     return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-            address->ip()->addressAsString()};
+            address.ip()->addressAsString()};
   }
 };
-
-template <>
-Matcher::DataInputGetResult
-DestinationIPInput<UdpMatchingData>::get(const UdpMatchingData& data) const;
 
 template <class MatchingDataType>
 class DestinationIPInputBaseFactory
@@ -65,18 +62,14 @@ template <class MatchingDataType>
 class DestinationPortInput : public Matcher::DataInput<MatchingDataType> {
 public:
   Matcher::DataInputGetResult get(const MatchingDataType& data) const override {
-    const auto& address = data.connectionInfoProvider().localAddress();
-    if (address->type() != Network::Address::Type::Ip) {
+    const auto& address = data.localAddress();
+    if (address.type() != Network::Address::Type::Ip) {
       return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
     }
     return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-            absl::StrCat(address->ip()->port())};
+            absl::StrCat(address.ip()->port())};
   }
 };
-
-template <>
-Matcher::DataInputGetResult
-DestinationPortInput<UdpMatchingData>::get(const UdpMatchingData& data) const;
 
 template <class MatchingDataType>
 class DestinationPortInputBaseFactory
@@ -95,17 +88,14 @@ template <class MatchingDataType>
 class SourceIPInput : public Matcher::DataInput<MatchingDataType> {
 public:
   Matcher::DataInputGetResult get(const MatchingDataType& data) const override {
-    const auto& address = data.connectionInfoProvider().remoteAddress();
-    if (address->type() != Network::Address::Type::Ip) {
+    const auto& address = data.remoteAddress();
+    if (address.type() != Network::Address::Type::Ip) {
       return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
     }
     return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-            address->ip()->addressAsString()};
+            address.ip()->addressAsString()};
   }
 };
-
-template <>
-Matcher::DataInputGetResult SourceIPInput<UdpMatchingData>::get(const UdpMatchingData& data) const;
 
 template <class MatchingDataType>
 class SourceIPInputBaseFactory
@@ -123,18 +113,14 @@ template <class MatchingDataType>
 class SourcePortInput : public Matcher::DataInput<MatchingDataType> {
 public:
   Matcher::DataInputGetResult get(const MatchingDataType& data) const override {
-    const auto& address = data.connectionInfoProvider().remoteAddress();
-    if (address->type() != Network::Address::Type::Ip) {
+    const auto& address = data.remoteAddress();
+    if (address.type() != Network::Address::Type::Ip) {
       return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
     }
     return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-            absl::StrCat(address->ip()->port())};
+            absl::StrCat(address.ip()->port())};
   }
 };
-
-template <>
-Matcher::DataInputGetResult
-SourcePortInput<UdpMatchingData>::get(const UdpMatchingData& data) const;
 
 template <class MatchingDataType>
 class SourcePortInputBaseFactory


### PR DESCRIPTION
This changes how we do generics for the different inputs slightly differently: instead of having the initial template
specify the behavior for the most common type and then override it for UdpMatchingData, instead we make all
inputs type conform to the same shape and use only a single template for these types.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, refactor
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
