### PR TITLE
mux: using base type to avoid cast

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -213,7 +213,7 @@ void GrpcMuxImpl::onDiscoveryResponse(
     // We have to walk all watches (and need an efficient map as a result) to
     // ensure we deliver empty config updates when a resource is dropped. We make the map ordered
     // for test determinism.
-    std::vector<DecodedResourceImplPtr> resources;
+    std::vector<DecodedResourcePtr> resources;
     absl::btree_map<std::string, DecodedResourceRef> resource_ref_map;
     std::vector<DecodedResourceRef> all_resource_refs;
     OpaqueResourceDecoder& resource_decoder = api_state.watches_.front()->resource_decoder_;
@@ -247,8 +247,7 @@ void GrpcMuxImpl::onDiscoveryResponse(
 
     // Execute external config validators if there are any watches.
     if (!api_state.watches_.empty()) {
-      config_validators_->executeValidators(
-          type_url, reinterpret_cast<std::vector<DecodedResourcePtr>&>(resources));
+      config_validators_->executeValidators(type_url, resources);
     }
 
     for (auto watch : api_state.watches_) {

--- a/source/common/config/watch_map.cc
+++ b/source/common/config/watch_map.cc
@@ -187,7 +187,7 @@ void WatchMap::onConfigUpdate(
   // Build a pair of maps: from watches, to the set of resources {added,removed} that each watch
   // cares about. Each entry in the map-pair is then a nice little bundle that can be fed directly
   // into the individual onConfigUpdate()s.
-  std::vector<DecodedResourceImplPtr> decoded_resources;
+  std::vector<DecodedResourcePtr> decoded_resources;
   absl::flat_hash_map<Watch*, std::vector<DecodedResourceRef>> per_watch_added;
   for (const auto& r : added_resources) {
     const absl::flat_hash_set<Watch*>& interested_in_r = watchesInterestedIn(r.name());
@@ -211,9 +211,7 @@ void WatchMap::onConfigUpdate(
   }
 
   // Execute external config validators.
-  config_validators_.executeValidators(
-      type_url_, reinterpret_cast<std::vector<DecodedResourcePtr>&>(decoded_resources),
-      removed_resources);
+  config_validators_.executeValidators(type_url_, decoded_resources, removed_resources);
 
   // We just bundled up the updates into nice per-watch packages. Now, deliver them.
   for (const auto& [cur_watch, resource_to_add] : per_watch_added) {


### PR DESCRIPTION
Commit Message: Updating grpc mux code to use a base type to avoid cast
Additional Description:
As noted in #21060, building with gcc in "opt" mode results in a compilation error:
```
ERROR: /workspaces/envoy/source/common/config/BUILD:414:17: Compiling source/common/config/watch_map.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 154 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox
source/common/config/watch_map.cc: In member function 'virtual void Envoy::Config::WatchMap::onConfigUpdate(const google::protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource>&, const google::protobuf::RepeatedPtrField<std::__cxx11::basic_string<char> >&, const string&)':
source/common/config/watch_map.cc:215:69: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
  215 |       type_url_, reinterpret_cast<std::vector<DecodedResourcePtr>&>(decoded_resources),
      |                                                                     ^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```
This PR changes the type of the original vector to be the base class type.

Risk Level: Low-Medium (no features changes, but updates config-plane code).
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
