### PR TITLE
Thrift: Keep downstream connection if response is complete without underflow

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -37,6 +37,9 @@ minor_behavior_changes:
 - area: thrift
   change: |
     add validate_clusters in :ref:`RouteConfiguration <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.v3.RouteConfiguration>` to override the default behavior of cluster validation.
+- area: thrift
+  change: |
+    keep downstream connection if the response is completed without underflow.
 - area: tls
   change: |
     if both :ref:`match_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` and :ref:`match_typed_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` are specified, the former (deprecated) field is ignored. Previously, setting both fields would result in an error.

--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -295,6 +295,7 @@ envoy_cc_library(
     name = "thrift_lib",
     hdrs = ["thrift.h"],
     deps = [
+        "//envoy/tcp:conn_pool_interface",
         "//source/common/common:assert_lib",
         "//source/common/singleton:const_singleton",
     ],

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -282,7 +282,7 @@ void UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstShare
 }
 
 static Upstream::Outlier::Result
-PoolFailureReasonToResult(ConnectionPool::PoolFailureReason reason) {
+poolFailureReasonToResult(ConnectionPool::PoolFailureReason reason) {
   switch (reason) {
   case ConnectionPool::PoolFailureReason::Overflow:
     FALLTHRU;
@@ -314,7 +314,7 @@ bool UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
   case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
     FALLTHRU;
   case ConnectionPool::PoolFailureReason::Timeout:
-    upstream_host_->outlierDetector().putResult(PoolFailureReasonToResult(reason));
+    upstream_host_->outlierDetector().putResult(poolFailureReasonToResult(reason));
 
     // Error occurred after a partial or underflow response, propagate the reset to the
     // downstream.
@@ -339,8 +339,9 @@ bool UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
   ENVOY_LOG(debug,
             "upstream reset complete. reason={}, close_downstream={}, response_started={}, "
             "response_complete={}, draining={}, response_underflow={}",
-            PoolFailureReasonNames::get().fromReason(reason), close_downstream, !!response_started_,
-            !!response_complete_, !!draining_, !!response_underflow_);
+            PoolFailureReasonNames::get().fromReason(reason), close_downstream,
+            static_cast<bool>(response_started_), static_cast<bool>(response_complete_),
+            static_cast<bool>(draining_), static_cast<bool>(response_underflow_));
   return close_downstream;
 }
 

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -15,6 +15,7 @@ UpstreamRequest::UpstreamRequest(RequestOwner& parent, Upstream::TcpPoolData& po
       transport_(NamedTransportConfigFactory::getFactory(transport_type).createTransport()),
       protocol_(NamedProtocolConfigFactory::getFactory(protocol_type).createProtocol()),
       request_complete_(false), response_started_(false), response_complete_(false),
+      draining_(false), response_underflow_(false), charged_response_timing_(false),
       close_downstream_on_error_(close_downstream_on_error) {}
 
 UpstreamRequest::~UpstreamRequest() {
@@ -135,7 +136,6 @@ UpstreamRequest::handleRegularResponse(Buffer::Instance& data,
 
   const auto status = callbacks.upstreamData(data);
   if (status == ThriftFilters::ResponseStatus::Complete) {
-    ENVOY_LOG(debug, "response complete");
 
     stats_.recordUpstreamResponseSize(cluster, response_size_);
 
@@ -166,9 +166,14 @@ UpstreamRequest::handleRegularResponse(Buffer::Instance& data,
     if (callbacks.responseMetadata()->isDraining()) {
       ENVOY_LOG(debug, "got draining signal");
       stats_.incCloseDrain(cluster);
+      // ResetStream triggers a local connection failure. However, we want to
+      // keep the downstream connection after the upstream connection, i.e.,
+      // `conn_data->connection()`, is closed. Therefore, introduce a new flag
+      // `drainging_` to hint that we got a draining signal and not to close
+      // the downstream connection.
+      draining_ = true;
       resetStream();
     }
-
     onResponseComplete();
   } else if (status == ThriftFilters::ResponseStatus::Reset) {
     // Note: invalid responses are not accounted in the response size histogram.
@@ -200,6 +205,7 @@ bool UpstreamRequest::handleUpstreamData(Buffer::Instance& data, bool end_stream
     // Response is incomplete, but no more data is coming.
     ENVOY_LOG(debug, "response underflow");
     onResponseComplete();
+    response_underflow_ = true;
     onResetStream(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
     return true;
   }
@@ -264,6 +270,7 @@ void UpstreamRequest::onRequestComplete() {
 }
 
 void UpstreamRequest::onResponseComplete() {
+  ENVOY_LOG(debug, "response complete");
   chargeResponseTiming();
   response_complete_ = true;
   conn_state_ = nullptr;
@@ -272,6 +279,21 @@ void UpstreamRequest::onResponseComplete() {
 
 void UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {
   upstream_host_ = host;
+}
+
+static Upstream::Outlier::Result
+PoolFailureReasonToResult(ConnectionPool::PoolFailureReason reason) {
+  switch (reason) {
+  case ConnectionPool::PoolFailureReason::Overflow:
+    FALLTHRU;
+  case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
+    FALLTHRU;
+  case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
+    return Upstream::Outlier::Result::LocalOriginConnectFailed;
+  case ConnectionPool::PoolFailureReason::Timeout:
+    return Upstream::Outlier::Result::LocalOriginTimeout;
+  }
+  PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
 bool UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
@@ -288,45 +310,37 @@ bool UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
     close_downstream = false;
     break;
   case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
-    upstream_host_->outlierDetector().putResult(
-        Upstream::Outlier::Result::LocalOriginConnectFailed);
-    // Should only happen if we closed the connection, due to an error condition, in which case
-    // we've already handled any possible downstream response.
-    parent_.resetDownstreamConnection();
-    break;
+    FALLTHRU;
   case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
+    FALLTHRU;
   case ConnectionPool::PoolFailureReason::Timeout:
-    if (reason == ConnectionPool::PoolFailureReason::Timeout) {
-      upstream_host_->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginTimeout);
-    } else if (reason == ConnectionPool::PoolFailureReason::RemoteConnectionFailure) {
-      upstream_host_->outlierDetector().putResult(
-          Upstream::Outlier::Result::LocalOriginConnectFailed);
-    }
-    stats_.incResponseLocalException(parent_.cluster());
+    upstream_host_->outlierDetector().putResult(PoolFailureReasonToResult(reason));
 
-    // TODO(zuercher): distinguish between these cases where appropriate (particularly timeout)
-    if (response_started_) {
-      ENVOY_LOG(debug, "reset downstream connection for a partial response");
-      // Error occurred after a partial response, propagate the reset to the downstream.
+    // Error occurred after a partial or underflow response, propagate the reset to the
+    // downstream.
+    if (response_underflow_ || (response_started_ && !draining_ && !response_complete_)) {
+      ENVOY_LOG(debug, "reset downstream connection for a partial or underflow response");
       parent_.resetDownstreamConnection();
-    } else {
+    } else if (!draining_ && !response_complete_) {
       close_downstream = close_downstream_on_error_;
+      stats_.incResponseLocalException(parent_.cluster());
       parent_.sendLocalReply(
-          AppException(
-              AppExceptionType::InternalError,
-              fmt::format("connection failure: {} '{}'",
-                          reason == ConnectionPool::PoolFailureReason::RemoteConnectionFailure
-                              ? "remote connection failure"
-                              : "timeout",
-                          (upstream_host_ != nullptr) ? upstream_host_->address()->asString()
-                                                      : "to upstream")),
+          AppException(AppExceptionType::InternalError,
+                       fmt::format("connection failure: {} '{}'",
+                                   PoolFailureReasonNames::get().fromReason(reason),
+                                   (upstream_host_ && upstream_host_->address())
+                                       ? upstream_host_->address()->asString()
+                                       : "to upstream")),
           close_downstream);
     }
     break;
   }
 
-  ENVOY_LOG(debug, "upstream reset complete reason {} (close_downstream={})",
-            static_cast<int>(reason), close_downstream);
+  ENVOY_LOG(debug,
+            "upstream reset complete. reason={}, close_downstream={}, response_started={}, "
+            "response_complete={}, draining={}, response_underflow={}",
+            PoolFailureReasonNames::get().fromReason(reason), close_downstream, !!response_started_,
+            !!response_complete_, !!draining_, !!response_underflow_);
   return close_downstream;
 }
 

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -169,8 +169,8 @@ UpstreamRequest::handleRegularResponse(Buffer::Instance& data,
       // ResetStream triggers a local connection failure. However, we want to
       // keep the downstream connection after the upstream connection, i.e.,
       // `conn_data->connection()`, is closed. Therefore, introduce a new flag
-      // `drainging_` to hint that we got a draining signal and not to close
-      // the downstream connection.
+      // `draining_` to hint that we got a draining signal and not to close the
+      //  downstream connection.
       draining_ = true;
       resetStream();
     }

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.h
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.h
@@ -74,12 +74,13 @@ struct UpstreamRequest : public Tcp::ConnectionPool::Callbacks,
   bool request_complete_ : 1;
   bool response_started_ : 1;
   bool response_complete_ : 1;
+  bool draining_ : 1;
+  bool response_underflow_ : 1;
+  bool charged_response_timing_ : 1;
+  bool close_downstream_on_error_ : 1;
 
-  bool charged_response_timing_{false};
   MonotonicTime downstream_request_complete_time_;
   uint64_t response_size_{};
-
-  bool close_downstream_on_error_;
 };
 
 } // namespace Router

--- a/source/extensions/filters/network/thrift_proxy/thrift.h
+++ b/source/extensions/filters/network/thrift_proxy/thrift.h
@@ -233,25 +233,25 @@ enum class AppExceptionType {
 };
 
 /**
- * Names of available reply types.
+ * Names of pool failure reason.
  */
 class PoolFailureReasonNameValues {
 public:
-  const std::string OVERFLOW = "overflow";
-  const std::string LOCAL_CONNECTION_FAILURE = "local connection failure";
-  const std::string REMOTE_CONNECTION_FAILURE = "remote connection failure";
-  const std::string TIMEOUT = "timeout";
+  const std::string OVERFLOW_NAME = "overflow";
+  const std::string LOCAL_CONNECTION_FAILURE_NAME = "local connection failure";
+  const std::string REMOTE_CONNECTION_FAILURE_NAME = "remote connection failure";
+  const std::string TIMEOUT_NAME = "timeout";
 
   const std::string& fromReason(ConnectionPool::PoolFailureReason reason) const {
     switch (reason) {
     case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
-      return LOCAL_CONNECTION_FAILURE;
+      return LOCAL_CONNECTION_FAILURE_NAME;
     case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
-      return REMOTE_CONNECTION_FAILURE;
+      return REMOTE_CONNECTION_FAILURE_NAME;
     case ConnectionPool::PoolFailureReason::Timeout:
-      return TIMEOUT;
+      return TIMEOUT_NAME;
     case ConnectionPool::PoolFailureReason::Overflow:
-      return OVERFLOW;
+      return OVERFLOW_NAME;
     }
     PANIC_DUE_TO_CORRUPT_ENUM;
   }

--- a/source/extensions/filters/network/thrift_proxy/thrift.h
+++ b/source/extensions/filters/network/thrift_proxy/thrift.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/tcp/conn_pool.h"
+
 #include "source/common/common/assert.h"
 #include "source/common/singleton/const_singleton.h"
 
@@ -229,6 +231,32 @@ enum class AppExceptionType {
   ChecksumMismatch = 14,
   Interruption = 15,
 };
+
+/**
+ * Names of available reply types.
+ */
+class PoolFailureReasonNameValues {
+public:
+  const std::string OVERFLOW = "overflow";
+  const std::string LOCAL_CONNECTION_FAILURE = "local connection failure";
+  const std::string REMOTE_CONNECTION_FAILURE = "remote connection failure";
+  const std::string TIMEOUT = "timeout";
+
+  const std::string& fromReason(ConnectionPool::PoolFailureReason reason) const {
+    switch (reason) {
+    case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
+      return LOCAL_CONNECTION_FAILURE;
+    case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
+      return REMOTE_CONNECTION_FAILURE;
+    case ConnectionPool::PoolFailureReason::Timeout:
+      return TIMEOUT;
+    case ConnectionPool::PoolFailureReason::Overflow:
+      return OVERFLOW;
+    }
+    PANIC_DUE_TO_CORRUPT_ENUM;
+  }
+};
+using PoolFailureReasonNames = ConstSingleton<PoolFailureReasonNameValues>;
 
 } // namespace ThriftProxy
 } // namespace NetworkFilters

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -281,7 +281,7 @@ stat_prefix: test
     Buffer::OwnedImpl msg;
     ProtocolPtr proto =
         NamedProtocolConfigFactory::getFactory(ProtocolType::Binary).createProtocol();
-    MessageMetadata metadata;
+    MessageMetadata metadata(msg_type == MessageType::Call);
     metadata.setMethodName("name");
     metadata.setMessageType(msg_type);
     metadata.setSequenceId(seq_id);


### PR DESCRIPTION

Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>


Commit Message:

serviceA --> envoyA --> envoyB --> serviceB

When envoyB sends drain header to envoyA, envoyA will close its upstream connection.
However, the local connection failure event in envoyA triggers the downstream disconnection, which should be prevented.
Otherwise, serviceA could keep sending request which will be failed by connection error.

Upstream request keeps a state {request_complete,  response_started, draining, response_complete} and try not to 
close downstream connection if the response is complete or in draining stage.

Additional Description:
Risk Level: medium
Testing: new unit test
Docs Changes: current.yaml
Release Notes:
Platform Specific Features:
