### PR TITLE
internal listener: fix assertion in passthrough state

### DIFF
--- a/source/extensions/io_socket/user_space/io_handle.h
+++ b/source/extensions/io_socket/user_space/io_handle.h
@@ -21,7 +21,7 @@ public:
 
   /**
    * Initialize the passthrough state from the downstream. This should be
-   * called exactly once before `mergeInto`.
+   * called at most once before `mergeInto`.
    */
   virtual void initialize(std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
                           std::unique_ptr<FilterStateObjects> filter_state_objects) PURE;

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -387,7 +387,7 @@ void PassthroughStateImpl::initialize(std::unique_ptr<envoy::config::core::v3::M
 }
 void PassthroughStateImpl::mergeInto(envoy::config::core::v3::Metadata& metadata,
                                      StreamInfo::FilterState& filter_state) {
-  ASSERT(state_ == State::Initialized);
+  ASSERT(state_ == State::Created || state_ == State::Initialized);
   if (metadata_) {
     metadata.MergeFrom(*metadata_);
   }


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>
Commit Message: Fix assertion in internal listener user space socket. The assertion would fail if internal upstream transport socket is not used, but it is not necessary.
Additional Description: Added an integration test as well (apparently there was none before without internal upstream transport)
Risk Level: low
Testing: yes
Docs Changes: none
Release Notes: none