### PR TITLE
docs: update flag status

### DIFF
--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -92,7 +92,7 @@ Happy Eyeballs Support
 ----------------------
 
 Envoy supports Happy Eyeballs, `RFC6555 <https://tools.ietf.org/html/rfc6555>`_,
-for upstream TCP connections. This behavior is off by default but can be enabled by the runtime flag
+for upstream TCP connections. This behavior is now on by default but can be disabled by the runtime flag
 ``envoy.reloadable_features.allow_multiple_dns_addresses``. For clusters which use
 :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`,
 this behavior is configured by setting the DNS IP address resolution policy in


### PR DESCRIPTION
Wasn't updated when https://github.com/envoyproxy/envoy/blob/main/source/common/runtime/runtime_features.cc#L35 was defaulted true
