### PR TITLE
Adding listener ECDS integration test case with two resources

### DIFF
--- a/test/integration/listener_extension_discovery_integration_test.cc
+++ b/test/integration/listener_extension_discovery_integration_test.cc
@@ -24,9 +24,11 @@ public:
 
   void addDynamicFilter(const std::string& name, bool apply_without_warming,
                         bool set_default_config = true, bool rate_limit = false,
-                        ListenerMatcherType matcher = ListenerMatcherType::NULLMATCHER) {
+                        ListenerMatcherType matcher = ListenerMatcherType::NULLMATCHER,
+                        const std::string& cluster_name = "ecds_cluster",
+                        bool second_stream = false) {
     config_helper_.addConfigModifier([name, apply_without_warming, set_default_config, rate_limit,
-                                      matcher,
+                                      matcher, cluster_name, second_stream,
                                       this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
       listener->set_stat_prefix("listener_stat");
@@ -54,7 +56,11 @@ public:
       }
       addListenerFilterMatcher(listener_filter, matcher);
       auto* grpc_service = api_config_source->add_grpc_services();
-      setGrpcService(*grpc_service, "ecds_cluster", getEcdsFakeUpstream().localAddress());
+      if (!second_stream) {
+        setGrpcService(*grpc_service, cluster_name, getEcdsFakeUpstream().localAddress());
+      } else {
+        setGrpcService(*grpc_service, cluster_name, getEcds2FakeUpstream().localAddress());
+      }
     });
   }
 
@@ -82,6 +88,17 @@ public:
     }
   }
 
+  void addEcdsCluster(const std::string& cluster_name) {
+    // Add an xDS cluster for extension config discovery.
+    config_helper_.addConfigModifier(
+        [cluster_name](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+          auto* ecds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+          ecds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+          ecds_cluster->set_name(cluster_name);
+          ConfigHelper::setHttp2(*ecds_cluster);
+        });
+  }
+
   void initialize() override {
     defer_listener_finalization_ = true;
     setUpstreamCount(1);
@@ -98,45 +115,58 @@ public:
       filter->mutable_typed_config()->PackFrom(config);
     });
 
-    // Add an xDS cluster for extension config discovery.
-    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      auto* ecds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      ecds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-      ecds_cluster->set_name("ecds_cluster");
-      ConfigHelper::setHttp2(*ecds_cluster);
-    });
+    addEcdsCluster("ecds_cluster");
+    // Add 2nd cluster in case of two streams.
+    if (two_stream_) {
+      addEcdsCluster("ecds2_cluster");
+    }
     BaseIntegrationTest::initialize();
     registerTestServerPorts({port_name_});
   }
 
-  ~ListenerExtensionDiscoveryIntegrationTest() override {
-    if (ecds_connection_ != nullptr) {
-      AssertionResult result = ecds_connection_->close();
+  void resetEcdsConnection(FakeHttpConnectionPtr& connection) {
+    if (connection != nullptr) {
+      AssertionResult result = connection->close();
       RELEASE_ASSERT(result, result.message());
-      result = ecds_connection_->waitForDisconnect();
+      result = connection->waitForDisconnect();
       RELEASE_ASSERT(result, result.message());
-      ecds_connection_.reset();
+      connection.reset();
     }
+  }
+
+  ~ListenerExtensionDiscoveryIntegrationTest() override {
+    resetEcdsConnection(ecds_connection_);
+    resetEcdsConnection(ecds2_connection_);
   }
 
   void createUpstreams() override {
     BaseIntegrationTest::createUpstreams();
-    // Create the extension config discovery upstream (fake_upstreams_[1]).
+    // Create two extension config discovery upstreams (fake_upstreams_[1] and fake_upstreams_[2]).
     addFakeUpstream(Http::CodecType::HTTP2);
+    if (two_stream_) {
+      addFakeUpstream(Http::CodecType::HTTP2);
+    }
+  }
+
+  void waitForEcdsStream(FakeUpstream& upstream, FakeHttpConnectionPtr& connection,
+                         FakeStreamPtr& stream) {
+    AssertionResult result = upstream.waitForHttpConnection(*dispatcher_, connection);
+    ASSERT_TRUE(result);
+    result = connection->waitForNewStream(*dispatcher_, stream);
+    ASSERT_TRUE(result);
+    stream->startGrpcStream();
   }
 
   void waitXdsStream() {
-    // Wait for ECDS stream.
-    auto& ecds_upstream = getEcdsFakeUpstream();
-    AssertionResult result = ecds_upstream.waitForHttpConnection(*dispatcher_, ecds_connection_);
-    ASSERT_TRUE(result);
-    result = ecds_connection_->waitForNewStream(*dispatcher_, ecds_stream_);
-    ASSERT_TRUE(result);
-    ecds_stream_->startGrpcStream();
+    waitForEcdsStream(getEcdsFakeUpstream(), ecds_connection_, ecds_stream_);
+    if (two_stream_) {
+      // Wait for 2nd ECDS stream.
+      waitForEcdsStream(getEcds2FakeUpstream(), ecds2_connection_, ecds2_stream_);
+    }
   }
 
   void sendXdsResponse(const std::string& name, const std::string& version,
-                       const uint32_t drain_bytes, bool ttl = false) {
+                       const uint32_t drain_bytes, bool ttl = false, bool second_stream = false) {
     // The to-be-drained bytes has to be smaller than data size.
     ASSERT(drain_bytes <= data_.size());
 
@@ -156,7 +186,11 @@ public:
       resource.mutable_ttl()->set_seconds(1);
     }
     response.add_resources()->PackFrom(resource);
-    ecds_stream_->sendGrpcMessage(response);
+    if (!second_stream) {
+      ecds_stream_->sendGrpcMessage(response);
+    } else {
+      ecds2_stream_->sendGrpcMessage(response);
+    }
   }
 
   // Client sends data_, which is drained by Envoy listener filter based on config, then received by
@@ -181,12 +215,16 @@ public:
   const std::string filter_name_;
   const std::string data_;
   const std::string port_name_;
+  bool two_stream_{false};
 
   FakeUpstream& getEcdsFakeUpstream() const { return *fake_upstreams_[1]; }
+  FakeUpstream& getEcds2FakeUpstream() const { return *fake_upstreams_[2]; }
 
-  // gRPC ECDS set-up
+  // gRPC two ECDS connections set-up.
   FakeHttpConnectionPtr ecds_connection_{nullptr};
   FakeStreamPtr ecds_stream_{nullptr};
+  FakeHttpConnectionPtr ecds2_connection_{nullptr};
+  FakeStreamPtr ecds2_stream_{nullptr};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, ListenerExtensionDiscoveryIntegrationTest,
@@ -373,6 +411,36 @@ TEST_P(ListenerExtensionDiscoveryIntegrationTest, TwoSubscriptionsSameName) {
       "extension_config_discovery.tcp_listener_filter." + filter_name_ + ".config_reload", 1);
   // Each filter drain 3 bytes.
   sendDataVerifyResults(6);
+}
+
+TEST_P(ListenerExtensionDiscoveryIntegrationTest, TwoSubscriptionsDifferentName) {
+  two_stream_ = true;
+  on_server_init_function_ = [&]() { waitXdsStream(); };
+  addDynamicFilter("foo", true);
+  addDynamicFilter("bar", false, true, false, ListenerMatcherType::NULLMATCHER, "ecds2_cluster",
+                   true);
+  initialize();
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
+
+  // Send 1st config update.
+  sendXdsResponse("foo", "1", 3);
+  sendXdsResponse("bar", "1", 4, false, true);
+  test_server_->waitForCounterGe("extension_config_discovery.tcp_listener_filter.foo.config_reload",
+                                 1);
+  test_server_->waitForCounterGe("extension_config_discovery.tcp_listener_filter.bar.config_reload",
+                                 1);
+  // The two filters drain 3 + 4  bytes.
+  sendDataVerifyResults(7);
+
+  // Send 2nd config update.
+  sendXdsResponse("foo", "2", 4);
+  sendXdsResponse("bar", "2", 5, false, true);
+  test_server_->waitForCounterGe("extension_config_discovery.tcp_listener_filter.foo.config_reload",
+                                 2);
+  test_server_->waitForCounterGe("extension_config_discovery.tcp_listener_filter.bar.config_reload",
+                                 2);
+  // The two filters drain 4 + 5  bytes.
+  sendDataVerifyResults(9);
 }
 
 // Testing it works with two static listener filter configuration.

--- a/test/integration/listener_extension_discovery_integration_test.cc
+++ b/test/integration/listener_extension_discovery_integration_test.cc
@@ -120,7 +120,7 @@ public:
     });
 
     addEcdsCluster(std::string(EcdsClusterName));
-    // Add 2nd cluster in case of two streams.
+    // Add 2nd cluster in case of two connections.
     if (two_connections_) {
       addEcdsCluster(std::string(Ecds2ClusterName));
     }
@@ -170,7 +170,8 @@ public:
   }
 
   void sendXdsResponse(const std::string& name, const std::string& version,
-                       const uint32_t drain_bytes, bool ttl = false, bool second_connection = false) {
+                       const uint32_t drain_bytes, bool ttl = false,
+                       bool second_connection = false) {
     // The to-be-drained bytes has to be smaller than data size.
     ASSERT(drain_bytes <= data_.size());
 


### PR DESCRIPTION
Adding listener ECDS integration test to cover the case that two dynamic listener filters with different names and two config provider resources.

This is a follow up commit for https://github.com/envoyproxy/envoy/pull/21133.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
