### PR TITLE
fuzz test: Limit number of threads for async file.

### DIFF
--- a/test/extensions/filters/http/common/fuzz/BUILD
+++ b/test/extensions/filters/http/common/fuzz/BUILD
@@ -55,6 +55,7 @@ envoy_cc_test_library(
         "//test/proto:bookstore_proto_cc_proto",
         "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
+        "@envoy_api//envoy/extensions/filters/http/file_system_buffer/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/tap/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/oss-fuzz-47373-filter_fuzz_test-5658415797501952
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/oss-fuzz-47373-filter_fuzz_test-5658415797501952
@@ -1,0 +1,1 @@
+config {   name: "envoy.filters.http.file_system_buffer"   typed_config {     type_url: "                   /envoy.extensions.filters.http.file_system_buffer.v3.FileSystemBufferFilterConfig"     value: "\n\007\022\005\010\200\200ÿ ÿ  "   }             l:    e } 


### PR DESCRIPTION
Commit Message: fuzz test: Limit number of threads for async file.
Additional Description:
Limit the number of threads created for FileSystemBuffer.thread_pool()
to reduce the load in the test.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
