### PR TITLE
protoxform: Use an aspect to build protoxform test

### DIFF
--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -55,3 +55,9 @@ protoxform_rule(
         "@envoy_api//versioning:frozen_protos",
     ],
 )
+
+protoxform_rule(
+    name = "test_protoxform",
+    visibility = ["//visibility:public"],
+    deps = ["//tools/testdata/protoxform:fix_protos"],
+)

--- a/tools/protoxform/protoxform.bzl
+++ b/tools/protoxform/protoxform.bzl
@@ -24,7 +24,8 @@ def _protoxform_rule_impl(ctx):
         for path in dep[OutputGroupInfo].proto.to_list():
             envoy_api = (
                 path.short_path.startswith("../envoy_api") or
-                path.short_path.startswith("../com_github_cncf_udpa")
+                path.short_path.startswith("../com_github_cncf_udpa") or
+                path.short_path.startswith("tools/testdata")
             )
             if envoy_api:
                 deps.append(path)

--- a/tools/protoxform/protoxform_test.sh
+++ b/tools/protoxform/protoxform_test.sh
@@ -15,7 +15,10 @@ PROTO_TARGETS=()
 protos=$(bazel query "labels(srcs, labels(deps, //tools/testdata/protoxform:fix_protos))")
 while read -r line; do PROTO_TARGETS+=("$line"); done \
     <<< "$protos"
-bazel build "${BAZEL_BUILD_OPTIONS[@]}" --//tools/api_proto_plugin:default_type_db_target=//tools/testdata/protoxform:fix_protos \
-  //tools/testdata/protoxform:fix_protos --aspects //tools/protoxform:protoxform.bzl%protoxform_aspect --output_groups=proto
+
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" \
+    --//tools/api_proto_plugin:default_type_db_target=//tools/testdata/protoxform:fix_protos \
+    //tools/protoxform:test_protoxform
+
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/protoxform:protoprint
 ./tools/protoxform/protoxform_test_helper.py fix "${PROTO_TARGETS[@]}"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

This just adds/make use of an aspect, in a follow up i will shift the test to bazel and clean up this test file further

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
