### PR TITLE
oauth2: add "default_expires_in" config option

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -7,6 +7,8 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "envoy/type/matcher/v3/path.proto";
 
+import "google/protobuf/duration.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -62,7 +64,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message OAuth2Config {
   // Endpoint on the authorization server to retrieve the access token from.
   config.core.v3.HttpUri token_endpoint = 1;
@@ -101,6 +103,9 @@ message OAuth2Config {
   // Optional resource parameter for authorization request
   // RFC: https://tools.ietf.org/html/rfc8707
   repeated string resources = 10;
+
+  // The default lifetime in seconds of the access token, if omitted by the authorization server.
+  google.protobuf.Duration default_expires_in = 11;
 }
 
 // Filter config.

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -23,7 +23,6 @@
 
 // Obtain the value of a wrapped field (e.g. google.protobuf.UInt32Value) if set. Otherwise, throw
 // a MissingFieldException.
-
 #define PROTOBUF_GET_WRAPPED_REQUIRED(message, field_name)                                         \
   ([](const auto& msg) {                                                                           \
     if (!msg.has_##field_name()) {                                                                 \
@@ -31,6 +30,7 @@
     }                                                                                              \
     return msg.field_name().value();                                                               \
   }((message)))
+
 // Obtain the milliseconds value of a google.protobuf.Duration field if set. Otherwise, return the
 // default value.
 #define PROTOBUF_GET_MS_OR_DEFAULT(message, field_name, default_value)                             \
@@ -58,6 +58,12 @@
     }                                                                                              \
     return DurationUtil::durationToMilliseconds(msg.field_name());                                 \
   }((message)))
+
+// Obtain the milliseconds value of a google.protobuf.Duration field if set. Otherwise, return the
+// default value.
+#define PROTOBUF_GET_SECONDS_OR_DEFAULT(message, field_name, default_value)                        \
+  ((message).has_##field_name() ? DurationUtil::durationToSeconds((message).field_name())          \
+                                : (default_value))
 
 // Obtain the seconds value of a google.protobuf.Duration field if set. Otherwise, throw a
 // MissingFieldException.

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -70,8 +70,8 @@ Http::FilterFactoryCb OAuth2Config::createFilterFactoryFromProtoTyped(
 
   return
       [&context, config, &cluster_manager](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-        std::unique_ptr<OAuth2Client> oauth_client =
-            std::make_unique<OAuth2ClientImpl>(cluster_manager, config->oauthTokenEndpoint());
+        std::unique_ptr<OAuth2Client> oauth_client = std::make_unique<OAuth2ClientImpl>(
+            cluster_manager, config->oauthTokenEndpoint(), config->defaultExpiresIn());
         callbacks.addStreamDecoderFilter(
             std::make_shared<OAuth2Filter>(config, std::move(oauth_client), context.timeSource()));
       };

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -139,7 +139,8 @@ FilterConfig::FilterConfig(
       encoded_resource_query_params_(encodeResourceList(proto_config.resources())),
       forward_bearer_token_(proto_config.forward_bearer_token()),
       pass_through_header_matchers_(headerMatchers(proto_config.pass_through_matcher())),
-      cookie_names_(proto_config.credentials().cookie_names()) {
+      cookie_names_(proto_config.credentials().cookie_names()),
+      default_expires_in_(PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_expires_in, 0)) {
   if (!cluster_manager.clusters().hasCluster(oauth_token_endpoint_.cluster())) {
     throw EnvoyException(fmt::format("OAuth2 filter: unknown cluster '{}' in config. Please "
                                      "specify which cluster to direct OAuth requests to.",

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -130,6 +130,7 @@ public:
   const std::vector<Http::HeaderUtility::HeaderData>& passThroughMatchers() const {
     return pass_through_header_matchers_;
   }
+  const std::chrono::seconds defaultExpiresIn() const { return default_expires_in_; }
 
   const envoy::config::core::v3::HttpUri& oauthTokenEndpoint() const {
     return oauth_token_endpoint_;
@@ -161,6 +162,7 @@ private:
   const bool forward_bearer_token_ : 1;
   const std::vector<Http::HeaderUtility::HeaderData> pass_through_header_matchers_;
   const CookieNames cookie_names_;
+  const std::chrono::seconds default_expires_in_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/source/extensions/filters/http/oauth2/oauth_client.cc
+++ b/source/extensions/filters/http/oauth2/oauth_client.cc
@@ -15,6 +15,8 @@
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/http/oauth2/oauth_response.pb.h"
 
+using namespace std::chrono_literals;
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -87,8 +89,8 @@ void OAuth2ClientImpl::onSuccess(const Http::AsyncClient::Request&,
 
   // TODO(snowp): Should this be a pgv validation instead? A more readable log
   // message might be good enough reason to do this manually?
-  if (!response.has_access_token() || !response.has_expires_in()) {
-    ENVOY_LOG(debug, "No access token or expiration after asyncGetAccessToken");
+  if (!response.has_access_token()) {
+    ENVOY_LOG(debug, "No access token after asyncGetAccessToken");
     parent_->sendUnauthorizedResponse();
     return;
   }
@@ -97,7 +99,16 @@ void OAuth2ClientImpl::onSuccess(const Http::AsyncClient::Request&,
   const std::string id_token{PROTOBUF_GET_WRAPPED_OR_DEFAULT(response, id_token, EMPTY_STRING)};
   const std::string refresh_token{
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(response, refresh_token, EMPTY_STRING)};
-  const std::chrono::seconds expires_in{PROTOBUF_GET_WRAPPED_REQUIRED(response, expires_in)};
+
+  std::chrono::seconds expires_in = default_expires_in_;
+  if (response.has_expires_in()) {
+    expires_in = std::chrono::seconds{response.expires_in().value()};
+  }
+  if (expires_in <= 0s) {
+    ENVOY_LOG(debug, "No default or explicit access token expiration value found after asyncGetAccessToken");
+    parent_->sendUnauthorizedResponse();
+    return;
+  }
 
   parent_->onGetAccessTokenSuccess(access_token, id_token, refresh_token, expires_in);
 }

--- a/source/extensions/filters/http/oauth2/oauth_client.h
+++ b/source/extensions/filters/http/oauth2/oauth_client.h
@@ -37,8 +37,9 @@ public:
 
 class OAuth2ClientImpl : public OAuth2Client, Logger::Loggable<Logger::Id::upstream> {
 public:
-  OAuth2ClientImpl(Upstream::ClusterManager& cm, const envoy::config::core::v3::HttpUri& uri)
-      : cm_(cm), uri_(uri) {}
+  OAuth2ClientImpl(Upstream::ClusterManager& cm, const envoy::config::core::v3::HttpUri& uri,
+                   const std::chrono::seconds default_expires_in)
+      : cm_(cm), uri_(uri), default_expires_in_(default_expires_in) {}
 
   ~OAuth2ClientImpl() override {
     if (in_flight_request_ != nullptr) {
@@ -68,6 +69,7 @@ private:
 
   Upstream::ClusterManager& cm_;
   const envoy::config::core::v3::HttpUri uri_;
+  const std::chrono::seconds default_expires_in_;
 
   // Tracks any outstanding in-flight requests, allowing us to cancel the request
   // if the filter ends before the request completes.


### PR DESCRIPTION
Signed-off-by: Richard Patel [me@terorie.dev](mailto:me@terorie.dev)

Commit Message: oauth2: add "default_expires_in" config option
Additional Description: Fixes compatibility with OAuth 2.0 authorization servers that don't provide the "expires_in" property in the token response
Risk Level: Low
Testing: Added OAuth client tests for two new branches (default expires_in, missing default or explicit expires_in)
Docs Changes: Inline API proto
Release Notes: oauth2 filter: added "default_expires_in" property for authorization servers that don't provide the "expires_in" token response property
Fixes https://github.com/envoyproxy/envoy/pull/14254
Continuation of #14625