### PR TITLE
ci: Remove tooling job

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -39,26 +39,6 @@ stages:
       # not all have fixes so improve condition/handling
       condition: failed()
 
-  - job: tooling
-    dependsOn: []
-    pool:
-      vmImage: "ubuntu-18.04"
-    steps:
-    - task: Cache@2
-      inputs:
-        key: "tooling | ./WORKSPACE | **/*.bzl"
-        path: $(Build.StagingDirectory)/repository_cache
-      continueOnError: true
-
-    - script: ci/run_envoy_docker.sh 'ci/do_ci.sh tooling'
-      workingDirectory: $(Build.SourcesDirectory)
-      env:
-        ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
-        BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-        BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
-        GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
-      displayName: "Run tooling checks"
-
   - job: format
     dependsOn: ["format_pre"]
     pool:


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

This job was added mostly to accomodate python tests which have now moved to pytooling, so it makes more sense to just test the remaining tools where they are used and cut CI time

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
