### PR TITLE
http: updating response code details

### DIFF
--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -156,8 +156,8 @@ struct ResponseCodeDetailValues {
   const std::string MaintenanceMode = "maintenance_mode";
   // The request was rejected by the router filter because there was no healthy upstream found.
   const std::string NoHealthyUpstream = "no_healthy_upstream";
-  // The upstream response timed out.
-  const std::string UpstreamTimeout = "upstream_response_timeout";
+  // The request was forwarded upstream but the response timed out.
+  const std::string ResponseTimeout = "response_timeout";
   // The final upstream try timed out.
   const std::string UpstreamPerTryTimeout = "upstream_per_try_timeout";
   // The final upstream try idle timed out.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -974,7 +974,7 @@ void Filter::onResponseTimeout() {
   }
 
   onUpstreamTimeoutAbort(StreamInfo::ResponseFlag::UpstreamRequestTimeout,
-                         StreamInfo::ResponseCodeDetails::get().UpstreamTimeout);
+                         StreamInfo::ResponseCodeDetails::get().ResponseTimeout);
 }
 
 // Called when the per try timeout is hit but we didn't reset the request

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1530,7 +1530,7 @@ void ConfigHelper::adjustUpstreamTimeoutForTsan(
   uint64_t timeout_ms = PROTOBUF_GET_MS_OR_DEFAULT(*route, timeout, 15000u);
   auto* timeout = route->mutable_timeout();
   // QUIC stream processing is slow under TSAN. Use larger timeout to prevent
-  // upstream_response_timeout.
+  // response_timeout.
   timeout->set_seconds(TSAN_TIMEOUT_FACTOR * timeout_ms / 1000);
 }
 

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -49,7 +49,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("504", response->headers().getStatusValue());
   EXPECT_EQ(response->headers().getProxyStatusValue(),
-            "envoy; error=connection_timeout; details=\"upstream_response_timeout; UT\"");
+            "envoy; error=connection_timeout; details=\"response_timeout; UT\"");
 }
 
 // Testing that `x-envoy-expected-timeout-ms` header, set by egress envoy, is respected by ingress


### PR DESCRIPTION
Per https://github.com/envoyproxy/envoy/issues/13068 the upstream_response_timeout can occur before an upstream has been assigned.  Renaming for clarity.

Risk Level: low
Testing: updated tests
Docs Changes: n/a
Release Notes:
Platform Specific Features:
[Optional Runtime guard:
