### PR TITLE
Test PR - bump to c++20 for designated initializers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -373,7 +373,7 @@ build:windows --define hot_restart=disabled
 build:windows --define tcmalloc=disabled
 build:windows --define wasm=disabled
 build:windows --define manual_stamp=manual_stamp
-build:windows --cxxopt="/std:c++17"
+build:windows --cxxopt="/std:c++20"
 
 # TODO(wrowe,sunjayBhatia): Resolve bugs upstream in curl and rules_foreign_cc
 # See issue https://github.com/bazelbuild/rules_foreign_cc/issues/301


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Adopt /std:c++20 for windows for designated initializers
Additional Description:
Google style permits designated initializers from C++20. MSVC is strict about C++17. 
The request is to allow Google style code in Windows CI even if it's not fully compliant with C++17. 
Options include using std=c++20 or std=c++latest in MSVC, the former is more predictable.

Likely shows up legacy changes required for c++20, which will cause msvc-cl builds to serve 
as a canary for errant new code that becomes invalid after we move on from c++17.

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>
Risk Level: Moderate
Testing: CI
Fixes: #18489
Platform Specific Features: Only needed on msvc, clang/gcc accept designated initializers

Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
