### PR TITLE
docs: add section for running Envoy via CLI

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -272,12 +272,14 @@ for how to update or override dependencies.
 
 ## Running the built Envoy binary on the host system
 
-After Envoy is built, it can be executed via CLI.
+After Envoy is built, it can be executed via CLI. 
+
+As Bazel's current ability to provide information about where it just built the artifacts is limited (as stated in [bazel's issue #8739](https://github.com/bazelbuild/bazel/issues/8739)), we can use the `bazel info bazel-genfiles` command to get the path where Envoy was built.
 
 For example, if Envoy was built using the `bazel build -c opt //source/exe:envoy-static` command, then it can be executed from the project's root directory by running:
 
 ```console
-bazel-bin/source/exe/envoy-static --config-path /path/to/your/envoy/config.yaml
+$(bazel info bazel-genfiles)/source/exe/envoy-static --config-path /path/to/your/envoy/config.yaml
 ```
 
 ## Building Envoy with the CI Docker image

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -270,6 +270,16 @@ for how to update or override dependencies.
 1. `bazel build envoy` from the Envoy source directory. Add `-c opt` for an optimized release build or
    `-c dbg` for an unoptimized, fully instrumented debugging build.
 
+## Running Envoy via CLI
+
+After Envoy is built, it can be executed via CLI.
+
+For example, if Envoy was built using the `bazel build -c opt //source/exe:envoy-static` command, then it can be executed from the project's root directory by running:
+
+```
+bazel-bin/source/exe/envoy-static --config-path /path/to/your/envoy/config.yaml
+```
+
 ## Building Envoy with the CI Docker image
 
 Envoy can also be built with the Docker image used for CI, by installing Docker and executing the following.

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -270,13 +270,13 @@ for how to update or override dependencies.
 1. `bazel build envoy` from the Envoy source directory. Add `-c opt` for an optimized release build or
    `-c dbg` for an unoptimized, fully instrumented debugging build.
 
-## Running Envoy via CLI
+## Running the built Envoy binary on the host system
 
 After Envoy is built, it can be executed via CLI.
 
 For example, if Envoy was built using the `bazel build -c opt //source/exe:envoy-static` command, then it can be executed from the project's root directory by running:
 
-```
+```console
 bazel-bin/source/exe/envoy-static --config-path /path/to/your/envoy/config.yaml
 ```
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -270,16 +270,6 @@ for how to update or override dependencies.
 1. `bazel build envoy` from the Envoy source directory. Add `-c opt` for an optimized release build or
    `-c dbg` for an unoptimized, fully instrumented debugging build.
 
-## Running the built Envoy binary on the host system
-
-After Envoy is built, it can be executed via CLI.
-
-For example, if Envoy was built using the `bazel build -c opt //source/exe:envoy-static` command, then it can be executed from the project's root directory by running:
-
-```console
-$(bazel info bazel-genfiles)/source/exe/envoy-static --config-path /path/to/your/envoy/config.yaml
-```
-
 ## Building Envoy with the CI Docker image
 
 Envoy can also be built with the Docker image used for CI, by installing Docker and executing the following.
@@ -379,6 +369,16 @@ building a linked envoy binary you can build the implicit `.stripped`
 target from [`cc_binary`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary)
 or pass [`--strip=always`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--strip)
 instead.
+
+# Running the built Envoy binary on the host system
+
+After Envoy is built, it can be executed via CLI.
+
+For example, if Envoy was built using the `bazel build -c opt //source/exe:envoy-static` command, then it can be executed from the project's root directory by running:
+
+```console
+$(bazel info bazel-genfiles)/source/exe/envoy-static --config-path /path/to/your/envoy/config.yaml
+```
 
 # Testing Envoy with Bazel
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -272,9 +272,7 @@ for how to update or override dependencies.
 
 ## Running the built Envoy binary on the host system
 
-After Envoy is built, it can be executed via CLI. 
-
-As Bazel's current ability to provide information about where it just built the artifacts is limited (as stated in [bazel's issue #8739](https://github.com/bazelbuild/bazel/issues/8739)), we can use the `bazel info bazel-genfiles` command to get the path where Envoy was built.
+After Envoy is built, it can be executed via CLI.
 
 For example, if Envoy was built using the `bazel build -c opt //source/exe:envoy-static` command, then it can be executed from the project's root directory by running:
 


### PR DESCRIPTION
As a beginner I've had a tough time getting around Envoy. One of the things that got me scratching my head for a while was "how to run Envoy directly from the CLI?".

Although testing Envoy with bazel is magnificently documented (10/10 to whoever wrote it), I couldn't find much information on how to run Envoy from the CLI.

I believe this small section will be of great use for beginners, although I'm not convinced if this doc is the right one for the "Running envoy via CLI" section. What do you thing? 

> PS, in case there is already information on this topic, maybe we should make it more visible or easy to find.

Signed-off-by: Lucas Martinez <57833320+martinezlucas98@users.noreply.github.com>