### PR TITLE
skywalking: set peer with tag value of peer.address

### DIFF
--- a/source/common/tracing/common_values.h
+++ b/source/common/tracing/common_values.h
@@ -23,6 +23,8 @@ public:
   const std::string HttpStatusCode = "http.status_code";
   const std::string HttpUrl = "http.url";
   const std::string MessageBusDestination = "message_bus.destination";
+  // Downstream remote address for the downstream span and upstream remote address for the upstream
+  // span.
   const std::string PeerAddress = "peer.address";
   const std::string PeerHostname = "peer.hostname";
   const std::string PeerIpv4 = "peer.ipv4";

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -234,8 +234,12 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
       Formatter::SubstitutionFormatUtils::protocolToStringOrDefault(stream_info.protocol()));
 
   if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-    span.setTag(Tracing::Tags::get().UpstreamAddress,
-                stream_info.upstreamInfo()->upstreamHost()->address()->asStringView());
+    auto upstream_address = stream_info.upstreamInfo()->upstreamHost()->address();
+    // TODO(wbpcode): seperate `upstream_address` may be is meaningful to the downstream span.
+    // But for the upstream span, `peer.address` should be used.
+    span.setTag(Tracing::Tags::get().UpstreamAddress, upstream_address->asStringView());
+    // TODO(wbpcode): may be set this tag in the setCommonTags.
+    span.setTag(Tracing::Tags::get().PeerAddress, upstream_address->asStringView());
   }
 
   setCommonTags(span, response_headers, response_trailers, stream_info, tracing_config);

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -235,7 +235,7 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
 
   if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
     auto upstream_address = stream_info.upstreamInfo()->upstreamHost()->address();
-    // TODO(wbpcode): separated `upstream_address` may be is meaningful to the downstream span.
+    // TODO(wbpcode): separated `upstream_address` may be meaningful to the downstream span.
     // But for the upstream span, `peer.address` should be used.
     span.setTag(Tracing::Tags::get().UpstreamAddress, upstream_address->asStringView());
     // TODO(wbpcode): may be set this tag in the setCommonTags.

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -235,7 +235,7 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
 
   if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
     auto upstream_address = stream_info.upstreamInfo()->upstreamHost()->address();
-    // TODO(wbpcode): seperate `upstream_address` may be is meaningful to the downstream span.
+    // TODO(wbpcode): separated `upstream_address` may be is meaningful to the downstream span.
     // But for the upstream span, `peer.address` should be used.
     span.setTag(Tracing::Tags::get().UpstreamAddress, upstream_address->asStringView());
     // TODO(wbpcode): may be set this tag in the setCommonTags.

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -24,6 +24,8 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
   } else if (name == Tracing::Tags::get().Error) {
     span_entity_->setErrorStatus();
     span_entity_->addTag(std::string(name), std::string(value));
+  } else if (name == Tracing::Tags::get().PeerAddress) {
+    span_entity_->setPeer(std::string(value));
   } else {
     span_entity_->addTag(std::string(name), std::string(value));
   }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -239,6 +239,7 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -292,6 +293,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -343,6 +345,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpanKeepParentSampling) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -1259,6 +1262,8 @@ TEST_F(AsyncClientImplTracingTest, CancelRequest) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
+
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -1349,6 +1354,7 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -1543,6 +1549,7 @@ TEST_F(AsyncClientImplTracingTest, RequestTimeout) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -330,6 +330,7 @@ TEST_F(RouterTestChildSpan, BasicFlow) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -384,6 +385,7 @@ TEST_F(RouterTestChildSpan, ResetFlow) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -430,6 +432,7 @@ TEST_F(RouterTestChildSpan, CancelFlow) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -477,6 +480,7 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
+  EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span_1,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));
@@ -522,6 +526,7 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
+  EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
   EXPECT_CALL(*child_span_2,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("observability_name")));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -843,6 +843,7 @@ TEST_F(HttpTracerImplTest, ChildUpstreamSpanTest) {
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(*second_span,
               setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq(expected_ip + ":0")));
+  EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip + ":0")));
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake cluster")));
   EXPECT_CALL(*second_span,
               setTag(Eq(Tracing::Tags::get().UpstreamClusterName), Eq("ob fake cluster")));

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -119,6 +119,10 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     span->setTag(Tracing::Tags::get().HttpUrl, "http://test.com/test/path");
     EXPECT_EQ("url", span->spanEntity()->tags().at(4).first);
 
+    // When setting peer address tag, the peer will be set.
+    span->setTag(Tracing::Tags::get().PeerAddress, "1.2.3.4:8080");
+    EXPECT_EQ("1.2.3.4:8080", span->spanEntity()->peer());
+
     span->log(SystemTime{std::chrono::duration<int, std::milli>(100)}, "abc");
     EXPECT_EQ(1, span->spanEntity()->logs().size());
     EXPECT_LT(0, span->spanEntity()->logs().at(0).time());


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>

Commit Message: skywalking: set peer with tag value of peer.address
Additional Description:

Peer is a important attribution of skywalking span. But in the previous skywalking tracer's implementation, it never be set correctly. This PR will set peer of skywalking span with that tag value of `peer.address`.

This PR consist of two part:
1. Set `peer.address` tag when we calling the `finalizeUpstreamSpan`.
2. Set peer of skywalking span base on the value of `peer.address` tag.

Risk Level: Low.
Testing: Added
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
