### PR TITLE
h3 pool: quic connection honors socket options

### DIFF
--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -115,9 +115,9 @@ Http3ConnPoolImpl::createClientConnection(Quic::QuicStatNames& quic_stat_names,
     source_address = Network::Utility::getLocalAddress(host_address->ip()->version());
   }
 
-  return Quic::createQuicNetworkConnection(quic_info_, std::move(crypto_config), server_id_,
-                                           dispatcher(), host()->address(), source_address,
-                                           quic_stat_names, rtt_cache, scope);
+  return Quic::createQuicNetworkConnection(
+      quic_info_, std::move(crypto_config), server_id_, dispatcher(), host()->address(),
+      source_address, quic_stat_names, rtt_cache, scope, socketOptions(), transportSocketOptions());
 }
 
 std::unique_ptr<Http3ConnPoolImpl>

--- a/source/common/quic/client_connection_factory_impl.h
+++ b/source/common/quic/client_connection_factory_impl.h
@@ -45,7 +45,9 @@ std::unique_ptr<Network::ClientConnection> createQuicNetworkConnection(
     const quic::QuicServerId& server_id, Event::Dispatcher& dispatcher,
     Network::Address::InstanceConstSharedPtr server_addr,
     Network::Address::InstanceConstSharedPtr local_addr, QuicStatNames& quic_stat_names,
-    OptRef<Http::HttpServerPropertiesCache> rtt_cache, Stats::Scope& scope);
+    OptRef<Http::HttpServerPropertiesCache> rtt_cache, Stats::Scope& scope,
+    const Network::ConnectionSocket::OptionsSharedPtr& options,
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options);
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -25,16 +25,16 @@ class EnvoyQuicClientSession : public QuicFilterManagerConnectionImpl,
                                public Network::ClientConnection,
                                public PacketsToReadDelegate {
 public:
-  EnvoyQuicClientSession(const quic::QuicConfig& config,
-                         const quic::ParsedQuicVersionVector& supported_versions,
-                         std::unique_ptr<EnvoyQuicClientConnection> connection,
-                         const quic::QuicServerId& server_id,
-                         std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config,
-                         quic::QuicClientPushPromiseIndex* push_promise_index,
-                         Event::Dispatcher& dispatcher, uint32_t send_buffer_limit,
-                         EnvoyQuicCryptoClientStreamFactoryInterface& crypto_stream_factory,
-                         QuicStatNames& quic_stat_names,
-                         OptRef<Http::HttpServerPropertiesCache> rtt_cache, Stats::Scope& scope);
+  EnvoyQuicClientSession(
+      const quic::QuicConfig& config, const quic::ParsedQuicVersionVector& supported_versions,
+      std::unique_ptr<EnvoyQuicClientConnection> connection, const quic::QuicServerId& server_id,
+      std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config,
+      quic::QuicClientPushPromiseIndex* push_promise_index, Event::Dispatcher& dispatcher,
+      uint32_t send_buffer_limit,
+      EnvoyQuicCryptoClientStreamFactoryInterface& crypto_stream_factory,
+      QuicStatNames& quic_stat_names, OptRef<Http::HttpServerPropertiesCache> rtt_cache,
+      Stats::Scope& scope,
+      const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options);
 
   ~EnvoyQuicClientSession() override;
 
@@ -117,6 +117,7 @@ private:
   OptRef<Http::HttpServerPropertiesCache> rtt_cache_;
   Stats::Scope& scope_;
   bool disable_keepalive_{false};
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
 };
 
 } // namespace Quic

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -80,7 +80,7 @@ TEST_P(QuicNetworkConnectionTest, BufferLimits) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig().serverNameIndication(), port, false},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, store_);
+      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, store_, nullptr, nullptr);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
   client_connection->connect();
@@ -89,6 +89,28 @@ TEST_P(QuicNetworkConnectionTest, BufferLimits) {
   EXPECT_EQ(highWatermark(session), 45);
   EXPECT_EQ(absl::nullopt, session->unixSocketPeerCredentials());
   EXPECT_NE(absl::nullopt, session->lastRoundTripTime());
+  client_connection->close(Network::ConnectionCloseType::NoFlush);
+}
+
+TEST_P(QuicNetworkConnectionTest, SocketOptions) {
+  initialize();
+
+  auto socket_option = std::make_shared<Network::MockSocketOption>();
+  auto socket_options = std::make_shared<Network::ConnectionSocket::Options>();
+  socket_options->push_back(socket_option);
+  const int port = 30;
+  EXPECT_CALL(*socket_option, setOption(_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
+  EXPECT_CALL(*socket_option, setOption(_, envoy::config::core::v3::SocketOption::STATE_BOUND));
+  EXPECT_CALL(*socket_option, setOption(_, envoy::config::core::v3::SocketOption::STATE_LISTENING));
+
+  std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
+      *quic_info_, crypto_config_,
+      quic::QuicServerId{factory_->clientContextConfig().serverNameIndication(), port, false},
+      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, store_, socket_options,
+      nullptr);
+  EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
+  session->Initialize();
+  client_connection->connect();
   client_connection->close(Network::ConnectionCloseType::NoFlush);
 }
 
@@ -104,7 +126,8 @@ TEST_P(QuicNetworkConnectionTest, Srtt) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       info, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig().serverNameIndication(), port, false},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, rtt_cache, store_);
+      dispatcher_, test_address_, test_address_, quic_stat_names_, rtt_cache, store_, nullptr,
+      nullptr);
 
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
 

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -41,8 +41,7 @@ public:
                                 Event::Dispatcher& dispatcher,
                                 Network::ConnectionSocketPtr&& connection_socket)
       : EnvoyQuicClientConnection(server_connection_id, helper, alarm_factory, &writer, false,
-                                  supported_versions, dispatcher, std::move(connection_socket),
-                                  nullptr) {
+                                  supported_versions, dispatcher, std::move(connection_socket)) {
     SetEncrypter(quic::ENCRYPTION_FORWARD_SECURE,
                  std::make_unique<quic::NullEncrypter>(quic::Perspective::IS_CLIENT));
     SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -41,7 +41,8 @@ public:
                                 Event::Dispatcher& dispatcher,
                                 Network::ConnectionSocketPtr&& connection_socket)
       : EnvoyQuicClientConnection(server_connection_id, helper, alarm_factory, &writer, false,
-                                  supported_versions, dispatcher, std::move(connection_socket)) {
+                                  supported_versions, dispatcher, std::move(connection_socket),
+                                  nullptr) {
     SetEncrypter(quic::ENCRYPTION_FORWARD_SECURE,
                  std::make_unique<quic::NullEncrypter>(quic::Perspective::IS_CLIENT));
     SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
@@ -76,7 +77,7 @@ public:
                             quic::QuicServerId("example.com", 443, false), crypto_config_, nullptr,
                             *dispatcher_,
                             /*send_buffer_limit*/ 1024 * 1024, crypto_stream_factory_,
-                            quic_stat_names_, {}, store_),
+                            quic_stat_names_, {}, store_, nullptr),
         stats_({ALL_HTTP3_CODEC_STATS(POOL_COUNTER_PREFIX(store_, "http3."),
                                       POOL_GAUGE_PREFIX(store_, "http3."))}),
         http_connection_(envoy_quic_session_, http_connection_callbacks_, stats_, http3_options_,

--- a/test/common/quic/test_utils.h
+++ b/test/common/quic/test_utils.h
@@ -160,7 +160,7 @@ public:
                                std::make_shared<quic::QuicCryptoClientConfig>(
                                    quic::test::crypto_test_utils::ProofVerifierForTesting()),
                                nullptr, dispatcher, send_buffer_limit, crypto_stream_factory,
-                               quic_stat_names_, {}, stats_store_) {}
+                               quic_stat_names_, {}, stats_store_, nullptr) {}
 
   void Initialize() override {
     EnvoyQuicClientSession::Initialize();

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -241,7 +241,6 @@ Network::ClientConnectionPtr HttpIntegrationTest::makeClientConnectionWithOption
   }
 #ifdef ENVOY_ENABLE_QUIC
   // Setting socket options is not supported for HTTP3.
-  ASSERT(!options);
   Network::Address::InstanceConstSharedPtr server_addr = Network::Utility::resolveUrl(
       fmt::format("udp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
   Network::Address::InstanceConstSharedPtr local_addr =
@@ -253,7 +252,7 @@ Network::ClientConnectionPtr HttpIntegrationTest::makeClientConnectionWithOption
       quic::QuicServerId(
           quic_transport_socket_factory_ref.clientContextConfig().serverNameIndication(),
           static_cast<uint16_t>(port)),
-      *dispatcher_, server_addr, local_addr, quic_stat_names_, {}, stats_store_);
+      *dispatcher_, server_addr, local_addr, quic_stat_names_, {}, stats_store_, options, nullptr);
 #else
   ASSERT(false, "running a QUIC integration test without compiling QUIC");
   return nullptr;

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -153,9 +153,9 @@ public:
     return makeClientConnectionWithHost(port, "", options);
   }
 
-  Network::ClientConnectionPtr
-  makeClientConnectionWithHost(uint32_t port, const std::string& host,
-                               const Network::ConnectionSocket::OptionConstSharedPtr& options) {
+  Network::ClientConnectionPtr makeClientConnectionWithHost(
+      uint32_t port, const std::string& host,
+      const Network::ConnectionSocket::OptionsSharedPtr& options = nullptr) {
     // Setting socket options is not supported.
     server_addr_ = Network::Utility::resolveUrl(
         fmt::format("udp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
@@ -167,7 +167,7 @@ public:
     // different version set on server side to test that.
     auto connection = std::make_unique<TestEnvoyQuicClientConnection>(
         getNextConnectionId(), server_addr_, conn_helper_, alarm_factory_,
-        quic::ParsedQuicVersionVector{supported_versions_[0]}, local_addr, *dispatcher_, nullptr,
+        quic::ParsedQuicVersionVector{supported_versions_[0]}, local_addr, *dispatcher_, options,
         validation_failure_on_path_response_);
     quic_connection_ = connection.get();
     ASSERT(quic_connection_persistent_info_ != nullptr);

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -150,12 +150,12 @@ public:
   Network::ClientConnectionPtr makeClientConnectionWithOptions(
       uint32_t port, const Network::ConnectionSocket::OptionsSharedPtr& options) override {
     // Setting socket options is not supported.
-    ASSERT(!options);
-    return makeClientConnectionWithHost(port, "");
+    return makeClientConnectionWithHost(port, "", options);
   }
 
-  Network::ClientConnectionPtr makeClientConnectionWithHost(uint32_t port,
-                                                            const std::string& host) {
+  Network::ClientConnectionPtr
+  makeClientConnectionWithHost(uint32_t port, const std::string& host,
+                               const Network::ConnectionSocket::OptionConstSharedPtr& options) {
     // Setting socket options is not supported.
     server_addr_ = Network::Utility::resolveUrl(
         fmt::format("udp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
@@ -183,7 +183,7 @@ public:
         // Use smaller window than the default one to have test coverage of client codec buffer
         // exceeding high watermark.
         /*send_buffer_limit=*/2 * Http2::Utility::OptionsLimits::MIN_INITIAL_STREAM_WINDOW_SIZE,
-        persistent_info.crypto_stream_factory_, quic_stat_names_, cache, stats_store_);
+        persistent_info.crypto_stream_factory_, quic_stat_names_, cache, stats_store_, nullptr);
     return session;
   }
 

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -229,7 +229,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
       *persistent_info, quic_transport_socket_factory.getCryptoConfig(),
       quic::QuicServerId(quic_transport_socket_factory.clientContextConfig().serverNameIndication(),
                          static_cast<uint16_t>(addr->ip()->port())),
-      *dispatcher, addr, local_address, quic_stat_names, {}, mock_stats_store);
+      *dispatcher, addr, local_address, quic_stat_names, {}, mock_stats_store, nullptr, nullptr);
   connection->addConnectionCallbacks(connection_callbacks);
   Http::CodecClientProd client(type, std::move(connection), host_description, *dispatcher, random);
   // Quic connection needs to finish handshake.


### PR DESCRIPTION
Commit Message: pass 2 cluster config knobs socket options and transport socket options to EnvoyQuicClientSession and EnvoyQuicClientConnection.

Risk Level: low
Testing: new unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
 