### PR TITLE
protoprint: Cleanups/fixes

### DIFF
--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -70,9 +70,6 @@ pkg_tar(
 py_binary(
     name = "format_api",
     srcs = ["format_api.py"],
-    args = [
-        "--api_root=%s/api" % PATH,
-    ],
     data = ["//:.clang-format"],
     deps = [
         ":data",
@@ -85,12 +82,11 @@ genrule(
     outs = ["formatted_api.tar"],
     cmd = """
     $(location :format_api) \
-        --api_root=%s/api \
         --outfile=$@ \
         --xformed=$(location :xformed) \
         --protoprinted=$(location //tools/protoprint:protoprinted) \
-    """ % PATH,
-    tools = [
+    """,
+    exec_tools = [
         ":format_api",
         ":xformed",
         "//tools/protoprint:protoprinted",

--- a/tools/proto_format/format_api.py
+++ b/tools/proto_format/format_api.py
@@ -238,9 +238,7 @@ def sync_build_files(cmd, dst_root):
             f.write(build_contents)
 
 
-def format_api(api_root, mode, outfile, xformed, printed):
-    # this is currently assumed by protoprint
-    os.chdir(pathlib.Path(api_root).parent)
+def format_api(mode, outfile, xformed, printed):
 
     with tempfile.TemporaryDirectory() as tmp:
         dst_dir = pathlib.Path(tmp)
@@ -272,13 +270,6 @@ def format_api(api_root, mode, outfile, xformed, printed):
             sync_proto_file(v, k)
         sync_build_files(mode, dst_dir)
 
-        # These support files are handled manually.
-        for f in ['envoy/annotations/resource.proto', 'envoy/annotations/deprecation.proto',
-                  'envoy/annotations/BUILD']:
-            copy_dst_dir = pathlib.Path(dst_dir, os.path.dirname(f))
-            copy_dst_dir.mkdir(exist_ok=True, parents=True)
-            shutil.copy(str(pathlib.Path(api_root, f)), str(copy_dst_dir))
-
         shutil.rmtree(str(printed_dir))
         shutil.rmtree(str(xformed_dir))
         with tarfile.open(outfile, "w") as tar:
@@ -288,12 +279,11 @@ def format_api(api_root, mode, outfile, xformed, printed):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--mode', choices=['check', 'fix'])
-    parser.add_argument('--api_root', default='./api')
     parser.add_argument('--outfile')
     parser.add_argument('--protoprinted')
     parser.add_argument('--xformed')
     args = parser.parse_args()
 
     format_api(
-        args.api_root, args.mode, str(pathlib.Path(args.outfile).absolute()),
+        args.mode, str(pathlib.Path(args.outfile).absolute()),
         str(pathlib.Path(args.xformed).absolute()), args.protoprinted)

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -3,6 +3,7 @@
 # Diff or copy pretty-printed artifacts to the source tree.
 
 import argparse
+import os
 import pathlib
 import shutil
 import subprocess
@@ -52,6 +53,13 @@ def sync(api_root, formatted, mode, is_ci):
         dst_dir = tmp_path.joinpath("b")
         with tarfile.open(formatted) as tar:
             tar.extractall(dst_dir)
+
+        # These support files are handled manually.
+        for f in ['envoy/annotations/resource.proto', 'envoy/annotations/deprecation.proto',
+                  'envoy/annotations/BUILD']:
+            copy_dst_dir = pathlib.Path(dst_dir, os.path.dirname(f))
+            copy_dst_dir.mkdir(exist_ok=True, parents=True)
+            shutil.copy(str(pathlib.Path(api_root, f)), str(copy_dst_dir))
 
         diff = subprocess.run(['diff', '-Npur', "a", "b"], cwd=tmp, stdout=subprocess.PIPE).stdout
 

--- a/tools/protoprint/BUILD
+++ b/tools/protoprint/BUILD
@@ -26,7 +26,6 @@ py_binary(
         requirement("packaging"),
         "//tools/type_whisperer",
         "//tools/type_whisperer:api_type_db_proto_py_proto",
-        "@bazel_tools//tools/python/runfiles",
         "@com_envoyproxy_protoc_gen_validate//validate:validate_py",
         "@com_github_cncf_udpa//udpa/annotations:pkg_py_proto",
         "@com_github_cncf_udpa//xds/annotations/v3:pkg_py_proto",
@@ -38,7 +37,10 @@ py_binary(
 
 protoprint_rule(
     name = "protoprinted_srcs",
-    deps = ["//tools/protoxform:api_protoxform"],
+    deps = [
+        "@envoy_api//versioning:active_protos",
+        "@envoy_api//versioning:frozen_protos",
+    ],
 )
 
 pkg_files(

--- a/tools/protoprint/protoprint.bzl
+++ b/tools/protoprint/protoprint.bzl
@@ -20,6 +20,7 @@ protoprint_aspect = api_proto_plugin_aspect(
     "//tools/protoprint",
     _protoprint_impl,
     use_type_db = True,
+    extra_inputs = ["//:.clang-format"],
 )
 
 def _protoprint_rule_impl(ctx):
@@ -28,7 +29,6 @@ def _protoprint_rule_impl(ctx):
         for path in dep[OutputGroupInfo].pproto.to_list():
             envoy_api = (
                 path.short_path.startswith("../envoy_api") or
-                # path.short_path.startswith("../com_github_cncf_udpa") or
                 path.short_path.startswith("tools/testdata")
             )
             if envoy_api:


### PR DESCRIPTION
- dont wait on protoxform
- improve handling of pybin args
- add `extra_inputs` to `api_proto_plugin`
- remove runfiles from `protoprint` (and sys.path hack)

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
