### PR TITLE
Revert "ci: Set timeout for BES/resultstore streaming (#21775)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -322,7 +322,6 @@ build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 # Build Event Service
 build:google-bes --bes_backend=grpcs://buildeventservice.googleapis.com
 build:google-bes --bes_results_url=https://source.cloud.google.com/results/invocations/
-build:google-bes --bes_timeout=5s
 
 # Fuzz builds
 


### PR DESCRIPTION
This reverts commit f1236bf27317c8dcd0ea0b5abf37f63fc193dcf5.

related to #21797 

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
