### PR TITLE
dockerfile: Add default platform and use 0 for uid/gid

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -5,12 +5,12 @@ ARG ENVOY_VRP_BASE_IMAGE=envoy
 
 FROM scratch AS binary
 
-ARG TARGETPLATFORM
+ARG TARGETPLATFORM=linux/amd64
 ARG ENVOY_BINARY=envoy
 ARG ENVOY_BINARY_SUFFIX=_stripped
 ADD ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release${ENVOY_BINARY_SUFFIX}/envoy* /usr/local/bin/
 ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
-COPY --chown=root:root ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release/su-exec /usr/local/bin/
+COPY --chown=0:0 ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release/su-exec /usr/local/bin/
 COPY ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release/schema_validator_tool /usr/local/bin/schema_validator_tool
 COPY ci/docker-entrypoint.sh /
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

following up on https://github.com/envoyproxy/envoy/issues/21899

switching the `COPY --chown` from `root` -> `0` resolved the following error i hit locally:

```console
unable to convert uid/gid chown string to host mapping: can't find uid for user root: open /var/lib/docker/overlay2/cd074b39f9fa59a8731b1b92200dfa7c652dd32739edaa52d595d75f0184c91d/merged/etc/passwd: no such file or directory             

```

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
