### PR TITLE
Fuzzer: Fix OOM that can occur in codec_impl_fuzz_test.

### DIFF
--- a/test/common/http/codec_impl_corpus/oom_due_to_leaky_expectation
+++ b/test/common/http/codec_impl_corpus/oom_due_to_leaky_expectation
@@ -1,0 +1,4552 @@
+h2_settings {
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 4127178752
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 4127178752
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "T"
+      }
+      headers {
+        key: ":authority"
+        value: "T"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      read_disable: true
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1024
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: "ckie"
+        value: "cookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 16765696
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: "/"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "ookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "Kie"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: ":path"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1600746016
+    server: true
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: "nosniff"
+        value: "ookcie"
+      }
+      headers {
+        key: "http"
+        value: "/"
+      }
+      headers {
+        key: "cooe"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 1793
+    }
+    dispatching_action {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 7
+    response {
+      data: 196544
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 100663295
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":metlod"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "ookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "ckie"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cooe"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 256
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 16384
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1809
+    request {
+      read_disable: true
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 7565160
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 7
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "htp"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=.ar"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data_value: "/"
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1024
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":hrity"
+        value: "cookie"
+      }
+      headers {
+        key: "T"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3004096
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: "foo2=bar2"
+        value: "cooe"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "http"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 16765696
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1308624641
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "ookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+    dispatching_action {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    response {
+      headers {
+        headers {
+          key: "co-length"
+          value: "5"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  swap_buffer {
+    server: true
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=.ar"
+      }
+      headers {
+        key: "cooe"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "h"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: ":authority"
+        value: "5"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":autho:ity"
+        value: ":path"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 263
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 16765696
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 218105601
+    request {
+      data: 1315267631
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: ":path"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: ":method"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 218105601
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 9729
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "http"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "http"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+    dispatching_action {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 16765696
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "htth"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "http"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cooe"
+      }
+      headers {
+        key: "htp"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "blah"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  mutate {
+    value: 170012532
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3004096
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+    dispatching_action {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data_value: "/"
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 16765696
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1942256896
+    response {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "htp"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=.ar"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  swap_buffer {
+    server: true
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  swap_buffer {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 12987840
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cooe"
+      }
+      headers {
+        key: "htp"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "b*h"
+        value: "lah"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 4127178752
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1600746016
+    server: true
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=.ar"
+      }
+      headers {
+        key: "cooe"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 218105601
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  swap_buffer {
+    server: true
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  mutate {
+    offset: 246
+  }
+}
+actions {
+  mutate {
+    value: 32768
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: ":path"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 7
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  mutate {
+    offset: 4
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cooe"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 2606784
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data_value: "/"
+    }
+  }
+}
+actions {
+  mutate {
+    offset: 4
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":mhoaethoa"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: "tacdG"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 50880
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+      end_stream: true
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1024
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+    value: 256
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "ethod"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "htp"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=.ar"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      reset_stream: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2999872
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 2999872
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 9729
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 7565160
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 50880
+    }
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 3000000
+    response {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 196544
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 45
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "ookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "ckie"
+        value: "Q"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 243597313
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "ookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "ckie"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "blah"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cooe"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "http"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 41
+    response {
+      headers {
+        headers {
+          key: "content-length"
+          value: "5"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data_value: "/"
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 8323072
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "ookie"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3004096
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 4127178752
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 0
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  mutate {
+    value: 1597121140
+  }
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 32512
+    }
+  }
+}
+actions {
+  swap_buffer {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":ahority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "blah"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1793
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "/"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "cookie"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "/"
+      }
+      headers {
+        key: "blah"
+        value: "/"
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "CONNECT"
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1793
+    request {
+      data: 3000000
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix OOM that can occur in codec_impl_fuzz_test.
Additional Description: See below
Risk Level: low
Testing: ran test
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA

My analysis is as follows:
1. Looking at the massif-out in visualizers, so the image below I see that we end up having allocating a lot of memory in directionAction via
a buffer ctor that takes a string view.
![Screenshot 2022-05-18 12 38 22 PM](https://user-images.githubusercontent.com/3191890/169308163-db282f30-c7b2-4acb-b623-e133c95f7e76.png)



I took this hint to then annotate the pending send buffer, as I though the slice which originally was allocated from directionalAction ends up in another buffer.

We can see:
```
[2022-05-17 23:58:43.204][1592727][debug][http2] [source/common/http/http2/codec_impl.cc:804] [C8] Stream 1 has 2776084051 in pending_send_data
[2022-05-17 23:58:43.205][1592727][debug][http2] [source/common/http/http2/codec_impl.cc:804] [C8] Stream 1 has 2776986899 in pending_send_data
[2022-05-17 23:58:43.205][1592727][debug][http2] [source/common/http/http2/codec_impl.cc:804] [C8] Stream 1 has 2777889747 in pending_send_data
[2022-05-17 23:58:43.207][1592727][debug][http2] [source/common/http/http2/codec_impl.cc:804] [C8] Stream 1 has 2778792595 in pending_send_data
```

that gets printed out, so the pending_send_data buffer grows large, up to 3328627027 bytes.

In the test harness we overshadown the default write to the connection https://github.com/envoyproxy/envoy/blob/53b5bc8d148763fbb095f00d9c2044039c5dbee5/test/mocks/network/connection.cc#L90-L92 for the data to drain here: https://github.com/envoyproxy/envoy/blob/53b5bc8d148763fbb095f00d9c2044039c5dbee5/test/common/http/codec_impl_fuzz_test.cc#L608-L620.

I then looked at the action that was causing the issue, it was a Quiesce drain. I inserted some code so I could break when the buffer transitions to having more than 2GB to to get a stacktrace of the situation:

```
#0  Envoy::Http::Http2::ConnectionImpl::StreamImpl::encodeDataHelper (this=0x54f6bfcdc600, data=..., end_stream=false,
    skip_encoding_empty_trailers=false) at source/common/http/http2/codec_impl.cc:806
#1  0x0000000002d509b9 in Envoy::Http::Http2::ConnectionImpl::StreamImpl::encodeData (this=0x54f6bfcdc600, data=..., end_stream=false)
    at source/common/http/http2/codec_impl.cc:789
#2  0x000000000172a09e in Envoy::Http::HttpStream::directionalAction (this=0x54f6bde08000, state=..., directional_action=...)
    at test/common/http/codec_impl_fuzz_test.cc:273

---------> This ends up invoking response_encoder_->encodeData(...) on codec_impl_fuzz_test.cc:273


#3  0x000000000172e48b in Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}::operator()() const
    (this=0x7ffffffeff78) at test/common/http/codec_impl_fuzz_test.cc:407

We can see the expectation from https://github.com/envoyproxy/envoy/blob/53b5bc8d148763fbb095f00d9c2044039c5dbee5/test/common/http/codec_impl_fuzz_test.cc#L407 is still active, in particular going to the frame we can see it has captured the following as its stream action:

the stream action is "request {\n  data: 3000000\n}\ndispatching_action {\n  data: 3000000\n}\n", a past action, so the expectation is still active.

So whenever the request_decoder has decodeData() invoked we will end up sending 1MB from the server to client, it ends up buffering in pending_send_data buffer that we see balloon.

I think this should be retired.

#4  0x000000000172e43d in testing::internal::InvokeWithoutArgsAction<Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}>::operator()<Envoy::Buffer::Instance, bool>(Envoy::Buffer::Instance const&, bool const&) (this=0x7ffffffeff78)
    at external/com_google_googletest/googlemock/include/gmock/gmock-actions.h:944
#5  0x000000000172e407 in std::__invoke_impl<void, testing::internal::InvokeWithoutArgsAction<Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}>&, Envoy::Buffer::Instance&, bool>(std::__invoke_other, testing::internal::InvokeWithoutArgsAction<Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}>&, Envoy::Buffer::Instance&, bool&&) (
    __f=..., __args=@0x7ffffffefe0f: false, __args=@0x7ffffffefe0f: false)
    at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#6  0x000000000172e387 in std::__invoke_r<void, testing::internal::InvokeWithoutArgsAction<Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}>&, Envoy::Buffer::Instance&, bool>(testing::internal::InvokeWithoutArgsAction<Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}>&, Envoy::Buffer::Instance&, bool&&) (__fn=...,
    __args=@0x7ffffffefe0f: false, __args=@0x7ffffffefe0f: false)
    at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#7  0x000000000172e257 in std::_Function_handler<void (Envoy::Buffer::Instance&, bool), testing::internal::InvokeWithoutArgsAction<Envoy::Http::HttpStream::streamAction(test::common::http::StreamAction const&)::{lambda()#2}> >::_M_invoke(std::_Any_data const&, Envoy::Buffer::Instance&, bool&&) (__functor=..., __args=@0x7ffffffefe0f: false, __args=@0x7ffffffefe0f: false)
    at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:290
#8  0x0000000001b87b4d in std::function<void (Envoy::Buffer::Instance&, bool)>::operator()(Envoy::Buffer::Instance&, bool) const (
    this=0x7ffffffeff78, __args=false, __args=false) at /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:590
#9  0x0000000001b87ab7 in testing::internal::ApplyImpl<std::function<void (Envoy::Buffer::Instance&, bool)> const&, std::tuple<Envoy::Buffer::Instance&, bool>, 0ul, 1ul> (f=..., args=...)
    at external/com_google_googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:420
#10 0x0000000001b87a52 in testing::internal::Apply<std::function<void (Envoy::Buffer::Instance&, bool)> const&, std::tuple<Envoy::Buffer::Instance&, bool> > (f=..., args=...) at external/com_google_googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:429
#11 0x0000000001b87540 in testing::Action<void (Envoy::Buffer::Instance&, bool)>::Perform(std::tuple<Envoy::Buffer::Instance&, bool>) const
    (this=0x7ffffffeff78, args=...) at external/com_google_googletest/googlemock/include/gmock/gmock-actions.h:497
#12 0x0000000001b87cce in testing::internal::ActionResultHolder<void>::PerformAction<void (Envoy::Buffer::Instance&, bool)>(testing::Action<void (Envoy::Buffer::Instance&, bool)> const&, testing::internal::Function<void (Envoy::Buffer::Instance&, bool)>::ArgumentTuple&&) (
    action=..., args=...) at external/com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h:1441
#13 0x0000000001b86ea5 in testing::internal::FunctionMocker<void (Envoy::Buffer::Instance&, bool)>::UntypedPerformAction(void const*, void*) const (this=0x54f6bde08200, untyped_action=0x54f6bfdfc3f8, untyped_args=0x7fffffff0878)
    at external/com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h:1556
#14 0x0000000003f342aa in testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith (this=0x54f6bde08200,
    untyped_args=0x7fffffff0878) at external/com_google_googletest/googlemock/src/gmock-spec-builders.cc:452
#15 0x000000000164f052 in testing::internal::FunctionMocker<void (Envoy::Buffer::Instance&, bool)>::Invoke(Envoy::Buffer::Instance&, bool)
    (this=0x54f6bde08200, args=false, args=false) at external/com_google_googletest/googlemock/include/gmock/gmock-spec-builders.h:1593
#16 0x00000000016e50f8 in Envoy::Http::MockRequestDecoder::decodeData (this=0x54f6bde081f8, gmock_a0=..., gmock_a1=false)
    at ./test/mocks/http/stream_decoder.h:17
#17 0x0000000002d4407d in Envoy::Http::Http2::ConnectionImpl::StreamImpl::decodeData (this=0x54f6bfcdc600)
    at source/common/http/http2/codec_impl.cc:546


We're draining the reorder buffer as part of the Quicense drain action, this ends up with the request_decoder (a mock) to recieve data which invokes the active expectation on the object.


#18 0x0000000002d5e806 in Envoy::Http::Http2::ConnectionImpl::onFrameReceived (this=0x54f6bfd0da48, frame=0x54f6bde72c10)
    at source/common/http/http2/codec_impl.cc:1311
#19 0x0000000002d7434d in Envoy::Http::Http2::ConnectionImpl::Http2Callbacks::Http2Callbacks(bool)::$_29::operator()(nghttp2_session*, nghttp2_frame const*, void*) const (this=0x54f6bde72a80, frame=0x54f6bde72c10, user_data=0x54f6bfd0da48)
    at source/common/http/http2/codec_impl.cc:1894
#20 0x0000000002d74315 in Envoy::Http::Http2::ConnectionImpl::Http2Callbacks::Http2Callbacks(bool)::$_29::__invoke(nghttp2_session*, nghttp2_frame const*, void*) (frame=0x54f6bde72c10, user_data=0x54f6bfd0da48) at source/common/http/http2/codec_impl.cc:1893
#21 0x000000000309d662 in session_call_on_frame_received (session=0x54f6bde72a80, frame=0x54f6bde72c10)
    at /usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/75388abe3eaf73a64e5fc0563befa9b7/sandbox/linux-sandbox/627/execroot/envoy/external/com_github_nghttp2_nghttp2/lib/nghttp2_session.c:3310
#22 0x000000000309f07e in nghttp2_session_on_data_received (session=0x54f6bde72a80, frame=0x54f6bde72c10)
    at /usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/75388abe3eaf73a64e5fc0563befa9b7/sandbox/linux-sandbox/627/execroot/envoy/external/com_github_nghttp2_nghttp2/lib/nghttp2_session.c:4984
#23 0x00000000030a3c17 in session_process_data_frame (session=0x54f6bde72a80)
    at /usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/75388abe3eaf73a64e5fc0563befa9b7/sandbox/linux-sandbox/627/execroot/envoy/external/com_github_nghttp2_nghttp2/lib/nghttp2_session.c:5003
#24 0x00000000030a1cc1 in nghttp2_session_mem_recv (session=0x54f6bde72a80, in=0x54f6bdded009 'a' <repeats 200 times>..., inlen=12297)
    at /usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/75388abe3eaf73a64e5fc0563befa9b7/sandbox/linux-sandbox/627/execroot/envoy/external/com_github_nghttp2_nghttp2/lib/nghttp2_session.c:6628
#25 0x0000000002d57127 in Envoy::Http::Http2::ConnectionImpl::dispatch (this=0x54f6bfd0da48, data=...)
    at source/common/http/http2/codec_impl.cc:1067
#26 0x0000000002d71756 in Envoy::Http::Http2::ServerConnectionImpl::dispatch (this=0x54f6bfd0da40, data=...)
    at source/common/http/http2/codec_impl.cc:2340
#27 0x0000000001647d60 in Envoy::Http::ReorderBuffer::drain (this=0x7fffffff3aa0) at test/common/http/codec_impl_fuzz_test.cc:475

<------------- this is us draining the reorder buffers which leads to dispatching the data to the Server above.

#28 0x0000000001638505 in Envoy::Http::(anonymous namespace)::codecFuzz(test::common::http::CodecImplFuzzTestCase const&, Envoy::Http::(anonymous namespace)::HttpVersion)::$_4::operator()() const (this=0x7fffffff3630) at test/common/http/codec_impl_fuzz_test.cc:650

<------- draining the client_write_buf (client_connection) writes from client -> server.

#29 0x0000000001637b73 in Envoy::Http::(anonymous namespace)::codecFuzz (input=...,
    http_version=Envoy::Http::(anonymous namespace)::HttpVersion::Http2Nghttp2) at test/common/http/codec_impl_fuzz_test.cc:741
#30 0x000000000163499a in Envoy::Http::TestOneProtoInput (input=...) at test/common/http/codec_impl_fuzz_test.cc:782
#31 0x0000000001634903 in LLVMFuzzerTestOneInput (
    data=0x54f6bde30000 "ettings {\n}\nactions {\n  stream_action {\n    request {\n      data: 8323072\n    }\n  }\n}\nactions {\n  stream_action {\n    request {\n      data: 1\n    }\n  }\n}\nactions {\n  quiesce_drain {\n  }\n}\nactions {\n  "..., size=52131)
    at test/common/http/codec_impl_fuzz_test.cc:777
#32 0x0000000002d31e92 in Envoy::(anonymous namespace)::FuzzerCorpusTest_RunOneCorpusFile_Test::TestBody (this=0x54f6bfdd0f80)
    at test/fuzz/main.cc:50
#33 0x0000000003f7979b in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (object=0x54f6bfdd0f80,
    method=&virtual testing::Test::TestBody(), location=0x460678 "the test body")
    at external/com_google_googletest/googletest/src/gtest.cc:2580
#34 0x0000000003f699fd in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=0x54f6bfdd0f80,
    method=&virtual testing::Test::TestBody(), location=0x460678 "the test body")
    at external/com_google_googletest/googletest/src/gtest.cc:2616
#35 0x0000000003f517a3 in testing::Test::Run (this=0x54f6bfdd0f80) at external/com_google_googletest/googletest/src/gtest.cc:2655
#36 0x0000000003f523aa in testing::TestInfo::Run (this=0x54f6bfd46990) at external/com_google_googletest/googletest/src/gtest.cc:2832
#37 0x0000000003f52c0b in testing::TestSuite::Run (this=0x54f6bfc9a880) at external/com_google_googletest/googletest/src/gtest.cc:2986
#38 0x0000000003f61a4b in testing::internal::UnitTestImpl::RunAllTests (this=0x54f6bfc69180)
    at external/com_google_googletest/googletest/src/gtest.cc:5697
#39 0x0000000003f7bf5b in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (
    object=0x54f6bfc69180,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x3f615f0 <testing::internal::UnitTestImpl::RunAllTests()>, location=0x28611f "auxiliary test code (environments or event listeners)")
    at external/com_google_googletest/googletest/src/gtest.cc:2580
#40 0x0000000003f6bdd3 in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (
    object=0x54f6bfc69180,
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x3f615f0 <testing::internal::UnitTestImpl::RunAllTests()>, location=0x28611f "auxiliary test code (environments or event listeners)")
    at external/com_google_googletest/googletest/src/gtest.cc:2616
#41 0x0000000003f6157e in testing::UnitTest::Run (this=0x4bb1718 <testing::UnitTest::GetInstance()::instance>)
    at external/com_google_googletest/googletest/src/gtest.cc:5280
#42 0x0000000002d34d11 in RUN_ALL_TESTS () at external/com_google_googletest/googletest/include/gtest/gtest.h:2485
#43 0x0000000002d30579 in main (argc=1, argv=0x7fffffffd808) at test/fuzz/main.cc:97
```

I think when we're draining the client write buf we end end dispatching some data to the ServerConnectionImpl which then invokes the decodeData multiple times on the RequestDecoder mock which then with the expectation set prior when we were doing a request action ends up adding data 1MB to the pending send buffer. This happens multiple times in a single drain action as we end up dispatching a buffer fragment (slice) at a time.

I annotated how much data we drain in a call to client_server_buf_drain and got client data drain values mostly ranging from 850KB - 13MB. Assuming 16k writes, we can easily see up to ~ 800MB could queue from a single drain.

I think the right fix here is to only generate the response if we're in the current stream action.

Grepping for the pending_send_data size with the fix we get 13791042 as the max which seems much more reasonable than 3328627027 bytes the maximum pending_send_data size otherwise.