### PR TITLE
bazel: Use experimental flags for fetching coverage output

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -86,7 +86,9 @@ trap cleanup EXIT
 
 "$(dirname "$0")"/../bazel/setup_clang.sh "${LLVM_ROOT}"
 
-[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=("--nocache_test_results")
+[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(
+        "--experimental_split_coverage_postprocessing"
+        "--experimental_fetch_all_coverage_outputs")
 
 # Use https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_repository_cache_hardlinks
 # to save disk space.


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

@lizan this is more of a question than anything

trying to track down why coverage is so much slower in postsubmit then presubmit and it would appear that its because postsubmit is set with `--nocache-test-results`

not sure why this is, whether it makes any difference if it they never pass/fail independently, and whether we can remove this flag

i saw some discussion of using this flag to workaround rbe not giving back all test results so wondered if this was related - hence proposed change, but im not sure how helpful that is


Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
