### PR TITLE
bazel: add root envoy.stripped alias

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,11 @@ alias(
     actual = "//source/exe:envoy",
 )
 
+alias(
+    name = "envoy.stripped",
+    actual = "//source/exe:envoy-static.stripped",
+)
+
 # These two definitions exist to help reduce Envoy upstream core code depending on extensions.
 # To avoid visibility problems, see notes in source/extensions/extensions_build_config.bzl
 #


### PR DESCRIPTION
This mirrors the envoy alias at the top level, since this is the
recommendation for release builds this allows people to easily build
this version a well.

This came up in https://github.com/envoyproxy/envoy/issues/21060

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>