### PR TITLE
doc: Remove SHA-1 cipher suites from the defaults on the server-side

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -66,12 +66,8 @@ message TlsParameters {
   //
   //   [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
   //   [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
-  //   ECDHE-ECDSA-AES128-SHA
-  //   ECDHE-RSA-AES128-SHA
   //   ECDHE-ECDSA-AES256-GCM-SHA384
   //   ECDHE-RSA-AES256-GCM-SHA384
-  //   ECDHE-ECDSA-AES256-SHA
-  //   ECDHE-RSA-AES256-SHA
   //
   // In builds using :ref:`BoringSSL FIPS <arch_overview_ssl_fips>`, the default server cipher list is:
   //
@@ -79,12 +75,8 @@ message TlsParameters {
   //
   //   ECDHE-ECDSA-AES128-GCM-SHA256
   //   ECDHE-RSA-AES128-GCM-SHA256
-  //   ECDHE-ECDSA-AES128-SHA
-  //   ECDHE-RSA-AES128-SHA
   //   ECDHE-ECDSA-AES256-GCM-SHA384
   //   ECDHE-RSA-AES256-GCM-SHA384
-  //   ECDHE-ECDSA-AES256-SHA
-  //   ECDHE-RSA-AES256-SHA
   //
   // In non-FIPS builds, the default client cipher list is:
   //


### PR DESCRIPTION
Related PR: https://github.com/envoyproxy/envoy/pull/20643

Signed-off-by: derekguo001 <dong.guo@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
