### PR TITLE
runtime: fix borked runtime guard, removing runtime singleton

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -42,6 +42,10 @@ minor_behavior_changes:
     guarded by ``envoy.reloadable_features.cares_accept_nodata``.
 
 bug_fixes:
+- area: runtime
+  change: |
+    Fixed a bug where was ``envoy.restart_features.no_runtime_singleton`` was inverted.
+    Runtime singleton status is now guarded by non-inverted ``envoy.restart_features.remove_runtime_singleton``.
 
 removed_config_or_runtime:
 - area: compressor
@@ -65,6 +69,9 @@ removed_config_or_runtime:
 - area: conn pool
   change: |
     removed ``envoy.reloadable_features.conn_pool_delete_when_idle`` and legacy code paths.
+- area: runtime
+  change: |
+    removed ``envoy.restart_features.no_runtime_singleton`` and replaced with ``envoy.restart_features.remove_runtime_singleton``.
 
 new_features:
 - area: access_log

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -65,7 +65,7 @@ RUNTIME_GUARD(envoy_reloadable_features_update_expected_rq_timeout_on_retry);
 RUNTIME_GUARD(envoy_reloadable_features_update_grpc_response_error_tag);
 RUNTIME_GUARD(envoy_reloadable_features_validate_connect);
 RUNTIME_GUARD(envoy_restart_features_explicit_wildcard_resource);
-RUNTIME_GUARD(envoy_restart_features_no_runtime_singleton);
+RUNTIME_GUARD(envoy_restart_features_remove_runtime_singleton);
 RUNTIME_GUARD(envoy_restart_features_use_apple_api_for_dns_lookups);
 
 // Begin false flags. These should come with a TODO to flip true.

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -102,7 +102,7 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   Runtime::LoaderPtr runtime_ptr = component_factory.createRuntime(*this, initial_config);
-  if (runtime_ptr->snapshot().getBoolean("envoy.restart_features.no_runtime_singleton", false)) {
+  if (runtime_ptr->snapshot().getBoolean("envoy.restart_features.remove_runtime_singleton", true)) {
     runtime_ = std::move(runtime_ptr);
   } else {
     runtime_singleton_ = std::make_unique<Runtime::ScopedLoaderSingleton>(std::move(runtime_ptr));

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -619,7 +619,7 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
   // Runtime gets initialized before the main configuration since during main configuration
   // load things may grab a reference to the loader for later use.
   Runtime::LoaderPtr runtime_ptr = component_factory.createRuntime(*this, initial_config);
-  if (runtime_ptr->snapshot().getBoolean("envoy.restart_features.no_runtime_singleton", false)) {
+  if (runtime_ptr->snapshot().getBoolean("envoy.restart_features.remove_runtime_singleton", true)) {
     runtime_ = std::move(runtime_ptr);
   } else {
     runtime_singleton_ = std::make_unique<Runtime::ScopedLoaderSingleton>(std::move(runtime_ptr));

--- a/test/integration/multi_envoy_test.cc
+++ b/test/integration/multi_envoy_test.cc
@@ -53,7 +53,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, MultiEnvoyTest,
 // This test does not currently support mixed protocol hops, or much of the other envoy test
 // framework knobs.
 TEST_P(MultiEnvoyTest, SimpleRequestAndResponse) {
-  config_helper_.addRuntimeOverride("envoy.restart_features.no_runtime_singleton", "true");
+  config_helper_.addRuntimeOverride("envoy.restart_features.remove_runtime_singleton", "true");
   initialize();
   createL1Envoy();
 
@@ -75,7 +75,7 @@ TEST_P(MultiEnvoyTest, SimpleRequestAndResponse) {
 
 // Similar to SimpleRequestAndResponse but tear down the L2 first.
 TEST_P(MultiEnvoyTest, SimpleRequestAndResponseL2Teardown) {
-  config_helper_.addRuntimeOverride("envoy.restart_features.no_runtime_singleton", "true");
+  config_helper_.addRuntimeOverride("envoy.restart_features.remove_runtime_singleton", "true");
   initialize();
   createL1Envoy();
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -220,6 +220,10 @@ TEST_P(DownstreamProtocolIntegrationTest, AddInvalidEncodedData) {
 
 // Verifies behavior for https://github.com/envoyproxy/envoy/pull/11248
 TEST_P(ProtocolIntegrationTest, AddBodyToRequestAndWaitForIt) {
+  // Make sure one end to end test verifies the old path with runtime singleton,
+  // to check for regresssions.
+  config_helper_.addRuntimeOverride("envoy.restart_features.remove_runtime_singleton", "false");
+
   config_helper_.prependFilter(R"EOF(
   name: wait-for-whole-request-and-response-filter
   )EOF");

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -221,7 +221,7 @@ TEST_P(DownstreamProtocolIntegrationTest, AddInvalidEncodedData) {
 // Verifies behavior for https://github.com/envoyproxy/envoy/pull/11248
 TEST_P(ProtocolIntegrationTest, AddBodyToRequestAndWaitForIt) {
   // Make sure one end to end test verifies the old path with runtime singleton,
-  // to check for regresssions.
+  // to check for regressions.
   config_helper_.addRuntimeOverride("envoy.restart_features.remove_runtime_singleton", "false");
 
   config_helper_.prependFilter(R"EOF(

--- a/test/test_common/test_runtime.h
+++ b/test/test_common/test_runtime.h
@@ -35,7 +35,7 @@ public:
     Runtime::LoaderPtr runtime_ptr = std::make_unique<Runtime::LoaderImpl>(
         dispatcher_, tls_, config, local_info_, store_, generator_, validation_visitor_, *api_);
     // This will ignore values set in test, but just use flag defaults!
-    if (Runtime::runtimeFeatureEnabled("envoy.restart_features.no_runtime_singleton")) {
+    if (Runtime::runtimeFeatureEnabled("envoy.restart_features.remove_runtime_singleton")) {
       runtime_ = std::move(runtime_ptr);
     } else {
       runtime_singleton_ = std::make_unique<Runtime::ScopedLoaderSingleton>(std::move(runtime_ptr));


### PR DESCRIPTION
The runtime guard for using runtime singleton was inverted, as debugged in envoy-mobile with multi-engine tests not working.

Risk Level: high (removing runtime singleton)
Testing: yes
Docs Changes: n/a
Release Notes: updated