### PR TITLE
tracing: remove unnecessary "spawnChild" annotations in OpenCensus tracer

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -116,6 +116,9 @@ minor_behavior_changes:
 - area: logging
   change: |
     changed category name for access log filter extensions to ``envoy.access_loggers.extension_filters``.
+- area: tracers
+  change: |
+    remove unnecessary "spawnChild" annotations in OpenCensus tracer.
 
 bug_fixes:
 - area: http

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -244,7 +244,6 @@ std::string Span::getTraceIdAsHex() const {
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config& /*config*/, const std::string& name,
                                   SystemTime /*start_time*/) {
-  span_.AddAnnotation("spawnChild");
   return std::make_unique<Span>(oc_config_,
                                 ::opencensus::trace::Span::StartSpan(name, /*parent=*/&span_));
 }

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -148,9 +148,9 @@ TEST(OpenCensusTracerTest, Span) {
     EXPECT_EQ(zeros, sd.parent_span_id());
     parent_span_id = sd.context().span_id();
 
-    ASSERT_EQ(3, sd.annotations().events().size());
+    ASSERT_EQ(2, sd.annotations().events().size());
     EXPECT_EQ("my annotation", sd.annotations().events()[0].event().description());
-    EXPECT_EQ("setSampled", sd.annotations().events()[2].event().description());
+    EXPECT_EQ("setSampled", sd.annotations().events()[1].event().description());
     EXPECT_TRUE(sd.has_ended());
   }
 

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -150,7 +150,6 @@ TEST(OpenCensusTracerTest, Span) {
 
     ASSERT_EQ(3, sd.annotations().events().size());
     EXPECT_EQ("my annotation", sd.annotations().events()[0].event().description());
-    EXPECT_EQ("spawnChild", sd.annotations().events()[1].event().description());
     EXPECT_EQ("setSampled", sd.annotations().events()[2].event().description());
     EXPECT_TRUE(sd.has_ended());
   }


### PR DESCRIPTION
Commit Message:

tracing: remove unnecessary "spawnChild" annotations in OpenCensus tracer

Additional Description:

This might be a left-over debug annotation from when the tracer was implemented. The annotations add no value and make traces harder to read. e.g.

![image](https://user-images.githubusercontent.com/11142171/175611419-a2190a8c-3942-4517-82c6-601896b98055.png)

Risk Level: Low

Testing: None

Docs Changes: No

Release Notes: Yes

Platform Specific Features: None

Signed-off-by: nareddyt <tejunareddy@gmail.com>