### PR TITLE
fuzz test: Fix clearing buffers

### DIFF
--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -100,6 +100,7 @@ void UberFilterFuzzer::reset() {
   encoder_filter_.reset();
 
   access_logger_.reset();
+  custom_stat_namespaces_ = Stats::CustomStatNamespacesImpl();
   decoding_buffer_ = nullptr;
   HttpFilterFuzzer::reset();
 }

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -100,6 +100,7 @@ void UberFilterFuzzer::reset() {
   encoder_filter_.reset();
 
   access_logger_.reset();
+  decoding_buffer_ = nullptr;
   HttpFilterFuzzer::reset();
 }
 


### PR DESCRIPTION
Commit Message: fuzz test: Fix clearing decoding_buffer and stats.
Additional Description:
In filter_fuzz_test a pointer to a buffer was stored, that could have
been freed between two fuzzer runs. Furthermore are stats reset, that
should be zero for each fuzzer run.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
