### PR TITLE
[WIP] Add upstream network RBAC filter

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -148,7 +148,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 13]
+// [#next-free-field: 16]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.Permission";
 
@@ -224,6 +224,18 @@ message Permission {
     // Extension for configuring custom matchers for RBAC.
     // [#extension-category: envoy.rbac.matchers]
     core.v3.TypedExtensionConfig matcher = 12;
+
+    // A CIDR block that describes the upstream destination IP.
+    // Note: Only valid in upstream filter context
+    core.v3.CidrRange upstream_destination_ip = 13;
+
+    // A port number that describes the destination port connecting to.
+    // Note: Only valid in upstream filter context
+    uint32 upstream_destination_port = 14 [(validate.rules).uint32 = {lte: 65535}];
+
+    // A port number range that describes a range of destination ports connecting to.
+    // Note: Only valid in upstream filter context
+    type.v3.Int32Range upstream_destination_port_range = 15;
   }
 }
 

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -17,7 +17,7 @@ namespace Envoy {
 
 namespace Server {
 namespace Configuration {
-class ServerFactoryContext;
+class CommonFactoryContext;
 }
 } // namespace Server
 
@@ -174,7 +174,7 @@ class InputMatcherFactory : public Config::TypedFactory {
 public:
   virtual InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              Server::Configuration::ServerFactoryContext& factory_context) PURE;
+                              Server::Configuration::CommonFactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.input_matchers"; }
 };
@@ -293,7 +293,7 @@ template <class DataType> class CustomMatcherFactory : public Config::TypedFacto
 public:
   virtual MatchTreeFactoryCb<DataType>
   createCustomMatcherFactoryCb(const Protobuf::Message& config,
-                               Server::Configuration::ServerFactoryContext& factory_context,
+                               Server::Configuration::CommonFactoryContext& factory_context,
                                DataInputFactoryCb<DataType> data_input,
                                absl::optional<OnMatchFactoryCb<DataType>> on_no_match,
                                OnMatchFactory<DataType>& on_match_factory) PURE;

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -433,6 +433,10 @@ public:
 
   virtual void setUpstreamProtocol(Http::Protocol protocol) PURE;
   virtual absl::optional<Http::Protocol> upstreamProtocol() const PURE;
+
+  virtual void
+  setUpstreamConnectionTerminationDetails(absl::string_view connection_termination_details) PURE;
+  virtual const absl::optional<std::string>& upstreamConnectionTerminationDetails() const PURE;
 };
 
 /**

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -974,6 +974,17 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                                     return stream_info.connectionTerminationDetails();
                                   });
                             }}},
+                          {"UPSTREAM_CONNECTION_TERMINATION_DETAILS",
+                           {CommandSyntaxChecker::COMMAND_ONLY,
+                            [](const std::string&, const absl::optional<size_t>&) {
+                              return std::make_unique<StreamInfoStringFieldExtractor>(
+                                  [](const StreamInfo::StreamInfo& stream_info) {
+                                    return stream_info.upstreamInfo()
+                                               ? stream_info.upstreamInfo()
+                                                     ->upstreamConnectionTerminationDetails()
+                                               : absl::nullopt;
+                                  });
+                            }}},
                           {"BYTES_SENT",
                            {CommandSyntaxChecker::COMMAND_ONLY,
                             [](const std::string&, const absl::optional<size_t>&) {

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -149,9 +149,9 @@ template <class DataType, class ActionFactoryContext>
 class MatchTreeFactory : public OnMatchFactory<DataType> {
 public:
   MatchTreeFactory(ActionFactoryContext& context,
-                   Server::Configuration::ServerFactoryContext& factory_context,
+                   Server::Configuration::CommonFactoryContext& factory_context,
                    MatchTreeValidationVisitor<DataType>& validation_visitor)
-      : action_factory_context_(context), server_factory_context_(factory_context),
+      : action_factory_context_(context), common_factory_context_(factory_context),
         match_input_factory_(factory_context.messageValidationVisitor(), validation_visitor) {}
 
   // TODO(snowp): Remove this type parameter once we only have one Matcher proto.
@@ -283,8 +283,8 @@ private:
           matcher.matcher_tree().custom_match());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
           matcher.matcher_tree().custom_match().typed_config(),
-          server_factory_context_.messageValidationVisitor(), factory);
-      return factory.createCustomMatcherFactoryCb(*message, server_factory_context_, data_input,
+          common_factory_context_.messageValidationVisitor(), factory);
+      return factory.createCustomMatcherFactoryCb(*message, common_factory_context_, data_input,
                                                   on_no_match, *this);
     }
     }
@@ -323,11 +323,11 @@ private:
       auto& factory = Config::Utility::getAndCheckFactory<ActionFactory<ActionFactoryContext>>(
           on_match.action());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          on_match.action().typed_config(), server_factory_context_.messageValidationVisitor(),
+          on_match.action().typed_config(), common_factory_context_.messageValidationVisitor(),
           factory);
 
       auto action_factory = factory.createActionFactoryCb(
-          *message, action_factory_context_, server_factory_context_.messageValidationVisitor());
+          *message, action_factory_context_, common_factory_context_.messageValidationVisitor());
       return [action_factory] { return OnMatch<DataType>{action_factory, {}}; };
     }
 
@@ -347,8 +347,8 @@ private:
           Config::Utility::getAndCheckFactory<InputMatcherFactory>(predicate.custom_match());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
           predicate.custom_match().typed_config(),
-          server_factory_context_.messageValidationVisitor(), factory);
-      return factory.createInputMatcherFactoryCb(*message, server_factory_context_);
+          common_factory_context_.messageValidationVisitor(), factory);
+      return factory.createInputMatcherFactoryCb(*message, common_factory_context_);
     }
     case SinglePredicateType::MATCHER_NOT_SET:
       PANIC_DUE_TO_PROTO_UNSET;
@@ -358,7 +358,7 @@ private:
 
   const std::string stats_prefix_;
   ActionFactoryContext& action_factory_context_;
-  Server::Configuration::ServerFactoryContext& server_factory_context_;
+  Server::Configuration::CommonFactoryContext& common_factory_context_;
   MatchInputFactory<DataType> match_input_factory_;
 };
 } // namespace Matcher

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -192,6 +192,7 @@ private:
   bool had_upstream_ : 1;
   Http::ConnectionPool::Instance::StreamOptions stream_options_;
   Event::TimerPtr max_stream_duration_timer_;
+  std::shared_ptr<StreamInfo::UpstreamInfo> upstream_info_;
 };
 
 } // namespace Router

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -59,6 +59,13 @@ struct UpstreamInfoImpl : public UpstreamInfo {
   const std::string& upstreamTransportFailureReason() const override {
     return upstream_transport_failure_reason_;
   }
+  void setUpstreamConnectionTerminationDetails(
+      absl::string_view connection_termination_details) override {
+    upstream_connection_termination_details_.emplace(connection_termination_details);
+  }
+  const absl::optional<std::string>& upstreamConnectionTerminationDetails() const override {
+    return upstream_connection_termination_details_;
+  }
   void setUpstreamHost(Upstream::HostDescriptionConstSharedPtr host) override {
     upstream_host_ = host;
   }
@@ -88,6 +95,7 @@ struct UpstreamInfoImpl : public UpstreamInfo {
   Ssl::ConnectionInfoConstSharedPtr upstream_ssl_info_;
   absl::optional<uint64_t> upstream_connection_id_;
   absl::optional<std::string> upstream_connection_interface_name_;
+  absl::optional<std::string> upstream_connection_termination_details_;
   std::string upstream_transport_failure_reason_;
   FilterStateSharedPtr upstream_filter_state_;
   size_t num_streams_{};

--- a/source/extensions/common/matcher/trie_matcher.h
+++ b/source/extensions/common/matcher/trie_matcher.h
@@ -115,7 +115,7 @@ class TrieMatcherFactoryBase : public ::Envoy::Matcher::CustomMatcherFactory<Dat
 public:
   ::Envoy::Matcher::MatchTreeFactoryCb<DataType>
   createCustomMatcherFactoryCb(const Protobuf::Message& config,
-                               Server::Configuration::ServerFactoryContext& factory_context,
+                               Server::Configuration::CommonFactoryContext& factory_context,
                                DataInputFactoryCb<DataType> data_input,
                                absl::optional<OnMatchFactoryCb<DataType>> on_no_match,
                                OnMatchFactory<DataType>& on_match_factory) override {

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -106,7 +106,7 @@ bool RoleBasedAccessControlEngineImpl::checkPolicyMatch(
 
 RoleBasedAccessControlMatcherEngineImpl::RoleBasedAccessControlMatcherEngineImpl(
     const xds::type::matcher::v3::Matcher& matcher,
-    Server::Configuration::ServerFactoryContext& factory_context,
+    Server::Configuration::CommonFactoryContext& factory_context,
     ActionValidationVisitor& validation_visitor, const EnforcementMode mode)
     : mode_(mode) {
   ActionContext context{false};

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -93,7 +93,7 @@ class RoleBasedAccessControlMatcherEngineImpl : public RoleBasedAccessControlEng
 public:
   RoleBasedAccessControlMatcherEngineImpl(
       const xds::type::matcher::v3::Matcher& matcher,
-      Server::Configuration::ServerFactoryContext& factory_context,
+      Server::Configuration::CommonFactoryContext& factory_context,
       ActionValidationVisitor& validation_visitor,
       const EnforcementMode mode = EnforcementMode::Enforced);
 

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -142,7 +142,13 @@ private:
  */
 class IPMatcher : public Matcher {
 public:
-  enum Type { ConnectionRemote = 0, DownstreamLocal, DownstreamDirectRemote, DownstreamRemote };
+  enum Type {
+    ConnectionRemote = 0,
+    DownstreamLocal,
+    DownstreamDirectRemote,
+    DownstreamRemote,
+    UpstreamRemote
+  };
 
   IPMatcher(const envoy::config::core::v3::CidrRange& range, Type type)
       : range_(Network::Address::CidrRange::create(range)), type_(type) {}
@@ -160,18 +166,23 @@ private:
  */
 class PortMatcher : public Matcher {
 public:
-  PortMatcher(const uint32_t port) : port_(port) {}
+  enum Type { DownstreamPort = 0, UpstreamPort };
+
+  PortMatcher(const uint32_t port, Type type) : port_(port), type_(type) {}
 
   bool matches(const Network::Connection&, const Envoy::Http::RequestHeaderMap&,
                const StreamInfo::StreamInfo& info) const override;
 
 private:
   const uint32_t port_;
+  const Type type_;
 };
 
 class PortRangeMatcher : public Matcher {
 public:
-  PortRangeMatcher(const ::envoy::type::v3::Int32Range& range);
+  enum Type { DownstreamPort = 0, UpstreamPort };
+
+  PortRangeMatcher(const ::envoy::type::v3::Int32Range& range, Type type);
 
   bool matches(const Network::Connection&, const Envoy::Http::RequestHeaderMap&,
                const StreamInfo::StreamInfo& info) const override;
@@ -179,6 +190,7 @@ public:
 private:
   const uint32_t start_;
   const uint32_t end_;
+  const Type type_;
 };
 
 /**

--- a/source/extensions/filters/common/rbac/utility.h
+++ b/source/extensions/filters/common/rbac/utility.h
@@ -39,7 +39,7 @@ generateStats(const std::string& prefix, const std::string& shadow_prefix, Stats
 
 template <class ConfigType>
 std::unique_ptr<RoleBasedAccessControlEngine>
-createEngine(const ConfigType& config, Server::Configuration::ServerFactoryContext& context,
+createEngine(const ConfigType& config, Server::Configuration::CommonFactoryContext& context,
              ProtobufMessage::ValidationVisitor& validation_visitor,
              ActionValidationVisitor& action_validation_visitor) {
   if (config.has_matcher()) {
@@ -59,7 +59,7 @@ createEngine(const ConfigType& config, Server::Configuration::ServerFactoryConte
 
 template <class ConfigType>
 std::unique_ptr<RoleBasedAccessControlEngine>
-createShadowEngine(const ConfigType& config, Server::Configuration::ServerFactoryContext& context,
+createShadowEngine(const ConfigType& config, Server::Configuration::CommonFactoryContext& context,
                    ProtobufMessage::ValidationVisitor& validation_visitor,
                    ActionValidationVisitor& action_validation_visitor) {
   if (config.has_shadow_matcher()) {

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -56,7 +56,7 @@ absl::Status ActionValidationVisitor::performDataInputValidation(
 RoleBasedAccessControlFilterConfig::RoleBasedAccessControlFilterConfig(
     const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
     const std::string& stats_prefix, Stats::Scope& scope,
-    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::CommonFactoryContext& context,
     ProtobufMessage::ValidationVisitor& validation_visitor)
     : stats_(Filters::Common::RBAC::generateStats(stats_prefix,
                                                   proto_config.shadow_rules_stat_prefix(), scope)),
@@ -81,7 +81,7 @@ RoleBasedAccessControlFilterConfig::engine(const Router::RouteConstSharedPtr rou
 
 RoleBasedAccessControlRouteSpecificFilterConfig::RoleBasedAccessControlRouteSpecificFilterConfig(
     const envoy::extensions::filters::http::rbac::v3::RBACPerRoute& per_route_config,
-    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::CommonFactoryContext& context,
     ProtobufMessage::ValidationVisitor& validation_visitor) {
   // Moved from member initializer to ctor body to overcome clang false warning about memory
   // leak (clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors).

--- a/source/extensions/filters/http/rbac/rbac_filter.h
+++ b/source/extensions/filters/http/rbac/rbac_filter.h
@@ -27,7 +27,7 @@ class RoleBasedAccessControlRouteSpecificFilterConfig : public Router::RouteSpec
 public:
   RoleBasedAccessControlRouteSpecificFilterConfig(
       const envoy::extensions::filters::http::rbac::v3::RBACPerRoute& per_route_config,
-      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::CommonFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);
 
   const Filters::Common::RBAC::RoleBasedAccessControlEngine*
@@ -50,7 +50,7 @@ public:
   RoleBasedAccessControlFilterConfig(
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
       const std::string& stats_prefix, Stats::Scope& scope,
-      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::CommonFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);
 
   Filters::Common::RBAC::RoleBasedAccessControlFilterStats& stats() { return stats_; }

--- a/source/extensions/filters/network/rbac/config.cc
+++ b/source/extensions/filters/network/rbac/config.cc
@@ -99,6 +99,26 @@ RoleBasedAccessControlNetworkFilterConfigFactory::createFilterFactoryFromProtoTy
 REGISTER_FACTORY(RoleBasedAccessControlNetworkFilterConfigFactory,
                  Server::Configuration::NamedNetworkFilterConfigFactory);
 
+Network::FilterFactoryCb
+UpstreamRoleBasedAccessControlNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::network::rbac::v3::RBAC& proto_config,
+    Server::Configuration::CommonFactoryContext& context) {
+  validateRbacRules(proto_config.rules());
+  validateRbacRules(proto_config.shadow_rules());
+  RoleBasedAccessControlFilterConfigSharedPtr config(
+      std::make_shared<RoleBasedAccessControlFilterConfig>(proto_config, context.scope(), context,
+                                                           context.messageValidationVisitor()));
+  return [config](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(std::make_shared<RoleBasedAccessControlFilter>(config));
+  };
+}
+
+/**
+ * Static registration for the upstream RBAC network filter. @see RegisterFactory.
+ */
+REGISTER_FACTORY(UpstreamRoleBasedAccessControlNetworkFilterConfigFactory,
+                 Server::Configuration::NamedUpstreamNetworkFilterConfigFactory);
+
 } // namespace RBACFilter
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/rbac/config.h
+++ b/source/extensions/filters/network/rbac/config.h
@@ -27,6 +27,19 @@ private:
       Server::Configuration::FactoryContext& context) override;
 };
 
+class UpstreamRoleBasedAccessControlNetworkFilterConfigFactory
+    : public Common::FactoryBaseUpstream<envoy::extensions::filters::network::rbac::v3::RBAC> {
+
+public:
+  UpstreamRoleBasedAccessControlNetworkFilterConfigFactory()
+      : FactoryBaseUpstream(NetworkFilterNames::get().Rbac) {}
+
+private:
+  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::network::rbac::v3::RBAC& proto_config,
+      Server::Configuration::CommonFactoryContext& context) override;
+};
+
 } // namespace RBACFilter
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -35,7 +35,7 @@ class RoleBasedAccessControlFilterConfig {
 public:
   RoleBasedAccessControlFilterConfig(
       const envoy::extensions::filters::network::rbac::v3::RBAC& proto_config, Stats::Scope& scope,
-      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::CommonFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);
 
   Filters::Common::RBAC::RoleBasedAccessControlFilterStats& stats() { return stats_; }

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.cc
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.cc
@@ -7,7 +7,7 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 Envoy::Matcher::InputMatcherFactoryCb ConsistentHashingConfig::createInputMatcherFactoryCb(
-    const Protobuf::Message& config, Server::Configuration::ServerFactoryContext& factory_context) {
+    const Protobuf::Message& config, Server::Configuration::CommonFactoryContext& factory_context) {
   const auto& consistent_hashing_config =
       MessageUtil::downcastAndValidate<const envoy::extensions::matching::input_matchers::
                                            consistent_hashing::v3::ConsistentHashing&>(

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.h
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.h
@@ -18,7 +18,7 @@ class ConsistentHashingConfig : public Envoy::Matcher::InputMatcherFactory {
 public:
   Envoy::Matcher::InputMatcherFactoryCb createInputMatcherFactoryCb(
       const Protobuf::Message& config,
-      Server::Configuration::ServerFactoryContext& factory_context) override;
+      Server::Configuration::CommonFactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.consistent_hashing"; }
 

--- a/source/extensions/matching/input_matchers/ip/config.cc
+++ b/source/extensions/matching/input_matchers/ip/config.cc
@@ -8,7 +8,7 @@ namespace IP {
 
 Envoy::Matcher::InputMatcherFactoryCb
 Config::createInputMatcherFactoryCb(const Protobuf::Message& config,
-                                    Server::Configuration::ServerFactoryContext& factory_context) {
+                                    Server::Configuration::CommonFactoryContext& factory_context) {
   const auto& ip_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::matching::input_matchers::ip::v3::Ip&>(
       config, factory_context.messageValidationVisitor());

--- a/source/extensions/matching/input_matchers/ip/config.h
+++ b/source/extensions/matching/input_matchers/ip/config.h
@@ -18,7 +18,7 @@ class Config : public Envoy::Matcher::InputMatcherFactory {
 public:
   Envoy::Matcher::InputMatcherFactoryCb createInputMatcherFactoryCb(
       const Protobuf::Message& config,
-      Server::Configuration::ServerFactoryContext& factory_context) override;
+      Server::Configuration::CommonFactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.ip"; }
 

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -66,6 +66,12 @@ MockUpstreamInfo::MockUpstreamInfo()
     upstream_protocol_ = protocol;
   }));
   ON_CALL(*this, upstreamProtocol()).WillByDefault(ReturnPointee(&upstream_protocol_));
+  ON_CALL(*this, setUpstreamConnectionTerminationDetails(_))
+      .WillByDefault(Invoke([this](absl::string_view connection_termination_details) {
+        upstream_connection_termination_details_ = std::string(connection_termination_details);
+      }));
+  ON_CALL(*this, upstreamConnectionTerminationDetails())
+      .WillByDefault(ReturnPointee(&upstream_connection_termination_details_));
 }
 
 MockUpstreamInfo::~MockUpstreamInfo() = default;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -44,6 +44,10 @@ public:
   MOCK_METHOD(uint64_t, upstreamNumStreams, (), (const));
   MOCK_METHOD(void, setUpstreamProtocol, (Http::Protocol protocol));
   MOCK_METHOD(absl::optional<Http::Protocol>, upstreamProtocol, (), (const));
+  MOCK_METHOD(void, setUpstreamConnectionTerminationDetails,
+              (absl::string_view connection_termination_details));
+  MOCK_METHOD(const absl::optional<std::string>&, upstreamConnectionTerminationDetails, (),
+              (const));
 
   absl::optional<uint64_t> upstream_connection_id_;
   absl::optional<absl::string_view> interface_name_;
@@ -55,6 +59,7 @@ public:
   FilterStateSharedPtr filter_state_;
   uint64_t num_streams_;
   absl::optional<Http::Protocol> upstream_protocol_;
+  absl::optional<std::string> upstream_connection_termination_details_;
 };
 
 class MockStreamInfo : public StreamInfo {


### PR DESCRIPTION
- Reuses the RBAC downstream filter, introduces new matcher/fields for
  upstream ip and port
- Propagates information from upstream filter back to downstream context if
  any

TODO:

- Downstream context is not available in upstream filter, find a way to
  propagate (so we can say `application with IP 1.2.3.4 can talk to upstream
  IP 4.5.6.7` etc)
- RBAC rule should be enforced before connection establishment, currently
  does it after establishment
- Documentation

Signed-off-by: Suresh Kumar <sureshkumar.pp@gmail.com>

Example usage:

```
static_resources:
  listeners:
  - name: listener_0
    address:
      socket_address:
        protocol: TCP
        address: 0.0.0.0
        port_value: 1234
    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          stat_prefix: ingress_http
          route_config:
            name: local_route
            virtual_hosts:
            - name: local_service
              domains: ["*"]
              routes:
              - match:
                  prefix: "/"
                route:
                  cluster: example_cluster
                  timeout: 1500s
          http_filters:
          - name: envoy.filters.http.router
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
  - name: example_cluster
    type: LOGICAL_DNS
    connect_timeout: 5s
    dns_lookup_family: V4_ONLY
    respect_dns_ttl: true
    dns_refresh_rate: 3000s
    load_assignment:
      cluster_name: example.com|8080
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: example.com
                port_value: 8080
    filters:            
    - name: envoy.filters.network.rbac
      typed_config:
        "@type": type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
        stat_prefix: rbac_upstream
        rules:
          action: DENY
          policies:
            "loopback":
              principals:
              - any: true
              permissions:
              - upstream_destination_ip:   
                  address_prefix: 127.0.0.1
                  prefix_len: 8
```
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Adds new upstream network RBAC filter
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA] #21178
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
