### PR TITLE
[balsa] Fix Http1ClientConnectionImplTest.NoContentLengthResponse.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -37,6 +37,12 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
 
 size_t BalsaParser::execute(const char* slice, int len) {
   ASSERT(status_ != ParserStatus::Error);
+
+  if (len == 0 && headers_processed_ && !isChunked() &&
+      ((!framer_.is_request() && hasTransferEncoding()) || !headers_.content_length_valid())) {
+    MessageDone();
+  }
+
   return framer_.ProcessInput(slice, len);
 }
 
@@ -165,6 +171,7 @@ void BalsaParser::HeaderDone() {
   if (status_ == ParserStatus::Error) {
     return;
   }
+  headers_processed_ = true;
   status_ = convertResult(connection_->onHeadersComplete());
 }
 

--- a/source/common/http/http1/balsa_parser.h
+++ b/source/common/http/http1/balsa_parser.h
@@ -65,6 +65,7 @@ private:
   quiche::BalsaHeaders trailers_;
 
   ParserCallbacks* connection_ = nullptr;
+  bool headers_processed_ = false;
   ParserStatus status_ = ParserStatus::Ok;
   absl::string_view error_message_;
 };

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -2562,6 +2562,8 @@ TEST_F(Http1ClientConnectionImplTest, NoContentLengthResponse) {
   TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
   EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
 
+  InSequence s;
+
   Buffer::OwnedImpl expected_data1("Hello World");
   EXPECT_CALL(response_decoder, decodeData(BufferEqual(&expected_data1), false));
 


### PR DESCRIPTION
Also add InSequence to tighten up test.

Tested by patching in #22039 and running
bazel test //test/common/http/http1:codec_impl_test
  --test_arg=--runtime-feature-override-for-tests=envoy.reloadable_features.http1_use_balsa_parser

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
