### PR TITLE
decompressor: more flexible way to limit output size of gzip decompressor

### DIFF
--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -30,7 +30,6 @@ message Gzip {
 
   // How many times the output buffer is allowed to be bigger than the size of
   // accumulated input. This value is used to detect compression bombs.
-  // TODO(rojkov): Re-design the Decompressor interface to handle compression
-  // bombs gracefully instead of this quick solution.
+  // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.]
   google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 0}];
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -27,4 +27,10 @@ message Gzip {
   // Value for zlib's decompressor output buffer. If not set, defaults to 4096.
   // See https://www.zlib.net/manual.html for more details.
   google.protobuf.UInt32Value chunk_size = 2 [(validate.rules).uint32 = {lte: 65536 gte: 4096}];
+
+  // How many times the output buffer is allowed to be bigger than the size of
+  // accumulated input. This value is used to detect compression bombs.
+  // TODO(rojkov): Re-design the Decompressor interface to handle compression
+  // bombs gracefully instead of this quick solution.
+  uint64_t max_inflate_ratio = 3;
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -32,5 +32,6 @@ message Gzip {
   // accumulated input. This value is used to detect compression bombs.
   // TODO(rojkov): Re-design the Decompressor interface to handle compression
   // bombs gracefully instead of this quick solution.
-  uint64_t max_inflate_ratio = 3;
+  google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 0}];
+
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -30,7 +30,7 @@ message Gzip {
 
   // An upper bound to the number of times the output buffer is allowed to be bigger than the size of
   // the accumulated input. This value is used to prevent decompression bombs. If not set, defaults to 100.
-  // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.]
-  // See https://github.com/envoyproxy/envoy/commit/d4c39e635603e2f23e1e08ddecf5a5fb5a706338 for details.
+  // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.
+  // See https://github.com/envoyproxy/envoy/commit/d4c39e635603e2f23e1e08ddecf5a5fb5a706338 for details.]
   google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 1}];
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -28,8 +28,8 @@ message Gzip {
   // See https://www.zlib.net/manual.html for more details.
   google.protobuf.UInt32Value chunk_size = 2 [(validate.rules).uint32 = {lte: 65536 gte: 4096}];
 
-  // How many times the output buffer is allowed to be bigger than the size of
-  // accumulated input. This value is used to detect compression bombs.
+  // An upper bound to the number of times the output buffer is allowed to be bigger than the size of
+  // the accumulated input. This value is used to prevent decompression bombs.
   // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.]
-  google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 0}];
+  google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 1}];
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -33,5 +33,4 @@ message Gzip {
   // TODO(rojkov): Re-design the Decompressor interface to handle compression
   // bombs gracefully instead of this quick solution.
   google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 0}];
-
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -29,7 +29,7 @@ message Gzip {
   google.protobuf.UInt32Value chunk_size = 2 [(validate.rules).uint32 = {lte: 65536 gte: 4096}];
 
   // An upper bound to the number of times the output buffer is allowed to be bigger than the size of
-  // the accumulated input. This value is used to prevent decompression bombs.
+  // the accumulated input. This value is used to prevent decompression bombs. If not set, defaults to 100.
   // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.]
   google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 1}];
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -31,5 +31,6 @@ message Gzip {
   // An upper bound to the number of times the output buffer is allowed to be bigger than the size of
   // the accumulated input. This value is used to prevent decompression bombs. If not set, defaults to 100.
   // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.]
+  // See https://github.com/envoyproxy/envoy/commit/d4c39e635603e2f23e1e08ddecf5a5fb5a706338 for details.
   google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 1}];
 }

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -32,5 +32,5 @@ message Gzip {
   // the accumulated input. This value is used to prevent decompression bombs. If not set, defaults to 100.
   // [#comment:TODO(rojkov): Re-design the Decompressor interface to handle compression bombs gracefully instead of this quick solution.
   // See https://github.com/envoyproxy/envoy/commit/d4c39e635603e2f23e1e08ddecf5a5fb5a706338 for details.]
-  google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 10000 gte: 1}];
+  google.protobuf.UInt32Value max_inflate_ratio = 3 [(validate.rules).uint32 = {lte: 1032 gte: 1}];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -44,6 +44,9 @@ new_features:
 - area: dns_resolver
   change: |
     added DNS stats for c-ares DNS resolver. Detailed documentation is available :ref:`here <arch_overview_dns_resolution>`.
+- area: gzip
+  change: |
+    added support for :ref:`max_inflate_ratio<envoy_v3_api_msg_extensions.compression.gzip.decompressor.v3.Gzip>`.
 - area: listener
   change: |
     added multiple listening addresses in single listener. :ref:`listener additional addresses<envoy_v3_api_field_config.listener.v3.Listener.additional_addresses>`.

--- a/source/extensions/compression/gzip/decompressor/config.cc
+++ b/source/extensions/compression/gzip/decompressor/config.cc
@@ -12,6 +12,7 @@ const uint32_t DefaultChunkSize = 4096;
 // When logical OR'ed to window bits, this tells zlib library to decompress gzip data per:
 // inflateInit2 in https://www.zlib.net/manual.html
 const uint32_t GzipHeaderValue = 16;
+const uint64_t DefaultMaxInflateRatio = 100;
 } // namespace
 
 GzipDecompressorFactory::GzipDecompressorFactory(
@@ -19,11 +20,12 @@ GzipDecompressorFactory::GzipDecompressorFactory(
     : scope_(scope),
       window_bits_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, window_bits, DefaultWindowBits) |
                    GzipHeaderValue),
-      chunk_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, chunk_size, DefaultChunkSize)) {}
+      chunk_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, chunk_size, DefaultChunkSize)),
+      max_inflate_ratio_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, max_inflate_ratio, DefaultMaxInflateRatio)) {}
 
 Envoy::Compression::Decompressor::DecompressorPtr
 GzipDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
-  auto decompressor = std::make_unique<ZlibDecompressorImpl>(scope_, stats_prefix, chunk_size_);
+  auto decompressor = std::make_unique<ZlibDecompressorImpl>(scope_, stats_prefix, chunk_size_, max_inflate_ratio_);
   decompressor->init(window_bits_);
   return decompressor;
 }

--- a/source/extensions/compression/gzip/decompressor/config.cc
+++ b/source/extensions/compression/gzip/decompressor/config.cc
@@ -21,11 +21,13 @@ GzipDecompressorFactory::GzipDecompressorFactory(
       window_bits_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, window_bits, DefaultWindowBits) |
                    GzipHeaderValue),
       chunk_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, chunk_size, DefaultChunkSize)),
-      max_inflate_ratio_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, max_inflate_ratio, DefaultMaxInflateRatio)) {}
+      max_inflate_ratio_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(gzip, max_inflate_ratio, DefaultMaxInflateRatio)) {}
 
 Envoy::Compression::Decompressor::DecompressorPtr
 GzipDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
-  auto decompressor = std::make_unique<ZlibDecompressorImpl>(scope_, stats_prefix, chunk_size_, max_inflate_ratio_);
+  auto decompressor =
+      std::make_unique<ZlibDecompressorImpl>(scope_, stats_prefix, chunk_size_, max_inflate_ratio_);
   decompressor->init(window_bits_);
   return decompressor;
 }

--- a/source/extensions/compression/gzip/decompressor/config.h
+++ b/source/extensions/compression/gzip/decompressor/config.h
@@ -39,6 +39,7 @@ private:
   Stats::Scope& scope_;
   const int32_t window_bits_;
   const uint32_t chunk_size_;
+  const uint64_t max_inflate_ratio_;
 };
 
 class GzipDecompressorLibraryFactory

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -17,16 +17,6 @@ namespace Compression {
 namespace Gzip {
 namespace Decompressor {
 
-// namespace {
-
-// // How many times the output buffer is allowed to be bigger than the size of
-// // accumulated input. This value is used to detect compression bombs.
-// // TODO(rojkov): Re-design the Decompressor interface to handle compression
-// // bombs gracefully instead of this quick solution.
-// constexpr uint64_t MaxInflateRatio = 100;
-
-// } // namespace
-
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix)
     : ZlibDecompressorImpl(scope, stats_prefix, 4096, 100) {}
 

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -18,13 +18,13 @@ namespace Gzip {
 namespace Decompressor {
 
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix,
-                                           uint64_t chunk_size)
+                                           uint64_t chunk_size, uint64_t max_inflate_ratio)
     : Common::Base(chunk_size,
-                   [](z_stream* z) {
-                     inflateEnd(z);
-                     delete z;
-                   }),
-      stats_(generateStats(stats_prefix, scope)) {
+                 [](z_stream* z) {
+                   inflateEnd(z);
+                   delete z;
+                 }),
+      stats_(generateStats(stats_prefix, scope)), max_inflate_ratio_(max_inflate_ratio) {
   zstream_ptr_->zalloc = Z_NULL;
   zstream_ptr_->zfree = Z_NULL;
   zstream_ptr_->opaque = Z_NULL;

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -20,10 +20,10 @@ namespace Decompressor {
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix,
                                            uint64_t chunk_size, uint64_t max_inflate_ratio)
     : Common::Base(chunk_size,
-                 [](z_stream* z) {
-                   inflateEnd(z);
-                   delete z;
-                 }),
+                   [](z_stream* z) {
+                     inflateEnd(z);
+                     delete z;
+                   }),
       stats_(generateStats(stats_prefix, scope)), max_inflate_ratio_(max_inflate_ratio) {
   zstream_ptr_->zalloc = Z_NULL;
   zstream_ptr_->zfree = Z_NULL;

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -17,9 +17,6 @@ namespace Compression {
 namespace Gzip {
 namespace Decompressor {
 
-ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix)
-    : ZlibDecompressorImpl(scope, stats_prefix, 4096, 100) {}
-
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix,
                                            uint64_t chunk_size)
     : Common::Base(chunk_size,

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.cc
@@ -17,18 +17,18 @@ namespace Compression {
 namespace Gzip {
 namespace Decompressor {
 
-namespace {
+// namespace {
 
-// How many times the output buffer is allowed to be bigger than the size of
-// accumulated input. This value is used to detect compression bombs.
-// TODO(rojkov): Re-design the Decompressor interface to handle compression
-// bombs gracefully instead of this quick solution.
-constexpr uint64_t MaxInflateRatio = 100;
+// // How many times the output buffer is allowed to be bigger than the size of
+// // accumulated input. This value is used to detect compression bombs.
+// // TODO(rojkov): Re-design the Decompressor interface to handle compression
+// // bombs gracefully instead of this quick solution.
+// constexpr uint64_t MaxInflateRatio = 100;
 
-} // namespace
+// } // namespace
 
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix)
-    : ZlibDecompressorImpl(scope, stats_prefix, 4096) {}
+    : ZlibDecompressorImpl(scope, stats_prefix, 4096, 100) {}
 
 ZlibDecompressorImpl::ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix,
                                            uint64_t chunk_size)
@@ -54,7 +54,7 @@ void ZlibDecompressorImpl::init(int64_t window_bits) {
 
 void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
                                       Buffer::Instance& output_buffer) {
-  uint64_t limit = MaxInflateRatio * input_buffer.length();
+  uint64_t limit = max_inflate_ratio_ * input_buffer.length();
 
   for (const Buffer::RawSlice& input_slice : input_buffer.getRawSlices()) {
     zstream_ptr_->avail_in = input_slice.len_;

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.h
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.h
@@ -50,7 +50,7 @@ public:
    * 256K bytes. @see http://zlib.net/zlib_how.html
    * @param chunk_size amount of memory reserved for the decompressor output.
    */
-  ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix, uint64_t chunk_size);
+  ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix, uint64_t chunk_size, uint64_t max_inflate_ratio);
 
   /**
    * Init must be called in order to initialize the decompressor. Once decompressor is initialized,
@@ -81,6 +81,7 @@ private:
   void chargeErrorStats(const int result);
 
   const ZlibDecompressorStats stats_;
+  const uint64_t max_inflate_ratio_;
 };
 
 } // namespace Decompressor

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.h
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.h
@@ -40,8 +40,6 @@ class ZlibDecompressorImpl : public Common::Base,
                              public Envoy::Compression::Decompressor::Decompressor,
                              public Logger::Loggable<Logger::Id::decompression> {
 public:
-  ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix);
-
   /**
    * Constructor that allows setting the size of decompressor's output buffer. It
    * should be called whenever a buffer size different than the 4096 bytes, normally set by the

--- a/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.h
+++ b/source/extensions/compression/gzip/decompressor/zlib_decompressor_impl.h
@@ -50,7 +50,8 @@ public:
    * 256K bytes. @see http://zlib.net/zlib_how.html
    * @param chunk_size amount of memory reserved for the decompressor output.
    */
-  ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix, uint64_t chunk_size, uint64_t max_inflate_ratio);
+  ZlibDecompressorImpl(Stats::Scope& scope, const std::string& stats_prefix, uint64_t chunk_size,
+                       uint64_t max_inflate_ratio);
 
   /**
    * Init must be called in order to initialize the decompressor. Once decompressor is initialized,

--- a/test/extensions/compression/gzip/compressor_fuzz_test.cc
+++ b/test/extensions/compression/gzip/compressor_fuzz_test.cc
@@ -23,7 +23,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   FuzzedDataProvider provider(buf, len);
   ZlibCompressorImpl compressor;
   Stats::IsolatedStoreImpl stats_store;
-  Decompressor::ZlibDecompressorImpl decompressor{stats_store, "test"};
+  Decompressor::ZlibDecompressorImpl decompressor{stats_store, "test", 4096, 100};
 
   // Select target compression level. We can't use ConsumeEnum() since the range
   // is non-contiguous.

--- a/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
@@ -251,7 +251,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   ASSERT_EQ(0, buffer.length());
 
   Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 16};
+  ZlibDecompressorImpl decompressor{stats_store, "test.", 16, 100};
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);

--- a/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
@@ -46,7 +46,7 @@ protected:
     ASSERT_EQ(0, buffer.length());
 
     Stats::IsolatedStoreImpl stats_store{};
-    ZlibDecompressorImpl decompressor{stats_store, "test."};
+    ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
     decompressor.init(window_bits);
 
     decompressor.decompress(accumulation_buffer, buffer);
@@ -67,7 +67,7 @@ class ZlibDecompressorImplFailureTest : public ZlibDecompressorImplTest {
 protected:
   static void decompressorBadInitTestHelper(int64_t window_bits) {
     Stats::IsolatedStoreImpl stats_store{};
-    ZlibDecompressorImpl decompressor{stats_store, "test."};
+    ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
     decompressor.init(window_bits);
   }
 
@@ -75,7 +75,7 @@ protected:
     Buffer::OwnedImpl input_buffer;
     Buffer::OwnedImpl output_buffer;
     Stats::IsolatedStoreImpl stats_store{};
-    ZlibDecompressorImpl decompressor{stats_store, "test."};
+    ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
     TestUtility::feedBufferWithRandomCharacters(input_buffer, 100);
     decompressor.decompress(input_buffer, output_buffer);
     ASSERT_TRUE(decompressor.decompression_error_ < 0);
@@ -109,7 +109,7 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   ASSERT_TRUE(compressor.checksum() > 0);
 
   Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test."};
+  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
   EXPECT_EQ(0, decompressor.checksum());
 
@@ -141,7 +141,7 @@ TEST_F(ZlibDecompressorImplTest, DetectExcessiveCompressionRatio) {
 
   Buffer::OwnedImpl output_buffer;
   Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test."};
+  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
   decompressor.decompress(buffer, output_buffer);
   ASSERT_EQ(stats_store.counterFromString("test.zlib_data_error").value(), 1);
@@ -180,7 +180,7 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   ASSERT_EQ(0, buffer.length());
 
   Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test."};
+  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
@@ -211,7 +211,7 @@ TEST_F(ZlibDecompressorImplTest, FailedDecompression) {
     drainBuffer(buffer);
   }
   Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test."};
+  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
@@ -318,7 +318,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressOfMultipleSlices) {
   accumulation_buffer.add(buffer);
 
   Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test."};
+  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
 
   drainBuffer(buffer);
@@ -337,7 +337,7 @@ protected:
   void chargeErrorStats(const int result) { decompressor_.chargeErrorStats(result); }
 
   Stats::IsolatedStoreImpl stats_store_{};
-  ZlibDecompressorImpl decompressor_{stats_store_, "test."};
+  ZlibDecompressorImpl decompressor_{stats_store_, "test.", 4096, 100};
 };
 
 TEST_F(ZlibDecompressorStatsTest, ChargeErrorStats) {

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -145,8 +145,8 @@ public:
   const uint64_t window_bits{15 | 16};
 
   Stats::IsolatedStoreImpl stats_store_;
-  Extensions::Compression::Gzip::Decompressor::ZlibDecompressorImpl decompressor_{stats_store_,
-                                                                                  "test"};
+  Extensions::Compression::Gzip::Decompressor::ZlibDecompressorImpl decompressor_{
+      stats_store_, "test", 4096, 100};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, CompressorIntegrationTest,

--- a/test/extensions/filters/http/decompressor/decompressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/decompressor/decompressor_filter_integration_test.cc
@@ -348,4 +348,79 @@ TEST_P(DecompressorIntegrationTest, DecompressAndBuffer) {
   EXPECT_EQ(1L, counter->value());
 }
 
+// Stop decompressing when output-buffer's size exceeds the number of
+// 'max_inflate_ratio*input-data-size'.
+TEST_P(DecompressorIntegrationTest, LimitMaxDecompressOutputSize) {
+  // Set max_inflate_ratio = 10.
+  initializeFilter(R"EOF(
+  name: envoy.filters.http.decompressor
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.decompressor.v3.Decompressor
+    decompressor_library:
+      name: testlib
+      typed_config:
+        "@type": "type.googleapis.com/envoy.extensions.compression.gzip.decompressor.v3.Gzip"
+        max_inflate_ratio: 10
+  )EOF");
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":scheme", "http"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {"content-encoding", "gzip"},
+                                                                 {":authority", "host"}});
+
+  auto request_encoder = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  // Compressed 20K zero bytes data.
+  constexpr uint8_t buffer[] = {0x1f, 0x8b, 0x08, 0x08, 0x8a, 0x51, 0xda, 0x62, 0x00, 0x03, 0x66,
+                                0x69, 0x6c, 0x65, 0x2e, 0x74, 0x78, 0x74, 0x00, 0xed, 0xc1, 0x31,
+                                0x01, 0x00, 0x00, 0x00, 0xc2, 0xa0, 0xf5, 0x4f, 0x6d, 0x0a, 0x3f,
+                                0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0xb7,
+                                0x01, 0x60, 0x83, 0xbc, 0xe6, 0x00, 0x50, 0x00, 0x00};
+
+  // Note that the threshold is max_inflate_ratio*48 = 480 which is less than 20K.
+  Buffer::OwnedImpl data(buffer, 48);
+  codec_client_->sendData(*request_encoder, data, true);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(10, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("gzip", upstream_request_->headers()
+                        .get(Http::LowerCaseString("accept-encoding"))[0]
+                        ->value()
+                        .getStringView());
+  EXPECT_TRUE(upstream_request_->headers().get(Http::LowerCaseString("content-encoding")).empty());
+
+  // Only 4096 bytes(one chunk) decompressed.
+  EXPECT_EQ(4096, upstream_request_->bodyLength());
+  EXPECT_EQ("48",
+            upstream_request_->trailers()
+                ->get(Http::LowerCaseString("x-envoy-decompressor-testlib-compressed-bytes"))[0]
+                ->value()
+                .getStringView());
+  EXPECT_EQ("4096",
+            upstream_request_->trailers()
+                ->get(Http::LowerCaseString("x-envoy-decompressor-testlib-uncompressed-bytes"))[0]
+                ->value()
+                .getStringView());
+
+  // Verify stats
+  test_server_->waitForCounterEq("http.config_test.decompressor.testlib.gzip.request.decompressed",
+                                 1);
+  test_server_->waitForCounterEq(
+      "http.config_test.decompressor.testlib.gzip.request.not_decompressed", 0);
+  test_server_->waitForCounterEq(
+      "http.config_test.decompressor.testlib.gzip.request.total_compressed_bytes", 48);
+  test_server_->waitForCounterEq(
+      "http.config_test.decompressor.testlib.gzip.request.total_uncompressed_bytes", 4096);
+  test_server_->waitForCounterGe(
+      "http.config_test.decompressor.testlib.gzip.decompressor_library.zlib_data_error", 1);
+}
+
 } // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Due to [quickfix of decompression oom](https://github.com/envoyproxy/envoy/commit/d4c39e635603e2f23e1e08ddecf5a5fb5a706338), decompressed data size will be truncated at around `input-size` * `fixed-ratio` currently which may cause incomplete decompression, see [1](https://github.com/envoyproxy/envoy/issues/21647), [2](https://github.com/envoyproxy/envoy/pull/21818).
So I add `max_inflate_ratio` in config instead of const value to limit output size.
