### PR TITLE
[Backport 1.22] regex: restoring regex behavior prior to runtime load (#21069)

### DIFF
--- a/source/common/common/regex.cc
+++ b/source/common/common/regex.cc
@@ -17,7 +17,7 @@ CompiledGoogleReMatcher::CompiledGoogleReMatcher(const std::string& regex,
     throw EnvoyException(regex_.error());
   }
 
-  if (do_program_size_check) {
+  if (do_program_size_check && Runtime::isRuntimeInitialized()) {
     const uint32_t regex_program_size = static_cast<uint32_t>(regex_.ProgramSize());
     const uint32_t max_program_size_error_level =
         Runtime::getInteger("re2.max_program_size.error_level", 100);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -90,6 +90,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_thrift_connection_draining);
 // TODO(birenroy) flip after a burn-in period
 // Requires envoy_reloadable_features_http2_new_codec_wrapper to be enabled.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
+// Used to track if runtime is initialized.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 
 // Block of non-boolean flags. These are deprecated. Do not add more.
 ABSL_FLAG(uint64_t, envoy_headermap_lazy_map_min_size, 3, "");  // NOLINT
@@ -180,6 +182,14 @@ uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
   }
   IS_ENVOY_BUG(absl::StrCat("requested an unsupported integer ", feature));
   return default_value;
+}
+
+void markRuntimeInitialized() {
+  maybeSetRuntimeGuard("envoy.reloadable_features.runtime_initialized", true);
+}
+
+bool isRuntimeInitialized() {
+  return runtimeFeatureEnabled("envoy.reloadable_features.runtime_initialized");
 }
 
 void maybeSetRuntimeGuard(absl::string_view name, bool value) {

--- a/source/common/runtime/runtime_features.h
+++ b/source/common/runtime/runtime_features.h
@@ -18,6 +18,9 @@ bool isRuntimeFeature(absl::string_view feature);
 bool runtimeFeatureEnabled(absl::string_view feature);
 uint64_t getInteger(absl::string_view feature, uint64_t default_value);
 
+void markRuntimeInitialized();
+bool isRuntimeInitialized();
+
 void maybeSetRuntimeGuard(absl::string_view name, bool value);
 
 void maybeSetDeprecatedInts(absl::string_view name, uint32_t value);

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -65,6 +65,7 @@ void refreshReloadableFlags(const Snapshot::EntryMap& flag_map) {
       maybeSetDeprecatedInts(it.first, it.second.uint_value_.value());
     }
   }
+  markRuntimeInitialized();
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message:
Additional Description:
Backport #21069 to 1.22
Risk Level: Low
Testing: New integration test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
