### PR TITLE
bazel/README.md: fix a typo

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -492,7 +492,7 @@ gdb bazel-bin/test/common/http/async_client_impl_test
 
 We need to use `-c dbg` Bazel option to generate debugging symbols and without
 that GDB will not be very useful. The debugging symbols are stored as separate
-debugging information files (`.dwo` files) and we can build a DWARF package file
+debugging information files (`.dwp` files) and we can build a DWARF package file
 with `.dwp ` target. The `.dwp` file need to be presented in the same folder with the
 binary for a full debugging experience.
 


### PR DESCRIPTION
Signed-off-by: Loong Dai <loong.dai@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix a typo.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
