### PR TITLE
Move regex engine initialization before stats store initialization

### DIFF
--- a/test/integration/regex_engine_integration_test.cc
+++ b/test/integration/regex_engine_integration_test.cc
@@ -14,8 +14,18 @@ class RegexEngineIntegrationTest : public testing::TestWithParam<Network::Addres
 public:
   RegexEngineIntegrationTest() : BaseIntegrationTest(GetParam(), config()) {}
 
+  // Ensure that regex definitions in the stats matcher config will parse too
   static std::string config() {
     return absl::StrCat(ConfigHelper::baseConfigNoListeners(), R"EOF(
+stats_config:
+  stats_matcher:
+    exclusion_list:
+      patterns:
+        - safe_regex:
+            regex: "foobar.+"
+        - safe_regex:
+            regex: "barbaz.+"
+
 default_regex_engine:
   name: envoy.regex_engines.google_re2
   typed_config:


### PR DESCRIPTION
Commit Message: Move regex engine initialization before stats store initialization
Additional Description: If the stats store bootstrap config contains regexes, Envoy initialization will fail with `[critical][assert] [external/envoy/source/common/singleton/threadsafe_singleton.h:56] assert failure: loader_ != nullptr. Details: InjectableSingleton used prior to initialization`. This PR initializes the regex engine before the stats store to fix this
Risk Level: low
Testing: updated the existing integration test to include a stats config with regexes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Signed-off-by: Jacky Tian <jtian@lyft.com>
