### PR TITLE
[ext_proc]: Refactor ext proc timeout handling

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -647,8 +647,8 @@ void Filter::onMessageTimeout() {
     // Return an error and stop processing the current stream.
     processing_complete_ = true;
     closeStream();
-    decoding_state_.setCallbackState(ProcessorState::CallbackState::Idle);
-    encoding_state_.setCallbackState(ProcessorState::CallbackState::Idle);
+    decoding_state_.onFinishCall();
+    encoding_state_.onFinishCall();
     ImmediateResponse errorResponse;
     errorResponse.mutable_status()->set_code(StatusCode::InternalServerError);
     errorResponse.set_details(absl::StrFormat("%s_per-message_timeout_exceeded", ErrorPrefix));
@@ -666,8 +666,8 @@ void Filter::clearAsyncState() {
 // Regardless of the current state, ensure that the timers won't fire
 // again.
 void Filter::cleanUpTimers() {
-  decoding_state_.cleanUpTimer();
-  encoding_state_.cleanUpTimer();
+  decoding_state_.onFinishCall();
+  encoding_state_.onFinishCall();
 }
 
 static const ImmediateMutationChecker& immediateResponseChecker() {

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -166,7 +166,7 @@ private:
   StreamOpenState openStream();
   void closeStream();
 
-  void cleanUpTimers();
+  void onFinishProcessorCalls();
   void clearAsyncState();
   void sendImmediateResponse(const envoy::service::ext_proc::v3::ImmediateResponse& response);
 

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -301,7 +301,7 @@ void ProcessorState::enqueueStreamingChunk(Buffer::Instance& data, bool end_stre
 }
 
 void ProcessorState::clearAsyncState() {
-  cleanUpTimer();
+  onFinishCall();
   while (auto queued_chunk = dequeueStreamingChunk(false)) {
     auto chunk = std::move(*queued_chunk);
     ENVOY_LOG(trace, "Injecting leftover buffer of {} bytes", chunk->data.length());
@@ -309,13 +309,6 @@ void ProcessorState::clearAsyncState() {
   }
   clearWatermark();
   continueIfNecessary();
-  callback_state_ = CallbackState::Idle;
-}
-
-void ProcessorState::cleanUpTimer() const {
-  if (message_timer_ && message_timer_->enabled()) {
-    message_timer_->disableTimer();
-  }
 }
 
 void ProcessorState::setBodyMode(ProcessingMode_BodySendMode body_mode) {

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -18,11 +18,20 @@ using envoy::service::ext_proc::v3::CommonResponse;
 using envoy::service::ext_proc::v3::HeadersResponse;
 using envoy::service::ext_proc::v3::TrailersResponse;
 
-void ProcessorState::startMessageTimer(Event::TimerCb cb, std::chrono::milliseconds timeout) {
+void ProcessorState::onStartCall(Event::TimerCb cb, std::chrono::milliseconds timeout,
+                                 CallbackState callback_state) {
+  callback_state_ = callback_state;
   if (!message_timer_) {
     message_timer_ = filter_callbacks_->dispatcher().createTimer(cb);
   }
   message_timer_->enableTimer(timeout);
+}
+
+void ProcessorState::onFinishCall(CallbackState next_state) {
+  callback_state_ = next_state;
+  if (message_timer_) {
+    message_timer_->disableTimer();
+  }
 }
 
 absl::Status ProcessorState::handleHeadersResponse(const HeadersResponse& response) {
@@ -42,8 +51,7 @@ absl::Status ProcessorState::handleHeadersResponse(const HeadersResponse& respon
     if (common_response.clear_route_cache()) {
       filter_callbacks_->clearRouteCache();
     }
-    callback_state_ = CallbackState::Idle;
-    message_timer_->disableTimer();
+    onFinishCall();
 
     if (common_response.status() == CommonResponse::CONTINUE_AND_REPLACE) {
       ENVOY_LOG(debug, "Replacing complete message");
@@ -180,7 +188,7 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
         });
       }
       clearWatermark();
-      callback_state_ = CallbackState::Idle;
+      onFinishCall();
       should_continue = true;
     } else if (callback_state_ == CallbackState::StreamedBodyCallback ||
                callback_state_ == CallbackState::StreamedBodyCallbackFinishing) {
@@ -209,7 +217,9 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
         clearWatermark();
       }
       if (chunk_queue_.empty()) {
-        callback_state_ = CallbackState::Idle;
+        onFinishCall();
+      } else {
+        onFinishCall(callback_state_);
       }
     } else if (callback_state_ == CallbackState::BufferedPartialBodyCallback) {
       // Apply changes to the buffer that we sent to the server
@@ -226,7 +236,7 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
       }
       should_continue = true;
       clearWatermark();
-      callback_state_ = CallbackState::Idle;
+      onFinishCall();
       partial_body_processed_ = true;
 
       // If anything else is left on the queue, inject it too
@@ -238,12 +248,13 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
           injectDataToFilterChain(chunk->data, false);
         }
       }
+    } else {
+      onFinishCall();
     }
 
     if (response.response().clear_route_cache()) {
       filter_callbacks_->clearRouteCache();
     }
-    message_timer_->disableTimer();
     headers_ = nullptr;
 
     if (send_trailers_ && trailers_available_) {
@@ -274,8 +285,7 @@ absl::Status ProcessorState::handleTrailersResponse(const TrailersResponse& resp
       }
     }
     trailers_ = nullptr;
-    callback_state_ = CallbackState::Idle;
-    message_timer_->disableTimer();
+    onFinishCall();
     continueIfNecessary();
     return absl::OkStatus();
   }

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -107,9 +107,9 @@ public:
   void setHeaders(Http::RequestOrResponseHeaderMap* headers) { headers_ = headers; }
   void setTrailers(Http::HeaderMap* trailers) { trailers_ = trailers; }
 
-  void onStartCall(Event::TimerCb cb, std::chrono::milliseconds timeout,
-                   CallbackState callback_state);
-  void onFinishCall(CallbackState next_state = CallbackState::Idle);
+  void onStartProcessorCall(Event::TimerCb cb, std::chrono::milliseconds timeout,
+                            CallbackState callback_state);
+  void onFinishProcessorCall(CallbackState next_state = CallbackState::Idle);
 
   // Idempotent methods for watermarking the body
   virtual void requestWatermark() PURE;

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -108,7 +108,9 @@ public:
   void setHeaders(Http::RequestOrResponseHeaderMap* headers) { headers_ = headers; }
   void setTrailers(Http::HeaderMap* trailers) { trailers_ = trailers; }
 
-  void startMessageTimer(Event::TimerCb cb, std::chrono::milliseconds timeout);
+  void onStartCall(Event::TimerCb cb, std::chrono::milliseconds timeout,
+                   CallbackState callback_state);
+  void onFinishCall(CallbackState next_state = CallbackState::Idle);
   void cleanUpTimer() const;
 
   // Idempotent methods for watermarking the body

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -87,7 +87,6 @@ public:
   ProcessorState& operator=(const ProcessorState&) = delete;
 
   CallbackState callbackState() const { return callback_state_; }
-  void setCallbackState(CallbackState state) { callback_state_ = state; }
   void setPaused(bool paused) { paused_ = paused; }
 
   bool completeBodyAvailable() const { return complete_body_available_; }
@@ -111,7 +110,6 @@ public:
   void onStartCall(Event::TimerCb cb, std::chrono::milliseconds timeout,
                    CallbackState callback_state);
   void onFinishCall(CallbackState next_state = CallbackState::Idle);
-  void cleanUpTimer() const;
 
   // Idempotent methods for watermarking the body
   virtual void requestWatermark() PURE;

--- a/test/extensions/filters/http/ext_proc/ordering_test.cc
+++ b/test/extensions/filters/http/ext_proc/ordering_test.cc
@@ -562,7 +562,7 @@ TEST_F(OrderingTest, ImmediateResponseOnResponse) {
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  EXPECT_CALL(*request_timer, disableTimer());
+  EXPECT_CALL(*request_timer, disableTimer()).Times(2);
   sendRequestHeadersReply();
 
   MockTimer* response_timer = new MockTimer(&dispatcher_);
@@ -710,7 +710,6 @@ TEST_F(OrderingTest, GrpcErrorInline) {
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
-  EXPECT_CALL(*request_timer, enabled()).WillOnce(Return(true));
   EXPECT_CALL(*request_timer, disableTimer());
   sendGrpcError();
   // The rest of the filter isn't called after this.
@@ -729,7 +728,6 @@ TEST_F(OrderingTest, GrpcErrorInlineIgnored) {
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  EXPECT_CALL(*request_timer, enabled()).WillOnce(Return(true));
   EXPECT_CALL(*request_timer, disableTimer());
   sendGrpcError();
 
@@ -750,11 +748,10 @@ TEST_F(OrderingTest, GrpcErrorOutOfLine) {
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  EXPECT_CALL(*request_timer, disableTimer());
+  EXPECT_CALL(*request_timer, disableTimer()).Times(2);
   sendRequestHeadersReply();
 
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
-  EXPECT_CALL(*request_timer, enabled()).WillOnce(Return(false));
   sendGrpcError();
 }
 

--- a/test/extensions/filters/http/ext_proc/ordering_test.cc
+++ b/test/extensions/filters/http/ext_proc/ordering_test.cc
@@ -782,6 +782,7 @@ TEST_F(OrderingTest, GrpcErrorAfterTimeout) {
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersGet(true);
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(*request_timer, disableTimer());
   request_timer->invokeCallback();
   // Nothing should happen now despite the gRPC error
   sendGrpcError();
@@ -811,7 +812,7 @@ TEST_F(OrderingTest, TimeoutOnResponseBody) {
   EXPECT_CALL(*request_timer, enableTimer(kMessageTimeout, nullptr));
   EXPECT_CALL(stream_delegate_, send(_, false));
   EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_body, true));
-  EXPECT_CALL(*request_timer, disableTimer());
+  EXPECT_CALL(*request_timer, disableTimer()).Times(2);
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
   sendRequestBodyReply();
 
@@ -826,7 +827,7 @@ TEST_F(OrderingTest, TimeoutOnResponseBody) {
   EXPECT_CALL(*response_timer, enableTimer(kMessageTimeout, nullptr));
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendResponseHeaders(true);
-  EXPECT_CALL(*response_timer, disableTimer());
+  EXPECT_CALL(*response_timer, disableTimer()).Times(2);
   sendResponseHeadersReply();
   EXPECT_CALL(*response_timer, enableTimer(kMessageTimeout, nullptr));
   EXPECT_CALL(stream_delegate_, send(_, false));
@@ -850,7 +851,7 @@ TEST_F(OrderingTest, TimeoutOnRequestBody) {
   EXPECT_CALL(*request_timer, enableTimer(kMessageTimeout, nullptr));
   EXPECT_CALL(stream_delegate_, send(_, false));
   sendRequestHeadersPost(true);
-  EXPECT_CALL(*request_timer, disableTimer());
+  EXPECT_CALL(*request_timer, disableTimer()).Times(2);
   sendRequestHeadersReply();
 
   Buffer::OwnedImpl req_body;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Move setCallbackState and startTimer or disableTimer into the same function call because callback_state and timer have the same lifetime. This will make the state machine management more consistent and easier to reason about.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
