### PR TITLE
deps: Bump py `envoy.dependency.check` -> 0.1.2

### DIFF
--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -5,7 +5,7 @@ colorama
 coloredlogs
 envoy.base.utils>=0.3.6
 envoy.code.check>=0.2.1
-envoy.dependency.check>=0.1.1
+envoy.dependency.check>=0.1.2
 envoy.dependency.pip_check>=0.1.2
 envoy.distribution.release>=0.0.7
 envoy.distribution.repo>=0.0.5

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -314,9 +314,9 @@ envoy-code-check==0.2.2 \
     --hash=sha256:25b4fcee184e4b40ad68b26cbfd0614bbe0a5f980aefc95b5e3f9c6803e68bbb \
     --hash=sha256:3ad2dd3e01ff57bfcc21475c1268e79d065959911bc9fe8bf1d3ea3cb3f5adf1
     # via -r requirements.in
-envoy-dependency-check==0.1.1 \
-    --hash=sha256:a33c16559315561f6eadd3176eebb3a7c5a232b9dafe9b420864a24950cdbad7 \
-    --hash=sha256:efb4af0c2074abfd073da78f78daf1da31bc0f2464d61cba0644709fc9e4d89b
+envoy-dependency-check==0.1.2 \
+    --hash=sha256:77f277e7d46c8d392ad0226eb62e9672c036f61a4a4bee8fd7f694b93277e6d0 \
+    --hash=sha256:bfa8bc027c8f1dcb690f6b25913ab4649de808ff27cf0a8b305536c49b8af155
     # via -r requirements.in
 envoy-dependency-pip-check==0.1.3 \
     --hash=sha256:b07ca0c1f2786b13b0dfcdfc82647afece3918d44dc7ddaca5739dfaadc9d0e8 \


### PR DESCRIPTION
Adds a workaround to prevent dependency issues being raised for
release binary deps

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
