### PR TITLE
docs: add uname troubleshooting section for macOS

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -147,6 +147,19 @@ for how to update or override dependencies.
     version of `ar` on the PATH, so if you run into issues building third party code like luajit
     consider uninstalling binutils.
 
+    If you see an error like so:
+    ```console
+    ERROR: An error occured during the fetch of repository 'python3_10':
+        Traceback (most recent call last):
+            File "/Users/user/Library/Caches/Bazel/..."
+                fail("No platform declared for host OS {} on arch {}".format(os_name, arch))
+    Error in fail: No platform declared for host OS mac os on arch 5.4.0
+    ```
+    Please check the output of uname `uname-a`, `which uname`.  The result should look something like this:
+    ```console
+    Darwin machine-name.local 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:00:00 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64 x86_64
+    ```
+
     ### Windows
 
     > Note: These instructions apply to **Windows 10 SDK, version 1803 (10.0.17134.12)**. Earlier versions will not compile because the `afunix.h` header is not available. **The recommended Windows version is equal or later than Windows 10 SDK, version 1903 (10.0.18362.1)**


### PR DESCRIPTION
Signed-off-by: Trenton Dyck <tdyck@protonmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add uname troubleshooting section for macOS
Additional Description: my /usr/local/bin/uname returned '5.4.0' which was unable to be parsed by the bazel build
Risk Level: Low
Testing: manual
Docs Changes: Additional troubleshooting section for macOS
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA] N/A
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
