### PR TITLE
fuzz test: Allow trailers for http1 only when configured

### DIFF
--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5074389318107136
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5074389318107136
@@ -1,0 +1,227 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=bar"
+      }
+      headers {
+        key: "cookie"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+        headers {
+          key: ":status"
+          value: "200"
+        }
+        headers {
+          key: "content-length"
+          value: "5"
+        }
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+      }
+    }
+    dispatching_action {
+      data: 54
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      read_disable: true
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      read_disable: false
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=bar"
+      }
+      headers {
+        key: "cookie"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    response {
+      headers {
+        headers {
+          key: ":status"
+          value: "200"
+        }
+        headers {
+          key: "content-length"
+          value: "5"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    response {
+      data: 5
+      end_stream: true
+    }
+  }
+}

--- a/test/common/http/codec_impl_fuzz.proto
+++ b/test/common/http/codec_impl_fuzz.proto
@@ -91,6 +91,7 @@ message Http1ServerSettings {
   bool allow_absolute_url = 1;
   bool accept_http_10 = 2;
   string default_host_for_http_10 = 3;
+  bool enable_trailers = 4;
 }
 
 message Http1ClientServerSettings {

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -59,6 +59,8 @@ fromSanitizedHeaders<TestRequestHeaderMapImpl>(const test::fuzz::Headers& header
 Http1Settings fromHttp1Settings(const test::common::http::Http1ServerSettings& settings) {
   Http1Settings h1_settings;
 
+  // When in future allowing trailers, then the kTrailers case in directionalAction() needs change,
+  // too.
   h1_settings.allow_absolute_url_ = settings.allow_absolute_url();
   h1_settings.accept_http_10_ = settings.accept_http_10();
   h1_settings.default_host_for_http_10_ = settings.default_host_for_http_10();
@@ -292,7 +294,9 @@ public:
       break;
     }
     case test::common::http::DirectionalAction::kTrailers: {
-      if (state.isLocalOpen() && state.stream_state_ == StreamState::PendingDataOrTrailers) {
+      // Trailers can by-configuration only be used for http2.
+      if (http_protocol_ == Protocol::Http2 && state.isLocalOpen() &&
+          state.stream_state_ == StreamState::PendingDataOrTrailers) {
         if (response) {
           state.response_encoder_->encodeTrailers(
               fromSanitizedHeaders<TestResponseTrailerMapImpl>(directional_action.trailers()));


### PR DESCRIPTION
Commit Message: Allow trailers for http1 in fuzz test only when configured
Additional Description: 
Add config-option to allow fuzzer to check http1-trailers. Enable using
trailers only when that option is set to prevent aborts.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
