### PR TITLE
bazel: add -no_deduplicate for dbg builds on darwin

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -594,6 +594,30 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
+    name = "apple_dbg",
+    match_all = [
+        ":apple",
+        ":dbg_build",
+    ],
+)
+
+selects.config_setting_group(
+    name = "apple_fastbuild",
+    match_all = [
+        ":apple",
+        ":fastbuild_build",
+    ],
+)
+
+selects.config_setting_group(
+    name = "apple_non_opt",
+    match_any = [
+        ":apple_dbg",
+        ":apple_fastbuild",
+    ],
+)
+
+selects.config_setting_group(
     name = "linux",
     match_any = [
         ":linux_aarch64",

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -3,6 +3,7 @@
 load(
     ":envoy_internal.bzl",
     "envoy_copts",
+    "envoy_dbg_linkopts",
     "envoy_external_dep_path",
     "envoy_stdlib_deps",
     "tcmalloc_external_dep",
@@ -29,6 +30,7 @@ def envoy_cc_binary(
     if stamped:
         linkopts = linkopts + _envoy_stamped_linkopts()
         deps = deps + _envoy_stamped_deps()
+    linkopts += envoy_dbg_linkopts()
     deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + envoy_stdlib_deps()
     native.cc_binary(
         name = name,

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -154,6 +154,13 @@ def envoy_stdlib_deps():
         "//conditions:default": ["@envoy//bazel:static_stdlib"],
     })
 
+def envoy_dbg_linkopts():
+    return select({
+        # TODO: Remove once we have https://github.com/bazelbuild/bazel/pull/15635
+        "@envoy//bazel:apple_non_opt": ["-Wl,-no_deduplicate"],
+        "//conditions:default": [],
+    })
+
 # Dependencies on tcmalloc_and_profiler should be wrapped with this function.
 def tcmalloc_external_dep(repository):
     return select({

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -8,6 +8,7 @@ load(":envoy_pch.bzl", "envoy_pch_copts")
 load(
     ":envoy_internal.bzl",
     "envoy_copts",
+    "envoy_dbg_linkopts",
     "envoy_external_dep_path",
     "envoy_linkstatic",
     "envoy_select_force_libcpp",
@@ -105,7 +106,7 @@ def envoy_cc_fuzz_test(
     native.cc_test(
         name = name,
         copts = envoy_copts("@envoy", test = True),
-        linkopts = _envoy_test_linkopts() + select({
+        linkopts = _envoy_test_linkopts() + envoy_dbg_linkopts() + select({
             "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
             "//conditions:default": [],
         }),


### PR DESCRIPTION
This is a linker optimization that trades link time for binary size.
This change enables -no_deduplicate for dbg and fastbuild, which on my
M1 Max mbp takes link time of the main envoy binary from 60s to 12s on
macOS.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>