### PR TITLE
tls/handshaker: extend HandshakerFactoryContext with singletonManager

### DIFF
--- a/envoy/ssl/handshaker.h
+++ b/envoy/ssl/handshaker.h
@@ -6,6 +6,7 @@
 #include "envoy/network/post_io_action.h"
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/server/options.h"
+#include "envoy/singleton/manager.h"
 
 #include "openssl/ssl.h"
 
@@ -63,6 +64,11 @@ using SslCtxCb = std::function<void(SSL_CTX*)>;
 class HandshakerFactoryContext {
 public:
   virtual ~HandshakerFactoryContext() = default;
+
+  /**
+   * Returns the singleton manager.
+   */
+  virtual Singleton::Manager& singletonManager() PURE;
 
   /**
    * @return reference to the server options

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -171,6 +171,7 @@ ContextConfigImpl::ContextConfigImpl(
     const std::string& default_cipher_suites, const std::string& default_curves,
     Server::Configuration::TransportSocketFactoryContext& factory_context)
     : api_(factory_context.api()), options_(factory_context.options()),
+      singleton_manager_(factory_context.singletonManager()),
       alpn_protocols_(RepeatedPtrUtil::join(config.alpn_protocols(), ",")),
       cipher_suites_(StringUtil::nonEmptyStringOrDefault(
           RepeatedPtrUtil::join(config.tls_params().cipher_suites(), ":"), default_cipher_suites)),
@@ -221,7 +222,8 @@ ContextConfigImpl::ContextConfigImpl(
     }
   }
 
-  HandshakerFactoryContextImpl handshaker_factory_context(api_, options_, alpn_protocols_);
+  HandshakerFactoryContextImpl handshaker_factory_context(api_, options_, alpn_protocols_,
+                                                          singleton_manager_);
   Ssl::HandshakerFactory* handshaker_factory;
   if (config.has_custom_handshaker()) {
     // If a custom handshaker is configured, derive the factory from the config.

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -75,6 +75,7 @@ protected:
                     Server::Configuration::TransportSocketFactoryContext& factory_context);
   Api::Api& api_;
   const Server::Options& options_;
+  Singleton::Manager& singleton_manager_;
 
 private:
   static unsigned tlsVersionFromProto(

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.h
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.h
@@ -71,18 +71,22 @@ using SslHandshakerImplSharedPtr = std::shared_ptr<SslHandshakerImpl>;
 class HandshakerFactoryContextImpl : public Ssl::HandshakerFactoryContext {
 public:
   HandshakerFactoryContextImpl(Api::Api& api, const Server::Options& options,
-                               absl::string_view alpn_protocols)
-      : api_(api), options_(options), alpn_protocols_(alpn_protocols) {}
+                               absl::string_view alpn_protocols,
+                               Singleton::Manager& singleton_manager)
+      : api_(api), options_(options), alpn_protocols_(alpn_protocols),
+        singleton_manager_(singleton_manager) {}
 
   // HandshakerFactoryContext
   Api::Api& api() override { return api_; }
   const Server::Options& options() const override { return options_; }
   absl::string_view alpnProtocols() const override { return alpn_protocols_; }
+  Singleton::Manager& singletonManager() override { return singleton_manager_; }
 
 private:
   Api::Api& api_;
   const Server::Options& options_;
   const std::string alpn_protocols_;
+  Singleton::Manager& singleton_manager_;
 };
 
 class HandshakerFactoryImpl : public Ssl::HandshakerFactory {

--- a/test/mocks/server/transport_socket_factory_context.cc
+++ b/test/mocks/server/transport_socket_factory_context.cc
@@ -12,7 +12,8 @@ namespace Configuration {
 using ::testing::ReturnRef;
 
 MockTransportSocketFactoryContext::MockTransportSocketFactoryContext()
-    : secret_manager_(std::make_unique<Secret::SecretManagerImpl>(config_tracker_)) {
+    : secret_manager_(std::make_unique<Secret::SecretManagerImpl>(config_tracker_)),
+      singleton_manager_(Thread::threadFactoryForTest()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
   ON_CALL(*this, messageValidationVisitor())
@@ -21,6 +22,7 @@ MockTransportSocketFactoryContext::MockTransportSocketFactoryContext()
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(store_));
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
+  ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(singleton_manager_));
 }
 
 MockTransportSocketFactoryContext::~MockTransportSocketFactoryContext() = default;

--- a/test/mocks/server/transport_socket_factory_context.h
+++ b/test/mocks/server/transport_socket_factory_context.h
@@ -48,6 +48,7 @@ public:
   testing::NiceMock<Server::MockOptions> options_;
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
+  Singleton::ManagerImpl singleton_manager_;
 };
 } // namespace Configuration
 } // namespace Server


### PR DESCRIPTION
Commit Message: tls/handshaker: extend HandshakerFactoryContext with singletonManager
Additional Description: Allow Handshaker extension to access singleton manager
Risk Level: No Risk
Testing: No tests added, existing mock updated
Docs Changes: No
Release Notes: No

Sometimes it is required to have access to some sort of "global cache" from TLS handshaker extension. So extending `HandshakerFactoryContext` with singletonManager property.