### PR TITLE
Partial revert "tooling: Remove (default) `remote_download_all` flags…

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -310,6 +310,10 @@ bazel build envoy --config=remote-clang \
 Change the value of `--remote_cache`, `--remote_executor` and `--remote_instance_name` for your remote build services. Tests can
 be run in remote execution too.
 
+Note: Currently the test run configuration in `.bazelrc` doesn't download test binaries and test logs,
+to override the behavior set [`--remote_download_outputs`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--remote_download_outputs)
+accordingly.
+
 ## Building Envoy with Docker sandbox
 
 Building Envoy with Docker sandbox uses the same Docker image used in CI with fixed C++ toolchain configuration. It produces more consistent


### PR DESCRIPTION
Commit Message:
Additional Description:

This is a partial  revert of #21733

It only restores the bazel README message, not the download in proto_format.sh

The reason for this is that i believe this was added due to the lack of an apect rule allowing the proto_sync invokation to take the ouputs from the aspect invokation as inputs

i have added the aspect rule already #21732 and im about to make use of it #21769 

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
