### PR TITLE
tools: Enable the VSCode completion db to use bazelisk if available

### DIFF
--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -2,8 +2,11 @@
 
 [[ -z "${SKIP_PROTO_FORMAT}" ]] && tools/proto_format/proto_format.sh fix
 
+bazel_or_isk=bazelisk
+command -v bazelisk &> /dev/null || bazel_or_isk=bazel
+
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk
 
 # Kill clangd to reload the compilation database
 pkill clangd || :


### PR DESCRIPTION
Running tools/vscode/refresh_compdb.py to generate the code completion symbols for VSCode produces an error because the .bazelversion in Envoy may not be available in certain environments.  The recommendation is to use `bazelisk`, but the compilation database script defaults to using `bazel`.  This change enables the VSCode compilation database generation script to use `bazelisk` if it is available on the system; if not, it will use `bazel`.

Signed-off-by: Ali Beyad <abeyad@google.com>

Risk Level: low
Testing: local
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A