### PR TITLE
contrib-sip-proxy: fix only first record-route add ep

### DIFF
--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -258,7 +258,7 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectRe
   const DirectResponse::ResponseType result = response.encode(metadata, buffer);
 
   ENVOY_CONN_LOG(
-      debug, "send local reply {} --> {} bytes {}\n", read_callbacks_->connection(),
+      debug, "send local reply {} --> {} bytes {}\n{}", read_callbacks_->connection(),
       read_callbacks_->connection().connectionInfoProvider().localAddress()->asStringView(),
       read_callbacks_->connection().connectionInfoProvider().remoteAddress()->asStringView(),
       buffer.length(), buffer.toString());
@@ -386,7 +386,7 @@ FilterStatus ConnectionManager::ResponseDecoder::transportEnd() {
 
   encoder->encode(metadata_, buffer);
 
-  ENVOY_STREAM_LOG(info, "send response {}\n{}", parent_, buffer.length(), buffer.toString());
+  ENVOY_STREAM_LOG(debug, "send response {}\n{}", parent_, buffer.length(), buffer.toString());
   cm.read_callbacks_->connection().write(buffer, false);
 
   cm.stats_.response_.inc();

--- a/contrib/sip_proxy/filters/network/source/decoder.cc
+++ b/contrib/sip_proxy/filters/network/source/decoder.cc
@@ -75,7 +75,6 @@ State DecoderStateMachine::run() {
 Decoder::Decoder(DecoderCallbacks& callbacks) : callbacks_(callbacks) {}
 
 void Decoder::complete() {
-  ENVOY_LOG(trace, "sip message COMPLETE");
   request_.reset();
   metadata_.reset();
   state_machine_ = nullptr;
@@ -85,6 +84,8 @@ void Decoder::complete() {
 
   first_via_ = true;
   first_route_ = true;
+  first_record_route_ = true;
+  first_service_route_ = true;
 }
 
 FilterStatus Decoder::onData(Buffer::Instance& data, bool continue_handling) {
@@ -294,22 +295,6 @@ int Decoder::HeaderHandler::processPCookieIPMap(absl::string_view& header) {
   metadata()->setPCookieIpMap(std::make_pair(std::string(lskpmc), std::string(ip)));
   metadata()->setOperation(Operation(OperationType::Delete, rawOffset(),
                                      DeleteOperationValue(header.length() + strlen("\r\n"))));
-  return 0;
-}
-//
-// 200 OK Header Handler
-//
-int Decoder::OK200HeaderHandler::processCseq(absl::string_view& header) {
-  if (header.find("INVITE") != absl::string_view::npos) {
-    metadata()->setRespMethodType(MethodType::Invite);
-  } else {
-    /**
-     * need to set a value, else when processRecordRoute,
-     * (metadata()->respMethodType() != MethodType::Invite) always false
-     * TODO: need to handle non-invite 200OK
-     */
-    metadata()->setRespMethodType(MethodType::NullMethod);
-  }
   return 0;
 }
 

--- a/contrib/sip_proxy/filters/network/source/decoder.h
+++ b/contrib/sip_proxy/filters/network/source/decoder.h
@@ -255,7 +255,6 @@ private:
   class OK200HeaderHandler : public HeaderHandler {
   public:
     using HeaderHandler::HeaderHandler;
-    int processCseq(absl::string_view& header) override;
   };
 
   class GeneralHeaderHandler : public HeaderHandler {

--- a/contrib/sip_proxy/filters/network/source/metadata.cc
+++ b/contrib/sip_proxy/filters/network/source/metadata.cc
@@ -89,9 +89,10 @@ void MessageMetadata::addEPOperation(
     const std::vector<envoy::extensions::filters::network::sip_proxy::v3alpha::LocalService>&
         local_services) {
   if (header.find(";ep=") != absl::string_view::npos) {
-    // already Contact have ep
+    // already have ep
     return;
   }
+
   auto pos = header.find(">");
   if (pos == absl::string_view::npos) {
     // no url

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -111,9 +111,6 @@ public:
   MethodType methodType() { return method_type_; }
   void setMethodType(MethodType data) { method_type_ = data; }
 
-  MethodType respMethodType() { return resp_method_type_; }
-  void setRespMethodType(MethodType data) { resp_method_type_ = data; }
-
   absl::optional<absl::string_view> ep() { return ep_; }
   void setEP(absl::string_view data) { ep_ = data; }
 
@@ -181,7 +178,6 @@ public:
 private:
   MsgType msg_type_;
   MethodType method_type_;
-  MethodType resp_method_type_;
   std::vector<std::vector<SipHeader>> headers_{HeaderType::HeaderMaxNum};
 
   std::vector<Operation> operation_list_;

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -103,7 +103,6 @@ RouteConstSharedPtr RouteMatcher::route(MessageMetadata& metadata) const {
   for (const auto& route : routes_) {
     RouteConstSharedPtr route_entry = route->matches(metadata);
     if (nullptr != route_entry) {
-      ENVOY_LOG(debug, "route matched!");
       return route_entry;
     }
   }


### PR DESCRIPTION
all sip message in single connection share the same connection manager,
so share the same decoder, the bug is that only the first record-route
will be setted ep, the first-record-route flag should be reset at decode
complete.

Signed-off-by: Felix Du <felix.du@nokia-sbell.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: sip-proxy: fix only first record-route add ep
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
