### PR TITLE
bazel: add config_setting for android

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -539,6 +539,13 @@ config_setting(
 )
 
 config_setting(
+    name = "android",
+    constraint_values = [
+        "@platforms//os:android",
+    ],
+)
+
+config_setting(
     name = "android_logger",
     values = {"define": "logger=android"},
 )


### PR DESCRIPTION
This is usable in selects for any android target.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>