### PR TITLE
Avoid creating DNS resolver for DNS filter in data plane

### DIFF
--- a/source/extensions/filters/udp/dns_filter/dns_filter.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.h
@@ -90,10 +90,7 @@ public:
   uint64_t retryCount() const { return retry_count_; }
   Random::RandomGenerator& random() const { return random_; }
   uint64_t maxPendingLookups() const { return max_pending_lookups_; }
-  const envoy::config::core::v3::TypedExtensionConfig& typedDnsResolverConfig() const {
-    return typed_dns_resolver_config_;
-  }
-  const Network::DnsResolverFactory& dnsResolverFactory() const { return *dns_resolver_factory_; }
+  const Network::DnsResolverSharedPtr& resolver() const { return resolver_; }
   Api::Api& api() const { return api_; }
   const TrieLookupTable<DnsVirtualDomainConfigSharedPtr>& getDnsTrie() const {
     return dns_lookup_trie_;
@@ -128,8 +125,6 @@ private:
   std::chrono::milliseconds resolver_timeout_;
   Random::RandomGenerator& random_;
   uint64_t max_pending_lookups_;
-  envoy::config::core::v3::TypedExtensionConfig typed_dns_resolver_config_;
-  Network::DnsResolverFactory* dns_resolver_factory_;
 };
 
 using DnsFilterEnvoyConfigSharedPtr = std::shared_ptr<const DnsFilterEnvoyConfig>;

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
@@ -21,11 +21,8 @@ class DnsFilterResolver : Logger::Loggable<Logger::Id::filter> {
 public:
   DnsFilterResolver(DnsFilterResolverCallback& callback, std::chrono::milliseconds timeout,
                     Event::Dispatcher& dispatcher, uint64_t max_pending_lookups,
-                    const envoy::config::core::v3::TypedExtensionConfig& typed_dns_resolver_config,
-                    const Network::DnsResolverFactory& dns_resolver_factory, Api::Api& api)
-      : timeout_(timeout), dispatcher_(dispatcher),
-        resolver_(
-            dns_resolver_factory.createDnsResolver(dispatcher, api, typed_dns_resolver_config)),
+                    const Network::DnsResolverSharedPtr& resolver)
+      : timeout_(timeout), dispatcher_(dispatcher), resolver_(resolver),
         callback_(callback), max_pending_lookups_(max_pending_lookups) {}
   /**
    * @brief entry point to resolve the name in a DnsQueryRecord


### PR DESCRIPTION
Create DNS resolver for DNS filter in control plane config parsing, not in data plane.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
