### PR TITLE
unified_mux: Keeping version_info in SotW reconnect

### DIFF
--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -36,7 +36,6 @@ bool SotwSubscriptionState::subscriptionUpdatePending() const {
 }
 
 void SotwSubscriptionState::markStreamFresh() {
-  last_good_version_info_ = absl::nullopt;
   last_good_nonce_ = absl::nullopt;
   update_pending_ = true;
   clearDynamicContextChanged();


### PR DESCRIPTION
Commit Message: unified_mux: Keeping version_info in SotW reconnect
Additional Description:
The SotW unified mux currently resets the version_info when a reconnect event occurs.
This PR changes the behavior so Envoy keeps the last valid version_info it has, and sends that upon reconnect.
Risk Level: Low - unified_mux is currently runtime guarded
Testing: Added unit test.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
