### PR TITLE
Simplify Parser HTTP version calls.

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -769,7 +769,7 @@ StatusOr<CallbackResult> ConnectionImpl::onHeadersCompleteImpl() {
   ENVOY_CONN_LOG(trace, "onHeadersCompleteBase", connection_);
   RETURN_IF_ERROR(completeLastHeader());
 
-  if (!(parser_->httpMajor() == 1 && parser_->httpMinor() == 1)) {
+  if (!parser_->isHttp11()) {
     // This is not necessarily true, but it's good enough since higher layers only care if this is
     // HTTP/1.1 or not.
     protocol_ = Protocol::Http10;

--- a/source/common/http/http1/legacy_parser_impl.cc
+++ b/source/common/http/http1/legacy_parser_impl.cc
@@ -95,9 +95,7 @@ public:
 
   uint16_t statusCode() const { return parser_.status_code; }
 
-  int httpMajor() const { return parser_.http_major; }
-
-  int httpMinor() const { return parser_.http_minor; }
+  bool isHttp11() const { return parser_.http_major == 1 && parser_.http_minor == 1; }
 
   absl::optional<uint64_t> contentLength() const {
     // An unset content length will be have all bits set.
@@ -152,9 +150,7 @@ ParserStatus LegacyHttpParserImpl::getStatus() { return intToStatus(impl_->getEr
 
 uint16_t LegacyHttpParserImpl::statusCode() const { return impl_->statusCode(); }
 
-int LegacyHttpParserImpl::httpMajor() const { return impl_->httpMajor(); }
-
-int LegacyHttpParserImpl::httpMinor() const { return impl_->httpMinor(); }
+bool LegacyHttpParserImpl::isHttp11() const { return impl_->isHttp11(); }
 
 absl::optional<uint64_t> LegacyHttpParserImpl::contentLength() const {
   return impl_->contentLength();

--- a/source/common/http/http1/legacy_parser_impl.h
+++ b/source/common/http/http1/legacy_parser_impl.h
@@ -19,8 +19,7 @@ public:
   CallbackResult pause() override;
   ParserStatus getStatus() override;
   uint16_t statusCode() const override;
-  int httpMajor() const override;
-  int httpMinor() const override;
+  bool isHttp11() const override;
   absl::optional<uint64_t> contentLength() const override;
   bool isChunked() const override;
   absl::string_view methodName() const override;

--- a/source/common/http/http1/parser.h
+++ b/source/common/http/http1/parser.h
@@ -135,11 +135,8 @@ public:
   // TODO(asraa): Return Envoy::Http::Code.
   virtual uint16_t statusCode() const PURE;
 
-  // Returns an integer representing the HTTP major version.
-  virtual int httpMajor() const PURE;
-
-  // Returns an integer representing the HTTP minor version.
-  virtual int httpMinor() const PURE;
+  // Returns whether HTTP version is 1.1.
+  virtual bool isHttp11() const PURE;
 
   // Returns the number of bytes in the body. absl::nullopt if no Content-Length header
   virtual absl::optional<uint64_t> contentLength() const PURE;


### PR DESCRIPTION
Replace Parser::httpMajor() and httpMinor() with a single isHttp11()
method, as that is the only thing ConnectionImpl cares about.  Note that
Protocol struct does not define HTTP/0.9 (in envoy/http/protocol.h)
anyway.

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
