### PR TITLE
Move ENVOY_BUG into the runtime-guarded block it was supposed to be in

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1904,7 +1904,6 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
   }
   if (protocols.size() == 1 && protocols[0] == Http::Protocol::Http2 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http2", 100)) {
-    ENVOY_BUG(origin.has_value(), "Unable to determine origin for host ");
     return Http::Http2::allocateConnPool(dispatcher, context_.api().randomGenerator(), host,
                                          priority, options, transport_socket_options, state, origin,
                                          alternate_protocols_cache);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1888,7 +1888,6 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
 #endif
   }
   if (protocols.size() >= 2) {
-    ENVOY_BUG(origin.has_value(), "Unable to determine origin for host ");
     if (Runtime::runtimeFeatureEnabled(
             "envoy.reloadable_features.allow_concurrency_for_alpn_pool")) {
       ENVOY_BUG(origin.has_value(), "Unable to determine origin for host ");
@@ -1905,6 +1904,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
   }
   if (protocols.size() == 1 && protocols[0] == Http::Protocol::Http2 &&
       context_.runtime().snapshot().featureEnabled("upstream.use_http2", 100)) {
+    ENVOY_BUG(origin.has_value(), "Unable to determine origin for host ");
     return Http::Http2::allocateConnPool(dispatcher, context_.api().randomGenerator(), host,
                                          priority, options, transport_socket_options, state, origin,
                                          alternate_protocols_cache);


### PR DESCRIPTION
Commit Message: Move ENVOY_BUG into the runtime-guarded block it was supposed to be in
Additional Description: This looks like a merge slip in PR #21228 that put the ENVOY_BUG in the wrong place, which can trigger surprising crashes in debug builds (found in end to end testing).
Risk Level: Less than introducing the change was. :)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
