### PR TITLE
upstream: fixing logical/strict DNS clusters for IPv6

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -68,6 +68,10 @@ bug_fixes:
   change: |
     Fixed an issue using the cluster wide CONNECT termination so it will successfully proxy payloads.
 
+- area: upstream
+  change: |
+    Fixed the LOGICAL_DNS cluster to work for IPv6.
+
 removed_config_or_runtime:
 - area: compressor
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -70,7 +70,7 @@ bug_fixes:
 
 - area: upstream
   change: |
-    Fixed the LOGICAL_DNS cluster to work for IPv6.
+    Fixed the LOGICAL_DNS and STRICT_DNS clusters to work for IPv6.
 
 removed_config_or_runtime:
 - area: compressor

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -72,47 +72,6 @@ bool Utility::urlIsUnixScheme(absl::string_view url) { return absl::StartsWith(u
 
 namespace {
 
-std::string hostFromUrl(const std::string& url, absl::string_view scheme,
-                        absl::string_view scheme_name) {
-  if (!absl::StartsWith(url, scheme)) {
-    throw EnvoyException(fmt::format("expected {} scheme, got: {}", scheme_name, url));
-  }
-
-  const size_t colon_index = url.find(':', scheme.size());
-
-  if (colon_index == std::string::npos) {
-    throw EnvoyException(absl::StrCat("malformed url: ", url));
-  }
-
-  return url.substr(scheme.size(), colon_index - scheme.size());
-}
-
-uint32_t portFromUrl(const std::string& url, absl::string_view scheme,
-                     absl::string_view scheme_name) {
-  if (!absl::StartsWith(url, scheme)) {
-    throw EnvoyException(fmt::format("expected {} scheme, got: {}", scheme_name, url));
-  }
-
-  const size_t colon_index = url.find(':', scheme.size());
-
-  if (colon_index == std::string::npos) {
-    throw EnvoyException(absl::StrCat("malformed url: ", url));
-  }
-
-  const size_t rcolon_index = url.rfind(':');
-  if (colon_index != rcolon_index) {
-    throw EnvoyException(absl::StrCat("malformed url: ", url));
-  }
-
-  try {
-    return std::stoi(url.substr(colon_index + 1));
-  } catch (const std::invalid_argument& e) {
-    throw EnvoyException(e.what());
-  } catch (const std::out_of_range& e) {
-    throw EnvoyException(e.what());
-  }
-}
-
 Api::IoCallUint64Result receiveMessage(uint64_t max_rx_datagram_size, Buffer::InstancePtr& buffer,
                                        IoHandle::RecvMsgOutput& output, IoHandle& handle,
                                        const Address::Instance& local_address) {
@@ -129,22 +88,6 @@ Api::IoCallUint64Result receiveMessage(uint64_t max_rx_datagram_size, Buffer::In
 }
 
 } // namespace
-
-std::string Utility::hostFromTcpUrl(const std::string& url) {
-  return hostFromUrl(url, TCP_SCHEME, "TCP");
-}
-
-uint32_t Utility::portFromTcpUrl(const std::string& url) {
-  return portFromUrl(url, TCP_SCHEME, "TCP");
-}
-
-std::string Utility::hostFromUdpUrl(const std::string& url) {
-  return hostFromUrl(url, UDP_SCHEME, "UDP");
-}
-
-uint32_t Utility::portFromUdpUrl(const std::string& url) {
-  return portFromUrl(url, UDP_SCHEME, "UDP");
-}
 
 Address::InstanceConstSharedPtr Utility::parseInternetAddressNoThrow(const std::string& ip_address,
                                                                      uint16_t port, bool v6only) {

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -132,34 +132,6 @@ public:
   static bool urlIsUnixScheme(absl::string_view url);
 
   /**
-   * Parses the host from a TCP URL
-   * @param the URL to parse host from
-   * @return std::string the parsed host
-   */
-  static std::string hostFromTcpUrl(const std::string& url);
-
-  /**
-   * Parses the port from a TCP URL
-   * @param the URL to parse port from
-   * @return uint32_t the parsed port
-   */
-  static uint32_t portFromTcpUrl(const std::string& url);
-
-  /**
-   * Parses the host from a UDP URL
-   * @param the URL to parse host from
-   * @return std::string the parsed host
-   */
-  static std::string hostFromUdpUrl(const std::string& url);
-
-  /**
-   * Parses the port from a UDP URL
-   * @param the URL to parse port from
-   * @return uint32_t the parsed port
-   */
-  static uint32_t portFromUdpUrl(const std::string& url);
-
-  /**
    * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address must
    * not include a port number. Throws EnvoyException if unable to parse the address.
    * @param ip_address string to be parsed as an internet address.

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -79,14 +79,14 @@ LogicalDnsCluster::LogicalDnsCluster(
   if (!socket_address.resolver_name().empty()) {
     throw EnvoyException("LOGICAL_DNS clusters must NOT have a custom resolver name set");
   }
+  dns_address_ = socket_address.address();
+  dns_port_ = socket_address.port_value();
 
-  dns_url_ = fmt::format("tcp://{}:{}", socket_address.address(), socket_address.port_value());
   if (lbEndpoint().endpoint().hostname().empty()) {
-    hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
+    hostname_ = dns_address_;
   } else {
     hostname_ = lbEndpoint().endpoint().hostname();
   }
-  Network::Utility::portFromTcpUrl(dns_url_);
   dns_lookup_family_ = getDnsLookupFamilyFromCluster(cluster);
 }
 
@@ -104,16 +104,15 @@ LogicalDnsCluster::~LogicalDnsCluster() {
 }
 
 void LogicalDnsCluster::startResolve() {
-  std::string dns_address = Network::Utility::hostFromTcpUrl(dns_url_);
-  ENVOY_LOG(debug, "starting async DNS resolution for {}", dns_address);
+  ENVOY_LOG(debug, "starting async DNS resolution for {}", dns_address_);
   info_->stats().update_attempt_.inc();
 
   active_dns_query_ = dns_resolver_->resolve(
-      dns_address, dns_lookup_family_,
-      [this, dns_address](Network::DnsResolver::ResolutionStatus status,
-                          std::list<Network::DnsResponse>&& response) -> void {
+      dns_address_, dns_lookup_family_,
+      [this](Network::DnsResolver::ResolutionStatus status,
+             std::list<Network::DnsResponse>&& response) -> void {
         active_dns_query_ = nullptr;
-        ENVOY_LOG(debug, "async DNS resolution complete for {}", dns_address);
+        ENVOY_LOG(debug, "async DNS resolution complete for {}", dns_address_);
 
         std::chrono::milliseconds final_refresh_rate = dns_refresh_rate_ms_;
 
@@ -124,11 +123,11 @@ void LogicalDnsCluster::startResolve() {
           info_->stats().update_success_.inc();
           const auto addrinfo = response.front().addrInfo();
           // TODO(mattklein123): Move port handling into the DNS interface.
-          uint32_t port = Network::Utility::portFromTcpUrl(dns_url_);
           ASSERT(addrinfo.address_ != nullptr);
           Network::Address::InstanceConstSharedPtr new_address =
-              Network::Utility::getAddressWithPort(*(response.front().addrInfo().address_), port);
-          auto address_list = DnsUtils::generateAddressList(response, port);
+              Network::Utility::getAddressWithPort(*(response.front().addrInfo().address_),
+                                                   dns_port_);
+          auto address_list = DnsUtils::generateAddressList(response, dns_port_);
 
           if (!logical_host_) {
             logical_host_ = std::make_shared<LogicalHost>(info_, hostname_, new_address,
@@ -163,14 +162,14 @@ void LogicalDnsCluster::startResolve() {
           if (respect_dns_ttl_ && addrinfo.ttl_ != std::chrono::seconds(0)) {
             final_refresh_rate = addrinfo.ttl_;
           }
-          ENVOY_LOG(debug, "DNS refresh rate reset for {}, refresh rate {} ms", dns_address,
+          ENVOY_LOG(debug, "DNS refresh rate reset for {}, refresh rate {} ms", dns_address_,
                     final_refresh_rate.count());
         } else {
           info_->stats().update_failure_.inc();
           final_refresh_rate =
               std::chrono::milliseconds(failure_backoff_strategy_->nextBackOffMs());
           ENVOY_LOG(debug, "DNS refresh rate reset for {}, (failure) refresh rate {} ms",
-                    dns_address, final_refresh_rate.count());
+                    dns_address_, final_refresh_rate.count());
         }
 
         onPreInitComplete();

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -67,7 +67,8 @@ private:
   const bool respect_dns_ttl_;
   Network::DnsLookupFamily dns_lookup_family_;
   Event::TimerPtr resolve_timer_;
-  std::string dns_url_;
+  std::string dns_address_;
+  uint32_t dns_port_;
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr current_resolved_address_;
   std::vector<Network::Address::InstanceConstSharedPtr> current_resolved_address_list_;

--- a/source/common/upstream/strict_dns_cluster.h
+++ b/source/common/upstream/strict_dns_cluster.h
@@ -26,7 +26,7 @@ public:
 private:
   struct ResolveTarget {
     ResolveTarget(StrictDnsClusterImpl& parent, Event::Dispatcher& dispatcher,
-                  const std::string& url,
+                  const std::string& dns_address, const uint32_t dns_port,
                   const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
                   const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint);
     ~ResolveTarget();

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -26,33 +26,6 @@ namespace Envoy {
 namespace Network {
 namespace {
 
-TEST(NetworkUtility, Url) {
-  EXPECT_EQ("foo", Utility::hostFromTcpUrl("tcp://foo:1234"));
-  EXPECT_EQ(1234U, Utility::portFromTcpUrl("tcp://foo:1234"));
-  EXPECT_THROW(Utility::hostFromTcpUrl("bogus://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::portFromTcpUrl("bogus://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromTcpUrl("abc://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromTcpUrl("abc://foo"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromTcpUrl("tcp://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:bar"), EnvoyException);
-  EXPECT_THROW(Utility::portFromTcpUrl("tcp://https://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromTcpUrl(""), EnvoyException);
-  EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:999999999999"), EnvoyException);
-}
-
-TEST(NetworkUtility, udpUrl) {
-  EXPECT_EQ("foo", Utility::hostFromUdpUrl("udp://foo:1234"));
-  EXPECT_EQ(1234U, Utility::portFromUdpUrl("udp://foo:1234"));
-  EXPECT_THROW(Utility::hostFromUdpUrl("bogus://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUdpUrl("bogus://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromUdpUrl("tcp://foo"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUdpUrl("tcp://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::portFromUdpUrl("udp://https://foo:1234"), EnvoyException);
-  EXPECT_THROW(Utility::hostFromUdpUrl(""), EnvoyException);
-  EXPECT_THROW(Utility::portFromUdpUrl("udp://foo:999999999999"), EnvoyException);
-}
-
 TEST(NetworkUtility, resolveUrl) {
   EXPECT_THROW(Utility::resolveUrl("foo"), EnvoyException);
   EXPECT_THROW(Utility::resolveUrl("abc://foo"), EnvoyException);

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -85,6 +85,22 @@ TEST_P(ProtocolIntegrationTest, LogicalDns) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+TEST_P(ProtocolIntegrationTest, StrictDns) {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
+    auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster.set_type(envoy::config::cluster::v3::Cluster::STRICT_DNS);
+    cluster.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
+  });
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Change the default route to be restrictive, and send a request to an alternate route.
 TEST_P(DownstreamProtocolIntegrationTest, RouterNotFound) { testRouterNotFound(); }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -69,6 +69,22 @@ TEST_P(ProtocolIntegrationTest, ShutdownWithActiveConnPoolConnections) {
   checkSimpleRequestSuccess(0U, 0U, response.get());
 }
 
+TEST_P(ProtocolIntegrationTest, LogicalDns) {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
+    auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster.set_type(envoy::config::cluster::v3::Cluster::LOGICAL_DNS);
+    cluster.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
+  });
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Change the default route to be restrictive, and send a request to an alternate route.
 TEST_P(DownstreamProtocolIntegrationTest, RouterNotFound) { testRouterNotFound(); }
 


### PR DESCRIPTION
Fixing a bug where Envoy would not start with logical or strict DNS clusters with IPv6 addresses.

Risk Level: medium
Testing: added integration tests actually using these clusters
Docs Changes: n/a
Release Notes: inline