### PR TITLE
Fix `--log-format-escaped` to only log one newline per log line

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -74,6 +74,9 @@ minor_behavior_changes:
     This means that encoder filters will be correctly invoked, including adding configured response
     headers, etc. This behavioral change can be reverted by setting runtime guard
     ``envoy.reloadable_features.lua_respond_with_send_local_reply`` to false.
+- area: logging
+  change: |
+    changed flag ``--log-format-escaped`` to only log one trailing newline per log line.
 
 bug_fixes:
 - area: runtime

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -157,7 +157,7 @@ following are the command line options that Envoy supports.
   *(optional)* This flag enables application log sanitization to escape C-style escape sequences.
   This can be used to prevent a single log line from spanning multiple lines in the underlying log.
   This sanitizes all escape sequences in `this list <https://en.cppreference.com/w/cpp/language/escape>`_.
-  Note that each line's trailing whitespace characters (such as EOL characters) will not be escaped.
+  Note that each line's final EOL character will not be escaped to preserve line format.
 
 .. option:: --restart-epoch <integer>
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "source/common/common/json_escape_string.h"
 #include "source/common/common/lock_guard.h"
@@ -126,7 +125,8 @@ std::string DelegatingLogSink::escapeLogLine(absl::string_view msg_view) {
   }
 
   // Log line ends with newline. Escape everything except the EOL to preserve line format.
-  absl::string_view msg_leading = absl::string_view(msg_view.data(), msg_view.size() - eol.length());
+  absl::string_view msg_leading =
+      absl::string_view(msg_view.data(), msg_view.size() - eol.length());
   return absl::StrCat(absl::CEscape(msg_leading), eol);
 }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -124,7 +124,8 @@ std::string DelegatingLogSink::escapeLogLine(absl::string_view msg_view) {
     return absl::CEscape(msg_view);
   }
 
-  // Log line ends with newline. Escape everything except the EOL to preserve line format.
+  // Log line ends with newline. Escape everything except the end-of-line character to preserve line
+  // format.
   absl::string_view msg_leading =
       absl::string_view(msg_view.data(), msg_view.size() - eol.length());
   return absl::StrCat(absl::CEscape(msg_leading), eol);

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "source/common/common/json_escape_string.h"
 #include "source/common/common/lock_guard.h"
@@ -118,14 +119,15 @@ void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
 }
 
 std::string DelegatingLogSink::escapeLogLine(absl::string_view msg_view) {
-  // Split the actual message from the trailing whitespace.
-  auto eol_it = std::find_if_not(msg_view.rbegin(), msg_view.rend(), absl::ascii_isspace);
-  absl::string_view msg_leading = msg_view.substr(0, msg_view.rend() - eol_it);
-  absl::string_view msg_trailing_whitespace =
-      msg_view.substr(msg_view.rend() - eol_it, eol_it - msg_view.rbegin());
+  absl::string_view eol = spdlog::details::os::default_eol;
+  if (!absl::EndsWith(msg_view, eol)) {
+    // Log does not end with newline, escape entire log.
+    return absl::CEscape(msg_view);
+  }
 
-  // Escape the message, but keep the whitespace unescaped.
-  return absl::StrCat(absl::CEscape(msg_leading), msg_trailing_whitespace);
+  // Log line ends with newline. Escape everything except the EOL to preserve line format.
+  absl::string_view msg_leading = absl::string_view(msg_view.data(), msg_view.size() - eol.length());
+  return absl::StrCat(absl::CEscape(msg_leading), eol);
 }
 
 DelegatingLogSinkSharedPtr DelegatingLogSink::init() {

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -15,41 +15,57 @@ using testing::Invoke;
 
 namespace Envoy {
 namespace Logger {
+namespace {
 
 TEST(LoggerTest, StackingStderrSinkDelegate) {
   StderrSinkDelegate stacked(Envoy::Logger::Registry::getSink());
 }
 
 TEST(LoggerEscapeTest, LinuxEOL) {
-  EXPECT_EQ("line 1 \\n line 2\n", DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"));
+  #ifdef _WIN32
+    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"), "line 1 \\n line 2\\n");
+  #else
+    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"), "line 1 \\n line 2\n");
+  #endif
+}
+
+TEST(LoggerEscapeTest, MultipleTrailingLinxEOL) {
+  #ifdef _WIN32
+    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1\n\n"), "line1\\n\\n");
+  #else
+    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1\n\n"), "line1\\n\n");
+  #endif
 }
 
 TEST(LoggerEscapeTest, WindowEOL) {
-  EXPECT_EQ("line 1 \\n line 2\r\n", DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"));
+  #ifdef _WIN32
+    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"), "line 1 \\n line 2\r\n");
+  #else
+    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"), "line 1 \\n line 2\\r\n");
+  #endif
 }
 
 TEST(LoggerEscapeTest, NoTrailingWhitespace) {
-  EXPECT_EQ("line 1 \\n line 2", DelegatingLogSink::escapeLogLine("line 1 \n line 2"));
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2"), "line 1 \\n line 2");
 }
 
 TEST(LoggerEscapeTest, NoWhitespace) {
-  EXPECT_EQ("line1", DelegatingLogSink::escapeLogLine("line1"));
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1"), "line1");
 }
 
 TEST(LoggerEscapeTest, AnyTrailingWhitespace) {
-  EXPECT_EQ("line 1 \\t tab 1 \\n line 2\t\n",
-            DelegatingLogSink::escapeLogLine("line 1 \t tab 1 \n line 2\t\n"));
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \t tab 1 \n line 2\t\t"), "line 1 \\t tab 1 \\n line 2\\t\\t");
 }
 
 TEST(LoggerEscapeTest, WhitespaceOnly) {
   // 8 spaces
-  EXPECT_EQ("        ", DelegatingLogSink::escapeLogLine("        "));
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("        "), "        ");
 
   // Any whitespace characters
-  EXPECT_EQ("\r\n\t \r\n \n", DelegatingLogSink::escapeLogLine("\r\n\t \r\n \n"));
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("\r\n\t \r\n \n\t"), "\\r\\n\\t \\r\\n \\n\\t");
 }
 
-TEST(LoggerEscapeTest, Empty) { EXPECT_EQ("", DelegatingLogSink::escapeLogLine("")); }
+TEST(LoggerEscapeTest, Empty) { EXPECT_EQ(DelegatingLogSink::escapeLogLine(""), ""); }
 
 TEST(JsonEscapeTest, Escape) {
   const auto expect_json_escape = [](absl::string_view to_be_escaped, absl::string_view escaped) {
@@ -248,5 +264,6 @@ TEST(LoggerTest, LogWithLogDetails) {
   ENVOY_LOG_MISC(info, "hello");
 }
 
+} // namespace
 } // namespace Logger
 } // namespace Envoy

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -22,27 +22,27 @@ TEST(LoggerTest, StackingStderrSinkDelegate) {
 }
 
 TEST(LoggerEscapeTest, LinuxEOL) {
-  #ifdef _WIN32
-    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"), "line 1 \\n line 2\\n");
-  #else
-    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"), "line 1 \\n line 2\n");
-  #endif
+#ifdef _WIN32
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"), "line 1 \\n line 2\\n");
+#else
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\n"), "line 1 \\n line 2\n");
+#endif
 }
 
 TEST(LoggerEscapeTest, MultipleTrailingLinxEOL) {
-  #ifdef _WIN32
-    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1\n\n"), "line1\\n\\n");
-  #else
-    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1\n\n"), "line1\\n\n");
-  #endif
+#ifdef _WIN32
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1\n\n"), "line1\\n\\n");
+#else
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line1\n\n"), "line1\\n\n");
+#endif
 }
 
 TEST(LoggerEscapeTest, WindowEOL) {
-  #ifdef _WIN32
-    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"), "line 1 \\n line 2\r\n");
-  #else
-    EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"), "line 1 \\n line 2\\r\n");
-  #endif
+#ifdef _WIN32
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"), "line 1 \\n line 2\r\n");
+#else
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \n line 2\r\n"), "line 1 \\n line 2\\r\n");
+#endif
 }
 
 TEST(LoggerEscapeTest, NoTrailingWhitespace) {
@@ -54,7 +54,8 @@ TEST(LoggerEscapeTest, NoWhitespace) {
 }
 
 TEST(LoggerEscapeTest, AnyTrailingWhitespace) {
-  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \t tab 1 \n line 2\t\t"), "line 1 \\t tab 1 \\n line 2\\t\\t");
+  EXPECT_EQ(DelegatingLogSink::escapeLogLine("line 1 \t tab 1 \n line 2\t\t"),
+            "line 1 \\t tab 1 \\n line 2\\t\\t");
 }
 
 TEST(LoggerEscapeTest, WhitespaceOnly) {


### PR DESCRIPTION
Commit Message: Fix `--log-format-escaped` to only log one newline per log line

Additional Description:

Previously, when a log line contained multiple trailing newline characters, it would result in creating multiple empty lines in the log output. 

For example, `ENVOY_LOG(debug, "message\n message \n\n")` is translated to log line `message\n message \n\n\n`. With `--log-format-escaped` enabled, this is logged as:

```
message\n message



```

Because **all trailing whitespace characters** would not be escaped under the previous implementation. The correct behavior is for all `\n` to be escaped **except** the last one:

```
message\n message\n\n

```

Risk Level: Low

Testing: Unit tests, including platform specific ones

Docs Changes: Updated wording in flag documentation

Release Notes: `--log-format-escaped` now only logs one newline per log line

Platform Specific Features: N/A