### PR TITLE
bazel: reorder PATH macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -95,8 +95,8 @@ build:clang-asan --linkopt --unwindlib=libgcc
 
 # macOS
 build:macos --cxxopt=-std=c++17
-build:macos --action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
-build:macos --host_action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
+build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
+build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
 build:macos --define wasm=disabled
 


### PR DESCRIPTION
Reorder PATH macOS so that package managers binaries take precedence
over system binaries.

Signed-off-by: Sergii Tkachenko <sergiitk@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: bazel: reorder PATH macOS
Additional Description: Reorder PATH macOS so that package managers binaries take precedence over system binaries.
1. `opt/homebrew/bin`: Homebrew
2. `/opt/local/bin`: commonly used by macports 
3. `/usr/local/bin:/usr/bin:/bin`: user tools -> common tools -> fundamental system tools
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

P.S. This bit me hard, I couldn't understand why `bazel run` was using different python version than `bazel build` genrule cmd.

cc @keith
