### PR TITLE
compressor filter: support selecting compressor to benchmark

### DIFF
--- a/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
@@ -264,6 +264,8 @@ compressChunks8192/5/manual_time        15.9 ms         16.1 ms           45
 */
 // SPELLCHECKER(on)
 
+#if defined(GZIP_TEST) || !defined(ZSTD_TEST)
+
 static std::vector<CompressionParams> gzip_compression_params = {
     // Speed + Standard + Small Window + Low mem level
     {Z_BEST_SPEED, Z_DEFAULT_STRATEGY, 9, 1},
@@ -371,6 +373,9 @@ BENCHMARK(compressChunks1024WithGzip)
     ->DenseRange(0, 8, 1)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
+#endif
+
+#if defined(ZSTD_TEST)
 
 static std::vector<CompressionParams> zstd_compression_params = {
     // level1 + default
@@ -518,6 +523,8 @@ BENCHMARK(compressChunks1024WithZstd)
     ->DenseRange(0, 21, 1)
     ->UseManualTime()
     ->Unit(benchmark::kMillisecond);
+
+#endif
 
 } // namespace Compressor
 } // namespace HttpFilters


### PR DESCRIPTION
Signed-off-by: giantcroc <changran.wang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: The simplest way to choose a compressor to benchmark
```
bazel test //test/extensions/filters/http/compressor:compressor_filter_speed_test --cxxopt=-DGZIP_TEST
bazel test //test/extensions/filters/http/compressor:compressor_filter_speed_test --cxxopt=-DZSTD_TEST
```
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
