### PR TITLE
[backport/v1.22] fix zstd compile error (#20918)

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -553,6 +553,7 @@ envoy_cmake(
     build_data = ["@com_github_facebook_zstd//:all"],
     cache_entries = {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_LIBDIR": "lib",
         "ZSTD_BUILD_SHARED": "off",
         "ZSTD_BUILD_STATIC": "on",
     },


### PR DESCRIPTION
When compile envoy on RedHat based OS like Fedra, zstd will compile error with complaining: external/envoy/bazel/foreign_cc/BUILD:551:12: output 'external/envoy/bazel/foreign_cc/zstd/lib/libzstd.a' was not created
This is because on RedHat based OS, CMAKE_INSTALL_LIBDIR default is set to lib64, so it will generate object in external/envoy/bazel/foreign_cc/zstd/lib64/libzstd.a

Add the cmake compile flag `CMAKE_INSTALL_LIBDIR: lib` to fix this.

Signed-off-by: Felix Du <durd07@gmail.com>

Cherrypick of https://github.com/envoyproxy/envoy/pull/20918