### PR TITLE
[contrib-sipproxy] fix the issue of top-uri

### DIFF
--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -198,6 +198,7 @@ FilterStatus Router::handleAffinity() {
 
     if (!options->customizedAffinity().entries().empty()) {
       for (const auto& aff : options->customizedAffinity().entries()) {
+        // default header is Route, TOP-URI also used as Route
         HeaderType header = HeaderType::Route;
         if (!aff.header().empty()) {
           header = HeaderTypes::get().str2Header(aff.header());
@@ -215,6 +216,11 @@ FilterStatus Router::handleAffinity() {
         } else if (type == "ep") {
           key = "ep";
         } else {
+          // If the header is Route, and the value is empty, then use the top-uri
+          if ((header == HeaderType::Route) && (metadata->header(HeaderType::Route).empty())) {
+            header = HeaderType::TopLine;
+          }
+
           metadata->parseHeader(header);
           if (metadata->header(header).hasParam(type)) {
             key = metadata->header(header).param(type);


### PR DESCRIPTION
If header of customized_affinity entities is `Route` and there is no
`Route` header in sip message, use `TOP-URI` instead

Signed-off-by: Felix Du <durd07@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
