### PR TITLE
ci: Re-organize format jobs

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -13,34 +13,34 @@ pr: none
 stages:
 - stage: precheck
   jobs:
-  - job: format_pre
+  - job: format
     dependsOn: []
     pool:
       vmImage: "ubuntu-18.04"
     steps:
     - task: Cache@2
       inputs:
-        key: "format_pre | ./WORKSPACE | **/*.bzl"
+        key: "format | ./WORKSPACE | **/*.bzl"
         path: $(Build.StagingDirectory)/repository_cache
       continueOnError: true
 
-    - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format_pre'
+    - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format'
       workingDirectory: $(Build.SourcesDirectory)
       env:
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
         GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
-      displayName: "Run format pre-checks"
+      displayName: "Run format checks"
     - task: PublishBuildArtifacts@1
       inputs:
-        pathtoPublish: "$(Build.StagingDirectory)/fix_format_pre.diff"
+        pathtoPublish: "$(Build.StagingDirectory)/fix_format.diff"
         artifactName: format
       # not all have fixes so improve condition/handling
       condition: failed()
 
-  - job: format
-    dependsOn: ["format_pre"]
+  - job: proto_format
+    dependsOn: []
     pool:
       vmImage: "ubuntu-18.04"
     steps:
@@ -61,7 +61,7 @@ stages:
 
     - task: PublishBuildArtifacts@1
       inputs:
-        pathtoPublish: "$(Build.StagingDirectory)/fix_format.diff"
+        pathtoPublish: "$(Build.StagingDirectory)/fix_proto_format.diff"
         artifactName: format
       condition: failed()
 

--- a/ci/check_and_fix_format.sh
+++ b/ci/check_and_fix_format.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIFF_OUTPUT="${DIFF_OUTPUT:-/build/fix_format.diff}"
+DIFF_OUTPUT="${DIFF_OUTPUT:-/build/fix_proto_format.diff}"
 
 # We set this for two reasons. First, we want to ensure belt-and-braces that we check these formats
 # in CI in case the skip-on-file-change heuristics in proto_format.sh etc. are buggy. Second, this
@@ -12,7 +12,7 @@ export FORCE_PYTHON_FORMAT=yes
 
 function fix {
   set +e
-  ci/do_ci.sh fix_format
+  ci/do_ci.sh fix_proto_format
   echo "Format check failed, try apply following patch to fix:"
   git add api
   git diff HEAD | tee "${DIFF_OUTPUT}"
@@ -23,4 +23,4 @@ function fix {
 # If any of the checks fail, run the fix function above.
 trap fix ERR
 
-ci/do_ci.sh check_format
+ci/do_ci.sh check_proto_format

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -6,7 +6,7 @@ set -e
 
 
 build_setup_args=""
-if [[ "$1" == "format_pre" || "$1" == "fix_format" || "$1" == "check_format" || "$1" == "docs" ||  \
+if [[ "$1" == "format" || "$1" == "fix_proto_format" || "$1" == "check_proto_format" || "$1" == "docs" ||  \
           "$1" == "bazel.clang_tidy" || "$1" == "bazel.distribution" \
           || "$1" == "deps" || "$1" == "verify_examples" || "$1" == "verify_build_examples" \
           || "$1" == "verify_distro" ]]; then
@@ -473,29 +473,18 @@ elif [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
   echo "Building envoy fuzzers and executing 100 fuzz iterations..."
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" --config=asan-fuzzer "${FUZZ_TEST_TARGETS[@]}" --test_arg="-runs=10"
   exit 0
-elif [[ "$CI_TARGET" == "format_pre" ]]; then
+elif [[ "$CI_TARGET" == "format" ]]; then
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" "${ENVOY_SRCDIR}"/ci/format_pre.sh
-elif [[ "$CI_TARGET" == "fix_format" ]]; then
+elif [[ "$CI_TARGET" == "fix_proto_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
-
-  echo "Run protoxform test"
-  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" ./tools/protoxform/protoxform_test.sh
-
-  # TODO(phlax): move this to a bazel rule
-  echo "check_format_test..."
-  "${ENVOY_SRCDIR}"/tools/code_format/check_format_test_helper.sh --log=WARN
-
-  echo "fix_format..."
-  "${ENVOY_SRCDIR}"/tools/code_format/check_format.py fix
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" "${ENVOY_SRCDIR}"/tools/proto_format/proto_format.sh fix
   exit 0
-elif [[ "$CI_TARGET" == "check_format" ]]; then
+elif [[ "$CI_TARGET" == "check_proto_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
-
-  echo "check_format..."
-  "${ENVOY_SRCDIR}"/tools/code_format/check_format.py check
+  echo "Run protoxform test"
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" ./tools/protoxform/protoxform_test.sh
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" "${ENVOY_SRCDIR}"/tools/proto_format/proto_format.sh check
   exit 0
 elif [[ "$CI_TARGET" == "docs" ]]; then

--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -10,7 +10,7 @@ CURRENT=""
 # AZP appears to make lines with this prefix red
 BASH_ERR_PREFIX="##[error]: "
 
-DIFF_OUTPUT="${DIFF_OUTPUT:-/build/fix_format_pre.diff}"
+DIFF_OUTPUT="${DIFF_OUTPUT:-/build/fix_format.diff}"
 
 read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
 
@@ -50,6 +50,13 @@ bazel run "${BAZEL_BUILD_OPTIONS[@]}" //configs:example_configs_validation
 
 CURRENT=spelling
 "${ENVOY_SRCDIR}"/tools/spelling/check_spelling_pedantic.py --mark check
+
+# TODO(phlax): move these to bazel rules
+CURRENT=check_format_test
+"${ENVOY_SRCDIR}"/tools/code_format/check_format_test_helper.sh --log=WARN
+
+CURRENT=check_format
+"${ENVOY_SRCDIR}"/tools/code_format/check_format.py fix
 
 if [[ "${#FAILED[@]}" -ne "0" ]]; then
     echo "${BASH_ERR_PREFIX}TESTS FAILED:" >&2


### PR DESCRIPTION
Commit Message:
Additional Description:

Now that the format_pre jobs are much faster, i think it makes sense to put the format jobs together, with a view to integrating them longer term

currently, the proto_format job takes a lot longer than everyting else - im working to optimize this separately, but i think for now lets keep this separate and run concurrently

this PR also makes a slight change to the check_format run in that it just runs `fix` immediately rather than running `check` and conditionally running `fix`

the current behaviour with proto_format and check_format grouped together means that if either fails both are run twice - so this at least resolves that (proto_format still runs twice if it fails - but we can address that as part of optimization)

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
