### PR TITLE
ci: Fix `CLANG_FORMAT` version

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -99,6 +99,7 @@ BAZEL_BUILD_OPTIONS=(
   "--noshow_loading_progress"
   "--repository_cache=${BUILD_DIR}/repository_cache"
   "--experimental_repository_cache_hardlinks"
+  "--action_env=CLANG_FORMAT"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -121,7 +121,7 @@ def check_tool_not_found_error():
     # Temporarily change PATH to test the error about lack of external tools.
     oldPath = os.environ["PATH"]
     os.environ["PATH"] = "/sbin:/usr/sbin"
-    clang_format = os.getenv("CLANG_FORMAT", "clang-format-11")
+    clang_format = os.getenv("CLANG_FORMAT", "clang-format")
     # If CLANG_FORMAT points directly to the binary, skip this test.
     if os.path.isfile(clang_format) and os.access(clang_format, os.X_OK):
         os.environ["PATH"] = oldPath

--- a/tools/protoxform/protoprint.py
+++ b/tools/protoxform/protoprint.py
@@ -78,7 +78,7 @@ def clang_format(contents):
     Returns:
         clang-formatted string
     """
-    clang_format_path = os.getenv("CLANG_FORMAT", "clang-format-11")
+    clang_format_path = os.getenv("CLANG_FORMAT", "clang-format")
     return subprocess.run(
         [clang_format_path,
          '--style=%s' % CLANG_FORMAT_STYLE, '--assume-filename=.proto'],


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

Currently the clang-format version is hardcoded to clang-format-11 if it doesnt find the one in env - this is wrong, so this PR fixes that.

Also, this currently works because whenever `CLANG_FORMAT` is required to be read from env it is running in a bazel `run` job so it can see the env var - this breaks if you try to run those jobs in a `build` job. This PR fixes that by adding `CLANG_FORMAT` as an `action_env` var


Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
