### PR TITLE
aws_lambda: allow cross account lambda function invocation

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -165,6 +165,9 @@ bug_fixes:
 - area: upstream
   change: |
     Fixed the LOGICAL_DNS and STRICT_DNS clusters to work for IPv6.
+- area: aws_lambda
+  change: |
+    Fixed the AWS cross account lambda function invocation issue.
 
 removed_config_or_runtime:
 - area: compressor

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -41,17 +41,11 @@ namespace {
 constexpr auto filter_metadata_key = "com.amazonaws.lambda";
 constexpr auto egress_gateway_metadata_key = "egress_gateway";
 
-void setLambdaHeaders(Http::RequestHeaderMap& headers,
-                      const absl::optional<Arn>& arn,
+void setLambdaHeaders(Http::RequestHeaderMap& headers, const absl::optional<Arn>& arn,
                       InvocationMode mode) {
   headers.setMethod(Http::Headers::get().MethodValues.Post);
-  auto lambda_arn = "arn:" +
-      arn->partition() + ":" +
-      arn->service() + ":" +
-      arn->region() + ":" +
-      arn->accountId() + ":" +
-      arn->resourceType() + ":" +
-      arn->functionName();
+  auto lambda_arn = "arn:" + arn->partition() + ":" + arn->service() + ":" + arn->region() + ":" +
+                    arn->accountId() + ":" + arn->resourceType() + ":" + arn->functionName();
   headers.setPath(fmt::format("/2015-03-31/functions/{}/invocations", lambda_arn));
   if (mode == InvocationMode::Synchronous) {
     headers.setReference(LambdaFilterNames::get().InvocationTypeHeader, "RequestResponse");

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -41,10 +41,18 @@ namespace {
 constexpr auto filter_metadata_key = "com.amazonaws.lambda";
 constexpr auto egress_gateway_metadata_key = "egress_gateway";
 
-void setLambdaHeaders(Http::RequestHeaderMap& headers, absl::string_view function_name,
+void setLambdaHeaders(Http::RequestHeaderMap& headers,
+                      const absl::optional<Arn>& arn,
                       InvocationMode mode) {
   headers.setMethod(Http::Headers::get().MethodValues.Post);
-  headers.setPath(fmt::format("/2015-03-31/functions/{}/invocations", function_name));
+  auto lambda_arn = "arn:" +
+      arn->partition() + ":" +
+      arn->service() + ":" +
+      arn->region() + ":" +
+      arn->accountId() + ":" +
+      arn->resourceType() + ":" +
+      arn->functionName();
+  headers.setPath(fmt::format("/2015-03-31/functions/{}/invocations", lambda_arn));
   if (mode == InvocationMode::Synchronous) {
     headers.setReference(LambdaFilterNames::get().InvocationTypeHeader, "RequestResponse");
   } else {
@@ -157,7 +165,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   }
 
   if (payload_passthrough_) {
-    setLambdaHeaders(headers, arn_->functionName(), invocation_mode_);
+    setLambdaHeaders(headers, arn_, invocation_mode_);
     sigv4_signer_->signEmptyPayload(headers);
     return Http::FilterHeadersStatus::Continue;
   }
@@ -166,7 +174,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   jsonizeRequest(headers, nullptr, json_buf);
   // We must call setLambdaHeaders *after* the JSON transformation of the request. That way we
   // reflect the actual incoming request headers instead of the overwritten ones.
-  setLambdaHeaders(headers, arn_->functionName(), invocation_mode_);
+  setLambdaHeaders(headers, arn_, invocation_mode_);
   headers.setContentLength(json_buf.length());
   headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   auto& hashing_util = Envoy::Common::Crypto::UtilitySingleton::get();
@@ -226,7 +234,7 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
     request_headers_->setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   }
 
-  setLambdaHeaders(*request_headers_, arn_->functionName(), invocation_mode_);
+  setLambdaHeaders(*request_headers_, arn_, invocation_mode_);
   const auto hash = Hex::encode(hashing_util.getSha256Digest(decoding_buffer));
   sigv4_signer_->sign(*request_headers_, hash);
   stats().upstream_rq_payload_size_.recordValue(decoding_buffer.length());

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -44,9 +44,7 @@ constexpr auto egress_gateway_metadata_key = "egress_gateway";
 void setLambdaHeaders(Http::RequestHeaderMap& headers, const absl::optional<Arn>& arn,
                       InvocationMode mode) {
   headers.setMethod(Http::Headers::get().MethodValues.Post);
-  auto lambda_arn = "arn:" + arn->partition() + ":" + arn->service() + ":" + arn->region() + ":" +
-                    arn->accountId() + ":" + arn->resourceType() + ":" + arn->functionName();
-  headers.setPath(fmt::format("/2015-03-31/functions/{}/invocations", lambda_arn));
+  headers.setPath(fmt::format("/2015-03-31/functions/{}/invocations", arn->arn()));
   if (mode == InvocationMode::Synchronous) {
     headers.setReference(LambdaFilterNames::get().InvocationTypeHeader, "RequestResponse");
   } else {
@@ -381,10 +379,10 @@ absl::optional<Arn> parseArn(absl::string_view arn) {
     std::string versioned_function_name = std::string(function_name);
     versioned_function_name.push_back(':');
     versioned_function_name += std::string(parts[7]);
-    return Arn{partition, service, region, account_id, resource_type, versioned_function_name};
+    return Arn{arn, partition, service, region, account_id, resource_type, versioned_function_name};
   }
 
-  return Arn{partition, service, region, account_id, resource_type, function_name};
+  return Arn{arn, partition, service, region, account_id, resource_type, function_name};
 }
 
 FilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -20,12 +20,13 @@ namespace AwsLambdaFilter {
 
 class Arn {
 public:
-  Arn(absl::string_view partition, absl::string_view service, absl::string_view region,
+  Arn(absl::string_view arn, absl::string_view partition, absl::string_view service, absl::string_view region,
       absl::string_view account_id, absl::string_view resource_type,
       absl::string_view function_name)
-      : partition_(partition), service_(service), region_(region), account_id_(account_id),
+      : arn_(arn), partition_(partition), service_(service), region_(region), account_id_(account_id),
         resource_type_(resource_type), function_name_(function_name) {}
 
+  const std::string& arn() const { return arn_; }
   const std::string& partition() const { return partition_; }
   const std::string& service() const { return service_; }
   const std::string& region() const { return region_; }
@@ -34,6 +35,7 @@ public:
   const std::string& functionName() const { return function_name_; }
 
 private:
+  std::string arn_;
   std::string partition_;
   std::string service_;
   std::string region_;

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -20,11 +20,11 @@ namespace AwsLambdaFilter {
 
 class Arn {
 public:
-  Arn(absl::string_view arn, absl::string_view partition, absl::string_view service, absl::string_view region,
-      absl::string_view account_id, absl::string_view resource_type,
+  Arn(absl::string_view arn, absl::string_view partition, absl::string_view service,
+      absl::string_view region, absl::string_view account_id, absl::string_view resource_type,
       absl::string_view function_name)
-      : arn_(arn), partition_(partition), service_(service), region_(region), account_id_(account_id),
-        resource_type_(resource_type), function_name_(function_name) {}
+      : arn_(arn), partition_(partition), service_(service), region_(region),
+        account_id_(account_id), resource_type_(resource_type), function_name_(function_name) {}
 
   const std::string& arn() const { return arn_; }
   const std::string& partition() const { return partition_; }

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -77,6 +77,8 @@ TEST_F(AwsLambdaFilterTest, HeaderOnlyShouldContinue) {
   EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>()));
   Http::TestRequestHeaderMapImpl input_headers;
   const auto result = filter_->decodeHeaders(input_headers, true /*end_stream*/);
+  EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
+            input_headers.getPathValue());
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
 
   Http::TestResponseHeaderMapImpl response_headers;
@@ -180,6 +182,8 @@ TEST_F(AwsLambdaFilterTest, DecodeDataShouldSign) {
   EXPECT_CALL(*signer_, sign(An<Http::RequestHeaderMap&>(), An<const std::string&>()));
 
   const auto data_result = filter_->decodeData(buffer, true /*end_stream*/);
+  EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
+            headers.getPathValue());
   EXPECT_EQ(Http::FilterDataStatus::Continue, data_result);
 }
 
@@ -221,7 +225,8 @@ TEST_F(AwsLambdaFilterTest, DecodeHeadersOnlyRequestWithJsonOn) {
   headers.addCopy("x-custom-header", "unit");
   headers.addCopy("x-custom-header", "test");
   const auto header_result = filter_->decodeHeaders(headers, true /*end_stream*/);
-
+  EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
+            headers.getPathValue());
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, header_result);
 
   // Assert it's not empty


### PR DESCRIPTION
Signed-off-by: Vaibhav Dhage <vddhage@amazon.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
- Allow cross account lambda function invocation by setting the path in header with complete Lambda ARN instead of the function name.

Additional Description:
- Without this change, lambda filter always calls the lambda function in the AWS account where envoy runs and fails if it can't find the function in that account with the same name.

Risk Level:
- Low

Testing:
- Unit Test
- Integration Test
- Manual testing in AWS cross account setup to make sure function invocation works for both in account and cross account.

Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
