### PR TITLE
Only call ares_library_init()/cleanup() routines in process_wide() if ares extension used in DNS resolving.

### DIFF
--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -46,8 +46,8 @@ public:
    * @returns the DNS Resolver factory.
    * @param typed_dns_resolver_config: the typed DNS resolver config
    */
-  static Network::DnsResolverFactory& createFactory(
-      const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config);
+  static Network::DnsResolverFactory&
+  createFactory(const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config);
 
   /**
    * Terminate the DNS resolver factory.

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -42,17 +42,17 @@ public:
   virtual void terminate() {}
 
   /**
-   * Find the DNS resolver factory based on the typed config and initialize it.
+   * Create the DNS resolver factory based on the typed config and initialize it.
    * @returns the DNS Resolver factory.
    * @param typed_dns_resolver_config: the typed DNS resolver config
    */
-  static Network::DnsResolverFactory& initializeDnsResolverFactory(
+  static Network::DnsResolverFactory& createFactory(
       const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config);
 
   /**
-   * Terminate the DNS resolver factories.
+   * Terminate the DNS resolver factory.
    */
-  static void terminateDnsResolverFactories();
+  static void terminateFactory();
 };
 
 } // namespace Network

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -26,7 +26,19 @@ public:
       const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) const PURE;
 
   std::string category() const override { return std::string(DnsResolverCategory); }
+
+  /*
+   * Initialize the related data for this type of DNS resolver.
+   * For some DNS resolvers, like c-ares, there are some specific data structure
+   * needs to be initialized before using it to resolve target.
+   */
   virtual void init() {}
+
+  /*
+   * Cleanup the related data for this type of DNS resolver.
+   * For some DNS resolvers, like c-ares, there are some specific data structure
+   * needs to be cleaned up before terminates Envoy.
+   */
   virtual void cleanup() {}
 };
 

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -42,5 +42,14 @@ public:
   virtual void terminate() {}
 };
 
+/**
+ * Terminate the DNS resolver factories.
+ */
+static inline void terminateDnsResolverFactories() {
+  auto& factories = Registry::FactoryRegistry<Network::DnsResolverFactory>::factories();
+  std::for_each(factories.begin(), factories.end(),
+                [](auto& factory_it) { factory_it.second->terminate(); });
+}
+
 } // namespace Network
 } // namespace Envoy

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -26,6 +26,8 @@ public:
       const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) const PURE;
 
   std::string category() const override { return std::string(DnsResolverCategory); }
+  virtual void init() {}
+  virtual void cleanup() {}
 };
 
 } // namespace Network

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -26,7 +26,6 @@ public:
       const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) const PURE;
 
   std::string category() const override { return std::string(DnsResolverCategory); }
-  virtual void init() {}
   virtual void cleanup() {}
 };
 

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -40,16 +40,20 @@ public:
    * needs to be cleaned up before terminates Envoy.
    */
   virtual void terminate() {}
-};
 
-/**
- * Terminate the DNS resolver factories.
- */
-static inline void terminateDnsResolverFactories() {
-  auto& factories = Registry::FactoryRegistry<Network::DnsResolverFactory>::factories();
-  std::for_each(factories.begin(), factories.end(),
-                [](auto& factory_it) { factory_it.second->terminate(); });
-}
+  /**
+   * Find the DNS resolver factory based on the typed config and initialize it.
+   * @returns the DNS Resolver factory.
+   * @param typed_dns_resolver_config: the typed DNS resolver config
+   */
+  static Network::DnsResolverFactory& initializeDnsResolverFactory(
+      const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config);
+
+  /**
+   * Terminate the DNS resolver factories.
+   */
+  static void terminateDnsResolverFactories();
+};
 
 } // namespace Network
 } // namespace Envoy

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -50,9 +50,9 @@ public:
   createFactory(const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config);
 
   /**
-   * Terminate the DNS resolver factory.
+   * Call the terminate method on all the registered DNS resolver factories.
    */
-  static void terminateFactory();
+  static void terminateFactories();
 };
 
 } // namespace Network

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -15,7 +15,7 @@ constexpr absl::string_view DnsResolverCategory = "envoy.network.dns_resolver";
 
 class DnsResolverFactory : public Config::TypedFactory {
 public:
-  /*
+  /**
    * @returns a DnsResolver object.
    * @param dispatcher: the local dispatcher thread
    * @param api: API interface to interact with system resources
@@ -27,19 +27,19 @@ public:
 
   std::string category() const override { return std::string(DnsResolverCategory); }
 
-  /*
+  /**
    * Initialize the related data for this type of DNS resolver.
    * For some DNS resolvers, like c-ares, there are some specific data structure
    * needs to be initialized before using it to resolve target.
    */
-  virtual void init() {}
+  virtual void initialize() {}
 
-  /*
+  /**
    * Cleanup the related data for this type of DNS resolver.
    * For some DNS resolvers, like c-ares, there are some specific data structure
    * needs to be cleaned up before terminates Envoy.
    */
-  virtual void cleanup() {}
+  virtual void terminate() {}
 };
 
 } // namespace Network

--- a/envoy/network/dns_resolver.h
+++ b/envoy/network/dns_resolver.h
@@ -26,6 +26,7 @@ public:
       const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) const PURE;
 
   std::string category() const override { return std::string(DnsResolverCategory); }
+  virtual void init() {}
   virtual void cleanup() {}
 };
 

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -241,17 +241,6 @@ public:
                                    POOL_HISTOGRAM(scope))};
   }
 
-
-
-  /**
-   * Get the hash map for this factory.
-   */
-  template <class Factory>
-  static absl::flat_hash_map<std::string, Factory*>&  getFactoryMap() {
-    return Registry::FactoryRegistry<Factory>::factories();
-  }
-
-
   /**
    * Get a Factory from the registry with a particular name (and templated type) with error checking
    * to ensure the name and factory are valid.

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -241,6 +241,17 @@ public:
                                    POOL_HISTOGRAM(scope))};
   }
 
+
+
+  /**
+   * Get the hash map for this factory.
+   */
+  template <class Factory>
+  static absl::flat_hash_map<std::string, Factory*>&  getFactoryMap() {
+    return Registry::FactoryRegistry<Factory>::factories();
+  }
+
+
   /**
    * Get a Factory from the registry with a particular name (and templated type) with error checking
    * to ensure the name and factory are valid.

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -79,10 +79,7 @@ void handleLegacyDnsResolverData(
 Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
     const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) {
   ENVOY_LOG_MISC(debug, "create DNS resolver type: {}", typed_dns_resolver_config.name());
-  auto& factory =
-      Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
-  factory.initialize();
-  return factory;
+  return DnsResolverFactory::initializeDnsResolverFactory(typed_dns_resolver_config);
 }
 
 // Create the default DNS resolver factory. apple for MacOS or c-ares for all others.
@@ -92,6 +89,20 @@ Network::DnsResolverFactory& createDefaultDnsResolverFactory(
     envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) {
   Network::makeDefaultDnsResolverConfig(typed_dns_resolver_config);
   return createDnsResolverFactoryFromTypedConfig(typed_dns_resolver_config);
+}
+
+Network::DnsResolverFactory& DnsResolverFactory::initializeDnsResolverFactory(
+    const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) {
+  auto& factory =
+      Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
+  factory.initialize();
+  return factory;
+}
+
+void DnsResolverFactory::terminateDnsResolverFactories() {
+  auto& factories = Registry::FactoryRegistry<Network::DnsResolverFactory>::factories();
+  std::for_each(factories.begin(), factories.end(),
+                [](auto& factory_it) { factory_it.second->terminate(); });
 }
 
 } // namespace Network

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -99,7 +99,7 @@ Network::DnsResolverFactory& DnsResolverFactory::createFactory(
   return factory;
 }
 
-void DnsResolverFactory::terminateFactory() {
+void DnsResolverFactory::terminateFactories() {
   auto& factories = Registry::FactoryRegistry<Network::DnsResolverFactory>::factories();
   std::for_each(factories.begin(), factories.end(),
                 [](auto& factory_it) { factory_it.second->terminate(); });

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -81,9 +81,7 @@ Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
   ENVOY_LOG_MISC(debug, "create DNS resolver type: {}", typed_dns_resolver_config.name());
   auto& factory =
       Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
-  if (factory.name() == std::string(CaresDnsResolver)) {
-    factory.initialize();
-  }
+  factory.initialize();
   return factory;
 }
 

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -79,7 +79,7 @@ void handleLegacyDnsResolverData(
 Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
     const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) {
   ENVOY_LOG_MISC(debug, "create DNS resolver type: {}", typed_dns_resolver_config.name());
-  return DnsResolverFactory::initializeDnsResolverFactory(typed_dns_resolver_config);
+  return DnsResolverFactory::createFactory(typed_dns_resolver_config);
 }
 
 // Create the default DNS resolver factory. apple for MacOS or c-ares for all others.
@@ -91,7 +91,7 @@ Network::DnsResolverFactory& createDefaultDnsResolverFactory(
   return createDnsResolverFactoryFromTypedConfig(typed_dns_resolver_config);
 }
 
-Network::DnsResolverFactory& DnsResolverFactory::initializeDnsResolverFactory(
+Network::DnsResolverFactory& DnsResolverFactory::createFactory(
     const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) {
   auto& factory =
       Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
@@ -99,7 +99,7 @@ Network::DnsResolverFactory& DnsResolverFactory::initializeDnsResolverFactory(
   return factory;
 }
 
-void DnsResolverFactory::terminateDnsResolverFactories() {
+void DnsResolverFactory::terminateFactory() {
   auto& factories = Registry::FactoryRegistry<Network::DnsResolverFactory>::factories();
   std::for_each(factories.begin(), factories.end(),
                 [](auto& factory_it) { factory_it.second->terminate(); });

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -81,7 +81,9 @@ Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
   ENVOY_LOG_MISC(debug, "create DNS resolver type: {}", typed_dns_resolver_config.name());
   auto& factory =
       Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
-  factory.initialize();
+  if (factory.name() == std::string(CaresDnsResolver)) {
+    factory.initialize();
+  }
   return factory;
 }
 

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -79,8 +79,11 @@ void handleLegacyDnsResolverData(
 Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
     const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config) {
   ENVOY_LOG_MISC(debug, "create DNS resolver type: {}", typed_dns_resolver_config.name());
-  return Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(
-      typed_dns_resolver_config);
+  auto& factory =
+      Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
+  // Perform factory initialization.
+  factory.init();
+  return factory;
 }
 
 // Create the default DNS resolver factory. apple for MacOS or c-ares for all others.

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -81,7 +81,6 @@ Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
   ENVOY_LOG_MISC(debug, "create DNS resolver type: {}", typed_dns_resolver_config.name());
   auto& factory =
       Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
-  // Perform factory initialization.
   factory.initialize();
   return factory;
 }

--- a/source/common/network/dns_resolver/dns_factory_util.cc
+++ b/source/common/network/dns_resolver/dns_factory_util.cc
@@ -82,7 +82,7 @@ Network::DnsResolverFactory& createDnsResolverFactoryFromTypedConfig(
   auto& factory =
       Config::Utility::getAndCheckFactory<Network::DnsResolverFactory>(typed_dns_resolver_config);
   // Perform factory initialization.
-  factory.init();
+  factory.initialize();
   return factory;
 }
 

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -141,7 +141,6 @@ envoy_cc_library(
     name = "process_wide_lib",
     srcs = ["process_wide.cc"],
     hdrs = ["process_wide.h"],
-    external_deps = ["ares"],
     deps = [
         "//envoy/network:dns_resolver_interface",
         "//source/common/common:assert_lib",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -143,6 +143,7 @@ envoy_cc_library(
     hdrs = ["process_wide.h"],
     external_deps = ["ares"],
     deps = [
+        "//envoy/network:dns_resolver_interface",
         "//source/common/common:assert_lib",
         "//source/common/event:libevent_lib",
         "//source/common/http/http2:nghttp2_lib",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -142,10 +142,10 @@ envoy_cc_library(
     srcs = ["process_wide.cc"],
     hdrs = ["process_wide.h"],
     deps = [
-        "//envoy/network:dns_resolver_interface",
         "//source/common/common:assert_lib",
         "//source/common/event:libevent_lib",
         "//source/common/http/http2:nghttp2_lib",
+        "//source/common/network/dns_resolver:dns_factory_util_lib",
         "//source/server:proto_descriptors_lib",
     ],
 )

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -61,7 +61,7 @@ ProcessWide::~ProcessWide() {
     // Clean it up here in case it is ever used.
     if (auto* dns_factory = Config::Utility::getAndCheckFactoryByName<Network::DnsResolverFactory>(
             std::string(Network::CaresDnsResolver), true)) {
-      dns_factory->cleanup();
+      dns_factory->terminate();
     }
   }
 }

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -57,7 +57,7 @@ ProcessWide::~ProcessWide() {
 
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
-    Network::terminateDnsResolverFactories();
+    Network::DnsResolverFactory::terminateDnsResolverFactories();
   }
 }
 

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -57,7 +57,8 @@ ProcessWide::~ProcessWide() {
 
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
-    // Cleanup c-ares library if it is linked in.
+    // The c-ares library init is done in a thread-safe way when it is actually used for resolving.
+    // Clean it up here in case it is ever used.
     if (auto* dns_factory = Config::Utility::getAndCheckFactoryByName<Network::DnsResolverFactory>(
             std::string(Network::CaresDnsResolver), true)) {
       dns_factory->cleanup();

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -57,7 +57,7 @@ ProcessWide::~ProcessWide() {
 
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
-    Network::DnsResolverFactory::terminateFactory();
+    Network::DnsResolverFactory::terminateFactories();
   }
 }
 

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -57,10 +57,7 @@ ProcessWide::~ProcessWide() {
 
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
-    for (const auto& dns_factory :
-         Config::Utility::getFactoryMap<Network::DnsResolverFactory>()) {
-      dns_factory.second->terminate();
-    }
+    Network::terminateDnsResolverFactories();
   }
 }
 

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -57,7 +57,7 @@ ProcessWide::~ProcessWide() {
 
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
-    Network::DnsResolverFactory::terminateDnsResolverFactories();
+    Network::DnsResolverFactory::terminateFactory();
   }
 }
 

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -6,8 +6,6 @@
 #include "source/common/http/http2/nghttp2.h"
 #include "source/server/proto_descriptors.h"
 
-#include "ares.h"
-
 namespace Envoy {
 namespace {
 

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -57,11 +57,9 @@ ProcessWide::~ProcessWide() {
 
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
-    // The c-ares library init is done in a thread-safe way when it is actually used for resolving.
-    // Clean it up here in case it is ever used.
-    if (auto* dns_factory = Config::Utility::getAndCheckFactoryByName<Network::DnsResolverFactory>(
-            std::string(Network::CaresDnsResolver), true)) {
-      dns_factory->terminate();
+    for (const auto& dns_factory :
+         Config::Utility::getFactoryMap<Network::DnsResolverFactory>()) {
+      dns_factory.second->terminate();
     }
   }
 }

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -30,12 +30,6 @@ ProcessWide::ProcessWide() {
   if (init_data.count_++ == 0) {
     // TODO(mattklein123): Audit the following as not all of these have to be re-initialized in the
     // edge case where something does init/destroy/init/destroy.
-
-    // Initialize c-ares library if it is linked in.
-    if (auto* dns_factory = Config::Utility::getAndCheckFactoryByName<Network::DnsResolverFactory>(
-            std::string(Network::CaresDnsResolver), true)) {
-      dns_factory->init();
-    }
     Event::Libevent::Global::initialize();
     Envoy::Server::validateProtoDescriptors();
     Http::Http2::initializeNghttp2Logging();

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -1,6 +1,7 @@
 #include "source/exe/process_wide.h"
 
 #include "envoy/network/dns_resolver.h"
+
 #include "source/common/common/assert.h"
 #include "source/common/event/libevent.h"
 #include "source/common/http/http2/nghttp2.h"
@@ -31,8 +32,8 @@ ProcessWide::ProcessWide() {
     // edge case where something does init/destroy/init/destroy.
 
     // Initialize c-ares library if it is linked in.
-    if  (auto* dns_factory = Config::Utility::getAndCheckFactoryByName
-         <Network::DnsResolverFactory>(std::string(Network::CaresDnsResolver), true)) {
+    if (auto* dns_factory = Config::Utility::getAndCheckFactoryByName<Network::DnsResolverFactory>(
+            std::string(Network::CaresDnsResolver), true)) {
       dns_factory->init();
     }
     Event::Libevent::Global::initialize();
@@ -63,8 +64,8 @@ ProcessWide::~ProcessWide() {
   ASSERT(init_data.count_ > 0);
   if (--init_data.count_ == 0) {
     // Cleanup c-ares library if it is linked in.
-    if  (auto* dns_factory = Config::Utility::getAndCheckFactoryByName
-         <Network::DnsResolverFactory>(std::string(Network::CaresDnsResolver), true)) {
+    if (auto* dns_factory = Config::Utility::getAndCheckFactoryByName<Network::DnsResolverFactory>(
+            std::string(Network::CaresDnsResolver), true)) {
       dns_factory->cleanup();
     }
   }

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -522,7 +522,7 @@ public:
     return std::make_shared<Network::DnsResolverImpl>(cares, dispatcher, resolvers);
   }
 
-  void init() override {
+  void initialize() override {
     // Initialize c-ares library in case first time.
     absl::MutexLock lock(&mutex_);
     if (!ares_library_initialized_) {
@@ -530,7 +530,7 @@ public:
       ares_library_init(ARES_LIB_INIT_ALL);
     }
   }
-  void cleanup() override {
+  void terminate() override {
     // Cleanup c-ares library if initialized.
     absl::MutexLock lock(&mutex_);
     if (ares_library_initialized_) {

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -495,7 +495,6 @@ DnsResolverImpl::AddrInfoPendingResolution::availableInterfaces() {
 // c-ares DNS resolver factory
 class CaresDnsResolverFactory : public DnsResolverFactory {
 public:
-  CaresDnsResolverFactory() : ares_library_initialized_(false) {}
   std::string name() const override { return std::string(CaresDnsResolver); }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -538,7 +537,7 @@ public:
   }
 
 private:
-  mutable bool ares_library_initialized_;
+  mutable bool ares_library_initialized_{false};
 };
 
 // Register the CaresDnsResolverFactory

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -524,6 +524,8 @@ public:
 
   void init() override {
     // Initialize c-ares library in case first time.
+    absl::Mutex mutex;
+    absl::MutexLock lock(&mutex);
     if (!ares_library_initialized_) {
       ares_library_initialized_ = true;
       ares_library_init(ARES_LIB_INIT_ALL);

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -521,6 +521,9 @@ public:
     }
     return std::make_shared<Network::DnsResolverImpl>(cares, dispatcher, resolvers);
   }
+
+  void init() override { ares_library_init(ARES_LIB_INIT_ALL); }
+  void cleanup() override { ares_library_cleanup(); }
 };
 
 // Register the CaresDnsResolverFactory

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -524,8 +524,7 @@ public:
 
   void init() override {
     // Initialize c-ares library in case first time.
-    absl::Mutex mutex;
-    absl::MutexLock lock(&mutex);
+    absl::MutexLock lock(&mutex_);
     if (!ares_library_initialized_) {
       ares_library_initialized_ = true;
       ares_library_init(ARES_LIB_INIT_ALL);
@@ -533,13 +532,16 @@ public:
   }
   void cleanup() override {
     // Cleanup c-ares library if initialized.
+    absl::MutexLock lock(&mutex_);
     if (ares_library_initialized_) {
+      ares_library_initialized_ = false;
       ares_library_cleanup();
     }
   }
 
 private:
-  mutable bool ares_library_initialized_{false};
+  bool ares_library_initialized_ ABSL_GUARDED_BY(mutex_){false};
+  absl::Mutex mutex_;
 };
 
 // Register the CaresDnsResolverFactory

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -494,7 +494,7 @@ DnsResolverImpl::AddrInfoPendingResolution::availableInterfaces() {
 
 // c-ares DNS resolver factory
 class CaresDnsResolverFactory : public DnsResolverFactory,
-                                public Logger::Loggable<Logger::Id::dns>{
+                                public Logger::Loggable<Logger::Id::dns> {
 public:
   std::string name() const override { return std::string(CaresDnsResolver); }
 

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -493,7 +493,8 @@ DnsResolverImpl::AddrInfoPendingResolution::availableInterfaces() {
 }
 
 // c-ares DNS resolver factory
-class CaresDnsResolverFactory : public DnsResolverFactory {
+class CaresDnsResolverFactory : public DnsResolverFactory,
+                                public Logger::Loggable<Logger::Id::dns>{
 public:
   std::string name() const override { return std::string(CaresDnsResolver); }
 
@@ -527,6 +528,7 @@ public:
     absl::MutexLock lock(&mutex_);
     if (!ares_library_initialized_) {
       ares_library_initialized_ = true;
+      ENVOY_LOG(info, "c-ares library initialized.");
       ares_library_init(ARES_LIB_INIT_ALL);
     }
   }
@@ -535,6 +537,7 @@ public:
     absl::MutexLock lock(&mutex_);
     if (ares_library_initialized_) {
       ares_library_initialized_ = false;
+      ENVOY_LOG(info, "c-ares library cleaned up.");
       ares_library_cleanup();
     }
   }

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -508,11 +508,6 @@ public:
                                              typed_dns_resolver_config) const override {
     envoy::extensions::network::dns_resolver::cares::v3::CaresDnsResolverConfig cares;
     std::vector<Network::Address::InstanceConstSharedPtr> resolvers;
-    // Initialize c-ares library in case first time.
-    if (!ares_library_initialized_) {
-      ares_library_init(ARES_LIB_INIT_ALL);
-      ares_library_initialized_ = true;
-    }
 
     ASSERT(dispatcher.isThreadSafe());
     // Only c-ares DNS factory will call into this function.
@@ -528,6 +523,13 @@ public:
     return std::make_shared<Network::DnsResolverImpl>(cares, dispatcher, resolvers);
   }
 
+  void init() override {
+    // Initialize c-ares library in case first time.
+    if (!ares_library_initialized_) {
+      ares_library_initialized_ = true;
+      ares_library_init(ARES_LIB_INIT_ALL);
+    }
+  }
   void cleanup() override {
     // Cleanup c-ares library if initialized.
     if (ares_library_initialized_) {


### PR DESCRIPTION
Only call ares_library_init()/cleanup() routines in process_wide() if ares extension is used in DNS resolving.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
