### PR TITLE
test: added MockUpstreamInfo

### DIFF
--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
@@ -727,7 +727,6 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateTest) {
   ON_CALL(Const(*mock_upstream_info.get()), upstreamFilterState())
       .WillByDefault(ReturnRef(upstream_filter_state));
   EXPECT_CALL(Const(*mock_upstream_info.get()), upstreamFilterState()).Times(2);
-  ;
 
   OpenTelemetryFormatMap expected = {{"test_key", "\"test_value\""},
                                      {"test_obj", "{\"inner_key\":\"inner_value\"}"}};

--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
@@ -711,7 +711,7 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateTest) {
   StreamInfo::MockStreamInfo stream_info;
   std::string body;
 
-  auto upstream_filter_state =
+  const StreamInfo::FilterStateSharedPtr upstream_filter_state =
       std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Request);
   upstream_filter_state->setData("test_key",
                                  std::make_unique<Router::StringAccessorImpl>("test_value"),
@@ -724,9 +724,9 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateTest) {
   std::shared_ptr<StreamInfo::MockUpstreamInfo> mock_upstream_info =
       std::dynamic_pointer_cast<StreamInfo::MockUpstreamInfo>(stream_info.upstreamInfo());
   EXPECT_CALL(Const(stream_info), upstreamInfo()).Times(testing::AtLeast(1));
-  ON_CALL(Const(*mock_upstream_info.get()), upstreamFilterState())
-      .WillByDefault(ReturnRef(upstream_filter_state));
-  EXPECT_CALL(Const(*mock_upstream_info.get()), upstreamFilterState()).Times(2);
+  EXPECT_CALL(Const(*mock_upstream_info), upstreamFilterState())
+      .Times(2)
+      .WillRepeatedly(ReturnRef(upstream_filter_state));
 
   OpenTelemetryFormatMap expected = {{"test_key", "\"test_value\""},
                                      {"test_obj", "{\"inner_key\":\"inner_value\"}"}};

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_test.cc
@@ -102,11 +102,16 @@ TEST_F(FilterTest, ValidAltSvc) {
       std::make_shared<Network::MockResolvedAddress>("1.2.3.4:443", "1.2.3.4:443");
   Network::MockIp ip;
   std::string hostname = "host1";
-  std::shared_ptr<Upstream::MockHostDescription> hd =
-      std::make_shared<Upstream::MockHostDescription>();
-  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(callbacks_, streamInfo()).Times(2).WillOnce(ReturnRef(stream_info));
-  stream_info.upstreamInfo()->setUpstreamHost(hd);
+  StreamInfo::MockStreamInfo stream_info;
+
+  EXPECT_CALL(callbacks_, streamInfo())
+      .Times(testing::AtLeast(1))
+      .WillRepeatedly(ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, upstreamInfo()).Times(testing::AtLeast(1));
+  // Get the pointer to MockHostDescription.
+  std::shared_ptr<const Upstream::MockHostDescription> hd =
+      std::dynamic_pointer_cast<const Upstream::MockHostDescription>(
+          stream_info.upstreamInfo()->upstreamHost());
   EXPECT_CALL(*hd, hostname()).WillOnce(ReturnRef(hostname));
   EXPECT_CALL(*hd, address()).WillOnce(Return(address));
   EXPECT_CALL(*address, ip()).WillOnce(Return(&ip));

--- a/test/mocks/stream_info/BUILD
+++ b/test/mocks/stream_info/BUILD
@@ -16,6 +16,7 @@ envoy_cc_mock(
         "//envoy/http:request_id_extension_interface",
         "//envoy/stream_info:stream_info_interface",
         "//envoy/upstream:upstream_interface",
+        "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/upstream:host_mocks",
         "//test/test_common:simulated_time_system_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -68,6 +68,8 @@ MockUpstreamInfo::MockUpstreamInfo()
   ON_CALL(*this, upstreamProtocol()).WillByDefault(ReturnPointee(&upstream_protocol_));
 }
 
+MockUpstreamInfo::~MockUpstreamInfo() = default;
+
 MockStreamInfo::MockStreamInfo()
     : start_time_(ts_.systemTime()),
       // upstream
@@ -111,7 +113,12 @@ MockStreamInfo::MockStreamInfo()
           Invoke([this]() -> OptRef<const DownstreamTiming> { return downstream_timing_; }));
   ON_CALL(*this, upstreamInfo()).WillByDefault(Invoke([this]() { return upstream_info_; }));
   ON_CALL(testing::Const(*this), upstreamInfo())
-      .WillByDefault(Invoke([this]() -> OptRef<const UpstreamInfo> { return *upstream_info_; }));
+      .WillByDefault(Invoke([this]() -> OptRef<const UpstreamInfo> {
+        if (!upstream_info_) {
+          return {};
+        }
+        return *upstream_info_;
+      }));
   ON_CALL(*this, downstreamAddressProvider())
       .WillByDefault(ReturnPointee(downstream_connection_info_provider_));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -2,6 +2,8 @@
 
 #include "source/common/network/address_impl.h"
 
+#include "test/mocks/ssl/mocks.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -15,6 +17,58 @@ using testing::ReturnRef;
 namespace Envoy {
 namespace StreamInfo {
 
+MockUpstreamInfo::MockUpstreamInfo()
+    : ssl_connection_info_(std::make_shared<testing::NiceMock<Ssl::MockConnectionInfo>>()),
+      upstream_local_address_(new Network::Address::Ipv4Instance("127.1.2.3", 58443)),
+      upstream_host_(new testing::NiceMock<Upstream::MockHostDescription>()) {
+  ON_CALL(*this, dumpState(_, _)).WillByDefault(Invoke([](std::ostream& os, int indent_level) {
+    os << "MockUpstreamInfo test dumpStatei with indent: " << indent_level << std::endl;
+  }));
+  ON_CALL(*this, setUpstreamConnectionId(_)).WillByDefault(Invoke([this](uint64_t id) {
+    upstream_connection_id_ = id;
+  }));
+  ON_CALL(*this, upstreamConnectionId()).WillByDefault(ReturnPointee(&upstream_connection_id_));
+  ON_CALL(*this, setUpstreamInterfaceName(_))
+      .WillByDefault(
+          Invoke([this](absl::string_view interface_name) { interface_name_ = interface_name; }));
+  ON_CALL(*this, upstreamInterfaceName()).WillByDefault(ReturnPointee(&interface_name_));
+  ON_CALL(*this, setUpstreamSslConnection(_))
+      .WillByDefault(Invoke([this](const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) {
+        ssl_connection_info_ = ssl_connection_info;
+      }));
+  ON_CALL(*this, upstreamSslConnection()).WillByDefault(ReturnPointee(&ssl_connection_info_));
+  ON_CALL(*this, upstreamTiming()).WillByDefault(ReturnRef(upstream_timing_));
+  ON_CALL(Const(*this), upstreamTiming()).WillByDefault(ReturnRef(upstream_timing_));
+  ON_CALL(*this, setUpstreamLocalAddress(_))
+      .WillByDefault(
+          Invoke([this](const Network::Address::InstanceConstSharedPtr& upstream_local_address) {
+            upstream_local_address_ = upstream_local_address;
+          }));
+  ON_CALL(*this, upstreamLocalAddress()).WillByDefault(ReturnRef(upstream_local_address_));
+  ON_CALL(*this, setUpstreamTransportFailureReason(_))
+      .WillByDefault(Invoke([this](absl::string_view failure_reason) {
+        failure_reason_ = std::string(failure_reason);
+      }));
+  ON_CALL(*this, upstreamTransportFailureReason()).WillByDefault(ReturnRef(failure_reason_));
+  ON_CALL(*this, setUpstreamHost(_))
+      .WillByDefault(Invoke([this](Upstream::HostDescriptionConstSharedPtr upstream_host) {
+        upstream_host_ = upstream_host;
+      }));
+  ON_CALL(*this, upstreamHost()).WillByDefault(ReturnPointee(&upstream_host_));
+  ON_CALL(*this, setUpstreamFilterState(_))
+      .WillByDefault(Invoke(
+          [this](const FilterStateSharedPtr& filter_state) { filter_state_ = filter_state; }));
+  ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(filter_state_));
+  ON_CALL(*this, setUpstreamNumStreams(_)).WillByDefault(Invoke([this](uint64_t num_streams) {
+    num_streams_ = num_streams;
+  }));
+  ON_CALL(*this, upstreamNumStreams()).WillByDefault(ReturnPointee(&num_streams_));
+  ON_CALL(*this, setUpstreamProtocol(_)).WillByDefault(Invoke([this](Http::Protocol protocol) {
+    upstream_protocol_ = protocol;
+  }));
+  ON_CALL(*this, upstreamProtocol()).WillByDefault(ReturnPointee(&upstream_protocol_));
+}
+
 MockStreamInfo::MockStreamInfo()
     : start_time_(ts_.systemTime()),
       filter_state_(std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)),
@@ -27,15 +81,7 @@ MockStreamInfo::MockStreamInfo()
   downstream_connection_info_provider_->setDirectRemoteAddressForTest(
       downstream_direct_remote_address);
   // upstream
-  upstream_info_ = std::make_unique<UpstreamInfoImpl>();
-  // upstream:host
-  Upstream::HostDescriptionConstSharedPtr host{
-      new testing::NiceMock<Upstream::MockHostDescription>()};
-  upstream_info_->setUpstreamHost(host);
-  // upstream:local
-  auto upstream_local_address = Network::Address::InstanceConstSharedPtr{
-      new Network::Address::Ipv4Instance("127.1.2.3", 58443)};
-  upstream_info_->setUpstreamLocalAddress(upstream_local_address);
+  upstream_info_ = std::make_shared<testing::NiceMock<MockUpstreamInfo>>();
 
   ON_CALL(*this, setResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag response_flag) {
     response_flags_ |= response_flag;
@@ -65,9 +111,14 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(
           Invoke([this]() -> OptRef<const DownstreamTiming> { return downstream_timing_; }));
   ON_CALL(*this, upstreamInfo()).WillByDefault(Invoke([this]() { return upstream_info_; }));
-  ON_CALL(testing::Const(*this), upstreamInfo()).WillByDefault(Invoke([this]() {
-    return OptRef<const UpstreamInfo>(*upstream_info_);
-  }));
+  ON_CALL(testing::Const(*this), upstreamInfo())
+      .WillByDefault(Invoke([this]() -> OptRef<const UpstreamInfo> {
+        std::shared_ptr<UpstreamInfo> upstream_info = upstreamInfo();
+        if (!upstream_info) {
+          return {};
+        }
+        return *upstream_info;
+      }));
   ON_CALL(*this, downstreamAddressProvider())
       .WillByDefault(ReturnPointee(downstream_connection_info_provider_));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -19,7 +19,7 @@ namespace StreamInfo {
 class MockUpstreamInfo : public UpstreamInfo {
 public:
   MockUpstreamInfo();
-  ~MockUpstreamInfo() override{};
+  ~MockUpstreamInfo() override;
 
   MOCK_METHOD(void, dumpState, (std::ostream & os, int indent_level), (const));
   MOCK_METHOD(void, setUpstreamConnectionId, (uint64_t id));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -16,6 +16,47 @@
 namespace Envoy {
 namespace StreamInfo {
 
+class MockUpstreamInfo : public UpstreamInfo {
+public:
+  MockUpstreamInfo();
+  ~MockUpstreamInfo() override{};
+
+  MOCK_METHOD(void, dumpState, (std::ostream & os, int indent_level), (const));
+  MOCK_METHOD(void, setUpstreamConnectionId, (uint64_t id));
+  MOCK_METHOD(absl::optional<uint64_t>, upstreamConnectionId, (), (const));
+  MOCK_METHOD(void, setUpstreamInterfaceName, (absl::string_view interface_name));
+  MOCK_METHOD(absl::optional<absl::string_view>, upstreamInterfaceName, (), (const));
+  MOCK_METHOD(void, setUpstreamSslConnection,
+              (const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info));
+  MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, upstreamSslConnection, (), (const));
+  MOCK_METHOD(UpstreamTiming&, upstreamTiming, ());
+  MOCK_METHOD(const UpstreamTiming&, upstreamTiming, (), (const));
+  MOCK_METHOD(void, setUpstreamLocalAddress,
+              (const Network::Address::InstanceConstSharedPtr& upstream_local_address));
+  MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, upstreamLocalAddress, (), (const));
+  MOCK_METHOD(void, setUpstreamTransportFailureReason, (absl::string_view failure_reason));
+  MOCK_METHOD(const std::string&, upstreamTransportFailureReason, (), (const));
+  MOCK_METHOD(void, setUpstreamHost, (Upstream::HostDescriptionConstSharedPtr host));
+  MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, upstreamHost, (), (const));
+  MOCK_METHOD(const FilterStateSharedPtr&, upstreamFilterState, (), (const));
+  MOCK_METHOD(void, setUpstreamFilterState, (const FilterStateSharedPtr& filter_state));
+  MOCK_METHOD(void, setUpstreamNumStreams, (uint64_t num_streams));
+  MOCK_METHOD(uint64_t, upstreamNumStreams, (), (const));
+  MOCK_METHOD(void, setUpstreamProtocol, (Http::Protocol protocol));
+  MOCK_METHOD(absl::optional<Http::Protocol>, upstreamProtocol, (), (const));
+
+  absl::optional<uint64_t> upstream_connection_id_;
+  absl::optional<absl::string_view> interface_name_;
+  Ssl::ConnectionInfoConstSharedPtr ssl_connection_info_;
+  UpstreamTiming upstream_timing_;
+  Network::Address::InstanceConstSharedPtr upstream_local_address_;
+  std::string failure_reason_;
+  Upstream::HostDescriptionConstSharedPtr upstream_host_;
+  FilterStateSharedPtr filter_state_;
+  uint64_t num_streams_;
+  absl::optional<Http::Protocol> upstream_protocol_;
+};
+
 class MockStreamInfo : public StreamInfo {
 public:
   MockStreamInfo();


### PR DESCRIPTION
While working on access log formatter for upstream host metadata, I could not simulate error conditions because mock 
for UpstreamInfo was missing.
Commit Message:
Added MockUpstreamInfo implementation and linked it to MockStreamInfo.
Additional Description:
Risk Level: Low
Testing: All existing unit tests are passing.
Docs Changes: No
Release Notes: No 
Platform Specific Features:
