### PR TITLE
[Cleanup] [contrib] Remove unused import to get rid of warnings

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
@@ -8,7 +8,6 @@ import "envoy/config/core/v3/grpc_service.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.tra.v3alpha";


### PR DESCRIPTION
Commit Message: [Cleanup] [contrib] Remove unused import to get rid of warnings
Additional Description: Building `//docs:html` outputs two warnings about this import
Risk Level: None.
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
