### PR TITLE
docs: Use stamping for deriving git sha

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -19,6 +19,11 @@ exports_files([
     "exported_symbols.txt",
 ])
 
+sh_library(
+    name = "volatile_env",
+    srcs = ["volatile_env.sh"],
+)
+
 genrule(
     name = "gnu_build_id",
     outs = ["gnu_build_id.ldscript"],

--- a/bazel/volatile_env.sh
+++ b/bazel/volatile_env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if [[ ! -f bazel-out/volatile-status.txt ]]; then
+    # shellcheck disable=SC2016
+    echo 'No `bazel-out/volatile-status.txt`, did you forget to stamp your build target?' >&2
+    exit 1
+fi
+
+VOLATILE=$(cat bazel-out/volatile-status.txt)
+
+while read -r line ; do
+    export "$(echo "${line}" | cut -d' ' -f 1)=$(echo "${line}" | cut -d' ' -f 2)"
+done <<< "$VOLATILE"

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -206,16 +206,40 @@ pkg_tar(
     ],
 )
 
+# TODO(phlax): Add `envoy_sphinx` rule to encapsulate these and above targets
+genrule(
+    name = "html_release",
+    outs = ["html_release.tar.gz"],
+    cmd = """
+    . $(location //bazel:volatile_env) \
+    && $(location //tools/docs:sphinx_runner) \
+         $${SPHINX_RUNNER_ARGS:-} \
+         --build_sha="$${BUILD_SCM_REVISION:-}" \
+         --docs_tag="$${BUILD_DOCS_TAG:-}" \
+         --version_file=$(location //:VERSION.txt) \
+         --descriptor_path=$(location @envoy_api//:v3_proto_set) \\
+         $(location rst) \
+         $@
+    """,
+    exec_tools = [
+        "//bazel:volatile_env",
+        "//tools/docs:sphinx_runner",
+        ":rst",
+        "//:VERSION.txt",
+        "@envoy_api//:v3_proto_set",
+    ],
+    stamp = 1,
+)
+
+# No git stamping, speeds up local dev switching branches
 genrule(
     name = "html",
     outs = ["html.tar.gz"],
     cmd = """
     $(location //tools/docs:sphinx_runner) \
          $${SPHINX_RUNNER_ARGS:-} \
-         --build_sha="$${BUILD_SHA:-}" \
-         --docs_tag="$${DOCS_TAG:-}" \
          --version_file=$(location //:VERSION.txt) \
-         --descriptor_path=$(location @envoy_api//:v3_proto_set) \\
+         --descriptor_path=$(location @envoy_api//:v3_proto_set) \
          $(location :rst) \
          $@
     """,

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -12,39 +12,39 @@ if [[ ! $(command -v bazel) ]]; then
 fi
 
 MAIN_BRANCH="refs/heads/main"
-RELEASE_TAG_REGEX="^refs/tags/v.*"
 
 # default is to build html only
 BUILD_TYPE=html
 
-if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
-    DOCS_TAG="${AZP_BRANCH/refs\/tags\//}"
-    export DOCS_TAG
-else
-    BUILD_SHA=$(git rev-parse HEAD)
-    export BUILD_SHA
-    if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
-        # no need to build html, just rst
-        BUILD_TYPE=rst
-    fi
+if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
+    # no need to build html, just rst
+    BUILD_TYPE=rst
+fi
+
+# This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
+IFS=" " read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
+
+if [[ "${AZP_BRANCH}" =~ ^refs/tags/v.* ]]; then
+    export BUILD_DOCS_TAG="${AZP_BRANCH/refs\/tags\//}"
+    echo "BUILD AZP RELEASE BRANCH ${BUILD_DOCS_TAG}"
+    BAZEL_BUILD_OPTIONS+=("--action_env=BUILD_DOCS_TAG")
 fi
 
 if [[ -n "${AZP_BRANCH}" ]] || [[ -n "${SPHINX_QUIET}" ]]; then
     export SPHINX_RUNNER_ARGS="-v warn"
+    BAZEL_BUILD_OPTIONS+=("--action_env=SPHINX_RUNNER_ARGS")
 fi
-
-
-# This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
-IFS=" " read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
-BAZEL_BUILD_OPTIONS+=(
-    "--action_env=DOCS_TAG"
-    "--action_env=BUILD_SHA"
-    "--action_env=SPHINX_RUNNER_ARGS"
-    "--action_env=SPHINX_SKIP_CONFIG_VALIDATION")
 
 # Building html/rst is determined by then needs of CI but can be overridden in dev.
 if [[ "${BUILD_TYPE}" == "html" ]] || [[ -n "${DOCS_BUILD_HTML}" ]]; then
     BUILD_HTML=1
+    BUILD_HTML_TARGET="//docs:html"
+    BUILD_HTML_TARBALL="bazel-bin/docs/html.tar"
+    if [[ -n "${AZP_BRANCH}" ]] || [[ -n "${DOCS_BUILD_RELEASE}" ]]; then
+        # CI build - use git sha
+        BUILD_HTML_TARGET="//docs:html_release"
+        BUILD_HTML_TARBALL="bazel-bin/docs/html_release.tar.gz"
+    fi
 fi
 if [[ "${BUILD_TYPE}" == "rst" ]] || [[ -n "${DOCS_BUILD_RST}" ]]; then
     BUILD_RST=1
@@ -55,7 +55,7 @@ if [[ -n "${BUILD_RST}" ]]; then
     bazel build "${BAZEL_BUILD_OPTIONS[@]}" //docs:rst
 fi
 if [[ -n "${BUILD_HTML}" ]]; then
-    bazel build "${BAZEL_BUILD_OPTIONS[@]}" //docs:html
+    bazel build "${BAZEL_BUILD_OPTIONS[@]}" "$BUILD_HTML_TARGET"
 fi
 
 [[ -z "${DOCS_OUTPUT_DIR}" ]] && DOCS_OUTPUT_DIR=generated/docs
@@ -64,7 +64,7 @@ mkdir -p "${DOCS_OUTPUT_DIR}"
 
 # Save html/rst to output directory
 if [[ -n "${BUILD_HTML}" ]]; then
-    tar -xzf bazel-bin/docs/html.tar.gz -C "$DOCS_OUTPUT_DIR"
+    tar -xzf "$BUILD_HTML_TARBALL" -C "$DOCS_OUTPUT_DIR"
 fi
 if [[ -n "${BUILD_RST}" ]]; then
     cp bazel-bin/docs/rst.tar.gz "$DOCS_OUTPUT_DIR"/envoy-docs-rst.tar.gz

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -10,7 +10,7 @@ envoy.dependency.pip_check>=0.1.2
 envoy.distribution.release>=0.0.7
 envoy.distribution.repo>=0.0.5
 envoy.distribution.verify>=0.0.8
-envoy.docs.sphinx-runner>=0.1.8
+envoy.docs.sphinx-runner>=0.1.9
 envoy.gpg.identity>=0.1.0
 envoy.gpg.sign>=0.1.0
 flake8

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -355,9 +355,9 @@ envoy-distribution-verify==0.0.8 \
 envoy-docker-utils==0.0.2 \
     --hash=sha256:a12cb57f0b6e204d646cbf94f927b3a8f5a27ed15f60d0576176584ec16a4b76
     # via envoy-distribution-distrotest
-envoy-docs-sphinx-runner==0.1.8 \
-    --hash=sha256:1a18eac3d54bf4ccb018af9687059c963caabe60389bb67acc28eb9c35e5d5c2 \
-    --hash=sha256:e920d73bdc416331eca135399d41ae738be9ff0fcc6939bd84d2e67a4415af4c
+envoy-docs-sphinx-runner==0.1.9 \
+    --hash=sha256:2b7596fc400feb0b2e27db2a67a68aaf484ee71f7be133495a689218cb3bf317 \
+    --hash=sha256:8223806c5a0f2bc1e32809c250a829aadb132959abe42b832f353cd270f38b3e
     # via -r requirements.in
 envoy-github-abstract==0.0.21 \
     --hash=sha256:243dae9457243fb42e4643b1f45006c3b0d3151c808884217447d29a081b26a1 \


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:

This speeds up building docs when switching branches by not automatically expiring caches on the git sha

It also pushes responsibility script -> bazel for determining the build env

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
