### PR TITLE
tools: Remove contrib from the VSCode code completion db

### DIFF
--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -18,8 +18,8 @@ def generate_compilation_database(args):
     ]
 
     source_dir_targets = args.bazel_targets
-    if args.include_contrib:
-        source_dir_targets.append("//contrib/...")
+    if args.no_contrib:
+        source_dir_targets.remove("//contrib/...")
 
     subprocess.check_call([args.bazel, "build"] + bazel_options + [
         "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
@@ -115,15 +115,14 @@ if __name__ == "__main__":
     parser.add_argument('--include_headers', action='store_true')
     parser.add_argument('--vscode', action='store_true')
     parser.add_argument('--include_all', action='store_true')
-    parser.add_argument('--include_contrib', action='store_true')
+    parser.add_argument('--no_contrib', action='store_true')
     parser.add_argument('--bazel', default='bazel')
     parser.add_argument(
-        'bazel_targets',
-        nargs='*',
-        default=[
+        'bazel_targets', nargs='*', default=[
             "//source/...",
             "//test/...",
             "//tools/...",
+            "//contrib/...",
         ])
     args = parser.parse_args()
     fix_compilation_database(args, generate_compilation_database(args))

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -17,10 +17,14 @@ def generate_compilation_database(args):
         "--remote_download_outputs=all",
     ]
 
+    source_dir_targets = args.bazel_targets
+    if args.include_contrib:
+        source_dir_targets.append("//contrib/...")
+
     subprocess.check_call([args.bazel, "build"] + bazel_options + [
         "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
         "--output_groups=compdb_files,header_files"
-    ] + args.bazel_targets)
+    ] + source_dir_targets)
 
     execroot = subprocess.check_output([args.bazel, "info", "execution_root"]
                                        + bazel_options).decode().strip()
@@ -111,6 +115,7 @@ if __name__ == "__main__":
     parser.add_argument('--include_headers', action='store_true')
     parser.add_argument('--vscode', action='store_true')
     parser.add_argument('--include_all', action='store_true')
+    parser.add_argument('--include_contrib', action='store_true')
     parser.add_argument('--bazel', default='bazel')
     parser.add_argument(
         'bazel_targets',
@@ -119,7 +124,6 @@ if __name__ == "__main__":
             "//source/...",
             "//test/...",
             "//tools/...",
-            "//contrib/...",
         ])
     args = parser.parse_args()
     fix_compilation_database(args, generate_compilation_database(args))

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -18,7 +18,7 @@ def generate_compilation_database(args):
     ]
 
     source_dir_targets = args.bazel_targets
-    if args.no_contrib:
+    if args.exclude_contrib:
         source_dir_targets.remove("//contrib/...")
 
     subprocess.check_call([args.bazel, "build"] + bazel_options + [
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     parser.add_argument('--include_headers', action='store_true')
     parser.add_argument('--vscode', action='store_true')
     parser.add_argument('--include_all', action='store_true')
-    parser.add_argument('--no_contrib', action='store_true')
+    parser.add_argument('--exclude_contrib', action='store_true')
     parser.add_argument('--bazel', default='bazel')
     parser.add_argument(
         'bazel_targets', nargs='*', default=[

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -118,7 +118,9 @@ if __name__ == "__main__":
     parser.add_argument('--exclude_contrib', action='store_true')
     parser.add_argument('--bazel', default='bazel')
     parser.add_argument(
-        'bazel_targets', nargs='*', default=[
+        'bazel_targets',
+        nargs='*',
+        default=[
             "//source/...",
             "//test/...",
             "//tools/...",

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -6,7 +6,7 @@ bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //source/... //envoy/... //api/... //test/... //tools/...
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //source/... //test/... //tools/...
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -6,7 +6,7 @@ bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //source/... //test/... //tools/...
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //source/... //envoy/... //api/... //test/... //tools/...
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -2,11 +2,16 @@
 
 [[ -z "${SKIP_PROTO_FORMAT}" ]] && tools/proto_format/proto_format.sh fix
 
+source_dirs=("//source/..." "//test/..." "//tools/...")
+if [ "$1" == "--include-contrib" ]; then
+  source_dirs+=("//contrib/...") 
+fi
+
 bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //source/... //test/... //tools/...
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk ${source_dirs[@]}
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -6,7 +6,7 @@ bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk "$@"
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk --no_contrib
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -4,14 +4,14 @@
 
 source_dirs=("//source/..." "//test/..." "//tools/...")
 if [ "$1" == "--include-contrib" ]; then
-  source_dirs+=("//contrib/...") 
+  source_dirs+=("//contrib/...")
 fi
 
 bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk ${source_dirs[@]}
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk "${source_dirs[@]}"
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -6,7 +6,7 @@ bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //source/... //test/... //tools/...
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -2,16 +2,11 @@
 
 [[ -z "${SKIP_PROTO_FORMAT}" ]] && tools/proto_format/proto_format.sh fix
 
-source_dirs=("//source/..." "//test/..." "//tools/...")
-if [ "$1" == "--include-contrib" ]; then
-  source_dirs+=("//contrib/...")
-fi
-
 bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk "${source_dirs[@]}"
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk "$@"
 
 # Kill clangd to reload the compilation database
 pkill clangd || :

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -6,7 +6,7 @@ bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk --no_contrib
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk --exclude_contrib
 
 # Kill clangd to reload the compilation database
 pkill clangd || :


### PR DESCRIPTION
The contrib directory sometimes doesn't build and prevents the VSCode code completion script
(tools/vscode/refresh_compdb.sh) from generating the symbols database.  This change overrides
the default directories built for the VSCode script by removing contrib and only building source,
test, and tools by default.

To allow including the contrib directories in the VSCode completion database, remove the 
`--exclude_contrib` flag from refresh_compdb.sh.

Signed-off-by: Ali Beyad <abeyad@google.com>
