### PR TITLE
fix: add envoy demo missing connect_timeout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+* text=auto
+* eol=lf
+
 /changelogs/*.yaml merge=union
 /generated_api_shadow/envoy/** linguist-generated=true
 /generated_api_shadow/bazel/** linguist-generated=true

--- a/docs/root/start/quick-start/_include/envoy-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo.yaml
@@ -37,6 +37,7 @@ static_resources:
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY
+    connect_timeout: 30s
     load_assignment:
       cluster_name: service_envoyproxy_io
       endpoints:


### PR DESCRIPTION
I assume that it would be nice that very first example in docs would work :)

Docs Changes: `envoy-demo.yaml`
