### PR TITLE
cert validator: rename CertValidator::doVerifyCertChain()

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -45,10 +45,9 @@ public:
    * @param leaf_cert the peer certificate to verify
    * @return 1 to indicate verification success and 0 to indicate verification failure.
    */
-  virtual int
-  doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
-                    X509& leaf_cert,
-                    const Network::TransportSocketOptions* transport_socket_options) PURE;
+  virtual int doSynchronousVerifyCertChain(
+      X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info, X509& leaf_cert,
+      const Network::TransportSocketOptions* transport_socket_options) PURE;
 
   /**
    * Called to initialize all ssl contexts

--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -46,7 +46,7 @@ public:
    * @return 1 to indicate verification success and 0 to indicate verification failure.
    */
   virtual int
-  doVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
+  doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
                     X509& leaf_cert,
                     const Network::TransportSocketOptions* transport_socket_options) PURE;
 

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -230,8 +230,8 @@ int DefaultCertValidator::doSynchronousVerifyCertChain(
   // `NotValidated` or `Validated`). If `trusted_ca` doesn't exist, we will need to make sure
   // other configurations are verified and the verification succeed.
   const bool success = verify_trusted_ca_
-                              ? validated != Envoy::Ssl::ClientValidationStatus::Failed
-                              : validated == Envoy::Ssl::ClientValidationStatus::Validated;
+                           ? validated != Envoy::Ssl::ClientValidationStatus::Failed
+                           : validated == Envoy::Ssl::ClientValidationStatus::Validated;
 
   return (allow_untrusted_certificate_ || success) ? 1 : 0;
 }

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -191,7 +191,7 @@ int DefaultCertValidator::initializeSslContexts(std::vector<SSL_CTX*> contexts,
   return verify_mode;
 }
 
-int DefaultCertValidator::doVerifyCertChain(
+int DefaultCertValidator::doSynchronousVerifyCertChain(
     X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info, X509& leaf_cert,
     const Network::TransportSocketOptions* transport_socket_options) {
   if (verify_trusted_ca_) {
@@ -229,11 +229,11 @@ int DefaultCertValidator::doVerifyCertChain(
   // sure the verification for other validation context configurations doesn't fail (i.e. either
   // `NotValidated` or `Validated`). If `trusted_ca` doesn't exist, we will need to make sure
   // other configurations are verified and the verification succeed.
-  int validation_status = verify_trusted_ca_
+  const bool success = verify_trusted_ca_
                               ? validated != Envoy::Ssl::ClientValidationStatus::Failed
                               : validated == Envoy::Ssl::ClientValidationStatus::Validated;
 
-  return allow_untrusted_certificate_ ? 1 : validation_status;
+  return (allow_untrusted_certificate_ || success) ? 1 : 0;
 }
 
 Envoy::Ssl::ClientValidationStatus DefaultCertValidator::verifyCertificate(

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
@@ -42,7 +42,7 @@ public:
   // Tls::CertValidator
   void addClientValidationContext(SSL_CTX* context, bool require_client_cert) override;
 
-  int doVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
+  int doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
                         X509& leaf_cert,
                         const Network::TransportSocketOptions* transport_socket_options) override;
 

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
@@ -42,9 +42,9 @@ public:
   // Tls::CertValidator
   void addClientValidationContext(SSL_CTX* context, bool require_client_cert) override;
 
-  int doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
-                        X509& leaf_cert,
-                        const Network::TransportSocketOptions* transport_socket_options) override;
+  int doSynchronousVerifyCertChain(
+      X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info, X509& leaf_cert,
+      const Network::TransportSocketOptions* transport_socket_options) override;
 
   int initializeSslContexts(std::vector<SSL_CTX*> contexts, bool provides_certificates) override;
 

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -140,8 +140,9 @@ int SPIFFEValidator::initializeSslContexts(std::vector<SSL_CTX*>, bool) {
 }
 
 int SPIFFEValidator::doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx,
-                                       Ssl::SslExtendedSocketInfo* ssl_extended_info,
-                                       X509& leaf_cert, const Network::TransportSocketOptions*) {
+                                                  Ssl::SslExtendedSocketInfo* ssl_extended_info,
+                                                  X509& leaf_cert,
+                                                  const Network::TransportSocketOptions*) {
   if (!SPIFFEValidator::certificatePrecheck(&leaf_cert)) {
     if (ssl_extended_info) {
       ssl_extended_info->setCertificateValidationStatus(Envoy::Ssl::ClientValidationStatus::Failed);

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -139,7 +139,7 @@ int SPIFFEValidator::initializeSslContexts(std::vector<SSL_CTX*>, bool) {
   return SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 }
 
-int SPIFFEValidator::doVerifyCertChain(X509_STORE_CTX* store_ctx,
+int SPIFFEValidator::doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx,
                                        Ssl::SslExtendedSocketInfo* ssl_extended_info,
                                        X509& leaf_cert, const Network::TransportSocketOptions*) {
   if (!SPIFFEValidator::certificatePrecheck(&leaf_cert)) {

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
@@ -41,9 +41,9 @@ public:
   // Tls::CertValidator
   void addClientValidationContext(SSL_CTX* context, bool require_client_cert) override;
 
-  int doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
-                        X509& leaf_cert,
-                        const Network::TransportSocketOptions* transport_socket_options) override;
+  int doSynchronousVerifyCertChain(
+      X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info, X509& leaf_cert,
+      const Network::TransportSocketOptions* transport_socket_options) override;
 
   int initializeSslContexts(std::vector<SSL_CTX*> contexts, bool provides_certificates) override;
 

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
@@ -41,7 +41,7 @@ public:
   // Tls::CertValidator
   void addClientValidationContext(SSL_CTX* context, bool require_client_cert) override;
 
-  int doVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
+  int doSynchronousVerifyCertChain(X509_STORE_CTX* store_ctx, Ssl::SslExtendedSocketInfo* ssl_extended_info,
                         X509& leaf_cert,
                         const Network::TransportSocketOptions* transport_socket_options) override;
 

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -430,7 +430,7 @@ int ContextImpl::verifyCallback(X509_STORE_CTX* store_ctx, void* arg) {
   SSL* ssl = reinterpret_cast<SSL*>(
       X509_STORE_CTX_get_ex_data(store_ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
   auto cert = bssl::UniquePtr<X509>(SSL_get_peer_certificate(ssl));
-  return impl->cert_validator_->doVerifyCertChain(
+  return impl->cert_validator_->doSynchronousVerifyCertChain(
       store_ctx,
       reinterpret_cast<Envoy::Ssl::SslExtendedSocketInfo*>(
           SSL_get_ex_data(ssl, ContextImpl::sslExtendedSocketInfoIndex())),
@@ -1166,7 +1166,7 @@ bool ContextImpl::verifyCertChain(X509& leaf_cert, STACK_OF(X509) & intermediate
     return false;
   }
 
-  int res = cert_validator_->doVerifyCertChain(ctx.get(), nullptr, leaf_cert, nullptr);
+  int res = cert_validator_->doSynchronousVerifyCertChain(ctx.get(), nullptr, leaf_cert, nullptr);
   // If |SSL_VERIFY_NONE|, the error is non-fatal, but we keep the error details.
   if (res <= 0 && SSL_CTX_get_verify_mode(ssl_ctx) != SSL_VERIFY_NONE) {
     error_details = Utility::getX509VerificationErrorInfo(ctx.get());

--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -177,7 +177,7 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithNoValidationContex
                                                  /*subject_alt_name_matchers=*/{}),
             Envoy::Ssl::ClientValidationStatus::NotValidated);
   bssl::UniquePtr<X509> cert(X509_new());
-  EXPECT_EQ(default_validator->doVerifyCertChain(/*store_ctx=*/nullptr,
+  EXPECT_EQ(default_validator->doSynchronousVerifyCertChain(/*store_ctx=*/nullptr,
                                                  /*ssl_extended_info=*/nullptr,
                                                  /*leaf_cert=*/*cert,
                                                  /*transport_socket_options=*/nullptr),

--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -178,9 +178,9 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithNoValidationContex
             Envoy::Ssl::ClientValidationStatus::NotValidated);
   bssl::UniquePtr<X509> cert(X509_new());
   EXPECT_EQ(default_validator->doSynchronousVerifyCertChain(/*store_ctx=*/nullptr,
-                                                 /*ssl_extended_info=*/nullptr,
-                                                 /*leaf_cert=*/*cert,
-                                                 /*transport_socket_options=*/nullptr),
+                                                            /*ssl_extended_info=*/nullptr,
+                                                            /*leaf_cert=*/*cert,
+                                                            /*transport_socket_options=*/nullptr),
             0);
 }
 

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
@@ -239,7 +239,7 @@ TEST_F(TestSPIFFEValidator, TestDoVerifyCertChainPrecheckFailure) {
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"));
 
   TestSslExtendedSocketInfo info;
-  EXPECT_FALSE(validator().doVerifyCertChain(store_ctx.get(), &info, *cert, nullptr));
+  EXPECT_FALSE(validator().doSynchronousVerifyCertChain(store_ctx.get(), &info, *cert, nullptr));
   EXPECT_EQ(1, stats().fail_verify_error_.value());
   EXPECT_EQ(info.certificateValidationStatus(), Envoy::Ssl::ClientValidationStatus::Failed);
 }
@@ -262,7 +262,7 @@ typed_config:
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"));
   X509StoreContextPtr store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_TRUE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_TRUE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   // Different trust domain so should be rejected.
   cert = readCertFromFile(TestEnvironment::substitute(
@@ -270,7 +270,7 @@ typed_config:
 
   store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_FALSE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_FALSE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   // Does not have san.
   cert = readCertFromFile(TestEnvironment::substitute(
@@ -278,7 +278,7 @@ typed_config:
 
   store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_FALSE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_FALSE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   EXPECT_EQ(2, stats().fail_verify_error_.value());
 }
@@ -304,13 +304,13 @@ typed_config:
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"));
   X509StoreContextPtr store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_TRUE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_TRUE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   cert = readCertFromFile(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/spiffe_san_cert.pem"));
   store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_TRUE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_TRUE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   // Trust domain matches but it has expired.
   cert = readCertFromFile(TestEnvironment::substitute(
@@ -318,7 +318,7 @@ typed_config:
       "}}/test/extensions/transport_sockets/tls/test_data/expired_spiffe_san_cert.pem"));
   store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_FALSE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_FALSE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   // Does not have san.
   cert = readCertFromFile(TestEnvironment::substitute(
@@ -326,7 +326,7 @@ typed_config:
 
   store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_FALSE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_FALSE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   EXPECT_EQ(2, stats().fail_verify_error_.value());
 }
@@ -352,7 +352,7 @@ typed_config:
       "}}/test/extensions/transport_sockets/tls/test_data/expired_spiffe_san_cert.pem"));
   X509StoreContextPtr store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), nullptr));
-  EXPECT_TRUE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_TRUE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   EXPECT_EQ(0, stats().fail_verify_error_.value());
 }
@@ -382,7 +382,7 @@ typed_config:
     matcher.set_prefix("spiffe://lyft.com/");
     setSanMatchers({matcher});
     initialize(config);
-    EXPECT_TRUE(validator().doVerifyCertChain(store_ctx.get(), &info, *cert, nullptr));
+    EXPECT_TRUE(validator().doSynchronousVerifyCertChain(store_ctx.get(), &info, *cert, nullptr));
     EXPECT_EQ(info.certificateValidationStatus(), Envoy::Ssl::ClientValidationStatus::Validated);
   }
   {
@@ -390,7 +390,7 @@ typed_config:
     matcher.set_prefix("spiffe://example.com/");
     setSanMatchers({matcher});
     initialize(config);
-    EXPECT_FALSE(validator().doVerifyCertChain(store_ctx.get(), &info, *cert, nullptr));
+    EXPECT_FALSE(validator().doSynchronousVerifyCertChain(store_ctx.get(), &info, *cert, nullptr));
     EXPECT_EQ(1, stats().fail_verify_error_.value());
     EXPECT_EQ(info.certificateValidationStatus(), Envoy::Ssl::ClientValidationStatus::Failed);
     stats().fail_verify_error_.reset();
@@ -423,7 +423,7 @@ typed_config:
 
   X509StoreContextPtr store_ctx = X509_STORE_CTX_new();
   EXPECT_TRUE(X509_STORE_CTX_init(store_ctx.get(), ssl_ctx.get(), cert.get(), intermediates));
-  EXPECT_TRUE(validator().doVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
+  EXPECT_TRUE(validator().doSynchronousVerifyCertChain(store_ctx.get(), nullptr, *cert, nullptr));
 
   sk_X509_pop_free(intermediates, X509_free);
 }


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: rename it to doSynchronousVerifyCertChain() to make its behavior difference more obvious from the the new interface in https://github.com/envoyproxy/envoy/pull/21417.

Risk Level: low, no behavior change
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
