### PR TITLE
fuzz test: Close only open connections.

### DIFF
--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -108,6 +108,7 @@ private:
   const Network::FilterChainSharedPtr filter_chain_;
   const std::vector<AccessLog::InstanceSharedPtr> empty_access_logs_;
   std::unique_ptr<Init::Manager> init_manager_;
+  bool connection_established_{};
 };
 
 } // namespace ListenerFilters

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_corpus/oss-fuzz-46844-tls_inspector_fuzz_test-5401720986927104
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_corpus/oss-fuzz-46844-tls_inspector_fuzz_test-5401720986927104
@@ -1,0 +1,7 @@
+config {
+}
+fuzzed {
+  sock {
+    local_address: "un:ix/L"
+  }
+}


### PR DESCRIPTION
Commit Message: fuzz test: Close only open connections.
Additional Description:
- In tls_inspector_fuzz_test an event-loop could block due to getting no
signal.
- Use a flag to indicate, that a connection has been opened and close it
only, when the flag has been set ensuring a close event can be received.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
