### PR TITLE
fuzz test: Improve on no match validation

### DIFF
--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-4870627644801024
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-4870627644801024
@@ -1,0 +1,24 @@
+config {
+  virtual_hosts {
+    name: "2"
+    domains: "*"
+    matcher {
+      on_no_match {
+        action {
+          name: "type.googleapis.com/envoy.config.route.v3.Route"
+          typed_config {
+            type_url: "type.googleapis.com/envoy.config.route.v3.Route"
+            value: "\n\002\n\000r\001Q\212\001\000"
+          }
+        }
+      }
+    }
+  }
+}
+headers {
+  headers {
+    key: "x-forwarded-proto"
+    value: "4"
+  }
+}
+random_value: 262144


### PR DESCRIPTION
Commit Message: fuzz test: Improve on_no_match validation. 
Additional Description:
When fuzzing a routeaction with on_no_match, reject a configuration, if some fields are unset.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a