### PR TITLE
lua extension: handle empty lua errors

### DIFF
--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -44,6 +44,9 @@ void Coroutine::resume(int num_args, const std::function<void()>& yield_callback
   } else {
     state_ = State::Finished;
     const char* error = lua_tostring(coroutine_state_.get(), -1);
+    if (!error) {
+      error = "unspecified lua error";
+    }
     throw LuaException(error);
   }
 }


### PR DESCRIPTION
Commit Message: lua extension: handle empty lua errors
Additional Description: Calling "error()" in a lua script would result in a NULL pointer for the
lua string. This commit handles this case.
Risk Level: Low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

This is a revival of https://github.com/envoyproxy/envoy/pull/15471 with the missing test.