### PR TITLE
Docs: Fix sphinx link syntax in connection pool documentation.

### DIFF
--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -71,8 +71,8 @@ stream, but if both TCP and QUIC connections are established, QUIC will eventual
 If an alternate protocol cache is configured via
 :ref:`alternate_protocols_cache_options <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.AutoHttpConfig.alternate_protocols_cache_options>`
 then HTTP/3 connections will only be attempted to servers which
-advertise HTTP/3 support either via `HTTP Alternative Services <https://tools.ietf.org/html/rfc7838>`, (eventually
-the `HTTPS DNS resource record<https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04>` or "QUIC hints"
+advertise HTTP/3 support either via `HTTP Alternative Services <https://tools.ietf.org/html/rfc7838>`_, (eventually
+the `HTTPS DNS resource record <https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04>`_ or "QUIC hints"
 which will be manually configured).
 If no such advertisement exists, then HTTP/2 or HTTP/1 will be used instead.
 


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Docs: Fix sphinx link syntax in connection pool documentation.
Additional Description:
Risk Level: na
Testing: played around in https://livesphinx.herokuapp.com/
Docs Changes: included
Release Notes: na
Platform Specific Features: na

