### PR TITLE
Remove Parser::statusToInt().

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -453,20 +453,19 @@ Status RequestEncoderImpl::encodeHeaders(const RequestHeaderMap& headers, bool e
   return okStatus();
 }
 
-int ConnectionImpl::setAndCheckCallbackStatus(Status&& status) {
+ParserStatus ConnectionImpl::setAndCheckCallbackStatus(Status&& status) {
   ASSERT(codec_status_.ok());
   codec_status_ = std::move(status);
-  return codec_status_.ok() ? parser_->statusToInt(ParserStatus::Success)
-                            : parser_->statusToInt(ParserStatus::Error);
+  return codec_status_.ok() ? ParserStatus::Success : ParserStatus::Error;
 }
 
-int ConnectionImpl::setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) {
+ParserStatus ConnectionImpl::setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) {
   ASSERT(codec_status_.ok());
   if (statusor.ok()) {
-    return parser_->statusToInt(statusor.value());
+    return statusor.value();
   } else {
     codec_status_ = std::move(statusor.status());
-    return parser_->statusToInt(ParserStatus::Error);
+    return ParserStatus::Error;
   }
 }
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -635,8 +635,7 @@ Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t 
     return codec_status_;
   }
 
-  if (rc != parser_->statusToInt(ParserStatus::Success) &&
-      rc != parser_->statusToInt(ParserStatus::Paused)) {
+  if (rc != ParserStatus::Success && rc != ParserStatus::Paused) {
     RETURN_IF_ERROR(sendProtocolError(Http1ResponseCodeDetails::get().HttpCodecError));
     // Avoid overwriting the codec_status_ set in the callbacks.
     ASSERT(codec_status_.ok());

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -630,17 +630,17 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
 
 Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t len) {
   ASSERT(codec_status_.ok() && dispatching_);
-  auto [nread, rc] = parser_->execute(slice, len);
+  auto [nread, status] = parser_->execute(slice, len);
   if (!codec_status_.ok()) {
     return codec_status_;
   }
 
-  if (rc != ParserStatus::Success && rc != ParserStatus::Paused) {
+  if (status != ParserStatus::Success && status != ParserStatus::Paused) {
     RETURN_IF_ERROR(sendProtocolError(Http1ResponseCodeDetails::get().HttpCodecError));
     // Avoid overwriting the codec_status_ set in the callbacks.
     ASSERT(codec_status_.ok());
     codec_status_ =
-        codecProtocolError(absl::StrCat("http/1.1 protocol error: ", parser_->errnoName(rc)));
+        codecProtocolError(absl::StrCat("http/1.1 protocol error: ", parser_->errnoName(status)));
     return codec_status_;
   }
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -349,8 +349,8 @@ private:
   Envoy::StatusOr<ParserStatus> onHeadersComplete() override;
   void bufferBody(const char* data, size_t length) override;
   StatusOr<ParserStatus> onMessageComplete() override;
-  int setAndCheckCallbackStatus(Http::Status&& status) override;
-  int setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) override;
+  ParserStatus setAndCheckCallbackStatus(Http::Status&& status) override;
+  ParserStatus setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) override;
 
   // Connection specific callback methods.
   virtual Envoy::StatusOr<ParserStatus> onHeadersCompleteBase() PURE;

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -44,32 +44,32 @@ public:
         [](http_parser* parser) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onMessageBegin();
-          return conn_impl->setAndCheckCallbackStatus(std::move(status));
+          return statusToInt(conn_impl->setAndCheckCallbackStatus(std::move(status)));
         },
         [](http_parser* parser, const char* at, size_t length) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onUrl(at, length);
-          return conn_impl->setAndCheckCallbackStatus(std::move(status));
+          return statusToInt(conn_impl->setAndCheckCallbackStatus(std::move(status)));
         },
         [](http_parser* parser, const char* at, size_t length) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onStatus(at, length);
-          return conn_impl->setAndCheckCallbackStatus(std::move(status));
+          return statusToInt(conn_impl->setAndCheckCallbackStatus(std::move(status)));
         },
         [](http_parser* parser, const char* at, size_t length) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onHeaderField(at, length);
-          return conn_impl->setAndCheckCallbackStatus(std::move(status));
+          return statusToInt(conn_impl->setAndCheckCallbackStatus(std::move(status)));
         },
         [](http_parser* parser, const char* at, size_t length) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onHeaderValue(at, length);
-          return conn_impl->setAndCheckCallbackStatus(std::move(status));
+          return statusToInt(conn_impl->setAndCheckCallbackStatus(std::move(status)));
         },
         [](http_parser* parser) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto statusor = conn_impl->onHeadersComplete();
-          return conn_impl->setAndCheckCallbackStatusOr(std::move(statusor));
+          return statusToInt(conn_impl->setAndCheckCallbackStatusOr(std::move(statusor)));
         },
         [](http_parser* parser, const char* at, size_t length) -> int {
           static_cast<ParserCallbacks*>(parser->data)->bufferBody(at, length);
@@ -78,7 +78,7 @@ public:
         [](http_parser* parser) -> int {
           auto* conn_impl = static_cast<ParserCallbacks*>(parser->data);
           auto status = conn_impl->onMessageComplete();
-          return conn_impl->setAndCheckCallbackStatusOr(std::move(status));
+          return statusToInt(conn_impl->setAndCheckCallbackStatusOr(std::move(status)));
         },
         [](http_parser* parser) -> int {
           // A 0-byte chunk header is used to signal the end of the chunked body.

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -178,8 +178,8 @@ bool LegacyHttpParserImpl::isChunked() const { return impl_->isChunked(); }
 
 absl::string_view LegacyHttpParserImpl::methodName() const { return impl_->methodName(); }
 
-absl::string_view LegacyHttpParserImpl::errnoName(int rc) const {
-  return http_errno_name(static_cast<http_errno>(rc));
+absl::string_view LegacyHttpParserImpl::errnoName(ParserStatus rc) const {
+  return http_errno_name(static_cast<http_errno>(statusToInt(rc)));
 }
 
 int LegacyHttpParserImpl::hasTransferEncoding() const { return impl_->hasTransferEncoding(); }

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -11,6 +11,7 @@ namespace Envoy {
 namespace Http {
 namespace Http1 {
 namespace {
+
 ParserStatus intToStatus(int rc) {
   // See
   // https://github.com/nodejs/http-parser/blob/5c5b3ac62662736de9e71640a8dc16da45b32503/http_parser.h#L72.
@@ -29,6 +30,26 @@ ParserStatus intToStatus(int rc) {
     return ParserStatus::Unknown;
   }
 }
+
+int statusToInt(const ParserStatus code) {
+  // See
+  // https://github.com/nodejs/http-parser/blob/5c5b3ac62662736de9e71640a8dc16da45b32503/http_parser.h#L72.
+  switch (code) {
+  case ParserStatus::Error:
+    return -1;
+  case ParserStatus::Success:
+    return 0;
+  case ParserStatus::NoBody:
+    return 1;
+  case ParserStatus::NoBodyData:
+    return 2;
+  case ParserStatus::Paused:
+    return 31;
+  default:
+    PANIC("not implemented");
+  }
+}
+
 } // namespace
 
 class LegacyHttpParserImpl::Impl {
@@ -184,25 +205,6 @@ absl::string_view LegacyHttpParserImpl::errnoName(ParserStatus rc) const {
 }
 
 int LegacyHttpParserImpl::hasTransferEncoding() const { return impl_->hasTransferEncoding(); }
-
-int LegacyHttpParserImpl::statusToInt(const ParserStatus code) const {
-  // See
-  // https://github.com/nodejs/http-parser/blob/5c5b3ac62662736de9e71640a8dc16da45b32503/http_parser.h#L72.
-  switch (code) {
-  case ParserStatus::Error:
-    return -1;
-  case ParserStatus::Success:
-    return 0;
-  case ParserStatus::NoBody:
-    return 1;
-  case ParserStatus::NoBodyData:
-    return 2;
-  case ParserStatus::Paused:
-    return 31;
-  default:
-    PANIC("not implemented");
-  }
-}
 
 } // namespace Http1
 } // namespace Http

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -94,7 +94,8 @@ public:
   }
 
   RcVal execute(const char* slice, int len) {
-    return {http_parser_execute(&parser_, &settings_, slice, len), HTTP_PARSER_ERRNO(&parser_)};
+    return {http_parser_execute(&parser_, &settings_, slice, len),
+            intToStatus(HTTP_PARSER_ERRNO(&parser_))};
   }
 
   void resume() { http_parser_pause(&parser_, 0); }

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -31,10 +31,10 @@ ParserStatus intToStatus(int rc) {
   }
 }
 
-int statusToInt(const ParserStatus code) {
+int statusToInt(const ParserStatus status) {
   // See
   // https://github.com/nodejs/http-parser/blob/5c5b3ac62662736de9e71640a8dc16da45b32503/http_parser.h#L72.
-  switch (code) {
+  switch (status) {
   case ParserStatus::Error:
     return -1;
   case ParserStatus::Success:
@@ -200,8 +200,8 @@ bool LegacyHttpParserImpl::isChunked() const { return impl_->isChunked(); }
 
 absl::string_view LegacyHttpParserImpl::methodName() const { return impl_->methodName(); }
 
-absl::string_view LegacyHttpParserImpl::errnoName(ParserStatus rc) const {
-  return http_errno_name(static_cast<http_errno>(statusToInt(rc)));
+absl::string_view LegacyHttpParserImpl::errnoName(ParserStatus status) const {
+  return http_errno_name(static_cast<http_errno>(statusToInt(status)));
 }
 
 int LegacyHttpParserImpl::hasTransferEncoding() const { return impl_->hasTransferEncoding(); }

--- a/source/common/http/http1/legacy_parser_impl.h
+++ b/source/common/http/http1/legacy_parser_impl.h
@@ -24,7 +24,7 @@ public:
   absl::optional<uint64_t> contentLength() const override;
   bool isChunked() const override;
   absl::string_view methodName() const override;
-  absl::string_view errnoName(ParserStatus rc) const override;
+  absl::string_view errnoName(ParserStatus status) const override;
   int hasTransferEncoding() const override;
 
 private:

--- a/source/common/http/http1/legacy_parser_impl.h
+++ b/source/common/http/http1/legacy_parser_impl.h
@@ -24,7 +24,7 @@ public:
   absl::optional<uint64_t> contentLength() const override;
   bool isChunked() const override;
   absl::string_view methodName() const override;
-  absl::string_view errnoName(int rc) const override;
+  absl::string_view errnoName(ParserStatus rc) const override;
   int hasTransferEncoding() const override;
   int statusToInt(const ParserStatus code) const override;
 

--- a/source/common/http/http1/legacy_parser_impl.h
+++ b/source/common/http/http1/legacy_parser_impl.h
@@ -26,7 +26,6 @@ public:
   absl::string_view methodName() const override;
   absl::string_view errnoName(ParserStatus rc) const override;
   int hasTransferEncoding() const override;
-  int statusToInt(const ParserStatus code) const override;
 
 private:
   class Impl;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -154,8 +154,8 @@ public:
   // Returns a textual representation of the method. For requests only.
   virtual absl::string_view methodName() const PURE;
 
-  // Returns a textual representation of the given return code.
-  virtual absl::string_view errnoName(int rc) const PURE;
+  // Returns a textual representation of the given parser status.
+  virtual absl::string_view errnoName(ParserStatus rc) const PURE;
 
   // Returns whether the Transfer-Encoding header is present.
   virtual int hasTransferEncoding() const PURE;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -117,7 +117,7 @@ public:
     // Number of parsed bytes.
     size_t nread;
     // Integer error from parser indicating return code.
-    int rc;
+    ParserStatus rc;
   };
   virtual ~Parser() = default;
 

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -159,9 +159,6 @@ public:
 
   // Returns whether the Transfer-Encoding header is present.
   virtual int hasTransferEncoding() const PURE;
-
-  // Converts a ParserStatus code to the parsers' integer return code value.
-  virtual int statusToInt(const ParserStatus code) const PURE;
 };
 
 using ParserPtr = std::unique_ptr<Parser>;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -106,8 +106,8 @@ public:
    */
   virtual void onChunkHeader(bool) PURE;
 
-  virtual int setAndCheckCallbackStatus(Status&& status) PURE;
-  virtual int setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) PURE;
+  virtual ParserStatus setAndCheckCallbackStatus(Status&& status) PURE;
+  virtual ParserStatus setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) PURE;
 };
 
 class Parser {

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -116,8 +116,8 @@ public:
   struct RcVal {
     // Number of parsed bytes.
     size_t nread;
-    // Integer error from parser indicating return code.
-    ParserStatus rc;
+    // Status from parser.
+    ParserStatus status;
   };
   virtual ~Parser() = default;
 
@@ -155,7 +155,7 @@ public:
   virtual absl::string_view methodName() const PURE;
 
   // Returns a textual representation of the given parser status.
-  virtual absl::string_view errnoName(ParserStatus rc) const PURE;
+  virtual absl::string_view errnoName(ParserStatus status) const PURE;
 
   // Returns whether the Transfer-Encoding header is present.
   virtual int hasTransferEncoding() const PURE;


### PR DESCRIPTION
Commit Message: Remove Parser::statusToInt().

Additional Description: Parser is an abstract interface, the integer status codes are an implementation detail of the http-parser library.  This change moves translations between integer and ParserStatus inside LegacyParserImpl, so that the API can use ParserStatus exclusively.  This will make it simpler to add other Parser implementations.

Risk Level: low, no behavioral change intended
Testing: existing
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
