### PR TITLE
xds: clarify endpoint weight default behavior

### DIFF
--- a/api/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/api/envoy/config/endpoint/v3/endpoint_components.proto
@@ -104,9 +104,9 @@ message LbEndpoint {
   // of the weights of all endpoints in the endpoint's locality to produce a
   // percentage of traffic for the endpoint. This percentage is then further
   // weighted by the endpoint's locality's load balancing weight from
-  // LocalityLbEndpoints. If unspecified, each host is presumed to have equal
-  // weight in a locality. The sum of the weights of all endpoints in the
-  // endpoint's locality must not exceed uint32_t maximal value (4294967295).
+  // LocalityLbEndpoints. If unspecified or 0, will be treated as 1. The sum
+  // of the weights of all endpoints in the endpoint's locality must not
+  // exceed uint32_t maximal value (4294967295).
   google.protobuf.UInt32Value load_balancing_weight = 4 [(validate.rules).uint32 = {gte: 1}];
 }
 

--- a/api/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/api/envoy/config/endpoint/v3/endpoint_components.proto
@@ -104,7 +104,7 @@ message LbEndpoint {
   // of the weights of all endpoints in the endpoint's locality to produce a
   // percentage of traffic for the endpoint. This percentage is then further
   // weighted by the endpoint's locality's load balancing weight from
-  // LocalityLbEndpoints. If unspecified or 0, will be treated as 1. The sum
+  // LocalityLbEndpoints. If unspecified, will be treated as 1. The sum
   // of the weights of all endpoints in the endpoint's locality must not
   // exceed uint32_t maximal value (4294967295).
   google.protobuf.UInt32Value load_balancing_weight = 4 [(validate.rules).uint32 = {gte: 1}];


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: xds: clarify endpoint weight default behavior
Additional Description: Updates the comment to reflect the underlying behavior.  The previous comment was misleading, because if some endpoints in a locality had weights but others did not, not all endpoints were given equal weight.  The actual behavior is that [we use a weight of 1](https://github.com/envoyproxy/envoy/blob/17d7d7908507888617824d73bc5904a3d79d1d17/source/common/upstream/upstream_impl.cc#L367) whenever the weight is unset.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
