### PR TITLE
Check owner of envoy docker build dir

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -54,6 +54,12 @@ fi
 [[ -z "${ENVOY_DOCKER_BUILD_DIR}" ]] && ENVOY_DOCKER_BUILD_DIR="${DEFAULT_ENVOY_DOCKER_BUILD_DIR}"
 # Replace backslash with forward slash for Windows style paths
 ENVOY_DOCKER_BUILD_DIR="${ENVOY_DOCKER_BUILD_DIR//\\//}"
+# Check if ${ENVOY_DOCKER_BUILD_DIR} exists and own by current user
+OWNER_ENVOY_DOCKER_BUILD_DIR=$(stat -c "%U" ${ENVOY_DOCKER_BUILD_DIR})
+if [[ -d "${ENVOY_DOCKER_BUILD_DIR}" ]] && [[ $OWNER_ENVOY_DOCKER_BUILD_DIR != $USER ]]; then
+  echo "ERROR: ENVOY_DOCKER_BUILD_DIR:${ENVOY_DOCKER_BUILD_DIR} is required to own by current user."
+  exit 1
+fi
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 
 [[ -t 1 ]] && ENVOY_DOCKER_OPTIONS+=("-it")


### PR DESCRIPTION
Commit Message: Check if `ENVOY_DOCKER_BUILD_DIR` is created and owned by other user. Build will exit to make sure permission problem is resolved
Additional Description: The permisson of files within `$ENVOY_DOCKER_BUILD_DIR` will stay the same with last build user. In that case, build from other user will be blocked by "permission denied". 
Platform Specific Features: Linux
