### PR TITLE
fuzz test: Include on_no_match.matcher into validation.

### DIFF
--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5167783282868224
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5167783282868224
@@ -1,0 +1,29 @@
+config {
+  name: "\237L"
+  virtual_hosts {
+    name: "&"
+    domains: "*"
+    matcher {
+      on_no_match {
+        matcher {
+          on_no_match {
+            action {
+              name: "+envoy.lb"
+              typed_config {
+                type_url: "typ-62488625co5m.si/envoy.config.route.v3.Route"
+                value: "\n\002\n\000\222\001\000"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+headers {
+  headers {
+    key: "x-forwarded-proto"
+    value: "i-"
+  }
+}
+random_value: 50

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -65,13 +65,15 @@ bool validateOnMatchConfig(const xds::type::matcher::v3::Matcher::OnMatch& on_ma
     return !isUnsupportedRouteConfig(on_match_route_action_config);
   }
   case xds::type::matcher::v3::Matcher_OnMatch::ON_MATCH_NOT_SET: {
-    // This alternative shall never occur. It is here to case on all values of Matcher_OnMatch and
-    // this way ensures that the compiler will report new entries to that enum as warning, which
-    // will finally result in an compiler error, when error on all warnings is set.
-    ASSERT(false);
+    // This alternative should never occur. But of course it does. By returning false the
+    // fuzzer will not follow this path any further.
     return false;
   }
+    // By not providing a default: the compiler will indicate new constants in the
+    // Matcher_OnMatch enum as compile warnings.
   }
+  // This is present only to silence compilers that do not analyze the switch above correctly.
+  return false;
 }
 
 bool validateMatcherConfig(const xds::type::matcher::v3::Matcher& matcher) {

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -69,11 +69,8 @@ bool validateOnMatchConfig(const xds::type::matcher::v3::Matcher::OnMatch& on_ma
     // fuzzer will not follow this path any further.
     return false;
   }
-    // By not providing a default: the compiler will indicate new constants in the
-    // Matcher_OnMatch enum as compile warnings.
   }
-  // This is present only to silence compilers that do not analyze the switch above correctly.
-  return false;
+  PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
 bool validateMatcherConfig(const xds::type::matcher::v3::Matcher& matcher) {

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -69,6 +69,7 @@ bool validateOnMatchConfig(const xds::type::matcher::v3::Matcher::OnMatch& on_ma
     // this way ensures that the compiler will report new entries to that enum as warning, which
     // will finally result in an compiler error, when error on all warnings is set.
     ASSERT(false);
+    return false;
   }
   }
 }

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -101,7 +101,8 @@ bool validateMatcherConfig(const xds::type::matcher::v3::Matcher& matcher) {
       }
     }
   }
-  if (matcher.on_no_match().has_action() && !validateOnMatchConfig(matcher.on_no_match())) {
+  if ((matcher.on_no_match().has_action() || matcher.on_no_match().has_matcher()) &&
+      !validateOnMatchConfig(matcher.on_no_match())) {
     ENVOY_LOG_MISC(debug, "matcher.on_no_match.action not sufficient for processing");
     return false;
   }


### PR DESCRIPTION
Commit Message: fuzz test: Include on_no_match.matcher into validation.
Additional Description:
In an on_no_match not only an action can be set, but also a matcher.
This is now included into checks for valid configuration.
Corpus added.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
