### PR TITLE
thrift: Increase test shard count (for windows)

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -342,7 +342,7 @@ envoy_extension_cc_test(
         "//test/extensions/filters/network/thrift_proxy/driver:generate_fixture",
     ],
     extension_names = ["envoy.filters.network.thrift_proxy"],
-    shard_count = 4,
+    shard_count = 12,
     deps = [
         ":integration_lib",
         ":utility_lib",


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

While testing python-toolchains the windows run of this test reliably fails

Trying to debug this, i noticed that it occasionally fails on other CI runs

Increasing the shards here, makes my PR work (or at least fail later after passing flakily)

Im guessing that increasing this would reduce windows flakes in CI more generally


Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
