### PR TITLE
quiche: Make QUICHE reloadable flag behavior match runtime guard behavior

### DIFF
--- a/source/common/quic/platform/quiche_flags_impl.cc
+++ b/source/common/quic/platform/quiche_flags_impl.cc
@@ -56,8 +56,8 @@ FlagRegistry& FlagRegistry::getInstance() {
 FlagRegistry::FlagRegistry() : flags_(makeFlagMap()) {}
 
 void FlagRegistry::resetFlags() const {
-  for (auto& kv : flags_) {
-    kv.second->resetValue();
+  for (auto& [flag_name, flag] : flags_) {
+    flag->resetValue();
   }
 }
 
@@ -68,12 +68,10 @@ Flag* FlagRegistry::findFlag(absl::string_view name) const {
 
 void FlagRegistry::updateReloadableFlags(
     const absl::flat_hash_map<std::string, bool>& quiche_flags_override) {
-  for (auto& kv : flags_) {
-    const auto it = quiche_flags_override.find(kv.first);
+  for (auto& [flag_name, flag] : flags_) {
+    const auto it = quiche_flags_override.find(flag_name);
     if (it != quiche_flags_override.end()) {
-      static_cast<TypedFlag<bool>*>(kv.second)->setReloadedValue(it->second);
-    } else {
-      kv.second->resetReloadedValue();
+      static_cast<TypedFlag<bool>*>(flag)->setReloadedValue(it->second);
     }
   }
 }

--- a/source/common/quic/platform/quiche_flags_impl.h
+++ b/source/common/quic/platform/quiche_flags_impl.h
@@ -59,8 +59,6 @@ public:
   // Reset flag to default value.
   virtual void resetValue() = 0;
 
-  virtual void resetReloadedValue() = 0;
-
   // Return flag name.
   absl::string_view name() const { return name_; }
 
@@ -104,11 +102,6 @@ public:
     absl::MutexLock lock(&mutex_);
     has_reloaded_value_ = true;
     reloaded_value_ = value;
-  }
-
-  void resetReloadedValue() override {
-    absl::MutexLock lock(&mutex_);
-    has_reloaded_value_ = false;
   }
 
 private:

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -507,26 +507,28 @@ TEST_F(QuicPlatformTest, QuicFlags) {
 }
 
 TEST_F(QuicPlatformTest, UpdateReloadableFlags) {
+  auto& flag_registry = quiche::FlagRegistry::getInstance();
+  flag_registry.resetFlags();
+
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
 
   // Flip both flags to a non-default value.
-  auto& flag_registry = quiche::FlagRegistry::getInstance();
   flag_registry.updateReloadableFlags(
-      {{ "FLAGS_quic_reloadable_flag_quic_testonly_default_false", true },
-       { "FLAGS_quic_reloadable_flag_quic_testonly_default_true", false }});
+      {{"FLAGS_quic_reloadable_flag_quic_testonly_default_false", true},
+       {"FLAGS_quic_reloadable_flag_quic_testonly_default_true", false}});
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
 
   // Flip one flag back to a default value.
   flag_registry.updateReloadableFlags(
-      {{ "FLAGS_quic_reloadable_flag_quic_testonly_default_false", false }});
+      {{"FLAGS_quic_reloadable_flag_quic_testonly_default_false", false}});
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
 
   // Flip the other back to a default value.
   flag_registry.updateReloadableFlags(
-      {{ "FLAGS_quic_reloadable_flag_quic_testonly_default_true", true }});
+      {{"FLAGS_quic_reloadable_flag_quic_testonly_default_true", true}});
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
 }

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -506,6 +506,31 @@ TEST_F(QuicPlatformTest, QuicFlags) {
   EXPECT_EQ(100, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
 }
 
+TEST_F(QuicPlatformTest, UpdateReloadableFlags) {
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
+
+  // Flip both flags to a non-default value.
+  auto& flag_registry = quiche::FlagRegistry::getInstance();
+  flag_registry.updateReloadableFlags(
+      {{ "FLAGS_quic_reloadable_flag_quic_testonly_default_false", true },
+       { "FLAGS_quic_reloadable_flag_quic_testonly_default_true", false }});
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
+
+  // Flip one flag back to a default value.
+  flag_registry.updateReloadableFlags(
+      {{ "FLAGS_quic_reloadable_flag_quic_testonly_default_false", false }});
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
+
+  // Flip the other back to a default value.
+  flag_registry.updateReloadableFlags(
+      {{ "FLAGS_quic_reloadable_flag_quic_testonly_default_true", true }});
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
+}
+
 class FileUtilsTest : public testing::Test {
 public:
   FileUtilsTest() : dir_path_(Envoy::TestEnvironment::temporaryPath("quic_file_util_test")) {

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -554,22 +554,20 @@ TEST_F(StaticLoaderImplTest, QuicheReloadableFlags) {
     envoy.reloadable_features.FLAGS_quic_reloadable_flag_spdy_testonly_default_false: false
   )EOF");
   SetQuicReloadableFlag(spdy_testonly_default_false, true);
-  EXPECT_EQ(true, GetQuicReloadableFlag(spdy_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(spdy_testonly_default_false));
   setup();
-  EXPECT_EQ(true, GetQuicReloadableFlag(quic_testonly_default_false));
-  EXPECT_EQ(false, GetQuicReloadableFlag(quic_testonly_default_true));
-  EXPECT_EQ(false, GetQuicReloadableFlag(spdy_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
+  EXPECT_FALSE(GetQuicReloadableFlag(spdy_testonly_default_false));
 
-  // Test 2 behaviors:
-  // 1. Removing overwritten config will make the flag fallback to default value.
-  // 2. Quiche flags can be overwritten again.
+  // Test that Quiche flags can be overwritten again.
   base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
     envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_testonly_default_true: true
   )EOF");
   setup();
-  EXPECT_EQ(false, GetQuicReloadableFlag(quic_testonly_default_false));
-  EXPECT_EQ(true, GetQuicReloadableFlag(quic_testonly_default_true));
-  EXPECT_EQ(true, GetQuicReloadableFlag(spdy_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
+  EXPECT_FALSE(GetQuicReloadableFlag(spdy_testonly_default_false));
 }
 #endif
 


### PR DESCRIPTION
quiche: Make QUICHE reloadable flag behavior match runtime guard behavior

Currently QUICHE reloadable flags have curious behavior. When reloading a new snapshot, any reloadable flags which are not present in the snapshot have their values reverted to their default values. However, runtime guards which are not present in the snapshot do not have their values changed. This PR changes QUICHE reloadable flag behavior to match 

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Medium
Testing: New unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A