### PR TITLE
Thrift Proxy: Fix tag extraction to work with filter stat_prefix

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -4,6 +4,18 @@ behavior_changes:
 - area: tls-inspector
   change: |
     the listener filter tls inspector's stats ``connection_closed`` and ``read_error`` are removed. The new stats are introduced for listener, ``downstream_peek_remote_close`` and ``read_error`` :ref:`listener stats <config_listener_stats>`.
+- area: listener
+  change: |
+    Fixed metric tag extraction so that :ref:stat_prefix <envoy_v3_api_field_config.listener.v3.Listener.stat_prefix>
+    is properly extracted. This changes the Prometheus name from
+    envoy_listener_myprefix_downstream_cx_overflow{} to envoy_listener_downstream_cx_overflow{envoy_listener_address="myprefix"}.
+    This does not affect the Prometheus name if stat_prefix is not set.
+- area: thrift_proxy
+  change: |
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.stat_prefix>`
+    is properly extracted. This changes the Prometheus name from
+    envoy_thrift_myprefix_request{} to envoy_thrift_request{envoy_thrift_prefix="myprefix"}.
+    This does not affect the Prometheus name if stat_prefix is not set.
 
 minor_behavior_changes:
 - area: thrift
@@ -117,17 +129,9 @@ bug_fixes:
 - area: tcp_proxy
   change: |
     Fixed an issue using the cluster wide CONNECT termination so it will successfully proxy payloads.
-- area: listener
-  change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_config.listener.v3.Listener.stat_prefix>`
-    is properly extracted.
 - area: upstream
   change: |
     Fixed the LOGICAL_DNS and STRICT_DNS clusters to work for IPv6.
-- area: thrift_proxy
-  change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.stat_prefix>`
-    is properly extracted.
 
 removed_config_or_runtime:
 - area: compressor

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -15,7 +15,6 @@ behavior_changes:
     Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.stat_prefix>`
     is properly extracted. This changes the Prometheus name from
     envoy_thrift_myprefix_request{} to envoy_thrift_request{envoy_thrift_prefix="myprefix"}.
-    This does not affect the Prometheus name if stat_prefix is not set.
 
 minor_behavior_changes:
 - area: thrift

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -124,6 +124,10 @@ bug_fixes:
 - area: upstream
   change: |
     Fixed the LOGICAL_DNS and STRICT_DNS clusters to work for IPv6.
+- area: thrift_proxy
+  change: |
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.stat_prefix>`
+    is properly extracted.
 
 removed_config_or_runtime:
 - area: compressor

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -151,6 +151,9 @@ TagNameValues::TagNameValues() {
 
   // listener_manager.(worker_<id>.)*
   addRe2(WORKER_ID, R"(^listener_manager\.((worker_\d+)\.))", "listener_manager.worker_");
+
+  // thrift.(<stat_prefix>.)*
+  addTokenized(THRIFT_PREFIX, "thrift.$.**");
 }
 
 void TagNameValues::addRe2(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -131,6 +131,8 @@ public:
   const std::string RDS_ROUTE_CONFIG = "envoy.rds_route_config";
   // Listener manager worker id
   const std::string WORKER_ID = "envoy.worker_id";
+  // Stats prefix for the Thrift Proxy network filter
+  const std::string THRIFT_PREFIX = "envoy.thrift_prefix";
 
   // Mapping from the names above to their respective regex strings.
   const std::vector<std::pair<std::string, std::string>> name_regex_pairs_;

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -393,6 +393,12 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
 
   regex_tester.testRegex("listener_manager.worker_123.dispatcher.loop_duration_us",
                          "listener_manager.dispatcher.loop_duration_us", {worker_id});
+
+  // Thrift Proxy Prefix
+  Tag thrift_prefix;
+  thrift_prefix.name_ = tag_names.THRIFT_PREFIX;
+  thrift_prefix.value_ = "thrift_prefix";
+  regex_tester.testRegex("thrift.thrift_prefix.response", "thrift.response", {thrift_prefix});
 }
 
 TEST(TagExtractorTest, ExtractRegexPrefix) {

--- a/test/extensions/filters/network/thrift_proxy/integration.h
+++ b/test/extensions/filters/network/thrift_proxy/integration.h
@@ -50,8 +50,7 @@ struct PayloadOptions {
 class BaseThriftIntegrationTest : public BaseIntegrationTest {
 public:
   BaseThriftIntegrationTest()
-      : BaseIntegrationTest(Network::Address::IpVersion::v4, thrift_config_) {
-  }
+      : BaseIntegrationTest(Network::Address::IpVersion::v4, thrift_config_) {}
 
   /**
    * Given PayloadOptions, generate a client request and server response and store the

--- a/test/extensions/filters/network/thrift_proxy/integration.h
+++ b/test/extensions/filters/network/thrift_proxy/integration.h
@@ -51,10 +51,6 @@ class BaseThriftIntegrationTest : public BaseIntegrationTest {
 public:
   BaseThriftIntegrationTest()
       : BaseIntegrationTest(Network::Address::IpVersion::v4, thrift_config_) {
-    // TODO(https://github.com/envoyproxy/envoy/issues/20201): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat 'thrift.thrift_stats.route_missing' and stat_prefix
-    // 'thrift_stats'.
-    skip_tag_extraction_rule_check_ = true;
   }
 
   /**


### PR DESCRIPTION
Commit Message:

Fixes issue #20201 by adding tag extraction for thrift proxy filter.

`curl 0.0.0.0:9901/stats/prometheus | grep this_is_a_thrift_tag`

```
envoy_thrift_cx_destroy_local_with_active_rq{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_cx_destroy_remote_with_active_rq{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_downstream_cx_max_requests{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_downstream_response_drain_close{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_no_healthy_upstream{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_request{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_request_call{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_request_decoding_error{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_request_invalid_type{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_request_oneway{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
envoy_thrift_request_passthrough{envoy_thrift_prefix="this_is_a_thrift_tag"} 0
```

Additional Description:
Risk Level: Small
Testing: Unit tests for tag extractor manual test.
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>
