### PR TITLE
[WIP] bazel: Set RBE downloads to minimal

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -27,6 +27,8 @@ stages:
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format'
       workingDirectory: $(Build.SourcesDirectory)
       env:
+        ENVOY_RBE: "true"
+        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
@@ -53,6 +55,8 @@ stages:
     - script: ci/run_envoy_docker.sh 'ci/check_and_fix_format.sh'
       workingDirectory: $(Build.SourcesDirectory)
       env:
+        ENVOY_RBE: "true"
+        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
@@ -80,6 +84,8 @@ stages:
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh docs'
       workingDirectory: $(Build.SourcesDirectory)
       env:
+        ENVOY_RBE: "true"
+        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
         AZP_BRANCH: $(Build.SourceBranch)
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
@@ -109,6 +115,8 @@ stages:
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh deps'
       workingDirectory: $(Build.SourcesDirectory)
       env:
+        ENVOY_RBE: "true"
+        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
@@ -430,6 +438,8 @@ stages:
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh docs'
       workingDirectory: $(Build.SourcesDirectory)
       env:
+        ENVOY_RBE: "true"
+        BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
         AZP_BRANCH: $(Build.SourceBranch)
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -189,7 +189,7 @@ stages:
         AZP_BRANCH: $(Build.SourceBranch)
 
 - stage: linux_x64
-  dependsOn: ["precheck"]
+  dependsOn: []  # "precheck"]
   # For post-submit builds, continue even if precheck fails
   condition: and(not(canceled()), or(succeeded(), eq(variables['PostSubmit'], true)))
   jobs:
@@ -203,7 +203,7 @@ stages:
         ciTarget: bazel.release
 
 - stage: linux_arm64
-  dependsOn: ["precheck"]
+  dependsOn: []  # "precheck"]
   # For post-submit builds, continue even if precheck fails
   condition: and(not(canceled()), or(succeeded(), eq(variables['PostSubmit'], true)))
   jobs:

--- a/.bazelrc
+++ b/.bazelrc
@@ -243,7 +243,8 @@ build:remote --strategy=Closure=remote,sandboxed,local
 build:remote --strategy=Genrule=remote,sandboxed,local
 build:remote --remote_timeout=7200
 build:remote --google_default_credentials=true
-build:remote --remote_download_toplevel
+build:remote --remote_download_minimal
+run:remote --remote_download_outputs=toplevel
 
 # Windows bazel does not allow sandboxed as a spawn strategy
 build:remote-windows --spawn_strategy=remote,local
@@ -252,7 +253,8 @@ build:remote-windows --strategy=Closure=remote,local
 build:remote-windows --strategy=Genrule=remote,local
 build:remote-windows --remote_timeout=7200
 build:remote-windows --google_default_credentials=true
-build:remote-windows --remote_download_toplevel
+build:remote-windows --remote_download_minimal
+run:remote-windows --remote_download_outputs=toplevel
 
 build:remote-clang --config=remote
 build:remote-clang --config=rbe-toolchain-clang

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -28,8 +28,8 @@ BAZEL_REMOTE_CACHE=grpcs://remotebuildexecution.googleapis.com
 BAZEL_BUILD_EXTRA_OPTIONS=--config=remote-ci --config=remote --jobs=<Number of jobs>
 ```
 
-By default the `--config=remote` implies [`--remote_download_toplevel`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--remote_download_toplevel),
-change this to `minimal` or `all` depending on where you're running the container by adding them to `BAZEL_BUILD_EXTRA_OPTIONS`.
+By default the `--config=remote` implies [`--remote_download_minimal`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--remote_download_minimal),
+change this to `toplevel` or `all` depending on where you're running the container by adding them to `BAZEL_BUILD_EXTRA_OPTIONS`.
 
 ### Disk performance
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -126,7 +126,11 @@ function bazel_binary_build() {
   echo "ENVOY_BIN=${ENVOY_BIN}"
 
   # This is a workaround for https://github.com/bazelbuild/bazel/issues/11834
-  [[ -n "${ENVOY_RBE}" ]] && rm -rf bazel-bin/"${ENVOY_BIN}"*
+  [[ -n "${ENVOY_RBE}" ]] && {
+      rm -rf bazel-bin/"${ENVOY_BIN}"*
+      # Seemingly due to above bug, `download_minimal` doesnt download the target
+      BAZEL_BUILD_OPTIONS+=("--remote_download_outputs=toplevel")
+  }
 
   bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c "${COMPILE_TYPE}" "${BUILD_TARGET}" ${CONFIG_ARGS}
   collect_build_profile "${BINARY_TYPE}"_build
@@ -235,6 +239,8 @@ elif [[ "$CI_TARGET" == "bazel.distribution" ]]; then
   echo "Building distro packages..."
 
   setup_clang_toolchain
+
+  BAZEL_BUILD_OPTIONS+=("--remote_download_outputs=toplevel")
 
   # By default the packages will be signed by the first available key.
   # If there is no key available, a throwaway key is created

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -37,6 +37,7 @@ fi
 # This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
 IFS=" " read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
 BAZEL_BUILD_OPTIONS+=(
+    "--remote_download_outputs=toplevel"
     "--action_env=DOCS_TAG"
     "--action_env=BUILD_SHA"
     "--action_env=SPHINX_RUNNER_ARGS"

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -90,6 +90,8 @@ genrule(
         --xformed=$(location :xformed) \
         --protoprinted=$(location //tools/protoprint:protoprinted) \
     """ % PATH,
+    # TODO(phlax): make protoprint work without repo `PATH`
+    tags = ["no-remote"],
     tools = [
         ":format_api",
         ":xformed",

--- a/tools/proto_format/proto_format.sh
+++ b/tools/proto_format/proto_format.sh
@@ -46,5 +46,5 @@ if [[ "$1" == "freeze" ]]; then
 fi
 
 # Generate api/BUILD file based on updated type database.
-bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/type_whisperer:api_build_file
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_outputs=toplevel //tools/type_whisperer:api_build_file
 cp -f bazel-bin/tools/type_whisperer/BUILD.api_build_file api/BUILD

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -14,6 +14,7 @@ import io
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 from collections import deque
@@ -92,7 +93,11 @@ def clang_format(contents):
     Returns:
         clang-formatted string
     """
-    clang_format_path = os.getenv("CLANG_FORMAT", "clang-format")
+    clang_format_path = os.getenv("CLANG_FORMAT", shutil.which("clang-format"))
+    if not clang_format_path:
+        if not os.path.exists("/opt/llvm/bin/clang-format"):
+            raise RuntimeError("Unable to find clang-format, sorry")
+        clang_format_path = "/opt/llvm/bin/clang-format"
     return subprocess.run(
         [clang_format_path,
          '--style=%s' % CLANG_FORMAT_STYLE, '--assume-filename=.proto'],


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

Testing RBE locally and it can in many cases take longer downloading files than it would have done just running locally

~Partly i think (mis)use of `pkg_tars` is to blame, and there are defo some optis that we could add, but i also think we want this set to minimal if possible~ i wasnt using the CI config

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
