### PR TITLE
skywalking: fix to avoid tracing all requests

### DIFF
--- a/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
+++ b/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
@@ -70,6 +70,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
   setupSkyWalkingDriver(yaml_string);
 
   Tracing::Decision decision;
+  decision.reason = Tracing::Reason::Sampling;
   decision.traced = true;
   auto& factory_context = context_.server_factory_context_;
 
@@ -170,6 +171,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestNoClientConfig) {
   setupSkyWalkingDriver(yaml_string);
 
   Tracing::Decision decision;
+  decision.reason = Tracing::Reason::Sampling;
   decision.traced = true;
 
   Http::TestRequestHeaderMapImpl request_headers{

--- a/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
+++ b/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
@@ -150,17 +150,13 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
     decision.traced = false;
     Http::TestRequestHeaderMapImpl request_headers{
         {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
-    Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, "TEST_OP",
-                                               time_system_.systemTime(), decision);
-    Span* new_span = dynamic_cast<Span*>(span.get());
-    ASSERT(new_span);
+    Tracing::SpanPtr org_null_span = driver_->startSpan(
+        mock_tracing_config_, request_headers, "TEST_OP", time_system_.systemTime(), decision);
 
-    EXPECT_TRUE(new_span->tracingContext()->skipAnalysis());
+    EXPECT_EQ(nullptr, dynamic_cast<Span*>(org_null_span.get()));
 
-    EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
-    span->finishSpan();
-
-    EXPECT_EQ(3U, factory_context.scope_.counter("tracing.skywalking.segments_sent").value());
+    auto& null_span = *org_null_span;
+    EXPECT_EQ(typeid(null_span).name(), typeid(Tracing::NullSpan).name());
   }
 }
 
@@ -173,11 +169,14 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestNoClientConfig) {
 
   setupSkyWalkingDriver(yaml_string);
 
+  Tracing::Decision decision;
+  decision.traced = true;
+
   Http::TestRequestHeaderMapImpl request_headers{
       {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
   Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, request_headers, "TEST_OP",
-                                                 time_system_.systemTime(), Tracing::Decision());
+                                                 time_system_.systemTime(), decision);
   EXPECT_NE(nullptr, org_span.get());
 
   Span* span = dynamic_cast<Span*>(org_span.get());


### PR DESCRIPTION
Commit Message: skywalking: fix to avoid tracing all requests
Additional Description:

Current skywalking tracer will tracing all the requests by default and igore the sampling decision of Envoy. 
But in fact, if there is no downstream tracing context (propagation header) is provided and samping decision of Envoy is false, the tracer should do nothing.

Risk Level: Low.
Testing: Updated.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
