### PR TITLE
fuzz test: Use in-memory files to prevent conflicts.

### DIFF
--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -39,11 +39,10 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v3::Bootstrap& input) {
   }
   testing::NiceMock<MockOptions> options;
   TestComponentFactory component_factory;
-  Fuzz::PerTestEnvironment test_env;
+  ABSL_ATTRIBUTE_UNUSED Filesystem::ScopedUseMemfiles use_memfiles{true};
 
-  const std::string bootstrap_path = test_env.temporaryPath("bootstrap.pb_text");
-  std::ofstream bootstrap_file(bootstrap_path);
-  bootstrap_file << sanitizedInput.DebugString();
+  const std::string bootstrap_path =
+      TestEnvironment::writeStringToFileForTest("bootstrap.pb_text", sanitizedInput.DebugString());
   options.config_path_ = bootstrap_path;
   options.log_level_ = Fuzz::Runner::logLevel();
 


### PR DESCRIPTION
Commit Message: fuzz test: Use in-memory files to prevent conflicts.
Additional Description:
The config_fuzz_test creates a file and failed some times, because a path was not create- or write-able. In-memory files prevent this issue.
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
