### PR TITLE
api: Add `buf` linting

### DIFF
--- a/api/buf.lock
+++ b/api/buf.lock
@@ -3,50 +3,29 @@ version: v1
 deps:
   - remote: buf.build
     owner: beta
-    repository: opencensus
-    branch: main
-    commit: 5f5f8259293649d68707d2e5b6285748
-    digest: b1-myYwcdM0Xu05qIwhiy4eWEcARYUuZZ1vTbYvrrHu1mU=
-    create_time: 2021-03-03T20:50:42.079743Z
-  - remote: buf.build
-    owner: beta
-    repository: opentelemetry
-    branch: main
-    commit: 549da630ffe24b53be3983fcee3bb346
-    digest: b1-HVAvWKH61BF6TdZSbHRhrD2SUuC0V7uAlZgCRimGPLI=
-    create_time: 2021-08-09T14:24:57.923964Z
-  - remote: buf.build
-    owner: beta
     repository: prometheus
-    branch: main
     commit: a91b42d18a994cd4b07b37f365f87cf9
-    digest: b1-uKmv58fyoNwJI855qg7UEagfdyUl6XNPsFAdDoi57f4=
-    create_time: 2021-06-23T20:16:58.410272Z
   - remote: buf.build
-    owner: beta
-    repository: protoc-gen-validate
-    branch: main
-    commit: 82388a0a0cb04e98a203f95dfed5e84b
-    digest: b1-lYgUMN58PxyCwvfQoopp40AJ-oHHjWXAzksF7v9U-U4=
-    create_time: 2021-06-21T22:00:30.152545Z
-  - remote: buf.build
-    owner: beta
+    owner: cncf
     repository: xds
-    branch: main
-    commit: 45f850b92541434cbde4aece01bc7d53
-    digest: b1-QZUL5DC6-nVgMMlajH_hlImwghg5HjRsqlEAOl0dZgI=
-    create_time: 2021-08-09T14:37:06.872899Z
+    commit: 0492166643854ea08814f4349286f9cb
+  - remote: buf.build
+    owner: envoyproxy
+    repository: protoc-gen-validate
+    commit: dc09a417d27241f7b069feae2cd74a0e
   - remote: buf.build
     owner: gogo
     repository: protobuf
-    branch: main
     commit: 4df00b267f944190a229ce3695781e99
-    digest: b1-sjLgsg7CzrkOrIjBDh3s-l0aMjE6oqTj85-OsoopKAw=
-    create_time: 2021-08-10T00:14:28.345069Z
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
     commit: d1a849b8f8304950832335723096e954
-    digest: b1-zJkwX0YeOp1Wa0Jaj_RqMLa2-oEzePH6PJEK8aaMeI4=
-    create_time: 2021-08-26T15:07:19.652533Z
+  - remote: buf.build
+    owner: opencensus
+    repository: opencensus
+    commit: d1d7ccd1281e4f42ab7ce9a7d2b29e33
+  - remote: buf.build
+    owner: opentelemetry
+    repository: opentelemetry
+    commit: 187ea5573ff044faa892a5d244cb2b48

--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -1,11 +1,11 @@
-version: v1beta1
+version: v1
 deps:
     - buf.build/googleapis/googleapis:d1a849b8f8304950832335723096e954
-    - buf.build/beta/opencensus
+    - buf.build/opencensus/opencensus
     - buf.build/beta/prometheus
-    - buf.build/beta/opentelemetry
+    - buf.build/opentelemetry/opentelemetry
     - buf.build/gogo/protobuf
-    - buf.build/beta/xds
+    - buf.build/cncf/xds
 breaking:
   ignore_unstable_packages: true
   use:
@@ -17,3 +17,6 @@ breaking:
     - FILE_SAME_PACKAGE
     - FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED
     - FIELD_NO_DELETE_UNLESS_NAME_RESERVED
+lint:
+  use:
+  - IMPORT_USED

--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -4,9 +4,7 @@ package envoy.config.trace.v3;
 
 import "envoy/config/core/v3/grpc_service.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";

--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -65,6 +65,11 @@ fix_format () {
 CURRENT=check_format
 "${ENVOY_SRCDIR}"/tools/code_format/check_format.py check || fix_format
 
+CURRENT=buf
+cd api/ || exit 1
+bazel run "${BAZEL_BUILD_OPTIONS[@]}" @com_github_bufbuild_buf//:bin/buf lint
+cd - || exit 1
+
 if [[ "${#FAILED[@]}" -ne "0" ]]; then
     echo "${BASH_ERR_PREFIX}TESTS FAILED:" >&2
     for failed in "${FAILED[@]}"; do


### PR DESCRIPTION
initially this will only check for "unused imports" but we can expand as other linting rules are met.

Commit Message:
Additional Description:

in order to get this to work i had to fix the buf deps which were currently failing

i have also switched the buf version to v1 which provides the unused import test

...and fixed failing protos

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
