### PR TITLE
bazel: bump host jvm size

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,9 @@
 # enough to consume all memory constrained by cgroup in large host.
 # Limiting JVM heapsize here to let it do GC more when approaching the limit to
 # leave room for compiler/linker.
-# The number 2G is chosen heuristically to both support large VM and small VM with RBE.
+# The number 3G is chosen heuristically to both support large VM and small VM with RBE.
 # Startup options cannot be selected via config.
-startup --host_jvm_args=-Xmx2g
+startup --host_jvm_args=-Xmx3g
 
 run --color=yes
 


### PR DESCRIPTION
We're seeing OOMs on the arm CI builds, this might fix that.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>