### PR TITLE
ci: move info filter to ci config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,7 +21,6 @@ build --tool_java_runtime_version=remotejdk_11
 build --platform_mappings=bazel/platform_mappings
 # silence absl logspam.
 build --copt=-DABSL_MIN_LOG_LEVEL=4
-build --ui_event_filters=-info
 
 # Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
 build --action_env=CC --host_action_env=CC

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -99,6 +99,7 @@ BAZEL_BUILD_OPTIONS=(
   "--noshow_loading_progress"
   "--repository_cache=${BUILD_DIR}/repository_cache"
   "--experimental_repository_cache_hardlinks"
+  "--ui_event_filters=-info"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 


### PR DESCRIPTION
Locally seeing bazel info lines can be helpful for things like
`--announce_rc`. This should disable for CI only. Except
for jobs that set `NO_BUILD_SETUP` which isn't many.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>