### PR TITLE
tls: update BoringSSL to 227ff6e6 (5060).

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -81,7 +81,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # 3. Find a commit in BoringSSL's "master-with-bazel" branch that merges <boringssl_revision>.
         #
         # chromium-103.0.5060.24 (linux/beta)
-        version = "227ff6e6425283b83594a91a1aa81cc78f1a88df",
+        version = "62079f7cb4e9a2d5d8a68fe8a4a3f2375dd53585"
         sha256 = "9b0ec8c81cea758960d12f6d1eafa1a9deb5888a42efcd39390ce3334ea4ed3f",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -80,13 +80,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # 2. Open https://chromium.googlesource.com/chromium/src/+/refs/tags/<current_version>/DEPS and note <boringssl_revision>.
         # 3. Find a commit in BoringSSL's "master-with-bazel" branch that merges <boringssl_revision>.
         #
-        # chromium-100.0.4896.30 (linux/beta)
-        version = "cacb5526268191ab52e3a8b2d71f686115776646",
-        sha256 = "fd72798ee22beb9f052d792d6c701d3ea94183c2e5b94e737866a53152b46f41",
+        # chromium-103.0.5060.24 (linux/beta)
+        version = "227ff6e6425283b83594a91a1aa81cc78f1a88df",
+        sha256 = "9b0ec8c81cea758960d12f6d1eafa1a9deb5888a42efcd39390ce3334ea4ed3f",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2022-02-08",
+        release_date = "2022-05-26",
         cpe = "cpe:2.3:a:google:boringssl:*",
     ),
     boringssl_fips = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -86,7 +86,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2022-05-26",
+        release_date = "2022-05-10",
         cpe = "cpe:2.3:a:google:boringssl:*",
     ),
     boringssl_fips = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -81,7 +81,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # 3. Find a commit in BoringSSL's "master-with-bazel" branch that merges <boringssl_revision>.
         #
         # chromium-103.0.5060.24 (linux/beta)
-        version = "62079f7cb4e9a2d5d8a68fe8a4a3f2375dd53585"
+        version = "62079f7cb4e9a2d5d8a68fe8a4a3f2375dd53585",
         sha256 = "9b0ec8c81cea758960d12f6d1eafa1a9deb5888a42efcd39390ce3334ea4ed3f",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -82,7 +82,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         #
         # chromium-103.0.5060.24 (linux/beta)
         version = "62079f7cb4e9a2d5d8a68fe8a4a3f2375dd53585",
-        sha256 = "9b0ec8c81cea758960d12f6d1eafa1a9deb5888a42efcd39390ce3334ea4ed3f",
+        sha256 = "770faf8dcea0c2872e0c8202fc0d71f5b623c71510d1fa580ab271d2de7e72a9",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: tls: update BoringSSL to 227ff6e6 (5060).
Additional Description: Updating BoringSSL to its latest revision.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
