### PR TITLE
UDP listener filter ECDS experiments---draft only

### DIFF
--- a/envoy/filter/config_provider_manager.h
+++ b/envoy/filter/config_provider_manager.h
@@ -22,6 +22,8 @@ using DynamicFilterConfigProviderPtr = std::unique_ptr<DynamicFilterConfigProvid
 // Listener filter config provider aliases
 using ListenerFilterFactoriesList =
     std::vector<FilterConfigProviderPtr<Network::ListenerFilterFactoryCb>>;
+using UdpListenerFilterFactoriesList =
+    std::vector<FilterConfigProviderPtr<Network::UdpListenerFilterFactoryCb>>;
 
 /**
  * The FilterConfigProviderManager exposes the ability to get an FilterConfigProvider

--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -103,9 +103,9 @@ public:
    * Creates a list of UDP listener filter factories.
    * @param filters supplies the configuration.
    * @param context supplies the factory creation context.
-   * @return std::vector<Network::UdpListenerFilterFactoryCb> the list of filter factories.
+   * @return Filter::UdpListenerFilterFactoriesList the list of filter factories.
    */
-  virtual std::vector<Network::UdpListenerFilterFactoryCb> createUdpListenerFilterFactoryList(
+  virtual Filter::UdpListenerFilterFactoriesList createUdpListenerFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>& filters,
       Configuration::ListenerFactoryContext& context) PURE;
 

--- a/source/extensions/filters/udp/udp_proxy/BUILD
+++ b/source/extensions/filters/udp/udp_proxy/BUILD
@@ -52,6 +52,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":udp_proxy_filter_lib",
         "//envoy/registry",

--- a/source/server/active_udp_listener.cc
+++ b/source/server/active_udp_listener.cc
@@ -113,6 +113,10 @@ ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concu
 }
 
 void ActiveRawUdpListener::onDataWorker(Network::UdpRecvData&& data) {
+  read_filters_.clear();
+  // Create the filter chain on data.
+  config_->filterChainFactory().createUdpListenerFilterChain(*this, *this);
+
   for (auto& read_filter : read_filters_) {
     Network::FilterStatus status = read_filter->onData(data);
     if (status == Network::FilterStatus::StopIteration) {

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -154,10 +154,11 @@ public:
     return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
         filters, context, tcp_listener_config_provider_manager_);
   }
-  std::vector<Network::UdpListenerFilterFactoryCb> createUdpListenerFilterFactoryList(
+  Filter::UdpListenerFilterFactoriesList createUdpListenerFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>& filters,
       Configuration::ListenerFactoryContext& context) override {
-    return ProdListenerComponentFactory::createUdpListenerFilterFactoryListImpl(filters, context);
+    return ProdListenerComponentFactory::createUdpListenerFilterFactoryListImpl(
+        filters, context, udp_listener_config_provider_manager_);
   }
   Network::SocketSharedPtr
   createListenSocket(Network::Address::InstanceConstSharedPtr, Network::Socket::Type,
@@ -236,6 +237,7 @@ private:
   ServerFactoryContextImpl server_contexts_;
   Quic::QuicStatNames quic_stat_names_;
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
+  Filter::UdpListenerFilterConfigProviderManagerImpl udp_listener_config_provider_manager_;
 };
 
 } // namespace Server

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -129,7 +129,6 @@ void FilterChainUtility::buildUdpFilterChain(
     const Filter::UdpListenerFilterFactoriesList& factories,
     Stats::Scope& stats_scope) {
   bool added_missing_config_filter = false;
-  std::cout << "\n Yanjun here 10 buildUdpFilterChain \n" << std::endl;
   for (const auto& filter_config_provider : factories) {
     auto config = filter_config_provider->config();
     if (config.has_value()) {

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -92,7 +92,8 @@ public:
   static void
   buildUdpFilterChain(Network::UdpListenerFilterManager& filter_manager,
                       Network::UdpReadFilterCallbacks& callbacks,
-                      const std::vector<Network::UdpListenerFilterFactoryCb>& factories);
+                      const Filter::UdpListenerFilterFactoriesList& factories,
+                      Stats::Scope& stats_scope);
 };
 
 /**

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -839,7 +839,8 @@ bool ListenerImpl::createListenerFilterChain(Network::ListenerFilterManager& man
 void ListenerImpl::createUdpListenerFilterChain(Network::UdpListenerFilterManager& manager,
                                                 Network::UdpReadFilterCallbacks& callbacks) {
   Configuration::FilterChainUtility::buildUdpFilterChain(manager, callbacks,
-                                                         udp_listener_filter_factories_);
+                                                         udp_listener_filter_factories_,
+                                                         listenerScope());
 }
 
 void ListenerImpl::debugLog(const std::string& message) {

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -440,7 +440,7 @@ private:
   std::unique_ptr<Init::Manager> dynamic_init_manager_;
 
   Filter::ListenerFilterFactoriesList listener_filter_factories_;
-  std::vector<Network::UdpListenerFilterFactoryCb> udp_listener_filter_factories_;
+  Filter::UdpListenerFilterFactoriesList udp_listener_filter_factories_;
   std::vector<AccessLog::InstanceSharedPtr> access_logs_;
   const envoy::config::listener::v3::Listener config_;
   const std::string version_info_;

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -61,9 +61,10 @@ public:
   /**
    * Static worker for createUdpListenerFilterFactoryList() that can be used directly in tests.
    */
-  static std::vector<Network::UdpListenerFilterFactoryCb> createUdpListenerFilterFactoryListImpl(
+  static Filter::UdpListenerFilterFactoriesList createUdpListenerFilterFactoryListImpl(
       const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>& filters,
-      Configuration::ListenerFactoryContext& context);
+      Configuration::ListenerFactoryContext& context,
+      Filter::UdpListenerFilterConfigProviderManagerImpl& config_provider_manager);
 
   static Network::ListenerFilterMatcherSharedPtr
   createListenerFilterMatcher(const envoy::config::listener::v3::ListenerFilter& listener_filter);
@@ -87,10 +88,11 @@ public:
     return createListenerFilterFactoryListImpl(filters, context,
                                                tcp_listener_config_provider_manager_);
   }
-  std::vector<Network::UdpListenerFilterFactoryCb> createUdpListenerFilterFactoryList(
+  Filter::UdpListenerFilterFactoriesList createUdpListenerFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>& filters,
       Configuration::ListenerFactoryContext& context) override {
-    return createUdpListenerFilterFactoryListImpl(filters, context);
+    return createUdpListenerFilterFactoryListImpl(filters, context,
+                                                  udp_listener_config_provider_manager_);
   }
   Network::SocketSharedPtr createListenSocket(
       Network::Address::InstanceConstSharedPtr address, Network::Socket::Type socket_type,
@@ -109,6 +111,7 @@ private:
   Instance& server_;
   uint64_t next_listener_tag_{1};
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
+  Filter::UdpListenerFilterConfigProviderManagerImpl udp_listener_config_provider_manager_;
 };
 
 class ListenerImpl;

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -120,16 +120,16 @@ public:
                 Server::Configuration::ListenerFactoryContext& context)
                 -> Filter::ListenerFilterFactoriesList {
               return Server::ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
-                  filters, context, *component_factory_.getTcpListenerConfigProviderManager());
+                  filters, context, tcp_listener_config_provider_manager_);
             }));
     ON_CALL(component_factory_, createUdpListenerFilterFactoryList(_, _))
         .WillByDefault(Invoke(
             [&](const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
                     filters,
                 Server::Configuration::ListenerFactoryContext& context)
-                -> std::vector<Network::UdpListenerFilterFactoryCb> {
+                -> Filter::UdpListenerFilterFactoriesList {
               return Server::ProdListenerComponentFactory::createUdpListenerFilterFactoryListImpl(
-                  filters, context);
+                  filters, context, udp_listener_config_provider_manager_);
             }));
     ON_CALL(server_, serverFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
 
@@ -161,6 +161,7 @@ public:
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls_};
   NiceMock<Filesystem::MockInstance> file_system_;
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
+  Filter::UdpListenerFilterConfigProviderManagerImpl udp_listener_config_provider_manager_;
 };
 
 void testMerge() {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1245,10 +1245,12 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/filters/udp/udp_proxy:config",
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/integration/filters:test_listener_filter_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/udp/udp_proxy/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/extension/v3:pkg_cc_proto",
     ],

--- a/test/integration/filters/test_listener_filter.cc
+++ b/test/integration/filters/test_listener_filter.cc
@@ -73,11 +73,8 @@ public:
     const auto& message = MessageUtil::downcastAndValidate<
         const test::integration::filters::TestUdpListenerFilterConfig&>(
         proto_config, context.messageValidationVisitor());
-    std::cout << "\n Yanjun Udp Listener factory from proto  here 2 drain_bytes " << message.drain_bytes() << std::endl;
     return [message](Network::UdpListenerFilterManager& filter_manager,
                      Network::UdpReadFilterCallbacks& callbacks) -> void {
-
-      std::cout << "\n Yanjun Udp Listener  proto  here 3 callback  drain_bytes " << message.drain_bytes() << std::endl;
       filter_manager.addReadFilter(std::make_unique<TestUdpListenerFilter>(callbacks, message.drain_bytes()));
     };
   }

--- a/test/integration/filters/test_listener_filter.cc
+++ b/test/integration/filters/test_listener_filter.cc
@@ -67,11 +67,18 @@ class TestUdpInspectorConfigFactory
 public:
   // NamedUdpListenerFilterConfigFactory
   Network::UdpListenerFilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message&,
-                               Server::Configuration::ListenerFactoryContext&) override {
-    return [](Network::UdpListenerFilterManager& filter_manager,
-              Network::UdpReadFilterCallbacks& callbacks) -> void {
-      filter_manager.addReadFilter(std::make_unique<TestUdpListenerFilter>(callbacks));
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               Server::Configuration::ListenerFactoryContext& context) override {
+
+    const auto& message = MessageUtil::downcastAndValidate<
+        const test::integration::filters::TestUdpListenerFilterConfig&>(
+        proto_config, context.messageValidationVisitor());
+    std::cout << "\n Yanjun Udp Listener factory from proto  here 2 drain_bytes " << message.drain_bytes() << std::endl;
+    return [message](Network::UdpListenerFilterManager& filter_manager,
+                     Network::UdpReadFilterCallbacks& callbacks) -> void {
+
+      std::cout << "\n Yanjun Udp Listener  proto  here 3 callback  drain_bytes " << message.drain_bytes() << std::endl;
+      filter_manager.addReadFilter(std::make_unique<TestUdpListenerFilter>(callbacks, message.drain_bytes()));
     };
   }
 

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -64,13 +64,10 @@ private:
 class TestUdpListenerFilter : public Network::UdpListenerReadFilter {
 public:
   TestUdpListenerFilter(Network::UdpReadFilterCallbacks& callbacks, const uint32_t drain_bytes)
-      : UdpListenerReadFilter(callbacks), drain_bytes_(drain_bytes) {
-    std::cout << "\n Yanjun Udp Listener ctor here 0 drain_bytes " << drain_bytes_ << std::endl;
-  }
+      : UdpListenerReadFilter(callbacks), drain_bytes_(drain_bytes) {}
 
   // Network::UdpListenerReadFilter callbacks
   Network::FilterStatus onData(Network::UdpRecvData& data) override {
-    std::cout << "\n Yanjun here 1 Udp Listener drain_bytes " << drain_bytes_ << std::endl;
     if (drain_bytes_ && drain_bytes_ <= data.buffer_->length()) {
       data.buffer_->drain(drain_bytes_);
     }

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -63,16 +63,25 @@ private:
  */
 class TestUdpListenerFilter : public Network::UdpListenerReadFilter {
 public:
-  TestUdpListenerFilter(Network::UdpReadFilterCallbacks& callbacks)
-      : UdpListenerReadFilter(callbacks) {}
+  TestUdpListenerFilter(Network::UdpReadFilterCallbacks& callbacks, const uint32_t drain_bytes)
+      : UdpListenerReadFilter(callbacks), drain_bytes_(drain_bytes) {
+    std::cout << "\n Yanjun Udp Listener ctor here 0 drain_bytes " << drain_bytes_ << std::endl;
+  }
 
   // Network::UdpListenerReadFilter callbacks
-  Network::FilterStatus onData(Network::UdpRecvData&) override {
+  Network::FilterStatus onData(Network::UdpRecvData& data) override {
+    std::cout << "\n Yanjun here 1 Udp Listener drain_bytes " << drain_bytes_ << std::endl;
+    if (drain_bytes_ && drain_bytes_ <= data.buffer_->length()) {
+      data.buffer_->drain(drain_bytes_);
+    }
     return Network::FilterStatus::Continue;
   }
   Network::FilterStatus onReceiveError(Api::IoError::IoErrorCode) override {
     return Network::FilterStatus::Continue;
   }
+
+private:
+  const uint32_t drain_bytes_;
 };
 
 } // namespace Envoy

--- a/test/integration/filters/test_listener_filter.proto
+++ b/test/integration/filters/test_listener_filter.proto
@@ -14,4 +14,5 @@ message TestTcpListenerFilterConfig {
 }
 // Configuration for UDP listener filter test
 message TestUdpListenerFilterConfig {
+ uint32 drain_bytes = 1 [(validate.rules).uint32 = {gte: 2}];
 }

--- a/test/integration/listener_extension_discovery_integration_test.cc
+++ b/test/integration/listener_extension_discovery_integration_test.cc
@@ -268,45 +268,14 @@ TEST_P(ListenerExtensionDiscoveryIntegrationTest, BasicSuccessUdp) {
   test_server_->waitForCounterGe(
       "extension_config_discovery.udp_listener_filter." + filter_name_ + ".config_reload", 1);
 
-  sendUdpDataVerifyResults(2);
+  sendUdpDataVerifyResults(5);
    // Send 2nd config update to have listener filter drain 7 bytes of data.
   sendXdsResponse(filter_name_, "1", 7);
   test_server_->waitForCounterGe(
       "extension_config_discovery.udp_listener_filter." + filter_name_ + ".config_reload", 2);
 
-  sendUdpDataVerifyResults(2);
+  sendUdpDataVerifyResults(7);
 }
-
-
-TEST_P(ListenerExtensionDiscoveryIntegrationTest, BasicSuccessUdpNoDefault) {
-  is_udp_ = true;
-  on_server_init_function_ = [&]() { waitXdsStream(); };
-  addDynamicFilter(filter_name_, false, false);
-  initialize();
-
-  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
-
-  // Send 1st config update to have listener filter drain 5 bytes of data.
-  sendXdsResponse(filter_name_, "1", 5);
-  test_server_->waitForCounterGe(
-      "extension_config_discovery.udp_listener_filter." + filter_name_ + ".config_reload", 1);
-
-  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initialized);
-  const uint32_t port = lookupPort(port_name_);
-  const auto listener_address = Network::Utility::resolveUrl(
-      fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
-
-  Network::Test::UdpSyncPeer client(version_, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
-  std::string request = data_;
-  client.write(request, *listener_address);
-
-   // The extension_listener_config_missing stats counter increases by 1.
-  test_server_->waitForCounterGe("listener.listener_stat.extension_udp_listener_config_missing", 1);
-
-}
-
-
-
 
 TEST_P(ListenerExtensionDiscoveryIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [&]() { waitXdsStream(); };

--- a/test/mocks/server/listener_component_factory.h
+++ b/test/mocks/server/listener_component_factory.h
@@ -33,7 +33,7 @@ public:
   MOCK_METHOD(Filter::ListenerFilterFactoriesList, createListenerFilterFactoryList,
               (const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&,
                Configuration::ListenerFactoryContext& context));
-  MOCK_METHOD(std::vector<Network::UdpListenerFilterFactoryCb>, createUdpListenerFilterFactoryList,
+  MOCK_METHOD(Filter::UdpListenerFilterFactoriesList, createUdpListenerFilterFactoryList,
               (const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&,
                Configuration::ListenerFactoryContext& context));
   MOCK_METHOD(Network::SocketSharedPtr, createListenSocket,

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -4677,7 +4677,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, Metadata) {
                      -> Filter::ListenerFilterFactoriesList {
             listener_factory_context = &context;
             return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
-                filters, context, *listener_factory_.getTcpListenerConfigProviderManager());
+                filters, context, tcp_listener_config_provider_manager_);
           }));
   server_.server_factory_context_->cluster_manager_.initializeClusters({"service_foo"}, {});
   addOrUpdateListener(parseListenerFromV3Yaml(yaml));

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -88,7 +88,7 @@ protected:
                   filters, filter_chain_factory_context);
             }));
     ON_CALL(listener_factory_, getTcpListenerConfigProviderManager())
-        .WillByDefault(Return(&tcp_listener_config_provider_manager_));
+            .WillByDefault(Return(&tcp_listener_config_provider_manager_));
     ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
         .WillByDefault(Invoke(
             [this](const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
@@ -96,16 +96,16 @@ protected:
                    Configuration::ListenerFactoryContext& context)
                 -> Filter::ListenerFilterFactoriesList {
               return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
-                  filters, context, *listener_factory_.getTcpListenerConfigProviderManager());
+                  filters, context, tcp_listener_config_provider_manager_);
             }));
     ON_CALL(listener_factory_, createUdpListenerFilterFactoryList(_, _))
-        .WillByDefault(
-            Invoke([](const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
+        .WillByDefault(Invoke(
+            [this](const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
                           filters,
                       Configuration::ListenerFactoryContext& context)
-                       -> std::vector<Network::UdpListenerFilterFactoryCb> {
-              return ProdListenerComponentFactory::createUdpListenerFilterFactoryListImpl(filters,
-                                                                                          context);
+                       -> Filter::UdpListenerFilterFactoriesList {
+              return ProdListenerComponentFactory::createUdpListenerFilterFactoryListImpl(
+                  filters, context, udp_listener_config_provider_manager_);
             }));
     ON_CALL(listener_factory_, nextListenerTag()).WillByDefault(Invoke([this]() {
       return listener_tag_++;
@@ -367,6 +367,7 @@ protected:
   // Test parameter indicating whether the unified filter chain matcher is enabled.
   bool use_matcher_;
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
+  Filter::UdpListenerFilterConfigProviderManagerImpl udp_listener_config_provider_manager_;
 };
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
UDP listener filter ECDS experiments---draft only

This is continue for issue: https://github.com/envoyproxy/envoy/issues/20049

UDP listener filter chain is created during listener creation. Thus ECDS may not work in UDP listener.

Created this draft PR so folks can discuss on it.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
