### PR TITLE
fuzz test: Sanitize status header before using them.

### DIFF
--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-4873141396045824.fuzz
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-4873141396045824.fuzz
@@ -1,0 +1,44 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "upgrade"
+        value: ":path"
+      }
+      headers {
+        key: "connection"
+        value: "upgRade"
+      }
+    }
+  }
+}
+actions {
+  mutate {
+    buffer: 2
+    offset: 4
+    value: 98
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+        headers {
+          key: "upgrade"
+        }
+        headers {
+          key: ":status"
+          value: "upgRade"
+        }
+        headers {
+          key: "connection"
+          value: "upgRade"
+        }
+      }
+    }
+  }
+}

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -245,13 +245,14 @@ public:
         if (response) {
           auto headers =
               fromSanitizedHeaders<TestResponseHeaderMapImpl>(directional_action.headers());
-          ConnectionManagerUtility::mutateResponseHeaders(headers, &request_.request_headers_,
-                                                          *context_.conn_manager_config_,
-                                                          /*via=*/"", stream_info_, /*node_id=*/"");
-          // Check for validity of response-status explicitly, as encodeHeaders() might throw.
+          // Check for validity of response-status explicitly, as mutateResponseHeaders() and
+          // encodeHeaders() might bug.
           if (!Utility::getResponseStatusOrNullopt(headers).has_value()) {
             headers.setReferenceKey(Headers::get().Status, "200");
           }
+          ConnectionManagerUtility::mutateResponseHeaders(headers, &request_.request_headers_,
+                                                          *context_.conn_manager_config_,
+                                                          /*via=*/"", stream_info_, /*node_id=*/"");
           state.response_encoder_->encodeHeaders(headers, end_stream);
         } else {
           state.request_encoder_


### PR DESCRIPTION
Commit Message: fuzz test: Sanitize status header before using them.
Additional Description:
Changing envoy's behaviour for invalid status values from throw to
envoy-bug, stopped the fuzzer from working. Sanitize :status headers
beforehand now (as was already done).

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
