### PR TITLE
dns_filter: simpilfy dns filter fuzz tests

### DIFF
--- a/test/extensions/filters/udp/dns_filter/dns_filter_fuzz_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_fuzz_test.cc
@@ -39,18 +39,12 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
 
     const uint16_t retry_count = data_provider.ConsumeIntegralInRange<uint16_t>(0, 3);
     DnsMessageParser message_parser(true, api->timeSource(), retry_count, random, histogram);
-    uint64_t offset = data_provider.ConsumeIntegralInRange<uint64_t>(0, query.size());
 
-    const uint8_t fuzz_function = data_provider.ConsumeIntegralInRange<uint8_t>(0, 1);
-    if (fuzz_function == 0) {
-      DnsQueryContextPtr query_context =
-          std::make_unique<DnsQueryContext>(local, peer, counters, retry_count);
-      bool result = message_parser.parseDnsObject(query_context, query_buffer);
-      UNREFERENCED_PARAMETER(result);
-    } else {
-      DnsQueryRecordPtr ptr = message_parser.parseDnsQueryRecord(query_buffer, offset);
-      UNREFERENCED_PARAMETER(ptr);
-    }
+    DnsQueryContextPtr query_context =
+        std::make_unique<DnsQueryContext>(local, peer, counters, retry_count);
+    bool result = message_parser.parseDnsObject(query_context, query_buffer);
+    UNREFERENCED_PARAMETER(result);
+
     query_buffer->drain(query_buffer->length());
   }
 }


### PR DESCRIPTION
Signed-off-by: Boteng Yao <boteng@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
* In this PR, [#20744](https://github.com/envoyproxy/envoy/pull/20744) the answer message is disabled. 
* Remove separate fuzzing of the parseDnsQueryRecord as it is tested as part of the parseDnsObject method.
* Remove fuzz_function randomization and only test the parseDnsObject method as it is used in the filter implementation.

Commit Message: simplify dns filter fuzz tests
Additional Description:
Risk Level: low
Testing: fuzz test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
