### PR TITLE
http: removing throw

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -361,7 +361,7 @@ Http::Status HeaderUtility::checkRequiredRequestHeaders(const Http::RequestHeade
 }
 
 Http::Status HeaderUtility::checkRequiredResponseHeaders(const Http::ResponseHeaderMap& headers) {
-  const absl::optional<uint64_t> status = Utility::getResponseStatusNoThrow(headers);
+  const absl::optional<uint64_t> status = Utility::getResponseStatusOrNullopt(headers);
   if (!status.has_value()) {
     return absl::InvalidArgumentError(
         absl::StrCat("missing required header: ", Envoy::Http::Headers::get().Status.get()));

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -384,7 +384,7 @@ static constexpr absl::string_view HTTP_10_RESPONSE_PREFIX = "HTTP/1.0 ";
 void ResponseEncoderImpl::encodeHeaders(const ResponseHeaderMap& headers, bool end_stream) {
   started_response_ = true;
 
-  // The contract is that client codecs must ensure that :status is present.
+  // The contract is that client codecs must ensure that :status is present and valid.
   ASSERT(headers.Status() != nullptr);
   uint64_t numeric_status = Utility::getResponseStatus(headers);
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -513,14 +513,15 @@ std::string Utility::makeSetCookieValue(const std::string& key, const std::strin
 }
 
 uint64_t Utility::getResponseStatus(const ResponseHeaderMap& headers) {
-  auto status = Utility::getResponseStatusNoThrow(headers);
+  auto status = Utility::getResponseStatusOrNullopt(headers);
   if (!status.has_value()) {
-    throw CodecClientException(":status must be specified and a valid unsigned long");
+    IS_ENVOY_BUG("No status in headers");
+    return 0;
   }
   return status.value();
 }
 
-absl::optional<uint64_t> Utility::getResponseStatusNoThrow(const ResponseHeaderMap& headers) {
+absl::optional<uint64_t> Utility::getResponseStatusOrNullopt(const ResponseHeaderMap& headers) {
   const HeaderEntry* header = headers.Status();
   uint64_t response_code;
   if (!header || !absl::SimpleAtoi(headers.getStatusValue(), &response_code)) {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -321,7 +321,7 @@ std::string makeSetCookieValue(const std::string& key, const std::string& value,
 /**
  * Get the response status from the response headers.
  * @param headers supplies the headers to get the status from.
- * @return uint64_t the response code or throws an exception if the headers are invalid.
+ * @return uint64_t the response code or returns 0 if headers are invalid.
  */
 uint64_t getResponseStatus(const ResponseHeaderMap& headers);
 
@@ -330,7 +330,7 @@ uint64_t getResponseStatus(const ResponseHeaderMap& headers);
  * @param headers supplies the headers to get the status from.
  * @return absl::optional<uint64_t> the response code or absl::nullopt if the headers are invalid.
  */
-absl::optional<uint64_t> getResponseStatusNoThrow(const ResponseHeaderMap& headers);
+absl::optional<uint64_t> getResponseStatusOrNullopt(const ResponseHeaderMap& headers);
 
 /**
  * Determine whether these headers are a valid Upgrade request or response.

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -190,7 +190,7 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
     return;
   }
   const absl::optional<uint64_t> optional_status =
-      Http::Utility::getResponseStatusNoThrow(*headers);
+      Http::Utility::getResponseStatusOrNullopt(*headers);
   if (!optional_status.has_value()) {
     details_ = Http3ResponseCodeDetailValues::invalid_http_header;
     onStreamError(!http3_options_.override_stream_error_on_invalid_http_message().value(),

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -381,20 +381,22 @@ RetryStateImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_he
                                                                   : RetryDecision::NoRetry;
   }
 
+  uint64_t response_status = Http::Utility::getResponseStatus(response_headers);
+
   if (retry_on_ & RetryPolicy::RETRY_ON_5XX) {
-    if (Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(response_headers))) {
+    if (Http::CodeUtility::is5xx(response_status)) {
       return RetryDecision::RetryWithBackoff;
     }
   }
 
   if (retry_on_ & RetryPolicy::RETRY_ON_GATEWAY_ERROR) {
-    if (Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(response_headers))) {
+    if (Http::CodeUtility::isGatewayError(response_status)) {
       return RetryDecision::RetryWithBackoff;
     }
   }
 
   if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_4XX)) {
-    Http::Code code = static_cast<Http::Code>(Http::Utility::getResponseStatus(response_headers));
+    Http::Code code = static_cast<Http::Code>(response_status);
     if (code == Http::Code::Conflict) {
       return RetryDecision::RetryWithBackoff;
     }
@@ -402,8 +404,7 @@ RetryStateImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_he
 
   if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES)) {
     for (auto code : retriable_status_codes_) {
-      uint32_t status_code = Http::Utility::getResponseStatus(response_headers);
-      if (status_code == code) {
+      if (response_status == code) {
         if (!conn_pool_new_stream_with_early_data_and_http3_ ||
             static_cast<Http::Code>(code) != Http::Code::TooEarly) {
           return RetryDecision::RetryWithBackoff;

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_impl.cc
@@ -69,7 +69,7 @@ void GcpAuthnClient::fetchToken(RequestCallbacks& callbacks, Http::RequestMessag
 
 void GcpAuthnClient::onSuccess(const Http::AsyncClient::Request&,
                                Http::ResponseMessagePtr&& response) {
-  auto status = Envoy::Http::Utility::getResponseStatusNoThrow(response->headers());
+  auto status = Envoy::Http::Utility::getResponseStatusOrNullopt(response->headers());
   active_request_ = nullptr;
   if (status.has_value()) {
     uint64_t status_code = status.value();

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -249,7 +249,7 @@ public:
                                                           *context_.conn_manager_config_,
                                                           /*via=*/"", stream_info_, /*node_id=*/"");
           // Check for validity of response-status explicitly, as encodeHeaders() might throw.
-          if (!Utility::getResponseStatusNoThrow(headers).has_value()) {
+          if (!Utility::getResponseStatusOrNullopt(headers).has_value()) {
             headers.setReferenceKey(Headers::get().Status, "200");
           }
           state.response_encoder_->encodeHeaders(headers, end_stream);

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -155,7 +155,8 @@ TEST(HttpUtility, replaceQueryString) {
 }
 
 TEST(HttpUtility, getResponseStatus) {
-  EXPECT_THROW(Utility::getResponseStatus(TestResponseHeaderMapImpl{}), CodecClientException);
+  EXPECT_ENVOY_BUG(Utility::getResponseStatus(TestResponseHeaderMapImpl{}),
+                   "Details: No status in headers");
   EXPECT_EQ(200U, Utility::getResponseStatus(TestResponseHeaderMapImpl{{":status", "200"}}));
 }
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -725,7 +725,8 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersSetViaRequestHeader) {
 
     expectTimerCreateAndEnable();
 
-    Http::TestResponseHeaderMapImpl response_headers{{"x-upstream-pushback", "yes"}};
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"x-upstream-pushback", "yes"}};
     EXPECT_EQ(RetryStatus::Yes,
               state_->shouldRetryHeaders(response_headers, request_headers, header_callback_));
   }
@@ -738,7 +739,7 @@ TEST_F(RouterRetryStateImplTest, RetriableHeadersSetViaRequestHeader) {
 
     expectTimerCreateAndEnable();
 
-    Http::TestResponseHeaderMapImpl response_headers{{"foobar", "false"}};
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"foobar", "false"}};
     EXPECT_EQ(RetryStatus::Yes,
               state_->shouldRetryHeaders(response_headers, request_headers, header_callback_));
   }

--- a/test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h
+++ b/test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h
@@ -145,9 +145,7 @@ inline Http::FilterHeadersStatus HttpFilterFuzzer::sendHeaders(Http::StreamEncod
   // Status must be a valid unsigned long. If not set, the utility function below will throw
   // an exception on the data path of some filters. This should never happen in production, so catch
   // the exception and set to a default value.
-  try {
-    (void)Http::Utility::getResponseStatus(response_headers_);
-  } catch (const Http::CodecClientException& e) {
+  if (!Http::Utility::getResponseStatusOrNullopt(response_headers_).has_value()) {
     response_headers_.setStatus(200);
   }
 


### PR DESCRIPTION
Removing the http status code check which throws an exception. By default status will now ENVOY_BUG and return 0 if the status header is not present.
May break downstream unit tests which relied on the throw (as I had to refactor envoy unit tests accordingly)

Risk Level: low
Testing: updated tests
Docs Changes: n/a
Release Notes: n/a