### PR TITLE
Add BalsaParser guarded by runtime flag.

### DIFF
--- a/source/common/http/http1/BUILD
+++ b/source/common/http/http1/BUILD
@@ -32,6 +32,7 @@ envoy_cc_library(
     srcs = ["codec_impl.cc"],
     hdrs = ["codec_impl.h"],
     deps = [
+        ":balsa_parser_lib",
         ":codec_stats_lib",
         ":header_formatter_lib",
         ":legacy_parser_lib",
@@ -114,5 +115,19 @@ envoy_cc_library(
     deps = [
         ":parser_interface",
         "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "balsa_parser_lib",
+    srcs = ["balsa_parser.cc"],
+    hdrs = ["balsa_parser.h"],
+    deps = [
+        ":parser_interface",
+        "//source/common/common:assert_lib",
+        "@com_github_google_quiche//:quiche_balsa_balsa_enums_lib",
+        "@com_github_google_quiche//:quiche_balsa_balsa_frame_lib",
+        "@com_github_google_quiche//:quiche_balsa_balsa_headers_lib",
+        "@com_github_google_quiche//:quiche_balsa_balsa_visitor_interface_lib",
     ],
 )

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -1,0 +1,204 @@
+#include "source/common/http/http1/balsa_parser.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+
+#include "source/common/common/assert.h"
+
+#include "absl/strings/match.h"
+
+using ::quiche::BalsaFrameEnums;
+using ::quiche::BalsaHeaders;
+
+namespace Envoy {
+namespace Http {
+namespace Http1 {
+
+namespace {
+constexpr absl::string_view kHttp11Suffix = "HTTP/1.1";
+} // anonymous namespace
+
+BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t max_header_length)
+    : connection_(connection) {
+  ASSERT(connection_ != nullptr);
+
+  framer_.set_balsa_headers(&headers_);
+  framer_.set_balsa_visitor(this);
+  framer_.set_max_header_length(max_header_length);
+
+  switch (type) {
+  case MessageType::Request:
+    framer_.set_is_request(true);
+    break;
+  case MessageType::Response:
+    framer_.set_is_request(false);
+    framer_.set_balsa_trailer(&trailers_);
+    break;
+  }
+}
+
+size_t BalsaParser::execute(const char* slice, int len) {
+  ASSERT(status_ != ParserStatus::Error);
+  return framer_.ProcessInput(slice, len);
+}
+
+void BalsaParser::resume() {
+  ASSERT(status_ != ParserStatus::Error);
+  status_ = ParserStatus::Ok;
+}
+
+CallbackResult BalsaParser::pause() {
+  ASSERT(status_ != ParserStatus::Error);
+  status_ = ParserStatus::Paused;
+  return CallbackResult::Success;
+}
+
+ParserStatus BalsaParser::getStatus() { return status_; }
+
+uint16_t BalsaParser::statusCode() const { return headers_.parsed_response_code(); }
+
+bool BalsaParser::isHttp11() const { return absl::EndsWith(headers_.first_line(), kHttp11Suffix); }
+
+absl::optional<uint64_t> BalsaParser::contentLength() const {
+  if (!headers_.content_length_valid()) {
+    return absl::nullopt;
+  }
+  return headers_.content_length();
+}
+
+bool BalsaParser::isChunked() const { return headers_.transfer_encoding_is_chunked(); }
+
+absl::string_view BalsaParser::methodName() const { return headers_.request_method(); }
+
+absl::string_view BalsaParser::errorMessage() const { return error_message_; }
+
+int BalsaParser::hasTransferEncoding() const { return headers_.HasHeader("transfer-encoding"); }
+
+void BalsaParser::OnRawBodyInput(absl::string_view /*input*/) {}
+
+void BalsaParser::OnBodyChunkInput(absl::string_view input) {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+
+  connection_->bufferBody(input.data(), input.size());
+}
+
+void BalsaParser::OnHeaderInput(absl::string_view /*input*/) {}
+void BalsaParser::OnTrailerInput(absl::string_view /*input*/) {}
+
+void BalsaParser::ProcessHeaders(const BalsaHeaders& headers) {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  headers.ForEachHeader([this](const absl::string_view key, const absl::string_view value) {
+    checkResult(connection_->onHeaderField(key.data(), key.length()));
+    if (status_ == ParserStatus::Error) {
+      return false;
+    }
+    checkResult(connection_->onHeaderValue(value.data(), value.length()));
+    if (status_ == ParserStatus::Error) {
+      return false;
+    }
+    return true;
+  });
+}
+
+void BalsaParser::ProcessTrailers(const BalsaHeaders& trailer) {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  trailer.ForEachHeader([this](const absl::string_view key, const absl::string_view value) {
+    checkResult(connection_->onHeaderField(key.data(), key.length()));
+    if (status_ == ParserStatus::Error) {
+      return false;
+    }
+    checkResult(connection_->onHeaderValue(value.data(), value.length()));
+    if (status_ == ParserStatus::Error) {
+      return false;
+    }
+    return true;
+  });
+}
+
+void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
+                                          absl::string_view /*method_input*/,
+                                          absl::string_view request_uri,
+                                          absl::string_view /*version_input*/) {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  checkResult(connection_->onMessageBegin());
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  checkResult(connection_->onUrl(request_uri.data(), request_uri.size()));
+}
+
+void BalsaParser::OnResponseFirstLineInput(absl::string_view /*line_input*/,
+                                           absl::string_view /*version_input*/,
+                                           absl::string_view status_input,
+                                           absl::string_view /*reason_input*/) {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  checkResult(connection_->onMessageBegin());
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  checkResult(connection_->onStatus(status_input.data(), status_input.size()));
+}
+
+void BalsaParser::OnChunkLength(size_t chunk_length) {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  const bool is_final_chunk = chunk_length == 0;
+  connection_->onChunkHeader(is_final_chunk);
+}
+
+void BalsaParser::OnChunkExtensionInput(absl::string_view /*input*/) {}
+
+void BalsaParser::HeaderDone() {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  checkResult(connection_->onHeadersComplete());
+}
+
+void BalsaParser::ContinueHeaderDone() {}
+
+void BalsaParser::MessageDone() {
+  if (status_ == ParserStatus::Error) {
+    return;
+  }
+  checkResult(connection_->onMessageComplete());
+  framer_.Reset();
+}
+
+void BalsaParser::HandleError(BalsaFrameEnums::ErrorCode error_code) {
+  status_ = ParserStatus::Error;
+  error_message_ = BalsaFrameEnums::ErrorCodeToString(error_code);
+  if (error_code == BalsaFrameEnums::UNKNOWN_TRANSFER_ENCODING) {
+    error_message_ = "unsupported transfer encoding";
+  }
+  if (error_code == BalsaFrameEnums::INVALID_CHUNK_LENGTH) {
+    error_message_ = "HPE_INVALID_CHUNK_SIZE";
+  }
+  if (error_code == BalsaFrameEnums::HEADERS_TOO_LONG) {
+    error_message_ = "size exceeds limit";
+  }
+}
+
+void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode /*error_code*/) {}
+
+void BalsaParser::checkResult(CallbackResult result) {
+  if (result == CallbackResult::Error) {
+    status_ = ParserStatus::Error;
+  }
+}
+
+} // namespace Http1
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/http1/balsa_parser.h
+++ b/source/common/http/http1/balsa_parser.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "source/common/http/http1/parser.h"
+
+#include "quiche/balsa/balsa_enums.h"
+#include "quiche/balsa/balsa_frame.h"
+#include "quiche/balsa/balsa_headers.h"
+#include "quiche/balsa/balsa_visitor_interface.h"
+
+namespace Envoy {
+namespace Http {
+namespace Http1 {
+
+class BalsaParser : public Parser, public quiche::BalsaVisitorInterface {
+public:
+  BalsaParser(MessageType type, ParserCallbacks* connection, size_t max_header_length);
+  ~BalsaParser() override = default;
+
+  // Http1::Parser implementation
+  size_t execute(const char* slice, int len) override;
+  void resume() override;
+  CallbackResult pause() override;
+  ParserStatus getStatus() override; // TODO: make const
+  uint16_t statusCode() const override;
+  bool isHttp11() const override;
+  absl::optional<uint64_t> contentLength() const override;
+  bool isChunked() const override;
+  absl::string_view methodName() const override;
+  absl::string_view errorMessage() const override;
+  int hasTransferEncoding() const override;
+
+  // quiche::BalsaVisitorInterface implementation
+  void OnRawBodyInput(absl::string_view input) override;
+  void OnBodyChunkInput(absl::string_view input) override;
+  void OnHeaderInput(absl::string_view input) override;
+  void OnTrailerInput(absl::string_view input) override;
+  void ProcessHeaders(const quiche::BalsaHeaders& headers) override;
+  void ProcessTrailers(const quiche::BalsaHeaders& trailer) override;
+  void OnRequestFirstLineInput(absl::string_view line_input, absl::string_view method_input,
+                               absl::string_view request_uri,
+                               absl::string_view version_input) override;
+  void OnResponseFirstLineInput(absl::string_view line_input, absl::string_view version_input,
+                                absl::string_view status_input,
+                                absl::string_view reason_input) override;
+  void OnChunkLength(size_t chunk_length) override;
+  void OnChunkExtensionInput(absl::string_view input) override;
+  void HeaderDone() override;
+  void ContinueHeaderDone() override;
+  void MessageDone() override;
+  void HandleError(quiche::BalsaFrameEnums::ErrorCode error_code) override;
+  void HandleWarning(quiche::BalsaFrameEnums::ErrorCode error_code) override;
+
+private:
+  void checkResult(CallbackResult result);
+
+  ParserCallbacks* connection_ = nullptr;
+  ParserStatus status_ = ParserStatus::Ok;
+  absl::string_view error_message_;
+
+  quiche::BalsaFrame framer_;
+  quiche::BalsaHeaders headers_;
+  quiche::BalsaHeaders trailers_;
+};
+
+} // namespace Http1
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -19,6 +19,7 @@
 #include "source/common/http/exception.h"
 #include "source/common/http/header_utility.h"
 #include "source/common/http/headers.h"
+#include "source/common/http/http1/balsa_parser.h"
 #include "source/common/http/http1/header_formatter.h"
 #include "source/common/http/http1/legacy_parser_impl.h"
 #include "source/common/http/utility.h"
@@ -500,7 +501,11 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
       processing_trailers_(false), handling_upgrade_(false), reset_stream_called_(false),
       deferred_end_stream_headers_(false), dispatching_(false), max_headers_kb_(max_headers_kb),
       max_headers_count_(max_headers_count) {
-  parser_ = std::make_unique<LegacyHttpParserImpl>(type, this);
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_use_balsa_parser")) {
+    parser_ = std::make_unique<BalsaParser>(type, this, max_headers_kb_ * 1024);
+  } else {
+    parser_ = std::make_unique<LegacyHttpParserImpl>(type, this);
+  }
 }
 
 Status ConnectionImpl::completeLastHeader() {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -91,6 +91,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_thrift_connection_draining);
 // TODO(birenroy) flip after a burn-in period
 // Requires envoy_reloadable_features_http2_new_codec_wrapper to be enabled.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
+// TODO(#21245): Finish BalsaParser implementation, then enable by default.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_http1_use_balsa_parser);
 // Used to track if runtime is initialized.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 


### PR DESCRIPTION
Add first draft of BalsaParser implementation.  This fails a large
number of tests and will require a lot of work until it can be enabled.

Add default-false runtime flag to use BalsaParser.  This will help local
testing when working on BalsaParser.

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
