### PR TITLE
network: allow Apple platforms to force IPv6 sockets

### DIFF
--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -503,8 +503,8 @@ Api::SysCallIntResult IoSocketHandleImpl::connect(Address::InstanceConstSharedPt
     memset(&sin6, 0, sizeof(sin6));
     sin6.sin6_family = AF_INET6;
     sin6.sin6_port = sin4.sin_port;
-    sin6.sin6_addr.s6_addr32[2] = htonl(0xffff);
-    sin6.sin6_addr.s6_addr32[3] = sin4.sin_addr.s_addr;
+    sin6.sin6_addr.__u6_addr.__u6_addr32[2] = htonl(0xffff);
+    sin6.sin6_addr.__u6_addr.__u6_addr32[3] = sin4.sin_addr.s_addr;
     ASSERT(IN6_IS_ADDR_V4MAPPED(&sin6.sin6_addr));
 
     sockaddr_to_use = reinterpret_cast<sockaddr*>(&sin6);

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -9,22 +9,6 @@
 #include "source/common/network/socket_interface_impl.h"
 #include "source/common/runtime/runtime_features.h"
 
-#include <net/if.h>
-//#include <net/route.h>
-//#include <net/raw_cb.h>
-//#include <net/dlil.h>
-
-#include <netinet/in.h>
-//#include <netinet/in_var.h>
-
-#include <netinet/ip6.h>
-//#include <netinet6/ip6_var.h>
-//#include <netinet6/scope6_var.h>
-//#include <netinet6/ip6_mroute.h>
-#include <netinet/icmp6.h>
-//#include <netinet6/pim6.h>
-//#include <netinet6/pim6_var.h>
-
 #include "absl/container/fixed_array.h"
 #include "absl/types/optional.h"
 

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -64,11 +64,12 @@ constexpr int messageTruncatedOption() {
 
 namespace Network {
 
-bool IoSocketHandleImpl::forceV6ForAndroid() {
+bool IoSocketHandleImpl::forceV6() {
 #ifndef __ANDROID_API__
-  return false;
+  return Runtime::runtimeFeatureEnabled("envoy.reloadable_features.always_use_v6");
 #else
-  return Runtime::runtimeFeatureEnabled("envoy.reloadable_features.android_always_use_v6");
+  return Runtime::runtimeFeatureEnabled("envoy.reloadable_features.always_use_v6") ||
+         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.android_always_use_v6");
 #endif
 }
 
@@ -477,9 +478,8 @@ IoHandlePtr IoSocketHandleImpl::accept(struct sockaddr* addr, socklen_t* addrlen
 Api::SysCallIntResult IoSocketHandleImpl::connect(Address::InstanceConstSharedPtr address) {
   auto sockaddr_to_use = address->sockAddr();
   auto sockaddr_len_to_use = address->sockAddrLen();
-#ifdef __ANDROID_API__
   sockaddr_in6 sin6;
-  if (sockaddr_to_use->sa_family == AF_INET && forceV6ForAndroid()) {
+  if (sockaddr_to_use->sa_family == AF_INET && forceV6()) {
     const sockaddr_in& sin4 = reinterpret_cast<const sockaddr_in&>(*sockaddr_to_use);
 
     // Android always uses IPv6 dual stack. Convert IPv4 to the IPv6 mapped address when
@@ -494,7 +494,6 @@ Api::SysCallIntResult IoSocketHandleImpl::connect(Address::InstanceConstSharedPt
     sockaddr_to_use = reinterpret_cast<sockaddr*>(&sin6);
     sockaddr_len_to_use = sizeof(sin6);
   }
-#endif
 
   return Api::OsSysCallsSingleton::get().connect(fd_, sockaddr_to_use, sockaddr_len_to_use);
 }
@@ -569,7 +568,7 @@ Address::InstanceConstSharedPtr IoSocketHandleImpl::peerAddress() {
           fmt::format("getsockname failed for '{}': {}", fd_, errorDetails(result.errno_)));
     }
   }
-  // TODO(mattklein123): If forceV6ForAndroid() is true, we should probably remap back to IPv4 from
+  // TODO(mattklein123): If forceV6() is true, we should probably remap back to IPv4 from
   // the mapped IPv6 address. Currently though it doesn't look like we use this function in the
   // client path so this probably doesn't matter. If it turns out to matter we can fix this.
   return Address::addressFromSockAddrOrThrow(ss, ss_len, socket_v6only_);

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -9,6 +9,22 @@
 #include "source/common/network/socket_interface_impl.h"
 #include "source/common/runtime/runtime_features.h"
 
+#include <net/if.h>
+//#include <net/route.h>
+//#include <net/raw_cb.h>
+//#include <net/dlil.h>
+
+#include <netinet/in.h>
+//#include <netinet/in_var.h>
+
+#include <netinet/ip6.h>
+//#include <netinet6/ip6_var.h>
+//#include <netinet6/scope6_var.h>
+//#include <netinet6/ip6_mroute.h>
+#include <netinet/icmp6.h>
+//#include <netinet6/pim6.h>
+//#include <netinet6/pim6_var.h>
+
 #include "absl/container/fixed_array.h"
 #include "absl/types/optional.h"
 

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -18,10 +18,10 @@ namespace Network {
 class IoSocketHandleImpl : public IoHandle, protected Logger::Loggable<Logger::Id::io> {
 public:
   /**
-   * Check whether we are a) on Android and b) configured via runtime to always use v6 sockets.
+   * Check whether we are configured via runtime to always use v6 sockets.
    * This appears to be what Android OS does for all platform sockets.
    */
-  static bool forceV6ForAndroid();
+  static bool forceV6();
 
   explicit IoSocketHandleImpl(os_fd_t fd = INVALID_SOCKET, bool socket_v6only = false,
                               absl::optional<int> domain = absl::nullopt)

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -18,7 +18,8 @@ namespace Network {
 class IoSocketHandleImpl : public IoHandle, protected Logger::Loggable<Logger::Id::io> {
 public:
   /**
-   * Check whether we are configured via runtime to always use v6 sockets.
+   * Check whether we are a) on Android or an Apple platform and b) configured via runtime to always
+   * use v6 sockets.
    * This appears to be what Android OS does for all platform sockets.
    */
   static bool forceV6();

--- a/source/common/network/socket_interface_impl.cc
+++ b/source/common/network/socket_interface_impl.cc
@@ -50,7 +50,7 @@ IoHandlePtr SocketInterfaceImpl::socket(Socket::Type socket_type, Address::Type 
 
   int domain;
   if (addr_type == Address::Type::Ip) {
-    if (version == Address::IpVersion::v6 || IoSocketHandleImpl::forceV6ForAndroid()) {
+    if (version == Address::IpVersion::v6 || IoSocketHandleImpl::forceV6()) {
       domain = AF_INET6;
     } else {
       ASSERT(version == Address::IpVersion::v4);
@@ -92,7 +92,7 @@ IoHandlePtr SocketInterfaceImpl::socket(Socket::Type socket_type,
   IoHandlePtr io_handle =
       SocketInterfaceImpl::socket(socket_type, addr->type(), ip_version, v6only, options);
   if (addr->type() == Address::Type::Ip && ip_version == Address::IpVersion::v6 &&
-      !IoSocketHandleImpl::forceV6ForAndroid()) {
+      !IoSocketHandleImpl::forceV6()) {
     // Setting IPV6_V6ONLY restricts the IPv6 socket to IPv6 connections only.
     const Api::SysCallIntResult result = io_handle->setOption(
         IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&v6only), sizeof(v6only));

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -95,10 +95,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 // Used to track if runtime is initialized.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 // TODO(mattklein123): Flip this to true and/or remove completely once verified by Envoy Mobile.
-// TODO(mattklein123): Also unit test this if this sticks and this becomes the default for Android.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_android_always_use_v6);
-// TODO(jpsim): Flip this to true and/or remove completely once verified by Envoy Mobile.
-// TODO(jpsim): Also unit test this if this sticks and this becomes the default for Envoy Mobile.
+// TODO(mattklein123): Also unit test this if this sticks and this becomes the default for Apple &
+// Android.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_always_use_v6);
 
 // Block of non-boolean flags. These are deprecated. Do not add more.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -97,6 +97,9 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 // TODO(mattklein123): Flip this to true and/or remove completely once verified by Envoy Mobile.
 // TODO(mattklein123): Also unit test this if this sticks and this becomes the default for Android.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_android_always_use_v6);
+// TODO(jpsim): Flip this to true and/or remove completely once verified by Envoy Mobile.
+// TODO(jpsim): Also unit test this if this sticks and this becomes the default for Envoy Mobile.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_always_use_v6);
 
 // Block of non-boolean flags. These are deprecated. Do not add more.
 ABSL_FLAG(uint64_t, envoy_headermap_lazy_map_min_size, 3, "");  // NOLINT


### PR DESCRIPTION
We suspect that under some conditions, non-Android platforms (i.e. iOS) also would benefit from forcibly using IPv6 sockets, so to validate this this change adds a new runtime feature generalizing the one added for Android.

Risk Level: Low, runtime guard defaults to false.
Testing: Tested on an iPhone 13 Pro via Envoy Mobile, confirmed that an IPv4 address was being mapped to an IPv6 one.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: Not platform specific, but intended to be used on Apple platforms.
Runtime guard: `envoy.reloadable_features.always_use_v6` (default false)