### PR TITLE
protodoc: Use (more) templates for api build

### DIFF
--- a/tools/protodoc/BUILD
+++ b/tools/protodoc/BUILD
@@ -1,5 +1,5 @@
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@base_pip3//:requirements.bzl", "requirement")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/protodoc:protodoc.bzl", "protodoc_rule")
@@ -13,7 +13,10 @@ py_binary(
     name = "generate_empty",
     srcs = ["generate_empty.py"],
     visibility = ["//visibility:public"],
-    deps = [":protodoc"],
+    deps = [
+        ":jinja",
+        ":protodoc",
+    ],
 )
 
 py_proto_library(
@@ -128,16 +131,26 @@ py_library(
 
 envoy_jinja_env(
     name = "jinja",
+    env_kwargs = {
+        "trim_blocks": True,
+        "lstrip_blocks": True,
+    },
     filters = {
         "rst_anchor": "tools.protodoc.rst_filters.rst_anchor",
         "rst_header": "tools.protodoc.rst_filters.rst_header",
     },
     templates = [
+        "templates/comment.rst.tpl",
+        "templates/content.rst.tpl",
+        "templates/contrib_message.rst.tpl",
         "templates/empty.rst.tpl",
+        "templates/enum.rst.tpl",
         "templates/extension.rst.tpl",
         "templates/extension_category.rst.tpl",
+        "templates/file.rst.tpl",
+        "templates/header.rst.tpl",
+        "templates/message.rst.tpl",
+        "templates/security.rst.tpl",
     ],
-    deps = [
-        ":rst_filters",
-    ],
+    deps = [":rst_filters"],
 )

--- a/tools/protodoc/generate_empty.py
+++ b/tools/protodoc/generate_empty.py
@@ -7,11 +7,11 @@ import pathlib
 import sys
 import tarfile
 
-import protodoc as protodoc
+import protodoc as _protodoc
 from tools.protodoc.jinja import env as jinja_env
 
 
-def generate_empty_extension_docs(extension, details, api_extensions_root):
+def generate_empty_extension_docs(protodoc, extension, details, api_extensions_root):
     extension_root = pathlib.Path(details['path'])
     path = pathlib.Path(api_extensions_root, extension_root, 'empty', extension_root.name + '.rst')
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -19,13 +19,13 @@ def generate_empty_extension_docs(extension, details, api_extensions_root):
     reflink = ''
     if 'ref' in details:
         reflink = '%s %s.' % (
-            details['title'], protodoc.format_internal_link(
-                'configuration overview', details['ref']))
+            details['title'],
+            _protodoc.format_internal_link('configuration overview', details['ref']))
     content = jinja_env.get_template("empty.rst.tpl").render(
         header=details['title'],
         description=description,
         reflink=reflink,
-        extension=protodoc.format_extension(extension))
+        extension=protodoc._extension(extension))
     path.write_text(content)
 
 
@@ -36,8 +36,9 @@ def main():
     api_extensions_root = os.path.join(generated_rst_dir, "api-v3/config")
 
     empty_extensions = json.loads(pathlib.Path(empty_extensions_path).read_text())
+    protodoc = _protodoc.RstFormatVisitor()
     for extension, details in empty_extensions.items():
-        generate_empty_extension_docs(extension, details, api_extensions_root)
+        generate_empty_extension_docs(protodoc, extension, details, api_extensions_root)
 
     with tarfile.open(output_filename, "w:gz") as tar:
         tar.add(generated_rst_dir, arcname=".")

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -4,35 +4,26 @@
 # https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html for Sphinx RST syntax.
 
 import logging
-import functools
 import sys
 from collections import defaultdict
-from functools import cached_property
+from functools import cached_property, lru_cache
+from typing import Dict, Iterable, Iterator, Set, Tuple
 
+from google.protobuf.descriptor_pb2 import FieldDescriptorProto as field_proto
 import yaml
-
-from envoy.code.check.checker import BackticksCheck
-
-from tools.api_proto_plugin import annotations, constants
-from tools.api_proto_plugin import plugin
-from tools.api_proto_plugin import visitor
-from tools.protodoc.data import data
-from tools.protodoc.jinja import env as jinja_env
 
 from udpa.annotations import security_pb2
 from udpa.annotations import status_pb2 as udpa_status_pb2
 from validate import validate_pb2
 from xds.annotations.v3 import status_pb2 as xds_status_pb2
 
-logger = logging.getLogger(__name__)
+from envoy.code.check.checker import BackticksCheck
 
-manifest_db = data["manifest"]
-EXTENSION_DB = data["extensions"]
-CONTRIB_EXTENSION_DB = data["contrib_extensions"]
-EXTENSION_CATEGORIES = data["extension_categories"]
-CONTRIB_EXTENSION_CATEGORIES = data["contrib_extension_categories"]
-EXTENSION_SECURITY_POSTURES = data["extension_security_postures"]
-EXTENSION_STATUS_VALUES = data["extension_status_values"]
+from tools.api_proto_plugin import annotations, constants, plugin, visitor
+from tools.protodoc import jinja
+from tools.protodoc.data import data
+
+logger = logging.getLogger(__name__)
 
 WIP_WARNING = (
     '.. warning::\n   This API feature is currently work-in-progress. API features marked as '
@@ -44,11 +35,6 @@ WIP_WARNING = (
 
 class ProtodocError(Exception):
     """Base error class for the protodoc module."""
-
-
-def hide_not_implemented(comment):
-    """Should a given type_context.Comment be hidden because it is tagged as [#not-implemented-hide:]?"""
-    return annotations.NOT_IMPLEMENTED_HIDE_ANNOTATION in comment.annotations
 
 
 def github_url(text, type_context):
@@ -68,206 +54,29 @@ def github_url(text, type_context):
     return f":repo:`{text} <api/{type_context.source_code_info.name}#L{type_context.location.span[0]}>`"
 
 
-def format_comment_with_annotations(comment, show_wip_warning=False):
-    """Format a comment string with additional RST for annotations.
-
-    Args:
-        comment: comment string.
-        show_wip_warning: whether to show the work in progress warning.
-
-    Returns:
-        A string with additional RST from annotations.
-    """
-    wip_warning = ''
-    if show_wip_warning:
-        wip_warning = WIP_WARNING
-
-    formatted_extension = ''
-    if annotations.EXTENSION_ANNOTATION in comment.annotations:
-        extension = comment.annotations[annotations.EXTENSION_ANNOTATION]
-        formatted_extension = format_extension(extension)
-    formatted_extension_category = ''
-    if annotations.EXTENSION_CATEGORY_ANNOTATION in comment.annotations:
-        for category in comment.annotations[annotations.EXTENSION_CATEGORY_ANNOTATION].split(","):
-            formatted_extension_category += format_extension_category(category)
-    comment = annotations.without_annotations(comment.raw + '\n')
-    return comment + wip_warning + formatted_extension + formatted_extension_category
-
-
-def map_lines(f, s):
-    """Apply a function across each line in a flat string.
-
-    Args:
-        f: A string transform function for a line.
-        s: A string consisting of potentially multiple lines.
-
-    Returns:
-        A flat string with f applied to each line.
-    """
-    return '\n'.join(f(line) for line in s.split('\n'))
-
-
-def indent(spaces, line):
-    """Indent a string."""
-    return ' ' * spaces + line
-
-
-def indent_lines(spaces, lines):
-    """Indent a list of strings."""
-    return map(functools.partial(indent, spaces), lines)
-
-
+@lru_cache
 def format_internal_link(text, ref):
     return ':ref:`%s <%s>`' % (text, ref)
 
 
+@lru_cache
 def format_external_link(text, ref):
     return '`%s <%s>`_' % (text, ref)
 
 
-def format_header(style, text, is_file=False):
+def rst_anchor(label):
+    """Format a label as an Envoy API RST anchor."""
+    return f".. _{label}:\n\n"
+
+
+def rst_header(text, style=None):
     """Format RST header.
-
-    Args:
-        style: underline style, e.g. '=', '-'.
-        text: header text
-
-    Returns:
-        RST formatted header.
     """
-    if is_file:
-        text = f"{text} (proto)"
-    return '%s\n%s\n\n' % (text, style * len(text))
+    style = style or "-"
+    return f"{text}\n{style * len(text)}\n\n"
 
 
-def format_extension(extension):
-    """Format extension metadata as RST.
-
-    Args:
-        extension: the name of the extension, e.g. com.acme.foo.
-
-    Returns:
-        RST formatted extension description.
-    """
-    try:
-        extension_metadata = EXTENSION_DB.get(extension, None)
-        contrib = ''
-        if extension_metadata is None:
-            extension_metadata = CONTRIB_EXTENSION_DB[extension]
-            contrib = """
-
-.. note::
-  This extension is only available in :ref:`contrib <install_contrib>` images.
-
-"""
-        status = (EXTENSION_STATUS_VALUES.get(extension_metadata.get('status')) or "").strip()
-        security_posture = EXTENSION_SECURITY_POSTURES[
-            extension_metadata['security_posture']].strip()
-        categories = extension_metadata["categories"]
-        type_urls = extension_metadata.get('type_urls') or []
-    except KeyError as e:
-        sys.stderr.write(
-            f"\n\nDid you forget to add '{extension}' to extensions_build_config.bzl, "
-            "extensions_metadata.yaml, contrib_build_config.bzl, "
-            "or contrib/extensions_metadata.yaml?\n\n")
-        exit(1)  # Raising the error buries the above message in tracebacks.
-
-    extension = jinja_env.get_template("extension.rst.tpl").render(
-        extension=extension,
-        contrib=contrib,
-        status=status,
-        security_posture=security_posture,
-        categories=categories,
-        type_urls=type_urls)
-    return f"\n{extension}\n"
-
-
-def format_extension_category(extension_category):
-    """Format extension metadata as RST.
-
-    Args:
-        extension_category: the name of the extension_category, e.g. com.acme.
-
-    Returns:
-        RST formatted extension category description.
-    """
-    extensions = EXTENSION_CATEGORIES.get(extension_category, [])
-    contrib_extensions = CONTRIB_EXTENSION_CATEGORIES.get(extension_category, [])
-    if not extensions and not contrib_extensions:
-        raise ProtodocError(f"\n\nUnable to find extension category:  {extension_category}\n\n")
-    extension_category = jinja_env.get_template("extension_category.rst.tpl").render(
-        category=extension_category,
-        extensions=sorted(extensions),
-        contrib_extensions=sorted(contrib_extensions))
-    return f"\n{extension_category}\n"
-
-
-def format_header_from_file(style, source_code_info, proto_name):
-    """Format RST header based on special file level title
-
-    Args:
-        style: underline style, e.g. '=', '-'.
-        source_code_info: SourceCodeInfo object.
-        proto_name: If the file_level_comment does not contain a user specified
-           title, use this as page title.
-
-    Returns:
-        RST formatted header, and file level comment without page title strings.
-    """
-    anchor = format_anchor(file_cross_ref_label(proto_name))
-    stripped_comment = annotations.without_annotations(
-        '\n'.join(c + '\n' for c in source_code_info.file_level_comments))
-    formatted_extension = ''
-    if annotations.EXTENSION_ANNOTATION in source_code_info.file_level_annotations:
-        extension = source_code_info.file_level_annotations[annotations.EXTENSION_ANNOTATION]
-        formatted_extension = format_extension(extension)
-    if annotations.DOC_TITLE_ANNOTATION in source_code_info.file_level_annotations:
-        return anchor + format_header(
-            style, source_code_info.file_level_annotations[annotations.DOC_TITLE_ANNOTATION],
-            True) + "\n\n" + formatted_extension, stripped_comment
-    return anchor + format_header(
-        style, proto_name, True) + "\n\n" + formatted_extension, stripped_comment
-
-
-def format_field_type_as_json(type_context, field):
-    """Format FieldDescriptorProto.Type as a pseudo-JSON string.
-
-    Args:
-        type_context: contextual information for message/enum/field.
-        field: FieldDescriptor proto.
-    Return: RST formatted pseudo-JSON string representation of field type.
-    """
-    if type_name_from_fqn(field.type_name) in type_context.map_typenames:
-        return "{...}"
-    if field.label == field.LABEL_REPEATED:
-        return "[]"
-    if field.type == field.TYPE_MESSAGE:
-        return "{...}"
-    return "..."
-
-
-def format_message_as_json(type_context, msg):
-    """Format a message definition DescriptorProto as a pseudo-JSON block.
-
-    Args:
-        type_context: contextual information for message/enum/field.
-        msg: message definition DescriptorProto.
-    Return: RST formatted pseudo-JSON string representation of message definition.
-    """
-    lines = []
-    for index, field in enumerate(msg.field):
-        field_type_context = type_context.extend_field(index, field.name)
-        leading_comment = field_type_context.leading_comment
-        if hide_not_implemented(leading_comment):
-            continue
-        lines.append('"%s": %s' % (field.name, format_field_type_as_json(type_context, field)))
-
-    if lines:
-        return '.. code-block:: json\n  :force:\n\n  {\n' + ',\n'.join(
-            indent_lines(4, lines)) + '\n  }\n\n'
-    return ""
-
-
+@lru_cache
 def normalize_field_type_name(field_fqn):
     """Normalize a fully qualified field type name, e.g.
 
@@ -297,62 +106,11 @@ def normalize_type_context_name(type_name):
         type_name: a name from a TypeContext.
     Return: Normalized type name.
     """
-    return normalize_field_type_name(qualify_type_name(type_name))
-
-
-def qualify_type_name(type_name):
-    return '.' + type_name
+    return normalize_field_type_name(f".{type_name}")
 
 
 def type_name_from_fqn(fqn):
     return fqn[1:]
-
-
-def format_field_type(type_context, field):
-    """Format a FieldDescriptorProto type description.
-
-    Adds cross-refs for message types.
-    TODO(htuch): Add cross-refs for enums as well.
-
-    Args:
-        type_context: contextual information for message/enum/field.
-        field: FieldDescriptor proto.
-    Return: RST formatted field type.
-    """
-    envoy_proto = (
-        field.type_name.startswith(constants.ENVOY_API_NAMESPACE_PREFIX)
-        or field.type_name.startswith(constants.ENVOY_PREFIX)
-        or field.type_name.startswith(constants.CNCF_PREFIX))
-    if envoy_proto:
-        type_name = normalize_field_type_name(field.type_name)
-        if field.type == field.TYPE_MESSAGE:
-            if type_context.map_typenames and type_name_from_fqn(
-                    field.type_name) in type_context.map_typenames:
-                return 'map<%s, %s>' % tuple(
-                    map(
-                        functools.partial(format_field_type, type_context),
-                        type_context.map_typenames[type_name_from_fqn(field.type_name)]))
-            return format_internal_link(type_name, message_cross_ref_label(type_name))
-        if field.type == field.TYPE_ENUM:
-            return format_internal_link(type_name, enum_cross_ref_label(type_name))
-    elif field.type_name.startswith(constants.WKT_NAMESPACE_PREFIX):
-        wkt = field.type_name[len(constants.WKT_NAMESPACE_PREFIX):]
-        return format_external_link(
-            wkt, 'https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#%s'
-            % wkt.lower())
-    elif field.type_name.startswith(constants.RPC_NAMESPACE_PREFIX):
-        rpc = field.type_name[len(constants.RPC_NAMESPACE_PREFIX):]
-        return format_external_link(
-            rpc, 'https://cloud.google.com/natural-language/docs/reference/rpc/google.rpc#%s'
-            % rpc.lower())
-    elif field.type_name:
-        return field.type_name
-
-    if field.type in constants.FIELD_TYPE_NAMES:
-        return format_external_link(
-            constants.FIELD_TYPE_NAMES[field.type],
-            'https://developers.google.com/protocol-buffers/docs/proto#scalar')
-    raise ProtodocError('Unknown field type ' + str(field.type))
 
 
 def file_cross_ref_label(msg_name):
@@ -375,285 +133,442 @@ def field_cross_ref_label(field_name):
     return 'envoy_v3_api_field_%s' % field_name
 
 
-def enum_value_cross_ref_label(enum_value_name):
-    """Enum value cross reference label."""
-    return 'envoy_v3_api_enum_value_%s' % enum_value_name
-
-
-def format_anchor(label):
-    """Format a label as an Envoy API RST anchor."""
-    return '.. _%s:\n\n' % label
-
-
-def format_security_options(security_option, field, type_context, edge_config):
-    sections = []
-
-    if security_option.configure_for_untrusted_downstream:
-        sections.append(
-            indent(
-                4, 'This field should be configured in the presence of untrusted *downstreams*.'))
-    if security_option.configure_for_untrusted_upstream:
-        sections.append(
-            indent(4, 'This field should be configured in the presence of untrusted *upstreams*.'))
-    if edge_config["note"]:
-        sections.append(indent(4, edge_config["note"].strip()))
-
-    example_dict = edge_config["example"]
-    field_name = type_context.name.split('.')[-1]
-    example = {field_name: example_dict}
-    sections.append(
-        indent(4, 'Example configuration for untrusted environments:\n\n')
-        + indent(4, '.. code-block:: yaml\n\n')
-        + '\n'.join(indent_lines(6,
-                                 yaml.dump(example).split('\n'))))
-
-    return '.. attention::\n' + '\n\n'.join(sections)
-
-
-def format_field_as_definition_list_item(
-        outer_type_context, type_context, field, protodoc_manifest):
-    """Format a FieldDescriptorProto as RST definition list item.
-
-    Args:
-        outer_type_context: contextual information for enclosing message.
-        type_context: contextual information for message/enum/field.
-        field: FieldDescriptorProto.
-        protodoc_manifest: tools.protodoc.Manifest for proto.
-
-    Returns:
-        RST formatted definition list item.
-    """
-    field_annotations = []
-
-    anchor = format_anchor(field_cross_ref_label(normalize_type_context_name(type_context.name)))
-    if field.options.HasExtension(validate_pb2.rules):
-        rule = field.options.Extensions[validate_pb2.rules]
-        if ((rule.HasField('message') and rule.message.required)
-                or (rule.HasField('duration') and rule.duration.required)
-                or (rule.HasField('string') and rule.string.min_len > 0)
-                or (rule.HasField('string') and rule.string.min_bytes > 0)
-                or (rule.HasField('repeated') and rule.repeated.min_items > 0)):
-            field_annotations = ['*REQUIRED*']
-    leading_comment = type_context.leading_comment
-    formatted_leading_comment = format_comment_with_annotations(
-        leading_comment,
-        field.options.HasExtension(xds_status_pb2.field_status)
-        and field.options.Extensions[xds_status_pb2.field_status].work_in_progress)
-    if hide_not_implemented(leading_comment):
-        return ''
-
-    if field.HasField('oneof_index'):
-        oneof_context = outer_type_context.extend_oneof(
-            field.oneof_index, type_context.oneof_names[field.oneof_index])
-        oneof_comment = oneof_context.leading_comment
-        formatted_oneof_comment = format_comment_with_annotations(oneof_comment)
-        if hide_not_implemented(oneof_comment):
-            return ''
-
-        # If the oneof only has one field and marked required, mark the field as required.
-        if len(type_context.oneof_fields[field.oneof_index]) == 1 and type_context.oneof_required[
-                field.oneof_index]:
-            field_annotations = ['*REQUIRED*']
-
-        if len(type_context.oneof_fields[field.oneof_index]) > 1:
-            # Fields in oneof shouldn't be marked as required when we have oneof comment below it.
-            field_annotations = []
-            oneof_template = '\nPrecisely one of %s must be set.\n' if type_context.oneof_required[
-                field.oneof_index] else '\nOnly one of %s may be set.\n'
-            formatted_oneof_comment += oneof_template % ', '.join(
-                format_internal_link(
-                    f,
-                    field_cross_ref_label(
-                        normalize_type_context_name(outer_type_context.extend_field(i, f).name)))
-                for i, f in type_context.oneof_fields[field.oneof_index])
-    else:
-        formatted_oneof_comment = ''
-
-    # If there is a udpa.annotations.security option, include it after the comment.
-    if field.options.HasExtension(security_pb2.security):
-        manifest_description = protodoc_manifest.get(type_context.name)
-        if not manifest_description:
-            raise ProtodocError('Missing protodoc manifest YAML for %s' % type_context.name)
-        formatted_security_options = format_security_options(
-            field.options.Extensions[security_pb2.security], field, type_context,
-            manifest_description)
-    else:
-        formatted_security_options = ''
-    comment = '(%s) ' % ', '.join(
-        [constants.FIELD_LABEL_NAMES[field.label] + format_field_type(type_context, field)]
-        + field_annotations) + formatted_leading_comment
-    return anchor + field.name + '\n' + map_lines(
-        functools.partial(indent, 2),
-        comment + formatted_oneof_comment) + formatted_security_options
-
-
-def format_message_as_definition_list(type_context, msg, protodoc_manifest):
-    """Format a DescriptorProto as RST definition list.
-
-    Args:
-        type_context: contextual information for message/enum/field.
-        msg: DescriptorProto.
-        protodoc_manifest: tools.protodoc.Manifest for proto.
-
-    Returns:
-        RST formatted definition list item.
-    """
-    type_context.oneof_fields = defaultdict(list)
-    type_context.oneof_required = defaultdict(bool)
-    type_context.oneof_names = defaultdict(list)
-    for index, field in enumerate(msg.field):
-        if field.HasField('oneof_index'):
-            leading_comment = type_context.extend_field(index, field.name).leading_comment
-            if hide_not_implemented(leading_comment):
-                continue
-            type_context.oneof_fields[field.oneof_index].append((index, field.name))
-    for index, oneof_decl in enumerate(msg.oneof_decl):
-        if oneof_decl.options.HasExtension(validate_pb2.required):
-            type_context.oneof_required[index] = oneof_decl.options.Extensions[
-                validate_pb2.required]
-        type_context.oneof_names[index] = oneof_decl.name
-    return '\n'.join(
-        format_field_as_definition_list_item(
-            type_context, type_context.extend_field(index, field.name), field, protodoc_manifest)
-        for index, field in enumerate(msg.field)) + '\n'
-
-
-def format_enum_value_as_definition_list_item(type_context, enum_value):
-    """Format a EnumValueDescriptorProto as RST definition list item.
-
-    Args:
-        type_context: contextual information for message/enum/field.
-        enum_value: EnumValueDescriptorProto.
-
-    Returns:
-        RST formatted definition list item.
-    """
-    anchor = format_anchor(
-        enum_value_cross_ref_label(normalize_type_context_name(type_context.name)))
-    default_comment = '*(DEFAULT)* ' if enum_value.number == 0 else ''
-    leading_comment = type_context.leading_comment
-    formatted_leading_comment = format_comment_with_annotations(leading_comment)
-    if hide_not_implemented(leading_comment):
-        return ''
-    comment = default_comment + constants.UNICODE_INVISIBLE_SEPARATOR + formatted_leading_comment
-    return anchor + enum_value.name + '\n' + map_lines(functools.partial(indent, 2), comment)
-
-
-def format_enum_as_definition_list(type_context, enum):
-    """Format a EnumDescriptorProto as RST definition list.
-
-    Args:
-        type_context: contextual information for message/enum/field.
-        enum: DescriptorProto.
-
-    Returns:
-        RST formatted definition list item.
-    """
-    return '\n'.join(
-        format_enum_value_as_definition_list_item(
-            type_context.extend_enum_value(index, enum_value.name), enum_value)
-        for index, enum_value in enumerate(enum.value)) + '\n'
-
-
-def format_proto_as_block_comment(proto):
-    """Format a proto as a RST block comment.
-
-    Useful in debugging, not usually referenced.
-    """
-    return '\n\nproto::\n\n' + map_lines(functools.partial(indent, 2), str(proto)) + '\n'
-
-
 class RstFormatVisitor(visitor.Visitor):
     """Visitor to generate a RST representation from a FileDescriptor proto.
 
     See visitor.Visitor for visitor method docs comments.
     """
 
-    def __init__(self):
-        self.protodoc_manifest = manifest_db
-
     @cached_property
-    def backticks_check(self):
+    def backticks_check(self) -> BackticksCheck:
         return BackticksCheck()
 
-    def visit_enum(self, enum_proto, type_context):
-        normal_enum_type = normalize_type_context_name(type_context.name)
-        anchor = format_anchor(enum_cross_ref_label(normal_enum_type))
-        header = format_header('-', 'Enum %s' % normal_enum_type)
-        proto_link = github_url(f"[{normal_enum_type} proto]", type_context) + '\n\n'
-        leading_comment = type_context.leading_comment
-        formatted_leading_comment = format_comment_with_annotations(leading_comment)
-        if hide_not_implemented(leading_comment):
-            return ''
-        return anchor + header + proto_link + formatted_leading_comment + format_enum_as_definition_list(
-            type_context, enum_proto)
+    @property
+    def contrib_extension_category_data(self):
+        return data["contrib_extension_categories"]
 
-    def visit_message(self, msg_proto, type_context, nested_msgs, nested_enums):
-        # Skip messages synthesized to represent map types.
-        if msg_proto.options.map_entry:
-            return ''
-        normal_msg_type = normalize_type_context_name(type_context.name)
-        anchor = format_anchor(message_cross_ref_label(normal_msg_type))
-        header = format_header('-', normal_msg_type)
-        proto_link = github_url(f"[{normal_msg_type} proto]", type_context) + '\n\n'
-        leading_comment = type_context.leading_comment
-        formatted_leading_comment = format_comment_with_annotations(
-            leading_comment,
-            msg_proto.options.HasExtension(xds_status_pb2.message_status)
-            and msg_proto.options.Extensions[xds_status_pb2.message_status].work_in_progress)
-        if hide_not_implemented(leading_comment):
-            return ''
+    @property
+    def contrib_extension_db(self):
+        return data["contrib_extensions"]
 
-        message = anchor + header + proto_link + formatted_leading_comment + format_message_as_json(
-            type_context, msg_proto) + format_message_as_definition_list(
-                type_context, msg_proto,
-                self.protodoc_manifest) + '\n'.join(nested_msgs) + '\n' + '\n'.join(nested_enums)
-        error = self.backticks_check(message)
-        if error:
-            logger.warning(f"Bad RST ({msg_proto.name}): {error}")
-        return message
+    @cached_property
+    def envoy_prefixes(self) -> Set[str]:
+        return set(
+            [constants.ENVOY_PREFIX, constants.ENVOY_API_NAMESPACE_PREFIX, constants.CNCF_PREFIX])
 
-    def visit_file(self, file_proto, type_context, services, msgs, enums):
+    @property
+    def extension_category_data(self):
+        return data["extension_categories"]
+
+    @property
+    def extension_db(self):
+        return data["extensions"]
+
+    @property
+    def extension_security_postures(self):
+        return data["extension_security_postures"]
+
+    @property
+    def extension_status_values(self):
+        return data["extension_status_values"]
+
+    @cached_property
+    def jinja_env(self):
+        return jinja.env
+
+    @cached_property
+    def protodoc_manifest(self) -> Dict:
+        return data["manifest"]
+
+    @property
+    def tpl_comment(self):
+        return self.jinja_env.get_template("comment.rst.tpl")
+
+    @property
+    def tpl_content(self):
+        return self.jinja_env.get_template("content.rst.tpl")
+
+    @property
+    def tpl_contrib_message(self):
+        return self.jinja_env.get_template("contrib_message.rst.tpl")
+
+    @property
+    def tpl_enum(self):
+        return self.jinja_env.get_template("enum.rst.tpl")
+
+    @property
+    def tpl_extension(self):
+        return self.jinja_env.get_template("extension.rst.tpl")
+
+    @property
+    def tpl_extension_category(self):
+        return self.jinja_env.get_template("extension_category.rst.tpl")
+
+    @property
+    def tpl_file(self):
+        return self.jinja_env.get_template("file.rst.tpl")
+
+    @property
+    def tpl_header(self):
+        return self.jinja_env.get_template("header.rst.tpl")
+
+    @property
+    def tpl_message(self):
+        return self.jinja_env.get_template("message.rst.tpl")
+
+    @property
+    def tpl_security(self):
+        return self.jinja_env.get_template("security.rst.tpl")
+
+    def visit_enum(self, enum_proto, ctx) -> str:
+        if self._hide(ctx.leading_comment.annotations):
+            return ''
+        name = normalize_type_context_name(ctx.name)
+        return self.tpl_content.render(
+            header=self.tpl_header.render(
+                anchor=enum_cross_ref_label(name),
+                title=f"Enum {name}",
+                proto_link=github_url(f"[{name} proto]", ctx),
+                comment=self._comment(ctx.leading_comment)),
+            body=self.tpl_enum.render(enum_items=self._enums(ctx, enum_proto)))
+
+    def visit_file(self, file_proto, ctx, services, msgs, enums) -> str:
         # If there is a file-level 'not-implemented-hide' annotation then return empty string.
-        if (annotations.NOT_IMPLEMENTED_HIDE_ANNOTATION
-                in type_context.source_code_info.file_level_annotations):
+        if self._hide(ctx.source_code_info.file_level_annotations):
             return ''
-
-        has_messages = True
-        if all(len(msg) == 0 for msg in msgs) and all(len(enum) == 0 for enum in enums):
-            has_messages = False
-
-        # TODO(mattklein123): The logic in both the doc and transform tool around files without messages
-        # is confusing and should be cleaned up. This is a stop gap to have titles for all proto docs
-        # in the common case.
-        if (has_messages and not annotations.DOC_TITLE_ANNOTATION
-                in type_context.source_code_info.file_level_annotations
-                and file_proto.name.startswith('envoy')):
+        body = self.tpl_file.render(msgs=msgs, enums=enums)
+        has_messages = bool(body.strip())
+        if self._missing_title(has_messages, file_proto, ctx):
             raise ProtodocError(
                 'Envoy API proto file missing [#protodoc-title:] annotation: {}'.format(
                     file_proto.name))
-
         # Find the earliest detached comment, attribute it to file level.
         # Also extract file level titles if any.
-        header, comment = format_header_from_file(
-            '=', type_context.source_code_info, file_proto.name)
+        return self.tpl_content.render(
+            header=self._header_from_file(ctx.source_code_info, file_proto, has_messages),
+            body=body)
 
-        # If there are no messages, we don't include in the doc tree (no support for
-        # service rendering yet). We allow these files to be missing from the
-        # toctrees.
-        if not has_messages:
-            header = ':orphan:\n\n' + header
-        warnings = ''
-        added_wip_warning = False
-        if file_proto.options.HasExtension(udpa_status_pb2.file_status):
-            if file_proto.options.Extensions[udpa_status_pb2.file_status].work_in_progress:
-                added_wip_warning = True
-                warnings += WIP_WARNING
-        if not added_wip_warning and file_proto.options.HasExtension(xds_status_pb2.file_status):
-            if file_proto.options.Extensions[xds_status_pb2.file_status].work_in_progress:
-                warnings += WIP_WARNING
-        # debug_proto = format_proto_as_block_comment(file_proto)
-        return header + warnings + comment + '\n'.join(msgs) + '\n'.join(enums)  # + debug_proto
+    def visit_message(self, msg_proto, ctx, nested_msgs: Iterable, nested_enums: Iterable) -> str:
+        # Skip messages synthesized to represent map types.
+        if msg_proto.options.map_entry or self._hide(ctx.leading_comment.annotations):
+            return ''
+        name = normalize_type_context_name(ctx.name)
+        return self.tpl_content.render(
+            header=self.tpl_header.render(
+                anchor=message_cross_ref_label(name),
+                title=name,
+                proto_link=github_url(f"[{name} proto]", ctx),
+                comment=self._comment(
+                    ctx.leading_comment,
+                    msg_proto.options.HasExtension(xds_status_pb2.message_status) and
+                    msg_proto.options.Extensions[xds_status_pb2.message_status].work_in_progress)),
+            body=self.tpl_message.render(
+                pretty_label_names=constants.FIELD_LABEL_NAMES,
+                json_values=self._json_values(msg_proto, ctx),
+                msgs=self._messages(ctx, msg_proto),
+                nested_msgs=nested_msgs,
+                nested_enums=nested_enums))
+
+    @lru_cache
+    def _comment(self, comment, show_wip_warning=False):
+        """Format a comment string with additional RST for annotations.
+        """
+        return self.tpl_comment.render(
+            comment=annotations.without_annotations(comment.raw),
+            wip_warning=WIP_WARNING if show_wip_warning else "",
+            extension=(
+                self._extension(extension) if
+                (extension := comment.annotations.get(annotations.EXTENSION_ANNOTATION)) else ""),
+            categories=self._extension_categories(comment))
+
+    def _enum(self, index, ctx, enum_value) -> Dict:
+        """Format a EnumValueDescriptorProto as RST definition list item.
+        """
+        ctx = ctx.extend_enum_value(index, enum_value.name)
+        if self._hide(ctx.leading_comment.annotations):
+            return ''
+        # move this to template
+        default_comment = '*(DEFAULT)* ' if enum_value.number == 0 else ''
+        comment = default_comment + constants.UNICODE_INVISIBLE_SEPARATOR + self._comment(
+            ctx.leading_comment)
+        return dict(
+            anchor=self._enum_anchor(normalize_type_context_name(ctx.name)),
+            value=enum_value,
+            comment=comment)
+
+    def _enum_anchor(self, name) -> str:
+        """Enum value cross reference label."""
+        return f"envoy_v3_api_enum_value_{name}"
+
+    def _enums(self, ctx, enum) -> Iterator[Dict]:
+        """Format a EnumDescriptorProto as RST definition list.
+        """
+        for i, enum_value in enumerate(enum.value):
+            if item := self._enum(i, ctx, enum_value):
+                yield item
+
+    def _extension(self, extension):
+        """Format extension metadata as RST.
+        """
+        try:
+            extension_metadata = self.extension_db.get(extension, None)
+            contrib = ''
+            if extension_metadata is None:
+                extension_metadata = self.contrib_extension_db[extension]
+                contrib = f"{self.tpl_contrib_message.render()}\n"
+            status = (self.extension_status_values.get(extension_metadata.get('status'))
+                      or '').strip()
+            security_posture = self.extension_security_postures[
+                extension_metadata['security_posture']].strip()
+            categories = extension_metadata["categories"]
+        except KeyError as e:
+            sys.stderr.write(
+                f"\n\nDid you forget to add '{extension}' to extensions_build_config.bzl, "
+                "extensions_metadata.yaml, contrib_build_config.bzl, "
+                "or contrib/extensions_metadata.yaml?\n\n")
+            exit(1)  # Raising the error buries the above message in tracebacks.
+
+        rendered_ext = self.tpl_extension.render(
+            extension=extension,
+            contrib=contrib,
+            status=status,
+            security_posture=security_posture,
+            categories=categories)
+        return f"{rendered_ext}\n"
+
+    def _extension_categories(self, comment):
+        formatted_extension_category = ''
+        if annotations.EXTENSION_CATEGORY_ANNOTATION in comment.annotations:
+            for category in comment.annotations[annotations.EXTENSION_CATEGORY_ANNOTATION].split(
+                    ","):
+                yield self._extension_category(category)
+
+    def _extension_category(self, extension_category):
+        """Format extension metadata as RST.
+        """
+        extensions = self.extension_category_data.get(extension_category, [])
+        contrib_extensions = self.contrib_extension_category_data.get(extension_category, [])
+        if not extensions and not contrib_extensions:
+            raise ProtodocError(f"\n\nUnable to find extension category:  {extension_category}\n\n")
+        return self.tpl_extension_category.render(
+            category=extension_category,
+            extensions=sorted(extensions),
+            contrib_extensions=sorted(contrib_extensions))
+
+    def _field_is_required(self, field) -> bool:
+        if not field.options.HasExtension(validate_pb2.rules):
+            return False
+        rule = field.options.Extensions[validate_pb2.rules]
+        return ((rule.HasField('message') and rule.message.required)
+                or (rule.HasField('duration') and rule.duration.required)
+                or (rule.HasField('string') and rule.string.min_len > 0)
+                or (rule.HasField('string') and rule.string.min_bytes > 0)
+                or (rule.HasField('repeated') and rule.repeated.min_items > 0))
+
+    def _field_security_options(self, field, type_context):
+        # If there is a udpa.annotations.security option, include it after the comment.
+        if not field.options.HasExtension(security_pb2.security):
+            return ""
+        security_option = field.options.Extensions[security_pb2.security]
+        return [
+            self._security_option(
+                type_context.name, security_option.configure_for_untrusted_upstream,
+                security_option.configure_for_untrusted_downstream)
+        ]
+
+    def _field_type(self, typenames, field_type, type_name):
+        """Format a FieldDescriptorProto type description.
+
+        Adds cross-refs for message types.
+        TODO(htuch): Add cross-refs for enums as well.
+        """
+        if type_name.startswith(constants.WKT_NAMESPACE_PREFIX):
+            return self._field_type_wkt(type_name)
+        elif type_name.startswith(constants.RPC_NAMESPACE_PREFIX):
+            return self._field_type_rpc(type_name)
+        elif self._is_envoy_proto(type_name):
+            if resolved := self._field_type_envoy(typenames, field_type, type_name):
+                return resolved
+        elif type_name:
+            return type_name
+        if field_type in constants.FIELD_TYPE_NAMES:
+            return format_external_link(
+                constants.FIELD_TYPE_NAMES[field_type],
+                'https://developers.google.com/protocol-buffers/docs/proto#scalar')
+        raise ProtodocError('Unknown field type ' + str(field_type))
+
+    def _field_type_envoy(self, typenames, field_type, type_name):
+        normal_type_name = normalize_field_type_name(type_name)
+        if field_type == field_proto.TYPE_MESSAGE:
+            # _type_name = type_name_from_fqn(normal_type_name)
+            _type_name = type_name_from_fqn(type_name)
+            if _type := typenames.get(_type_name):
+                k, v = _type
+                return f'map<{self._field_type(typenames, k.type, k.type_name)}, {self._field_type(typenames, v.type, v.type_name)}>'
+            return format_internal_link(normal_type_name, message_cross_ref_label(normal_type_name))
+        if field_type == field_proto.TYPE_ENUM:
+            return format_internal_link(normal_type_name, enum_cross_ref_label(normal_type_name))
+
+    @lru_cache
+    def _field_type_rpc(self, type_name) -> str:
+        rpc = type_name[len(constants.RPC_NAMESPACE_PREFIX):]
+        return format_external_link(
+            rpc, 'https://cloud.google.com/natural-language/docs/reference/rpc/google.rpc#%s'
+            % rpc.lower())
+
+    @lru_cache
+    def _field_type_wkt(self, type_name) -> str:
+        wkt = type_name[len(constants.WKT_NAMESPACE_PREFIX):]
+        return format_external_link(
+            wkt,
+            f"https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#{wkt.lower()}"
+        )
+
+    def _header_from_file(self, source_code_info, file_proto, has_messages) -> str:
+        """Format RST header based on special file level title
+        """
+        proto_name = file_proto.name
+        stripped_comment = annotations.without_annotations(
+            '\n'.join(c + '\n' for c in source_code_info.file_level_comments))
+        formatted_extension = (
+            self._extension(
+                source_code_info.file_level_annotations[annotations.EXTENSION_ANNOTATION])
+            if annotations.EXTENSION_ANNOTATION in source_code_info.file_level_annotations else "")
+        title = (
+            source_code_info.file_level_annotations[annotations.DOC_TITLE_ANNOTATION]
+            if annotations.DOC_TITLE_ANNOTATION in source_code_info.file_level_annotations else
+            proto_name)
+        return self.tpl_header.render(
+            anchor=file_cross_ref_label(proto_name),
+            title=f"{title} (proto)",
+            style="=",
+            orphan=not has_messages,
+            extension=formatted_extension,
+            comment=stripped_comment,
+            warnings=self._warnings(file_proto))
+
+    def _hide(self, _annotations) -> bool:
+        """Should a given type_context.Comment be hidden because it is tagged as [#not-implemented-hide:]?"""
+        return annotations.NOT_IMPLEMENTED_HIDE_ANNOTATION in _annotations
+
+    def _is_envoy_proto(self, type_name) -> bool:
+        return any(type_name.startswith(prefix) for prefix in self.envoy_prefixes)
+
+    def _json_value(self, ctx, field) -> str:
+        """Format FieldDescriptorProto.Type as a pseudo-JSON string.
+        """
+        if type_name_from_fqn(field.type_name) in ctx.map_typenames:
+            return '{...}'
+        if field.label == field.LABEL_REPEATED:
+            return '[]'
+        if field.type == field.TYPE_MESSAGE:
+            return '{...}'
+        return '...'
+
+    def _json_values(self, msg_proto, ctx) -> Iterator[Tuple[str, str]]:
+        for i, field in enumerate(msg_proto.field):
+            if self._hide(ctx.extend_field(i, field.name).leading_comment.annotations):
+                continue
+            yield field.name, self._json_value(ctx, field)
+
+    def _message(self, outer_ctx, ctx, field) -> Dict:
+        """Format a FieldDescriptorProto as RST definition list item.
+        """
+        if self._hide(ctx.leading_comment.annotations):
+            return {}
+
+        field_annotations = []
+
+        if self._field_is_required(field):
+            field_annotations = ['*REQUIRED*']
+
+        if field.HasField('oneof_index'):
+            oneof_context = outer_ctx.extend_oneof(
+                field.oneof_index, ctx.oneof_names[field.oneof_index])
+            if self._hide(oneof_context.leading_comment.annotations):
+                return {}
+            oneof_comment = oneof_context.leading_comment
+            formatted_oneof_comment = self._comment(oneof_comment)
+
+            # If the oneof only has one field and marked required, mark the field as required.
+            if len(ctx.oneof_fields[field.oneof_index]) == 1 and ctx.oneof_required[
+                    field.oneof_index]:
+                field_annotations = ['*REQUIRED*']
+
+            if len(ctx.oneof_fields[field.oneof_index]) > 1:
+                # Fields in oneof shouldn't be marked as required when we have oneof comment below it.
+                field_annotations = []
+                oneof_template = '\nPrecisely one of %s must be set.\n' if ctx.oneof_required[
+                    field.oneof_index] else '\nOnly one of %s may be set.\n'
+                formatted_oneof_comment += oneof_template % ', '.join(
+                    format_internal_link(
+                        f,
+                        field_cross_ref_label(
+                            normalize_type_context_name(outer_ctx.extend_field(i, f).name)))
+                    for i, f in ctx.oneof_fields[field.oneof_index])
+        else:
+            formatted_oneof_comment = ''
+
+        security_options = self._field_security_options(field, ctx)
+
+        return dict(
+            anchor=field_cross_ref_label(normalize_type_context_name(ctx.name)),
+            field=field,
+            field_name=field.name,
+            comment=self._field_type(ctx.map_typenames, field.type, field.type_name),
+            field_annotations=",".join(field_annotations),
+            formatted_leading_comment=self._comment(
+                ctx.leading_comment,
+                field.options.HasExtension(xds_status_pb2.field_status)
+                and field.options.Extensions[xds_status_pb2.field_status].work_in_progress),
+            formatted_oneof_comment=formatted_oneof_comment,
+            security_options=security_options)
+
+    def _messages(self, type_context, msg):
+        type_context.oneof_fields = defaultdict(list)
+        type_context.oneof_required = defaultdict(bool)
+        type_context.oneof_names = defaultdict(list)
+        for index, field in enumerate(msg.field):
+            if field.HasField('oneof_index'):
+                leading_comment = type_context.extend_field(index, field.name).leading_comment
+                if self._hide(leading_comment.annotations):
+                    continue
+                type_context.oneof_fields[field.oneof_index].append((index, field.name))
+        for index, oneof_decl in enumerate(msg.oneof_decl):
+            if oneof_decl.options.HasExtension(validate_pb2.required):
+                type_context.oneof_required[index] = oneof_decl.options.Extensions[
+                    validate_pb2.required]
+            type_context.oneof_names[index] = oneof_decl.name
+        for index, field in enumerate(msg.field):
+            item = self._message(type_context, type_context.extend_field(index, field.name), field)
+            if item:
+                yield item
+
+    def _missing_title(self, has_messages, file_proto, ctx):
+        # TODO(mattklein123): The logic in both the doc and transform tool around files without messages
+        # is confusing and should be cleaned up. This is a stop gap to have titles for all proto docs
+        # in the common case.
+        return (
+            has_messages
+            and not annotations.DOC_TITLE_ANNOTATION in ctx.source_code_info.file_level_annotations
+            and file_proto.name.startswith('envoy'))
+
+    def _security_option(self, name, untrusted_upstream, untrusted_downstream):
+        if not (config := self.protodoc_manifest.get(name)):
+            raise ProtodocError('Missing protodoc manifest YAML for %s' % name)
+        return self.tpl_security.render(
+            untrusted_downstream=untrusted_downstream,
+            untrusted_upstream=untrusted_upstream,
+            note=config["note"].strip(),
+            example=yaml.dump({name.split('.')[-1]: config["example"]}))
+
+    def _warnings(self, file_proto):
+        _warnings = ((
+            file_proto.options.HasExtension(udpa_status_pb2.file_status)
+            and file_proto.options.Extensions[udpa_status_pb2.file_status].work_in_progress) or (
+                file_proto.options.HasExtension(xds_status_pb2.file_status)
+                and file_proto.options.Extensions[xds_status_pb2.file_status].work_in_progress))
+        return ([WIP_WARNING] if _warnings else [])
 
 
 def main():

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -498,8 +498,7 @@ class RstFormatVisitor(visitor.Visitor):
             formatted_oneof_comment = self._comment(oneof_comment)
             formatted_leading_comment = (
                 formatted_leading_comment.strip()
-                if not formatted_leading_comment.strip()
-                else formatted_leading_comment)
+                if not formatted_leading_comment.strip() else formatted_leading_comment)
 
             # If the oneof only has one field and marked required, mark the field as required.
             if len(ctx.oneof_fields[field.oneof_index]) == 1 and ctx.oneof_required[

--- a/tools/protodoc/rst_filters.py
+++ b/tools/protodoc/rst_filters.py
@@ -1,10 +1,10 @@
 def rst_anchor(label):
     """Format a label as an Envoy API RST anchor."""
-    return f".. _{label}:\n\n"
+    return f".. _{label}:\n"
 
 
 def rst_header(text, style=None):
     """Format RST header.
     """
     style = style or "-"
-    return f"{text}\n{style * len(text)}\n\n"
+    return f"{text}\n{style * len(text)}\n"

--- a/tools/protodoc/templates/comment.rst.tpl
+++ b/tools/protodoc/templates/comment.rst.tpl
@@ -3,7 +3,7 @@
 {{ wip_warning }}
 {%- endif -%}
 {%- if extension %}
-{{ extension | indent(10) }}
+{{ extension }}
 {%- endif -%}
 {%- if categories %}
 {% for category in categories %}

--- a/tools/protodoc/templates/comment.rst.tpl
+++ b/tools/protodoc/templates/comment.rst.tpl
@@ -1,0 +1,12 @@
+{{ comment }}
+{%- if wip_warning %}
+{{ wip_warning }}
+{%- endif -%}
+{%- if extension %}
+{{ extension | indent(10) }}
+{%- endif -%}
+{%- if categories %}
+{% for category in categories %}
+{{ category }}
+{% endfor -%}
+{%- endif -%}

--- a/tools/protodoc/templates/content.rst.tpl
+++ b/tools/protodoc/templates/content.rst.tpl
@@ -1,0 +1,2 @@
+{{ header }}
+{{ body }}

--- a/tools/protodoc/templates/contrib_message.rst.tpl
+++ b/tools/protodoc/templates/contrib_message.rst.tpl
@@ -1,0 +1,3 @@
+.. note::
+
+  This extension is only available in :ref:`contrib <install_contrib>` images.

--- a/tools/protodoc/templates/enum.rst.tpl
+++ b/tools/protodoc/templates/enum.rst.tpl
@@ -1,0 +1,6 @@
+{%- for item in enum_items %}
+{{ item.anchor | rst_anchor }}
+
+{{ item.value.name }}
+  {{ item.comment | indent(2) }}
+{%- endfor -%}

--- a/tools/protodoc/templates/extension.rst.tpl
+++ b/tools/protodoc/templates/extension.rst.tpl
@@ -1,6 +1,7 @@
 .. _extension_{{extension}}:
 
 This extension has the qualified name ``{{extension}}``
+
 {{contrib}}
 .. note::
   {{status | indent(2) }}
@@ -22,6 +23,6 @@ This extension has the qualified name ``{{extension}}``
   - :ref:`type.googleapis.com/{{type_url}} <envoy_v3_api_msg_{{type_url[6:]}}>`
 {% else %}
   - ``type.googleapis.com/{{type_url}}``
-{% endif %}
-{% endfor %}
-{% endif %}
+{% endif -%}
+{% endfor -%}
+{% endif -%}

--- a/tools/protodoc/templates/file.rst.tpl
+++ b/tools/protodoc/templates/file.rst.tpl
@@ -1,0 +1,11 @@
+{{ header }}
+{{ warnings }}
+{%- if comment %}
+{{ comment }}
+{%- endif -%}
+{%- for msg in msgs %}
+{{ msg }}
+{% endfor %}
+{%- for enum in enums %}
+{{ enum }}
+{% endfor %}

--- a/tools/protodoc/templates/header.rst.tpl
+++ b/tools/protodoc/templates/header.rst.tpl
@@ -1,0 +1,19 @@
+{{ anchor | rst_anchor }}
+{% if orphan -%}
+
+:orphan:
+
+{% endif -%}
+{{ title | rst_header(style) }}
+{% if extension -%}
+{{ extension }}
+{% endif -%}
+{%- if warnings %}
+{{ warnings }}
+{% endif -%}
+{%- if proto_link %}
+{{ proto_link }}
+{% endif -%}
+{%- if comment %}
+{{ comment }}
+{%- endif -%}

--- a/tools/protodoc/templates/message.rst.tpl
+++ b/tools/protodoc/templates/message.rst.tpl
@@ -1,0 +1,39 @@
+{%- if json_values %}
+{%- for key, value in json_values %}
+{%- if loop.index == 1 %}
+.. code-block:: json
+  :force:
+
+  {
+{%- endif %}
+    "{{ key }}": {{ value }}{% if not loop.last %},{% endif %}
+{%- if loop.last %}
+  }
+{%- endif -%}
+{% endfor %}
+{%- endif %}
+{% for msg in msgs %}
+{{ msg.anchor | rst_anchor }}
+
+{{ msg.field_name }}
+  ({{ pretty_label_names[msg.field.label] }}{{ msg.comment }}{% if msg.field_annotations %}, {{ msg.field_annotations }}{% endif %}) {{ msg.formatted_leading_comment | indent(2)}}
+
+{%- if msg.formatted_oneof_comment %}
+  {{ msg.formatted_oneof_comment | indent(2) }}
+{%- endif -%}
+{%- if msg.security_options %}
+{%- for section in msg.security_options %}
+{%- if loop.index0 == 0 %}
+  .. attention::
+
+{%- endif -%}
+    {{ section | indent(4) }}
+{% endfor -%}
+{%- endif -%}
+{% endfor -%}
+{% for message in nested_msgs %}
+{{ message }}
+{% endfor -%}
+{%- for enum in nested_enums %}
+{{ enum }}
+{% endfor -%}

--- a/tools/protodoc/templates/message.rst.tpl
+++ b/tools/protodoc/templates/message.rst.tpl
@@ -17,10 +17,10 @@
 
 {{ msg.field_name }}
   ({{ pretty_label_names[msg.field.label] }}{{ msg.comment }}{% if msg.field_annotations %}, {{ msg.field_annotations }}{% endif %}) {{ msg.formatted_leading_comment | indent(2)}}
-
 {%- if msg.formatted_oneof_comment %}
   {{ msg.formatted_oneof_comment | indent(2) }}
-{%- endif -%}
+{%- endif %}
+
 {%- if msg.security_options %}
 {%- for section in msg.security_options %}
 {%- if loop.index0 == 0 %}

--- a/tools/protodoc/templates/security.rst.tpl
+++ b/tools/protodoc/templates/security.rst.tpl
@@ -1,0 +1,15 @@
+{%- if untrusted_downstream %}
+This field should be configured in the presence of untrusted *downstreams*.
+{% endif %}
+{%- if untrusted_upstream %}
+This field should be configured in the presence of untrusted *upstreams*.
+{%- endif -%}
+{%- if note %}
+{{ note }}
+{%- endif %}
+
+Example configuration for untrusted environments:
+
+.. code-block:: yaml
+
+  {{ example | indent(2) }}


### PR DESCRIPTION
This shifts the rendering code from python into jinja templates.

The logic for parsing protodoc should not change much, but how we want to present it does so this separates the changeable code out, and should make it easier to update, it should also make the code easier to read/understand

This is a further step towards using templates (we use some already) and once it has landed we can look at moving further in this direction.

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
