### PR TITLE
dynamic_forward_proxy: add outlier detection support

### DIFF
--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -170,6 +170,9 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     if (host_it == cluster_.host_map_.end()) {
       return nullptr;
     } else {
+      if (host_it->second.logical_host_->health() == Upstream::Host::Health::Unhealthy) {
+        return nullptr;
+      }
       host_it->second.shared_host_info_->touch();
       return host_it->second.logical_host_;
     }


### PR DESCRIPTION
Commit Message: dynamic_forward_proxy: add outlier detection support
Additional Description: Currently dfp doesn't honor host ejections, continuous to use ejected
hosts. This adds support for honoring ejections/de-ejections.
Risk Level: Low
Testing: Unit and manual testing
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
