### PR TITLE
Make cancel callbacks more consistent

### DIFF
--- a/source/extensions/common/async_files/async_file_context_base.cc
+++ b/source/extensions/common/async_files/async_file_context_base.cc
@@ -17,7 +17,7 @@ namespace AsyncFiles {
 
 AsyncFileContextBase::AsyncFileContextBase(AsyncFileManager& manager) : manager_(manager) {}
 
-std::function<void()> AsyncFileContextBase::enqueue(std::shared_ptr<AsyncFileAction> action) {
+CancelFunction AsyncFileContextBase::enqueue(std::shared_ptr<AsyncFileAction> action) {
   return manager_.enqueue(std::move(action));
 }
 

--- a/source/extensions/common/async_files/async_file_context_base.h
+++ b/source/extensions/common/async_files/async_file_context_base.h
@@ -23,7 +23,7 @@ public:
 
 protected:
   // Queue up an action with the AsyncFileManager.
-  std::function<void()> enqueue(std::shared_ptr<AsyncFileAction> action);
+  CancelFunction enqueue(std::shared_ptr<AsyncFileAction> action);
 
   explicit AsyncFileContextBase(AsyncFileManager& manager);
 

--- a/source/extensions/common/async_files/async_file_context_thread_pool.h
+++ b/source/extensions/common/async_files/async_file_context_thread_pool.h
@@ -21,17 +21,17 @@ class AsyncFileContextThreadPool final : public AsyncFileContextBase {
 public:
   explicit AsyncFileContextThreadPool(AsyncFileManager& manager, int fd);
 
-  absl::StatusOr<std::function<void()>>
+  absl::StatusOr<CancelFunction>
   createHardLink(absl::string_view filename,
                  std::function<void(absl::Status)> on_complete) override;
   absl::Status close(std::function<void(absl::Status)> on_complete) override;
-  absl::StatusOr<std::function<void()>>
+  absl::StatusOr<CancelFunction>
   read(off_t offset, size_t length,
        std::function<void(absl::StatusOr<Buffer::InstancePtr>)> on_complete) override;
-  absl::StatusOr<std::function<void()>>
+  absl::StatusOr<CancelFunction>
   write(Buffer::Instance& contents, off_t offset,
         std::function<void(absl::StatusOr<size_t>)> on_complete) override;
-  absl::StatusOr<std::function<void()>>
+  absl::StatusOr<CancelFunction>
   duplicate(std::function<void(absl::StatusOr<AsyncFileHandle>)> on_complete) override;
 
   int& fileDescriptor() { return file_descriptor_; }
@@ -39,8 +39,7 @@ public:
   ~AsyncFileContextThreadPool() override;
 
 protected:
-  absl::StatusOr<std::function<void()>>
-  checkFileAndEnqueue(std::shared_ptr<AsyncFileAction> action);
+  absl::StatusOr<CancelFunction> checkFileAndEnqueue(std::shared_ptr<AsyncFileAction> action);
 
   int file_descriptor_;
 };

--- a/source/extensions/common/async_files/async_file_manager.cc
+++ b/source/extensions/common/async_files/async_file_manager.cc
@@ -21,7 +21,7 @@ public:
 };
 } // namespace
 
-std::function<void()> AsyncFileManager::whenReady(std::function<void(absl::Status)> on_complete) {
+CancelFunction AsyncFileManager::whenReady(std::function<void(absl::Status)> on_complete) {
   return enqueue(std::make_shared<ActionWhenReady>(std::move(on_complete)));
 }
 

--- a/source/extensions/common/async_files/async_file_manager_thread_pool.cc
+++ b/source/extensions/common/async_files/async_file_manager_thread_pool.cc
@@ -235,20 +235,19 @@ private:
 
 } // namespace
 
-std::function<void()> AsyncFileManagerThreadPool::createAnonymousFile(
+CancelFunction AsyncFileManagerThreadPool::createAnonymousFile(
     absl::string_view path, std::function<void(absl::StatusOr<AsyncFileHandle>)> on_complete) {
   return enqueue(std::make_shared<ActionCreateAnonymousFile>(*this, path, on_complete));
 }
 
-std::function<void()> AsyncFileManagerThreadPool::openExistingFile(
+CancelFunction AsyncFileManagerThreadPool::openExistingFile(
     absl::string_view filename, Mode mode,
     std::function<void(absl::StatusOr<AsyncFileHandle>)> on_complete) {
   return enqueue(std::make_shared<ActionOpenExistingFile>(*this, filename, mode, on_complete));
 }
 
-std::function<void()>
-AsyncFileManagerThreadPool::unlink(absl::string_view filename,
-                                   std::function<void(absl::Status)> on_complete) {
+CancelFunction AsyncFileManagerThreadPool::unlink(absl::string_view filename,
+                                                  std::function<void(absl::Status)> on_complete) {
   return enqueue(std::make_shared<ActionUnlink>(posix(), filename, on_complete));
 }
 

--- a/source/extensions/common/async_files/async_file_manager_thread_pool.h
+++ b/source/extensions/common/async_files/async_file_manager_thread_pool.h
@@ -30,14 +30,14 @@ public:
       const envoy::extensions::common::async_files::v3::AsyncFileManagerConfig& config,
       Api::OsSysCalls& posix);
   ~AsyncFileManagerThreadPool() ABSL_LOCKS_EXCLUDED(queue_mutex_) override;
-  std::function<void()>
+  CancelFunction
   createAnonymousFile(absl::string_view path,
                       std::function<void(absl::StatusOr<AsyncFileHandle>)> on_complete) override;
-  std::function<void()>
+  CancelFunction
   openExistingFile(absl::string_view filename, Mode mode,
                    std::function<void(absl::StatusOr<AsyncFileHandle>)> on_complete) override;
-  std::function<void()> unlink(absl::string_view filename,
-                               std::function<void(absl::Status)> on_complete) override;
+  CancelFunction unlink(absl::string_view filename,
+                        std::function<void(absl::Status)> on_complete) override;
   std::string describe() const override;
   Api::OsSysCalls& posix() const { return posix_; }
 


### PR DESCRIPTION
Commit Message: [async_files] Make cancel callbacks more consistent.
Additional Description: CancelFunction was defined to make the intent of returned callbacks in async_files more clear, but it was only partially applied. This change increases the usage.
Risk Level: None, no practical change.
Testing: Existing test coverage.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
