### PR TITLE
api_proto_plugin: Add `protoshared` aspect

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -11,6 +11,8 @@ load(
     "EXTERNAL_PROTO_PY_BAZEL_DEP_MAP",
 )
 
+EnvoyProtoDepsInfo = provider(fields = ["deps"])
+
 _PY_PROTO_SUFFIX = "_py_proto"
 _CC_PROTO_SUFFIX = "_cc_proto"
 _CC_GRPC_SUFFIX = "_cc_grpc"

--- a/tools/protoshared/BUILD
+++ b/tools/protoshared/BUILD
@@ -1,0 +1,18 @@
+load(":protoshared.bzl", "protoshared_descriptor_set", "protoshared_rule")
+
+licenses(["notice"])  # Apache 2
+
+protoshared_rule(
+    name = "shared_protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@envoy_api//versioning:active_protos",
+        "@envoy_api//versioning:frozen_protos",
+    ],
+)
+
+protoshared_descriptor_set(
+    name = "protoshared",
+    shared = ":shared_protos",
+    visibility = ["//visibility:public"],
+)

--- a/tools/protoshared/protoshared.bzl
+++ b/tools/protoshared/protoshared.bzl
@@ -1,0 +1,86 @@
+load("@envoy_api//bazel:api_build_system.bzl", "EnvoyProtoDepsInfo")
+
+MNEMONIC = "ProtoShared"
+
+def _protoshared_aspect_impl(target, ctx):
+    descriptors = []
+    for dep in ctx.rule.attr.deps:
+        ws = dep.label.workspace_name
+        if ws and ws != "envoy_api":
+            continue
+        for transitive in dep[ProtoInfo].transitive_descriptor_sets.to_list():
+            if dep.label != transitive.owner:
+                descriptors.append(transitive)
+    return [OutputGroupInfo(transitive = descriptors)]
+
+# Cycle through deps finding their deps and collecting descriptors for them.
+protoshared_aspect = aspect(
+    implementation = _protoshared_aspect_impl,
+    attr_aspects = ["deps"],
+)
+
+def _protoshared_rule_impl(ctx):
+    deps = {}
+    transitive = []
+
+    for dep in ctx.attr.deps:
+        for t in dep[OutputGroupInfo].transitive.to_list():
+            deps[str(t.owner)] = True
+            transitive.append(t)
+    return [
+        OutputGroupInfo(transitive = depset(transitive)),
+        EnvoyProtoDepsInfo(deps = deps.keys()),
+    ]
+
+protoshared_rule = rule(
+    implementation = _protoshared_rule_impl,
+    attrs = {
+        "deps": attr.label_list(aspects = [protoshared_aspect]),
+    },
+)
+
+def _protoshared_descriptor_set_impl(ctx):
+    args = ctx.actions.args()
+    transitive = []
+
+    for source in ctx.attr.shared[OutputGroupInfo].transitive.to_list():
+        ws_name = source.owner.workspace_name
+        if ws_name and ws_name != "envoy_api":
+            transitive.append(source)
+        elif str(source.owner) in ctx.attr.shared[EnvoyProtoDepsInfo].deps:
+            transitive.append(source)
+
+    output = ctx.actions.declare_file("%s.pb" % ctx.attr.name)
+    args.add(output)
+    args.add_all(transitive)
+
+    ctx.actions.run(
+        executable = ctx.executable._file_concat,
+        mnemonic = MNEMONIC,
+        inputs = transitive,
+        outputs = [output],
+        arguments = [args],
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output]),
+            runfiles = ctx.runfiles(files = [output]),
+        ),
+    ]
+
+protoshared_descriptor_set = rule(
+    implementation = _protoshared_descriptor_set_impl,
+    attrs = {
+        "shared": attr.label(providers = [EnvoyProtoDepsInfo]),
+        "_file_concat": attr.label(
+            default = "@rules_proto//tools/file_concat",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = """
+Collects all `FileDescriptorSet`s from the `deps` of `deps` and combines them
+into a single `FileDescriptorSet` containing all the `FileDescriptorProto`.
+""".strip(),
+)


### PR DESCRIPTION
This cycles proto deps and creates a descriptor file from them - but only for dependencies, not targets - thereby creating a descriptor of all envoy's proto deps.

This will allow other proto plugins to call protoc with the descriptor
file and just their `direct_sources` and not all of the `transitive_sources`

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
