### PR TITLE
Split codec_impl_fuzz_test targets out by protocol

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -81,12 +81,16 @@ envoy_proto_library(
     deps = ["//test/fuzz:common_proto"],
 )
 
+# TODO(kbaichoo): We split the fuzzer by protocol to allow the fuzzer to
+# better explore the individual protocols and catagorize failures for the
+# particular protocol that fails. In the future we might want to further
+# split out the codec fuzzer to better model the individual protocols.
 [
     envoy_cc_fuzz_test(
-        name = "%s_codec_impl_fuzz_test" % codec_type,
+        name = "%s_codec_impl_fuzz_test" % http_protocol,
         srcs = ["codec_impl_fuzz_test.cc"],
         corpus = "codec_impl_corpus",
-        defines = ["FUZZ_CODEC_%s" % codec_type],
+        defines = ["FUZZ_PROTOCOL_%s" % http_protocol],
         deps = [
             ":codec_impl_fuzz_proto_cc_proto",
             "//source/common/http:conn_manager_lib",
@@ -100,11 +104,9 @@ envoy_proto_library(
             "//test/test_common:test_runtime_lib",
         ],
     )
-    for codec_type in [
+    for http_protocol in [
         "http1",
-        "nghttp2",
-        "wrapped_nghttp2",
-        "oghttp2",
+        "http2",
     ]
 ]
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -81,23 +81,32 @@ envoy_proto_library(
     deps = ["//test/fuzz:common_proto"],
 )
 
-envoy_cc_fuzz_test(
-    name = "codec_impl_fuzz_test",
-    srcs = ["codec_impl_fuzz_test.cc"],
-    corpus = "codec_impl_corpus",
-    deps = [
-        ":codec_impl_fuzz_proto_cc_proto",
-        "//source/common/http:conn_manager_lib",
-        "//source/common/http:header_map_lib",
-        "//source/common/http/http1:codec_lib",
-        "//source/common/http/http2:codec_lib",
-        "//test/common/http/http2:codec_impl_test_util",
-        "//test/fuzz:utility_lib",
-        "//test/mocks/http:http_mocks",
-        "//test/mocks/network:network_mocks",
-        "//test/test_common:test_runtime_lib",
-    ],
-)
+[
+    envoy_cc_fuzz_test(
+        name = "%s_codec_impl_fuzz_test" % codec_type,
+        srcs = ["codec_impl_fuzz_test.cc"],
+        corpus = "codec_impl_corpus",
+        defines = ["FUZZ_CODEC_%s" % codec_type],
+        deps = [
+            ":codec_impl_fuzz_proto_cc_proto",
+            "//source/common/http:conn_manager_lib",
+            "//source/common/http:header_map_lib",
+            "//source/common/http/http1:codec_lib",
+            "//source/common/http/http2:codec_lib",
+            "//test/common/http/http2:codec_impl_test_util",
+            "//test/fuzz:utility_lib",
+            "//test/mocks/http:http_mocks",
+            "//test/mocks/network:network_mocks",
+            "//test/test_common:test_runtime_lib",
+        ],
+    )
+    for codec_type in [
+        "http1",
+        "nghttp2",
+        "wrapped_nghttp2",
+        "oghttp2",
+    ]
+]
 
 envoy_cc_test(
     name = "filter_manager_test",

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -786,9 +786,16 @@ DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
   try {
     // Validate input early.
     TestUtility::validate(input);
+#ifdef FUZZ_CODEC_http1
     codecFuzz(input, HttpVersion::Http1);
+#endif
+#ifdef FUZZ_CODEC_nghttp2
     codecFuzz(input, HttpVersion::Http2Nghttp2);
+#endif
+#ifdef FUZZ_CODEC_wrapped_nghttp2
     codecFuzz(input, HttpVersion::Http2WrappedNghttp2);
+#endif
+#ifdef FUZZ_CODEC_oghttp2
     // Prevent oghttp2 from aborting the program.
     // If when disabling the FATAL log abort the fuzzer will create a test that reaches an
     // inconsistent state (and crashes/accesses inconsistent memory), then it will be a bug we'll
@@ -796,6 +803,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
     // happen in production environments.
     quiche::setDFatalExitDisabled(true);
     codecFuzz(input, HttpVersion::Http2Oghttp2);
+#endif
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
   }

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -779,6 +779,26 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
   server_connection.dispatcher_.to_delete_.clear();
 }
 
+#ifdef FUZZ_PROTOCOL_http1
+void codecFuzzHttp1(const test::common::http::CodecImplFuzzTestCase& input) {
+  codecFuzz(input, HttpVersion::Http1);
+}
+#endif
+
+#ifdef FUZZ_PROTOCOL_http2
+void codecFuzzHttp2Nghttp2(const test::common::http::CodecImplFuzzTestCase& input) {
+  codecFuzz(input, HttpVersion::Http2Nghttp2);
+}
+
+void codecFuzzHttp2WrappedNghttp2(const test::common::http::CodecImplFuzzTestCase& input) {
+  codecFuzz(input, HttpVersion::Http2WrappedNghttp2);
+}
+
+void codecFuzzHttp2Oghttp2(const test::common::http::CodecImplFuzzTestCase& input) {
+  codecFuzz(input, HttpVersion::Http2Oghttp2);
+}
+#endif
+
 } // namespace
 
 // Fuzz the H1/H2 codec implementations.
@@ -786,23 +806,19 @@ DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
   try {
     // Validate input early.
     TestUtility::validate(input);
-#ifdef FUZZ_CODEC_http1
-    codecFuzz(input, HttpVersion::Http1);
+#ifdef FUZZ_PROTOCOL_http1
+    codecFuzzHttp1(input);
 #endif
-#ifdef FUZZ_CODEC_nghttp2
-    codecFuzz(input, HttpVersion::Http2Nghttp2);
-#endif
-#ifdef FUZZ_CODEC_wrapped_nghttp2
-    codecFuzz(input, HttpVersion::Http2WrappedNghttp2);
-#endif
-#ifdef FUZZ_CODEC_oghttp2
+#ifdef FUZZ_PROTOCOL_http2
+    codecFuzzHttp2Nghttp2(input);
+    codecFuzzHttp2WrappedNghttp2(input);
     // Prevent oghttp2 from aborting the program.
     // If when disabling the FATAL log abort the fuzzer will create a test that reaches an
     // inconsistent state (and crashes/accesses inconsistent memory), then it will be a bug we'll
     // need to further evaluate. However, in fuzzing we allow oghttp2 reaching FATAL states that may
     // happen in production environments.
     quiche::setDFatalExitDisabled(true);
-    codecFuzz(input, HttpVersion::Http2Oghttp2);
+    codecFuzzHttp2Oghttp2(input);
 #endif
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -810,6 +810,8 @@ DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
     codecFuzzHttp1(input);
 #endif
 #ifdef FUZZ_PROTOCOL_http2
+    // We wrap the calls to *codecFuzz* through these functions in order for
+    // the codec name to explicitly be in any stacktrace.
     codecFuzzHttp2Nghttp2(input);
     codecFuzzHttp2WrappedNghttp2(input);
     // Prevent oghttp2 from aborting the program.


### PR DESCRIPTION
This allows the fuzzer to focus on the individual protocols better and allows us to categorize failures by protocol.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Split codec_impl_fuzz_test targets out by protocol.
Additional Description:
Risk Level: low
Testing: built and ran target
Docs Changes: na
Release Notes: na
Platform Specific Features: na
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
