### PR TITLE
Shrink Heap: Remove assert in try shrink heap as it can fail if an allocation occurs

### DIFF
--- a/source/common/memory/utils.cc
+++ b/source/common/memory/utils.cc
@@ -38,9 +38,8 @@ void Utils::tryShrinkHeap() {
   auto total_physical_bytes = Stats::totalPhysicalBytes();
   auto allocated_size_by_app = Stats::totalCurrentlyAllocated();
 
-  ASSERT(total_physical_bytes >= allocated_size_by_app);
-
-  if ((total_physical_bytes - allocated_size_by_app) >= MAX_UNFREED_MEMORY_BYTE) {
+  if (total_physical_bytes >= allocated_size_by_app &&
+      (total_physical_bytes - allocated_size_by_app) >= MAX_UNFREED_MEMORY_BYTE) {
     Utils::releaseFreeMemory();
   }
 #endif


### PR DESCRIPTION
between when the measurements are taken.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Remove assert in try shrink heap as it can fail if an allocation occurs between when the measurements are taken.
Additional Description: 
Risk Level: low
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
