### PR TITLE
internal address: fix assertion in config_dump?include_eds

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -457,11 +457,14 @@ void Utility::addressToProtobufAddress(const Address::Instance& address,
                                        envoy::config::core::v3::Address& proto_address) {
   if (address.type() == Address::Type::Pipe) {
     proto_address.mutable_pipe()->set_path(address.asString());
-  } else {
-    ASSERT(address.type() == Address::Type::Ip);
+  } else if (address.type() == Address::Type::Ip) {
     auto* socket_address = proto_address.mutable_socket_address();
     socket_address->set_address(address.ip()->addressAsString());
     socket_address->set_port_value(address.ip()->port());
+  } else {
+    ASSERT(address.type() == Address::Type::EnvoyInternal);
+    auto* internal_address = proto_address.mutable_envoy_internal_address();
+    internal_address->set_server_listener_name(address.envoyInternalAddress()->addressId());
   }
 }
 

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -421,6 +421,13 @@ TEST(NetworkUtility, AddressToProtobufAddress) {
     EXPECT_EQ(true, proto_address.has_pipe());
     EXPECT_EQ("/hello", proto_address.pipe().path());
   }
+  {
+    envoy::config::core::v3::Address proto_address;
+    Address::EnvoyInternalInstance address("internal_address");
+    Utility::addressToProtobufAddress(address, proto_address);
+    EXPECT_TRUE(proto_address.has_envoy_internal_address());
+    EXPECT_EQ("internal_address", proto_address.envoy_internal_address().server_listener_name());
+  }
 }
 
 TEST(NetworkUtility, ProtobufAddressSocketType) {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Fix crash in config_dump when using internal address.
Risk Level: low
Testing: yes
Docs Changes: none
Release Notes: none