### PR TITLE
logger: avoid nullptr err in enableFancyLogger

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -199,8 +199,8 @@ bool Context::useFancyLogger() {
 }
 
 void Context::enableFancyLogger() {
-  current_context->enable_fine_grain_logging_ = true;
   if (current_context) {
+    current_context->enable_fine_grain_logging_ = true;
     getFancyContext().setDefaultFancyLevelFormat(current_context->log_level_,
                                                  current_context->log_format_);
     current_context->fancy_default_level_ = current_context->log_level_;


### PR DESCRIPTION
Signed-off-by: Boteng Yao <boteng@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

`current_context` can be `nullptr` at beginning 
`static Context* current_context = nullptr;`

Commit Message: logger: avoid nullptr err in enableFancyLogger
Additional Description:
Risk Level: low
Testing: unit tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
