### PR TITLE
change order of members of ConnectionHandlerImpl

### DIFF
--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -134,13 +134,13 @@ private:
   const absl::optional<uint32_t> worker_index_;
   Event::Dispatcher& dispatcher_;
   const std::string per_handler_stat_prefix_;
+  std::atomic<uint64_t> num_handler_connections_{};
   absl::flat_hash_map<uint64_t, std::unique_ptr<ActiveListenerDetails>> listener_map_by_tag_;
   absl::flat_hash_map<std::string, std::shared_ptr<PerAddressActiveListenerDetails>>
       tcp_listener_map_by_address_;
   absl::flat_hash_map<std::string, std::shared_ptr<PerAddressActiveListenerDetails>>
       internal_listener_map_by_address_;
 
-  std::atomic<uint64_t> num_handler_connections_{};
   bool disable_listeners_;
   UnitFloat listener_reject_fraction_{UnitFloat::min()};
 };


### PR DESCRIPTION
Commit Message: change order of ConnectionHandlerImpl members
Additional Description: By changing the order of these members, the possibility of accessing uninitialized memory is removed (as detected by memory sanitizer https://clang.llvm.org/docs/MemorySanitizer.html, specifically -sanitize-memory-param-retval).  This was occurring during destruction on this line: https://github.com/envoyproxy/envoy/blob/main/source/server/connection_handler_impl.cc#L26
Risk Level: Low
Testing: first time contributing, I'm not sure how to run the tests.  I did run my unit tests which showed the problem and it cleared up.
Docs Changes: none
Release Notes: reordering members of ConnectionHandlerImpl
Platform Specific Features: none
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
