### PR TITLE
Remove Parser::statusToInt().

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -453,20 +453,19 @@ Status RequestEncoderImpl::encodeHeaders(const RequestHeaderMap& headers, bool e
   return okStatus();
 }
 
-int ConnectionImpl::setAndCheckCallbackStatus(Status&& status) {
+ParserStatus ConnectionImpl::setAndCheckCallbackStatus(Status&& status) {
   ASSERT(codec_status_.ok());
   codec_status_ = std::move(status);
-  return codec_status_.ok() ? parser_->statusToInt(ParserStatus::Success)
-                            : parser_->statusToInt(ParserStatus::Error);
+  return codec_status_.ok() ? ParserStatus::Success : ParserStatus::Error;
 }
 
-int ConnectionImpl::setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) {
+ParserStatus ConnectionImpl::setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) {
   ASSERT(codec_status_.ok());
   if (statusor.ok()) {
-    return parser_->statusToInt(statusor.value());
+    return statusor.value();
   } else {
     codec_status_ = std::move(statusor.status());
-    return parser_->statusToInt(ParserStatus::Error);
+    return ParserStatus::Error;
   }
 }
 

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -349,8 +349,8 @@ private:
   Envoy::StatusOr<ParserStatus> onHeadersComplete() override;
   void bufferBody(const char* data, size_t length) override;
   StatusOr<ParserStatus> onMessageComplete() override;
-  int setAndCheckCallbackStatus(Http::Status&& status) override;
-  int setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) override;
+  ParserStatus setAndCheckCallbackStatus(Http::Status&& status) override;
+  ParserStatus setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) override;
 
   // Connection specific callback methods.
   virtual Envoy::StatusOr<ParserStatus> onHeadersCompleteBase() PURE;

--- a/source/common/http/http1/legacy_parser_impl.h
+++ b/source/common/http/http1/legacy_parser_impl.h
@@ -26,7 +26,6 @@ public:
   absl::string_view methodName() const override;
   absl::string_view errorMessage() const override;
   int hasTransferEncoding() const override;
-  int statusToInt(const ParserStatus code) const override;
 
 private:
   class Impl;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -106,8 +106,8 @@ public:
    */
   virtual void onChunkHeader(bool) PURE;
 
-  virtual int setAndCheckCallbackStatus(Status&& status) PURE;
-  virtual int setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) PURE;
+  virtual ParserStatus setAndCheckCallbackStatus(Status&& status) PURE;
+  virtual ParserStatus setAndCheckCallbackStatusOr(Envoy::StatusOr<ParserStatus>&& statusor) PURE;
 };
 
 class Parser {
@@ -152,9 +152,6 @@ public:
 
   // Returns whether the Transfer-Encoding header is present.
   virtual int hasTransferEncoding() const PURE;
-
-  // Converts a ParserStatus code to the parsers' integer return code value.
-  virtual int statusToInt(const ParserStatus code) const PURE;
 };
 
 using ParserPtr = std::unique_ptr<Parser>;


### PR DESCRIPTION
The motivation is that the int errno is implementation-specific (in this
case defined by http-parser).  Removing this method from the abstract
Parser interface and changing
ParserCallbacks::setAndCheckCallbackStatus* methods to return
ParserStatus instead of this implementation-specific int will make it
simpler to add another Parser implementation, one not based on
http-parser.

Instead of applying statusToInt() within setAndCheckCallbackStatus() and
setAndCheckCallbackStatusOr() before returning in ConnectionImpl, return
ParserStatus, and apply statusToInt() within LegacyHttpParserImpl.  This
allows statusToInt() to be moved to legacy_parser_impl.cc anonymous
namespace, right next to its counterpart intToStatus().

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
