### PR TITLE
local rate limit: more robust refill logic

### DIFF
--- a/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.h
+++ b/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.h
@@ -36,9 +36,11 @@ private:
     mutable std::atomic<uint32_t> tokens_;
     MonotonicTime fill_time_;
   };
+  int64_t counter_{0};
   struct LocalDescriptorImpl : public RateLimit::LocalDescriptor {
     std::shared_ptr<TokenState> token_state_;
     RateLimit::TokenBucket token_bucket_;
+    int64_t multiplier_;
     std::string toString() const {
       std::vector<std::string> entries;
       entries.reserve(entries_.size());


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Change token refill logic for descriptors to take into account the inherent variability in the real world clock.
Additional Description: Descriptors are refilled at multiples of the global refill interval. Because the global timer hits with some uncertainty +/-O(10ms), there is a high likelihood that the recorded clock time at the refill times N and N+1 is less than the interval itself. That means that even when the descriptor fill interval and the global fill interval are the same, the descriptors are not refilled as often. That's very counter-intuitive and results in a very noticeable rate limit under-run (~20% less than desired observed at refill interval 10s). 

This change simply uses modular arithmetic to count when to trigger the descriptor refill. This fixes the example shown in https://github.com/envoyproxy/envoy/issues/19474.
  

Risk Level: low
Testing: tests unmodified
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes: https://github.com/envoyproxy/envoy/issues/19474