### PR TITLE
dfp: consistent behavior on DNS resolution failure

### DIFF
--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -146,13 +146,11 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
 
     auto const& host = config_->cache().getHost(headers.Host()->value().getStringView());
     latchTime(decoder_callbacks_, DNS_END);
-    if (host.has_value()) {
-      if (!host.value()->address()) {
-        onDnsResolutionFail();
-        return Http::FilterHeadersStatus::StopIteration;
-      }
-      addHostAddressToFilterState(host.value()->address());
+    if (!host.has_value() || !host.value()->address()) {
+      onDnsResolutionFail();
+      return Http::FilterHeadersStatus::StopIteration;
     }
+    addHostAddressToFilterState(host.value()->address());
 
     return Http::FilterHeadersStatus::Continue;
   }

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -283,7 +283,7 @@ TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomain) {
   response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("dns_resolution_failure"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("dns_resolution_failure"));
 }
 
 TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomainAndNoCaching) {
@@ -305,7 +305,7 @@ TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomainAndNoCaching) {
   response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("dns_resolution_failure"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("dns_resolution_failure"));
 }
 
 // Verify that after we populate the cache and reload the cluster we reattach to the cache with


### PR DESCRIPTION
Fixes a bug in https://github.com/envoyproxy/envoy/pull/19588 (and previously) where after DNS resolutoin fail, subsequent requests weren't blackholed by the filter.

Risk Level: low
Testing: fixed integration tests
Docs Changes: n/a
Release Notes: n/a
Fixes https://github.com/envoyproxy/envoy/issues/21410
