### PR TITLE
examples: fix gzip decompression

### DIFF
--- a/docs/root/start/sandboxes/gzip.rst
+++ b/docs/root/start/sandboxes/gzip.rst
@@ -14,11 +14,12 @@ By enabling compression in Envoy you can save some network bandwidth, at the exp
 
 Envoy supports compression and decompression for both requests and responses.
 
-This sandbox provides an example of response compression served over ``HTTP``. Although ``HTTPS`` is not demonstrated, compression can be used for this also.
+This sandbox provides an example of response compression and request decompression served over ``HTTP``. Although ``HTTPS`` is not demonstrated, compression can be used for this also.
 
-The sandbox covers two scenarios:
+The sandbox covers three scenarios:
 
 - compression of files from an upstream server
+- decompression of files from a downstream client
 - compression of Envoy's own statistics
 
 Step 1: Start all of our containers
@@ -63,7 +64,29 @@ As only files with a content-type of ``application/json`` are configured to be g
 
     $ curl -si -H "Accept-Encoding: gzip" localhost:10000/file.txt | grep "content-encoding"
 
-Step 3: Test compression of Envoy’s statistics
+Step 3: Test Envoy’s decompression of downstream files
+******************************************************
+
+The sandbox is configured with one endpoint on port ``10000`` for uploading downstream files:
+
+- ``/upload``
+
+Use ``curl`` to get compressed file ``file.gz``
+
+.. code-block:: console
+
+    $ curl -s -H "Accept-Encoding: gzip" -o file.gz localhost:10000/file.json
+
+Use ``curl`` to check that the response from uploading ``file.gz`` contains the ``decompressed-size`` header.
+
+You will need to add an ``content-encoding: gzip`` request header.
+
+.. code-block:: console
+
+    $ curl -si -H "Content-Encoding: gzip" localhost:10000/upload --data-binary "@file.gz" | grep "decompressed-size"
+    decompressed-size: ~1130000
+
+Step 4: Test compression of Envoy’s statistics
 **********************************************
 
 The sandbox is configured with two ports serving Envoy’s admin and statistics interface:
@@ -85,11 +108,17 @@ Now, use ``curl`` to make a request for the compressed statistics:
     content-encoding: gzip
 
 .. seealso::
-   :ref:`Gzip API <envoy_v3_api_msg_extensions.compression.gzip.compressor.v3.Gzip>`
-      API and configuration reference for Envoy's gzip compression.
+    :ref:`Gzip Compression API <envoy_v3_api_msg_extensions.compression.gzip.compressor.v3.Gzip>`
+        API and configuration reference for Envoy's gzip compression.
 
-   :ref:`Compression configuration <config_http_filters_compressor>`
-      Reference documentation for Envoy's compressor filter.
+    :ref:`Gzip Decompression API <envoy_v3_api_msg_extensions.compression.gzip.decompressor.v3.Gzip>`
+        API and configuration reference for Envoy's gzip decompression.
 
-   :ref:`Envoy admin quick start guide <start_quick_start_admin>`
-      Quick start guide to the Envoy admin interface.
+    :ref:`Compression configuration <config_http_filters_compressor>`
+        Reference documentation for Envoy's compressor filter.
+
+    :ref:`Decompression configuration <config_http_filters_decompressor>`
+        Reference documentation for Envoy's decompressor filter.
+
+    :ref:`Envoy admin quick start guide <start_quick_start_admin>`
+        Quick start guide to the Envoy admin interface.

--- a/examples/gzip/gzip-envoy.yaml
+++ b/examples/gzip/gzip-envoy.yaml
@@ -37,6 +37,20 @@ static_resources:
                   "@type": type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
                   memory_level: 3
                   window_bits: 10
+          - name: envoy.filters.http.decompressor
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.decompressor.v3.Decompressor
+              decompressor_library:
+                name: upload
+                typed_config:
+                  "@type": "type.googleapis.com/envoy.extensions.compression.gzip.decompressor.v3.Gzip"
+                  window_bits: 9
+                  chunk_size: 8192
+              response_direction_config:
+                common_config:
+                  enabled:
+                    default_value: false
+                    runtime_key: response_decompressor_enabled
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/examples/gzip/service.py
+++ b/examples/gzip/service.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request, Response
 from flask.helpers import send_from_directory
 
 app = Flask(__name__)
@@ -12,6 +12,12 @@ def get_plain_file():
 @app.route('/file.json')
 def get_json_file():
     return send_from_directory("data", "file.json")
+
+@app.route("/upload", methods=['POST'])
+def test_decompressor():
+    resp = Response("OK")
+    resp.headers["decompressed-size"] = len(next(iter(request.form)))
+    return resp
 
 
 if __name__ == "__main__":

--- a/examples/gzip/service.py
+++ b/examples/gzip/service.py
@@ -19,6 +19,5 @@ def test_decompressor():
     resp.headers["decompressed-size"] = len(next(iter(request.form)))
     return resp
 
-
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=8080)

--- a/examples/gzip/verify.sh
+++ b/examples/gzip/verify.sh
@@ -17,6 +17,14 @@ responds_without_header \
     http://localhost:10000/file.txt \
     -i -H "Accept-Encoding: gzip"
 
+run_log "Test service: localhost:10000/upload with decompression"
+curl -s -H "Accept-Encoding: gzip" -o file.gz localhost:10000/file.json
+responds_with \
+    "decompressed-size" \
+    http://localhost:10000/upload \
+    -X POST -i -H "Content-Encoding: gzip" --data-binary "@file.gz"
+rm file.gz
+
 run_log "Test service: localhost:9901/stats/prometheus without compression"
 responds_without_header \
     "content-encoding: gzip" \


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Due to [quickfix of decompression oom](https://github.com/envoyproxy/envoy/commit/d4c39e635603e2f23e1e08ddecf5a5fb5a706338), `decompressed-size` will be truncated at around the size of file.gz * `MaxInflateRatio` . And we could not get fixed `decompressed-size` which is approximately 1130000. 

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
