### PR TITLE
redis_proxy: support multiple passwords

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message RedisProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
@@ -252,14 +252,21 @@ message RedisProxy {
   PrefixRoutes prefix_routes = 5;
 
   // Authenticate Redis client connections locally by forcing downstream clients to issue a `Redis
-  // AUTH command <https://redis.io/commands/auth>`_ with this password before enabling any other
-  // command. If an AUTH command's password matches this password, an "OK" response will be returned
-  // to the client. If the AUTH command password does not match this password, then an "ERR invalid
-  // password" error will be returned. If any other command is received before AUTH when this
+  // AUTH command <https://redis.io/commands/auth>`_ with this password or with the one in
+  // :ref:`extra_downstream_auth_passwords<envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.extra_downstream_auth_passwords>`
+  // before enabling any other command. If an AUTH command's password matches one of these passwords,
+  // an "OK" response will be returned to the client. If the AUTH command password does not match this password,
+  // then an "ERR invalid password" error will be returned. If any other command is received before AUTH when this
   // password is set, then a "NOAUTH Authentication required." error response will be sent to the
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   config.core.v3.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+
+  // Additional passwords to use when authenticating downstream clients locally. Please see
+  // :ref:`downstream_auth_password<envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_password>`
+  // details.
+  repeated config.core.v3.DataSource extra_downstream_auth_passwords = 9
+      [(udpa.annotations.sensitive) = true];
 
   // List of faults to inject. Faults currently come in two flavors:
   // - Delay, which delays a request.

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
@@ -252,20 +253,32 @@ message RedisProxy {
   PrefixRoutes prefix_routes = 5;
 
   // Authenticate Redis client connections locally by forcing downstream clients to issue a `Redis
-  // AUTH command <https://redis.io/commands/auth>`_ with this password or with the one in
-  // :ref:`extra_downstream_auth_passwords<envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.extra_downstream_auth_passwords>`
-  // before enabling any other command. If an AUTH command's password matches one of these passwords,
-  // an "OK" response will be returned to the client. If the AUTH command password does not match this password,
-  // then an "ERR invalid password" error will be returned. If any other command is received before AUTH when this
+  // AUTH command <https://redis.io/commands/auth>`_ with this password before enabling any other
+  // command. If an AUTH command's password matches this password, an "OK" response will be returned
+  // to the client. If the AUTH command password does not match this password, then an "ERR invalid
+  // password" error will be returned. If any other command is received before AUTH when this
   // password is set, then a "NOAUTH Authentication required." error response will be sent to the
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
-  config.core.v3.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+  //
+  // .. attention::
+  //   This field is deprecated. Use :ref:`downstream_auth_passwords
+  //   <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
+  config.core.v3.DataSource downstream_auth_password = 6 [
+    deprecated = true,
+    (udpa.annotations.sensitive) = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0"
+  ];
 
-  // Additional passwords to use when authenticating downstream clients locally. Please see
-  // :ref:`downstream_auth_password<envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_password>`
-  // details.
-  repeated config.core.v3.DataSource extra_downstream_auth_passwords = 9
+  // Authenticate Redis client connections locally by forcing downstream clients to issue a `Redis
+  // AUTH command <https://redis.io/commands/auth>`_ with one of these passwords before enabling any other
+  // command. If an AUTH command's password matches one of these passwords, an "OK" response will be returned
+  // to the client. If the AUTH command password does not match, then an "ERR invalid
+  // password" error will be returned. If any other command is received before AUTH when the
+  // password(s) are set, then a "NOAUTH Authentication required." error response will be sent to the
+  // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
+  // AUTH, but no password is set" error will be returned.
+  repeated config.core.v3.DataSource downstream_auth_passwords = 9
       [(udpa.annotations.sensitive) = true];
 
   // List of faults to inject. Faults currently come in two flavors:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -229,9 +229,9 @@ new_features:
 - area: listener
   change: |
     added dynamic listener filter configuration for listener filters. :ref:`dynamic listener filter re-configuration<envoy_v3_api_field_config.listener.v3.ListenerFilter.config_discovery>`. This dynamic listener filter configuration is only supported in TCP listeners.
-- area: redis_proxy
+- area: redis
   change: |
-    added support for multiple passwords to the redis proxy.
+    added support for multiple passwords to the redis proxy. See :ref:`downstream_auth_passwords <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
 - area: thrift
   change: |
     added flag to router to control downstream local close. :ref:`close_downstream_on_upstream_error <envoy_v3_api_field_extensions.filters.network.thrift_proxy.router.v3.Router.close_downstream_on_upstream_error>`.
@@ -317,3 +317,7 @@ deprecated:
 - area: matching
   change: |
     :ref:`google_re2 <envoy_v3_api_field_type.matcher.v3.RegexMatcher.google_re2>` has been deprecated.
+- area: redis
+  change: |
+    :ref:`downstream_auth_password <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_password>` has been deprecated. Please use
+    :ref:`downstream_auth_passwords <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -231,7 +231,7 @@ new_features:
     added dynamic listener filter configuration for listener filters. :ref:`dynamic listener filter re-configuration<envoy_v3_api_field_config.listener.v3.ListenerFilter.config_discovery>`. This dynamic listener filter configuration is only supported in TCP listeners.
 - area: redis_proxy
   change: |
-    added support for multiple passwords to the redis proxy
+    added support for multiple passwords to the redis proxy.
 - area: thrift
   change: |
     added flag to router to control downstream local close. :ref:`close_downstream_on_upstream_error <envoy_v3_api_field_extensions.filters.network.thrift_proxy.router.v3.Router.close_downstream_on_upstream_error>`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -229,6 +229,9 @@ new_features:
 - area: listener
   change: |
     added dynamic listener filter configuration for listener filters. :ref:`dynamic listener filter re-configuration<envoy_v3_api_field_config.listener.v3.ListenerFilter.config_discovery>`. This dynamic listener filter configuration is only supported in TCP listeners.
+- area: redis_proxy
+  change: |
+    added support for multiple passwords to the redis proxy
 - area: thrift
   change: |
     added flag to router to control downstream local close. :ref:`close_downstream_on_upstream_error <envoy_v3_api_field_extensions.filters.network.thrift_proxy.router.v3.Router.close_downstream_on_upstream_error>`.

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -37,7 +37,9 @@ ProxyFilterConfig::ProxyFilterConfig(
                                        config.extra_downstream_auth_passwords().size());
     for (const auto& source : config.extra_downstream_auth_passwords()) {
       const auto p = Config::DataSource::read(source, true, api);
-      downstream_auth_passwords_.emplace_back(p);
+      if (!p.empty()) {
+        downstream_auth_passwords_.emplace_back(p);
+      }
     }
   }
 }

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -24,9 +24,23 @@ ProxyFilterConfig::ProxyFilterConfig(
       stat_prefix_(fmt::format("redis.{}.", config.stat_prefix())),
       stats_(generateStats(stat_prefix_, scope)),
       downstream_auth_username_(
-          Config::DataSource::read(config.downstream_auth_username(), true, api)),
-      downstream_auth_password_(
-          Config::DataSource::read(config.downstream_auth_password(), true, api)) {}
+          Config::DataSource::read(config.downstream_auth_username(), true, api)) {
+
+  auto downstream_auth_password =
+      Config::DataSource::read(config.downstream_auth_password(), true, api);
+  if (!downstream_auth_password.empty()) {
+    downstream_auth_passwords_.emplace_back(downstream_auth_password);
+  }
+
+  if (config.extra_downstream_auth_passwords_size() > 0) {
+    downstream_auth_passwords_.reserve(downstream_auth_passwords_.size() +
+                                       config.extra_downstream_auth_passwords().size());
+    for (const auto& source : config.extra_downstream_auth_passwords()) {
+      const auto p = Config::DataSource::read(source, true, api);
+      downstream_auth_passwords_.emplace_back(p);
+    }
+  }
+}
 
 ProxyStats ProxyFilterConfig::generateStats(const std::string& prefix, Stats::Scope& scope) {
   return {
@@ -41,7 +55,7 @@ ProxyFilter::ProxyFilter(Common::Redis::DecoderFactory& factory,
   config_->stats_.downstream_cx_total_.inc();
   config_->stats_.downstream_cx_active_.inc();
   connection_allowed_ =
-      config_->downstream_auth_username_.empty() && config_->downstream_auth_password_.empty();
+      config_->downstream_auth_username_.empty() && config_->downstream_auth_passwords_.empty();
 }
 
 ProxyFilter::~ProxyFilter() {
@@ -85,10 +99,10 @@ void ProxyFilter::onEvent(Network::ConnectionEvent event) {
 
 void ProxyFilter::onAuth(PendingRequest& request, const std::string& password) {
   Common::Redis::RespValuePtr response{new Common::Redis::RespValue()};
-  if (config_->downstream_auth_password_.empty()) {
+  if (config_->downstream_auth_passwords_.empty()) {
     response->type(Common::Redis::RespType::Error);
     response->asString() = "ERR Client sent AUTH, but no password is set";
-  } else if (password == config_->downstream_auth_password_) {
+  } else if (checkPassword(password)) {
     response->type(Common::Redis::RespType::SimpleString);
     response->asString() = "OK";
     connection_allowed_ = true;
@@ -103,17 +117,16 @@ void ProxyFilter::onAuth(PendingRequest& request, const std::string& password) {
 void ProxyFilter::onAuth(PendingRequest& request, const std::string& username,
                          const std::string& password) {
   Common::Redis::RespValuePtr response{new Common::Redis::RespValue()};
-  if (config_->downstream_auth_username_.empty() && config_->downstream_auth_password_.empty()) {
+  if (config_->downstream_auth_username_.empty() && config_->downstream_auth_passwords_.empty()) {
     response->type(Common::Redis::RespType::Error);
     response->asString() = "ERR Client sent AUTH, but no username-password pair is set";
   } else if (config_->downstream_auth_username_.empty() && username == "default" &&
-             password == config_->downstream_auth_password_) {
+             checkPassword(password)) {
     // empty username and "default" are synonymous in Redis 6 ACLs
     response->type(Common::Redis::RespType::SimpleString);
     response->asString() = "OK";
     connection_allowed_ = true;
-  } else if (username == config_->downstream_auth_username_ &&
-             password == config_->downstream_auth_password_) {
+  } else if (username == config_->downstream_auth_username_ && checkPassword(password)) {
     response->type(Common::Redis::RespType::SimpleString);
     response->asString() = "OK";
     connection_allowed_ = true;
@@ -123,6 +136,15 @@ void ProxyFilter::onAuth(PendingRequest& request, const std::string& username,
     connection_allowed_ = false;
   }
   request.onResponse(std::move(response));
+}
+
+bool ProxyFilter::checkPassword(const std::string& password) {
+  for (const auto& p : config_->downstream_auth_passwords_) {
+    if (password == p) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value) {

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -32,10 +32,10 @@ ProxyFilterConfig::ProxyFilterConfig(
     downstream_auth_passwords_.emplace_back(downstream_auth_password);
   }
 
-  if (config.extra_downstream_auth_passwords_size() > 0) {
+  if (config.downstream_auth_passwords_size() > 0) {
     downstream_auth_passwords_.reserve(downstream_auth_passwords_.size() +
-                                       config.extra_downstream_auth_passwords().size());
-    for (const auto& source : config.extra_downstream_auth_passwords()) {
+                                       config.downstream_auth_passwords().size());
+    for (const auto& source : config.downstream_auth_passwords()) {
       const auto p = Config::DataSource::read(source, true, api);
       if (!p.empty()) {
         downstream_auth_passwords_.emplace_back(p);

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -57,7 +57,7 @@ public:
   const std::string redis_drain_close_runtime_key_{"redis.drain_close_enabled"};
   ProxyStats stats_;
   const std::string downstream_auth_username_;
-  const std::string downstream_auth_password_;
+  std::vector<std::string> downstream_auth_passwords_;
 
 private:
   static ProxyStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -117,6 +117,7 @@ private:
   void onAuth(PendingRequest& request, const std::string& password);
   void onAuth(PendingRequest& request, const std::string& username, const std::string& password);
   void onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value);
+  bool checkPassword(const std::string& password);
 
   Common::Redis::DecoderPtr decoder_;
   Common::Redis::EncoderPtr encoder_;

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -76,7 +76,7 @@ public:
 
   void expectConnectionCreation(size_t id) {
     EXPECT_CALL(*connection_provider_, createNextConnection(_))
-        .WillOnce(testing::Invoke([ this, id ](uint64_t conn_id) -> auto {
+        .WillOnce(testing::Invoke([ this, id ](uint64_t conn_id) -> auto{
           EXPECT_EQ(connection_provider_->nextConnection(), id);
           return connection_provider_->getNextConnection(conn_id);
         }));

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -76,7 +76,7 @@ public:
 
   void expectConnectionCreation(size_t id) {
     EXPECT_CALL(*connection_provider_, createNextConnection(_))
-        .WillOnce(testing::Invoke([ this, id ](uint64_t conn_id) -> auto{
+        .WillOnce(testing::Invoke([ this, id ](uint64_t conn_id) -> auto {
           EXPECT_EQ(connection_provider_->nextConnection(), id);
           return connection_provider_->getNextConnection(conn_id);
         }));

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -104,7 +104,7 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamMultipleAuthPasswordsSet) {
     op_timeout: 0.01s
   downstream_auth_password:
     inline_string: somepassword
-  extra_downstream_auth_passwords:
+  downstream_auth_passwords:
   - inline_string: newpassword1
   - inline_string: newpassword2
   )EOF";
@@ -126,7 +126,7 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamOnlyExraAuthPasswordsSet) {
   stat_prefix: foo
   settings:
     op_timeout: 0.01s
-  extra_downstream_auth_passwords:
+  downstream_auth_passwords:
   - inline_string: newpassword1
   - inline_string: newpassword2
   )EOF";
@@ -173,7 +173,7 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSetWithMultiplePasswords) {
     inline_string: someusername
   downstream_auth_password:
     inline_string: somepassword
-  extra_downstream_auth_passwords:
+  downstream_auth_passwords:
   - inline_string: newpassword1
   - inline_string: newpassword2
   )EOF";
@@ -198,7 +198,7 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSetWithOnlyExtraPasswords) {
     op_timeout: 0.01s
   downstream_auth_username:
     inline_string: someusername
-  extra_downstream_auth_passwords:
+  downstream_auth_passwords:
   - inline_string: newpassword1
   - inline_string: newpassword2
   )EOF";
@@ -531,7 +531,7 @@ settings:
   op_timeout: 0.01s
 downstream_auth_password:
   inline_string: somepassword
-extra_downstream_auth_passwords:
+downstream_auth_passwords:
 -  inline_string: newpassword1
 -  inline_string: newpassword2
 )EOF";
@@ -760,7 +760,7 @@ downstream_auth_username:
   inline_string: someusername
 downstream_auth_password:
   inline_string: somepassword
-extra_downstream_auth_passwords:
+downstream_auth_passwords:
 -  inline_string: newpassword1
 -  inline_string: newpassword2
 )EOF";

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -63,7 +63,7 @@ TEST_F(RedisProxyFilterConfigTest, Normal) {
   ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
   EXPECT_EQ("redis.foo.", config.stat_prefix_);
   EXPECT_TRUE(config.downstream_auth_username_.empty());
-  EXPECT_TRUE(config.downstream_auth_password_.empty());
+  EXPECT_TRUE(config.downstream_auth_passwords_.empty());
 }
 
 TEST_F(RedisProxyFilterConfigTest, BadRedisProxyConfig) {
@@ -90,7 +90,53 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthPasswordSet) {
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
   ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
-  EXPECT_EQ(config.downstream_auth_password_, "somepassword");
+  EXPECT_EQ(config.downstream_auth_passwords_.size(), 1);
+  EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
+}
+
+TEST_F(RedisProxyFilterConfigTest, DownstreamMultipleAuthPasswordsSet) {
+  const std::string yaml_string = R"EOF(
+  prefix_routes:
+    catch_all_route:
+      cluster: fake_cluster
+  stat_prefix: foo
+  settings:
+    op_timeout: 0.01s
+  downstream_auth_password:
+    inline_string: somepassword
+  extra_downstream_auth_passwords:
+  - inline_string: newpassword1
+  - inline_string: newpassword2
+  )EOF";
+
+  envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
+      parseProtoFromYaml(yaml_string);
+  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
+  EXPECT_EQ(config.downstream_auth_passwords_.size(), 3);
+  EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
+  EXPECT_EQ(config.downstream_auth_passwords_[1], "newpassword1");
+  EXPECT_EQ(config.downstream_auth_passwords_[2], "newpassword2");
+}
+
+TEST_F(RedisProxyFilterConfigTest, DownstreamOnlyExraAuthPasswordsSet) {
+  const std::string yaml_string = R"EOF(
+  prefix_routes:
+    catch_all_route:
+      cluster: fake_cluster
+  stat_prefix: foo
+  settings:
+    op_timeout: 0.01s
+  extra_downstream_auth_passwords:
+  - inline_string: newpassword1
+  - inline_string: newpassword2
+  )EOF";
+
+  envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
+      parseProtoFromYaml(yaml_string);
+  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
+  EXPECT_EQ(config.downstream_auth_passwords_.size(), 2);
+  EXPECT_EQ(config.downstream_auth_passwords_[0], "newpassword1");
+  EXPECT_EQ(config.downstream_auth_passwords_[1], "newpassword2");
 }
 
 TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSet) {
@@ -111,7 +157,59 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSet) {
       parseProtoFromYaml(yaml_string);
   ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
   EXPECT_EQ(config.downstream_auth_username_, "someusername");
-  EXPECT_EQ(config.downstream_auth_password_, "somepassword");
+  EXPECT_EQ(config.downstream_auth_passwords_.size(), 1);
+  EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
+}
+
+TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSetWithMultiplePasswords) {
+  const std::string yaml_string = R"EOF(
+  prefix_routes:
+    catch_all_route:
+      cluster: fake_cluster
+  stat_prefix: foo
+  settings:
+    op_timeout: 0.01s
+  downstream_auth_username:
+    inline_string: someusername
+  downstream_auth_password:
+    inline_string: somepassword
+  extra_downstream_auth_passwords:
+  - inline_string: newpassword1
+  - inline_string: newpassword2
+  )EOF";
+
+  envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
+      parseProtoFromYaml(yaml_string);
+  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
+  EXPECT_EQ(config.downstream_auth_username_, "someusername");
+  EXPECT_EQ(config.downstream_auth_passwords_.size(), 3);
+  EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
+  EXPECT_EQ(config.downstream_auth_passwords_[1], "newpassword1");
+  EXPECT_EQ(config.downstream_auth_passwords_[2], "newpassword2");
+}
+
+TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSetWithOnlyExtraPasswords) {
+  const std::string yaml_string = R"EOF(
+  prefix_routes:
+    catch_all_route:
+      cluster: fake_cluster
+  stat_prefix: foo
+  settings:
+    op_timeout: 0.01s
+  downstream_auth_username:
+    inline_string: someusername
+  extra_downstream_auth_passwords:
+  - inline_string: newpassword1
+  - inline_string: newpassword2
+  )EOF";
+
+  envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
+      parseProtoFromYaml(yaml_string);
+  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_);
+  EXPECT_EQ(config.downstream_auth_username_, "someusername");
+  EXPECT_EQ(config.downstream_auth_passwords_.size(), 2);
+  EXPECT_EQ(config.downstream_auth_passwords_[0], "newpassword1");
+  EXPECT_EQ(config.downstream_auth_passwords_[1], "newpassword2");
 }
 
 class RedisProxyFilterTest : public testing::Test, public Common::Redis::DecoderFactory {
@@ -424,6 +522,134 @@ TEST_F(RedisProxyFilterWithAuthPasswordTest, AuthPasswordIncorrect) {
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
 }
 
+const std::string downstream_multiple_auth_passwords_config = R"EOF(
+prefix_routes:
+  catch_all_route:
+      cluster: fake_cluster
+stat_prefix: foo
+settings:
+  op_timeout: 0.01s
+downstream_auth_password:
+  inline_string: somepassword
+extra_downstream_auth_passwords:
+-  inline_string: newpassword1
+-  inline_string: newpassword2
+)EOF";
+
+class RedisProxyFilterWithMultipleAuthPasswordsTest : public RedisProxyFilterTest {
+public:
+  RedisProxyFilterWithMultipleAuthPasswordsTest()
+      : RedisProxyFilterTest(downstream_multiple_auth_passwords_config) {}
+};
+
+TEST_F(RedisProxyFilterWithMultipleAuthPasswordsTest, AuthPasswordCorrect) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::SimpleString);
+            reply->asString() = "OK";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("somepassword");
+            // callbacks cannot be accessed now.
+            EXPECT_TRUE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithMultipleAuthPasswordsTest, AuthNewPassword1Correct) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::SimpleString);
+            reply->asString() = "OK";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("newpassword1");
+            // callbacks cannot be accessed now.
+            EXPECT_TRUE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithMultipleAuthPasswordsTest, AuthNewPassword2Correct) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::SimpleString);
+            reply->asString() = "OK";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("newpassword2");
+            // callbacks cannot be accessed now.
+            EXPECT_TRUE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithMultipleAuthPasswordsTest, AuthPasswordIncorrect) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::Error);
+            reply->asString() = "ERR invalid password";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("wrongpassword");
+            // callbacks cannot be accessed now.
+            EXPECT_FALSE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
 const std::string downstream_auth_acl_config = R"EOF(
 prefix_routes:
   catch_all_route:
@@ -497,6 +723,161 @@ TEST_F(RedisProxyFilterWithAuthAclTest, AuthAclUsernameIncorrect) {
 }
 
 TEST_F(RedisProxyFilterWithAuthAclTest, AuthAclPasswordIncorrect) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::Error);
+            reply->asString() = "WRONGPASS invalid username-password pair";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("someusername", "wrongpassword");
+            // callbacks cannot be accessed now.
+            EXPECT_FALSE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+const std::string downstream_auth_acl_multiple_passwords_config = R"EOF(
+prefix_routes:
+  catch_all_route:
+      cluster: fake_cluster
+stat_prefix: foo
+settings:
+  op_timeout: 0.01s
+downstream_auth_username:
+  inline_string: someusername
+downstream_auth_password:
+  inline_string: somepassword
+extra_downstream_auth_passwords:
+-  inline_string: newpassword1
+-  inline_string: newpassword2
+)EOF";
+
+class RedisProxyFilterWithAuthAclMultiplePasswordsTest : public RedisProxyFilterTest {
+public:
+  RedisProxyFilterWithAuthAclMultiplePasswordsTest()
+      : RedisProxyFilterTest(downstream_auth_acl_multiple_passwords_config) {}
+};
+
+TEST_F(RedisProxyFilterWithAuthAclMultiplePasswordsTest, AuthAclCorrect) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::SimpleString);
+            reply->asString() = "OK";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("someusername", "somepassword");
+            // callbacks cannot be accessed now.
+            EXPECT_TRUE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithAuthAclMultiplePasswordsTest, AuthAclCorrect1) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::SimpleString);
+            reply->asString() = "OK";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("someusername", "newpassword1");
+            EXPECT_TRUE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithAuthAclMultiplePasswordsTest, AuthAclCorrect2) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::SimpleString);
+            reply->asString() = "OK";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("someusername", "newpassword2");
+            EXPECT_TRUE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithAuthAclMultiplePasswordsTest, AuthAclUsernameIncorrect) {
+  InSequence s;
+
+  Buffer::OwnedImpl fake_data;
+  Common::Redis::RespValuePtr request(new Common::Redis::RespValue());
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data))).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    decoder_callbacks_->onRespValue(std::move(request));
+  }));
+  EXPECT_CALL(splitter_, makeRequest_(Ref(*request), _, _))
+      .WillOnce(
+          Invoke([&](const Common::Redis::RespValue&, CommandSplitter::SplitCallbacks& callbacks,
+                     Event::Dispatcher&) -> CommandSplitter::SplitRequest* {
+            EXPECT_FALSE(callbacks.connectionAllowed());
+            Common::Redis::RespValuePtr reply(new Common::Redis::RespValue());
+            reply->type(Common::Redis::RespType::Error);
+            reply->asString() = "WRONGPASS invalid username-password pair";
+            EXPECT_CALL(*encoder_, encode(Eq(ByRef(*reply)), _));
+            EXPECT_CALL(filter_callbacks_.connection_, write(_, _));
+            callbacks.onAuth("wrongusername", "somepassword");
+            // callbacks cannot be accessed now.
+            EXPECT_FALSE(filter_->connectionAllowed());
+            return nullptr;
+          }));
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data, false));
+}
+
+TEST_F(RedisProxyFilterWithAuthAclMultiplePasswordsTest, AuthAclPasswordIncorrect) {
   InSequence s;
 
   Buffer::OwnedImpl fake_data;

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -201,7 +201,8 @@ const std::string CONFIG_WITH_MIRROR = CONFIG_WITH_ROUTES_BASE + R"EOF(
 )EOF";
 
 const std::string CONFIG_WITH_DOWNSTREAM_AUTH_PASSWORD_SET = CONFIG + R"EOF(
-          downstream_auth_password: { inline_string: somepassword }
+          downstream_auth_passwords:
+          - inline_string: somepassword
 )EOF";
 
 const std::string CONFIG_WITH_ROUTES_AND_AUTH_PASSWORDS = fmt::format(R"EOF(

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -201,8 +201,13 @@ const std::string CONFIG_WITH_MIRROR = CONFIG_WITH_ROUTES_BASE + R"EOF(
 )EOF";
 
 const std::string CONFIG_WITH_DOWNSTREAM_AUTH_PASSWORD_SET = CONFIG + R"EOF(
+          downstream_auth_password: { inline_string: somepassword }
+)EOF";
+
+const std::string CONFIG_WITH_MULTIPLE_DOWNSTREAM_AUTH_PASSWORDS_SET = CONFIG + R"EOF(
           downstream_auth_passwords:
           - inline_string: somepassword
+          - inline_string: someotherpassword
 )EOF";
 
 const std::string CONFIG_WITH_ROUTES_AND_AUTH_PASSWORDS = fmt::format(R"EOF(
@@ -458,6 +463,12 @@ public:
       : RedisProxyIntegrationTest(CONFIG_WITH_DOWNSTREAM_AUTH_PASSWORD_SET, 2) {}
 };
 
+class RedisProxyWithMultipleDownstreamAuthIntegrationTest : public RedisProxyIntegrationTest {
+public:
+  RedisProxyWithMultipleDownstreamAuthIntegrationTest()
+      : RedisProxyIntegrationTest(CONFIG_WITH_MULTIPLE_DOWNSTREAM_AUTH_PASSWORDS_SET, 2) {}
+};
+
 class RedisProxyWithRoutesAndAuthPasswordsIntegrationTest : public RedisProxyIntegrationTest {
 public:
   RedisProxyWithRoutesAndAuthPasswordsIntegrationTest()
@@ -498,6 +509,10 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, RedisProxyWithRoutesIntegrationTest,
                          TestUtility::ipTestParamsToString);
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, RedisProxyWithDownstreamAuthIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, RedisProxyWithMultipleDownstreamAuthIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
@@ -942,7 +957,8 @@ TEST_P(RedisProxyWithRoutesIntegrationTest, SimpleRequestAndResponseRoutedByPref
 // is set for the redis_proxy filter. It also verifies the errors sent by the proxy
 // when no password or the wrong password is received.
 
-TEST_P(RedisProxyWithDownstreamAuthIntegrationTest, ErrorsUntilCorrectPasswordSent) {
+TEST_P(RedisProxyWithDownstreamAuthIntegrationTest,
+       DEPRECATED_FEATURE_TEST(ErrorsUntilCorrectPasswordSent)) {
   initialize();
 
   IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
@@ -962,6 +978,62 @@ TEST_P(RedisProxyWithDownstreamAuthIntegrationTest, ErrorsUntilCorrectPasswordSe
                     redis_client);
 
   proxyResponseStep(makeBulkStringArray({"auth", "somepassword"}), "+OK\r\n", redis_client);
+
+  roundtripToUpstreamStep(fake_upstreams_[0], makeBulkStringArray({"get", "foo"}), "$3\r\nbar\r\n",
+                          redis_client, fake_upstream_connection, "", "");
+
+  EXPECT_TRUE(fake_upstream_connection->close());
+  redis_client->close();
+}
+
+TEST_P(RedisProxyWithMultipleDownstreamAuthIntegrationTest, ErrorsUntilCorrectPasswordSent1) {
+  initialize();
+
+  IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
+  FakeRawConnectionPtr fake_upstream_connection;
+
+  proxyResponseStep(makeBulkStringArray({"get", "foo"}), "-NOAUTH Authentication required.\r\n",
+                    redis_client);
+
+  std::stringstream error_response;
+  error_response << "-" << RedisCmdSplitter::Response::get().InvalidRequest << "\r\n";
+  proxyResponseStep(makeBulkStringArray({"auth"}), error_response.str(), redis_client);
+
+  proxyResponseStep(makeBulkStringArray({"auth", "wrongpassword"}), "-ERR invalid password\r\n",
+                    redis_client);
+
+  proxyResponseStep(makeBulkStringArray({"get", "foo"}), "-NOAUTH Authentication required.\r\n",
+                    redis_client);
+
+  proxyResponseStep(makeBulkStringArray({"auth", "somepassword"}), "+OK\r\n", redis_client);
+
+  roundtripToUpstreamStep(fake_upstreams_[0], makeBulkStringArray({"get", "foo"}), "$3\r\nbar\r\n",
+                          redis_client, fake_upstream_connection, "", "");
+
+  EXPECT_TRUE(fake_upstream_connection->close());
+  redis_client->close();
+}
+
+TEST_P(RedisProxyWithMultipleDownstreamAuthIntegrationTest, ErrorsUntilCorrectPasswordSent2) {
+  initialize();
+
+  IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
+  FakeRawConnectionPtr fake_upstream_connection;
+
+  proxyResponseStep(makeBulkStringArray({"get", "foo"}), "-NOAUTH Authentication required.\r\n",
+                    redis_client);
+
+  std::stringstream error_response;
+  error_response << "-" << RedisCmdSplitter::Response::get().InvalidRequest << "\r\n";
+  proxyResponseStep(makeBulkStringArray({"auth"}), error_response.str(), redis_client);
+
+  proxyResponseStep(makeBulkStringArray({"auth", "wrongpassword"}), "-ERR invalid password\r\n",
+                    redis_client);
+
+  proxyResponseStep(makeBulkStringArray({"get", "foo"}), "-NOAUTH Authentication required.\r\n",
+                    redis_client);
+
+  proxyResponseStep(makeBulkStringArray({"auth", "someotherpassword"}), "+OK\r\n", redis_client);
 
   roundtripToUpstreamStep(fake_upstreams_[0], makeBulkStringArray({"get", "foo"}), "$3\r\nbar\r\n",
                           redis_client, fake_upstream_connection, "", "");


### PR DESCRIPTION
Commit Message: redis_proxy: support multiple passwords
Additional Description: When rotating passwords, we need to support multiple passwords for graceful deployment/rollout. This change adds support for multiple passwords in AUTH, for both old auth and new ACL based one.
Risk Level: Low
Testing: Integration and unit tests
Docs Changes: Added
Release Notes: Added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Signed-off-by: Suresh Kumar <sureshkumar.pp@gmail.com>
Signed-off-by: Suresh Kumar <suresh.ponnusamy@freshworks.com>
