### PR TITLE
api_proto_plugin: Normalize `SourceCodeInfo.comments` in `type_context`

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
@@ -153,9 +153,9 @@ message Cache {
 
 // Local Service
 message LocalService {
-  //The domain need to matched
+  // The domain need to matched
   string domain = 1;
 
-  //The parameter to get domain
+  // The parameter to get domain
   string parameter = 2;
 }

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -111,7 +111,7 @@ def format_comment_with_annotations(comment, show_wip_warning=False):
     if annotations.EXTENSION_CATEGORY_ANNOTATION in comment.annotations:
         for category in comment.annotations[annotations.EXTENSION_CATEGORY_ANNOTATION].split(","):
             formatted_extension_category += format_extension_category(category)
-    comment = annotations.without_annotations(strip_leading_space(comment.raw) + '\n')
+    comment = annotations.without_annotations(comment.raw + '\n')
     return comment + wip_warning + formatted_extension + formatted_extension_category
 
 
@@ -235,7 +235,7 @@ def format_header_from_file(style, source_code_info, proto_name):
     """
     anchor = format_anchor(file_cross_ref_label(proto_name))
     stripped_comment = annotations.without_annotations(
-        strip_leading_space('\n'.join(c + '\n' for c in source_code_info.file_level_comments)))
+        '\n'.join(c + '\n' for c in source_code_info.file_level_comments))
     formatted_extension = ''
     if annotations.EXTENSION_ANNOTATION in source_code_info.file_level_annotations:
         extension = source_code_info.file_level_annotations[annotations.EXTENSION_ANNOTATION]
@@ -387,11 +387,6 @@ def format_field_type(type_context, field):
             pretty_type_names[field.type],
             'https://developers.google.com/protocol-buffers/docs/proto#scalar')
     raise ProtodocError('Unknown field type ' + str(field.type))
-
-
-def strip_leading_space(s):
-    """Remove leading space in flat comment strings."""
-    return map_lines(lambda s: s[1:], s)
 
 
 def file_cross_ref_label(msg_name):

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -116,6 +116,12 @@ def format_block(block):
     return ''
 
 
+# TODO(htuch): not sure why this is needed, but clang-format does some weird
+# stuff with // comment indents when we have these trailing \
+def fixup_trailing_backslash(s):
+    return s[:-1].rstrip() if s.endswith('\\') else s
+
+
 def format_comments(comments):
     """Format a list of comment blocks from SourceCodeInfo.
 
@@ -129,16 +135,12 @@ def format_comments(comments):
         A string reprenting the formatted comment blocks.
     """
 
-    # TODO(htuch): not sure why this is needed, but clang-format does some weird
-    # stuff with // comment indents when we have these trailing \
-    def fixup_trailing_backslash(s):
-        return s[:-1].rstrip() if s.endswith('\\') else s
-
-    comments = '\n\n'.join(
-        '\n'.join(['//%s' % fixup_trailing_backslash(line)
-                   for line in comment.split('\n')[:-1]])
-        for comment in comments)
-    return format_block(comments)
+    return format_block(
+        '\n\n'.join(
+            '\n'.join(
+                ['// %s' % fixup_trailing_backslash(line)
+                 for line in comment.split('\n')[:-1]])
+            for comment in comments))
 
 
 def create_next_free_field_xform(msg_proto):

--- a/tools/protoprint/protoprint_test.py
+++ b/tools/protoprint/protoprint_test.py
@@ -9,8 +9,6 @@ import sys
 import tarfile
 import tempfile
 
-sys.path = [p for p in sys.path if not p.endswith('bazel_tools')]
-
 from tools.protoprint.test_data import data as test_data
 from tools.run_command import run_command
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

This is a general cleanup to shift responsibility for normalizing comment strings in `type_context`

This will make it easier to shift protodoc to templates, and also will enforce comments have a preceding space - ie `// comment` not `//comment` and prevent bugs as can be seen here https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto.html?highlight=sip_proxy#extensions-filters-network-sip-proxy-v3alpha-localservice

it also shifts some v inefficient closures

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
