### PR TITLE
Listener: the API change for multiple addresses support

### DIFF
--- a/api/envoy/admin/v3/listeners.proto
+++ b/api/envoy/admin/v3/listeners.proto
@@ -34,4 +34,9 @@ message ListenerStatus {
   // The actual local address that the listener is listening on. If a listener was configured
   // to listen on port 0, then this address has the port that was allocated by the OS.
   config.core.v3.Address local_address = 2;
+
+  // The additional actual local addresses that the listener is listening on. If a listener was configured
+  // to listen on port 0, then this address has the port that was allocated by the OS.
+  // [#not-implemented-hide:]
+  repeated config.core.v3.Address additional_local_addresses = 3;
 }

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -109,6 +109,13 @@ message Listener {
   // Required unless *api_listener* or *listener_specifier* is populated.
   core.v3.Address address = 2;
 
+  // The additional addresses the listener should listen on. The address must be unqiue across all
+  // the listeners, also in the single listener. Multiple addresses with port 0 can be supported,
+  // same as the `address` field described. For multiple addresses in single listener,
+  // all addresses use the same protocol, and multiple internal addresses are not yet supported.
+  // [#not-implemented-hide:]
+  repeated core.v3.Address additional_addresses = 33;
+
   // Optional prefix to use on listener stats. If empty, the stats will be rooted at
   // `listener.<address as string>.`. If non-empty, stats will be rooted at
   // `listener.<stat_prefix>.`.


### PR DESCRIPTION
Commit Message: Listener: the API change for multiple addresses support
Additional Description:

Both listener and admin API are changed to support multiple addresses.

Risk Level: low
Testing: n/a
Docs Changes: API doc
Release Notes: n/a
Platform Specific Features: n/a
Part of Fixes #11184
