### PR TITLE
codeowners: replace yxue@ with penguingao@ as aggregate cluster owner.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -135,7 +135,7 @@ extensions/filters/common/original_src @snowp @klarose
 /*/extensions/filters/udp/dns_filter @abaptiste @mattklein123 @yanjunxiang-google
 /*/extensions/filters/network/direct_response @kyessenov @zuercher
 /*/extensions/filters/udp/udp_proxy @mattklein123 @danzh2010
-/*/extensions/clusters/aggregate @yxue @snowp
+/*/extensions/clusters/aggregate @penguingao @snowp
 # support for on-demand VHDS requests
 /*/extensions/filters/http/on_demand @dmitri-d @htuch @lambdai
 /*/extensions/filters/network/connection_limit @mattklein123 @alyssawilk @delong-coder


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: replace yxue@ with peng as aggregate cluster owner.
Additional Description: yxue@ seems to no longer be working on istio/envoy
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
