### PR TITLE
[cleanup] Remove quiche_spdy_platform which points at a nonentity

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -900,10 +900,6 @@ def _com_github_google_quiche():
         actual = "@com_github_google_quiche//:http2_adapter",
     )
     native.bind(
-        name = "quiche_spdy_platform",
-        actual = "@com_github_google_quiche//:spdy_platform",
-    )
-    native.bind(
         name = "quiche_quic_platform",
         actual = "@com_github_google_quiche//:quic_platform",
     )


### PR DESCRIPTION
Commit Message: [cleanup] Remove quiche_spdy_platform which points at a nonentity
Additional Description: There is no target "spdy_platform" in quiche now, neither in the original nor the replacement build file.
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
