### PR TITLE
[socket] PassthroughSocket: Add implementation for `connect`.

### DIFF
--- a/source/extensions/transport_sockets/common/passthrough.cc
+++ b/source/extensions/transport_sockets/common/passthrough.cc
@@ -24,6 +24,10 @@ absl::string_view PassthroughSocket::failureReason() const {
 
 bool PassthroughSocket::canFlushClose() { return transport_socket_->canFlushClose(); }
 
+Api::SysCallIntResult PassthroughSocket::connect(Network::ConnectionSocket& socket) {
+  return transport_socket_->connect(socket);
+}
+
 void PassthroughSocket::closeSocket(Network::ConnectionEvent event) {
   transport_socket_->closeSocket(event);
 }

--- a/source/extensions/transport_sockets/common/passthrough.h
+++ b/source/extensions/transport_sockets/common/passthrough.h
@@ -38,6 +38,7 @@ public:
   std::string protocol() const override;
   absl::string_view failureReason() const override;
   bool canFlushClose() override;
+  Api::SysCallIntResult connect(Network::ConnectionSocket& socket) override;
   void closeSocket(Network::ConnectionEvent event) override;
   Network::IoResult doRead(Buffer::Instance& buffer) override;
   Network::IoResult doWrite(Buffer::Instance& buffer, bool end_stream) override;

--- a/test/extensions/transport_sockets/common/passthrough_test.cc
+++ b/test/extensions/transport_sockets/common/passthrough_test.cc
@@ -1,3 +1,4 @@
+#include "source/common/network/io_socket_handle_impl.h"
 #include "source/extensions/transport_sockets/common/passthrough.h"
 
 #include "test/mocks/buffer/mocks.h"
@@ -43,6 +44,14 @@ TEST_F(PassthroughTest, ProtocolDefersToInnerSocket) {
 TEST_F(PassthroughTest, FailureReasonDefersToInnerSocket) {
   EXPECT_CALL(*inner_socket_, failureReason());
   passthrough_socket_->failureReason();
+}
+
+// Test connect method defers to inner socket
+TEST_F(PassthroughTest, ConnectDefersToInnerSocket) {
+  auto io_handle = std::make_unique<Network::IoSocketHandleImpl>();
+  Network::ConnectionSocketImpl socket(std::move(io_handle), nullptr, nullptr);
+  EXPECT_CALL(*inner_socket_, connect(testing::Ref(socket)));
+  passthrough_socket_->connect(socket);
 }
 
 // Test canFlushClose method defers to inner socket

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -74,7 +74,9 @@ envoy_cc_mock(
     srcs = ["transport_socket.cc"],
     hdrs = ["transport_socket.h"],
     deps = [
+        "//envoy/network:io_handle_interface",
         "//envoy/network:transport_socket_interface",
+        "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
     ],
 )

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -7,6 +7,8 @@
 
 #include "envoy/network/transport_socket.h"
 
+#include "source/common/network/listen_socket_impl.h"
+
 #include "gmock/gmock.h"
 
 namespace Envoy {
@@ -21,6 +23,7 @@ public:
   MOCK_METHOD(std::string, protocol, (), (const));
   MOCK_METHOD(absl::string_view, failureReason, (), (const));
   MOCK_METHOD(bool, canFlushClose, ());
+  MOCK_METHOD(Api::SysCallIntResult, connect, (Network::ConnectionSocket & socket));
   MOCK_METHOD(void, closeSocket, (Network::ConnectionEvent event));
   MOCK_METHOD(IoResult, doRead, (Buffer::Instance & buffer));
   MOCK_METHOD(IoResult, doWrite, (Buffer::Instance & buffer, bool end_stream));


### PR DESCRIPTION
Socket extensions like `proxy_protocol` socket extends PassthroughSocket which currently does not
delegate the `connect` call to the wrapped socket. This renders the wrapped sockets unable to
intercept `connect`.

This change fixes this problem by adding an override for `connect` method in PassthroughSocket.

Signed-off-by: Jojy George Varghese <jojy_varghese@apple.com>


Risk Level: Low
Testing: Unit tests, Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

