### PR TITLE
Remove absl::string_view(nullptr) use as it is deprecated

### DIFF
--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -291,7 +291,7 @@ TEST_F(GrpcHttp1BridgeFilterTest, ProtobufUpgradedHeaderSanitized) {
   EXPECT_CALL(decoder_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc, request_headers.getContentTypeValue());
-  EXPECT_EQ(nullptr, request_headers.getContentLengthValue());
+  EXPECT_EQ("", request_headers.getContentLengthValue());
 }
 
 } // namespace


### PR DESCRIPTION
Additional Description:
This change brings `absl::string_view` inline with `std::string_view`. Where the latter disallows passing `null` to its constructor.

Risk Level: Low, Test Only
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
