### PR TITLE
Remove `skip_tag_extraction_rule_check_` from RedisClusterTest

### DIFF
--- a/test/extensions/clusters/redis/redis_cluster_integration_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_integration_test.cc
@@ -147,12 +147,7 @@ class RedisClusterIntegrationTest : public testing::TestWithParam<Network::Addre
 public:
   RedisClusterIntegrationTest(const std::string& config = testConfig(), int num_upstreams = 2)
       : BaseIntegrationTest(GetParam(), config), num_upstreams_(num_upstreams),
-        version_(GetParam()) {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat 'redis.redis_stats.command.sadd.total' and
-    // stat_prefix 'redis_stats'.
-    skip_tag_extraction_rule_check_ = true;
-  }
+        version_(GetParam()) {}
 
   void initialize() override {
     setUpstreamCount(num_upstreams_);


### PR DESCRIPTION
Test is now passing with https://github.com/envoyproxy/envoy/pull/21785

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>
