### PR TITLE
test: Enable addFakeUpstream() to create AutonomousUpstreams

### DIFF
--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -82,7 +82,8 @@ typed_config:
         auto http2_config = configWithType(Http::CodecType::HTTP2);
         Network::DownstreamTransportSocketFactoryPtr http2_factory =
             createUpstreamTlsContext(http2_config);
-        addFakeUpstream(std::move(http2_factory), Http::CodecType::HTTP2);
+        addFakeUpstream(std::move(http2_factory), Http::CodecType::HTTP2,
+                        /*autonomous_upstream=*/false);
 
         // Make the next upstream is HTTP/3
         auto http3_config = configWithType(Http::CodecType::HTTP3);
@@ -291,11 +292,11 @@ protected:
     if (use_http2_) {
       auto config = configWithType(Http::CodecType::HTTP2);
       Network::DownstreamTransportSocketFactoryPtr factory = createUpstreamTlsContext(config);
-      addFakeUpstream(std::move(factory), Http::CodecType::HTTP2);
+      addFakeUpstream(std::move(factory), Http::CodecType::HTTP2, /*autonomous_upstream=*/false);
     } else {
       auto config = configWithType(Http::CodecType::HTTP3);
       Network::DownstreamTransportSocketFactoryPtr factory = createUpstreamTlsContext(config);
-      addFakeUpstream(std::move(factory), Http::CodecType::HTTP3);
+      addFakeUpstream(std::move(factory), Http::CodecType::HTTP3, /*autonomous_upstream=*/false);
       writeFile();
     }
   }

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -130,7 +130,7 @@ typed_config:
     if (upstream_tls_) {
       addFakeUpstream(Ssl::createFakeUpstreamSslContext(upstream_cert_name_, context_manager_,
                                                         factory_context_),
-                      Http::CodecType::HTTP1);
+                      Http::CodecType::HTTP1, /*autonomous_upstream=*/false);
     } else {
       HttpIntegrationTest::createUpstreams();
     }

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -46,7 +46,8 @@ public:
   }
 
   void createUpstreams() override {
-    addFakeUpstream(createUpstreamSslContext(), Http::CodecType::HTTP1);
+    addFakeUpstream(createUpstreamSslContext(), Http::CodecType::HTTP1,
+                    /*autonomous_upstream=*/false);
   }
 
   Network::DownstreamTransportSocketFactoryPtr createUpstreamSslContext() {

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -88,7 +88,7 @@ typed_config:
   void createUpstreams() override {
     addFakeUpstream(
         Ssl::createFakeUpstreamSslContext(upstream_cert_name_, context_manager_, factory_context_),
-        Http::CodecType::HTTP1);
+        Http::CodecType::HTTP1, /*autonomous_upstream=*/false);
   }
 
   Network::ClientConnectionPtr

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -16,20 +16,15 @@
 #include "envoy/service/discovery/v3/discovery.pb.h"
 
 #include "source/common/common/assert.h"
-#include "source/common/common/fmt.h"
-#include "source/common/config/api_version.h"
 #include "source/common/event/libevent.h"
 #include "source/common/network/utility.h"
 #include "source/extensions/transport_sockets/tls/context_config_impl.h"
 #include "source/extensions/transport_sockets/tls/ssl_socket.h"
 
-#include "test/integration/autonomous_upstream.h"
 #include "test/integration/utility.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
-#include "absl/container/fixed_array.h"
-#include "absl/strings/str_join.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -518,7 +513,7 @@ void BaseIntegrationTest::createXdsUpstream() {
     upstream_stats_store_ = std::make_unique<Stats::TestIsolatedStoreImpl>();
     auto context = std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
         std::move(cfg), context_manager_, *upstream_stats_store_, std::vector<std::string>{});
-    addFakeUpstream(std::move(context), Http::CodecType::HTTP2);
+    addFakeUpstream(std::move(context), Http::CodecType::HTTP2, /*autonomous_upstream=*/false);
   }
   xds_upstream_ = fake_upstreams_.back().get();
 }

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -57,10 +57,12 @@ public:
 
     // Endpoint connections
     if (tls_hosts_) {
-      host_upstream_ = &addFakeUpstream(
-          HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()), http_conn_type_);
-      host2_upstream_ = &addFakeUpstream(
-          HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()), http_conn_type_);
+      host_upstream_ =
+          &addFakeUpstream(HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()),
+                           http_conn_type_, /*autonomous_upstream=*/false);
+      host2_upstream_ =
+          &addFakeUpstream(HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()),
+                           http_conn_type_, /*autonomous_upstream=*/false);
     } else {
       host_upstream_ = &addFakeUpstream(http_conn_type_);
       host2_upstream_ = &addFakeUpstream(http_conn_type_);

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -587,7 +587,7 @@ public:
 
   void createUpstreams() override {
     // Fake upstream with SSL/TLS for the first cluster.
-    addFakeUpstream(createUpstreamSslContext(), upstreamProtocol());
+    addFakeUpstream(createUpstreamSslContext(), upstreamProtocol(), /*autonomous_upstream=*/false);
     create_xds_upstream_ = true;
   }
 
@@ -778,7 +778,7 @@ public:
   void createUpstreams() override {
     // This is for backend with ssl
     addFakeUpstream(createUpstreamSslContext(context_manager_, *api_, test_quic_),
-                    upstreamProtocol());
+                    upstreamProtocol(), /*autonomous_upstream=*/false);
     create_xds_upstream_ = true;
   }
 };

--- a/test/integration/sds_static_integration_test.cc
+++ b/test/integration/sds_static_integration_test.cc
@@ -143,7 +143,8 @@ public:
   }
 
   void createUpstreams() override {
-    addFakeUpstream(createUpstreamSslContext(context_manager_, *api_), Http::CodecType::HTTP1);
+    addFakeUpstream(createUpstreamSslContext(context_manager_, *api_), Http::CodecType::HTTP1,
+                    /*autonomous_upstream=*/false);
   }
 
 private:

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -136,7 +136,8 @@ Network::ClientConnectionPtr XfccIntegrationTest::makeMtlsClientConnection() {
 }
 
 void XfccIntegrationTest::createUpstreams() {
-  addFakeUpstream(createUpstreamSslContext(), Http::CodecType::HTTP1);
+  addFakeUpstream(createUpstreamSslContext(), Http::CodecType::HTTP1,
+                  /*autonomous_upstream=*/false);
 }
 
 void XfccIntegrationTest::initialize() {


### PR DESCRIPTION
Previously, the BaseIntegrationTest::addFakeUpstream() function would only create a FakeUpstream, not taking
BaseIntegrationTest::autonomous_upstream_ into account.  This could lead to confusing integration test behavior.

With this change, the addFakeUpstream() function takes a required autonomous_upstream parameter that
indicates whether an AutonomousUpstream should be created instead of a FakeUpstream. 

Signed-off-by: Ali Beyad <abeyad@google.com>