### PR TITLE
fuzz test: Prevent illegal config for tap.

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_corpus/oss-fuzz-46967-filter_fuzz_test-6312516046684160
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/oss-fuzz-46967-filter_fuzz_test-6312516046684160
@@ -1,0 +1,4 @@
+config {   name: "envoy.filters.http.tap"   
+typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap"
+    value: "\n\017\022\r\022\013\n\t*\007\010\200\200\200\200\200\010"   } } 


### PR DESCRIPTION
Commit Message: fuzz test: Prevent illegal config for tap.
Additional Description:
No longer cause abort due to illegal fuzzed configuration in the
filter_fuzz_test.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
