### PR TITLE
Fixing comipling issue related to any.proto type_url.

### DIFF
--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -232,7 +232,7 @@ void FilterConfigProviderManagerImplBase::applyLastOrDefaultConfig(
 
 void FilterConfigProviderManagerImplBase::validateProtoConfigDefaultFactory(
     const bool null_default_factory, const std::string& filter_config_name,
-    const std::string& type_url) const {
+    absl::string_view type_url) const {
   if (null_default_factory) {
     throw EnvoyException(fmt::format("Error: cannot find filter factory {} for default filter "
                                      "configuration with type URL {}.",

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -364,7 +364,7 @@ protected:
                                 const std::string& filter_config_name);
   void validateProtoConfigDefaultFactory(const bool null_default_factory,
                                          const std::string& filter_config_name,
-                                         const std::string& type_url) const;
+                                         absl::string_view type_url) const;
   void validateProtoConfigTypeUrl(const std::string& type_url,
                                   const absl::flat_hash_set<std::string>& require_type_urls) const;
 


### PR DESCRIPTION
The type_url filed in any.proto is type: absl::string_view.

Receiving it with std::string is causing compiling issues in some systems. Change it to absl::string_view.


Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!



For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
