### PR TITLE
admin: fix problem with large /stats requests via adminRequest API

### DIFF
--- a/envoy/server/admin.h
+++ b/envoy/server/admin.h
@@ -114,6 +114,12 @@ public:
      * is not sent, and a subsequent call to nextChunk can be made later,
      * possibly after a post() or low-watermark callback on the http filter.
      *
+     * It is not necessary for the caller to drain the response after each call;
+     * it can leave the data in response if it's necessary to buffer the entire
+     * response prior to sending it to the network. It is preferable to stream
+     * the data out, draining the response buffer on each call, but not
+     * required.
+     *
      * @param response a buffer in which to write the chunk
      * @return whether or not any chunks follow this one.
      */

--- a/source/server/admin/stats_request.cc
+++ b/source/server/admin/stats_request.cc
@@ -107,8 +107,6 @@ void StatsRequest::startPhase() {
     StatOrScopes& variant = stat_map_[stats_.symbolTable().toString(scope->prefix())];
     if (variant.index() == absl::variant_npos) {
       variant = ScopeVec();
-    } else {
-      ASSERT(static_cast<StatOrScopesIndex>(variant.index()) == StatOrScopesIndex::Scopes);
     }
     absl::get<ScopeVec>(variant).emplace_back(scope);
   }

--- a/source/server/admin/stats_request.cc
+++ b/source/server/admin/stats_request.cc
@@ -42,7 +42,7 @@ bool StatsRequest::nextChunk(Buffer::Instance& response) {
 
   // nextChunk's contract is to add up to chunk_size_ additional bytes. The
   // caller is not required to drain the bytes after each call to nextChunk.
-  uint32_t starting_response_length = response.length();
+  uint64_t starting_response_length = response.length();
   while (response.length() - starting_response_length < chunk_size_) {
     while (stat_map_.empty()) {
       switch (phase_) {

--- a/source/server/admin/stats_request.cc
+++ b/source/server/admin/stats_request.cc
@@ -42,7 +42,7 @@ bool StatsRequest::nextChunk(Buffer::Instance& response) {
 
   // nextChunk's contract is to add up to chunk_size_ additional bytes. The
   // caller is not required to drain the bytes after each call to nextChunk.
-  uint64_t starting_response_length = response.length();
+  const uint64_t starting_response_length = response.length();
   while (response.length() - starting_response_length < chunk_size_) {
     while (stat_map_.empty()) {
       switch (phase_) {

--- a/source/server/admin/stats_request.h
+++ b/source/server/admin/stats_request.h
@@ -35,7 +35,7 @@ class StatsRequest : public Admin::Request {
   };
 
 public:
-  static constexpr uint32_t DefaultChunkSize = 2 * 1000 * 1000;
+  static constexpr uint64_t DefaultChunkSize = 2 * 1000 * 1000;
 
   StatsRequest(Stats::Store& stats, const StatsParams& params);
 

--- a/source/server/admin/stats_request.h
+++ b/source/server/admin/stats_request.h
@@ -35,6 +35,8 @@ class StatsRequest : public Admin::Request {
   };
 
 public:
+  static constexpr uint32_t DefaultChunkSize = 2 * 1000 * 1000;
+
   StatsRequest(Stats::Store& stats, const StatsParams& params);
 
   // Admin::Request
@@ -103,7 +105,7 @@ private:
   absl::btree_map<std::string, StatOrScopes> stat_map_;
   Phase phase_{Phase::TextReadouts};
   Buffer::OwnedImpl response_;
-  uint64_t chunk_size_{2 * 1000 * 1000};
+  uint64_t chunk_size_{DefaultChunkSize};
 };
 
 } // namespace Server

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -236,7 +236,7 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, getCallback("/", header_map, response));
   const Http::HeaderString& content_type = header_map.ContentType()->value();
-  EXPECT_THAT(std::string(content_type.getStringView()), testing::HasSubstr("text/html"));
+  EXPECT_THAT(std::string(content_type.getStringView()), HasSubstr("text/html"));
   EXPECT_EQ(-1, response.search(planets.data(), planets.size(), 0, 0));
   const std::string escaped_planets = "jupiter&gt;saturn&gt;mars";
   EXPECT_NE(-1, response.search(escaped_planets.data(), escaped_planets.size(), 0, 0));

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -27,6 +27,7 @@
 #include "gtest/gtest.h"
 
 using testing::HasSubstr;
+using testing::StartsWith;
 
 namespace Envoy {
 namespace Server {
@@ -201,6 +202,7 @@ TEST_P(AdminInstanceTest, StatsWithMultipleChunks) {
   EXPECT_EQ(Http::Code::OK, getCallback("/stats", header_map, response));
   EXPECT_LT(expected_size, response.length());
   EXPECT_LT(StatsRequest::DefaultChunkSize, response.length());
+  EXPECT_THAT(response.toString(), StartsWith(absl::StrCat(prefix, "0: 0\n", prefix)));
 }
 
 TEST_P(AdminInstanceTest, RejectHandlerWithXss) {

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -193,7 +193,9 @@ TEST_P(AdminInstanceTest, StatsWithMultipleChunks) {
   // call.
   const std::string prefix(1000, 'a');
   uint32_t expected_size = 0;
-  uint32_t n = (StatsRequest::DefaultChunkSize + prefix.size() / 2) / prefix.size() + 1;
+
+  // Declare enough counters so that we are sure to exceed the chunk size.
+  const uint32_t n = (StatsRequest::DefaultChunkSize + prefix.size() / 2) / prefix.size() + 1;
   for (uint32_t i = 0; i <= n; ++i) {
     const std::string name = absl::StrCat(prefix, i);
     store.counterFromString(name);


### PR DESCRIPTION
Commit Message: The Admin infrastructure's nextChunk() contract does not require its caller to drain the buffer on each call. This fixes the logic in StatsRequest::nextChunk to append up to N *additional* bytes on each call, and adds tests in both stats_request_test.cc and in admin_test.cc that repro'd the problem and verifies that it is fixed.

This problem did *not* affect the admin HTTP port because when admin_filter.cc calls nextChunk(), since it drains the response buffer and sends it to the network.
Additional Description:
Risk Level: low
Testing: //test/server/admin/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
