### PR TITLE
xds: Listener.address field is not required when api_listener is populated

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -106,7 +106,8 @@ message Listener {
   // The address that the listener should listen on. In general, the address must be unique, though
   // that is governed by the bind rules of the OS. E.g., multiple listeners can listen on port 0 on
   // Linux as the actual port will be allocated by the OS.
-  core.v3.Address address = 2 [(validate.rules).message = {required: true}];
+  // Required unless *api_listener* or *listener_specifier* is populated.
+  core.v3.Address address = 2;
 
   // Optional prefix to use on listener stats. If empty, the stats will be rooted at
   // `listener.<address as string>.`. If non-empty, stats will be rooted at

--- a/test/tools/schema_validator/test/config/lds_pgv_fail.yaml
+++ b/test/tools/schema_validator/test/config/lds_pgv_fail.yaml
@@ -8,13 +8,8 @@ resources:
         "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         stat_prefix: ingress_http
         use_remote_address: true
-        rds:
-          route_config_name: ingress_http
-          config_source:
-            resource_api_version: V3
-            path_config_source:
-              path: /config_map/rds/rds.yaml
-              watched_directory:
-                path: /config_map/rds
+        route_config:
+          virtual_hosts:
+          - name: foo
         http_filters:
         - name: envoy.filters.http.router

--- a/test/tools/schema_validator/test/schema_validator_test.cc
+++ b/test/tools/schema_validator/test/schema_validator_test.cc
@@ -98,7 +98,10 @@ TEST_F(SchemaValidatorTest, BootstrapPgvFail) {
 TEST_F(SchemaValidatorTest, LdsRecursivePgvFail) {
   EXPECT_THROW_WITH_REGEX(
       run("schema_validator_tool -c {} -t discovery_response", "lds_pgv_fail.yaml"), EnvoyException,
-      "Proto constraint validation failed \\(ListenerValidationError.Address: value is required");
+      "Proto constraint validation failed \\(HttpConnectionManagerValidationError.RouteConfig: "
+      "embedded message failed validation | caused by RouteConfigurationValidationError."
+      "VirtualHosts[0]: embedded message failed validation | caused by "
+      "VirtualHostValidationError.Domains: value must contain at least 1 item(s)");
 }
 
 } // namespace Envoy

--- a/test/tools/schema_validator/test/schema_validator_test.cc
+++ b/test/tools/schema_validator/test/schema_validator_test.cc
@@ -98,10 +98,9 @@ TEST_F(SchemaValidatorTest, BootstrapPgvFail) {
 TEST_F(SchemaValidatorTest, LdsRecursivePgvFail) {
   EXPECT_THROW_WITH_REGEX(
       run("schema_validator_tool -c {} -t discovery_response", "lds_pgv_fail.yaml"), EnvoyException,
-      "Proto constraint validation failed \\(HttpConnectionManagerValidationError.RouteConfig: "
-      "embedded message failed validation | caused by RouteConfigurationValidationError."
-      "VirtualHosts[0]: embedded message failed validation | caused by "
-      "VirtualHostValidationError.Domains: value must contain at least 1 item(s)");
+      "Proto constraint validation failed \\(HttpConnectionManagerValidationError.RouteConfig:"
+      ".* caused by RouteConfigurationValidationError.VirtualHosts.*"
+      "VirtualHostValidationError.Domains: value must contain at least 1 item\\(s\\)");
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: xds: Listener.address field is not required when api_listener is populated
Additional Description: This removes the overly restrictive PGV annotation that the address field is required, since there are cases where it does not need to be populated.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

The right long-term solution is to use a oneof for the different types of listeners, as described in #15372.  But in the interim, it should not be necessary to populate the address field for non-socket listeners.

CC @costinm 