### PR TITLE
WiP admin: add flow-control and yielding between admin chunks

### DIFF
--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -299,16 +299,11 @@ public:
   bool nextChunk(Buffer::Instance& response) override {
     // Artificially make 1M chunks from the buffered admin output, to see if we
     // can observe chunking in a live server.
-#if 0
-    response.move(response_);
-    return false;
-#else
     std::string str = response_.toString();
     absl::string_view head(str.data(), std::min(size_t(1000000), str.size()));
     response.add(head);
     response_.drain(head.size());
     return response_.length() > 0;
-#endif
   }
 
 private:

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -297,8 +297,18 @@ public:
   }
 
   bool nextChunk(Buffer::Instance& response) override {
+    // Artificially make 1M chunks from the buffered admin output, to see if we
+    // can observe chunking in a live server.
+#if 0
     response.move(response_);
     return false;
+#else
+    std::string str = response_.toString();
+    absl::string_view head(str.data(), std::min(size_t(1000000), str.size()));
+    response.add(head);
+    response_.drain(head.size());
+    return response_.length() > 0;
+#endif
   }
 
 private:

--- a/source/server/admin/admin_filter.cc
+++ b/source/server/admin/admin_filter.cc
@@ -101,20 +101,6 @@ void AdminFilter::nextChunk() {
     ENVOY_LOG_MISC(error, "nextChunk reset");
     request_.reset();
   }
-
-#if 0
-  bool more_data;
-  do {
-    Buffer::OwnedImpl response;
-    more_data = request_->nextChunk(response);
-    bool end_stream = end_stream_on_complete_ && !more_data;
-    ENVOY_LOG_MISC(debug, "nextChunk: response.length={} more_data={} end_stream={}",
-                   response.length(), more_data, end_stream);
-    if (response.length() > 0 || end_stream) {
-      decoder_callbacks_->encodeData(response, end_stream);
-    }
-  } while (more_data);
-#endif
 }
 
 } // namespace Server

--- a/source/server/admin/admin_filter.h
+++ b/source/server/admin/admin_filter.h
@@ -30,8 +30,8 @@ public:
 
   class WatermarkCallbacks : public Http::DownstreamWatermarkCallbacks {
   public:
-    WatermarkCallbacks(AdminFilter& filter) : filter_(filter) {}
-    virtual ~WatermarkCallbacks() = default;
+    explicit WatermarkCallbacks(AdminFilter& filter) : filter_(filter) {}
+    ~WatermarkCallbacks() override = default;
     void onAboveWriteBufferHighWatermark() override {
       ENVOY_LOG_MISC(error, "Above high-watermark callback");
       filter_.can_write_ = false;

--- a/source/server/admin/admin_filter.h
+++ b/source/server/admin/admin_filter.h
@@ -32,9 +32,13 @@ public:
   public:
     WatermarkCallbacks(AdminFilter& filter) : filter_(filter) {}
     virtual ~WatermarkCallbacks() = default;
-    void onAboveWriteBufferHighWatermark() override { filter_.can_write_ = false; }
+    void onAboveWriteBufferHighWatermark() override {
+      ENVOY_LOG_MISC(error, "Above high-watermark callback");
+      filter_.can_write_ = false;
+    }
     void onBelowWriteBufferLowWatermark() override {
       filter_.can_write_ = true;
+      ENVOY_LOG_MISC(error, "Below high-watermark callback");
       filter_.nextChunk();
     }
 


### PR DESCRIPTION
Commit Message: This is a candidate attempt at making the admin pages do flow-control with chunked responses. The responses were already chunked and streamed out to the network, but prior to this PR that just happened in a loop until we completed the request.

With this PR we yield after every chunk and post() a callback to do the next one until we are done. That all seems to work. The work done so far was based on an earlier chat with @alyssawilk .

However I could use @alyssawilk's help to understand better how to make the high-watermark code activate. From reading https://github.com/envoyproxy/envoy/blob/main/source/docs/flow_control.md it looks like the filter needs to determine the high-watermark thresholds with setEncoderBufferLimit, but I don't know what the right number to set it to in the production code is, and I'm not sure I'd expect users to know how to configure it.

For a manual test I created 100k clusters and ran /stats, and it takes about 7 seconds wall-clock time measured from the client (`time wget -O /dev/null ...`) to generate 1.25G of data in 627 chunks. However it never activated the high-watermark callback. Should it have?

I also tried hitting ^Z during the `wget` but still it just seems like the process or network buffered all 1.25G and when I resumed the `wget` it got all the rest of it pretty quickly.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
