### PR TITLE
async: fix UB with uninitialized parent context

### DIFF
--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -173,7 +173,7 @@ public:
    * A context from the caller of an async client.
    */
   struct ParentContext {
-    const StreamInfo::StreamInfo* stream_info;
+    const StreamInfo::StreamInfo* stream_info{nullptr};
   };
 
   /**

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -154,6 +154,28 @@ TEST_F(EnvoyAsyncClientImplTest, MetadataIsInitialized) {
   EXPECT_EQ(grpc_stream, nullptr);
 }
 
+// Validate that metadata is initialized without async client parent context.
+TEST_F(EnvoyAsyncClientImplTest, MetadataIsInitializedWithoutStreamInfo) {
+  NiceMock<MockAsyncStreamCallbacks<helloworld::HelloReply>> grpc_callbacks;
+  Http::AsyncClient::StreamCallbacks* http_callbacks;
+
+  Http::MockAsyncClientStream http_stream;
+  EXPECT_CALL(http_client_, start(_, _))
+      .WillOnce(
+          Invoke([&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
+                                                 const Http::AsyncClient::StreamOptions&) {
+            http_callbacks = &callbacks;
+            return &http_stream;
+          }));
+
+  EXPECT_CALL(http_stream, sendHeaders(_, _))
+      .WillOnce(Invoke([&http_callbacks](Http::HeaderMap&, bool) { http_callbacks->onReset(); }));
+
+  Http::AsyncClient::StreamOptions stream_options;
+  auto grpc_stream = grpc_client_->start(*method_descriptor_, grpc_callbacks, stream_options);
+  EXPECT_EQ(grpc_stream, nullptr);
+}
+
 // Validate that a failure in the HTTP client returns immediately with status
 // UNAVAILABLE.
 TEST_F(EnvoyAsyncClientImplTest, StreamHttpStartFail) {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Async call API does not enforce that parent context is always set. When not set, `stream_info` is accessed as a raw pointer, which eventually leads to the following UB:
```
source/common/router/header_formatter.cc:289:24: runtime error: member call on address 0x7fff213f83a0 which does not point to an object of type 'Envoy::StreamInfo::StreamInfo'
0x7fff213f83a0: note: object has a possibly invalid vptr: abs(offset to top) too big
 20 00 00 00  b0 47 19 00 20 60 00 00  02 00 00 00 00 00 00 00  f0 03 91 07 00 00 00 00  a0 85 3f 21
              ^~~~~~~~~~~~~~~~~~~~~~~
              possibly invalid vptr
```
The fix is to initialize the field to `nullptr`.

Risk Level: low, internal API
Testing: added regression test
Docs Changes: none
Release Notes: none