### PR TITLE
docs: hide docs for unused HeaderAppendAction enum

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -334,7 +334,7 @@ message HeaderValueOption {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HeaderValueOption";
 
-  // Describes the supported actions types for header append action.
+  // [#not-implemented-hide:] Describes the supported actions types for header append action.
   enum HeaderAppendAction {
     // This action will append the specified value to the existing values if the header
     // already exists. If the header doesn't exist then this will add the header with


### PR DESCRIPTION
Signed-off-by: Diogo Campos me@diogocampos.com

Commit Message: Hide docs for unused HeaderAppendAction enum
Additional Description: This hides the documentation for the unused HeaderAppendActions enum that may cause a reader to try a feature that doesn't exist. It's a very tiny PR up for your consideration, perfectly happy for you to close it/not merge. I did spend some time trying to use this Enum before seeing envoyproxy#19856, where it was suggested that we could hide this enum.
Risk Level: Low
Testing: N/A
Docs Changes: Hides an unused enum in the HeaderValueOption message
Release Notes: None
Platform Specific Features: None
Fixes #Issue: envoyproxy#19856