### PR TITLE
docs: update extproc stats

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_proc_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_proc_filter.rst
@@ -48,3 +48,5 @@ The following statistics are supported:
   streams_closed, Counter, The number of streams successfully closed on either end
   streams_failed, Counter, The number of times a stream produced a gRPC error
   failure_mode_allowed, Counter, The number of times an error was ignored due to configuration
+  message_timeouts, Counter, The number of times a message fails to receive a response within the configured timeout
+  rejected_header_mutations, Counter, The number of attempts to change diallowed headers

--- a/docs/root/configuration/http/http_filters/ext_proc_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_proc_filter.rst
@@ -48,5 +48,5 @@ The following statistics are supported:
   streams_closed, Counter, The number of streams successfully closed on either end
   streams_failed, Counter, The number of times a stream produced a gRPC error
   failure_mode_allowed, Counter, The number of times an error was ignored due to configuration
-  message_timeouts, Counter, The number of times a message fails to receive a response within the configured timeout
-  rejected_header_mutations, Counter, The number of attempts to change diallowed headers
+  message_timeouts, Counter, The number of times a message failed to receive a response within the configured timeout
+  rejected_header_mutations, Counter, The number of rejected header mutations


### PR DESCRIPTION
Signed-off-by: Tony Tang <tsukiy0@users.noreply.github.com>

Commit Message: update extproc stats
Additional Description: added missing `message_timeouts` and `rejected_header_mutations` stats to ext_proc docs
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
