### PR TITLE
http: Skip useless check when get Connected event in CodecClient::onEvent

### DIFF
--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -88,6 +88,7 @@ void CodecClient::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::Connected) {
     ENVOY_CONN_LOG(debug, "connected", *connection_);
     connected_ = true;
+    return;
   }
 
   if (event == Network::ConnectionEvent::RemoteClose) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: http: Skip useless check when get Connected event in CodecClient::onEvent
Additional Description:

When reviewing the HTTP code, I think we can just `return` when getting a  `Network::ConnectionEvent::Connected` event to skip the unnecessary checks.

Additional Description:
Risk Level: Low.
Testing: Waiting.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
