### PR TITLE
bazel: decrease size of test summary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,6 +29,7 @@ build --action_env=LLVM_CONFIG --host_action_env=LLVM_CONFIG
 build --action_env=PATH --host_action_env=PATH
 
 build --enable_platform_specific_config
+build --test_summary=terse
 
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation


### PR DESCRIPTION
Previously on CI there are so many tests that you have to scroll past
many successful test lines to find the last error. Now only the failing
tests are printed in the summary.