### PR TITLE
ci: propagate NUM_CPUS to bazel

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -100,6 +100,7 @@ BAZEL_BUILD_OPTIONS=(
   "--repository_cache=${BUILD_DIR}/repository_cache"
   "--experimental_repository_cache_hardlinks"
   "--action_env=CLANG_FORMAT"
+  "--jobs=${NUM_CPUS}"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 


### PR DESCRIPTION
Commit Message: ci: propagate NUM_CPUS to bazel
Additional Description:
This commit ensures that NUM_CPUS env var is correctly propagated to
bazel. Without this change, if NUM_CPUS is set, for example, to a lower
than the actual CPU count number, bazel still consumes all CPUs
available on a host.
Risk Level: low
Testing: PR github workflow
Docs Changes: no
Release Notes: no
Platform Specific Features: no
