### PR TITLE
sip_proxy: add SIP context to TRA requests

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
@@ -90,6 +90,8 @@ message TraServiceResponse {
 
 message CreateRequest {
   map<string, string> data = 1;
+
+  map<string, string> context = 2;
 }
 
 message CreateResponse {
@@ -97,6 +99,8 @@ message CreateResponse {
 
 message UpdateRequest {
   map<string, string> data = 1;
+
+  map<string, string> context = 2;
 }
 
 message UpdateResponse {
@@ -104,6 +108,8 @@ message UpdateResponse {
 
 message RetrieveRequest {
   string key = 1;
+
+  map<string, string> context = 2;
 }
 
 message RetrieveResponse {
@@ -112,6 +118,8 @@ message RetrieveResponse {
 
 message DeleteRequest {
   string key = 1;
+
+  map<string, string> context = 2;
 }
 
 message DeleteResponse {

--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 message SipProxy {
   message SipSettings {
-    // transaction timeout timer [Timer B] unit is milliseconds, default value 64*T1.
+    // transaction timeout timer [Titsmer B] unit is milliseconds, default value 64*T1.
     //
     // Session Initiation Protocol (SIP) timer summary
     //

--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 message SipProxy {
   message SipSettings {
-    // transaction timeout timer [Titsmer B] unit is milliseconds, default value 64*T1.
+    // transaction timeout timer [Timer B] unit is milliseconds, default value 64*T1.
     //
     // Session Initiation Protocol (SIP) timer summary
     //

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -53,8 +53,8 @@ QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
   if (activetrans.metadata()->affinityIteration()->query()) {
     parent_.pushIntoPendingList(type, key, activetrans, [&]() {
       if (traClient()) {
-        traClient()->retrieveTrafficRoutingAssistant(type, key, context, Tracing::NullSpan::instance(),
-                                                     stream_info_);
+        traClient()->retrieveTrafficRoutingAssistant(type, key, context,
+                                                     Tracing::NullSpan::instance(), stream_info_);
       }
     });
     host = "";

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -98,12 +98,11 @@ void TrafficRoutingAssistantHandler::complete(const TrafficRoutingAssistant::Res
             envoy::extensions::filters::network::sip_proxy::tra::v3alpha::RetrieveResponse>(resp)
             .data();
     for (const auto& item : resp_data) {
-      ENVOY_LOG(trace, "TRA === RetrieveResp {} {}={}, item.second.empty()={}, size={}, length={}", message_type, item.first, item.second, item.second.empty(), item.second.size(), item.second.length());
+      ENVOY_LOG(trace, "TRA === RetrieveResp {} {}={}", message_type, item.first, item.second);
       if (!item.second.empty()) {
         parent_.onResponseHandleForPendingList(
             message_type, item.first,
             [&](MessageMetadataSharedPtr metadata, DecoderEventHandler& decoder_event_handler) {
-              ENVOY_LOG(trace, "JONAH - TRA Adding Item to Cache {} {}", item.first, item.second);
               cache_manager_[message_type].emplace(item.first, item.second);
               metadata->setDestination(item.second);
               return parent_.continueHandling(metadata, decoder_event_handler);
@@ -114,7 +113,6 @@ void TrafficRoutingAssistantHandler::complete(const TrafficRoutingAssistant::Res
       parent_.onResponseHandleForPendingList(
           message_type, item.first,
           [&](MessageMetadataSharedPtr metadata, DecoderEventHandler& decoder_event_handler) {
-            ENVOY_LOG(trace, "JONAH - TRA Trying next affinity", item.first, item.second);
             metadata->nextAffinityIteration();
             parent_.continueHandling(metadata, decoder_event_handler);
           });

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -28,22 +28,25 @@ TrafficRoutingAssistantHandler::TrafficRoutingAssistantHandler(
   }
 }
 
-void TrafficRoutingAssistantHandler::updateTrafficRoutingAssistant(const std::string& type,
-                                                                   const std::string& key,
-                                                                   const std::string& val) {
+void TrafficRoutingAssistantHandler::updateTrafficRoutingAssistant(
+    const std::string& type,
+    const std::string& key,
+    const std::string& val,
+    const absl::optional<TraContextMap> context) {
   if (cache_manager_[type][key] != val) {
     cache_manager_.insertCache(type, key, val);
     if (traClient()) {
       traClient()->updateTrafficRoutingAssistant(
           type, absl::flat_hash_map<std::string, std::string>{std::make_pair(key, val)},
-          Tracing::NullSpan::instance(), stream_info_);
+          context, Tracing::NullSpan::instance(), stream_info_);
     }
   }
 }
 
 QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
     const std::string& type, const std::string& key,
-    const TraContextMap& context, SipFilters::DecoderFilterCallbacks& activetrans, 
+    const absl::optional<TraContextMap> context,
+    SipFilters::DecoderFilterCallbacks& activetrans, 
     std::string& host) {
   if (cache_manager_.contains(type, key)) {
     host = cache_manager_[type][key];
@@ -64,11 +67,13 @@ QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
   return QueryStatus::Stop;
 }
 
-void TrafficRoutingAssistantHandler::deleteTrafficRoutingAssistant(const std::string& type,
-                                                                   const std::string& key) {
+void TrafficRoutingAssistantHandler::deleteTrafficRoutingAssistant(
+      const std::string& type,
+      const std::string& key,
+      const absl::optional<TraContextMap> context) {
   cache_manager_[type].erase(key);
   if (traClient()) {
-    traClient()->deleteTrafficRoutingAssistant(type, key, Tracing::NullSpan::instance(),
+    traClient()->deleteTrafficRoutingAssistant(type, key, context, Tracing::NullSpan::instance(),
                                                stream_info_);
   }
 }

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -29,25 +29,21 @@ TrafficRoutingAssistantHandler::TrafficRoutingAssistantHandler(
 }
 
 void TrafficRoutingAssistantHandler::updateTrafficRoutingAssistant(
-    const std::string& type,
-    const std::string& key,
-    const std::string& val,
+    const std::string& type, const std::string& key, const std::string& val,
     const absl::optional<TraContextMap> context) {
   if (cache_manager_[type][key] != val) {
     cache_manager_.insertCache(type, key, val);
     if (traClient()) {
       traClient()->updateTrafficRoutingAssistant(
-          type, absl::flat_hash_map<std::string, std::string>{std::make_pair(key, val)},
-          context, Tracing::NullSpan::instance(), stream_info_);
+          type, absl::flat_hash_map<std::string, std::string>{std::make_pair(key, val)}, context,
+          Tracing::NullSpan::instance(), stream_info_);
     }
   }
 }
 
 QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
-    const std::string& type, const std::string& key,
-    const absl::optional<TraContextMap> context,
-    SipFilters::DecoderFilterCallbacks& activetrans, 
-    std::string& host) {
+    const std::string& type, const std::string& key, const absl::optional<TraContextMap> context,
+    SipFilters::DecoderFilterCallbacks& activetrans, std::string& host) {
   if (cache_manager_.contains(type, key)) {
     host = cache_manager_[type][key];
     return QueryStatus::Continue;
@@ -68,9 +64,7 @@ QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
 }
 
 void TrafficRoutingAssistantHandler::deleteTrafficRoutingAssistant(
-      const std::string& type,
-      const std::string& key,
-      const absl::optional<TraContextMap> context) {
+    const std::string& type, const std::string& key, const absl::optional<TraContextMap> context) {
   cache_manager_[type].erase(key);
   if (traClient()) {
     traClient()->deleteTrafficRoutingAssistant(type, key, context, Tracing::NullSpan::instance(),

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -43,8 +43,8 @@ void TrafficRoutingAssistantHandler::updateTrafficRoutingAssistant(const std::st
 
 QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
     const std::string& type, const std::string& key,
-    const absl::flat_hash_map<std::string, std::string>& context,
-    SipFilters::DecoderFilterCallbacks& activetrans, std::string& host) {
+    const TraContextMap& context, SipFilters::DecoderFilterCallbacks& activetrans, 
+    std::string& host) {
   if (cache_manager_.contains(type, key)) {
     host = cache_manager_[type][key];
     return QueryStatus::Continue;

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -69,6 +69,7 @@ public:
                                              const std::string& val);
   virtual QueryStatus
   retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                  const absl::flat_hash_map<std::string, std::string>& context,
                                   SipFilters::DecoderFilterCallbacks& activetrans,
                                   std::string& host);
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key);

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -66,13 +66,15 @@ public:
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
 
   virtual void updateTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                             const std::string& val);
+                                             const std::string& val, 
+                                             const absl::optional<TraContextMap> context);
   virtual QueryStatus
   retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                  const TraContextMap& context,
+                                  const absl::optional<TraContextMap> context,
                                   SipFilters::DecoderFilterCallbacks& activetrans,
                                   std::string& host);
-  virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key);
+  virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key, 
+                                             const absl::optional<TraContextMap> context);
   virtual void subscribeTrafficRoutingAssistant(const std::string& type);
   void complete(const TrafficRoutingAssistant::ResponseType& type, const std::string& message_type,
                 const absl::any& resp) override;

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -69,7 +69,7 @@ public:
                                              const std::string& val);
   virtual QueryStatus
   retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                  const absl::flat_hash_map<std::string, std::string>& context,
+                                  const TraContextMap& context,
                                   SipFilters::DecoderFilterCallbacks& activetrans,
                                   std::string& host);
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key);

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -66,14 +66,12 @@ public:
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
 
   virtual void updateTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                             const std::string& val, 
+                                             const std::string& val,
                                              const absl::optional<TraContextMap> context);
-  virtual QueryStatus
-  retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                  const absl::optional<TraContextMap> context,
-                                  SipFilters::DecoderFilterCallbacks& activetrans,
-                                  std::string& host);
-  virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key, 
+  virtual QueryStatus retrieveTrafficRoutingAssistant(
+      const std::string& type, const std::string& key, const absl::optional<TraContextMap> context,
+      SipFilters::DecoderFilterCallbacks& activetrans, std::string& host);
+  virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
                                              const absl::optional<TraContextMap> context);
   virtual void subscribeTrafficRoutingAssistant(const std::string& type);
   void complete(const TrafficRoutingAssistant::ResponseType& type, const std::string& message_type,

--- a/contrib/sip_proxy/filters/network/source/decoder.cc
+++ b/contrib/sip_proxy/filters/network/source/decoder.cc
@@ -180,10 +180,8 @@ FilterStatus Decoder::onDataReady(Buffer::Instance& data) {
 }
 
 auto Decoder::sipHeaderType(absl::string_view sip_line) {
-  auto header_type_str = sip_line.substr(0, sip_line.find_first_of(':'));
-  auto header_value = sip_line.substr(sip_line.find_first_of(':') + strlen(":"));
-  Utility::trimStringView(header_type_str);
-  Utility::trimStringView(header_value);
+  auto header_type_str = StringUtil::trim(sip_line.substr(0, sip_line.find_first_of(':')));
+  auto header_value = StringUtil::trim(sip_line.substr(sip_line.find_first_of(':') + strlen(":")));
   return std::tuple<HeaderType, absl::string_view>{HeaderTypes::get().str2Header(header_type_str),
                                                    header_value};
 }

--- a/contrib/sip_proxy/filters/network/source/decoder.cc
+++ b/contrib/sip_proxy/filters/network/source/decoder.cc
@@ -1,6 +1,5 @@
 #include "contrib/sip_proxy/filters/network/source/decoder.h"
 
-#include <cstdio>
 #include <utility>
 
 #include "envoy/buffer/buffer.h"
@@ -185,9 +184,8 @@ auto Decoder::sipHeaderType(absl::string_view sip_line) {
   auto header_value = sip_line.substr(sip_line.find_first_of(':') + strlen(":"));
   Utility::trimStringView(header_type_str);
   Utility::trimStringView(header_value);
-  return std::tuple<HeaderType, absl::string_view>{
-      HeaderTypes::get().str2Header(header_type_str),
-      header_value};
+  return std::tuple<HeaderType, absl::string_view>{HeaderTypes::get().str2Header(header_type_str),
+                                                   header_value};
 }
 
 MsgType Decoder::sipMsgType(absl::string_view top_line) {

--- a/contrib/sip_proxy/filters/network/source/decoder.cc
+++ b/contrib/sip_proxy/filters/network/source/decoder.cc
@@ -1,5 +1,6 @@
 #include "contrib/sip_proxy/filters/network/source/decoder.h"
 
+#include <cstdio>
 #include <utility>
 
 #include "envoy/buffer/buffer.h"
@@ -181,9 +182,12 @@ FilterStatus Decoder::onDataReady(Buffer::Instance& data) {
 
 auto Decoder::sipHeaderType(absl::string_view sip_line) {
   auto header_type_str = sip_line.substr(0, sip_line.find_first_of(':'));
+  auto header_value = sip_line.substr(sip_line.find_first_of(':') + strlen(":"));
+  Utility::trimStringView(header_type_str);
+  Utility::trimStringView(header_value);
   return std::tuple<HeaderType, absl::string_view>{
       HeaderTypes::get().str2Header(header_type_str),
-      sip_line.substr(sip_line.find_first_of(':') + strlen(": "))};
+      header_value};
 }
 
 MsgType Decoder::sipMsgType(absl::string_view top_line) {

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -178,6 +178,15 @@ public:
 
   std::vector<SipHeader>& listHeader(HeaderType type) { return headers_[type]; }
 
+  auto traContext() {
+    auto context = absl::flat_hash_map<std::string, std::string>{};
+    auto fromHeader = listHeader(HeaderType::From);
+    std::string method = methodStr[methodType()];
+    context.emplace(std::make_pair("method_type", method));
+    context.emplace(std::make_pair("from_header", fromHeader.front().text()));
+    return context;
+  }
+
 private:
   MsgType msg_type_;
   MethodType method_type_;

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -180,10 +180,9 @@ public:
 
   auto traContext() {
     auto context = absl::flat_hash_map<std::string, std::string>{};
-    auto fromHeader = listHeader(HeaderType::From);
-    std::string method = methodStr[methodType()];
-    context.emplace(std::make_pair("method_type", method));
-    context.emplace(std::make_pair("from_header", fromHeader.front().text()));
+    auto fromHeader = listHeader(HeaderType::From).front().text();
+    context.emplace(std::make_pair("method_type", methodStr[methodType()]));
+    context.emplace(std::make_pair("from_header", fromHeader));
     return context;
   }
 

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -180,12 +180,15 @@ public:
 
   std::vector<SipHeader>& listHeader(HeaderType type) { return headers_[type]; }
 
-  auto traContext() {
-    auto context = TraContextMap();
-    auto fromHeader = listHeader(HeaderType::From).front().text();
-    context.emplace(std::make_pair("method_type", methodStr[methodType()]));
-    context.emplace(std::make_pair("from_header", fromHeader));
-    return context;
+  absl::optional<TraContextMap> traContext() {
+    auto fromHeaderList = listHeader(HeaderType::From);
+    if (fromHeaderList.empty()) {
+      return absl::nullopt;
+    }
+    auto fromHeader = fromHeaderList.front().text();
+    tra_context_map_.emplace(std::make_pair("method_type", methodStr[methodType()]));
+    tra_context_map_.emplace(std::make_pair("from_header", fromHeader));
+    return tra_context_map_;
   }
 
 private:
@@ -209,6 +212,8 @@ private:
   std::string raw_msg_{};
   State state_{State::TransportBegin};
   bool stop_load_balance_{};
+
+  TraContextMap tra_context_map_{};
 
   bool isDomainMatched(
       absl::string_view& header,

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -26,6 +26,8 @@ namespace SipProxy {
   FUNCTION(HandleAffinity)                                                                         \
   FUNCTION(Done)
 
+using TraContextMap = absl::flat_hash_map<std::string, std::string>;
+
 /**
  * ProtocolState represents a set of states used in a state machine to decode
  * Sip requests and responses.
@@ -179,7 +181,7 @@ public:
   std::vector<SipHeader>& listHeader(HeaderType type) { return headers_[type]; }
 
   auto traContext() {
-    auto context = absl::flat_hash_map<std::string, std::string>{};
+    auto context = TraContextMap();
     auto fromHeader = listHeader(HeaderType::From).front().text();
     context.emplace(std::make_pair("method_type", methodStr[methodType()]));
     context.emplace(std::make_pair("from_header", fromHeader));

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -180,14 +180,12 @@ public:
 
   std::vector<SipHeader>& listHeader(HeaderType type) { return headers_[type]; }
 
-  absl::optional<TraContextMap> traContext() {
-    auto fromHeaderList = listHeader(HeaderType::From);
-    if (fromHeaderList.empty()) {
-      return absl::nullopt;
+  TraContextMap traContext() {
+    if (tra_context_map_.empty()) {
+      auto fromHeader = listHeader(HeaderType::From).front().text();
+      tra_context_map_.emplace(std::make_pair("method_type", methodStr[methodType()]));
+      tra_context_map_.emplace(std::make_pair("from_header", fromHeader));
     }
-    auto fromHeader = fromHeaderList.front().text();
-    tra_context_map_.emplace(std::make_pair("method_type", methodStr[methodType()]));
-    tra_context_map_.emplace(std::make_pair("from_header", fromHeader));
     return tra_context_map_;
   }
 

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -182,7 +182,7 @@ FilterStatus Router::handleAffinity() {
   if (metadata->pCookieIpMap().has_value()) {
     auto [key, val] = metadata->pCookieIpMap().value();
     ENVOY_LOG(trace, "update p-cookie-ip-map {}={}", key, val);
-    callbacks_->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val);
+    callbacks_->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val, absl::nullopt);
   }
 
   const std::shared_ptr<const ProtocolOptionsConfig> options =
@@ -696,7 +696,7 @@ FilterStatus ResponseDecoder::transportBegin(MessageMetadataSharedPtr metadata) 
       if (metadata->pCookieIpMap().has_value()) {
         auto [key, val] = metadata->pCookieIpMap().value();
         ENVOY_LOG(trace, "update p-cookie-ip-map {}={}", key, val);
-        active_trans->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val);
+        active_trans->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val, absl::nullopt);
       }
 
       active_trans->startUpstreamResponse();

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -157,10 +157,11 @@ QueryStatus Router::handleCustomizedAffinity(const std::string& header, const st
     }
   } else if (type == "text") {
     auto header_type = HeaderTypes::get().str2Header(header);
+  
     ret = callbacks_->traHandler()->retrieveTrafficRoutingAssistant(
-        header, std::string(metadata->header(header_type).text()), *callbacks_, host);
+        header, std::string(metadata->header(header_type).text()), metadata->traContext(), *callbacks_, host);
   } else {
-    ret = callbacks_->traHandler()->retrieveTrafficRoutingAssistant(type, key, *callbacks_, host);
+    ret = callbacks_->traHandler()->retrieveTrafficRoutingAssistant(type, key, metadata->traContext(),  *callbacks_, host);
   }
 
   if (QueryStatus::Continue == ret) {

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -157,11 +157,13 @@ QueryStatus Router::handleCustomizedAffinity(const std::string& header, const st
     }
   } else if (type == "text") {
     auto header_type = HeaderTypes::get().str2Header(header);
-  
+
     ret = callbacks_->traHandler()->retrieveTrafficRoutingAssistant(
-        header, std::string(metadata->header(header_type).text()), metadata->traContext(), *callbacks_, host);
+        header, std::string(metadata->header(header_type).text()), metadata->traContext(),
+        *callbacks_, host);
   } else {
-    ret = callbacks_->traHandler()->retrieveTrafficRoutingAssistant(type, key, metadata->traContext(),  *callbacks_, host);
+    ret = callbacks_->traHandler()->retrieveTrafficRoutingAssistant(
+        type, key, metadata->traContext(), *callbacks_, host);
   }
 
   if (QueryStatus::Continue == ret) {

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -696,7 +696,8 @@ FilterStatus ResponseDecoder::transportBegin(MessageMetadataSharedPtr metadata) 
       if (metadata->pCookieIpMap().has_value()) {
         auto [key, val] = metadata->pCookieIpMap().value();
         ENVOY_LOG(trace, "update p-cookie-ip-map {}={}", key, val);
-        active_trans->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val, absl::nullopt);
+        active_trans->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val,
+                                                                  absl::nullopt);
       }
 
       active_trans->startUpstreamResponse();

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -55,6 +55,7 @@ public:
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
       Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                               const absl::flat_hash_map<std::string, std::string>& context,
                                                Tracing::Span& parent_span,
                                                const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -54,10 +54,11 @@ public:
   virtual void updateTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
       Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
-  virtual void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                               const absl::flat_hash_map<std::string, std::string>& context,
-                                               Tracing::Span& parent_span,
-                                               const StreamInfo::StreamInfo& stream_info) PURE;
+  virtual void
+  retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                  const absl::flat_hash_map<std::string, std::string>& context,
+                                  Tracing::Span& parent_span,
+                                  const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
                                              Tracing::Span& parent_span,
                                              const StreamInfo::StreamInfo& stream_info) PURE;

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -20,6 +20,8 @@ namespace NetworkFilters {
 namespace SipProxy {
 namespace TrafficRoutingAssistant {
 
+using TraContextMap = absl::flat_hash_map<std::string, std::string>;
+
 enum class ResponseType {
   CreateResp,
   UpdateResp,
@@ -56,7 +58,7 @@ public:
       Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void
   retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                  const absl::flat_hash_map<std::string, std::string>& context,
+                                  const TraContextMap& context,
                                   Tracing::Span& parent_span,
                                   const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -52,16 +52,17 @@ public:
   virtual void setRequestCallbacks(RequestCallbacks& callbacks) PURE;
   virtual void createTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-      Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
+      const absl::optional<TraContextMap> context, Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void updateTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-      Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
+      const absl::optional<TraContextMap> context, Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void
   retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                  const TraContextMap& context,
+                                  const absl::optional<TraContextMap> context, 
                                   Tracing::Span& parent_span,
                                   const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                             const absl::optional<TraContextMap> context, 
                                              Tracing::Span& parent_span,
                                              const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void subscribeTrafficRoutingAssistant(const std::string& type, Tracing::Span& parent_span,

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -52,17 +52,18 @@ public:
   virtual void setRequestCallbacks(RequestCallbacks& callbacks) PURE;
   virtual void createTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-      const absl::optional<TraContextMap> context, Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
+      const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+      const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void updateTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-      const absl::optional<TraContextMap> context, Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) PURE;
-  virtual void
-  retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                  const absl::optional<TraContextMap> context, 
-                                  Tracing::Span& parent_span,
-                                  const StreamInfo::StreamInfo& stream_info) PURE;
+      const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+      const StreamInfo::StreamInfo& stream_info) PURE;
+  virtual void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                               const absl::optional<TraContextMap> context,
+                                               Tracing::Span& parent_span,
+                                               const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                             const absl::optional<TraContextMap> context, 
+                                             const absl::optional<TraContextMap> context,
                                              Tracing::Span& parent_span,
                                              const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void subscribeTrafficRoutingAssistant(const std::string& type, Tracing::Span& parent_span,

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -95,7 +95,7 @@ void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
   request.mutable_retrieve_request()->set_key(key);
 
   for (auto& item : context) {
-    (*request.mutable_update_request()->mutable_data())[item.first] = item.second;
+    (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
   }
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -86,12 +86,17 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
 
 void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
                                                      const std::string& key,
+                                                     const absl::flat_hash_map<std::string, std::string>& context,
                                                      Tracing::Span& parent_span,
                                                      const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
   request.mutable_retrieve_request()->set_key(key);
+
+  for (auto& item : context) {
+    (*request.mutable_update_request()->mutable_data())[item.first] = item.second;
+  }
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Retrieve");

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -84,11 +84,10 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
   LinkedList::moveIntoList(std::move(callback), request_callbacks_);
 }
 
-void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
-                                                     const std::string& key,
-                                                     const absl::flat_hash_map<std::string, std::string>& context,
-                                                     Tracing::Span& parent_span,
-                                                     const StreamInfo::StreamInfo& stream_info) {
+void GrpcClientImpl::retrieveTrafficRoutingAssistant(
+    const std::string& type, const std::string& key,
+    const absl::flat_hash_map<std::string, std::string>& context, Tracing::Span& parent_span,
+    const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -44,7 +44,7 @@ void GrpcClientImpl::setRequestCallbacks(RequestCallbacks& callbacks) {
 
 void GrpcClientImpl::createTrafficRoutingAssistant(
     const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-    const absl::optional<TraContextMap> context, Tracing::Span& parent_span, 
+    const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
     const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
@@ -73,7 +73,7 @@ void GrpcClientImpl::createTrafficRoutingAssistant(
 
 void GrpcClientImpl::updateTrafficRoutingAssistant(
     const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-    const absl::optional<TraContextMap> context, Tracing::Span& parent_span, 
+    const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
     const StreamInfo::StreamInfo& stream_info) {
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
@@ -98,10 +98,11 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
   LinkedList::moveIntoList(std::move(callback), request_callbacks_);
 }
 
-void GrpcClientImpl::retrieveTrafficRoutingAssistant(
-    const std::string& type, const std::string& key,
-    const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
-    const StreamInfo::StreamInfo& stream_info) {
+void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
+                                                     const std::string& key,
+                                                     const absl::optional<TraContextMap> context,
+                                                     Tracing::Span& parent_span,
+                                                     const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -44,13 +44,20 @@ void GrpcClientImpl::setRequestCallbacks(RequestCallbacks& callbacks) {
 
 void GrpcClientImpl::createTrafficRoutingAssistant(
     const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-    Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) {
+    const absl::optional<TraContextMap> context, Tracing::Span& parent_span, 
+    const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
 
   for (auto& item : data) {
     (*request.mutable_create_request()->mutable_data())[item.first] = item.second;
+  }
+
+  if (context.has_value()) {
+    for (auto& item : context.value()) {
+      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
+    }
   }
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
@@ -66,12 +73,19 @@ void GrpcClientImpl::createTrafficRoutingAssistant(
 
 void GrpcClientImpl::updateTrafficRoutingAssistant(
     const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-    Tracing::Span& parent_span, const StreamInfo::StreamInfo& stream_info) {
+    const absl::optional<TraContextMap> context, Tracing::Span& parent_span, 
+    const StreamInfo::StreamInfo& stream_info) {
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
 
   for (auto& item : data) {
     (*request.mutable_update_request()->mutable_data())[item.first] = item.second;
+  }
+
+  if (context.has_value()) {
+    for (auto& item : context.value()) {
+      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
+    }
   }
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
@@ -86,15 +100,17 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
 
 void GrpcClientImpl::retrieveTrafficRoutingAssistant(
     const std::string& type, const std::string& key,
-    const TraContextMap& context, Tracing::Span& parent_span,
+    const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
     const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
   request.mutable_retrieve_request()->set_key(key);
 
-  for (auto& item : context) {
-    (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
+  if (context.has_value()) {
+    for (auto& item : context.value()) {
+      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
+    }
   }
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
@@ -108,12 +124,19 @@ void GrpcClientImpl::retrieveTrafficRoutingAssistant(
 }
 
 void GrpcClientImpl::deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                                   const absl::optional<TraContextMap> context,
                                                    Tracing::Span& parent_span,
                                                    const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
   request.mutable_delete_request()->set_key(key);
+
+  if (context.has_value()) {
+    for (auto& item : context.value()) {
+      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
+    }
+  }
 
   const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
       "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Delete");

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -86,7 +86,7 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
 
 void GrpcClientImpl::retrieveTrafficRoutingAssistant(
     const std::string& type, const std::string& key,
-    const absl::flat_hash_map<std::string, std::string>& context, Tracing::Span& parent_span,
+    const TraContextMap& context, Tracing::Span& parent_span,
     const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -56,6 +56,7 @@ public:
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                       const absl::flat_hash_map<std::string, std::string>& context,
                                        Tracing::Span& parent_span,
                                        const StreamInfo::StreamInfo& stream_info) override;
   void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -56,7 +56,7 @@ public:
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                       const absl::flat_hash_map<std::string, std::string>& context,
+                                       const TraContextMap& context,
                                        Tracing::Span& parent_span,
                                        const StreamInfo::StreamInfo& stream_info) override;
   void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -58,7 +58,7 @@ public:
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                     const absl::optional<TraContextMap> context,
+                                       const absl::optional<TraContextMap> context,
                                        Tracing::Span& parent_span,
                                        const StreamInfo::StreamInfo& stream_info) override;
   void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -49,17 +49,20 @@ public:
   void setRequestCallbacks(RequestCallbacks& callbacks) override;
   void createTrafficRoutingAssistant(const std::string& type,
                                      const absl::flat_hash_map<std::string, std::string>& data,
+                                     const absl::optional<TraContextMap> context,
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void updateTrafficRoutingAssistant(const std::string& type,
                                      const absl::flat_hash_map<std::string, std::string>& data,
+                                     const absl::optional<TraContextMap> context,
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                       const TraContextMap& context,
+                                     const absl::optional<TraContextMap> context,
                                        Tracing::Span& parent_span,
                                        const StreamInfo::StreamInfo& stream_info) override;
   void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
+                                     const absl::optional<TraContextMap> context,
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void subscribeTrafficRoutingAssistant(const std::string& type, Tracing::Span& parent_span,

--- a/contrib/sip_proxy/filters/network/source/utility.h
+++ b/contrib/sip_proxy/filters/network/source/utility.h
@@ -10,6 +10,7 @@
 #include "contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.pb.h"
 #include "contrib/sip_proxy/filters/network/source/decoder_events.h"
 #include "contrib/sip_proxy/filters/network/source/metadata.h"
+#include <cstddef>
 
 namespace Envoy {
 namespace Extensions {
@@ -158,6 +159,10 @@ public:
         .address()
         ->ip()
         ->addressAsString();
+  }
+  static void trimStringView(absl::string_view& string) {
+    string.remove_prefix(std::min(string.find_first_not_of(' '), string.size()));
+    string.remove_suffix(std::max(string.size() - string.find_last_not_of(' ') - 1, 0ul));
   }
 };
 

--- a/contrib/sip_proxy/filters/network/source/utility.h
+++ b/contrib/sip_proxy/filters/network/source/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/server/transport_socket_config.h"
@@ -10,7 +12,6 @@
 #include "contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.pb.h"
 #include "contrib/sip_proxy/filters/network/source/decoder_events.h"
 #include "contrib/sip_proxy/filters/network/source/metadata.h"
-#include <cstddef>
 
 namespace Envoy {
 namespace Extensions {

--- a/contrib/sip_proxy/filters/network/source/utility.h
+++ b/contrib/sip_proxy/filters/network/source/utility.h
@@ -161,10 +161,6 @@ public:
         ->ip()
         ->addressAsString();
   }
-  static void trimStringView(absl::string_view& string) {
-    string.remove_prefix(std::min(string.find_first_not_of(' '), string.size()));
-    string.remove_suffix(std::max(string.size() - string.find_last_not_of(' ') - 1, 0ul));
-  }
 };
 
 /**

--- a/contrib/sip_proxy/filters/network/test/decoder_test.cc
+++ b/contrib/sip_proxy/filters/network/test/decoder_test.cc
@@ -275,7 +275,6 @@ TEST_F(SipDecoderTest, DecodeOK200) {
   EXPECT_EQ(0U, store_.counter("test.response").value());
 }
 
-
 TEST_F(SipDecoderTest, DecodeOK200EmptyHeader) {
   initializeFilter(yaml);
 

--- a/contrib/sip_proxy/filters/network/test/decoder_test.cc
+++ b/contrib/sip_proxy/filters/network/test/decoder_test.cc
@@ -274,6 +274,32 @@ TEST_F(SipDecoderTest, DecodeOK200) {
   EXPECT_EQ(2U, stats_.request_active_.value());
   EXPECT_EQ(0U, store_.counter("test.response").value());
 }
+
+
+TEST_F(SipDecoderTest, DecodeOK200EmptyHeader) {
+  initializeFilter(yaml);
+
+  const std::string SIP_OK200_EMPTY_HEADER =
+      "SIP/2.0 200 OK\x0d\x0a"
+      "Via:SIP/2.0/TCP 11.0.0.10:15060;branch=z9hG4bK-3193-1-0\x0d\x0a"
+      "From:<sip:User.0001@tas01.defult.svc.cluster.local>;tag=1\x0d\x0a"
+      "To:<sip:User.0000@tas01.defult.svc.cluster.local>\x0d\x0a"
+      "Call-ID:1-3193@11.0.0.10\x0d\x0a"
+      "CSeq:100 REGISTER\x0d\x0a"
+      "Session-ID:fdc85ff600804114a90b50e04de2b988;remote=b74c76b50080450dabd12317fb6b8aa7\x0d\x0a"
+      "User-Agent:test-client-v1.1\x0d\x0a"
+      "Supported:\x0d\x0a"
+      "Contact:<sip:User.0001@11.0.0.10:15060;transport=TCP>\x0d\x0a"
+      "Content-Length:0\x0d\x0a"
+      "\x0d\x0a";
+  buffer_.add(SIP_OK200_EMPTY_HEADER);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, stats_.request_active_.value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+}
+
 TEST_F(SipDecoderTest, DecodeGeneral) {
   initializeFilter(yaml);
 

--- a/contrib/sip_proxy/filters/network/test/decoder_test.cc
+++ b/contrib/sip_proxy/filters/network/test/decoder_test.cc
@@ -299,6 +299,30 @@ TEST_F(SipDecoderTest, DecodeOK200EmptyHeader) {
   EXPECT_EQ(0U, store_.counter("test.response").value());
 }
 
+TEST_F(SipDecoderTest, DecodeOK200DifferentHeaderFormats) {
+  initializeFilter(yaml);
+
+  const std::string SIP_OK200_DIFF_HEADER_FORMATS =
+      "SIP/2.0 200 OK\x0d\x0a"
+      "Via:             SIP/2.0/TCP 11.0.0.10:15060;branch=z9hG4bK-3193-1-0\x0d\x0a"
+      "From          :<sip:User.0001@tas01.defult.svc.cluster.local>;tag=1\x0d\x0a"
+      "To      :           <sip:User.0000@tas01.defult.svc.cluster.local>\x0d\x0a"
+      "Call-ID:1-3193@11.0.0.10\x0d\x0a"
+      "CSeq: 100 REGISTER\x0d\x0a"
+      "Session-ID:   fdc85ff600804114ae04de2b988;remote=b74c76b50050dabd12317fb6b8aa7\x0d\x0a"
+      "User-Agent  :    test-client-v1.1\x0d\x0a"
+      "Supported   :\x0d\x0a"
+      "Contact  :  <sip:User.0001@11.0.0.10:15060;transport=TCP>\x0d\x0a"
+      "Content-Length: 0\x0d\x0a"
+      "\x0d\x0a";
+  buffer_.add(SIP_OK200_DIFF_HEADER_FORMATS);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, stats_.request_active_.value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+}
+
 TEST_F(SipDecoderTest, DecodeGeneral) {
   initializeFilter(yaml);
 

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -97,10 +97,10 @@ MockTrafficRoutingAssistantHandler::MockTrafficRoutingAssistantHandler(
     const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
     Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info)
     : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {
-  ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _,_))
+  ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillByDefault(
-          Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
-                     std::string& host) -> QueryStatus {
+          Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+                     SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Continue;
           }));

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -97,9 +97,9 @@ MockTrafficRoutingAssistantHandler::MockTrafficRoutingAssistantHandler(
     const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
     Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info)
     : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {
-  ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _))
+  ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _,_))
       .WillByDefault(
-          Invoke([&](const std::string&, const std::string&, SipFilters::DecoderFilterCallbacks&,
+          Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
                      std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Continue;

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -99,7 +99,7 @@ MockTrafficRoutingAssistantHandler::MockTrafficRoutingAssistantHandler(
     : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {
   ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillByDefault(
-          Invoke([&](const std::string&, const std::string&, const TraContextMap&,
+          Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Continue;

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -99,7 +99,7 @@ MockTrafficRoutingAssistantHandler::MockTrafficRoutingAssistantHandler(
     : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {
   ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillByDefault(
-          Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+          Invoke([&](const std::string&, const std::string&, const TraContextMap&,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Continue;

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -21,6 +21,8 @@
 
 using testing::NiceMock;
 
+using tra_context_map = absl::flat_hash_map<std::string, std::string>;
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -195,8 +197,7 @@ public:
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
               (const std::string&, const std::string&, const std::string&), ());
   MOCK_METHOD(QueryStatus, retrieveTrafficRoutingAssistant,
-              (const std::string&, const std::string&, SipFilters::DecoderFilterCallbacks&,
-               std::string&),
+              (const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&, std::string&),
               ());
   MOCK_METHOD(void, deleteTrafficRoutingAssistant, (const std::string&, const std::string&), ());
   MOCK_METHOD(void, subscribeTrafficRoutingAssistant, (const std::string&), ());

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -197,7 +197,8 @@ public:
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
               (const std::string&, const std::string&, const std::string&), ());
   MOCK_METHOD(QueryStatus, retrieveTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&, std::string&),
+              (const std::string&, const std::string&, const tra_context_map&,
+               SipFilters::DecoderFilterCallbacks&, std::string&),
               ());
   MOCK_METHOD(void, deleteTrafficRoutingAssistant, (const std::string&, const std::string&), ());
   MOCK_METHOD(void, subscribeTrafficRoutingAssistant, (const std::string&), ());

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -193,12 +193,12 @@ public:
       const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const std::string&), ());
+              (const std::string&, const std::string&, const std::string&, const absl::optional<TraContextMap>), ());
   MOCK_METHOD(QueryStatus, retrieveTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const TraContextMap&,
+              (const std::string&, const std::string&, const absl::optional<TraContextMap>,
                SipFilters::DecoderFilterCallbacks&, std::string&),
               ());
-  MOCK_METHOD(void, deleteTrafficRoutingAssistant, (const std::string&, const std::string&), ());
+  MOCK_METHOD(void, deleteTrafficRoutingAssistant, (const std::string&, const std::string&, const absl::optional<TraContextMap>), ());
   MOCK_METHOD(void, subscribeTrafficRoutingAssistant, (const std::string&), ());
   MOCK_METHOD(void, complete,
               (const TrafficRoutingAssistant::ResponseType&, const std::string&, const absl::any&),

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -193,12 +193,15 @@ public:
       const envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig& config,
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const std::string&, const absl::optional<TraContextMap>), ());
+              (const std::string&, const std::string&, const std::string&,
+               const absl::optional<TraContextMap>),
+              ());
   MOCK_METHOD(QueryStatus, retrieveTrafficRoutingAssistant,
               (const std::string&, const std::string&, const absl::optional<TraContextMap>,
                SipFilters::DecoderFilterCallbacks&, std::string&),
               ());
-  MOCK_METHOD(void, deleteTrafficRoutingAssistant, (const std::string&, const std::string&, const absl::optional<TraContextMap>), ());
+  MOCK_METHOD(void, deleteTrafficRoutingAssistant,
+              (const std::string&, const std::string&, const absl::optional<TraContextMap>), ());
   MOCK_METHOD(void, subscribeTrafficRoutingAssistant, (const std::string&), ());
   MOCK_METHOD(void, complete,
               (const TrafficRoutingAssistant::ResponseType&, const std::string&, const absl::any&),

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -21,7 +21,7 @@
 
 using testing::NiceMock;
 
-using tra_context_map = absl::flat_hash_map<std::string, std::string>;
+using TraContextMap = absl::flat_hash_map<std::string, std::string>;
 
 namespace Envoy {
 namespace Extensions {
@@ -197,7 +197,7 @@ public:
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
               (const std::string&, const std::string&, const std::string&), ());
   MOCK_METHOD(QueryStatus, retrieveTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const tra_context_map&,
+              (const std::string&, const std::string&, const TraContextMap&,
                SipFilters::DecoderFilterCallbacks&, std::string&),
               ());
   MOCK_METHOD(void, deleteTrafficRoutingAssistant, (const std::string&, const std::string&), ());

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -21,8 +21,6 @@
 
 using testing::NiceMock;
 
-using TraContextMap = absl::flat_hash_map<std::string, std::string>;
-
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -247,8 +247,8 @@ public:
 
     EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
         .WillRepeatedly(
-            Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
-                       std::string& host) -> QueryStatus {
+            Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+                       SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
               host = "10.0.0.11";
               return QueryStatus::Pending;
             }));
@@ -456,8 +456,8 @@ TEST_F(SipRouterTest, QueryPending) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
-                     std::string& host) -> QueryStatus {
+          Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+                     SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Pending;
           }));
@@ -474,8 +474,8 @@ TEST_F(SipRouterTest, QueryStop) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
-                     std::string& host) -> QueryStatus {
+          Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+                     SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Stop;
           }));

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -165,6 +165,7 @@ public:
         "Route: "
         "<sip:test@pcsf-cfed.cncs.svc.cluster.local;role=anch;lr;transport=udp;x-suri="
         "sip:scscf-internal.cncs.svc.cluster.local:5060;ep=10.0.0.1>");
+    metadata_->addMsgHeader(HeaderType::From, "User.0001@10.0.0.1:5060");
     metadata_->parseHeader(HeaderType::Route);
     metadata_->resetAffinityIteration();
     if (set_destination) {
@@ -228,6 +229,7 @@ public:
         "SIP/2.0 200 OK\x0d\x0a"
         "Call-ID: 1-3193@11.0.0.10\x0d\x0a"
         "CSeq: 1 INVITE\x0d\x0a"
+        "From: <sip:User.0001@tas01.defult.svc.cluster.local>;tag=1\x0d\x0a"
         "Contact: <sip:User.0001@11.0.0.10:15060;transport=TCP>\x0d\x0a"
         "Record-Route: <sip:+16959000000:15306;role=anch;lr;transport=udp>\x0d\x0a"
         "Route: <sip:+16959000000:15306;role=anch;lr;transport=udp>\x0d\x0a"
@@ -243,9 +245,9 @@ public:
 
     initializeMetadata(msg_type, MethodType::Ok200, false);
 
-    EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _))
+    EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
         .WillRepeatedly(
-            Invoke([&](const std::string&, const std::string&, SipFilters::DecoderFilterCallbacks&,
+            Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
                        std::string& host) -> QueryStatus {
               host = "10.0.0.11";
               return QueryStatus::Pending;
@@ -452,9 +454,9 @@ TEST_F(SipRouterTest, QueryPending) {
   metadata_->parseHeader(HeaderType::Route);
   metadata_->affinity().emplace_back("Route", "lskpmc", "S1F1", false, false);
   metadata_->resetAffinityIteration();
-  EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _))
+  EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, SipFilters::DecoderFilterCallbacks&,
+          Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
                      std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Pending;
@@ -470,9 +472,9 @@ TEST_F(SipRouterTest, QueryStop) {
   metadata_->affinity().clear();
   metadata_->affinity().emplace_back("Route", "lskpmc", "S1F1", false, false);
   metadata_->resetAffinityIteration();
-  EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _))
+  EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, SipFilters::DecoderFilterCallbacks&,
+          Invoke([&](const std::string&, const std::string&, const tra_context_map&, SipFilters::DecoderFilterCallbacks&,
                      std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Stop;

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -247,7 +247,7 @@ public:
 
     EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
         .WillRepeatedly(
-            Invoke([&](const std::string&, const std::string&, const TraContextMap&,
+            Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
                        SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
               host = "10.0.0.11";
               return QueryStatus::Pending;
@@ -456,7 +456,7 @@ TEST_F(SipRouterTest, QueryPending) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const TraContextMap&,
+          Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Pending;
@@ -474,7 +474,7 @@ TEST_F(SipRouterTest, QueryStop) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const TraContextMap&,
+          Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Stop;

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -247,7 +247,7 @@ public:
 
     EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
         .WillRepeatedly(
-            Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+            Invoke([&](const std::string&, const std::string&, const TraContextMap&,
                        SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
               host = "10.0.0.11";
               return QueryStatus::Pending;
@@ -456,7 +456,7 @@ TEST_F(SipRouterTest, QueryPending) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+          Invoke([&](const std::string&, const std::string&, const TraContextMap&,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Pending;
@@ -474,7 +474,7 @@ TEST_F(SipRouterTest, QueryStop) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const tra_context_map&,
+          Invoke([&](const std::string&, const std::string&, const TraContextMap&,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Stop;

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -90,10 +90,11 @@ TEST_F(SipTraTest, TraRetrieveContinue) {
   tra_handler->updateTrafficRoutingAssistant("lskpmc", "S1F1", "10.0.0.1");
 
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks;
-  absl::flat_hash_map<std::string, std::string> tra_context = absl::flat_hash_map<std::string, std::string>{};
+  absl::flat_hash_map<std::string, std::string> tra_context =
+      absl::flat_hash_map<std::string, std::string>{};
   std::string host = "";
-  EXPECT_EQ(QueryStatus::Continue,
-            tra_handler->retrieveTrafficRoutingAssistant("lskpmc", "S1F1", tra_context, callbacks, host));
+  EXPECT_EQ(QueryStatus::Continue, tra_handler->retrieveTrafficRoutingAssistant(
+                                       "lskpmc", "S1F1", tra_context, callbacks, host));
   EXPECT_EQ(host, "10.0.0.1");
 }
 
@@ -108,8 +109,8 @@ TEST_F(SipTraTest, TraRetrievePending) {
   metadata->resetAffinityIteration();
   EXPECT_CALL(callbacks, metadata()).WillRepeatedly(Return(metadata));
   std::string host = "";
-  EXPECT_EQ(QueryStatus::Pending,
-            tra_handler->retrieveTrafficRoutingAssistant("lskpmc", "S1F1", metadata->traContext(), callbacks, host));
+  EXPECT_EQ(QueryStatus::Pending, tra_handler->retrieveTrafficRoutingAssistant(
+                                      "lskpmc", "S1F1", metadata->traContext(), callbacks, host));
   EXPECT_EQ(host, "");
 }
 
@@ -124,8 +125,8 @@ TEST_F(SipTraTest, TraRetrieveStop) {
   metadata->resetAffinityIteration();
   EXPECT_CALL(callbacks, metadata()).WillRepeatedly(Return(metadata));
   std::string host = "10.0.0.1";
-  EXPECT_EQ(QueryStatus::Stop,
-            tra_handler->retrieveTrafficRoutingAssistant("lskpmc", "S1F1", metadata->traContext(), callbacks, host));
+  EXPECT_EQ(QueryStatus::Stop, tra_handler->retrieveTrafficRoutingAssistant(
+                                   "lskpmc", "S1F1", metadata->traContext(), callbacks, host));
 }
 
 TEST_F(SipTraTest, TraCompleteUpdateRsp) {

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -100,7 +100,6 @@ TEST_F(SipTraTest, TraRetrieveContinue) {
 TEST_F(SipTraTest, TraRetrievePending) {
   auto tra_handler = initTraHandler();
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks;
-  absl::flat_hash_map<std::string, std::string> tra_context = absl::flat_hash_map<std::string, std::string>{};
 
   MessageMetadataSharedPtr metadata = std::make_shared<MessageMetadata>("");
   metadata->setMethodType(MethodType::Register);
@@ -117,7 +116,6 @@ TEST_F(SipTraTest, TraRetrievePending) {
 TEST_F(SipTraTest, TraRetrieveStop) {
   auto tra_handler = initTraHandler();
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks;
-  absl::flat_hash_map<std::string, std::string> tra_context = absl::flat_hash_map<std::string, std::string>{};
 
   MessageMetadataSharedPtr metadata = std::make_shared<MessageMetadata>("");
   metadata->setMethodType(MethodType::Register);

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -382,16 +382,11 @@ TEST_F(SipTraTest, TraGetTraContextFromMetadata) {
   metadata->addMsgHeader(HeaderType::From, "user@sip.com");
 
   auto context = metadata->traContext();
-  EXPECT_EQ(context.value()["from_header"], "user@sip.com");
-  EXPECT_EQ(context.value()["method_type"], "REGISTER");
-}
+  EXPECT_EQ(context["from_header"], "user@sip.com");
+  EXPECT_EQ(context["method_type"], "REGISTER");
 
-TEST_F(SipTraTest, TraGetTraContextFromMetadataNoFromHeaderSet) {
-  MessageMetadataSharedPtr metadata = std::make_shared<MessageMetadata>("");
-  metadata->setMethodType(MethodType::Cancel);
-
-  auto context = metadata->traContext();
-  EXPECT_EQ(context.has_value(), false);
+  auto context2 = metadata->traContext();
+  EXPECT_EQ(context2, context);
 }
 
 } // namespace SipProxy

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -90,8 +90,7 @@ TEST_F(SipTraTest, TraRetrieveContinue) {
   tra_handler->updateTrafficRoutingAssistant("lskpmc", "S1F1", "10.0.0.1");
 
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks;
-  absl::flat_hash_map<std::string, std::string> tra_context =
-      absl::flat_hash_map<std::string, std::string>{};
+  TraContextMap tra_context = TraContextMap();
   std::string host = "";
   EXPECT_EQ(QueryStatus::Continue, tra_handler->retrieveTrafficRoutingAssistant(
                                        "lskpmc", "S1F1", tra_context, callbacks, host));

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -82,18 +82,25 @@ public:
 
 TEST_F(SipTraTest, TraUpdate) {
   auto tra_handler = initTraHandler();
-  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S2F1", "10.0.0.1");
+  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S2F1", "10.0.0.1", absl::nullopt);
+}
+
+TEST_F(SipTraTest, TraUpdateWithSIPContext) {
+  auto tra_handler = initTraHandler();
+  MessageMetadataSharedPtr metadata = std::make_shared<MessageMetadata>("");
+  metadata->setMethodType(MethodType::Register);
+  metadata->addMsgHeader(HeaderType::From, "user@sip.com");
+  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S2F1", "10.0.0.1", metadata->traContext());
 }
 
 TEST_F(SipTraTest, TraRetrieveContinue) {
   auto tra_handler = initTraHandler();
-  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S1F1", "10.0.0.1");
+  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S1F1", "10.0.0.1", absl::nullopt);
 
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks;
-  TraContextMap tra_context = TraContextMap();
   std::string host = "";
   EXPECT_EQ(QueryStatus::Continue, tra_handler->retrieveTrafficRoutingAssistant(
-                                       "lskpmc", "S1F1", tra_context, callbacks, host));
+                                       "lskpmc", "S1F1", absl::nullopt, callbacks, host));
   EXPECT_EQ(host, "10.0.0.1");
 }
 
@@ -187,7 +194,15 @@ TEST_F(SipTraTest, TraDoSubscribe) {
 
 TEST_F(SipTraTest, TraDelete) {
   auto tra_handler = initTraHandler();
-  tra_handler->deleteTrafficRoutingAssistant("lskpmc", "S1F1");
+  tra_handler->deleteTrafficRoutingAssistant("lskpmc", "S1F1", absl::nullopt);
+}
+
+TEST_F(SipTraTest, TraDeleteWithSIPContext) {
+  auto tra_handler = initTraHandler();
+  MessageMetadataSharedPtr metadata = std::make_shared<MessageMetadata>("");
+  metadata->setMethodType(MethodType::Bye);
+  metadata->addMsgHeader(HeaderType::From, "user@sip.com");
+  tra_handler->deleteTrafficRoutingAssistant("lskpmc", "S1F1", metadata->traContext());
 }
 
 TEST_F(SipTraTest, TraSubscribe) {
@@ -337,7 +352,7 @@ TEST_F(SipTraTest, Misc) {
 
   absl::flat_hash_map<std::string, std::string> data;
   data.emplace(std::make_pair("S1F1", "10.0.0.1"));
-  grpc_client.createTrafficRoutingAssistant("lskpmc", data, span_, stream_info_);
+  grpc_client.createTrafficRoutingAssistant("lskpmc", data, absl::nullopt, span_, stream_info_);
 
   Http::TestRequestHeaderMapImpl request_headers;
   request_cb->onCreateInitialMetadata(request_headers);

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -382,8 +382,16 @@ TEST_F(SipTraTest, TraGetTraContextFromMetadata) {
   metadata->addMsgHeader(HeaderType::From, "user@sip.com");
 
   auto context = metadata->traContext();
-  EXPECT_EQ(context["from_header"], "user@sip.com");
-  EXPECT_EQ(context["method_type"], "REGISTER");
+  EXPECT_EQ(context.value()["from_header"], "user@sip.com");
+  EXPECT_EQ(context.value()["method_type"], "REGISTER");
+}
+
+TEST_F(SipTraTest, TraGetTraContextFromMetadataNoFromHeaderSet) {
+  MessageMetadataSharedPtr metadata = std::make_shared<MessageMetadata>("");
+  metadata->setMethodType(MethodType::Cancel);
+
+  auto context = metadata->traContext();
+  EXPECT_EQ(context.has_value(), false);
 }
 
 } // namespace SipProxy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: SIP Proxy extension TRA API updated to send additional SIP context.
Co-authored-by: Jonah Murphy <jonamurp@cisco.com>

Additional Description: This PR contains the following changes:
1. SIP Proxy extension TRA API updated to send additional SIP context (method type and from header), so TRA service can use this information for customized affinity management.
2. Fix an error with decoding of SIP headers with a valid format causing Envoy proxy to crash in case of empty header fields.

Risk Level: Low
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
