### PR TITLE
Split StopIteration into two statuses

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/active_message.cc
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.cc
@@ -245,16 +245,24 @@ void ActiveMessage::onStreamDecoded(MessageMetadataSharedPtr metadata, ContextSh
   };
 
   auto status = applyDecoderFilters(nullptr, FilterIterationStartState::CanStartFromCurrent);
-  if (status == FilterStatus::StopIteration) {
-    ENVOY_LOG(debug, "dubbo request: stop calling decoder filter, id is {}", metadata->requestId());
+  switch (status) {
+  case FilterStatus::StopIteration:
+    ENVOY_LOG(debug, "dubbo request: pause calling decoder filter, id is {}",
+              metadata->requestId());
     pending_stream_decoded_ = true;
     return;
+  case FilterStatus::AbortIteration:
+    ENVOY_LOG(debug, "dubbo request: abort calling decoder filter, id is {}",
+              metadata->requestId());
+    parent_.deferredMessage(*this);
+    return;
+  case FilterStatus::Continue:
+    ENVOY_LOG(debug, "dubbo request: complete processing of downstream request messages, id is {}",
+              metadata->requestId());
+    finalizeRequest();
+    return;
   }
-
-  finalizeRequest();
-
-  ENVOY_LOG(debug, "dubbo request: complete processing of downstream request messages, id is {}",
-            metadata->requestId());
+  PANIC_DUE_TO_CORRUPT_ENUM
 }
 
 void ActiveMessage::finalizeRequest() {

--- a/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
@@ -15,10 +15,12 @@ namespace DubboProxy {
 enum class FilterStatus : uint8_t {
   // Continue filter chain iteration.
   Continue,
-  // Do not iterate to any of the remaining filters in the chain. Returning
-  // FilterDataStatus::Continue from decodeData()/encodeData() or calling
-  // continueDecoding()/continueEncoding() MUST be called if continued filter iteration is desired.
+  // Pause iterating to any of the remaining filters in the chain.
+  // The current message remains in the connection manager to wait to be continued.
+  // ContinueDecoding()/continueEncoding() MUST be called to continue filter iteration.
   StopIteration,
+  // Abort the iteration and remove the current message from the connection manager.
+  AbortIteration,
 };
 
 class StreamDecoder {

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
@@ -35,7 +35,7 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
                                             fmt::format("dubbo router: no route for interface '{}'",
                                                         invocation.serviceName())),
                                false);
-    return FilterStatus::StopIteration;
+    return FilterStatus::AbortIteration;
   }
 
   route_entry_ = route_->routeEntry();
@@ -49,7 +49,7 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
         AppException(ResponseStatus::ServerError, fmt::format("dubbo router: unknown cluster '{}'",
                                                               route_entry_->clusterName())),
         false);
-    return FilterStatus::StopIteration;
+    return FilterStatus::AbortIteration;
   }
 
   cluster_ = cluster->info();
@@ -62,7 +62,7 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
                      fmt::format("dubbo router: maintenance mode for cluster '{}'",
                                  route_entry_->clusterName())),
         false);
-    return FilterStatus::StopIteration;
+    return FilterStatus::AbortIteration;
   }
 
   auto conn_pool_data = cluster->tcpConnPool(Upstream::ResourcePriority::Default, this);
@@ -72,7 +72,7 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
             ResponseStatus::ServerError,
             fmt::format("dubbo router: no healthy upstream for '{}'", route_entry_->clusterName())),
         false);
-    return FilterStatus::StopIteration;
+    return FilterStatus::AbortIteration;
   }
 
   ENVOY_STREAM_LOG(debug, "dubbo router: decoding request", *callbacks_);

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -871,7 +871,7 @@ TEST_F(ConnectionManagerTest, OnDataWithFilterSendsLocalReply) {
       .WillOnce(Invoke([&](MessageMetadataSharedPtr, ContextSharedPtr) -> FilterStatus {
         callbacks->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
         callbacks->sendLocalReply(direct_response, false);
-        return FilterStatus::StopIteration;
+        return FilterStatus::AbortIteration;
       }));
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false))
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
@@ -918,7 +918,7 @@ TEST_F(ConnectionManagerTest, OnDataWithFilterSendsLocalErrorReply) {
   EXPECT_CALL(*first_filter, onMessageDecoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr, ContextSharedPtr) -> FilterStatus {
         callbacks->sendLocalReply(direct_response, false);
-        return FilterStatus::StopIteration;
+        return FilterStatus::AbortIteration;
       }));
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false))
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
@@ -1274,7 +1274,7 @@ TEST_F(ConnectionManagerTest, SendLocalReplyInMessageDecoded) {
         EXPECT_EQ(1, conn_manager_->getActiveMessagesForTest().size());
         EXPECT_NE(nullptr, conn_manager_->getActiveMessagesForTest().front()->metadata());
         callbacks->sendLocalReply(direct_response, false);
-        return FilterStatus::StopIteration;
+        return FilterStatus::AbortIteration;
       }));
 
   // The sendLocalReply is called, the ActiveMessage object should be destroyed.

--- a/test/extensions/filters/network/dubbo_proxy/router_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/router_test.cc
@@ -484,7 +484,7 @@ TEST_F(DubboRouterTest, ClusterMaintenanceMode) {
         EXPECT_THAT(app_ex.what(), ContainsRegex(".*maintenance mode.*"));
         EXPECT_FALSE(end_stream);
       }));
-  EXPECT_EQ(FilterStatus::StopIteration, router_->onMessageDecoded(metadata_, message_context_));
+  EXPECT_EQ(FilterStatus::AbortIteration, router_->onMessageDecoded(metadata_, message_context_));
 }
 
 TEST_F(DubboRouterTest, NoHealthyHosts) {
@@ -505,7 +505,7 @@ TEST_F(DubboRouterTest, NoHealthyHosts) {
         EXPECT_FALSE(end_stream);
       }));
 
-  EXPECT_EQ(FilterStatus::StopIteration, router_->onMessageDecoded(metadata_, message_context_));
+  EXPECT_EQ(FilterStatus::AbortIteration, router_->onMessageDecoded(metadata_, message_context_));
 }
 
 TEST_F(DubboRouterTest, PoolConnectionFailureWithOnewayMessage) {
@@ -537,7 +537,7 @@ TEST_F(DubboRouterTest, NoRoute) {
         EXPECT_THAT(app_ex.what(), ContainsRegex(".*no route.*"));
         EXPECT_FALSE(end_stream);
       }));
-  EXPECT_EQ(FilterStatus::StopIteration, router_->onMessageDecoded(metadata_, message_context_));
+  EXPECT_EQ(FilterStatus::AbortIteration, router_->onMessageDecoded(metadata_, message_context_));
 }
 
 TEST_F(DubboRouterTest, NoCluster) {
@@ -556,7 +556,7 @@ TEST_F(DubboRouterTest, NoCluster) {
         EXPECT_THAT(app_ex.what(), ContainsRegex(".*unknown cluster.*"));
         EXPECT_FALSE(end_stream);
       }));
-  EXPECT_EQ(FilterStatus::StopIteration, router_->onMessageDecoded(metadata_, message_context_));
+  EXPECT_EQ(FilterStatus::AbortIteration, router_->onMessageDecoded(metadata_, message_context_));
 }
 
 TEST_F(DubboRouterTest, MetadataMatchCriteriaFromRequest) {


### PR DESCRIPTION
The meaning of the StopIteration status is ambiguous: it is used in two scenarios now:

* Pause the current iteration of the l7 filter chain and the execution of the filter chain will be resumed later.  In this case, the current implementation is fine.
* Abort the iteration of the l7 filter chain. In this case, the current implementation results in memory leak since the active message will not be deleted from the connection manager until the downstream connection is closed.

This PR solves this issue by splitting StopIteration into two unambiguous statuses: PauseIteration and AbortIteration

* PauseIteration: the filter iteration is paused and will be resumed later, for e.g, waiting for an available connection. The corresponding message remains in the connection manager.
* AbortIteration: the filter iteration is aborted, for e.g, the upstream host is not found, and the corresponding message will be deleted from the connection manager.

Signed-off-by: zhaohuabing <zhaohuabing@gmail.com>

Commit Message: Split StopIteration into two statuses
Additional Description:
Risk Level: low
Testing: yes
Docs Changes: none
Release Notes: none
