### PR TITLE
Simplify Parser::execute() and Parser::errnoName().

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -631,18 +631,18 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
 
 Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t len) {
   ASSERT(codec_status_.ok() && dispatching_);
-  auto [nread, rc] = parser_->execute(slice, len);
+  size_t nread = parser_->execute(slice, len);
   if (!codec_status_.ok()) {
     return codec_status_;
   }
 
-  if (rc != parser_->statusToInt(ParserStatus::Success) &&
-      rc != parser_->statusToInt(ParserStatus::Paused)) {
+  ParserStatus status = parser_->getStatus();
+  if (status != ParserStatus::Success && status != ParserStatus::Paused) {
     RETURN_IF_ERROR(sendProtocolError(Http1ResponseCodeDetails::get().HttpCodecError));
     // Avoid overwriting the codec_status_ set in the callbacks.
     ASSERT(codec_status_.ok());
     codec_status_ =
-        codecProtocolError(absl::StrCat("http/1.1 protocol error: ", parser_->errnoName(rc)));
+        codecProtocolError(absl::StrCat("http/1.1 protocol error: ", parser_->errorMessage()));
     return codec_status_;
   }
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -631,12 +631,12 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
 
 Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t len) {
   ASSERT(codec_status_.ok() && dispatching_);
-  size_t nread = parser_->execute(slice, len);
+  const size_t nread = parser_->execute(slice, len);
   if (!codec_status_.ok()) {
     return codec_status_;
   }
 
-  ParserStatus status = parser_->getStatus();
+  const ParserStatus status = parser_->getStatus();
   if (status != ParserStatus::Success && status != ParserStatus::Paused) {
     RETURN_IF_ERROR(sendProtocolError(Http1ResponseCodeDetails::get().HttpCodecError));
     // Avoid overwriting the codec_status_ set in the callbacks.

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -93,8 +93,8 @@ public:
     };
   }
 
-  RcVal execute(const char* slice, int len) {
-    return {http_parser_execute(&parser_, &settings_, slice, len), HTTP_PARSER_ERRNO(&parser_)};
+  size_t execute(const char* slice, int len) {
+    return http_parser_execute(&parser_, &settings_, slice, len);
   }
 
   void resume() { http_parser_pause(&parser_, 0); }
@@ -154,7 +154,7 @@ LegacyHttpParserImpl::LegacyHttpParserImpl(MessageType type, ParserCallbacks* da
 // same compilation unit so that the destructor has a complete definition of Impl.
 LegacyHttpParserImpl::~LegacyHttpParserImpl() = default;
 
-LegacyHttpParserImpl::RcVal LegacyHttpParserImpl::execute(const char* slice, int len) {
+size_t LegacyHttpParserImpl::execute(const char* slice, int len) {
   return impl_->execute(slice, len);
 }
 
@@ -178,8 +178,8 @@ bool LegacyHttpParserImpl::isChunked() const { return impl_->isChunked(); }
 
 absl::string_view LegacyHttpParserImpl::methodName() const { return impl_->methodName(); }
 
-absl::string_view LegacyHttpParserImpl::errnoName(int rc) const {
-  return http_errno_name(static_cast<http_errno>(rc));
+absl::string_view LegacyHttpParserImpl::errorMessage() const {
+  return http_errno_name(static_cast<http_errno>(impl_->getErrno()));
 }
 
 int LegacyHttpParserImpl::hasTransferEncoding() const { return impl_->hasTransferEncoding(); }

--- a/source/common/http/http1/legacy_parser_impl.h
+++ b/source/common/http/http1/legacy_parser_impl.h
@@ -14,7 +14,7 @@ public:
   ~LegacyHttpParserImpl() override;
 
   // Http1::Parser
-  RcVal execute(const char* data, int len) override;
+  size_t execute(const char* slice, int len) override;
   void resume() override;
   ParserStatus pause() override;
   ParserStatus getStatus() override;
@@ -24,7 +24,7 @@ public:
   absl::optional<uint64_t> contentLength() const override;
   bool isChunked() const override;
   absl::string_view methodName() const override;
-  absl::string_view errnoName(int rc) const override;
+  absl::string_view errorMessage() const override;
   int hasTransferEncoding() const override;
   int statusToInt(const ParserStatus code) const override;
 

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -112,18 +112,9 @@ public:
 
 class Parser {
 public:
-  // Struct containing the return value from parser execution.
-  struct RcVal {
-    // Number of parsed bytes.
-    size_t nread;
-    // Integer error from parser indicating return code.
-    int rc;
-  };
-  virtual ~Parser() = default;
-
   // Executes the parser.
-  // @return an RcVal containing the number of parsed bytes and return code.
-  virtual RcVal execute(const char* slice, int len) PURE;
+  // @return the number of parsed bytes.
+  virtual size_t execute(const char* slice, int len) PURE;
 
   // Unpauses the parser.
   virtual void resume() PURE;
@@ -155,7 +146,7 @@ public:
   virtual absl::string_view methodName() const PURE;
 
   // Returns a textual representation of the given return code.
-  virtual absl::string_view errnoName(int rc) const PURE;
+  virtual absl::string_view errorMessage() const PURE;
 
   // Returns whether the Transfer-Encoding header is present.
   virtual int hasTransferEncoding() const PURE;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -112,6 +112,8 @@ public:
 
 class Parser {
 public:
+  virtual ~Parser() = default;
+
   // Executes the parser.
   // @return the number of parsed bytes.
   virtual size_t execute(const char* slice, int len) PURE;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -147,7 +147,7 @@ public:
   // Returns a textual representation of the method. For requests only.
   virtual absl::string_view methodName() const PURE;
 
-  // Returns a textual representation of the given return code.
+  // Returns a textual representation of the internal error state of the parser.
   virtual absl::string_view errorMessage() const PURE;
 
   // Returns whether the Transfer-Encoding header is present.


### PR DESCRIPTION
The motivation is to not expose integer error codes internal to
http-parser.  This will make it easier to add another Parser
implementation based on a different library.

LegacyHttpParserImpl::execute() returns HTTP_PARSER_ERRNO.  This serves
two purposes at the sole call site in ConnectionImpl::dispatchSlice():
first, it is converted to a ParserStatus and compared to Success and
Pause.  This PR calls getStatus() directly instead.  Then the errno is
fed back to LegacyHttpParserImpl::errnoName(), which converts it to a
string.  This PR removes the errnoName() argument and makes this method
call HTTP_PARSER_ERRNO instead (via Impl::getErrno()).  This allows the
error code to be removed from the return struct of Parser::execute()
altogether.

Also, errnoName() is renamed to the more generic errorMessage(), to
reflect that other Parser implementations might not call internal error
codes "errno".

Note that comparing an int to statusToInt(Success) (or Pause) is
equivalent to feeding that int to intToStatus and comparting the result
to Success (or Pause).

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
