### PR TITLE
docs: add python@3.10 brew install recommendation for macOS

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -105,9 +105,11 @@ for how to update or override dependencies.
     ### macOS
     On macOS, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):
     ```console
-    brew install coreutils wget cmake libtool go bazel automake ninja clang-format autoconf aspell
+    brew install coreutils wget cmake libtool go bazel automake ninja clang-format autoconf aspell python@3.10
     ```
     _notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`
+    
+    _notes_: See Homebrew python setup notes: https://docs.brew.sh/Homebrew-and-Python.
 
     The full version of Xcode (not just Command Line Tools) is also required to build Envoy on macOS.
     Envoy compiles and passes tests with the version of clang installed by Xcode 11.1:


### PR DESCRIPTION
Python 3.10 is implicitly required: `trycast` expected __required_fields__, which was added in 3.9). Bazel pip dependencies are compiled with python 3.10, so it's better to recommend 3.10.

Signed-off-by: Sergii Tkachenko <sergiitk@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs: add python@3.10 brew install recommendation for macOS
Additional Description: Python 3.10 is implicitly required: `trycast` expected __required_fields__, which was added in 3.9). Bazel pip dependencies are compiled with python 3.10, so it's better to recommend 3.10.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

phlax@, @keith 