### PR TITLE
bazel: Add `API_VERSION` to `@envoy_repo` repository rule

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -57,26 +57,26 @@ _default_envoy_build_config = repository_rule(
 def _envoy_repo_impl(repository_ctx):
     """This provides information about the Envoy repository
 
-    You can access the current version and path to the repository in .bzl/BUILD
-    files as follows:
+    You can access the current project and api versions and the path to the repository in
+    .bzl/BUILD files as follows:
 
     ```starlark
-    load("@envoy_repo//:version.bzl", "VERSION")
+    load("@envoy_repo//:version.bzl", "VERSION", "API_VERSION")
     ```
 
-    `VERSION` can be used to derive version-specific rules and can be passed
+    `*VERSION` can be used to derive version-specific rules and can be passed
     to the rules.
 
-    The `VERSION` and also the local `PATH` to the repo can be accessed in
+    The `VERSION`s and also the local `PATH` to the repo can be accessed in
     python libraries/binaries. By adding `@envoy_repo` to `deps` they become
     importable through the `envoy_repo` namespace.
 
     As the `PATH` is local to the machine, it is generally only useful for
     jobs that will run locally.
 
-    This can be useful for example, for tooling that needs to check the
-    repository, or to run bazel queries that cannot be run within the
-    constraints of a `genquery`.
+    This can be useful, for example, for bazel run jobs to run bazel queries that cannot be run
+    within the constraints of a `genquery`, or that otherwise need access to the repository
+    files.
 
     """
     repo_version_path = repository_ctx.path(repository_ctx.attr.envoy_version)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -79,11 +79,13 @@ def _envoy_repo_impl(repository_ctx):
     constraints of a `genquery`.
 
     """
-    repo_path = repository_ctx.path(repository_ctx.attr.envoy_version)
-    version = repository_ctx.read(repo_path.dirname.get_child(repo_path.basename)).strip()
-    repository_ctx.file("version.bzl", "VERSION = '%s'" % version)
-    repository_ctx.file("path.bzl", "PATH = '%s'" % repo_path.dirname)
-    repository_ctx.file("__init__.py", "PATH = '%s'\nVERSION = '%s'" % (repo_path.dirname, version))
+    repo_version_path = repository_ctx.path(repository_ctx.attr.envoy_version)
+    api_version_path = repository_ctx.path(repository_ctx.attr.envoy_api_version)
+    version = repository_ctx.read(repo_version_path).strip()
+    api_version = repository_ctx.read(api_version_path).strip()
+    repository_ctx.file("version.bzl", "VERSION = '%s'\nAPI_VERSION = '%s'" % (version, api_version))
+    repository_ctx.file("path.bzl", "PATH = '%s'" % repo_version_path.dirname)
+    repository_ctx.file("__init__.py", "PATH = '%s'\nVERSION = '%s'\nAPI_VERSION = '%s'" % (repo_version_path.dirname, version, api_version))
     repository_ctx.file("WORKSPACE", "")
     repository_ctx.file("BUILD", """
 load("@rules_python//python:defs.bzl", "py_library")
@@ -96,6 +98,7 @@ _envoy_repo = repository_rule(
     implementation = _envoy_repo_impl,
     attrs = {
         "envoy_version": attr.label(default = "@envoy//:VERSION.txt"),
+        "envoy_api_version": attr.label(default = "@envoy//:API_VERSION.txt"),
     },
 )
 


### PR DESCRIPTION
this make it easier to use the api version in python jobs

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
