### PR TITLE
matching: fix unmatched response trailers input

### DIFF
--- a/source/common/http/matching/inputs.h
+++ b/source/common/http/matching/inputs.h
@@ -135,7 +135,7 @@ public:
 
 class HttpResponseTrailersDataInputFactory
     : public HttpHeadersDataInputFactoryBase<
-          HttpRequestTrailersDataInput, envoy::type::matcher::v3::HttpResponseTrailerMatchInput> {
+          HttpResponseTrailersDataInput, envoy::type::matcher::v3::HttpResponseTrailerMatchInput> {
 public:
   HttpResponseTrailersDataInputFactory() : HttpHeadersDataInputFactoryBase("response_trailers") {}
 };


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: matching: fix unmatched response trailers input
Additional Description: the patch fixes unmatched response trailers input and proto in its factory, and also adds tests for all HTTP matching inputs.
Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
