### PR TITLE
fuzz test: Continue processing only on open conn. 

### DIFF
--- a/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/clusterfuzz-testcase-minimized-network_readfilter_fuzz_test-4766957658832896
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/clusterfuzz-testcase-minimized-network_readfilter_fuzz_test-4766957658832896
@@ -1,0 +1,18 @@
+config {
+  name: "envoy.filters.network.http_connection_manager"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    value: "\022\001l\"\000R4\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\230\001\200X"
+  }
+}
+actions {
+  on_data {
+    data: "X"
+  }
+}
+}
+actions {
+  on_data {
+    data: "-"
+  }
+}

--- a/test/extensions/filters/network/common/fuzz/uber_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_readfilter.cc
@@ -115,6 +115,11 @@ void UberFilterFuzzer::fuzz(
       ASSERT(read_filter_ != nullptr);
       Buffer::OwnedImpl buffer(action.on_data().data());
       read_filter_->onData(buffer, action.on_data().end_stream());
+      if (read_filter_callbacks_->connection_.state_ != Envoy::Network::Connection::State::Open) {
+        ENVOY_LOG_MISC(trace, "Connection closed after data processing.");
+        reset();
+        return;
+      }
 
       break;
     }


### PR DESCRIPTION
Commit Message: fuzz test: Continue processing only on open conn. 
Additional Description:
Continue processing of corpus file only while the connection is still
open. Reset the fuzzer and terminate the loop else.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
