### PR TITLE
Fix flaky async_file_manager test

### DIFF
--- a/test/extensions/common/async_files/async_file_handle_thread_pool_test.cc
+++ b/test/extensions/common/async_files/async_file_handle_thread_pool_test.cc
@@ -88,6 +88,12 @@ public:
     EXPECT_CALL(mock_posix_file_operations_, close(_))
         .WillRepeatedly(Return(Api::SysCallIntResult{0, 0}));
   }
+  void TearDown() override {
+    // manager_ must be torn down before mock_posix_file_operations_ to ensure that file
+    // operations are completed before the mock is destroyed.
+    manager_ = nullptr;
+    factory_ = nullptr;
+  }
   StrictMock<Api::MockOsSysCalls> mock_posix_file_operations_;
 };
 


### PR DESCRIPTION
Signed-off-by: Raven Black <ravenblack@dropbox.com>

Commit Message: Fix flaky async_file_manager test
Additional Description: A race in the test destructor, fixed by explicitly deleting the things that have to go first in TearDown. Fixes issue #[21854](https://github.com/envoyproxy/envoy/issues/21854)
Risk Level: None
Testing: test-only change
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
