### PR TITLE
Make cache filter not re-fetch the cache for each connection

### DIFF
--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -18,12 +18,13 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
         fmt::format("Didn't find a registered implementation for type: '{}'", type));
   }
 
-  HttpCache* cache = &http_cache_factory->getCache(config, context);
+  // Capture the cache instance as a reference; the factory must own it.
+  auto cache = std::ref(http_cache_factory->getCache(config, context));
 
   return [config, stats_prefix, &context,
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
-                                                            context.timeSource(), *cache));
+                                                            context.timeSource(), cache));
   };
 }
 

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -18,11 +18,12 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
         fmt::format("Didn't find a registered implementation for type: '{}'", type));
   }
 
+  HttpCache* cache = &http_cache_factory->getCache(config, context);
+
   return [config, stats_prefix, &context,
-          http_cache_factory](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(
-        std::make_shared<CacheFilter>(config, stats_prefix, context.scope(), context.timeSource(),
-                                      http_cache_factory->getCache(config, context)));
+          cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
+                                                            context.timeSource(), *cache));
   };
 }
 

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -19,6 +19,8 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
   }
 
   // Capture the cache instance as a reference; the factory must own it.
+  // TODO: getCache should be returning a shared_ptr (and using SingletonManager), to avoid
+  // keeping potentially large structures in static variables.
   auto cache = std::ref(http_cache_factory->getCache(config, context));
 
   return [config, stats_prefix, &context,


### PR DESCRIPTION
Commit Message: Make cache filter not re-fetch the cache for each connection
Additional Description: While in the case of SimpleHttpCache this re-fetching operation is inexpensive, for another cache implementation it could potentially be a significant amount of config parsing, which is best avoided on a per-connection basis. (And there is no downside to avoiding it here.)
Risk Level: Very low, filter is tagged WIP and getCache should be idempotent.
Testing: Existing tests should already cover as the expected behavior is the same. Tests still pass.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
