### PR TITLE
tooling: Add python data macro

### DIFF
--- a/tools/protodoc/BUILD
+++ b/tools/protodoc/BUILD
@@ -2,6 +2,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("@base_pip3//:requirements.bzl", "requirement")
 load("//bazel:envoy_build_system.bzl", "envoy_package", "envoy_proto_library")
 load("//tools/protodoc:protodoc.bzl", "protodoc_rule")
+load("//tools/base:envoy_python.bzl", "envoy_py_data")
 
 licenses(["notice"])  # Apache 2
 
@@ -19,25 +20,36 @@ envoy_proto_library(
     srcs = ["manifest.proto"],
 )
 
+envoy_py_data(
+    name = "extensions_db",
+    src = "//source/extensions:extensions_metadata.yaml",
+)
+
+envoy_py_data(
+    name = "contrib_extensions_db",
+    src = "//contrib:extensions_metadata.yaml",
+)
+
+envoy_py_data(
+    name = "protodoc_manifest_untyped",
+    src = "//docs:protodoc_manifest.yaml",
+)
+
 py_binary(
     name = "protodoc",
     srcs = ["protodoc.py"],
-    data = [
-        "//contrib:extensions_metadata.yaml",
-        "//docs:protodoc_manifest.yaml",
-        "//docs:v2_mapping.json",
-        "//source/extensions:extensions_metadata.yaml",
-    ],
     visibility = ["//visibility:public"],
     deps = [
+        ":contrib_extensions_db",
+        ":extensions_db",
         ":manifest_proto_py_proto",
+        ":protodoc_manifest_untyped",
         "//tools/api_proto_plugin",
         "//tools/config_validation:validate_fragment",
         "@com_envoyproxy_protoc_gen_validate//validate:validate_py",
         "@com_github_cncf_udpa//udpa/annotations:pkg_py_proto",
         "@com_github_cncf_udpa//xds/annotations/v3:pkg_py_proto",
         "@com_google_protobuf//:protobuf_python",
-        requirement("envoy.base.utils"),
         requirement("envoy.code.check"),
         requirement("Jinja2"),
     ],

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 from functools import cached_property
 
 from google.protobuf import json_format
-from bazel_tools.tools.python.runfiles import runfiles
 import yaml
 
 from jinja2 import Template
@@ -23,13 +22,15 @@ from jinja2 import Template
 # just remove it from the sys.path.
 sys.path = [p for p in sys.path if not p.endswith('bazel_tools')]
 
-from envoy.base import utils
 from envoy.code.check.checker import BackticksCheck
 
 from tools.api_proto_plugin import annotations
 from tools.api_proto_plugin import plugin
 from tools.api_proto_plugin import visitor
 from tools.config_validation import validate_fragment
+from tools.protodoc.protodoc_manifest_untyped import data as protodoc_manifest_untyped
+from tools.protodoc.extensions_db import data as EXTENSION_DB
+from tools.protodoc.contrib_extensions_db import data as CONTRIB_EXTENSION_DB
 
 from tools.protodoc import manifest_pb2
 from udpa.annotations import security_pb2
@@ -140,11 +141,6 @@ WIP_WARNING = (
     '<arch_overview_threat_model>`, are not supported by the security team, and are subject to '
     'breaking changes. Do not use this feature without understanding each of the previous '
     'points.\n\n')
-
-r = runfiles.Create()
-
-EXTENSION_DB = utils.from_yaml(r.Rlocation("envoy/source/extensions/extensions_metadata.yaml"))
-CONTRIB_EXTENSION_DB = utils.from_yaml(r.Rlocation("envoy/contrib/extensions_metadata.yaml"))
 
 
 # create an index of extension categories from extension db
@@ -708,8 +704,6 @@ class RstFormatVisitor(visitor.Visitor):
     def __init__(self):
         # Load as YAML, emit as JSON and then parse as proto to provide type
         # checking.
-        protodoc_manifest_untyped = utils.from_yaml(
-            r.Rlocation('envoy/docs/protodoc_manifest.yaml'))
         self.protodoc_manifest = manifest_pb2.Manifest()
         json_format.Parse(json.dumps(protodoc_manifest_untyped), self.protodoc_manifest)
 


### PR DESCRIPTION
For optimized preloading of data

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

This macro takes a yaml or json data source, creates a python data pickle from it and exposes a python lib containing the `data`

If we load all of protodoc's data this way (and do any other validation/cleanup/mangling beforehand) we should be able to reduce overheads

in this initial pr the data artefacts required by protodoc are imported individually - in a followup i will merge the data to a single artefact

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
