### PR TITLE
fuzz test: Prevent endless loop by checking for progress.

### DIFF
--- a/test/common/http/codec_impl_corpus/oss-fuzz-45481-codec_impl_fuzz_test-4765897875652608
+++ b/test/common/http/codec_impl_corpus/oss-fuzz-45481-codec_impl_fuzz_test-4765897875652608
@@ -1,0 +1,32 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: "content-length"
+        value: "2"
+      }
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3
+    }
+    dispatching_action {
+      data: 3
+    }
+  }
+}


### PR DESCRIPTION
Commit Message: fuzz test: Prevent endless loop by checking for progress.
Additional Description:
In codec_impl_fuzz_test a client_server_buffer_drain could get caught
into a loop where readDisabled(true) was set and the buffer wouldn't get
drained. Break that loop by checking that the buffer length changes.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
