### PR TITLE
fuzz test: Ensure content type is valid.

### DIFF
--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -106,7 +106,8 @@ message SubstitutionFormatString {
   //
   //   content_type: "text/html; charset=UTF-8"
   //
-  string content_type = 4;
+  string content_type = 4
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Specifies a collection of Formatter plugins that can be called from the access log configuration.
   // See the formatters extensions documentation for details.

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/oss-fuzz-26856-network_readfilter_fuzz_test-5364876991791104
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/oss-fuzz-26856-network_readfilter_fuzz_test-5364876991791104
@@ -1,0 +1,12 @@
+config {
+  name: "envoy.filters.network.http_connection_manager"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    value: "\022\037envoy.filters.thrift.rate_limit\032\004\n\002\032\000R)envoy.config.core.v3.ExtensionConfigSourc\200\001\002\230\001\'\240\001\001\250\001\001\200\002\001\210\002\001\262\002\013\022\t\022\000\"\005\n\003\022\001N\270\002\001"
+  }
+}
+actions {
+  on_data {
+    data: "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  }
+}


### PR DESCRIPTION
Commit Message: fuzz test: Ensure content type is valid.
Additional Description:
In http_connection_manager check that the content-type in a
local_reply_config contains only allowed characters.

Signed-off-by: Andre Vehreschild [vehre@x41-dsec.de](mailto:vehre@x41-dsec.de)
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
API Considerations: Added validator to existing option enabling automatic checking for legal content-type.
