### PR TITLE
proto_format: Use aspect to protoprint formatted api

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -487,6 +487,7 @@ elif [[ "$CI_TARGET" == "check_proto_format" ]]; then
   echo "Run protoxform test"
   bazel run "${BAZEL_BUILD_OPTIONS[@]}" \
         --//tools/api_proto_plugin:default_type_db_target=//tools/testdata/protoxform:fix_protos \
+        --//tools/api_proto_plugin:extra_args=api_version:3.7 \
         //tools/protoprint:protoprint_test
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" "${ENVOY_SRCDIR}"/tools/proto_format/proto_format.sh check
   exit 0

--- a/tools/api_proto_plugin/plugin.bzl
+++ b/tools/api_proto_plugin/plugin.bzl
@@ -23,6 +23,12 @@ def _path_ignoring_repository(f):
 def api_proto_plugin_impl(target, ctx, output_group, mnemonic, output_suffixes):
     # Compute output files from the current proto_library node's dependencies.
     transitive_outputs = depset(transitive = [dep.output_groups[output_group] for dep in ctx.rule.attr.deps])
+
+    # TODO(phlax): Return `ProtoInfo` from `proto` aspects, and this should
+    #    not be necessary.
+    if ProtoInfo not in target:
+        return [OutputGroupInfo(**{output_group: transitive_outputs})]
+
     proto_sources = [
         f
         for f in target[ProtoInfo].direct_sources

--- a/tools/api_proto_plugin/plugin.py
+++ b/tools/api_proto_plugin/plugin.py
@@ -35,7 +35,7 @@ def direct_output_descriptor(output_suffix, visitor, want_params=False):
 
 
 # TODO(phlax): make this into a class
-def plugin(output_descriptors):
+def plugin(output_descriptors, traverser=None):
     """Protoc plugin entry point.
 
     This defines protoc plugin and manages the stdin -> stdout flow. An
@@ -48,6 +48,9 @@ def plugin(output_descriptors):
     Args:
         output_descriptors: a list of OutputDescriptors.
     """
+
+    traverser = traverser or traverse.traverse_file
+
     request = plugin_pb2.CodeGeneratorRequest()
     request.ParseFromString(sys.stdin.buffer.read())
     response = plugin_pb2.CodeGeneratorResponse()
@@ -72,7 +75,7 @@ def plugin(output_descriptors):
             else:
                 xformed_proto = od.xform(file_proto)
                 visitor_factory = od.visitor_factory()
-            f.content = traverse.traverse_file(xformed_proto, visitor_factory)
+            f.content = traverser(xformed_proto, visitor_factory)
         if cprofile_enabled:
             pr.disable()
             stats_stream = io.StringIO()

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -72,14 +72,11 @@ py_binary(
     srcs = ["format_api.py"],
     args = [
         "--api_root=%s/api" % PATH,
-        "--protoprint=$(location //tools/protoprint)",
-        "--descriptor=$(location //tools/type_whisperer:api_type_db.pb_text)",
     ],
-    data = ["//tools/type_whisperer:api_type_db.pb_text"],
+    data = ["//:.clang-format"],
     deps = [
         ":data",
         "//tools/api_proto_plugin:utils",
-        "//tools/protoprint",
     ],
 )
 
@@ -89,16 +86,14 @@ genrule(
     cmd = """
     $(location :format_api) \
         --api_root=%s/api \
-        --protoprint=$(location //tools/protoprint) \
-        --descriptor=$(location //tools/type_whisperer:api_type_db.pb_text) \
         --outfile=$@ \
         --xformed=$(location :xformed) \
+        --protoprinted=$(location //tools/protoprint:protoprinted) \
     """ % PATH,
     tools = [
         ":format_api",
         ":xformed",
-        "//tools/protoprint",
-        "//tools/type_whisperer:api_type_db.pb_text",
+        "//tools/protoprint:protoprinted",
     ],
 )
 

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -12,7 +12,8 @@ import tempfile
 
 
 def git_status(path):
-    return subprocess.check_output(['git', 'status', '--porcelain', str(path)]).decode()
+    return subprocess.check_output(
+        ['git', 'status', '--porcelain', str(path)], cwd=str(path)).decode()
 
 
 def generate_current_api_dir(api_dir, dst_dir):

--- a/tools/protoprint/BUILD
+++ b/tools/protoprint/BUILD
@@ -1,7 +1,10 @@
 load("//bazel:envoy_build_system.bzl", "envoy_package")
+load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("//tools/base:envoy_python.bzl", "envoy_py_data")
+load("//tools/protoprint:protoprint.bzl", "protoprint_rule")
 
 licenses(["notice"])  # Apache 2
 
@@ -12,7 +15,6 @@ py_binary(
     srcs = ["protoprint.py"],
     data = [
         "//:.clang-format",
-        "//:API_VERSION.txt",
         "//tools/type_whisperer:api_type_db.pb_text",
     ],
     visibility = ["//visibility:public"],
@@ -20,8 +22,11 @@ py_binary(
         "//tools/api_versioning:utils",
         "//tools/protoxform:options",
         "//tools/protoxform:utils",
+        "@envoy_repo",
+        requirement("packaging"),
         "//tools/type_whisperer",
         "//tools/type_whisperer:api_type_db_proto_py_proto",
+        "@bazel_tools//tools/python/runfiles",
         "@com_envoyproxy_protoc_gen_validate//validate:validate_py",
         "@com_github_cncf_udpa//udpa/annotations:pkg_py_proto",
         "@com_github_cncf_udpa//xds/annotations/v3:pkg_py_proto",
@@ -29,6 +34,44 @@ py_binary(
         "@com_google_protobuf//:protobuf_python",
         "@envoy_api//envoy/annotations:pkg_py_proto",
     ],
+)
+
+protoprint_rule(
+    name = "protoprinted_srcs",
+    deps = ["//tools/protoxform:api_protoxform"],
+)
+
+pkg_files(
+    name = "protoprinted_files",
+    srcs = [":protoprinted_srcs"],
+    strip_prefix = strip_prefix.from_pkg(),
+)
+
+pkg_files(
+    name = "protoprinted_files_stripped",
+    srcs = [":protoprinted_files"],
+    strip_prefix = "pkg",
+)
+
+pkg_tar(
+    name = "protoprinted",
+    srcs = [":protoprinted_files_stripped"],
+)
+
+protoprint_rule(
+    name = "test_protoprinted_srcs",
+    deps = ["//tools/protoxform:test_protoxform"],
+)
+
+pkg_files(
+    name = "test_protoprinted_files_stripped",
+    srcs = [":test_protoprinted_srcs"],
+    strip_prefix = strip_prefix.from_pkg(),
+)
+
+pkg_tar(
+    name = "test_protoprinted",
+    srcs = [":test_protoprinted_files_stripped"],
 )
 
 pkg_tar(
@@ -45,18 +88,14 @@ py_binary(
     name = "protoprint_test",
     srcs = ["protoprint_test.py"],
     args = [
-        "$(location :protoprint)",
-        "$(location //tools/type_whisperer:api_type_db.pb_text)",
-        "$(location //tools/protoxform:xformed_test_protos)",
-        "$(location :golden_test_protos)",
+        "--formatted=$(location :test_protoprinted)",
+        "--golden=$(location :golden_test_protos)",
     ],
     data = [
         ":golden_test_protos",
-        "//tools/protoxform:xformed_test_protos",
-        "//tools/type_whisperer:api_type_db.pb_text",
+        ":test_protoprinted",
     ],
     deps = [
-        ":protoprint",
         ":test_data",
         "//tools:run_command",
         "@envoy_repo",

--- a/tools/protoprint/protoprint.bzl
+++ b/tools/protoprint/protoprint.bzl
@@ -1,0 +1,52 @@
+load("//tools/api_proto_plugin:plugin.bzl", "api_proto_plugin_aspect", "api_proto_plugin_impl")
+
+def _protoprint_impl(target, ctx):
+    return api_proto_plugin_impl(
+        target,
+        ctx,
+        "pproto",
+        "protoprint",
+        [".proto"],
+    )
+
+# Bazel aspect (https://docs.bazel.build/versions/master/starlark/aspects.html)
+# that can be invoked from the CLI to perform API transforms via //tools/protoprint for
+# proto_library targets. Example use:
+#
+#   bazel build //api --aspects tools/protoprint/protoprint.bzl%protoprint_aspect \
+#       --output_groups=proto
+#
+protoprint_aspect = api_proto_plugin_aspect(
+    "//tools/protoprint",
+    _protoprint_impl,
+    use_type_db = True,
+)
+
+def _protoprint_rule_impl(ctx):
+    deps = []
+    for dep in ctx.attr.deps:
+        for path in dep[OutputGroupInfo].pproto.to_list():
+            envoy_api = (
+                path.short_path.startswith("../envoy_api") or
+                # path.short_path.startswith("../com_github_cncf_udpa") or
+                path.short_path.startswith("tools/testdata")
+            )
+            if envoy_api:
+                deps.append(path)
+
+    return [
+        DefaultInfo(
+            files = depset(
+                transitive = [
+                    depset(deps),
+                ],
+            ),
+        ),
+    ]
+
+protoprint_rule = rule(
+    implementation = _protoprint_rule_impl,
+    attrs = {
+        "deps": attr.label_list(aspects = [protoprint_aspect]),
+    },
+)

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -23,6 +23,11 @@ from packaging import version
 
 from bazel_tools.tools.python.runfiles import runfiles
 
+# We have to do some evil things to sys.path due to the way that Python module
+# resolution works; we have both tools/ trees in bazel_tools and envoy. By
+# default, Bazel leaves us with a sys.path in which the @bazel_tools repository
+# takes precedence. Now that we're done with importing runfiles above, we can
+# just remove it from the sys.path.
 sys.path = [p for p in sys.path if not p.endswith('bazel_tools')]
 
 from tools.api_proto_plugin import annotations, plugin, traverse, visitor

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -8,7 +8,6 @@
 # Usage: protoprint.py <source file path> <type database path> <load type db path>
 #                      <api version file path>
 
-from collections import deque
 import copy
 import functools
 import io
@@ -17,8 +16,16 @@ import pathlib
 import re
 import subprocess
 import sys
+from collections import deque
+from functools import cached_property
 
-from tools.api_proto_plugin import annotations, traverse, visitor
+from packaging import version
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+sys.path = [p for p in sys.path if not p.endswith('bazel_tools')]
+
+from tools.api_proto_plugin import annotations, plugin, traverse, visitor
 from tools.api_versioning import utils as api_version_utils
 from tools.protoxform import options as protoxform_options, utils
 from tools.type_whisperer import type_whisperer, types_pb2
@@ -29,6 +36,8 @@ from google.protobuf import text_format
 from envoy.annotations import deprecation_pb2
 from udpa.annotations import migrate_pb2, status_pb2
 from xds.annotations.v3 import status_pb2 as xds_status_pb2
+
+import envoy_repo
 
 NEXT_FREE_FIELD_MIN = 5
 
@@ -65,8 +74,8 @@ def extract_clang_proto_style(clang_format_text):
     return str(format_dict)
 
 
-# Ensure we are using the canonical clang-format proto style.
-CLANG_FORMAT_STYLE = extract_clang_proto_style(pathlib.Path('.clang-format').read_text())
+CLANG_FORMAT_STYLE = extract_clang_proto_style(
+    pathlib.Path(runfiles.Create().Rlocation("envoy/.clang-format")).read_text())
 
 
 def clang_format(contents):
@@ -593,13 +602,24 @@ class ProtoFormatVisitor(visitor.Visitor):
 
     See visitor.Visitor for visitor method docs comments.
     """
+    _api_version = None
+    _requires_deprecation_annotation_import = False
 
-    def __init__(self, api_version_file_path, frozen_proto):
-        current_api_version = api_version_utils.get_api_version(api_version_file_path)
-        self._deprecated_annotation_version_value = '{}.{}'.format(
-            current_api_version.major, current_api_version.minor)
-        self._requires_deprecation_annotation_import = False
-        self._frozen_proto = frozen_proto
+    def __init__(self, params):
+        if params['type_db_path']:
+            utils.load_type_db(params['type_db_path'])
+
+        if extra_args := params.get("extra_args"):
+            if extra_args.startswith("api_version:"):
+                self._api_version = extra_args.split(":")[1]
+
+    @cached_property
+    def current_api_version(self):
+        return version.Version(self._api_version or envoy_repo.API_VERSION)
+
+    @cached_property
+    def _deprecated_annotation_version_value(self):
+        return f"{self.current_api_version.major}.{self.current_api_version.minor}"
 
     def _add_deprecation_version(self, field_or_evalue, deprecation_tag, disallowed_tag):
         """Adds a deprecation version annotation if needed to the given field or enum value.
@@ -652,6 +672,7 @@ class ProtoFormatVisitor(visitor.Visitor):
             return ''
         # Verify that not hidden deprecated enum values of non-frozen protos have valid version
         # annotations.
+
         for v in enum_proto.value:
             self._add_deprecation_version(
                 v, deprecation_pb2.deprecated_at_minor_version_enum,
@@ -726,20 +747,22 @@ class ProtoFormatVisitor(visitor.Visitor):
         return clang_format(header + formatted_services + formatted_enums + formatted_msgs)
 
 
-if __name__ == '__main__':
-    proto_desc_path = sys.argv[1]
+class ProtoprintTraverser:
 
+    def traverse_file(self, file_proto, visitor):
+        # This breaks the Visitor contract, ie class props should not be set on individual visitation.
+        visitor._frozen_proto = (
+            file_proto.options.Extensions[status_pb2.file_status].package_version_status ==
+            status_pb2.FROZEN)
+        return traverse.traverse_file(file_proto, visitor)
+
+
+def main(data=None):
     utils.load_protos()
 
-    file_proto = descriptor_pb2.FileDescriptorProto()
-    input_text = pathlib.Path(proto_desc_path).read_text()
-    if not input_text:
-        sys.exit(0)
-    text_format.Merge(input_text, file_proto)
-    dst_path = pathlib.Path(sys.argv[2])
-    utils.load_type_db(sys.argv[3])
-    api_version_file_path = pathlib.Path(sys.argv[4])
-    frozen_proto = file_proto.options.Extensions[
-        status_pb2.file_status].package_version_status == status_pb2.FROZEN
-    dst_path.write_bytes(
-        traverse.traverse_file(file_proto, ProtoFormatVisitor(api_version_file_path, frozen_proto)))
+    plugin.plugin([plugin.direct_output_descriptor('.proto', ProtoFormatVisitor, want_params=True)],
+                  traverser=ProtoprintTraverser().traverse_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -750,7 +750,8 @@ class ProtoFormatVisitor(visitor.Visitor):
 class ProtoprintTraverser:
 
     def traverse_file(self, file_proto, visitor):
-        # This breaks the Visitor contract, ie class props should not be set on individual visitation.
+        # TODO(phlax): Figure out how to pass this to visitors
+        #   This currently breaks the Visitor contract, ie class props should not be set on individual visitation.
         visitor._frozen_proto = (
             file_proto.options.Extensions[status_pb2.file_status].package_version_status ==
             status_pb2.FROZEN)

--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -63,6 +63,7 @@ jq(
 
 protoxform_rule(
     name = "test_protoxform",
+    visibility = ["//visibility:public"],
     deps = ["//tools/testdata/protoxform:fix_protos"],
 )
 


### PR DESCRIPTION
Commit Message:

This switches from calling protoprint in scripts with python multiproc to using a bazel aspect

Both the `proto_format.sh` job and the `protoprint_test` are switched to using a prebuilt protoprinted version of the api/test protos

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
