### PR TITLE
bazel: fix useless info warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -414,3 +414,5 @@ build:windows --dynamic_mode=off
 try-import %workspace%/clang.bazelrc
 try-import %workspace%/user.bazelrc
 try-import %workspace%/local_tsan.bazelrc
+
+info --ui_event_filters=-WARNING


### PR DESCRIPTION
Signed-off-by: Loong Dai <loong.dai@intel.com>

The warning itself is not useful anyway:
```
WARNING: info command does not support starlark options. Ignoring options: [--@com_googlesource_googleurl//build_config:system_icu=0]
```

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
