### PR TITLE
ci: Differentiate check jobs (for azp analytics)

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -57,7 +57,7 @@ steps:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
-  displayName: "Run CI script"
+  displayName: "Run CI script ${{ parameters.ciTarget }}"
 
 - bash: |
     echo "disk space at end of build:"


### PR DESCRIPTION
currently all check jobs run as "Run CI script" and there is no
way to differentiate them in azp analytics. This should resolve that.

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
