### PR TITLE
extension: Add Span::setTag for setting attributes in OTLP Tracer

### DIFF
--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -75,7 +75,7 @@ public:
 
   // Tracing::Span functions
   void setOperation(absl::string_view /*operation*/) override{};
-  void setTag(absl::string_view /*name*/, absl::string_view /*value*/) override{};
+  void setTag(absl::string_view /*name*/, absl::string_view /*value*/) override;
   void log(SystemTime /*timestamp*/, const std::string& /*event*/) override{};
   void finishSpan() override;
   void injectContext(Envoy::Tracing::TraceContext& /*trace_context*/,

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -311,6 +311,66 @@ TEST_F(OpenTelemetryDriverTest, SpawnChildSpan) {
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
 
+TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithAttributes) {
+  setupValidDriver();
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
+      context_.server_factory_context_.api_.random_;
+  int64_t generated_int = 1;
+  EXPECT_CALL(mock_random_generator_, random()).Times(3).WillRepeatedly(Return(generated_int));
+  SystemTime timestamp = time_system_.systemTime();
+
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
+                                             timestamp, {Tracing::Reason::Sampling, true});
+  EXPECT_NE(span.get(), nullptr);
+
+  span->setTag("first_tag_name", "first_tag_value");
+  span->setTag("second_tag_name", "second_tag_value");
+  // Try an empty tag.
+  span->setTag("", "empty_tag_value");
+  // Overwrite a tag.
+  span->setTag("first_tag_name", "first_tag_new_value");
+
+  // Note the placeholders for the bytes - cleaner to manually set after.
+  const std::string request_yaml = R"(
+resource_spans:
+  instrumentation_library_spans:
+    spans:
+      trace_id: "AAA"
+      span_id: "AAA"
+      name: "test"
+      kind: SPAN_KIND_SERVER
+      start_time_unix_nano: {}
+      end_time_unix_nano: {}
+      attributes:
+        - key: "first_tag_name"
+          value:
+            string_value: "first_tag_new_value"
+        - key: "second_tag_name"
+          value:
+            string_value: "second_tag_value"
+  )";
+  opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
+  int64_t timestamp_ns = std::chrono::nanoseconds(timestamp.time_since_epoch()).count();
+  TestUtility::loadFromYaml(fmt::format(request_yaml, timestamp_ns, timestamp_ns), request_proto);
+  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
+  auto* expected_span = request_proto.mutable_resource_spans(0)
+                            ->mutable_instrumentation_library_spans(0)
+                            ->mutable_spans(0);
+  expected_span->set_trace_id(
+      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
+  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
+      .Times(1)
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(*mock_stream_ptr_,
+              sendMessageRaw_(Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _));
+  span->finishSpan();
+  EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+}
+
 } // namespace OpenTelemetry
 } // namespace Tracers
 } // namespace Extensions


### PR DESCRIPTION
Signed-off-by: Alex Ellis <ellisonjtk@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:  Add Span::setTag for setting attributes in OTLP Tracer
Additional Description: Adding attributes to the OTLP traces generated in the OTLP tracer (see https://github.com/envoyproxy/envoy/issues/9958). 

Here's a sampling of the attributes Envoy creates in a basic test setup (Envoy making a child span for its call to the Nighthawk test server) by just adding this method:

![image](https://user-images.githubusercontent.com/17228751/175791258-aa7d6bec-2190-48b6-b9b3-37a4e8100f94.png)


Risk Level: low
Testing: Added a unit test (with fleshed out proto expectations)
Docs Changes: N/A
Part of #9958 
