### PR TITLE
test: Fix h1 persistant capture fuzz test flakiness

### DIFF
--- a/test/mocks/runtime/mocks.cc
+++ b/test/mocks/runtime/mocks.cc
@@ -1,10 +1,8 @@
 #include "mocks.h"
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::NiceMock;
 using testing::Return;
 using testing::ReturnArg;
 
@@ -21,9 +19,7 @@ MockSnapshot::MockSnapshot() {
 MockSnapshot::~MockSnapshot() = default;
 
 MockLoader::MockLoader() {
-  ON_CALL(*this, threadsafeSnapshot()).WillByDefault(testing::Invoke([]() {
-    return std::make_shared<const NiceMock<MockSnapshot>>();
-  }));
+  ON_CALL(*this, threadsafeSnapshot()).WillByDefault(Return(threadsafe_snapshot_));
   ON_CALL(*this, snapshot()).WillByDefault(ReturnRef(snapshot_));
   ON_CALL(*this, getRootScope()).WillByDefault(ReturnRef(store_));
 }

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -69,6 +69,8 @@ public:
   MOCK_METHOD(Stats::Scope&, getRootScope, ());
   MOCK_METHOD(void, countDeprecatedFeatureUse, (), (const));
 
+  SnapshotConstSharedPtr threadsafe_snapshot_{
+      std::make_shared<const testing::NiceMock<MockSnapshot>>()};
   testing::NiceMock<MockSnapshot> snapshot_;
   testing::NiceMock<Stats::MockStore> store_;
 };


### PR DESCRIPTION
Commit Message: Fix h1 persistant capture fuzz test TSAN flakiness
Additional Description:
Executed `bazel test //test/integration:h1_capture_persistent_fuzz_test --config=remote-tsan --runs_per_test=1000` and had no failures.
Risk Level: Low - tests only.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #Issue: #20382

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
