### PR TITLE
fuzz test: Allow aws signing filter to run. 

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-4845350742523904
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-4845350742523904
@@ -1,0 +1,14 @@
+config {
+  name: "envoy.filters.http.aws_request_signing"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning"
+    value: "\nZtype.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning\022\013&&&&&&&&&&&"
+  }
+}
+data {
+  http_body {
+    data: "\000\000\000\023"
+  }
+}
+upstream_data {
+}

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -57,6 +57,8 @@ private:
   // Mocked callbacks.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+
+  const Buffer::Instance* decoding_buffer_{};
 };
 
 } // namespace HttpFilters

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -138,6 +138,13 @@ void UberFilterFuzzer::perFilterSetup() {
       .WillByDefault(testing::ReturnRef(listener_metadata_));
   ON_CALL(factory_context_.api_, customStatNamespaces())
       .WillByDefault(testing::ReturnRef(custom_stat_namespaces_));
+
+  // Prepare expectations for AWSRequestSigning filter
+  ON_CALL(decoder_callbacks_, addDecodedData(_, _))
+      .WillByDefault([this](Buffer::Instance& data, bool) { decoding_buffer_ = &data; });
+  ON_CALL(decoder_callbacks_, decodingBuffer()).WillByDefault([this]() -> const Buffer::Instance* {
+    return decoding_buffer_;
+  });
 }
 
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message: fuzz test: Allow aws signing filter to run.
Additional Description:
- Provide decoding_buffer_ to aws signing filter, allowing it to run
further.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
