### PR TITLE
config-plane: Refactoring OpaqueResourceDecoder to be a shared pointer

### DIFF
--- a/envoy/config/grpc_mux.h
+++ b/envoy/config/grpc_mux.h
@@ -100,7 +100,7 @@ public:
   virtual GrpcMuxWatchPtr addWatch(const std::string& type_url,
                                    const absl::flat_hash_set<std::string>& resources,
                                    SubscriptionCallbacks& callbacks,
-                                   OpaqueResourceDecoder& resource_decoder,
+                                   OpaqueResourceDecoderSharedPtr& resource_decoder,
                                    const SubscriptionOptions& options) PURE;
 
   virtual void requestOnDemandUpdate(const std::string& type_url,

--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -83,6 +83,8 @@ public:
   virtual std::string resourceName(const Protobuf::Message& resource) PURE;
 };
 
+using OpaqueResourceDecoderSharedPtr = std::shared_ptr<OpaqueResourceDecoder>;
+
 /**
  * Subscription to DecodedResources.
  */

--- a/envoy/config/subscription_factory.h
+++ b/envoy/config/subscription_factory.h
@@ -39,7 +39,7 @@ public:
   virtual SubscriptionPtr subscriptionFromConfigSource(
       const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
       Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-      OpaqueResourceDecoder& resource_decoder, const SubscriptionOptions& options) PURE;
+      OpaqueResourceDecoderSharedPtr& resource_decoder, const SubscriptionOptions& options) PURE;
 
   /**
    * Collection subscription factory interface for xDS-TP URLs.
@@ -60,7 +60,7 @@ public:
                                 const envoy::config::core::v3::ConfigSource& config,
                                 absl::string_view type_url, Stats::Scope& scope,
                                 SubscriptionCallbacks& callbacks,
-                                OpaqueResourceDecoder& resource_decoder) PURE;
+                                OpaqueResourceDecoderSharedPtr& resource_decoder) PURE;
 };
 
 } // namespace Config

--- a/source/common/config/filesystem_subscription_impl.cc
+++ b/source/common/config/filesystem_subscription_impl.cc
@@ -21,7 +21,7 @@ envoy::config::core::v3::PathConfigSource makePathConfigSource(const std::string
 FilesystemSubscriptionImpl::FilesystemSubscriptionImpl(
     Event::Dispatcher& dispatcher,
     const envoy::config::core::v3::PathConfigSource& path_config_source,
-    SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+    SubscriptionCallbacks& callbacks, OpaqueResourceDecoderSharedPtr& resource_decoder,
     SubscriptionStats stats, ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api)
     : path_(path_config_source.path()), callbacks_(callbacks), resource_decoder_(resource_decoder),
       stats_(stats), api_(api), validation_visitor_(validation_visitor) {
@@ -69,7 +69,7 @@ std::string FilesystemSubscriptionImpl::refreshInternal(ProtobufTypes::MessagePt
   MessageUtil::loadFromFile(path_, message, validation_visitor_, api_);
   *config_update = std::move(owned_message);
   const auto decoded_resources =
-      DecodedResourcesWrapper(resource_decoder_, message.resources(), message.version_info());
+      DecodedResourcesWrapper(*resource_decoder_, message.resources(), message.version_info());
   callbacks_.onConfigUpdate(decoded_resources.refvec_, message.version_info());
   return message.version_info();
 }
@@ -107,7 +107,7 @@ void FilesystemSubscriptionImpl::refresh() {
 FilesystemCollectionSubscriptionImpl::FilesystemCollectionSubscriptionImpl(
     Event::Dispatcher& dispatcher,
     const envoy::config::core::v3::PathConfigSource& path_config_source,
-    SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+    SubscriptionCallbacks& callbacks, OpaqueResourceDecoderSharedPtr& resource_decoder,
     SubscriptionStats stats, ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api)
     : FilesystemSubscriptionImpl(dispatcher, path_config_source, callbacks, resource_decoder, stats,
                                  validation_visitor, api) {}
@@ -150,7 +150,7 @@ FilesystemCollectionSubscriptionImpl::refreshInternal(ProtobufTypes::MessagePtr*
     // TODO(htuch): implement indirect collection entries.
     if (collection_entry.has_inline_entry()) {
       decoded_resources.pushBack(std::make_unique<DecodedResourceImpl>(
-          resource_decoder_, collection_entry.inline_entry()));
+          *resource_decoder_, collection_entry.inline_entry()));
     }
   }
   *config_update = std::move(owned_resource_message);

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -26,7 +26,8 @@ public:
   FilesystemSubscriptionImpl(Event::Dispatcher& dispatcher,
                              const envoy::config::core::v3::PathConfigSource& path_config_source,
                              SubscriptionCallbacks& callbacks,
-                             OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
+                             OpaqueResourceDecoderSharedPtr& resource_decoder,
+                             SubscriptionStats stats,
                              ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api);
 
   // Config::Subscription
@@ -48,7 +49,7 @@ protected:
   std::unique_ptr<Filesystem::Watcher> file_watcher_;
   WatchedDirectoryPtr directory_watcher_;
   SubscriptionCallbacks& callbacks_;
-  OpaqueResourceDecoder& resource_decoder_;
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   SubscriptionStats stats_;
   Api::Api& api_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
@@ -61,7 +62,7 @@ public:
   FilesystemCollectionSubscriptionImpl(
       Event::Dispatcher& dispatcher,
       const envoy::config::core::v3::PathConfigSource& path_config_source,
-      SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+      SubscriptionCallbacks& callbacks, OpaqueResourceDecoderSharedPtr& resource_decoder,
       SubscriptionStats stats, ProtobufMessage::ValidationVisitor& validation_visitor,
       Api::Api& api);
 

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -106,7 +106,7 @@ void GrpcMuxImpl::sendDiscoveryRequest(absl::string_view type_url) {
 GrpcMuxWatchPtr GrpcMuxImpl::addWatch(const std::string& type_url,
                                       const absl::flat_hash_set<std::string>& resources,
                                       SubscriptionCallbacks& callbacks,
-                                      OpaqueResourceDecoder& resource_decoder,
+                                      OpaqueResourceDecoderSharedPtr& resource_decoder,
                                       const SubscriptionOptions&) {
   auto watch =
       std::make_unique<GrpcMuxWatchImpl>(resources, callbacks, resource_decoder, type_url, *this);
@@ -216,7 +216,7 @@ void GrpcMuxImpl::onDiscoveryResponse(
     std::vector<DecodedResourcePtr> resources;
     absl::btree_map<std::string, DecodedResourceRef> resource_ref_map;
     std::vector<DecodedResourceRef> all_resource_refs;
-    OpaqueResourceDecoder& resource_decoder = api_state.watches_.front()->resource_decoder_;
+    OpaqueResourceDecoder& resource_decoder = *api_state.watches_.front()->resource_decoder_;
 
     const auto scoped_ttl_update = api_state.ttl_.scopedTtlUpdate();
 

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -59,7 +59,7 @@ public:
   GrpcMuxWatchPtr addWatch(const std::string& type_url,
                            const absl::flat_hash_set<std::string>& resources,
                            SubscriptionCallbacks& callbacks,
-                           OpaqueResourceDecoder& resource_decoder,
+                           OpaqueResourceDecoderSharedPtr& resource_decoder,
                            const SubscriptionOptions& options) override;
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {
@@ -89,8 +89,9 @@ private:
 
   struct GrpcMuxWatchImpl : public GrpcMuxWatch {
     GrpcMuxWatchImpl(const absl::flat_hash_set<std::string>& resources,
-                     SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
-                     const std::string& type_url, GrpcMuxImpl& parent)
+                     SubscriptionCallbacks& callbacks,
+                     OpaqueResourceDecoderSharedPtr& resource_decoder, const std::string& type_url,
+                     GrpcMuxImpl& parent)
         : callbacks_(callbacks), resource_decoder_(resource_decoder), type_url_(type_url),
           parent_(parent), watches_(parent.apiStateFor(type_url).watches_) {
       std::copy(resources.begin(), resources.end(), std::inserter(resources_, resources_.begin()));
@@ -119,7 +120,7 @@ private:
     // Maintain deterministic wire ordering via ordered std::set.
     std::set<std::string> resources_;
     SubscriptionCallbacks& callbacks_;
-    OpaqueResourceDecoder& resource_decoder_;
+    OpaqueResourceDecoderSharedPtr& resource_decoder_;
     const std::string type_url_;
     GrpcMuxImpl& parent_;
 
@@ -210,7 +211,7 @@ public:
   }
 
   GrpcMuxWatchPtr addWatch(const std::string&, const absl::flat_hash_set<std::string>&,
-                           SubscriptionCallbacks&, OpaqueResourceDecoder&,
+                           SubscriptionCallbacks&, OpaqueResourceDecoderSharedPtr&,
                            const SubscriptionOptions&) override {
     ExceptionUtil::throwEnvoyException("ADS must be configured to support an ADS config source");
   }

--- a/source/common/config/grpc_subscription_impl.cc
+++ b/source/common/config/grpc_subscription_impl.cc
@@ -2,6 +2,8 @@
 
 #include <chrono>
 
+#include "envoy/config/subscription.h"
+
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
@@ -17,7 +19,7 @@ constexpr std::chrono::milliseconds UpdateDurationLogThreshold = std::chrono::mi
 
 GrpcSubscriptionImpl::GrpcSubscriptionImpl(GrpcMuxSharedPtr grpc_mux,
                                            SubscriptionCallbacks& callbacks,
-                                           OpaqueResourceDecoder& resource_decoder,
+                                           OpaqueResourceDecoderSharedPtr& resource_decoder,
                                            SubscriptionStats stats, absl::string_view type_url,
                                            Event::Dispatcher& dispatcher,
                                            std::chrono::milliseconds init_fetch_timeout,
@@ -142,7 +144,7 @@ void GrpcSubscriptionImpl::disableInitFetchTimeoutTimer() {
 
 GrpcCollectionSubscriptionImpl::GrpcCollectionSubscriptionImpl(
     const xds::core::v3::ResourceLocator& collection_locator, GrpcMuxSharedPtr grpc_mux,
-    SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+    SubscriptionCallbacks& callbacks, OpaqueResourceDecoderSharedPtr& resource_decoder,
     SubscriptionStats stats, Event::Dispatcher& dispatcher,
     std::chrono::milliseconds init_fetch_timeout, bool is_aggregated,
     const SubscriptionOptions& options)

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -22,7 +22,7 @@ class GrpcSubscriptionImpl : public Subscription,
                              Logger::Loggable<Logger::Id::config> {
 public:
   GrpcSubscriptionImpl(GrpcMuxSharedPtr grpc_mux, SubscriptionCallbacks& callbacks,
-                       OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
+                       OpaqueResourceDecoderSharedPtr& resource_decoder, SubscriptionStats stats,
                        absl::string_view type_url, Event::Dispatcher& dispatcher,
                        std::chrono::milliseconds init_fetch_timeout, bool is_aggregated,
                        const SubscriptionOptions& options);
@@ -49,7 +49,7 @@ private:
 
   GrpcMuxSharedPtr grpc_mux_;
   SubscriptionCallbacks& callbacks_;
-  OpaqueResourceDecoder& resource_decoder_;
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   SubscriptionStats stats_;
   const std::string type_url_;
   GrpcMuxWatchPtr watch_;
@@ -75,8 +75,8 @@ class GrpcCollectionSubscriptionImpl : public GrpcSubscriptionImpl {
 public:
   GrpcCollectionSubscriptionImpl(const xds::core::v3::ResourceLocator& collection_locator,
                                  GrpcMuxSharedPtr grpc_mux, SubscriptionCallbacks& callbacks,
-                                 OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
-                                 Event::Dispatcher& dispatcher,
+                                 OpaqueResourceDecoderSharedPtr& resource_decoder,
+                                 SubscriptionStats stats, Event::Dispatcher& dispatcher,
                                  std::chrono::milliseconds init_fetch_timeout, bool is_aggregated,
                                  const SubscriptionOptions& options);
 

--- a/source/common/config/http_subscription_impl.cc
+++ b/source/common/config/http_subscription_impl.cc
@@ -25,7 +25,7 @@ HttpSubscriptionImpl::HttpSubscriptionImpl(
     Random::RandomGenerator& random, std::chrono::milliseconds refresh_interval,
     std::chrono::milliseconds request_timeout, const Protobuf::MethodDescriptor& service_method,
     absl::string_view type_url, SubscriptionCallbacks& callbacks,
-    OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
+    OpaqueResourceDecoderSharedPtr& resource_decoder, SubscriptionStats stats,
     std::chrono::milliseconds init_fetch_timeout,
     ProtobufMessage::ValidationVisitor& validation_visitor)
     : Http::RestApiFetcher(cm, remote_cluster_name, dispatcher, random, refresh_interval,
@@ -91,7 +91,7 @@ void HttpSubscriptionImpl::parseResponse(const Http::ResponseMessage& response) 
   }
   TRY_ASSERT_MAIN_THREAD {
     const auto decoded_resources =
-        DecodedResourcesWrapper(resource_decoder_, message.resources(), message.version_info());
+        DecodedResourcesWrapper(*resource_decoder_, message.resources(), message.version_info());
     callbacks_.onConfigUpdate(decoded_resources.refvec_, message.version_info());
     request_.set_version_info(message.version_info());
     stats_.update_time_.set(DateUtil::nowToMilliseconds(dispatcher_.timeSource()));

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -27,8 +27,9 @@ public:
                        Random::RandomGenerator& random, std::chrono::milliseconds refresh_interval,
                        std::chrono::milliseconds request_timeout,
                        const Protobuf::MethodDescriptor& service_method, absl::string_view type_url,
-                       SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
-                       SubscriptionStats stats, std::chrono::milliseconds init_fetch_timeout,
+                       SubscriptionCallbacks& callbacks,
+                       OpaqueResourceDecoderSharedPtr& resource_decoder, SubscriptionStats stats,
+                       std::chrono::milliseconds init_fetch_timeout,
                        ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // Config::Subscription
@@ -53,7 +54,7 @@ private:
   Protobuf::RepeatedPtrField<std::string> resources_;
   envoy::service::discovery::v3::DiscoveryRequest request_;
   Config::SubscriptionCallbacks& callbacks_;
-  Config::OpaqueResourceDecoder& resource_decoder_;
+  Config::OpaqueResourceDecoderSharedPtr resource_decoder_;
   SubscriptionStats stats_;
   Event::Dispatcher& dispatcher_;
   std::chrono::milliseconds init_fetch_timeout_;

--- a/source/common/config/new_grpc_mux_impl.cc
+++ b/source/common/config/new_grpc_mux_impl.cc
@@ -154,7 +154,7 @@ void NewGrpcMuxImpl::start() { grpc_stream_.establishNewStream(); }
 GrpcMuxWatchPtr NewGrpcMuxImpl::addWatch(const std::string& type_url,
                                          const absl::flat_hash_set<std::string>& resources,
                                          SubscriptionCallbacks& callbacks,
-                                         OpaqueResourceDecoder& resource_decoder,
+                                         OpaqueResourceDecoderSharedPtr& resource_decoder,
                                          const SubscriptionOptions& options) {
   auto entry = subscriptions_.find(type_url);
   if (entry == subscriptions_.end()) {
@@ -163,7 +163,7 @@ GrpcMuxWatchPtr NewGrpcMuxImpl::addWatch(const std::string& type_url,
     return addWatch(type_url, resources, callbacks, resource_decoder, options);
   }
 
-  Watch* watch = entry->second->watch_map_.addWatch(callbacks, resource_decoder);
+  Watch* watch = entry->second->watch_map_.addWatch(callbacks, *resource_decoder);
   // updateWatch() queues a discovery request if any of 'resources' are not yet subscribed.
   updateWatch(type_url, watch, resources, options);
   return std::make_unique<WatchImpl>(type_url, watch, *this, options);

--- a/source/common/config/new_grpc_mux_impl.h
+++ b/source/common/config/new_grpc_mux_impl.h
@@ -50,7 +50,7 @@ public:
   GrpcMuxWatchPtr addWatch(const std::string& type_url,
                            const absl::flat_hash_set<std::string>& resources,
                            SubscriptionCallbacks& callbacks,
-                           OpaqueResourceDecoder& resource_decoder,
+                           OpaqueResourceDecoderSharedPtr& resource_decoder,
                            const SubscriptionOptions& options) override;
 
   void requestOnDemandUpdate(const std::string& type_url,

--- a/source/common/config/subscription_base.h
+++ b/source/common/config/subscription_base.h
@@ -12,12 +12,13 @@ template <typename Current> struct SubscriptionBase : public Config::Subscriptio
 public:
   SubscriptionBase(ProtobufMessage::ValidationVisitor& validation_visitor,
                    absl::string_view name_field)
-      : resource_decoder_(validation_visitor, name_field) {}
+      : resource_decoder_(std::make_shared<Config::OpaqueResourceDecoderImpl<Current>>(
+            validation_visitor, name_field)) {}
 
   std::string getResourceName() const { return Envoy::Config::getResourceName<Current>(); }
 
 protected:
-  Config::OpaqueResourceDecoderImpl<Current> resource_decoder_;
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
 };
 
 } // namespace Config

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -28,8 +28,8 @@ SubscriptionFactoryImpl::SubscriptionFactoryImpl(
 
 SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
     const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
-    Stats::Scope& scope, SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
-    const SubscriptionOptions& options) {
+    Stats::Scope& scope, SubscriptionCallbacks& callbacks,
+    OpaqueResourceDecoderSharedPtr& resource_decoder, const SubscriptionOptions& options) {
   Config::Utility::checkLocalInfo(type_url, local_info_);
   SubscriptionStats stats = Utility::generateStats(scope);
 
@@ -145,7 +145,7 @@ SubscriptionPtr SubscriptionFactoryImpl::collectionSubscriptionFromUrl(
     const xds::core::v3::ResourceLocator& collection_locator,
     const envoy::config::core::v3::ConfigSource& config, absl::string_view resource_type,
     Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-    OpaqueResourceDecoder& resource_decoder) {
+    OpaqueResourceDecoderSharedPtr& resource_decoder) {
   SubscriptionStats stats = Utility::generateStats(scope);
 
   switch (collection_locator.scheme()) {

--- a/source/common/config/subscription_factory_impl.h
+++ b/source/common/config/subscription_factory_impl.h
@@ -25,14 +25,14 @@ public:
   SubscriptionPtr subscriptionFromConfigSource(const envoy::config::core::v3::ConfigSource& config,
                                                absl::string_view type_url, Stats::Scope& scope,
                                                SubscriptionCallbacks& callbacks,
-                                               OpaqueResourceDecoder& resource_decoder,
+                                               OpaqueResourceDecoderSharedPtr& resource_decoder,
                                                const SubscriptionOptions& options) override;
   SubscriptionPtr
   collectionSubscriptionFromUrl(const xds::core::v3::ResourceLocator& collection_locator,
                                 const envoy::config::core::v3::ConfigSource& config,
                                 absl::string_view resource_type, Stats::Scope& scope,
                                 SubscriptionCallbacks& callbacks,
-                                OpaqueResourceDecoder& resource_decoder) override;
+                                OpaqueResourceDecoderSharedPtr& resource_decoder) override;
 
 private:
   const LocalInfo::LocalInfo& local_info_;

--- a/source/common/config/xds_mux/delta_subscription_state.h
+++ b/source/common/config/xds_mux/delta_subscription_state.h
@@ -114,7 +114,7 @@ public:
   ~DeltaSubscriptionStateFactory() override = default;
   std::unique_ptr<DeltaSubscriptionState>
   makeSubscriptionState(const std::string& type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        OpaqueResourceDecoder&) override {
+                        OpaqueResourceDecoderSharedPtr&) override {
     return std::make_unique<DeltaSubscriptionState>(type_url, callbacks, dispatcher_);
   }
 

--- a/source/common/config/xds_mux/grpc_mux_impl.cc
+++ b/source/common/config/xds_mux/grpc_mux_impl.cc
@@ -77,7 +77,7 @@ void GrpcMuxImpl<S, F, RQ, RS>::onDynamicContextUpdate(absl::string_view resourc
 template <class S, class F, class RQ, class RS>
 Config::GrpcMuxWatchPtr GrpcMuxImpl<S, F, RQ, RS>::addWatch(
     const std::string& type_url, const absl::flat_hash_set<std::string>& resources,
-    SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+    SubscriptionCallbacks& callbacks, OpaqueResourceDecoderSharedPtr& resource_decoder,
     const SubscriptionOptions& options) {
   auto watch_map = watch_maps_.find(type_url);
   if (watch_map == watch_maps_.end()) {
@@ -92,7 +92,7 @@ Config::GrpcMuxWatchPtr GrpcMuxImpl<S, F, RQ, RS>::addWatch(
     subscription_ordering_.emplace_back(type_url);
   }
 
-  Watch* watch = watch_map->second->addWatch(callbacks, resource_decoder);
+  Watch* watch = watch_map->second->addWatch(callbacks, *resource_decoder);
   // updateWatch() queues a discovery request if any of 'resources' are not yet subscribed.
   updateWatch(type_url, watch, resources, options);
   return std::make_unique<WatchImpl>(type_url, watch, *this, options);
@@ -389,7 +389,8 @@ GrpcMuxSotw::GrpcMuxSotw(Grpc::RawAsyncClientPtr&& async_client, Event::Dispatch
 
 Config::GrpcMuxWatchPtr NullGrpcMuxImpl::addWatch(const std::string&,
                                                   const absl::flat_hash_set<std::string>&,
-                                                  SubscriptionCallbacks&, OpaqueResourceDecoder&,
+                                                  SubscriptionCallbacks&,
+                                                  OpaqueResourceDecoderSharedPtr&,
                                                   const SubscriptionOptions&) {
   throw EnvoyException("ADS must be configured to support an ADS config source");
 }

--- a/source/common/config/xds_mux/grpc_mux_impl.h
+++ b/source/common/config/xds_mux/grpc_mux_impl.h
@@ -81,7 +81,7 @@ public:
   Config::GrpcMuxWatchPtr addWatch(const std::string& type_url,
                                    const absl::flat_hash_set<std::string>& resources,
                                    SubscriptionCallbacks& callbacks,
-                                   OpaqueResourceDecoder& resource_decoder,
+                                   OpaqueResourceDecoderSharedPtr& resource_decoder,
                                    const SubscriptionOptions& options) override;
   void updateWatch(const std::string& type_url, Watch* watch,
                    const absl::flat_hash_set<std::string>& resources,
@@ -252,7 +252,7 @@ public:
   }
 
   Config::GrpcMuxWatchPtr addWatch(const std::string&, const absl::flat_hash_set<std::string>&,
-                                   SubscriptionCallbacks&, OpaqueResourceDecoder&,
+                                   SubscriptionCallbacks&, OpaqueResourceDecoderSharedPtr&,
                                    const SubscriptionOptions&) override;
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {

--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -9,7 +9,7 @@ namespace XdsMux {
 SotwSubscriptionState::SotwSubscriptionState(std::string type_url,
                                              UntypedConfigUpdateCallbacks& callbacks,
                                              Event::Dispatcher& dispatcher,
-                                             OpaqueResourceDecoder& resource_decoder)
+                                             OpaqueResourceDecoderSharedPtr& resource_decoder)
     : BaseSubscriptionState(std::move(type_url), callbacks, dispatcher),
       resource_decoder_(resource_decoder) {}
 
@@ -59,7 +59,7 @@ void SotwSubscriptionState::handleGoodResponse(
       }
 
       auto decoded_resource =
-          DecodedResourceImpl::fromResource(resource_decoder_, any, message.version_info());
+          DecodedResourceImpl::fromResource(*resource_decoder_, any, message.version_info());
       setResourceTtl(*decoded_resource);
       if (isHeartbeatResource(*decoded_resource, message.version_info())) {
         continue;

--- a/source/common/config/xds_mux/sotw_subscription_state.h
+++ b/source/common/config/xds_mux/sotw_subscription_state.h
@@ -21,7 +21,8 @@ class SotwSubscriptionState
 public:
   // Note that, outside of tests, we expect callbacks to always be a WatchMap.
   SotwSubscriptionState(std::string type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        Event::Dispatcher& dispatcher, OpaqueResourceDecoder& resource_decoder);
+                        Event::Dispatcher& dispatcher,
+                        OpaqueResourceDecoderSharedPtr& resource_decoder);
   ~SotwSubscriptionState() override;
 
   // Update which resources we're interested in subscribing to.
@@ -46,7 +47,7 @@ private:
   void setResourceTtl(const DecodedResourceImpl& decoded_resource);
   bool isHeartbeatResource(const DecodedResource& resource, const std::string& version);
 
-  OpaqueResourceDecoder& resource_decoder_;
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
 
   // The version_info carried by the last accepted DiscoveryResponse.
   // Remains empty until one is accepted.
@@ -68,7 +69,7 @@ public:
   ~SotwSubscriptionStateFactory() override = default;
   std::unique_ptr<SotwSubscriptionState>
   makeSubscriptionState(const std::string& type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        OpaqueResourceDecoder& resource_decoder) override {
+                        OpaqueResourceDecoderSharedPtr& resource_decoder) override {
     return std::make_unique<SotwSubscriptionState>(type_url, callbacks, dispatcher_,
                                                    resource_decoder);
   }

--- a/source/common/config/xds_mux/subscription_state.h
+++ b/source/common/config/xds_mux/subscription_state.h
@@ -121,9 +121,9 @@ template <class T> class SubscriptionStateFactory {
 public:
   virtual ~SubscriptionStateFactory() = default;
   // Note that, outside of tests, we expect callbacks to always be a WatchMap.
-  virtual std::unique_ptr<T> makeSubscriptionState(const std::string& type_url,
-                                                   UntypedConfigUpdateCallbacks& callbacks,
-                                                   OpaqueResourceDecoder& resource_decoder) PURE;
+  virtual std::unique_ptr<T>
+  makeSubscriptionState(const std::string& type_url, UntypedConfigUpdateCallbacks& callbacks,
+                        OpaqueResourceDecoderSharedPtr& resource_decoder) PURE;
 };
 
 } // namespace XdsMux

--- a/source/common/rds/common/route_config_provider_manager_impl.h
+++ b/source/common/rds/common/route_config_provider_manager_impl.h
@@ -49,7 +49,7 @@ public:
           auto config_update = std::make_unique<RouteConfigUpdateReceiverImpl>(
               config_traits_, proto_traits_, factory_context);
           auto resource_decoder =
-              std::make_unique<Envoy::Config::OpaqueResourceDecoderImpl<RouteConfiguration>>(
+              std::make_shared<Envoy::Config::OpaqueResourceDecoderImpl<RouteConfiguration>>(
                   factory_context.messageValidationContext().dynamicValidationVisitor(),
                   getNameFieldName());
           auto subscription = std::make_shared<RdsRouteConfigSubscription>(

--- a/source/common/rds/rds_route_config_subscription.cc
+++ b/source/common/rds/rds_route_config_subscription.cc
@@ -8,7 +8,7 @@ namespace Rds {
 
 RdsRouteConfigSubscription::RdsRouteConfigSubscription(
     RouteConfigUpdatePtr&& config_update,
-    std::unique_ptr<Envoy::Config::OpaqueResourceDecoder>&& resource_decoder,
+    Envoy::Config::OpaqueResourceDecoderSharedPtr&& resource_decoder,
     const envoy::config::core::v3::ConfigSource& config_source,
     const std::string& route_config_name, const uint64_t manager_identifier,
     Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
@@ -34,7 +34,7 @@ RdsRouteConfigSubscription::RdsRouteConfigSubscription(
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
           config_source, Envoy::Grpc::Common::typeUrl(resource_type), *scope_, *this,
-          *resource_decoder_, {});
+          resource_decoder_, {});
   local_init_manager_.add(local_init_target_);
 }
 

--- a/source/common/rds/rds_route_config_subscription.h
+++ b/source/common/rds/rds_route_config_subscription.h
@@ -43,13 +43,14 @@ struct RdsStats {
 class RdsRouteConfigSubscription : Envoy::Config::SubscriptionCallbacks,
                                    protected Logger::Loggable<Logger::Id::rds> {
 public:
-  RdsRouteConfigSubscription(
-      RouteConfigUpdatePtr&& config_update,
-      std::unique_ptr<Envoy::Config::OpaqueResourceDecoder>&& resource_decoder,
-      const envoy::config::core::v3::ConfigSource& config_source,
-      const std::string& route_config_name, const uint64_t manager_identifier,
-      Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
-      const std::string& rds_type, RouteConfigProviderManager& route_config_provider_manager);
+  RdsRouteConfigSubscription(RouteConfigUpdatePtr&& config_update,
+                             Envoy::Config::OpaqueResourceDecoderSharedPtr&& resource_decoder,
+                             const envoy::config::core::v3::ConfigSource& config_source,
+                             const std::string& route_config_name,
+                             const uint64_t manager_identifier,
+                             Server::Configuration::ServerFactoryContext& factory_context,
+                             const std::string& stat_prefix, const std::string& rds_type,
+                             RouteConfigProviderManager& route_config_provider_manager);
 
   ~RdsRouteConfigSubscription() override;
 
@@ -99,7 +100,7 @@ protected:
   const uint64_t manager_identifier_;
   absl::optional<RouteConfigProvider*> route_config_provider_opt_;
   RouteConfigUpdatePtr config_update_info_;
-  std::unique_ptr<Envoy::Config::OpaqueResourceDecoder> resource_decoder_;
+  Envoy::Config::OpaqueResourceDecoderSharedPtr resource_decoder_;
 };
 
 using RdsRouteConfigSubscriptionSharedPtr = std::shared_ptr<RdsRouteConfigSubscription>;

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -75,7 +75,7 @@ ConfigConstSharedPtr StaticRouteConfigProviderImpl::configCast() const {
 // TODO(htuch): If support for multiple clusters is added per #1170 cluster_name_
 RdsRouteConfigSubscription::RdsRouteConfigSubscription(
     RouteConfigUpdatePtr&& config_update,
-    std::unique_ptr<Envoy::Config::OpaqueResourceDecoder>&& resource_decoder,
+    Envoy::Config::OpaqueResourceDecoderSharedPtr&& resource_decoder,
     const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
     const uint64_t manager_identifier, Server::Configuration::ServerFactoryContext& factory_context,
     const std::string& stat_prefix, Rds::RouteConfigProviderManager& route_config_provider_manager)
@@ -233,7 +233,7 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::createRdsRo
        this](uint64_t manager_identifier) {
         auto config_update = std::make_unique<RouteConfigUpdateReceiverImpl>(
             proto_traits_, factory_context, optional_http_filters);
-        auto resource_decoder = std::make_unique<
+        auto resource_decoder = std::make_shared<
             Envoy::Config::OpaqueResourceDecoderImpl<envoy::config::route::v3::RouteConfiguration>>(
             factory_context.messageValidationContext().dynamicValidationVisitor(), "name");
         auto subscription = std::make_shared<RdsRouteConfigSubscription>(

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -99,7 +99,7 @@ class RdsRouteConfigSubscription : public Rds::RdsRouteConfigSubscription {
 public:
   RdsRouteConfigSubscription(
       RouteConfigUpdatePtr&& config_update,
-      std::unique_ptr<Envoy::Config::OpaqueResourceDecoder>&& resource_decoder,
+      Envoy::Config::OpaqueResourceDecoderSharedPtr&& resource_decoder,
       const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
       const uint64_t manager_identifier,
       Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -280,7 +280,7 @@ void EdsClusterImpl::onAssignmentTimeout() {
   ProtobufWkt::Any any_resource;
   any_resource.PackFrom(resource);
   auto decoded_resource =
-      Config::DecodedResourceImpl::fromResource(resource_decoder_, any_resource, "");
+      Config::DecodedResourceImpl::fromResource(*resource_decoder_, any_resource, "");
   std::vector<Config::DecodedResourceRef> resource_refs = {*decoded_resource};
   onConfigUpdate(resource_refs, "");
   // Stat to track how often we end up with stale assignments.

--- a/test/common/config/delta_subscription_impl_test.cc
+++ b/test/common/config/delta_subscription_impl_test.cc
@@ -140,7 +140,8 @@ TEST_P(DeltaSubscriptionNoGrpcStreamTest, NoGrpcStream) {
   NiceMock<Random::MockRandomGenerator> random;
   Envoy::Config::RateLimitSettings rate_limit_settings;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks;
-  NiceMock<Config::MockOpaqueResourceDecoder> resource_decoder;
+  OpaqueResourceDecoderSharedPtr resource_decoder(
+      std::make_shared<NiceMock<Config::MockOpaqueResourceDecoder>>());
   auto* async_client = new Grpc::MockAsyncClient();
 
   const Protobuf::MethodDescriptor* method_descriptor =

--- a/test/common/config/delta_subscription_test_harness.h
+++ b/test/common/config/delta_subscription_test_harness.h
@@ -41,6 +41,8 @@ public:
       : method_descriptor_(Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.endpoint.v3.EndpointDiscoveryService.StreamEndpoints")),
         async_client_(new Grpc::MockAsyncClient()),
+        resource_decoder_(std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+                              envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")),
         should_use_unified_(legacy_or_unified == Envoy::Config::LegacyOrUnified::Unified) {
     node_.set_id("fo0");
     EXPECT_CALL(local_info_, node()).WillRepeatedly(testing::ReturnRef(node_));
@@ -227,8 +229,7 @@ public:
   Event::MockTimer* init_timeout_timer_;
   envoy::config::core::v3::Node node_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   std::queue<std::string> nonce_acks_required_;
   std::queue<std::string> nonce_acks_sent_;
   bool subscription_started_{};

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -34,6 +34,8 @@ public:
   FilesystemSubscriptionTestHarness()
       : path_(makePathConfigSource(TestEnvironment::temporaryPath("eds.json"))),
         api_(Api::createApiForTest(stats_store_, simTime())), dispatcher_(setupDispatcher()),
+        resource_decoder_(std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+                              envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")),
         subscription_(*dispatcher_, path_, callbacks_, resource_decoder_, stats_,
                       validation_visitor_, *api_) {}
 
@@ -133,8 +135,7 @@ public:
   Event::DispatcherPtr dispatcher_;
   Filesystem::Watcher::OnChangedCb on_changed_cb_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   FilesystemSubscriptionImpl subscription_;
   bool file_at_start_{false};
 };

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -44,6 +44,8 @@ public:
       : method_descriptor_(Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.endpoint.v3.EndpointDiscoveryService.StreamEndpoints")),
         async_client_(new NiceMock<Grpc::MockAsyncClient>()),
+        resource_decoder_(std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+                              envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")),
         config_validators_(std::make_unique<NiceMock<MockCustomConfigValidators>>()),
         should_use_unified_(legacy_or_unified == Envoy::Config::LegacyOrUnified::Unified) {
     node_.set_id("fo0");
@@ -221,8 +223,7 @@ public:
   Event::MockTimer* ttl_timer_;
   envoy::config::core::v3::Node node_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   CustomConfigValidatorsPtr config_validators_;
   NiceMock<Grpc::MockAsyncStream> async_stream_;

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -42,7 +42,10 @@ public:
   HttpSubscriptionTestHarness(std::chrono::milliseconds init_fetch_timeout)
       : method_descriptor_(Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.endpoint.v3.EndpointDiscoveryService.FetchEndpoints")),
-        timer_(new Event::MockTimer()), http_request_(&cm_.thread_local_cluster_.async_client_) {
+        timer_(new Event::MockTimer()), http_request_(&cm_.thread_local_cluster_.async_client_),
+        resource_decoder_(
+            std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+                envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")) {
     node_.set_id("fo0");
     EXPECT_CALL(local_info_, node()).WillOnce(testing::ReturnRef(node_));
     EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([this](Event::TimerCb timer_cb) {
@@ -199,8 +202,7 @@ public:
   Http::MockAsyncClientRequest http_request_;
   Http::AsyncClient::Callbacks* http_callbacks_;
   Config::MockSubscriptionCallbacks callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   std::unique_ptr<HttpSubscriptionImpl> subscription_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   Event::MockTimer* init_timeout_timer_;

--- a/test/common/config/new_grpc_mux_impl_test.cc
+++ b/test/common/config/new_grpc_mux_impl_test.cc
@@ -52,6 +52,8 @@ public:
   NewGrpcMuxImplTestBase(LegacyOrUnified legacy_or_unified)
       : async_client_(new Grpc::MockAsyncClient()),
         config_validators_(std::make_unique<NiceMock<MockCustomConfigValidators>>()),
+        resource_decoder_(std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+                              envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")),
         control_plane_stats_(Utility::generateControlPlaneStats(stats_)),
         control_plane_connected_state_(
             stats_.gauge("control_plane.connected_state", Stats::Gauge::ImportMode::NeverImport)),
@@ -157,8 +159,7 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   std::unique_ptr<GrpcMux> grpc_mux_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   Stats::TestUtil::TestStore stats_;
   Envoy::Config::RateLimitSettings rate_limit_settings_;
   ControlPlaneStats control_plane_stats_;

--- a/test/common/config/sotw_subscription_state_test.cc
+++ b/test/common/config/sotw_subscription_state_test.cc
@@ -26,7 +26,10 @@ namespace {
 
 class SotwSubscriptionStateTest : public testing::Test {
 protected:
-  SotwSubscriptionStateTest() : resource_decoder_("cluster_name") {
+  SotwSubscriptionStateTest()
+      : resource_decoder_(
+            std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+                envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")) {
     ttl_timer_ = new Event::MockTimer(&dispatcher_);
     state_ = std::make_unique<XdsMux::SotwSubscriptionState>(
         Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>(), callbacks_,
@@ -104,8 +107,7 @@ protected:
   }
 
   NiceMock<MockUntypedConfigUpdateCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_;
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   Event::MockTimer* ttl_timer_;
   // We start out interested in three resources: name1, name2, and name3.

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -42,7 +42,8 @@ enum class LegacyOrUnified { Legacy, Unified };
 class SubscriptionFactoryTest : public testing::Test {
 public:
   SubscriptionFactoryTest()
-      : http_request_(&cm_.thread_local_cluster_.async_client_),
+      : resource_decoder_(std::make_shared<MockOpaqueResourceDecoder>()),
+        http_request_(&cm_.thread_local_cluster_.async_client_),
         api_(Api::createApiForTest(stats_store_, random_)),
         subscription_factory_(local_info_, dispatcher_, cm_, validation_visitor_, *api_, server_) {}
 
@@ -66,7 +67,7 @@ public:
   Event::MockDispatcher dispatcher_;
   NiceMock<Random::MockRandomGenerator> random_;
   MockSubscriptionCallbacks callbacks_;
-  MockOpaqueResourceDecoder resource_decoder_;
+  OpaqueResourceDecoderSharedPtr resource_decoder_;
   Http::MockAsyncClientRequest http_request_;
   Stats::MockIsolatedStatsStore stats_store_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;

--- a/test/common/config/xds_grpc_mux_impl_test.cc
+++ b/test/common/config/xds_grpc_mux_impl_test.cc
@@ -110,7 +110,7 @@ public:
   Config::GrpcMuxWatchPtr makeWatch(const std::string& type_url,
                                     const absl::flat_hash_set<std::string>& resources,
                                     NiceMock<MockSubscriptionCallbacks>& callbacks,
-                                    Config::OpaqueResourceDecoder& resource_decoder) {
+                                    Config::OpaqueResourceDecoderSharedPtr& resource_decoder) {
     return grpc_mux_->addWatch(type_url, resources, callbacks, resource_decoder, {});
   }
 
@@ -122,8 +122,9 @@ public:
   CustomConfigValidatorsPtr config_validators_;
   std::unique_ptr<XdsMux::GrpcMuxSotw> grpc_mux_;
   NiceMock<MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder_{
+      std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+          envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")};
   Stats::TestUtil::TestStore stats_;
   ControlPlaneStats control_plane_stats_;
   Envoy::Config::RateLimitSettings rate_limit_settings_;
@@ -345,8 +346,9 @@ TEST_F(GrpcMuxImplTest, ResourceTTL) {
 
   time_system_.setSystemTime(std::chrono::seconds(0));
 
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder("cluster_name");
+  OpaqueResourceDecoderSharedPtr resource_decoder(
+      std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+          envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name"));
   const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
   InSequence s;
   auto* ttl_timer = new Event::MockTimer(&dispatcher_);
@@ -913,6 +915,87 @@ TEST_F(GrpcMuxImplTest, BadLocalInfoEmptyNodeName) {
       "--service-node and --service-cluster options.");
 }
 
+// Validate that a valid resource decoder is used after removing a subscription.
+TEST_F(GrpcMuxImplTest, ValidResourceDecoderAfterRemoval) {
+  setup();
+  const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
+
+  {
+    // Subscribe to resource "x" with some callbacks and resource decoder.
+    NiceMock<MockSubscriptionCallbacks> foo_callbacks;
+    OpaqueResourceDecoderSharedPtr foo_decoder(
+        std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+            envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name"));
+    // TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
+    //    foo_decoder{"cluster_name"};
+    auto foo_sub = makeWatch(type_url, {"x"}, foo_callbacks, foo_decoder);
+
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
+    expectSendMessage(type_url, {"x"}, "", true);
+    grpc_mux_->start();
+
+    // Send just x; only foo_callbacks should receive an onConfigUpdate(),
+    // and foo_decoder should be invoked.
+    {
+      auto response = std::make_unique<envoy::service::discovery::v3::DiscoveryResponse>();
+      response->set_type_url(type_url);
+      response->set_version_info("1");
+      envoy::config::endpoint::v3::ClusterLoadAssignment load_assignment;
+      load_assignment.set_cluster_name("x");
+      response->add_resources()->PackFrom(load_assignment);
+      EXPECT_CALL(foo_callbacks, onConfigUpdate(_, "1"))
+          .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
+                                              const std::string&) {
+            EXPECT_EQ(1, resources.size());
+            const auto& expected_assignment =
+                dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+                    resources[0].get().resource());
+            EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
+          }));
+      expectSendMessage(type_url, {"x"}, "1");
+      grpc_mux_->onDiscoveryResponse(std::move(response), control_plane_stats_);
+    }
+
+    expectSendMessage(type_url, {}, "1");
+  }
+  // foo_sub no longer valid, watcher was removed, and foo_decoder no longer valid.
+
+  // Subscribe to resource "y" with other callbacks and resource decoder.
+  std::cerr << "ADI: Subscribing to y" << std::endl;
+  NiceMock<MockSubscriptionCallbacks> bar_callbacks;
+  OpaqueResourceDecoderSharedPtr bar_decoder(
+      std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+          envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name"));
+  // TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
+  //    bar_decoder{"cluster_name"};
+  expectSendMessage(type_url, {"y"}, "1");
+  auto bar_sub = makeWatch(type_url, {"y"}, bar_callbacks, bar_decoder);
+
+  // Send y; only bar_callbacks should receive an onConfigUpdate(), and
+  // bar_decoder should be invoked (not foo_callbacks or foo_decoder).
+  {
+    auto response = std::make_unique<envoy::service::discovery::v3::DiscoveryResponse>();
+    response->set_type_url(type_url);
+    response->set_version_info("2");
+    envoy::config::endpoint::v3::ClusterLoadAssignment load_assignment;
+    load_assignment.set_cluster_name("y");
+    response->add_resources()->PackFrom(load_assignment);
+    EXPECT_CALL(bar_callbacks, onConfigUpdate(_, "2"))
+        .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
+                                            const std::string&) {
+          EXPECT_EQ(1, resources.size());
+          const auto& expected_assignment =
+              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+                  resources[0].get().resource());
+          EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
+        }));
+    expectSendMessage(type_url, {"y"}, "2");
+    grpc_mux_->onDiscoveryResponse(std::move(response), control_plane_stats_);
+  }
+
+  expectSendMessage(type_url, {}, "2");
+}
+
 // Validate behavior when dynamic context parameters are updated.
 TEST_F(GrpcMuxImplTest, DynamicContextParameters) {
   setup();
@@ -956,8 +1039,6 @@ public:
   NullGrpcMuxImplTest() : null_mux_(std::make_unique<Config::XdsMux::NullGrpcMuxImpl>()) {}
   Config::GrpcMuxPtr null_mux_;
   NiceMock<MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
 };
 
 TEST_F(NullGrpcMuxImplTest, StartImplemented) { EXPECT_NO_THROW(null_mux_->start()); }
@@ -980,8 +1061,9 @@ TEST_F(NullGrpcMuxImplTest, RequestOnDemandNotImplemented) {
 
 TEST_F(NullGrpcMuxImplTest, AddWatchRaisesException) {
   NiceMock<MockSubscriptionCallbacks> callbacks;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder{"cluster_name"};
+  OpaqueResourceDecoderSharedPtr resource_decoder(
+      std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+          envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name"));
 
   EXPECT_THROW_WITH_REGEX(null_mux_->addWatch("type_url", {}, callbacks, resource_decoder, {}),
                           EnvoyException, "ADS must be configured to support an ADS config source");

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -424,8 +424,9 @@ TEST_P(HeaderMapImplTest, AllInlineHeaders) {
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
   }
   {
-      // No request trailer O(1) headers.
-  } {
+    // No request trailer O(1) headers.
+  }
+  {
     auto header_map = ResponseHeaderMapImpl::create();
     INLINE_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)
     INLINE_REQ_RESP_STRING_HEADERS(TEST_INLINE_STRING_HEADER_FUNCS)

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -349,7 +349,7 @@ protected:
         .WillRepeatedly(
             Invoke([this](const envoy::config::core::v3::ConfigSource&, absl::string_view,
                           Stats::Scope&, Envoy::Config::SubscriptionCallbacks& callbacks,
-                          Envoy::Config::OpaqueResourceDecoder&,
+                          Envoy::Config::OpaqueResourceDecoderSharedPtr&,
                           const Envoy::Config::SubscriptionOptions&) {
               auto ret = std::make_unique<NiceMock<Envoy::Config::MockSubscription>>();
               rds_subscription_by_config_subscription_[ret.get()] = &callbacks;

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -873,10 +873,11 @@ public:
     }
     EXPECT_CALL(cm_, subscriptionFactory()).Times(layers_.size());
     ON_CALL(cm_.subscription_factory_, subscriptionFromConfigSource(_, _, _, _, _, _))
-        .WillByDefault(testing::Invoke(
-            [this](const envoy::config::core::v3::ConfigSource&, absl::string_view, Stats::Scope&,
-                   Config::SubscriptionCallbacks& callbacks, Config::OpaqueResourceDecoder&,
-                   const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
+        .WillByDefault(
+            testing::Invoke([this](const envoy::config::core::v3::ConfigSource&, absl::string_view,
+                                   Stats::Scope&, Config::SubscriptionCallbacks& callbacks,
+                                   Config::OpaqueResourceDecoderSharedPtr&,
+                                   const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
               auto ret = std::make_unique<testing::NiceMock<Config::MockSubscription>>();
               rtds_subscriptions_.push_back(ret.get());
               rtds_callbacks_.push_back(&callbacks);

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -100,8 +100,9 @@ TEST_F(SdsApiTest, InitManagerInitialised) {
   const std::string sds_config_path = TestEnvironment::writeStringToFileForTest(
       "sds.yaml", TestEnvironment::substitute(sds_config), false);
   NiceMock<Config::MockSubscriptionCallbacks> callbacks;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::extensions::transport_sockets::tls::v3::Secret>
-      resource_decoder("name");
+  Config::OpaqueResourceDecoderSharedPtr resource_decoder(
+      std::make_shared<TestUtility::TestOpaqueResourceDecoderImpl<
+          envoy::extensions::transport_sockets::tls::v3::Secret>>("name"));
   Config::SubscriptionStats stats(Config::Utility::generateStats(stats_));
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
   envoy::config::core::v3::ConfigSource config_source;
@@ -110,7 +111,7 @@ TEST_F(SdsApiTest, InitManagerInitialised) {
       .WillOnce(Invoke([this, &sds_config_path, &resource_decoder,
                         &stats](const envoy::config::core::v3::ConfigSource&, absl::string_view,
                                 Stats::Scope&, Config::SubscriptionCallbacks& cbs,
-                                Config::OpaqueResourceDecoder&,
+                                Config::OpaqueResourceDecoderSharedPtr&,
                                 const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
         return std::make_unique<Config::FilesystemSubscriptionImpl>(
             *dispatcher_, Config::makePathConfigSource(sds_config_path), cbs, resource_decoder,

--- a/test/common/upstream/eds_speed_test.cc
+++ b/test/common/upstream/eds_speed_test.cc
@@ -165,8 +165,9 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   EdsClusterImplSharedPtr cluster_;
   Config::SubscriptionCallbacks* eds_callbacks_{};
-  Config::OpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{validation_visitor_, "cluster_name"};
+  Config::OpaqueResourceDecoderSharedPtr resource_decoder_{std::make_shared<
+      Config::OpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>>(
+      validation_visitor_, "cluster_name")};
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;

--- a/test/common/upstream/leds_test.cc
+++ b/test/common/upstream/leds_test.cc
@@ -105,7 +105,7 @@ public:
             [this, &leds_config](const xds::core::v3::ResourceLocator& locator_url,
                                  const envoy::config::core::v3::ConfigSource&, absl::string_view,
                                  Stats::Scope&, Envoy::Config::SubscriptionCallbacks& callbacks,
-                                 Envoy::Config::OpaqueResourceDecoder&) {
+                                 Envoy::Config::OpaqueResourceDecoderSharedPtr&) {
               // Verify that the locator is correct.
               Config::XdsResourceIdentifier::EncodeOptions encode_options;
               encode_options.sort_context_params_ = true;

--- a/test/mocks/config/mocks.cc
+++ b/test/mocks/config/mocks.cc
@@ -13,15 +13,15 @@ namespace Config {
 
 MockSubscriptionFactory::MockSubscriptionFactory() {
   ON_CALL(*this, subscriptionFromConfigSource(_, _, _, _, _, _))
-      .WillByDefault(
-          Invoke([this](const envoy::config::core::v3::ConfigSource&, absl::string_view,
-                        Stats::Scope&, SubscriptionCallbacks& callbacks, OpaqueResourceDecoder&,
-                        const SubscriptionOptions&) -> SubscriptionPtr {
-            auto ret = std::make_unique<NiceMock<MockSubscription>>();
-            subscription_ = ret.get();
-            callbacks_ = &callbacks;
-            return ret;
-          }));
+      .WillByDefault(Invoke([this](const envoy::config::core::v3::ConfigSource&, absl::string_view,
+                                   Stats::Scope&, SubscriptionCallbacks& callbacks,
+                                   OpaqueResourceDecoderSharedPtr&,
+                                   const SubscriptionOptions&) -> SubscriptionPtr {
+        auto ret = std::make_unique<NiceMock<MockSubscription>>();
+        subscription_ = ret.get();
+        callbacks_ = &callbacks;
+        return ret;
+      }));
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
 }

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -82,12 +82,13 @@ public:
   MOCK_METHOD(SubscriptionPtr, subscriptionFromConfigSource,
               (const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
                Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-               OpaqueResourceDecoder& resource_decoder, const SubscriptionOptions& options));
+               OpaqueResourceDecoderSharedPtr& resource_decoder,
+               const SubscriptionOptions& options));
   MOCK_METHOD(SubscriptionPtr, collectionSubscriptionFromUrl,
               (const xds::core::v3::ResourceLocator& collection_locator,
                const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
                Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-               OpaqueResourceDecoder& resource_decoder));
+               OpaqueResourceDecoderSharedPtr& resource_decoder));
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
 
   MockSubscription* subscription_{};
@@ -120,7 +121,7 @@ public:
 
   MOCK_METHOD(GrpcMuxWatchPtr, addWatch,
               (const std::string& type_url, const absl::flat_hash_set<std::string>& resources,
-               SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+               SubscriptionCallbacks& callbacks, OpaqueResourceDecoderSharedPtr& resource_decoder,
                const SubscriptionOptions& options));
 
   MOCK_METHOD(void, requestOnDemandUpdate,


### PR DESCRIPTION
Commit Message: Refactoring OpaqueResourceDecoder to be a shared pointer
Additional Description:
Prior to this PR the OpaqueResourceDecoder is owned by each of the Subscriptions, and a reference to it is used by the GrpcMux's. This can cause an issue if the Mux outlives the subscription, as can happen in the newly added test "ValidResourceDecoderAfterRemoval", and in the unified Mux implementation.
This PR converts the OpaqueResourceDecoder to a shared pointer, that can be used by both.

Risk Level: Low/Medium - modifying many places in the config-plane codebase, but the refactor moves from reference to shared pointer.
Testing: Added a unit test that passes after the refactor.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
