### PR TITLE
Copy downstream metadata to upstream

### DIFF
--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -320,6 +320,7 @@ envoy_cc_library(
         "//source/common/tracing:http_tracer_lib",
         "//source/common/upstream:load_balancer_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",
+        "//source/extensions/filters/network:well_known_names",
         "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -224,7 +224,7 @@ const Network::Connection& UpstreamRequest::connection() const {
   return *parent_.callbacks()->connection();
 }
 
-void UpstreamRequest::copyDynamicMetaDataFromDownstream(StreamInfo::StreamInfo& l4_stream_info) {
+void UpstreamRequest::copyDynamicMetaDataFromL4Downstream(StreamInfo::StreamInfo& l4_stream_info) {
   if (parent_.callbacks()->connection() != nullptr) {
     const StreamInfo::StreamInfo& downstream_streamInfo =
         parent_.callbacks()->connection()->streamInfo();
@@ -541,7 +541,7 @@ void UpstreamRequest::onPoolReady(
         [this]() -> void { onStreamMaxDurationReached(); });
     max_stream_duration_timer_->enableTimer(*max_stream_duration);
   }
-  copyDynamicMetaDataFromDownstream(info);
+  copyDynamicMetaDataFromL4Downstream(info);
 
   const Http::Status status =
       upstream_->encodeHeaders(*parent_.downstreamHeaders(), shouldSendEndStream());

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -130,7 +130,7 @@ public:
   StreamInfo::StreamInfo& streamInfo() { return stream_info_; }
   bool hadUpstream() const { return had_upstream_; }
   // Copy the dynamic meta data from downstream to l4 upstream
-  void copyDynamicMetaDataFromDownstream(StreamInfo::StreamInfo& l4_stream_info);
+  void copyDynamicMetaDataFromL4Downstream(StreamInfo::StreamInfo& l4_stream_info);
 
 private:
   StreamInfo::UpstreamTiming& upstreamTiming() {

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -129,6 +129,8 @@ public:
   // Exposes streamInfo for the upstream stream.
   StreamInfo::StreamInfo& streamInfo() { return stream_info_; }
   bool hadUpstream() const { return had_upstream_; }
+  // Copy the dynamic meta data from downstream to l4 upstream
+  void copyDynamicMetaDataFromDownstream(StreamInfo::StreamInfo& l4_stream_info);
 
 private:
   StreamInfo::UpstreamTiming& upstreamTiming() {

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -61,7 +61,7 @@ public:
   const std::string Wasm = "envoy.filters.network.wasm";
   // A common namespace which will propagated the dynamic metadata from
   // downstream to upstream
-  const std::string DownToUp = "envoy.common.down_up";
+  const std::string SharedWithUpstream = "envoy.common.shared_with_upstream";
 };
 
 using NetworkFilterNames = ConstSingleton<NetworkFilterNameValues>;

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -59,8 +59,9 @@ public:
   const std::string ZooKeeperProxy = "envoy.filters.network.zookeeper_proxy";
   // WebAssembly filter
   const std::string Wasm = "envoy.filters.network.wasm";
-  // Copy dynamic metadata from downstream to upstream
-  const std::string DownToUp = "envoy.filters.network.down_up";
+  // A common namespace which will propagated the dynamic metadata from
+  // downstream to upstream
+  const std::string DownToUp = "envoy.common.down_up";
 };
 
 using NetworkFilterNames = ConstSingleton<NetworkFilterNameValues>;

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -59,6 +59,8 @@ public:
   const std::string ZooKeeperProxy = "envoy.filters.network.zookeeper_proxy";
   // WebAssembly filter
   const std::string Wasm = "envoy.filters.network.wasm";
+  // Copy dynamic metadata from downstream to upstream
+  const std::string DownToUp = "envoy.filters.network.down_up";
 };
 
 using NetworkFilterNames = ConstSingleton<NetworkFilterNameValues>;

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "source/common/common/utility.h"
 #include "source/common/network/utility.h"
 #include "source/common/router/upstream_request.h"
@@ -44,15 +46,65 @@ TEST_F(UpstreamRequestTest, CopyDynamicMetaData) {
   fields.insert({"envoy.common.test", val});
   const_cast<Network::Connection*>(connection)
       ->streamInfo()
-      .setDynamicMetadata("envoy.common.down_up", metadata);
+      .setDynamicMetadata("envoy.common.shared_with_upstream", metadata);
   upstream_request_.copyDynamicMetaDataFromL4Downstream(l4_stream_info);
-  auto metadata1 = l4_stream_info.dynamicMetadata().filter_metadata();
-  auto down2up = metadata1.find("envoy.common.down_up");
-  EXPECT_TRUE(down2up != metadata1.end());
-  auto data = down2up->second.fields();
-  auto value = data.find("envoy.common.test");
-  EXPECT_TRUE(value != data.end());
-  EXPECT_EQ(data_value, value->second.number_value());
+  auto down2up =
+      l4_stream_info.dynamicMetadata().filter_metadata().find("envoy.common.shared_with_upstream");
+  auto id = std::to_string(connection->id());
+  EXPECT_TRUE(down2up != l4_stream_info.dynamicMetadata().filter_metadata().end());
+  EXPECT_TRUE(down2up->second.fields().find(id) != down2up->second.fields().end());
+  const ProtobufWkt::Struct& data = down2up->second.fields().find(id)->second.struct_value();
+  EXPECT_TRUE(data.fields().find("envoy.common.test") != data.fields().end());
+  EXPECT_TRUE(data.fields().find("envoy.common.test")->second.number_value() == data_value);
+}
+
+TEST_F(UpstreamRequestTest, CopyDynamicMetaData1) {
+  Event::SimulatedTimeSystem test_time_;
+  StreamInfo::StreamInfoImpl l4_stream_info(test_time_, nullptr);
+  auto connection = router_filter_interface_.callbacks_.connection();
+
+  /*There is a existing metadata in upstream metadata*/
+  auto data_value1 = 8888;
+  ProtobufWkt::Struct metadata;
+  auto& fields = *metadata.mutable_fields();
+  auto val = ProtobufWkt::Value();
+  val.set_number_value(data_value1);
+  fields.insert({"envoy.common.test", val});
+  ProtobufWkt::Struct metadata1;
+  auto& fields1 = *metadata1.mutable_fields();
+  ProtobufWkt::Value val1;
+  val1 = ValueUtil::structValue(metadata);
+  auto existing_id = "1000";
+  fields1.insert({existing_id, val1});
+  l4_stream_info.setDynamicMetadata("envoy.common.shared_with_upstream", metadata1);
+
+  /*copy the metadata from another downstream connection*/
+  auto data_value2 = 9999;
+  ProtobufWkt::Struct metadata2;
+  auto& fields2 = *metadata2.mutable_fields();
+  auto val2 = ProtobufWkt::Value();
+  val2.set_number_value(data_value2);
+  fields2.insert({"envoy.common.test", val2});
+  const_cast<Network::Connection*>(connection)
+      ->streamInfo()
+      .setDynamicMetadata("envoy.common.shared_with_upstream", metadata2);
+
+  upstream_request_.copyDynamicMetaDataFromL4Downstream(l4_stream_info);
+  auto down2up =
+      l4_stream_info.dynamicMetadata().filter_metadata().find("envoy.common.shared_with_upstream");
+  EXPECT_TRUE(down2up != l4_stream_info.dynamicMetadata().filter_metadata().end());
+
+  auto id = std::to_string(connection->id());
+  EXPECT_TRUE(down2up->second.fields().find(id) != down2up->second.fields().end());
+  const ProtobufWkt::Struct& data = down2up->second.fields().find(id)->second.struct_value();
+  EXPECT_TRUE(data.fields().find("envoy.common.test") != data.fields().end());
+  EXPECT_TRUE(data.fields().find("envoy.common.test")->second.number_value() == data_value2);
+
+  EXPECT_TRUE(down2up->second.fields().find(existing_id) != down2up->second.fields().end());
+  const ProtobufWkt::Struct& data1 =
+      down2up->second.fields().find(existing_id)->second.struct_value();
+  EXPECT_TRUE(data1.fields().find("envoy.common.test") != data1.fields().end());
+  EXPECT_TRUE(data1.fields().find("envoy.common.test")->second.number_value() == data_value1);
 }
 
 // UpstreamRequest is responsible processing for passing 101 upgrade headers to onUpstreamHeaders.

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -129,9 +129,9 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(Invoke([this](const BytesMeterSharedPtr& downstream_bytes_meter) {
         downstream_bytes_meter_ = downstream_bytes_meter;
       }));
-  ON_CALL(*this, setDynamicMetadata("envoy.common.down_up", _))
+  ON_CALL(*this, setDynamicMetadata("envoy.common.shared_with_upstream", _))
       .WillByDefault(Invoke([this](const std::string&, const ProtobufWkt::Struct& obj) {
-        (*metadata_.mutable_filter_metadata())["envoy.common.down_up"].MergeFrom(obj);
+        (*metadata_.mutable_filter_metadata())["envoy.common.shared_with_upstream"].MergeFrom(obj);
       }));
 }
 

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -129,6 +129,10 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(Invoke([this](const BytesMeterSharedPtr& downstream_bytes_meter) {
         downstream_bytes_meter_ = downstream_bytes_meter;
       }));
+  ON_CALL(*this, setDynamicMetadata("envoy.common.down_up", _))
+      .WillByDefault(Invoke([this](const std::string&, const ProtobufWkt::Struct& obj) {
+        (*metadata_.mutable_filter_metadata())["envoy.common.down_up"].MergeFrom(obj);
+      }));
 }
 
 MockStreamInfo::~MockStreamInfo() = default;


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/issues/20536
Add a new dynamic metadata namespace "envoy.common.down_up",  you can add your own dynamic metadata into this namespace if you want to propagate your downstream dynamic metadata to the upstream stream info.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
