### PR TITLE
fuzz test: Sanitize status header before use, part 2.

### DIFF
--- a/test/common/http/conn_manager_impl_corpus/oss-fuzz-48096-conn_manager_impl_fuzz_test-4884773308334080
+++ b/test/common/http/conn_manager_impl_corpus/oss-fuzz-48096-conn_manager_impl_fuzz_test-4884773308334080
@@ -1,0 +1,1 @@
+actions {   new_stream {     request_headers {       headers {         key: ":path"         value: "/"       }     }   } } actions {   stream_action {     response {       headers {       }     }   } } 

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -483,14 +483,10 @@ public:
         // The client codec will ensure we always have a valid :status.
         // Similarly, local replies should always contain this.
         const auto status = Utility::getResponseStatusOrNullopt(*headers);
-        if (!status.has_value()) {
-          headers->setReferenceKey(Headers::get().Status, "200");
-        }
         // The only 1xx header that may be provided to encodeHeaders() is a 101 upgrade,
         // guaranteed by the codec parsers. See include/envoy/http/filter.h.
-        if (CodeUtility::is1xx(status.value_or(enumToInt(Http::Code::OK))) &&
-            status.value_or(enumToInt(Http::Code::OK)) !=
-                enumToInt(Http::Code::SwitchingProtocols)) {
+        if (!status.has_value() || (CodeUtility::is1xx(status.value()) &&
+                                    status.value() != enumToInt(Http::Code::SwitchingProtocols))) {
           headers->setReferenceKey(Headers::get().Status, "200");
         }
         decoder_filter_->callbacks_->encodeHeaders(std::move(headers), end_stream, "details");

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -482,15 +482,15 @@ public:
             Fuzz::fromHeaders<TestResponseHeaderMapImpl>(response_action.headers()));
         // The client codec will ensure we always have a valid :status.
         // Similarly, local replies should always contain this.
-        uint64_t status;
-        try {
-          status = Utility::getResponseStatus(*headers);
-        } catch (const CodecClientException&) {
+        const auto status = Utility::getResponseStatusOrNullopt(*headers);
+        if (!status.has_value()) {
           headers->setReferenceKey(Headers::get().Status, "200");
         }
         // The only 1xx header that may be provided to encodeHeaders() is a 101 upgrade,
         // guaranteed by the codec parsers. See include/envoy/http/filter.h.
-        if (CodeUtility::is1xx(status) && status != enumToInt(Http::Code::SwitchingProtocols)) {
+        if (CodeUtility::is1xx(status.value_or(enumToInt(Http::Code::OK))) &&
+            status.value_or(enumToInt(Http::Code::OK)) !=
+                enumToInt(Http::Code::SwitchingProtocols)) {
           headers->setReferenceKey(Headers::get().Status, "200");
         }
         decoder_filter_->callbacks_->encodeHeaders(std::move(headers), end_stream, "details");


### PR DESCRIPTION
Commit Message: fuzz test: Sanitize status header before use, part 2.
Additional Description:
In conn_manager_impl_fuzz_test the:status header needs to be sanitized
before use, too, due to the change having the getResponseHeader() no
longer throw but bug.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
