### PR TITLE
lua: microseconds accuracy in timestamp

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,6 +31,10 @@ minor_behavior_changes:
     `PR21114 <https://github.com/envoyproxy/envoy/pull/21114>`_ for example.
 - area: lua
   change: |
+    added microsecond resolution in timestamp function. The return value is a string representing the 
+    integer value of selected time resolution since epoch.
+- area: lua
+  change: |
     export symbols of LuaJit by default on Linux. This is useful in cases where you have a lua script
     that loads shared object libraries, such as those installed via luarocks.
 - area: admin

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,8 +31,8 @@ minor_behavior_changes:
     `PR21114 <https://github.com/envoyproxy/envoy/pull/21114>`_ for example.
 - area: lua
   change: |
-    added microsecond resolution in timestamp function. The return value is a string representing the 
-    integer value of selected time resolution since epoch.
+    new function ``timestampString`` returning the time since epoch as a string. Supported
+    resolutions are millisecond and microsecond.
 - area: lua
   change: |
     export symbols of LuaJit by default on Linux. This is useful in cases where you have a lua script

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -515,8 +515,9 @@ timestamp()
 
   timestamp = handle:timestamp(format)
 
-High resolution timestamp function. *format* is an optional enum parameter to indicate the format of the timestamp.
-*EnvoyTimestampResolution.MILLISECOND* is supported
+High resolution timestamp function. Timestamp is returned as string representing the integer value of the selected resolution.
+*format* is an optional enum parameter to indicate the format of the timestamp.
+*EnvoyTimestampResolution.MILLISECOND* and *EnvoyTimestampResolution.MICROSECOND* is supported.
 The function returns timestamp in milliseconds since epoch by default if format is not set.
 
 .. _config_http_filters_lua_header_wrapper:

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -515,10 +515,21 @@ timestamp()
 
   timestamp = handle:timestamp(format)
 
-High resolution timestamp function. Timestamp is returned as string representing the integer value of the selected resolution.
-*format* is an optional enum parameter to indicate the format of the timestamp.
-*EnvoyTimestampResolution.MILLISECOND* and *EnvoyTimestampResolution.MICROSECOND* is supported.
+High resolution timestamp function. *format* is an optional enum parameter to indicate the format of the timestamp.
+*EnvoyTimestampResolution.MILLISECOND* is supported
 The function returns timestamp in milliseconds since epoch by default if format is not set.
+
+timestampString()
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  timestamp = handle:timestampString(resolution)
+
+Timestamp function. Timestamp is returned as a string. It represents the integer value of the selected resolution
+since epoch. *resolution* is an optional enum parameter to indicate the resolution of the timestamp.
+Supported resolutions are *EnvoyTimestampResolution.MILLISECOND* and *EnvoyTimestampResolution.MICROSECOND*.
+Default resolution is millisecond if *resolution* is not set.
 
 .. _config_http_filters_lua_header_wrapper:
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -633,6 +633,27 @@ int StreamHandleWrapper::luaTimestamp(lua_State* state) {
   auto now = time_source_.systemTime().time_since_epoch();
 
   absl::string_view unit_parameter = luaL_optstring(state, 2, "");
+
+  auto milliseconds_since_epoch =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+  absl::uint128 resolution_as_int_from_state = 0;
+  if (unit_parameter.empty()) {
+    lua_pushnumber(state, milliseconds_since_epoch);
+  } else if (absl::SimpleAtoi(unit_parameter, &resolution_as_int_from_state) &&
+             resolution_as_int_from_state == enumToInt(Timestamp::Resolution::Millisecond)) {
+    lua_pushnumber(state, milliseconds_since_epoch);
+  } else {
+    luaL_error(state, "timestamp format must be MILLISECOND.");
+  }
+
+  return 1;
+}
+
+int StreamHandleWrapper::luaTimestampString(lua_State* state) {
+  auto now = time_source_.systemTime().time_since_epoch();
+
+  absl::string_view unit_parameter = luaL_optstring(state, 2, "");
   auto resolution = getTimestampResolution(unit_parameter);
   if (resolution == Timestamp::Resolution::Millisecond) {
     auto milliseconds_since_epoch =

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -16,7 +16,6 @@
 #include "source/common/http/message_impl.h"
 
 #include "absl/strings/escaping.h"
-#include "wrappers.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -3,7 +3,6 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
-#include <string>
 
 #include "envoy/http/codes.h"
 

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -168,7 +168,8 @@ public:
             {"importPublicKey", static_luaImportPublicKey},
             {"verifySignature", static_luaVerifySignature},
             {"base64Escape", static_luaBase64Escape},
-            {"timestamp", static_luaTimestamp}};
+            {"timestamp", static_luaTimestamp},
+            {"timestampString", static_luaTimestampString}};
   }
 
 private:
@@ -286,10 +287,18 @@ private:
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestamp);
 
-  int doSynchronousHttpCall(lua_State* state, Tracing::Span& span);
-  int doAsynchronousHttpCall(lua_State* state, Tracing::Span& span);
+    /**
+   * TimestampString.
+   * @param1 (string) optional format (e.g. milliseconds_from_epoch, microseconds_from_epoch).
+   * Defaults to milliseconds_from_epoch.
+   * @return (string) timestamp.
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestampString);
 
   enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
+
+  int doSynchronousHttpCall(lua_State* state, Tracing::Span& span);
+  int doAsynchronousHttpCall(lua_State* state, Tracing::Span& span);
 
   // Filters::Common::Lua::BaseLuaObject
   void onMarkDead() override {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -287,7 +287,7 @@ private:
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestamp);
 
-    /**
+  /**
    * TimestampString.
    * @param1 (string) optional format (e.g. milliseconds_from_epoch, microseconds_from_epoch).
    * Defaults to milliseconds_from_epoch.

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -10,8 +10,6 @@
 #include "source/extensions/filters/http/common/factory_base.h"
 #include "source/extensions/filters/http/lua/wrappers.h"
 
-#include "wrappers.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -10,6 +10,8 @@
 #include "source/extensions/filters/http/common/factory_base.h"
 #include "source/extensions/filters/http/lua/wrappers.h"
 
+#include "wrappers.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -287,7 +289,7 @@ private:
   int doSynchronousHttpCall(lua_State* state, Tracing::Span& span);
   int doAsynchronousHttpCall(lua_State* state, Tracing::Span& span);
 
-  int timestamp(int timestamp, absl::uint128 resolution);
+  enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
 
   // Filters::Common::Lua::BaseLuaObject
   void onMarkDead() override {

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -277,7 +277,7 @@ private:
 
 class Timestamp {
 public:
-  enum Resolution { Millisecond };
+  enum Resolution { Millisecond, Microsecond, Undefined };
 };
 
 } // namespace Lua

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -100,7 +100,7 @@ public:
 
   void setupFilter() {
     Event::SimulatedTimeSystem test_time;
-    test_time.setSystemTime(std::chrono::milliseconds(1583879145572));
+    test_time.setSystemTime(std::chrono::microseconds(1583879145572237));
 
     filter_ = std::make_unique<TestFilter>(config_, test_time.timeSystem());
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
@@ -2304,7 +2304,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterBase64Escape) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(response_body, true));
 }
 
-TEST_F(LuaHttpFilterTest, Timestamp_ReturnsFormatSet) {
+TEST_F(LuaHttpFilterTest, Timestamp_ReturnsMilliFormatSet) {
   const std::string SCRIPT{R"EOF(
       function envoy_on_request(request_handle)
         request_handle:logTrace(request_handle:timestamp(EnvoyTimestampResolution.MILLISECOND))
@@ -2320,7 +2320,24 @@ TEST_F(LuaHttpFilterTest, Timestamp_ReturnsFormatSet) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("1583879145572")));
   // Invalid format
   EXPECT_CALL(*filter_,
-              scriptLog(spdlog::level::err, HasSubstr("timestamp format must be MILLISECOND.")));
+              scriptLog(spdlog::level::err,
+                        HasSubstr("timestamp format must be MILLISECOND or MICROSECOND.")));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(LuaHttpFilterTest, Timestamp_ReturnsMicroFormatSet) {
+  const std::string SCRIPT{R"EOF(
+      function envoy_on_request(request_handle)
+        request_handle:logTrace(request_handle:timestamp(EnvoyTimestampResolution.MICROSECOND))
+      end
+    )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  // Explicitly set to microseconds
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("1583879145572237")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -2320,8 +2320,7 @@ TEST_F(LuaHttpFilterTest, Timestamp_ReturnsFormatSet) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("1583879145572")));
   // Invalid format
   EXPECT_CALL(*filter_,
-              scriptLog(spdlog::level::err,
-                        HasSubstr("timestamp format must be MILLISECOND.")));
+              scriptLog(spdlog::level::err, HasSubstr("timestamp format must be MILLISECOND.")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Added microsecond resolution in lua timestamp function.
Timestamp function now returns a string representing the integer value of the selected resolution since epoch time.

Additional Description:
N/A

Risk Level: Low

Testing:
New unit test of lua timestamp function added. It checks the valid return of a microsecond resolution timestamp.
Slight modification of relevant millisecond unit test.

Docs Changes:
Added info in lua timestamp documentation. It clarifies that the return value is a string representing the integer value of the selected resolution.

Release Notes:
Added a relevant release note.

Platform Specific Features: 
N/A

[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA] N/A
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
