### PR TITLE
nghttp2: Prevent assert in getStream.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1092,13 +1092,18 @@ const ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) c
   return const_cast<ConnectionImpl*>(this)->getStream(stream_id);
 }
 
-ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) {
+ConnectionImpl::StreamImpl* ConnectionImpl::getStreamUnchecked(int32_t stream_id) const {
   StreamImpl* stream;
   if (use_new_codec_wrapper_) {
     stream = static_cast<StreamImpl*>(adapter_->GetStreamUserData(stream_id));
   } else {
     stream = static_cast<StreamImpl*>(nghttp2_session_get_stream_user_data(session_, stream_id));
   }
+  return stream;
+}
+
+ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) {
+  StreamImpl* stream = getStreamUnchecked(stream_id);
   SLOW_ASSERT(stream != nullptr || !slowContainsStreamId(stream_id));
   return stream;
 }
@@ -1376,7 +1381,7 @@ int ConnectionImpl::onInvalidFrame(int32_t stream_id, int error_code) {
                  stream_id);
 
   // Set details of error_code in the stream whenever we have one.
-  StreamImpl* stream = getStream(stream_id);
+  StreamImpl* stream = getStreamUnchecked(stream_id);
   if (stream != nullptr) {
     stream->setDetails(Http2ResponseCodeDetails::get().errorDetails(error_code));
   }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1092,7 +1092,7 @@ const ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) c
   return const_cast<ConnectionImpl*>(this)->getStream(stream_id);
 }
 
-ConnectionImpl::StreamImpl* ConnectionImpl::getStreamUnchecked(int32_t stream_id) const {
+ConnectionImpl::StreamImpl* ConnectionImpl::getStreamUnchecked(int32_t stream_id) {
   StreamImpl* stream;
   if (use_new_codec_wrapper_) {
     stream = static_cast<StreamImpl*>(adapter_->GetStreamUserData(stream_id));

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -538,6 +538,8 @@ protected:
   // edge cases (such as for METADATA frames) where nghttp2 will issue a callback for a stream_id
   // that is not associated with an existing stream.
   const StreamImpl* getStream(int32_t stream_id) const;
+  // Same as getStream, but without the ASSERT.
+  StreamImpl* getStreamUnchecked(int32_t stream_id) const;
   StreamImpl* getStream(int32_t stream_id);
   int saveHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value);
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -539,7 +539,7 @@ protected:
   // that is not associated with an existing stream.
   const StreamImpl* getStream(int32_t stream_id) const;
   // Same as getStream, but without the ASSERT.
-  StreamImpl* getStreamUnchecked(int32_t stream_id) const;
+  StreamImpl* getStreamUnchecked(int32_t stream_id);
   StreamImpl* getStream(int32_t stream_id);
   int saveHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value);
 

--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-4785896639037440.fuzz
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-4785896639037440.fuzz
@@ -1,0 +1,110 @@
+h2_settings {
+  client {
+    hpack_table_size: 29029
+  }
+  server {
+    hpack_table_size: 29029
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":scheme"
+        value: "p"
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  mutate {
+    buffer: 65279
+table_size: 29029
+  }
+  server {
+    hpack_table_size: 29029
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":scheme"
+        value: "p"
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+      offset: 8
+    server: true
+  }
+}
+actions {
+  mutate {
+    offset: 3
+    value: 6
+  }
+}
+actions {
+  mutate {
+    offset: 3
+    value: 6
+    server: true
+  }
+}
+actions {
+  swap_buffer {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+        headers {
+          key: ":scheme"
+          value: "h+tpN"
+        }
+      }
+    }
+  }
+}
+actions {
+  mutate {
+    offset: 8
+    value: 3
+    server: true
+  }
+}
+actions {
+  mutate {
+    offset: 3
+    value: 6
+    server: true
+  }
+}


### PR DESCRIPTION
Commit Message: nghttp2: Prevent assert in getStream.
Additional Description:
getStream() in error conditions can return a nullptr, which is valid and
treated correctly on call site. Introducing an unchecked version of
getStream without assert.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
