### PR TITLE
docs: Add a link to the Fix Lead Checklist from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,8 @@ necessary and is unlikely to make a public disclosure less damaging.
 
 For each vulnerability a member of the PST will volunteer to lead coordination with the "Fix Team"
 and is responsible for sending disclosure emails to the rest of the community. This lead will be
-referred to as the "Fix Lead."
+referred to as the "Fix Lead." The detailed list of responsibilities is outlined on the
+[Fix Lead Checklist](https://docs.google.com/document/d/1cuU0m9hTQ73Te3i06-8LjQkFVn83IL22FbCoc_4IFEY/edit#heading=h.c6thx0zc0gtz)
 
 The role of Fix Lead should rotate round-robin across the PST.
 


### PR DESCRIPTION
docs: Add a link to the Fix Lead Checklist from SECURITY.md

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: N/A
Docs Changes: SECURITY.md
Release Notes: N/A
Platform Specific Features: N/A