### PR TITLE
skywalking: use request path as operation name

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -35,6 +35,9 @@ minor_behavior_changes:
     that loads shared object libraries, such as those installed via luarocks.
 - area: skywalking
   change: |
+    use request path as operation name of ENTRY/EXIT spans.
+- area: skywalking
+  change: |
     use upstream host address as ``addressUsedAtClient`` in propagation header.
 - area: dns
   change: |

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -45,7 +45,7 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
 }
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config&, Tracing::TraceContext& trace_context,
-                                   const std::string& operation_name, Envoy::SystemTime,
+                                   const std::string&, Envoy::SystemTime,
                                    const Tracing::Decision decision) {
   auto& tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer();
   TracingContextPtr tracing_context;
@@ -70,7 +70,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config&, Tracing::TraceContext
     }
   }
 
-  return tracer.startSpan(operation_name, tracing_context);
+  return tracer.startSpan(trace_context.path(), tracing_context);
 }
 
 void Driver::loadConfig(const envoy::config::trace::v3::ClientConfig& client_config,

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -41,7 +41,7 @@ public:
    *
    * @return The unique ptr to the newly created span.
    */
-  Tracing::SpanPtr startSpan(const std::string& name, TracingContextPtr tracing_context);
+  Tracing::SpanPtr startSpan(absl::string_view name, TracingContextPtr tracing_context);
 
 private:
   TraceSegmentReporterPtr reporter_;
@@ -51,16 +51,16 @@ using TracerPtr = std::unique_ptr<Tracer>;
 
 class Span : public Tracing::Span {
 public:
-  Span(const std::string& name, TracingContextPtr tracing_context, Tracer& parent_tracer)
+  Span(absl::string_view name, TracingContextPtr tracing_context, Tracer& parent_tracer)
       : parent_tracer_(parent_tracer), tracing_context_(tracing_context),
         span_entity_(tracing_context_->createEntrySpan()) {
-    span_entity_->startSpan(name);
+    span_entity_->startSpan({name.data(), name.size()});
   }
-  Span(const std::string& name, Span& parent_span, TracingContextPtr tracing_context,
+  Span(absl::string_view name, Span& parent_span, TracingContextPtr tracing_context,
        Tracer& parent_tracer)
       : parent_tracer_(parent_tracer), tracing_context_(tracing_context),
         span_entity_(tracing_context_->createExitSpan(parent_span.spanEntity())) {
-    span_entity_->startSpan(name);
+    span_entity_->startSpan({name.data(), name.size()});
   }
 
   // Tracing::Span

--- a/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
+++ b/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
@@ -89,6 +89,10 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
     Span* span = dynamic_cast<Span*>(org_span.get());
     ASSERT(span);
 
+    // "TEST_OP" will be ignored and path of downstream request will be used as the operation name
+    // of ENTRY span.
+    EXPECT_EQ("/path", span->spanEntity()->operationName());
+
     EXPECT_EQ("FAKE_FAKE_FAKE", span->tracingContext()->service());
     EXPECT_EQ("FAKE_FAKE_FAKE_INSTANCE", span->tracingContext()->serviceInstance());
 
@@ -112,6 +116,9 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
 
     Span* span = dynamic_cast<Span*>(org_span.get());
     ASSERT(span);
+
+    // Path of downstream request will be used as the operation name of ENTRY span.
+    EXPECT_EQ("/path", span->spanEntity()->operationName());
 
     EXPECT_FALSE(span->tracingContext()->skipAnalysis());
 

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -78,10 +78,10 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   // Create a new SegmentContext.
   auto segment_context = SkyWalkingTestHelper::createSegmentContext(true, "CURR", "");
 
-  Envoy::Tracing::SpanPtr org_span = tracer_->startSpan("TEST_OP", segment_context);
-  {
-    Span* span = dynamic_cast<Span*>(org_span.get());
+  Envoy::Tracing::SpanPtr org_span = tracer_->startSpan("/downstream/path", segment_context);
+  Span* span = dynamic_cast<Span*>(org_span.get());
 
+  {
     EXPECT_TRUE(span->spanEntity()->spanType() == skywalking::v3::SpanType::Entry);
     EXPECT_EQ("", span->getBaggage("FakeStringAndNothingToDo"));
     span->setOperation("FakeStringAndNothingToDo");
@@ -95,7 +95,7 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
 
     // The initial operation name is consistent with the 'operation' parameter in the 'startSpan'
     // method call.
-    EXPECT_EQ("TEST_OP", span->spanEntity()->operationName());
+    EXPECT_EQ("/downstream/path", span->spanEntity()->operationName());
 
     // Test whether the tag can be set correctly.
     span->setTag("TestTagKeyA", "TestTagValueA");
@@ -146,64 +146,74 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     EXPECT_EQ(1, first_child_span->spanEntity()->spanId());
     EXPECT_EQ(0, first_child_span->spanEntity()->parentSpanId());
 
-    EXPECT_EQ("TestChild", first_child_span->spanEntity()->operationName());
+    // "TestChild" will be ignored and operation name of parent span will be used by default for
+    // child span (EXIT span).
+    EXPECT_EQ(span->spanEntity()->operationName(), first_child_span->spanEntity()->operationName());
 
     first_child_span->finishSpan();
     EXPECT_NE(0, first_child_span->spanEntity()->endTime());
 
-    Http::TestRequestHeaderMapImpl first_child_headers{{":authority", "test.com"}};
+    Http::TestRequestHeaderMapImpl first_child_headers{{":authority", "test.com"},
+                                                       {":path", "/upstream/path"}};
     Upstream::HostDescriptionConstSharedPtr host{
         new testing::NiceMock<Upstream::MockHostDescription>()};
 
     first_child_span->injectContext(first_child_headers, host);
+    // Operation name of child span (EXIT span) will be override by the latest path of upstream
+    // request.
+    EXPECT_EQ("/upstream/path", first_child_span->spanEntity()->operationName());
+
     auto sp = createSpanContext(first_child_headers.get_("sw8"));
     EXPECT_EQ("CURR#SERVICE", sp->service());
     EXPECT_EQ("CURR#INSTANCE", sp->serviceInstance());
-    EXPECT_EQ("TEST_OP", sp->endpoint());
+    EXPECT_EQ("/downstream/path", sp->endpoint());
     EXPECT_EQ("10.0.0.1:443", sp->targetAddress());
   }
 
   {
-    Envoy::Tracing::SpanPtr org_first_child_span =
+    Envoy::Tracing::SpanPtr org_second_child_span =
         org_span->spawnChild(mock_tracing_config_, "TestChild", mock_time_source_.systemTime());
 
-    Span* first_child_span = dynamic_cast<Span*>(org_first_child_span.get());
+    Span* second_child_span = dynamic_cast<Span*>(org_second_child_span.get());
 
-    EXPECT_TRUE(first_child_span->spanEntity()->spanType() == skywalking::v3::SpanType::Exit);
+    EXPECT_TRUE(second_child_span->spanEntity()->spanType() == skywalking::v3::SpanType::Exit);
 
-    EXPECT_FALSE(first_child_span->spanEntity()->skipAnalysis());
-    EXPECT_EQ(2, first_child_span->spanEntity()->spanId());
-    EXPECT_EQ(0, first_child_span->spanEntity()->parentSpanId());
+    EXPECT_FALSE(second_child_span->spanEntity()->skipAnalysis());
+    EXPECT_EQ(2, second_child_span->spanEntity()->spanId());
+    EXPECT_EQ(0, second_child_span->spanEntity()->parentSpanId());
 
-    EXPECT_EQ("TestChild", first_child_span->spanEntity()->operationName());
+    // "TestChild" will be ignored and operation name of parent span will be used by default for
+    // child span (EXIT span).
+    EXPECT_EQ(span->spanEntity()->operationName(),
+              second_child_span->spanEntity()->operationName());
 
-    first_child_span->finishSpan();
-    EXPECT_NE(0, first_child_span->spanEntity()->endTime());
+    second_child_span->finishSpan();
+    EXPECT_NE(0, second_child_span->spanEntity()->endTime());
 
-    Http::TestRequestHeaderMapImpl first_child_headers{{":authority", "test.com"}};
+    Http::TestRequestHeaderMapImpl second_child_headers{{":authority", "test.com"}};
 
-    first_child_span->injectContext(first_child_headers, nullptr);
-    auto sp = createSpanContext(first_child_headers.get_("sw8"));
+    second_child_span->injectContext(second_child_headers, nullptr);
+    auto sp = createSpanContext(second_child_headers.get_("sw8"));
     EXPECT_EQ("CURR#SERVICE", sp->service());
     EXPECT_EQ("CURR#INSTANCE", sp->serviceInstance());
-    EXPECT_EQ("TEST_OP", sp->endpoint());
+    EXPECT_EQ("/downstream/path", sp->endpoint());
     EXPECT_EQ("test.com", sp->targetAddress());
   }
 
   segment_context->setSkipAnalysis();
 
   {
-    Envoy::Tracing::SpanPtr org_second_child_span =
+    Envoy::Tracing::SpanPtr org_third_child_span =
         org_span->spawnChild(mock_tracing_config_, "TestChild", mock_time_source_.systemTime());
-    Span* second_child_span = dynamic_cast<Span*>(org_second_child_span.get());
+    Span* third_child_span = dynamic_cast<Span*>(org_third_child_span.get());
 
     // SkipAnalysis is true by default with calling setSkipAnalysis() on segment_context.
-    EXPECT_TRUE(second_child_span->spanEntity()->skipAnalysis());
-    EXPECT_EQ(3, second_child_span->spanEntity()->spanId());
-    EXPECT_EQ(0, second_child_span->spanEntity()->parentSpanId());
+    EXPECT_TRUE(third_child_span->spanEntity()->skipAnalysis());
+    EXPECT_EQ(3, third_child_span->spanEntity()->spanId());
+    EXPECT_EQ(0, third_child_span->spanEntity()->parentSpanId());
 
-    second_child_span->finishSpan();
-    EXPECT_NE(0, second_child_span->spanEntity()->endTime());
+    third_child_span->finishSpan();
+    EXPECT_NE(0, third_child_span->spanEntity()->endTime());
   }
 
   // When the child span ends, the data is not reported immediately, but the end time is set.

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -150,9 +150,6 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     // child span (EXIT span).
     EXPECT_EQ(span->spanEntity()->operationName(), first_child_span->spanEntity()->operationName());
 
-    first_child_span->finishSpan();
-    EXPECT_NE(0, first_child_span->spanEntity()->endTime());
-
     Http::TestRequestHeaderMapImpl first_child_headers{{":authority", "test.com"},
                                                        {":path", "/upstream/path"}};
     Upstream::HostDescriptionConstSharedPtr host{
@@ -168,6 +165,9 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     EXPECT_EQ("CURR#INSTANCE", sp->serviceInstance());
     EXPECT_EQ("/downstream/path", sp->endpoint());
     EXPECT_EQ("10.0.0.1:443", sp->targetAddress());
+
+    first_child_span->finishSpan();
+    EXPECT_NE(0, first_child_span->spanEntity()->endTime());
   }
 
   {
@@ -187,9 +187,6 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     EXPECT_EQ(span->spanEntity()->operationName(),
               second_child_span->spanEntity()->operationName());
 
-    second_child_span->finishSpan();
-    EXPECT_NE(0, second_child_span->spanEntity()->endTime());
-
     Http::TestRequestHeaderMapImpl second_child_headers{{":authority", "test.com"}};
 
     second_child_span->injectContext(second_child_headers, nullptr);
@@ -198,6 +195,9 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     EXPECT_EQ("CURR#INSTANCE", sp->serviceInstance());
     EXPECT_EQ("/downstream/path", sp->endpoint());
     EXPECT_EQ("test.com", sp->targetAddress());
+
+    second_child_span->finishSpan();
+    EXPECT_NE(0, second_child_span->spanEntity()->endTime());
   }
 
   segment_context->setSkipAnalysis();


### PR DESCRIPTION
Commit Message: skywalking: use request path as operation name
Additional Description:

To pick up #20452 .

Risk Level: Low.
Testing: Added.
Docs Changes: n/a.
Release Notes: Added.
Platform Specific Features: n/a.