### PR TITLE
extensions: fix log_records entry in OTEL access logger test

### DIFF
--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -240,7 +240,7 @@ values:
           value:
             int_value: 1655429509
     instrumentation_library_logs:
-      - logs:
+      - log_records:
           - severity_text: "test-severity-text"
   )EOF");
   opentelemetry::proto::logs::v1::LogRecord entry;


### PR DESCRIPTION
Signed-off-by: Alex Ellis <ellisonjtk@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix broken test after OpenTelemetry Tracer PR merge
Additional Description: As part of OpenTelemetry Tracer PR, I upgraded the OTLP proto library version. This included a breaking change to the OpenTelemetry Log proto, where the `logs` field in instrumentation_library_logs was renamed to `log_records`. Earlier today, a new test was added with `logs` in the yaml, and when my PR was merged in, this caused the new test to fail:


```
unknown file: Failure
C++ exception with description "Protobuf message (type opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest reason INVALID_ARGUMENT:(resource_logs.instrumentation_library_logs[0]) logs: Cannot find field.) has unknown fields" thrown in the test body.
test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc:51: Failure
Actual function call count doesn't match EXPECT_CALL(*async_client, startRaw(_, _, _, _))...
         Expected: to be called once
           Actual: never called - unsatisfied and active
```

This is a quick forward fix to update that field name.

Risk Level: Low (fixing broken test)
Testing: Added unit tests for the new tracer and performed manual testing with the OpenTelemetry Collector
Release Notes: opentelemetry: add OpenTelemetry tracer extension
Platform Specific Features: N/A
Part of https://github.com/envoyproxy/envoy/issues/9958
