### PR TITLE
fuzz test: Prevent fuzzing of unimplemented router configs.

### DIFF
--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -13,6 +13,9 @@ namespace Envoy {
 namespace Router {
 namespace {
 
+// Limit the size of the input.
+static const size_t MaxInputSize = 64 * 1024;
+
 // Remove regex matching route configs.
 envoy::config::route::v3::RouteConfiguration
 cleanRouteConfig(envoy::config::route::v3::RouteConfiguration route_config) {
@@ -22,7 +25,8 @@ cleanRouteConfig(envoy::config::route::v3::RouteConfiguration route_config) {
                 [](envoy::config::route::v3::VirtualHost& virtual_host) {
                   auto routes = virtual_host.mutable_routes();
                   for (int i = 0; i < routes->size();) {
-                    if (routes->Get(i).has_filter_action()) {
+                    if (routes->Get(i).has_filter_action() ||
+                        routes->Get(i).has_non_forwarding_action()) {
                       routes->erase(routes->begin() + i);
                     } else {
                       ++i;
@@ -33,8 +37,29 @@ cleanRouteConfig(envoy::config::route::v3::RouteConfiguration route_config) {
   return clean_config;
 }
 
+// Check configuration for size and unimplemented options.
+bool validateConfig(const test::common::router::RouteTestCase& input) {
+  const auto input_size = input.ByteSizeLong();
+  if (input_size > MaxInputSize) {
+    ENVOY_LOG_MISC(debug, "Input size {}kB exceeds {}kB ({}B > {}B).", input_size / 1024,
+                   MaxInputSize / 1024, input_size, MaxInputSize);
+    return false;
+  }
+  for (const auto& virtual_host : input.config().virtual_hosts()) {
+    if (virtual_host.has_retry_policy_typed_config()) {
+      ENVOY_LOG_MISC(debug, "retry_policy_typed_config: not implemented");
+      return false;
+    }
+  }
+  return true;
+}
+
 // TODO(htuch): figure out how to generate via a genrule from config_impl_test the full corpus.
 DEFINE_PROTO_FUZZER(const test::common::router::RouteTestCase& input) {
+  if (!validateConfig(input)) {
+    return;
+  }
+
   static NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   static NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
   try {


### PR DESCRIPTION
Commit Message: fuzz test: Prevent fuzzing of unimplemented router configs.
Additional Description:
- Add router config option non_forwarding_action marked not-implemented to
  the filter loop to prevent fuzzing them.
- In VirtualHost config the retry_policy_typed_config is flagged as not
  implemented. Prevent the fuzzer from wasting time and space fuzzing it.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
