### PR TITLE
tools: limiting dependency reviews to envoyproxy/envoy

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'envoyproxy'
+    if: github.repository == 'envoyproxy/envoy'
     steps:
       - name: Checkout repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'envoyproxy'
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'envoyproxy'
+    if: github.repository == 'envoyproxy/envoy'
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -7,8 +7,7 @@ jobs:
   pr_notifier:
     name: PR Notifier
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'envoyproxy'
-
+    if: github.repository == 'envoyproxy/envoy'
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - name: Set up Python 3.8


### PR DESCRIPTION
also consistently using the same envoyproxy/envoy checks across the workflow files.