### PR TITLE
tooling: Remove (default) `remote_download_outputs` flags

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -310,10 +310,6 @@ bazel build envoy --config=remote-clang \
 Change the value of `--remote_cache`, `--remote_executor` and `--remote_instance_name` for your remote build services. Tests can
 be run in remote execution too.
 
-Note: Currently the test run configuration in `.bazelrc` doesn't download test binaries and test logs,
-to override the behavior set [`--experimental_remote_download_outputs`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_remote_download_outputs)
-accordingly.
-
 ## Building Envoy with Docker sandbox
 
 Building Envoy with Docker sandbox uses the same Docker image used in CI with fixed C++ toolchain configuration. It produces more consistent

--- a/tools/proto_format/proto_format.sh
+++ b/tools/proto_format/proto_format.sh
@@ -23,9 +23,6 @@ read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
 # Generate //versioning:active_protos.
 ./tools/proto_format/active_protos_gen.py ./api > ./api/versioning/BUILD
 
-# This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
-BAZEL_BUILD_OPTIONS+=("--remote_download_outputs=all")
-
 # If the specified command is 'freeze', we tell protoxform to adjust package version status to
 # reflect a major version freeze and then do a regular 'fix'.
 PROTO_SYNC_CMD="$1"


### PR DESCRIPTION
the flag is no longer experimental, and the default is what we
are setting it to.

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
