### PR TITLE
Local Rate Limit: Fix tag extraction to work with filter stat_prefix

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,6 +18,11 @@ behavior_changes:
   change: |
     Fixed metric tag extraction so that worker_id is properly extracted from the listener stats. This changes the Prometheus name from
     envoy_listener_worker_1_downstream_cx_active{envoy_listener_address="0.0.0.0_10000"} to envoy_listener_downstream_cx_active{envoy_listener_address="0.0.0.0_10000", envoy_worker_id="1"} .
+- area: stats local_rate_limit
+  change: |
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_rate_limit.v3.LocalRateLimit.stat_prefix>`
+    is properly extracted. This changes the Prometheus name from
+    envoy_myprefix_http_local_rate_limit_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix=="myprefix"}.
 - area: stats server
   change: |
     Fixed metric tag extraction so that worker_id is properly extracted fromt the server stats. This changes the Prometheus name from

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,11 +18,16 @@ behavior_changes:
   change: |
     Fixed metric tag extraction so that worker_id is properly extracted from the listener stats. This changes the Prometheus name from
     envoy_listener_worker_1_downstream_cx_active{envoy_listener_address="0.0.0.0_10000"} to envoy_listener_downstream_cx_active{envoy_listener_address="0.0.0.0_10000", envoy_worker_id="1"} .
-- area: stats local_rate_limit
+- area: stats http local_rate_limit
   change: |
     Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
     is properly extracted. This changes the Prometheus name from
-    envoy_myprefix_http_local_rate_limit_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix=="myprefix"}.
+    envoy_myprefix_http_local_rate_limit_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_http_ratelimit_prefix="myprefix"}.
+- area: stats network local_rate_limit
+  change: |
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
+    is properly extracted. This changes the Prometheus name from
+    envoy_local_rate_limit_rate_myprefix_limited{} to :-envoy_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix="myprefix"}.
 - area: stats server
   change: |
     Fixed metric tag extraction so that worker_id is properly extracted fromt the server stats. This changes the Prometheus name from

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -20,7 +20,7 @@ behavior_changes:
     envoy_listener_worker_1_downstream_cx_active{envoy_listener_address="0.0.0.0_10000"} to envoy_listener_downstream_cx_active{envoy_listener_address="0.0.0.0_10000", envoy_worker_id="1"} .
 - area: stats local_rate_limit
   change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_rate_limit.v3.LocalRateLimit.stat_prefix>`
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
     is properly extracted. This changes the Prometheus name from
     envoy_myprefix_http_local_rate_limit_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix=="myprefix"}.
 - area: stats server

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -167,7 +167,10 @@ TagNameValues::TagNameValues() {
   addTokenized(REDIS_PREFIX, "redis.$.**");
 
   // (<stat_prefix>.).http_local_rate_limit.**
-  addTokenized(LOCAL_RATELIMIT_PREFIX, "$.http_local_rate_limit.**");
+  addTokenized(LOCAL_HTTP_RATELIMIT_PREFIX, "$.http_local_rate_limit.**");
+
+  // local_rate_limit.(<stat_prefix>.)
+  addTokenized(LOCAL_RATELIMIT_PREFIX, "local_rate_limit.$.**");
 }
 
 void TagNameValues::addRe2(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -165,6 +165,9 @@ TagNameValues::TagNameValues() {
 
   // redis.(<stat_prefix>.)*
   addTokenized(REDIS_PREFIX, "redis.$.**");
+
+  // (<stat_prefix>.).http_local_rate_limit.**
+  addTokenized(LOCAL_RATELIMIT_PREFIX, "$.http_local_rate_limit.**");
 }
 
 void TagNameValues::addRe2(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -103,6 +103,8 @@ public:
   const std::string MONGO_CALLSITE = "envoy.mongo_callsite";
   // Stats prefix for the Ratelimit network filter
   const std::string RATELIMIT_PREFIX = "envoy.ratelimit_prefix";
+  // Stats prefix for the Local Ratelimit network filter
+  const std::string LOCAL_RATELIMIT_PREFIX = "envoy.local_ratelimit_prefix";
   // Stats prefix for the TCP Proxy network filter
   const std::string TCP_PREFIX = "envoy.tcp_prefix";
   // Stats prefix for the UDP Proxy network filter

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -104,6 +104,8 @@ public:
   // Stats prefix for the Ratelimit network filter
   const std::string RATELIMIT_PREFIX = "envoy.ratelimit_prefix";
   // Stats prefix for the Local Ratelimit network filter
+  const std::string LOCAL_HTTP_RATELIMIT_PREFIX = "envoy.local_http_ratelimit_prefix";
+  // Stats prefix for the Local Ratelimit network filter
   const std::string LOCAL_RATELIMIT_PREFIX = "envoy.local_ratelimit_prefix";
   // Stats prefix for the TCP Proxy network filter
   const std::string TCP_PREFIX = "envoy.tcp_prefix";

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -259,8 +259,8 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
 
   // Local network Ratelimit
   local_ratelimit_prefix.name_ = tag_names.LOCAL_RATELIMIT_PREFIX;
-  regex_tester.testRegex("local_rate_limit.foo_ratelimiter.rate_limited", "local_rate_limit.rate_limited",
-                         {local_ratelimit_prefix});
+  regex_tester.testRegex("local_rate_limit.foo_ratelimiter.rate_limited",
+                         "local_rate_limit.rate_limited", {local_ratelimit_prefix});
 
   // Dynamo
   Tag dynamo_http_prefix;

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -250,11 +250,16 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   regex_tester.testRegex("ratelimit.foo_ratelimiter.over_limit", "ratelimit.over_limit",
                          {ratelimit_prefix});
 
-  // Local Ratelimit
+  // Local Http Ratelimit
   Tag local_ratelimit_prefix;
-  local_ratelimit_prefix.name_ = tag_names.LOCAL_RATELIMIT_PREFIX;
+  local_ratelimit_prefix.name_ = tag_names.LOCAL_HTTP_RATELIMIT_PREFIX;
   local_ratelimit_prefix.value_ = "foo_ratelimiter";
   regex_tester.testRegex("foo_ratelimiter.http_local_rate_limit.ok", "http_local_rate_limit.ok",
+                         {local_ratelimit_prefix});
+
+  // Local network Ratelimit
+  local_ratelimit_prefix.name_ = tag_names.LOCAL_RATELIMIT_PREFIX;
+  regex_tester.testRegex("local_rate_limit.foo_ratelimiter.rate_limited", "local_rate_limit.rate_limited",
                          {local_ratelimit_prefix});
 
   // Dynamo

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -250,6 +250,13 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   regex_tester.testRegex("ratelimit.foo_ratelimiter.over_limit", "ratelimit.over_limit",
                          {ratelimit_prefix});
 
+  // Local Ratelimit
+  Tag local_ratelimit_prefix;
+  local_ratelimit_prefix.name_ = tag_names.LOCAL_RATELIMIT_PREFIX;
+  local_ratelimit_prefix.value_ = "foo_ratelimiter";
+  regex_tester.testRegex("foo_ratelimiter.http_local_rate_limit.ok", "http_local_rate_limit.ok",
+                         {local_ratelimit_prefix});
+
   // Dynamo
   Tag dynamo_http_prefix;
   dynamo_http_prefix.name_ = tag_names.HTTP_CONN_MANAGER_PREFIX;

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -8,13 +8,7 @@ namespace {
 class LocalRateLimitFilterIntegrationTest : public Event::TestUsingSimulatedTime,
                                             public HttpProtocolIntegrationTest {
 protected:
-  LocalRateLimitFilterIntegrationTest() {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat
-    // 'http_local_rate_limiter.http_local_rate_limit.enabled' and stat_prefix
-    // 'http_local_rate_limiter'.
-    skip_tag_extraction_rule_check_ = true;
-  }
+  LocalRateLimitFilterIntegrationTest() {}
   void initializeFilter(const std::string& filter_config) {
     config_helper_.prependFilter(filter_config);
     initialize();

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_integration_test.cc
@@ -8,13 +8,7 @@ class LocalRateLimitIntegrationTest : public Event::TestUsingSimulatedTime,
                                       public BaseIntegrationTest {
 public:
   LocalRateLimitIntegrationTest()
-      : BaseIntegrationTest(GetParam(), ConfigHelper::tcpProxyConfig()) {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat
-    // 'http_local_rate_limiter.http_local_rate_limit.rate_limited' and stat_prefix
-    // 'http_local_rate_limiter'.
-    skip_tag_extraction_rule_check_ = true;
-  }
+      : BaseIntegrationTest(GetParam(), ConfigHelper::tcpProxyConfig()) {}
 
   void setup(const std::string& filter_yaml = {}) {
     if (!filter_yaml.empty()) {


### PR DESCRIPTION
Working towards #21595. Adds tag extraction for local rate limit.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>