### PR TITLE
tooling: Add  `genjson` macro

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -11,14 +11,15 @@ load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_depend
 load("@base_pip3//:requirements.bzl", pip_dependencies = "install_deps")
 load("@emsdk//:emscripten_deps.bzl", "emscripten_deps")
 load("@com_github_aignas_rules_shellcheck//:deps.bzl", "shellcheck_dependencies")
-load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains", "register_yq_toolchains")
 
 # go version for rules_go
 GO_VERSION = "1.17.5"
 
 JQ_VERSION = "1.6"
+YQ_VERSION = "4.24.4"
 
-def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION):
+def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, yq_version = YQ_VERSION):
     # TODO: allow building of tools for easier onboarding
     rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
     go_rules_dependencies()
@@ -52,6 +53,7 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION):
     )
     emscripten_deps()
     register_jq_toolchains(version = jq_version)
+    register_yq_toolchains(version = yq_version)
 
     # These dependencies, like most of the Go in this repository, exist only for the API.
     go_repository(

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -1,5 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@base_pip3//:requirements.bzl", base_entry_point = "entry_point")
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@aspect_bazel_lib//lib:yq.bzl", "yq")
 
 def envoy_entry_point(
         name,
@@ -54,4 +56,57 @@ def envoy_entry_point(
         main = entry_point_py,
         args = (args or []),
         data = (data or []),
+    )
+
+def envoy_genjson(name, srcs = [], yaml_srcs = [], filter = None, args = None):
+    '''Generate JSON from JSON and YAML sources
+
+    By default the sources will be merged in jq `slurp` mode.
+
+    Specify a jq `filter` to mangle the data.
+
+    Example - places the sources into a dictionary with separate keys, but merging
+    the data from one of the JSON files with the data from the YAML file:
+
+    ```starlark
+
+    envoy_genjson(
+        name = "myjson",
+        srcs = [
+            ":json_data.json",
+            "@com_somewhere//:other_json_data.json",
+        ],
+        yaml_srcs = [
+            ":yaml_data.yaml",
+        ],
+        filter = """
+        {first_data: .[0], rest_of_data: .[1] * .[2]}
+        """,
+    )
+
+    ```
+    '''
+    if not srcs and not yaml_srcs:
+        fail("At least one of `srcs` or `yaml_srcs` must be provided")
+
+    yaml_json = []
+    for i, yaml_src in enumerate(yaml_srcs):
+        yaml_name = "%s_yaml_%s" % (name, i)
+        yq(
+            name = yaml_name,
+            srcs = [yaml_src],
+            args = ["-o=json"],
+            outs = ["%s.json" % yaml_name],
+        )
+        yaml_json.append(yaml_name)
+
+    all_srcs = srcs + yaml_json
+    args = args or ["--slurp"]
+    filter = filter or " *".join([(".[%s]" % i) for i, x in enumerate(all_srcs)])
+    jq(
+        name = name,
+        srcs = all_srcs,
+        out = "%s.json" % name,
+        args = args,
+        filter = filter,
     )


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

Allows for easy merging/mangling of yaml and json data

Adds `yq` to allow dumping yaml to json

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
