### PR TITLE
[Backport 1.22] stateful session: allow empty filter config (#20960)

### DIFF
--- a/api/envoy/extensions/filters/http/stateful_session/v3/stateful_session.proto
+++ b/api/envoy/extensions/filters/http/stateful_session/v3/stateful_session.proto
@@ -22,8 +22,7 @@ message StatefulSession {
   // get address of the upstream host to which the session is assigned.
   //
   // [#extension-category: envoy.http.stateful_session]
-  config.core.v3.TypedExtensionConfig session_state = 1
-      [(validate.rules).message = {required: true}];
+  config.core.v3.TypedExtensionConfig session_state = 1;
 }
 
 message StatefulSessionPerRoute {

--- a/source/extensions/filters/http/stateful_session/config.cc
+++ b/source/extensions/filters/http/stateful_session/config.cc
@@ -15,8 +15,7 @@ Http::FilterFactoryCb StatefulSessionFactoryConfig::createFilterFactoryFromProto
   auto filter_config(std::make_shared<StatefulSessionConfig>(proto_config, context));
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(
-        Http::StreamFilterSharedPtr{new StatefulSession(filter_config.get())});
+    callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new StatefulSession(filter_config)});
   };
 }
 

--- a/source/extensions/filters/http/stateful_session/stateful_session.h
+++ b/source/extensions/filters/http/stateful_session/stateful_session.h
@@ -55,7 +55,7 @@ using PerRouteStatefulSessionConfigSharedPtr = std::shared_ptr<PerRouteStatefulS
 class StatefulSession : public Http::PassThroughFilter,
                         public Logger::Loggable<Logger::Id::filter> {
 public:
-  StatefulSession(const StatefulSessionConfig* config) : config_(config) {}
+  StatefulSession(StatefulSessionConfigSharedPtr config) : config_(std::move(config)) {}
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
@@ -68,7 +68,7 @@ public:
 private:
   Http::SessionStatePtr session_state_;
 
-  const StatefulSessionConfig* config_{nullptr};
+  StatefulSessionConfigSharedPtr config_{};
 };
 
 } // namespace StatefulSession

--- a/test/extensions/filters/http/stateful_session/stateful_session_test.cc
+++ b/test/extensions/filters/http/stateful_session/stateful_session_test.cc
@@ -35,7 +35,7 @@ public:
 
     config_ = std::make_shared<StatefulSessionConfig>(proto_config, context_);
 
-    filter_ = std::make_shared<StatefulSession>(config_.get());
+    filter_ = std::make_shared<StatefulSession>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
 
@@ -204,6 +204,17 @@ TEST_F(StatefulSessionTest, NullSessionState) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
+}
+
+TEST(EmpytProtoConfigTest, EmpytProtoConfigTest) {
+  ProtoConfig empty_proto_config;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  StatefulSessionConfig config(empty_proto_config, server_context);
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":path", "/"}, {":method", "GET"}, {":authority", "test.com"}};
+  EXPECT_EQ(nullptr, config.createSessionState(request_headers));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message:

Backport https://github.com/envoyproxy/envoy/pull/20960 to 1.22. Check https://github.com/envoyproxy/envoy/pull/20960#issuecomment-1134572736 for some more context.

Additional Description: n/a.
Risk Level: Low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.