### PR TITLE
quiche: Move the code which sets FLAGS_quic_buffered_data_threshold 

### DIFF
--- a/source/common/quic/envoy_quic_dispatcher.cc
+++ b/source/common/quic/envoy_quic_dispatcher.cc
@@ -8,7 +8,6 @@
 #include "envoy/common/optref.h"
 
 #include "source/common/common/safe_memcpy.h"
-#include "source/common/http/utility.h"
 #include "source/common/quic/envoy_quic_server_connection.h"
 #include "source/common/quic/envoy_quic_utils.h"
 
@@ -31,20 +30,7 @@ EnvoyQuicDispatcher::EnvoyQuicDispatcher(
       connection_handler_(connection_handler), listener_config_(&listener_config),
       listener_stats_(listener_stats), per_worker_stats_(per_worker_stats), dispatcher_(dispatcher),
       listen_socket_(listen_socket), quic_stat_names_(quic_stat_names),
-      crypto_server_stream_factory_(crypto_server_stream_factory) {
-  // Set send buffer twice of max flow control window to ensure that stream send
-  // buffer always takes all the data.
-  // The max amount of data buffered is the per-stream high watermark + the max
-  // flow control window of upstream. The per-stream high watermark should be
-  // smaller than max flow control window to make sure upper stream can be flow
-  // control blocked early enough not to send more than the threshold allows.
-  // TODO(#8826) Ideally we should use the negotiated value from upstream which is not accessible
-  // for now. 512MB is way to large, but the actual bytes buffered should be bound by the negotiated
-  // upstream flow control window.
-  SetQuicFlag(
-      FLAGS_quic_buffered_data_threshold,
-      2 * ::Envoy::Http2::Utility::OptionsLimits::DEFAULT_INITIAL_STREAM_WINDOW_SIZE); // 512MB
-}
+      crypto_server_stream_factory_(crypto_server_stream_factory) {}
 
 void EnvoyQuicDispatcher::OnConnectionClosed(quic::QuicConnectionId connection_id,
                                              quic::QuicErrorCode error,

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -46,6 +46,7 @@ envoy_quiche_platform_impl_cc_library(
     ],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/http:utility_lib",
         "@com_github_google_quiche//:quic_core_flags_list_lib",
         "@com_github_google_quiche//:quic_core_protocol_flags_list_lib",
     ],


### PR DESCRIPTION
quiche: Move the code which sets FLAGS_quic_buffered_data_threshold from EnvoyQuicDispatcher to quiche_flag_impl.h

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A