### PR TITLE
http1: allowing for upstream absolutele URIs

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -247,7 +247,7 @@ message HttpProtocolOptions {
   google.protobuf.UInt32Value max_requests_per_connection = 6;
 }
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message Http1ProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.Http1ProtocolOptions";
@@ -331,6 +331,10 @@ message Http1ProtocolOptions {
   // If set, this overrides any HCM :ref:`stream_error_on_invalid_http_messaging
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`.
   google.protobuf.BoolValue override_stream_error_on_invalid_http_message = 7;
+
+  // Allows sending fully qualified URLs when proxying the first line of the
+  // response. By default, Envoy will only send the path components in the first line.
+  bool send_fully_qualified_url = 8;
 }
 
 message KeepaliveSettings {

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -335,8 +335,8 @@ message Http1ProtocolOptions {
   // Allows sending fully qualified URLs when proxying the first line of the
   // response. By default, Envoy will only send the path components in the first line.
   // If this is true, Envoy will create a fully qualified URI composing scheme
-  // (infered if not present), host (from the host/:authority header) and path
-  // (from firstline or :path header).
+  // (inferred if not present), host (from the host/:authority header) and path
+  // (from first line or :path header).
   bool send_fully_qualified_url = 8;
 }
 

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -334,6 +334,9 @@ message Http1ProtocolOptions {
 
   // Allows sending fully qualified URLs when proxying the first line of the
   // response. By default, Envoy will only send the path components in the first line.
+  // If this is true, Envoy will create a fully qualified URI composing scheme
+  // (infered if not present), host (from the host/:authority header) and path
+  // (from firstline or :path header).
   bool send_fully_qualified_url = 8;
 }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -132,6 +132,8 @@ new_features:
 - area: http
   change: |
     added new :ref:`file_system_buffer <config_http_filters_file_system_buffer>` http filter.
+  change: |
+    added a :ref:`configuration option <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.send_fully_qualified_url>` to send absolute URLs for HTTP/1.1.
 - area: http
   change: |
     preserve case header formatter support innner formatter on Envoy headers in :ref:`formatter_type_on_envoy_headers <envoy_v3_api_field_extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig.formatter_type_on_envoy_headers>`.

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -453,6 +453,9 @@ struct Http1Settings {
   // True if this is an edge Envoy (using downstream address, no trusted hops)
   // and https:// URLs should be rejected over unencrypted connections.
   bool validate_scheme_{false};
+
+  // If true, Envoy will send a fully qualified URL in the firstline of the request.
+  bool send_fully_qualified_url_{false};
 };
 
 /**

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -438,15 +438,34 @@ Status RequestEncoderImpl::encodeHeaders(const RequestHeaderMap& headers, bool e
     upgrade_request_ = true;
   }
 
-  absl::string_view host_or_path_view;
-  if (is_connect) {
-    host_or_path_view = host->value().getStringView();
-  } else {
-    host_or_path_view = path->value().getStringView();
-  }
+  if (connection_.sendFullyQualifiedUrl() && !is_connect) {
+    const HeaderEntry* scheme = headers.Scheme();
+    if (!scheme) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("missing required header: ", Envoy::Http::Headers::get().Scheme.get()));
+    }
+    if (!host) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("missing required header: ", Envoy::Http::Headers::get().Host.get()));
+    }
+    ASSERT(path);
+    ASSERT(host);
 
-  connection_.buffer().addFragments(
-      {method->value().getStringView(), SPACE, host_or_path_view, REQUEST_POSTFIX});
+    std::string url = absl::StrCat(scheme->value().getStringView(), "://",
+                                   host->value().getStringView(), path->value().getStringView());
+    connection_.buffer().addFragments(
+        {method->value().getStringView(), SPACE, url, REQUEST_POSTFIX});
+  } else {
+    absl::string_view host_or_path_view;
+    if (is_connect) {
+      host_or_path_view = host->value().getStringView();
+    } else {
+      host_or_path_view = path->value().getStringView();
+    }
+
+    connection_.buffer().addFragments(
+        {method->value().getStringView(), SPACE, host_or_path_view, REQUEST_POSTFIX});
+  }
 
   encodeHeadersBase(headers, absl::nullopt, end_stream,
                     HeaderUtility::requestShouldHaveNoBody(headers));

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -230,6 +230,7 @@ public:
   virtual void maybeAddSentinelBufferFragment(Buffer::Instance&) {}
   CodecStats& stats() { return stats_; }
   bool enableTrailers() const { return codec_settings_.enable_trailers_; }
+  bool sendFullyQualifiedUrl() const { return codec_settings_.send_fully_qualified_url_; }
   HeaderKeyFormatterOptConstRef formatter() const {
     return makeOptRefFromPtr(encode_only_header_key_formatter_.get());
   }

--- a/source/common/http/http1/settings.cc
+++ b/source/common/http/http1/settings.cc
@@ -13,6 +13,7 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
   Http1Settings ret;
   ret.allow_absolute_url_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, allow_absolute_url, true);
   ret.accept_http_10_ = config.accept_http_10();
+  ret.send_fully_qualified_url_ = config.send_fully_qualified_url();
   ret.default_host_for_http_10_ = config.default_host_for_http_10();
   ret.enable_trailers_ = config.enable_trailers();
   ret.allow_chunked_length_ = config.allow_chunked_length();


### PR DESCRIPTION
Risk Level: low (and config guarded)
Testing: new unit, integration tests
Docs Changes: in with APIs
Release Notes: inline

part of https://github.com/envoyproxy/envoy-mobile/issues/1622