### PR TITLE
docs: add configuration reference links for clusters

### DIFF
--- a/docs/root/configuration/upstream/clusters.rst
+++ b/docs/root/configuration/upstream/clusters.rst
@@ -1,0 +1,9 @@
+.. _config_clusters:
+
+Clusters
+========
+
+The top level Envoy configuration contains a list of :ref:`clusters <arch_overview_clusters>`.
+Each individual cluster configuration has the following format:
+
+* :ref:`v3 API reference <envoy_v3_api_msg_config.cluster.v3.Cluster>`

--- a/docs/root/configuration/upstream/upstream.rst
+++ b/docs/root/configuration/upstream/upstream.rst
@@ -4,5 +4,6 @@ Upstream clusters
 .. toctree::
   :maxdepth: 2
 
+  clusters
   cluster_manager/cluster_manager
   health_checkers/health_checkers

--- a/docs/root/intro/arch_overview/upstream/upstream.rst
+++ b/docs/root/intro/arch_overview/upstream/upstream.rst
@@ -1,3 +1,5 @@
+.. _arch_overview_clusters:
+
 Upstream clusters
 =================
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: There was no easy-to-find link to the cluster configuration docs from the main configuration reference.
Additional Description:
Risk Level: Low
Testing: docs-only
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
