### PR TITLE
Implement no throw version of `unpackTo` to avoid throwing exception on dataplane

### DIFF
--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -55,6 +55,7 @@ envoy_cc_library(
     deps = [
         "//envoy/api:api_interface",
         "//envoy/protobuf:message_validator_interface",
+        "//source/common/common:statusor_lib",
         "//source/common/common:stl_helpers",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -562,14 +562,15 @@ void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Messag
   }
 }
 
-absl::optional<std::string> MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
-                                                         Protobuf::Message& message) {
+ProtobufUtil::Status MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
+                                                  Protobuf::Message& message) {
   if (!any_message.UnpackTo(&message)) {
-    return absl::StrCat("Unable to unpack as ", message.GetDescriptor()->full_name(), ": ",
-                        any_message.DebugString());
+    return ProtobufUtil::Status(google::protobuf::util::StatusCode::kInternal,
+                                "Unable to unpack as " + message.GetDescriptor()->full_name() +
+                                    ": " + any_message.DebugString());
   }
-  // No error message is returned if `UnpackTo` succeeded.
-  return absl::nullopt;
+  // Ok Status is returned if `UnpackTo` succeeded.
+  return ProtobufUtil::OkStatus();
 }
 
 void MessageUtil::jsonConvert(const Protobuf::Message& source, ProtobufWkt::Struct& dest) {

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -562,6 +562,16 @@ void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Messag
   }
 }
 
+absl::optional<std::string> MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
+                                                         Protobuf::Message& message) {
+  if (!any_message.UnpackTo(&message)) {
+    return absl::StrCat("Unable to unpack as ", message.GetDescriptor()->full_name(), ": ",
+                        any_message.DebugString());
+  }
+  // No error message is returned if `UnpackTo` succeeded.
+  return absl::nullopt;
+}
+
 void MessageUtil::jsonConvert(const Protobuf::Message& source, ProtobufWkt::Struct& dest) {
   // Any proto3 message can be transformed to Struct, so there is no need to check for unknown
   // fields. There is one catch; Duration/Timestamp etc. which have non-object canonical JSON

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -562,15 +562,15 @@ void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Messag
   }
 }
 
-ProtobufUtil::Status MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
-                                                  Protobuf::Message& message) {
+absl::Status MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
+                                          Protobuf::Message& message) {
   if (!any_message.UnpackTo(&message)) {
-    return ProtobufUtil::Status(google::protobuf::util::StatusCode::kInternal,
-                                "Unable to unpack as " + message.GetDescriptor()->full_name() +
-                                    ": " + any_message.DebugString());
+    return {absl::StatusCode::kInternal, "Unable to unpack as " +
+                                             message.GetDescriptor()->full_name() + ": " +
+                                             any_message.DebugString()};
   }
   // Ok Status is returned if `UnpackTo` succeeded.
-  return ProtobufUtil::OkStatus();
+  return absl::OkStatus();
 }
 
 void MessageUtil::jsonConvert(const Protobuf::Message& source, ProtobufWkt::Struct& dest) {

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -565,8 +565,8 @@ void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Messag
 absl::Status MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
                                           Protobuf::Message& message) {
   if (!any_message.UnpackTo(&message)) {
-    return absl::InternalError(absl::StrCat("Unable to unpack as " +
-                                            message.GetDescriptor()->full_name() + ": " +
+    return absl::InternalError(absl::StrCat("Unable to unpack as ",
+                                            message.GetDescriptor()->full_name(), ": ",
                                             any_message.DebugString()));
   }
   // Ok Status is returned if `UnpackTo` succeeded.

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -565,9 +565,9 @@ void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Messag
 absl::Status MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
                                           Protobuf::Message& message) {
   if (!any_message.UnpackTo(&message)) {
-    return {absl::StatusCode::kInternal, "Unable to unpack as " +
-                                             message.GetDescriptor()->full_name() + ": " +
-                                             any_message.DebugString()};
+    return absl::InternalError(absl::StrCat("Unable to unpack as " +
+                                            message.GetDescriptor()->full_name() + ": " +
+                                            any_message.DebugString()));
   }
   // Ok Status is returned if `UnpackTo` succeeded.
   return absl::OkStatus();

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -14,6 +14,7 @@
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/singleton/const_singleton.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/str_join.h"
 
 // Obtain the value of a wrapped field (e.g. google.protobuf.UInt32Value) if set. Otherwise, return
@@ -364,10 +365,10 @@ public:
    * @param any_message source google.protobuf.Any message.
    * @param message destination to unpack to.
    *
-   * @return ProtobufUtil::Status.
+   * @return absl::Status
    */
-  static ProtobufUtil::Status unpackToNoThrow(const ProtobufWkt::Any& any_message,
-                                              Protobuf::Message& message);
+  static absl::Status unpackToNoThrow(const ProtobufWkt::Any& any_message,
+                                      Protobuf::Message& message);
 
   /**
    * Convert from google.protobuf.Any to bytes as std::string

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -358,6 +358,18 @@ public:
   static void unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message);
 
   /**
+   * Convert from google.protobuf.Any to a typed message. This should be used
+   * instead of the inbuilt UnpackTo as it performs validation of results.
+   *
+   * @param any_message source google.protobuf.Any message.
+   * @param message destination to unpack to.
+   *
+   * @return erro message if the message does not unpack.
+   */
+  static absl::optional<std::string> unpackToNoThrow(const ProtobufWkt::Any& any_message,
+                                                     Protobuf::Message& message);
+
+  /**
    * Convert from google.protobuf.Any to bytes as std::string
    * @param any source google.protobuf.Any message.
    *

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -364,10 +364,10 @@ public:
    * @param any_message source google.protobuf.Any message.
    * @param message destination to unpack to.
    *
-   * @return erro message if the message does not unpack.
+   * @return ProtobufUtil::Status.
    */
-  static absl::optional<std::string> unpackToNoThrow(const ProtobufWkt::Any& any_message,
-                                                     Protobuf::Message& message);
+  static ProtobufUtil::Status unpackToNoThrow(const ProtobufWkt::Any& any_message,
+                                              Protobuf::Message& message);
 
   /**
    * Convert from google.protobuf.Any to bytes as std::string

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -50,6 +50,7 @@ envoy_cc_test(
         "//test/proto:sensitive_proto_cc_proto",
         "//test/test_common:environment_lib",
         "//test/test_common:logging_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1477,7 +1477,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
   ASSERT_TRUE(error_msg.has_value());
   EXPECT_THAT(error_msg.value(),
-              testing::MatchesRegex("Unable to unpack as google.protobuf.Timestamp: .*"));
+              testing::MatchesRegex("Unable to unpack as google.protobuf.Timestamp.*"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1460,7 +1460,6 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowRightType) {
   ProtobufWkt::Any source_any;
   source_any.PackFrom(src_duration);
   ProtobufWkt::Duration dst_duration;
-  // Expects unpack succeeds.
   EXPECT_TRUE(MessageUtil::unpackToNoThrow(source_any, dst_duration).ok());
   // Source and destination are expected to be equal.
   EXPECT_EQ(src_duration, dst_duration);

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1476,10 +1476,8 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   ProtobufWkt::Timestamp dst;
   auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
   ASSERT_TRUE(error_msg.has_value());
-  EXPECT_THAT(
-      error_msg.value(),
-      testing::MatchesRegex(
-          R"(Unable to unpack as google.protobuf.Timestamp: .*)"));
+  EXPECT_THAT(error_msg.value(),
+              testing::MatchesRegex(R"(Unable to unpack as google.protobuf.Timestamp: .*)"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1477,7 +1477,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
   ASSERT_TRUE(error_msg.has_value());
   EXPECT_THAT(error_msg.value(),
-              testing::MatchesRegex(R"(Unable to unpack as google.protobuf.Timestamp: .*)"));
+              testing::MatchesRegex("Unable to unpack as google.protobuf.Timestamp: .*"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1477,7 +1477,8 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
   ASSERT_TRUE(error_msg.has_value());
   EXPECT_THAT(error_msg.value(),
-              testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: \\[type.googleapis.com/google.protobuf.Duration\\] .*"));
+              testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: "
+                                     "\\[type.googleapis.com/google.protobuf.Duration\\] .*"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1476,9 +1476,10 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   ProtobufWkt::Timestamp dst;
   auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
   ASSERT_TRUE(error_msg.has_value());
-  EXPECT_THAT(error_msg.value(),
-              testing::MatchesRegex("Unable to unpack as google.protobuf.Timestamp: "
-                                    "\\[type.googleapis.com/google.protobuf.Duration\\].*"));
+  EXPECT_THAT(
+      error_msg.value(),
+      testing::MatchesRegex(
+          R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\].*)"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1479,7 +1479,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   EXPECT_THAT(
       error_msg.value(),
       testing::MatchesRegex(
-          R"(Unable to unpack as google.protobuf.Timestamp: \[type.googleapis.com/google.protobuf.Duration\].*)"));
+          R"(Unable to unpack as google.protobuf.Timestamp: .*)"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1477,7 +1477,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
   ASSERT_TRUE(error_msg.has_value());
   EXPECT_THAT(error_msg.value(),
-              testing::MatchesRegex("Unable to unpack as google.protobuf.Timestamp.*"));
+              testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: \\[type.googleapis.com/google.protobuf.Duration\\] .*"));
 }
 
 // MessageUtility::loadFromJson() throws on garbage JSON.

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1461,7 +1461,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowRightType) {
   ProtobufWkt::Any source_any;
   source_any.PackFrom(src_duration);
   ProtobufWkt::Duration dst_duration;
-  EXPECT_THAT(MessageUtil::unpackToNoThrow(source_any, dst_duration), StatusHelpers::IsOk());
+  EXPECT_OK(MessageUtil::unpackToNoThrow(source_any, dst_duration));
   // Source and destination are expected to be equal.
   EXPECT_EQ(src_duration, dst_duration);
 }
@@ -1474,7 +1474,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   source_any.PackFrom(source_duration);
   ProtobufWkt::Timestamp dst;
   auto status = MessageUtil::unpackToNoThrow(source_any, dst);
-  EXPECT_EQ(status.code(), ProtobufUtil::StatusCode::kInternal);
+  EXPECT_FALSE(status.ok());
   EXPECT_THAT(std::string(status.message()),
               testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: "
                                      "\\[type.googleapis.com/google.protobuf.Duration\\] .*"));

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1454,7 +1454,7 @@ TEST_F(ProtobufUtilityTest, UnpackToSameVersion) {
 }
 
 // MessageUtility::unpackToNoThrow() with the right type.
-TEST_F(ProtobufUtilityTest, unpackToNoThrowRightType) {
+TEST_F(ProtobufUtilityTest, UnpackToNoThrowRightType) {
   ProtobufWkt::Duration src_duration;
   src_duration.set_seconds(42);
   ProtobufWkt::Any source_any;
@@ -1468,7 +1468,7 @@ TEST_F(ProtobufUtilityTest, unpackToNoThrowRightType) {
 }
 
 // MessageUtility::unpackToNoThrow() with the wrong type.
-TEST_F(ProtobufUtilityTest, unpackToNoThrowWrongType) {
+TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   ProtobufWkt::Duration source_duration;
   source_duration.set_seconds(42);
   ProtobufWkt::Any source_any;

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1460,10 +1460,9 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowRightType) {
   ProtobufWkt::Any source_any;
   source_any.PackFrom(src_duration);
   ProtobufWkt::Duration dst_duration;
-  auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst_duration);
-  // No error message was returned.
-  EXPECT_FALSE(error_msg.has_value());
-  // source and destination are equal.
+  // Expects unpack succeeds.
+  EXPECT_TRUE(MessageUtil::unpackToNoThrow(source_any, dst_duration).ok());
+  // Source and destination are expected to be equal.
   EXPECT_EQ(src_duration, dst_duration);
 }
 
@@ -1474,9 +1473,9 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   ProtobufWkt::Any source_any;
   source_any.PackFrom(source_duration);
   ProtobufWkt::Timestamp dst;
-  auto error_msg = MessageUtil::unpackToNoThrow(source_any, dst);
-  ASSERT_TRUE(error_msg.has_value());
-  EXPECT_THAT(error_msg.value(),
+  auto status = MessageUtil::unpackToNoThrow(source_any, dst);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
               testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: "
                                      "\\[type.googleapis.com/google.protobuf.Duration\\] .*"));
 }

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -35,6 +35,7 @@
 #include "test/proto/sensitive.pb.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
@@ -1460,7 +1461,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowRightType) {
   ProtobufWkt::Any source_any;
   source_any.PackFrom(src_duration);
   ProtobufWkt::Duration dst_duration;
-  EXPECT_TRUE(MessageUtil::unpackToNoThrow(source_any, dst_duration).ok());
+  EXPECT_THAT(MessageUtil::unpackToNoThrow(source_any, dst_duration), StatusHelpers::IsOk());
   // Source and destination are expected to be equal.
   EXPECT_EQ(src_duration, dst_duration);
 }
@@ -1473,8 +1474,8 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   source_any.PackFrom(source_duration);
   ProtobufWkt::Timestamp dst;
   auto status = MessageUtil::unpackToNoThrow(source_any, dst);
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.message(),
+  EXPECT_EQ(status.code(), ProtobufUtil::StatusCode::kInternal);
+  EXPECT_THAT(std::string(status.message()),
               testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: "
                                      "\\[type.googleapis.com/google.protobuf.Duration\\] .*"));
 }

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1474,7 +1474,7 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
   source_any.PackFrom(source_duration);
   ProtobufWkt::Timestamp dst;
   auto status = MessageUtil::unpackToNoThrow(source_any, dst);
-  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(absl::IsInternal(status));
   EXPECT_THAT(std::string(status.message()),
               testing::ContainsRegex("Unable to unpack as google.protobuf.Timestamp: "
                                      "\\[type.googleapis.com/google.protobuf.Duration\\] .*"));

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -638,7 +638,8 @@ class FormatChecker:
                     "use Registry::InjectFactory instead.")
         if not self.allow_listed_for_unpack_to(file_path):
             if "UnpackTo" in line:
-                report_error("Don't use UnpackTo() directly, use MessageUtil::unpackTo() instead")
+                report_error(
+                    "Don't use UnpackTo() directly, use MessageUtil::unpackToNoThrow() instead")
         # Check that we use the absl::Time library
         if self.token_in_line("std::get_time", line):
             if "test/" in file_path:

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -173,7 +173,7 @@ def run_checks():
     errors += check_unfixable_error("system_clock.cc", real_time_inject_error)
     errors += check_unfixable_error("steady_clock.cc", real_time_inject_error)
     errors += check_unfixable_error(
-        "unpack_to.cc", "Don't use UnpackTo() directly, use MessageUtil::unpackTo() instead")
+        "unpack_to.cc", "Don't use UnpackTo() directly, use MessageUtil::unpackToNoThrow() instead")
     errors += check_unfixable_error(
         "condvar_wait_for.cc", "Don't use CondVar::waitFor(); use TimeSystem::waitFor() instead.")
     errors += check_unfixable_error("sleep.cc", real_time_inject_error)


### PR DESCRIPTION
Return the error message to the caller site and let caller decides how to handle it (e.g., logging etc) instead of throwing the exception.

Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

