### PR TITLE
fuzz test: Filter ext_authz plugin.

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6004616048803840
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6004616048803840
@@ -1,0 +1,1 @@
+config {   name: "envoy.ext_authz"   typed_config {     type_url: "                   /envoy.extensions.filters.http.ext_authz.v3.ExtAuthz"     value: "`\002"   } } 

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -15,8 +15,11 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& i
   // The filters to exclude in this general fuzzer. For some of them dedicated fuzzer
   // exists. See #20737 or #21141.
   static const absl::flat_hash_set<absl::string_view> exclusion_list = {
-      "envoy.ext_proc", "envoy.filters.http.alternate_protocols_cache",
-      "envoy.filters.http.composite", "envoy.filters.http.ext_proc",
+      "envoy.ext_proc",
+      "envoy.filters.http.alternate_protocols_cache",
+      "envoy.filters.http.composite",
+      "envoy.filters.http.ext_proc",
+      "envoy.ext_authz",
       "envoy.filters.http.ext_authz"};
 
   ABSL_ATTRIBUTE_UNUSED static PostProcessorRegistration reg = {


### PR DESCRIPTION
Commit Message: fuzz test: Filter ext_authz plugin.
Additional Description:
Filter ext_authz extension from being tested in the general
filter_fuzz_test, because it has a dedicated test and needs some
additional setup to work.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
