### PR TITLE
cleanup: Fix `protoprint` test data

### DIFF
--- a/tools/testdata/protoxform/envoy/v2/BUILD
+++ b/tools/testdata/protoxform/envoy/v2/BUILD
@@ -15,8 +15,11 @@ proto_library(
     deps = [
         "//tools/testdata/protoxform/external:external_protos",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_google_googleapis//google/api:annotations_proto",
+        "@com_google_protobuf//:any_proto",
         "@envoy_api//envoy/annotations:pkg",
         "@envoy_api//envoy/api/v2:pkg",
+        "@envoy_api//envoy/api/v2/core:pkg",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

I believe this target currently works as whatever calls it provides required dependencies.

if you try to build it directly, or to include it in a `proto_descriptor_set` then it fails without the addition of these deps.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
