### PR TITLE
test: deflaking alpn test

### DIFF
--- a/test/integration/alpn_integration_test.cc
+++ b/test/integration/alpn_integration_test.cc
@@ -155,8 +155,8 @@ TEST_P(AlpnIntegrationTest, Http1RememberLimits) {
   ASSERT_TRUE(response->waitForEndStream());
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_destroy", 1);
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_total", 1);
+  fake_upstreams_.clear();
   {
-    absl::MutexLock l(&fake_upstreams_[0]->lock());
     IntegrationCodecClientPtr codec_client1 = makeHttpConnection(lookupPort("http"));
     auto response1 = codec_client1->makeHeaderOnlyRequest(default_request_headers_);
     IntegrationCodecClientPtr codec_client2 = makeHttpConnection(lookupPort("http"));


### PR DESCRIPTION
Snagging the mutex meant there was still outstanding connections happening to the autonomous upstream on destruction which doesn't work well.
instead simply tearing things down while there's no outstanding work.