### PR TITLE
router: update method of 'UpstreamToDownstream' to return 'Route'

### DIFF
--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1309,9 +1309,9 @@ public:
 class UpstreamToDownstream : public Http::ResponseDecoder, public Http::StreamCallbacks {
 public:
   /**
-   * @return return the routeEntry for the downstream stream.
+   * @return return the route for the downstream stream.
    */
-  virtual const RouteEntry& routeEntry() const PURE;
+  virtual const Route& route() const PURE;
   /**
    * @return return the connection for the downstream stream.
    */

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -304,7 +304,7 @@ public:
   virtual bool downstreamEndStream() const PURE;
   virtual uint32_t attemptCount() const PURE;
   virtual const VirtualCluster* requestVcluster() const PURE;
-  virtual const RouteEntry* routeEntry() const PURE;
+  virtual const Route* route() const PURE;
   virtual const std::list<UpstreamRequestPtr>& upstreamRequests() const PURE;
   virtual const UpstreamRequest* finalUpstreamRequest() const PURE;
   virtual TimeSource& timeSource() PURE;
@@ -488,7 +488,7 @@ public:
   bool downstreamEndStream() const override { return downstream_end_stream_; }
   uint32_t attemptCount() const override { return attempt_count_; }
   const VirtualCluster* requestVcluster() const override { return request_vcluster_; }
-  const RouteEntry* routeEntry() const override { return route_entry_; }
+  const Route* route() const override { return route_.get(); }
   const std::list<UpstreamRequestPtr>& upstreamRequests() const override {
     return upstream_requests_;
   }

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -217,7 +217,7 @@ void UpstreamRequest::dumpState(std::ostream& os, int indent_level) const {
   DUMP_DETAILS(request_headers);
 }
 
-const RouteEntry& UpstreamRequest::routeEntry() const { return *parent_.routeEntry(); }
+const Route& UpstreamRequest::route() const { return *parent_.route(); }
 
 const Network::Connection& UpstreamRequest::connection() const {
   return *parent_.callbacks()->connection();
@@ -490,9 +490,10 @@ void UpstreamRequest::onPoolReady(
 
   calling_encode_headers_ = true;
   auto* headers = parent_.downstreamHeaders();
-  if (parent_.routeEntry()->autoHostRewrite() && !host->hostname().empty()) {
+  const auto* route_entry = parent_.route()->routeEntry();
+  if (route_entry->autoHostRewrite() && !host->hostname().empty()) {
     Http::Utility::updateAuthority(*parent_.downstreamHeaders(), host->hostname(),
-                                   parent_.routeEntry()->appendXfh());
+                                   route_entry->appendXfh());
   }
 
   if (span_ != nullptr) {

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -70,10 +70,8 @@ public:
   void onAboveWriteBufferHighWatermark() override { disableDataFromDownstreamForFlowControl(); }
   void onBelowWriteBufferLowWatermark() override { enableDataFromDownstreamForFlowControl(); }
   // UpstreamToDownstream
-  const RouteEntry& routeEntry() const override;
+  const Route& route() const override;
   const Network::Connection& connection() const override;
-
-  // UpstreamToDownstream
   const Http::ConnectionPool::Instance::StreamOptions& upstreamStreamOptions() const override {
     return stream_options_;
   }

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -47,9 +47,11 @@ Envoy::Http::Status TcpUpstream::encodeHeaders(const Envoy::Http::RequestHeaderM
                                                bool end_stream) {
   // Headers should only happen once, so use this opportunity to add the proxy
   // proto header, if configured.
-  if (upstream_request_->routeEntry().connectConfig().has_value()) {
+  const Router::RouteEntry* route_entry = upstream_request_->route().routeEntry();
+  ASSERT(route_entry != nullptr);
+  if (route_entry->connectConfig().has_value()) {
     Buffer::OwnedImpl data;
-    auto& connect_config = upstream_request_->routeEntry().connectConfig().value();
+    auto& connect_config = route_entry->connectConfig().value();
     if (connect_config.has_proxy_protocol_config()) {
       Extensions::Common::ProxyProtocol::generateProxyProtoHeader(
           connect_config.proxy_protocol_config(), upstream_request_->connection(), data);

--- a/test/extensions/upstreams/http/tcp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/tcp/upstream_request_test.cc
@@ -148,7 +148,7 @@ TEST_F(TcpUpstreamTest, Basic) {
 
 TEST_F(TcpUpstreamTest, V1Header) {
   envoy::config::core::v3::ProxyProtocolConfig* proxy_config =
-      mock_router_filter_.route_entry_.connect_config_->mutable_proxy_protocol_config();
+      mock_router_filter_.route_.route_entry_.connect_config_->mutable_proxy_protocol_config();
   proxy_config->set_version(envoy::config::core::v3::ProxyProtocolConfig::V1);
   mock_router_filter_.client_connection_.stream_info_.downstream_connection_info_provider_
       ->setRemoteAddress(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 5));
@@ -171,7 +171,7 @@ TEST_F(TcpUpstreamTest, V1Header) {
 
 TEST_F(TcpUpstreamTest, V2Header) {
   envoy::config::core::v3::ProxyProtocolConfig* proxy_config =
-      mock_router_filter_.route_entry_.connect_config_->mutable_proxy_protocol_config();
+      mock_router_filter_.route_.route_entry_.connect_config_->mutable_proxy_protocol_config();
   proxy_config->set_version(envoy::config::core::v3::ProxyProtocolConfig::V2);
   mock_router_filter_.client_connection_.stream_info_.downstream_connection_info_provider_
       ->setRemoteAddress(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 5));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -570,7 +570,7 @@ class MockGenericConnPool : public GenericConnPool {
 
 class MockUpstreamToDownstream : public UpstreamToDownstream {
 public:
-  MOCK_METHOD(const RouteEntry&, routeEntry, (), (const));
+  MOCK_METHOD(const Route&, route, (), (const));
   MOCK_METHOD(const Network::Connection&, connection, (), (const));
 
   MOCK_METHOD(void, decodeData, (Buffer::Instance&, bool));

--- a/test/mocks/router/router_filter_interface.cc
+++ b/test/mocks/router/router_filter_interface.cc
@@ -20,9 +20,9 @@ MockRouterFilterInterface::MockRouterFilterInterface()
   ON_CALL(*this, upstreamRequests()).WillByDefault(ReturnRef(requests_));
   EXPECT_CALL(callbacks_.dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
   EXPECT_CALL(callbacks_.dispatcher_, popTrackedObject(_)).Times(AnyNumber());
-  ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_));
+  ON_CALL(*this, route()).WillByDefault(Return(&route_));
   ON_CALL(callbacks_, connection()).WillByDefault(Return(&client_connection_));
-  route_entry_.connect_config_.emplace(RouteEntry::ConnectConfig());
+  route_.route_entry_.connect_config_.emplace(RouteEntry::ConnectConfig());
 }
 
 MockRouterFilterInterface::~MockRouterFilterInterface() = default;

--- a/test/mocks/router/router_filter_interface.h
+++ b/test/mocks/router/router_filter_interface.h
@@ -45,13 +45,13 @@ public:
   MOCK_METHOD(bool, downstreamEndStream, (), (const));
   MOCK_METHOD(uint32_t, attemptCount, (), (const));
   MOCK_METHOD(const VirtualCluster*, requestVcluster, (), (const));
-  MOCK_METHOD(const RouteEntry*, routeEntry, (), (const));
+  MOCK_METHOD(const Route*, route, (), (const));
   MOCK_METHOD(const std::list<UpstreamRequestPtr>&, upstreamRequests, (), (const));
   MOCK_METHOD(const UpstreamRequest*, finalUpstreamRequest, (), (const));
   MOCK_METHOD(TimeSource&, timeSource, ());
 
   NiceMock<Envoy::Http::MockStreamDecoderFilterCallbacks> callbacks_;
-  NiceMock<MockRouteEntry> route_entry_;
+  NiceMock<MockRoute> route_;
   NiceMock<Network::MockConnection> client_connection_;
 
   envoy::extensions::filters::http::router::v3::Router router_proto;


### PR DESCRIPTION
Commit Message: router: update method of 'UpstreamToDownstream' to return 'Route'
Additional Description:

Some important methods were moved from `RouteEntry` to `Route` in the #17359. This change make it impossible to access `metadata`/`typed metadata` in the custom `GenericConnPool` implementations.

This PR update method of `UpstreamToDownstream` to provide `Route` rather than provide `RouteEntry`.

Risk Level: Low.
Testing: Added.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
