### PR TITLE
ci: Set timeout for BES/resultstore streaming

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -322,6 +322,7 @@ build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 # Build Event Service
 build:google-bes --bes_backend=grpcs://buildeventservice.googleapis.com
 build:google-bes --bes_results_url=https://source.cloud.google.com/results/invocations/
+build:google-bes --bes_timeout=5s
 
 # Fuzz builds
 


### PR DESCRIPTION
Commit Message:
Additional Description:

Since adding BES streaming/resultstore some jobs can timeout or take a very long time in CI

It doesnt happen all the time and is seemingly a bit random, although  it does appear to happen after jobs that invoke aspects so my suspicion is that it is uploading all the info for each aspect job despite not publishing any URL anywhere for them (i havent been able to confirm this, but it seems correct)

I have found a couple of jobs in resultstore where this has happened that show as ~"tool broken"~ "tool failed"

I tried setting the timeout very low, in the hope that it would just raise a warning and move on, but it errors - so i have instead set it to 5s (the `--bes_best_effort` flag might've help here but is deprecated).

If this breaks anything we can revert and/or try to track down what is happening. 

I have tried to get upload/streaming telemetry to confirm my suspicions, but that does not appear to be available.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
