### PR TITLE
tools: create //tools/config_validation:textproto2yaml helper

### DIFF
--- a/tools/config_validation/BUILD
+++ b/tools/config_validation/BUILD
@@ -14,3 +14,15 @@ py_binary(
         "@com_google_protobuf//:protobuf_python",
     ],
 )
+
+py_binary(
+    name = "textproto2yaml",
+    srcs = ["textproto2yaml.py"],
+    data = ["//tools/type_whisperer:all_protos_with_ext_pb_text.pb_text"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("PyYAML"),
+        "@bazel_tools//tools/python/runfiles",
+        "@com_google_protobuf//:protobuf_python",
+    ],
+)

--- a/tools/config_validation/BUILD
+++ b/tools/config_validation/BUILD
@@ -6,12 +6,9 @@ licenses(["notice"])  # Apache 2
 py_binary(
     name = "validate_fragment",
     srcs = ["validate_fragment.py"],
-    data = ["//tools/type_whisperer:all_protos_with_ext_pb_text.pb_text"],
     visibility = ["//visibility:public"],
     deps = [
-        requirement("PyYAML"),
-        "@bazel_tools//tools/python/runfiles",
-        "@com_google_protobuf//:protobuf_python",
+        ":common",
     ],
 )
 
@@ -28,6 +25,8 @@ py_library(
     name = "common",
     srcs = ["common.py"],
     data = ["//tools/type_whisperer:all_protos_with_ext_pb_text.pb_text"],
+    # Needed for //docs:html genrule to work.
+    imports = ["."],
     deps = [
         requirement("PyYAML"),
         "@bazel_tools//tools/python/runfiles",

--- a/tools/config_validation/BUILD
+++ b/tools/config_validation/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@base_pip3//:requirements.bzl", "requirement")
 
 licenses(["notice"])  # Apache 2
@@ -18,8 +18,16 @@ py_binary(
 py_binary(
     name = "textproto2yaml",
     srcs = ["textproto2yaml.py"],
-    data = ["//tools/type_whisperer:all_protos_with_ext_pb_text.pb_text"],
     visibility = ["//visibility:public"],
+    deps = [
+        ":common",
+    ],
+)
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    data = ["//tools/type_whisperer:all_protos_with_ext_pb_text.pb_text"],
     deps = [
         requirement("PyYAML"),
         "@bazel_tools//tools/python/runfiles",

--- a/tools/config_validation/BUILD
+++ b/tools/config_validation/BUILD
@@ -34,3 +34,15 @@ py_library(
         "@com_google_protobuf//:protobuf_python",
     ],
 )
+
+py_test(
+    name = "textproto2yaml_test",
+    srcs = ["textproto2yaml_test.py"],
+    data = [
+        "//tools/testdata/config_validation:textproto2yaml_testdata",
+    ],
+    main = "textproto2yaml_test.py",
+    deps = [
+        ":textproto2yaml",
+    ],
+)

--- a/tools/config_validation/common.py
+++ b/tools/config_validation/common.py
@@ -1,0 +1,57 @@
+# Common tools for building and validating Envoy doc fragments.
+
+import pathlib
+
+import yaml
+
+from google.protobuf import descriptor_pb2
+from google.protobuf import descriptor_pool
+from google.protobuf import message_factory
+from google.protobuf import text_format
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+
+class IgnoredKey(yaml.YAMLObject):
+    """Python support type for Envoy's config !ignore tag."""
+    yaml_tag = '!ignore'
+
+    def __init__(self, strval):
+        self.strval = strval
+
+    def __repr__(self):
+        return f'IgnoredKey({str})'
+
+    def __eq__(self, other):
+        return isinstance(other, IgnoredKey) and self.strval == other.strval
+
+    def __hash__(self):
+        return hash((self.yaml_tag, self.strval))
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        return IgnoredKey(node.value)
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_scalar(cls.yaml_tag, data.strval)
+
+
+def load_pool(type_name, descriptor_path=None):
+    if not descriptor_path:
+        r = runfiles.Create()
+        descriptor_path = r.Rlocation(
+            'envoy/tools/type_whisperer/all_protos_with_ext_pb_text.pb_text')
+
+    file_desc_set = descriptor_pb2.FileDescriptorSet()
+    text_format.Parse(
+        pathlib.Path(descriptor_path).read_text(), file_desc_set,
+        allow_unknown_extension=True)
+
+    pool = descriptor_pool.DescriptorPool()
+    for f in file_desc_set.file:
+        pool.Add(f)
+    desc = pool.FindMessageTypeByName(type_name)
+    msg = message_factory.MessageFactory(pool=pool).GetPrototype(desc)()
+
+    return msg, pool

--- a/tools/config_validation/common.py
+++ b/tools/config_validation/common.py
@@ -45,8 +45,7 @@ def load_pool(type_name, descriptor_path=None):
 
     file_desc_set = descriptor_pb2.FileDescriptorSet()
     text_format.Parse(
-        pathlib.Path(descriptor_path).read_text(), file_desc_set,
-        allow_unknown_extension=True)
+        pathlib.Path(descriptor_path).read_text(), file_desc_set, allow_unknown_extension=True)
 
     pool = descriptor_pool.DescriptorPool()
     for f in file_desc_set.file:

--- a/tools/config_validation/textproto2yaml.py
+++ b/tools/config_validation/textproto2yaml.py
@@ -1,0 +1,120 @@
+# Validate a YAML fragment against an Envoy API proto3 type.
+#
+# Example usage:
+#
+# bazel run //tools/config_validation:textproto2yaml -- \
+#   envoy.config.bootstrap.v3.Bootstrap $PWD/configs/envoyproxy_io_proxy.textproto
+
+import json
+import pathlib
+
+import yaml
+
+from google.protobuf import descriptor_pb2
+from google.protobuf import descriptor_pool
+from google.protobuf import json_format
+from google.protobuf import message_factory
+from google.protobuf import text_format
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+import argparse
+
+
+class IgnoredKey(yaml.YAMLObject):
+    """Python support type for Envoy's config !ignore tag."""
+    yaml_tag = '!ignore'
+
+    def __init__(self, strval):
+        self.strval = strval
+
+    def __repr__(self):
+        return f'IgnoredKey({str})'
+
+    def __eq__(self, other):
+        return isinstance(other, IgnoredKey) and self.strval == other.strval
+
+    def __hash__(self):
+        return hash((self.yaml_tag, self.strval))
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        return IgnoredKey(node.value)
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_scalar(cls.yaml_tag, data.strval)
+
+
+def load_pool(type_name, descriptor_path=None):
+    if not descriptor_path:
+        r = runfiles.Create()
+        descriptor_path = r.Rlocation(
+            'envoy/tools/type_whisperer/all_protos_with_ext_pb_text.pb_text')
+
+    file_desc_set = descriptor_pb2.FileDescriptorSet()
+    text_format.Parse(
+        pathlib.Path(descriptor_path).read_text(), file_desc_set, allow_unknown_extension=True)
+
+    pool = descriptor_pool.DescriptorPool()
+    for f in file_desc_set.file:
+        pool.Add(f)
+    desc = pool.FindMessageTypeByName(type_name)
+    msg = message_factory.MessageFactory(pool=pool).GetPrototype(desc)()
+
+    return msg, pool
+
+
+def textproto_to_yaml(in_textproto, pool):
+    yaml.SafeLoader.add_constructor('!ignore', IgnoredKey.from_yaml)
+    yaml.SafeDumper.add_multi_representer(IgnoredKey, IgnoredKey.to_yaml)
+    json_msg = json_format.MessageToJson(
+      in_textproto,
+      descriptor_pool=pool,
+      preserving_proto_field_name=True)
+    # print(in_textproto)
+    # print("----")
+    # print(json_msg)
+    # print("----")
+    return yaml.dump(json.loads(json_msg), sort_keys=False)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Print textproto as YAML.')
+    parser.add_argument(
+        'message_type',
+        help='a string providing the type name, e.g. envoy.config.bootstrap.v3.Bootstrap.')
+    parser.add_argument('textproto_path', nargs='?', help='Path to a .textproto configuration fragment.')
+    parser.add_argument('--descriptor_path', nargs='?', help='Path to a protobuf descriptor file.')
+    parser.add_argument('--as_fragment', action=argparse.BooleanOptionalAction, help='Print as a fragment.')
+    return parser.parse_args()
+
+
+def main(message_type, descriptor_path, content, *, as_fragment=False):
+  msg, pool = load_pool(message_type, descriptor_path=descriptor_path)
+  in_textproto = text_format.Parse(content, msg, descriptor_pool=pool)
+  out_yaml: str = textproto_to_yaml(in_textproto, pool)
+
+  if not as_fragment:
+    return out_yaml.rstrip('\n')
+
+  fragment = [
+    '// .. validated-code-block:: yaml',
+    f'//   :type-name: {message_type}',
+    '//',
+  ]
+  for line in out_yaml.splitlines():
+    fragment.append(f'//   {line}')
+
+  fragment.append('//')
+  return '\n'.join(fragment)
+
+
+if __name__ == '__main__':
+    parsed_args = parse_args()
+    out = main(parsed_args.message_type,
+         parsed_args.descriptor_path,
+         pathlib.Path(parsed_args.textproto_path).read_text(),
+         as_fragment=parsed_args.as_fragment)
+
+    print(out,)

--- a/tools/config_validation/textproto2yaml.py
+++ b/tools/config_validation/textproto2yaml.py
@@ -24,14 +24,11 @@ def proto_message_to_yaml(proto_message, pool):
     yaml.SafeLoader.add_constructor('!ignore', IgnoredKey.from_yaml)
     yaml.SafeDumper.add_multi_representer(IgnoredKey, IgnoredKey.to_yaml)
     json_msg = json_format.MessageToJson(
-      proto_message,
-      descriptor_pool=pool,
-      preserving_proto_field_name=True)
+        proto_message, descriptor_pool=pool, preserving_proto_field_name=True)
     return yaml.dump(json.loads(json_msg), sort_keys=False)
 
 
-def textproto_file_to_yaml(textproto_path, message_type, *,
-                           descriptor_path=None) -> str:
+def textproto_file_to_yaml(textproto_path, message_type, *, descriptor_path=None) -> str:
     msg, pool = load_pool(message_type, descriptor_path=descriptor_path)
     content = pathlib.Path(textproto_path).read_text()
     proto_message = text_format.Parse(content, msg, descriptor_pool=pool)
@@ -56,12 +53,11 @@ def parse_args(args):
         'message_type',
         help=('a string providing the type name, '
               'e.g. envoy.config.bootstrap.v3.Bootstrap.'))
-    parser.add_argument('textproto_path', nargs='?',
-                        help='Path to a .textproto configuration fragment.')
-    parser.add_argument('--descriptor_path', nargs='?',
-                        help='Path to a protobuf descriptor file.')
-    parser.add_argument('--as_fragment', action=argparse.BooleanOptionalAction,
-                        help='Print as a fragment.')
+    parser.add_argument(
+        'textproto_path', nargs='?', help='Path to a .textproto configuration fragment.')
+    parser.add_argument('--descriptor_path', nargs='?', help='Path to a protobuf descriptor file.')
+    parser.add_argument(
+        '--as_fragment', action=argparse.BooleanOptionalAction, help='Print as a fragment.')
     return parser.parse_args(args)
 
 

--- a/tools/config_validation/textproto2yaml.py
+++ b/tools/config_validation/textproto2yaml.py
@@ -1,10 +1,20 @@
-# Validate a YAML fragment against an Envoy API proto3 type.
-#
-# Example usage:
-#
-# bazel run //tools/config_validation:textproto2yaml -- --as_fragment \
-#   envoy.config.bootstrap.v3.Bootstrap \
-#   $PWD/tools/testdata/config_validation/input.textproto
+"""Validate a YAML fragment against an Envoy API proto3 type.
+
+Usage examples.
+
+Covert textproto to raw yaml. Can be used for `literalinclude` blocks:
+Note that `literalinclude` is generally preferable to `validated-code-block`.
+
+    bazel run //tools/config_validation:textproto2yaml -- \
+      envoy.config.bootstrap.v3.Bootstrap \
+      $PWD/tools/testdata/config_validation/input.textproto
+
+Covert textproto to yaml, and output as a `validated-code-block`:
+
+    bazel run //tools/config_validation:textproto2yaml -- --as_fragment \
+      envoy.config.bootstrap.v3.Bootstrap \
+      $PWD/tools/testdata/config_validation/input.textproto
+"""
 
 import argparse
 import json

--- a/tools/config_validation/textproto2yaml.py
+++ b/tools/config_validation/textproto2yaml.py
@@ -3,118 +3,79 @@
 # Example usage:
 #
 # bazel run //tools/config_validation:textproto2yaml -- \
-#   envoy.config.bootstrap.v3.Bootstrap $PWD/configs/envoyproxy_io_proxy.textproto
+#   --as_fragment envoy.config.bootstrap.v3.Bootstrap path/to/message.textproto
 
+import argparse
 import json
 import pathlib
+import sys
 
 import yaml
 
-from google.protobuf import descriptor_pb2
-from google.protobuf import descriptor_pool
 from google.protobuf import json_format
-from google.protobuf import message_factory
 from google.protobuf import text_format
 
-from bazel_tools.tools.python.runfiles import runfiles
 
-import argparse
-
-
-class IgnoredKey(yaml.YAMLObject):
-    """Python support type for Envoy's config !ignore tag."""
-    yaml_tag = '!ignore'
-
-    def __init__(self, strval):
-        self.strval = strval
-
-    def __repr__(self):
-        return f'IgnoredKey({str})'
-
-    def __eq__(self, other):
-        return isinstance(other, IgnoredKey) and self.strval == other.strval
-
-    def __hash__(self):
-        return hash((self.yaml_tag, self.strval))
-
-    @classmethod
-    def from_yaml(cls, loader, node):
-        return IgnoredKey(node.value)
-
-    @classmethod
-    def to_yaml(cls, dumper, data):
-        return dumper.represent_scalar(cls.yaml_tag, data.strval)
+from common import load_pool
+from common import IgnoredKey
 
 
-def load_pool(type_name, descriptor_path=None):
-    if not descriptor_path:
-        r = runfiles.Create()
-        descriptor_path = r.Rlocation(
-            'envoy/tools/type_whisperer/all_protos_with_ext_pb_text.pb_text')
-
-    file_desc_set = descriptor_pb2.FileDescriptorSet()
-    text_format.Parse(
-        pathlib.Path(descriptor_path).read_text(), file_desc_set, allow_unknown_extension=True)
-
-    pool = descriptor_pool.DescriptorPool()
-    for f in file_desc_set.file:
-        pool.Add(f)
-    desc = pool.FindMessageTypeByName(type_name)
-    msg = message_factory.MessageFactory(pool=pool).GetPrototype(desc)()
-
-    return msg, pool
-
-
-def textproto_to_yaml(in_textproto, pool):
+def proto_message_to_yaml(proto_message, pool):
     yaml.SafeLoader.add_constructor('!ignore', IgnoredKey.from_yaml)
     yaml.SafeDumper.add_multi_representer(IgnoredKey, IgnoredKey.to_yaml)
     json_msg = json_format.MessageToJson(
-      in_textproto,
+      proto_message,
       descriptor_pool=pool,
       preserving_proto_field_name=True)
-    # print(in_textproto)
-    # print("----")
-    # print(json_msg)
-    # print("----")
     return yaml.dump(json.loads(json_msg), sort_keys=False)
 
 
-def parse_args():
+def textproto_file_to_yaml(textproto_path, message_type, *,
+                           descriptor_path=None) -> str:
+    msg, pool = load_pool(message_type, descriptor_path=descriptor_path)
+    content = pathlib.Path(textproto_path).read_text()
+    proto_message = text_format.Parse(content, msg, descriptor_pool=pool)
+    return proto_message_to_yaml(proto_message, pool)
+
+
+def yaml_to_fragment(yaml_message, message_type) -> str:
+    fragment = [
+        '// .. validated-code-block:: yaml',
+        f'//   :type-name: {message_type}',
+        '//',
+    ]
+    for line in yaml_message.splitlines():
+        fragment.append(f'//   {line}')
+    fragment.append('//')
+    return '\n'.join(fragment) + '\n'
+
+
+def parse_args(args):
     parser = argparse.ArgumentParser(description='Print textproto as YAML.')
     parser.add_argument(
         'message_type',
-        help='a string providing the type name, e.g. envoy.config.bootstrap.v3.Bootstrap.')
-    parser.add_argument('textproto_path', nargs='?', help='Path to a .textproto configuration fragment.')
-    parser.add_argument('--descriptor_path', nargs='?', help='Path to a protobuf descriptor file.')
-    parser.add_argument('--as_fragment', action=argparse.BooleanOptionalAction, help='Print as a fragment.')
-    return parser.parse_args()
+        help=('a string providing the type name, '
+              'e.g. envoy.config.bootstrap.v3.Bootstrap.'))
+    parser.add_argument('textproto_path', nargs='?',
+                        help='Path to a .textproto configuration fragment.')
+    parser.add_argument('--descriptor_path', nargs='?',
+                        help='Path to a protobuf descriptor file.')
+    parser.add_argument('--as_fragment', action=argparse.BooleanOptionalAction,
+                        help='Print as a fragment.')
+    return parser.parse_args(args)
 
 
-def main(message_type, descriptor_path, content, *, as_fragment=False):
-  msg, pool = load_pool(message_type, descriptor_path=descriptor_path)
-  in_textproto = text_format.Parse(content, msg, descriptor_pool=pool)
-  out_yaml: str = textproto_to_yaml(in_textproto, pool)
-
-  if not as_fragment:
-    return out_yaml.rstrip('\n')
-
-  fragment = [
-    '// .. validated-code-block:: yaml',
-    f'//   :type-name: {message_type}',
-    '//',
-  ]
-  for line in out_yaml.splitlines():
-    fragment.append(f'//   {line}')
-
-  fragment.append('//')
-  return '\n'.join(fragment)
+def main(*args) -> int:
+    parsed_args = parse_args(args)
+    yaml_message = textproto_file_to_yaml(
+        parsed_args.textproto_path,
+        parsed_args.message_type,
+        descriptor_path=parsed_args.descriptor_path)
+    out = yaml_message if not parsed_args.as_fragment else yaml_to_fragment(
+        yaml_message, parsed_args.message_type)
+    sys.stdout.write(out)
+    return 0
 
 
-if __name__ == '__main__':
-    parsed_args = parse_args()
-    out = main(parsed_args.message_type,
-         parsed_args.descriptor_path,
-         pathlib.Path(parsed_args.textproto_path).read_text(),
-         as_fragment=parsed_args.as_fragment)
-
-    print(out,)
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/tools/config_validation/textproto2yaml.py
+++ b/tools/config_validation/textproto2yaml.py
@@ -2,8 +2,9 @@
 #
 # Example usage:
 #
-# bazel run //tools/config_validation:textproto2yaml -- \
-#   --as_fragment envoy.config.bootstrap.v3.Bootstrap path/to/message.textproto
+# bazel run //tools/config_validation:textproto2yaml -- --as_fragment \
+#   envoy.config.bootstrap.v3.Bootstrap \
+#   $PWD/tools/testdata/config_validation/input.textproto
 
 import argparse
 import json
@@ -14,7 +15,6 @@ import yaml
 
 from google.protobuf import json_format
 from google.protobuf import text_format
-
 
 from common import load_pool
 from common import IgnoredKey

--- a/tools/config_validation/textproto2yaml_test.py
+++ b/tools/config_validation/textproto2yaml_test.py
@@ -1,4 +1,5 @@
-"""Tests the api version header file generation.
+"""Tests the textproto2yaml helper converting textproto
+to yaml and validated code fragment.
 """
 import os
 import pathlib

--- a/tools/config_validation/textproto2yaml_test.py
+++ b/tools/config_validation/textproto2yaml_test.py
@@ -1,9 +1,7 @@
 """Tests the textproto2yaml helper converting textproto
 to yaml and validated code fragment.
 """
-import os
 import pathlib
-import tempfile
 import unittest
 
 import textproto2yaml
@@ -75,24 +73,20 @@ EXPECTED_FRAGMENT = """// .. validated-code-block:: yaml
 
 
 class TextprotoToYamlTest(unittest.TestCase):
+
     def setUp(self) -> None:
-        testdata_path = pathlib.Path(pathlib.Path.cwd(), 'tools',
-                                     'testdata',
-                                     'config_validation')
+        testdata_path = pathlib.Path(pathlib.Path.cwd(), 'tools', 'testdata', 'config_validation')
         self.textproto_path = testdata_path / 'input.textproto'
         # Enable full diffs for multiline checks
         self.maxDiff = None
 
     def test_textproto_file_to_yaml(self):
-        result_yaml = textproto2yaml.textproto_file_to_yaml(
-            self.textproto_path, MESSAGE_TYPE)
+        result_yaml = textproto2yaml.textproto_file_to_yaml(self.textproto_path, MESSAGE_TYPE)
         self.assertMultiLineEqual(result_yaml, EXPECTED_YAML)
 
     def test_yaml_to_fragment(self):
-        result_yaml = textproto2yaml.textproto_file_to_yaml(
-            self.textproto_path, MESSAGE_TYPE)
-        result_fragment = textproto2yaml.yaml_to_fragment(result_yaml,
-                                                          MESSAGE_TYPE)
+        result_yaml = textproto2yaml.textproto_file_to_yaml(self.textproto_path, MESSAGE_TYPE)
+        result_fragment = textproto2yaml.yaml_to_fragment(result_yaml, MESSAGE_TYPE)
         self.assertMultiLineEqual(result_fragment, EXPECTED_FRAGMENT)
 
 

--- a/tools/config_validation/textproto2yaml_test.py
+++ b/tools/config_validation/textproto2yaml_test.py
@@ -1,0 +1,99 @@
+"""Tests the api version header file generation.
+"""
+import os
+import pathlib
+import tempfile
+import unittest
+
+import textproto2yaml
+
+MESSAGE_TYPE = 'xds.type.matcher.v3.Matcher'
+EXPECTED_YAML = """matcher_list:
+  matchers:
+  - predicate:
+      single_predicate:
+        input:
+          typed_config:
+            '@type': type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+            header_name: env
+        value_match:
+          exact: staging
+    on_match:
+      action:
+        typed_config:
+          '@type': type.googleapis.com/envoy.type.v3.TokenBucket
+          max_tokens: 120
+  - predicate:
+      single_predicate:
+        input:
+          typed_config:
+            '@type': type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+            header_name: env
+        value_match:
+          exact: prod
+    on_match:
+      action:
+        typed_config:
+          '@type': type.googleapis.com/xds.type.v3.Int32Range
+          start: -100
+"""
+
+EXPECTED_FRAGMENT = """// .. validated-code-block:: yaml
+//   :type-name: xds.type.matcher.v3.Matcher
+//
+//   matcher_list:
+//     matchers:
+//     - predicate:
+//         single_predicate:
+//           input:
+//             typed_config:
+//               '@type': type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+//               header_name: env
+//           value_match:
+//             exact: staging
+//       on_match:
+//         action:
+//           typed_config:
+//             '@type': type.googleapis.com/envoy.type.v3.TokenBucket
+//             max_tokens: 120
+//     - predicate:
+//         single_predicate:
+//           input:
+//             typed_config:
+//               '@type': type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+//               header_name: env
+//           value_match:
+//             exact: prod
+//       on_match:
+//         action:
+//           typed_config:
+//             '@type': type.googleapis.com/xds.type.v3.Int32Range
+//             start: -100
+//
+"""
+
+
+class TextprotoToYamlTest(unittest.TestCase):
+    def setUp(self) -> None:
+        testdata_path = pathlib.Path(pathlib.Path.cwd(), 'tools',
+                                     'testdata',
+                                     'config_validation')
+        self.textproto_path = testdata_path / 'input.textproto'
+        # Enable full diffs for multiline checks
+        self.maxDiff = None
+
+    def test_textproto_file_to_yaml(self):
+        result_yaml = textproto2yaml.textproto_file_to_yaml(
+            self.textproto_path, MESSAGE_TYPE)
+        self.assertMultiLineEqual(result_yaml, EXPECTED_YAML)
+
+    def test_yaml_to_fragment(self):
+        result_yaml = textproto2yaml.textproto_file_to_yaml(
+            self.textproto_path, MESSAGE_TYPE)
+        result_fragment = textproto2yaml.yaml_to_fragment(result_yaml,
+                                                          MESSAGE_TYPE)
+        self.assertMultiLineEqual(result_fragment, EXPECTED_FRAGMENT)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/testdata/config_validation/BUILD
+++ b/tools/testdata/config_validation/BUILD
@@ -1,0 +1,9 @@
+licenses(["notice"])  # Apache 2
+
+filegroup(
+    name = "textproto2yaml_testdata",
+    srcs = [
+        "input.textproto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/testdata/config_validation/input.textproto
+++ b/tools/testdata/config_validation/input.textproto
@@ -1,0 +1,68 @@
+# proto-file: xds/type/matcher/v3/matcher.proto
+# proto-message: Matcher
+# proto-import: envoy/type/matcher/v3/http_inputs.proto
+# proto-import: envoy/type/v3/token_bucket.proto
+# proto-import: xds/type/v3/range.proto
+
+# Note: this is just for testing purposes. Features for testing:
+# - typed config
+# - cncf/xds Matchers chosen to verify that messages from the dependencies works
+# - cncf/xds Range used to verify mix-and-match with dependencies works
+
+matcher_list {
+
+  matchers {
+    predicate {
+      single_predicate {
+        input {
+          typed_config {
+            [type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput] {
+              header_name: "env"
+            }
+          }
+        }
+        value_match {
+          exact: "staging"
+        }
+      }
+    }
+    on_match {
+      action {
+        typed_config {
+          [type.googleapis.com/envoy.type.v3.TokenBucket] {
+            max_tokens: 120
+          }
+        }
+      }
+    }
+  }
+
+  matchers {
+    predicate {
+      single_predicate {
+        input {
+          typed_config {
+            [type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput] {
+              header_name: "env"
+            }
+          }
+        }
+        value_match {
+          exact: "prod"
+        }
+      }
+    }
+    on_match {
+      action {
+        typed_config {
+          [type.googleapis.com/xds.type.v3.Int32Range] {
+            start: -100
+            end: 0
+          }
+        }
+      }
+    }
+  }
+
+}
+


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: tools: create //tools/config_validation:textproto2yaml helper
Additional Description: A helper than can convert textproto files to yaml, and format them as `// .. validated-code-block:: yaml` fragments.

Usage example:

```sh
bazel run //tools/config_validation:textproto2yaml -- --as_fragment \
  envoy.config.bootstrap.v3.Bootstrap \
  $PWD/tools/testdata/config_validation/input.textproto
```

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
