### PR TITLE
api_proto_plugin: Use `ctx.actions.args`

### DIFF
--- a/tools/api_proto_plugin/plugin.bzl
+++ b/tools/api_proto_plugin/plugin.bzl
@@ -55,22 +55,24 @@ def api_proto_plugin_impl(target, ctx, output_group, mnemonic, output_suffixes):
     inputs = target[ProtoInfo].transitive_sources
     ctx_path = ctx.label.package + "/" + ctx.label.name
     output_path = outputs[0].root.path + "/" + outputs[0].owner.workspace_root + "/" + ctx_path
-    args = ["-I./" + ctx.label.workspace_root]
-    args += ["-I" + import_path for import_path in import_paths]
-    args += ["--plugin=protoc-gen-api_proto_plugin=" + ctx.executable._api_proto_plugin.path, "--api_proto_plugin_out=" + output_path]
+    args = ctx.actions.args()
+    args.add(ctx.label.workspace_root, format = "-I./%s")
+    args.add_all(import_paths, format_each = "-I%s")
+    args.add(ctx.executable._api_proto_plugin, format = "--plugin=protoc-gen-api_proto_plugin=%s")
+    args.add(output_path, format = "--api_proto_plugin_out=%s")
     if hasattr(ctx.attr, "_type_db"):
         inputs = depset(transitive = [inputs] + [ctx.attr._type_db.files])
         if len(ctx.attr._type_db.files.to_list()) != 1:
             fail("{} must have one type database file".format(ctx.attr._type_db))
-        args.append("--api_proto_plugin_opt=type_db_path=" + ctx.attr._type_db.files.to_list()[0].path)
-    if hasattr(ctx.attr, "_extra_args"):
-        args.append("--api_proto_plugin_opt=extra_args=" + ctx.attr._extra_args[BuildSettingInfo].value)
-    args += [src.path for src in target[ProtoInfo].direct_sources]
+        args.add(ctx.attr._type_db.files.to_list()[0], format = "--api_proto_plugin_opt=type_db_path=%s")
+    if hasattr(ctx.attr, "_extra_args") and ctx.attr._extra_args[BuildSettingInfo].value:
+        args.add(ctx.attr._extra_args[BuildSettingInfo].value, format = "--api_proto_plugin_opt=extra_args=%s")
+    args.add_all(target[ProtoInfo].direct_sources)
     env = {}
 
     ctx.actions.run(
         executable = ctx.executable._protoc,
-        arguments = args,
+        arguments = [args],
         inputs = inputs,
         tools = [ctx.executable._api_proto_plugin],
         outputs = outputs,


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

My understanding is that this parses args lazily, saves mem and optimizes aspects

Probs the args could be optimized further - this at least switches to using `ctx.actions.args`

More context here: https://docs.bazel.build/versions/main/skylark/performance.html#use-ctxactionsargs-for-command-lines

reading that page, i think there are a few more optis to be had around our handling of deps in rules

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
