### PR TITLE
[backport/v1.21] docker: Update distroless image -> `d65ac1a`

### DIFF
--- a/ci/Dockerfile-envoy-distroless
+++ b/ci/Dockerfile-envoy-distroless
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/base-debian11@sha256:d65ac1a65a4d82a48ebd0a22aea2acdd95d7abeeda245dfee932ec0018c781f4
 
 ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
