### PR TITLE
[balsa] Verify method.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -19,14 +19,15 @@ using ::quiche::BalsaFrameEnums;
 using ::quiche::BalsaHeaders;
 
 bool isMethodValid(absl::string_view method) {
-  static const absl::flat_hash_set<absl::string_view> kValidMethods{
+  static constexpr absl::string_view kValidMethods[] = {
       "ACL",       "BIND",    "CHECKOUT", "CONNECT", "COPY",       "DELETE",     "GET",
       "HEAD",      "LINK",    "LOCK",     "MERGE",   "MKACTIVITY", "MKCALENDAR", "MKCOL",
       "MOVE",      "MSEARCH", "NOTIFY",   "OPTIONS", "PATCH",      "POST",       "PROPFIND",
       "PROPPATCH", "PURGE",   "PUT",      "REBIND",  "REPORT",     "SEARCH",     "SOURCE",
       "SUBSCRIBE", "TRACE",   "UNBIND",   "UNLINK",  "UNLOCK",     "UNSUBSCRIBE"};
 
-  return kValidMethods.count(method) == 1;
+  return std::binary_search(&kValidMethods[0], &kValidMethods[0] + ABSL_ARRAYSIZE(kValidMethods),
+                            method);
 }
 
 } // anonymous namespace

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -13,8 +13,23 @@ namespace Envoy {
 namespace Http {
 namespace Http1 {
 
+namespace {
+
 using ::quiche::BalsaFrameEnums;
 using ::quiche::BalsaHeaders;
+
+bool isMethodValid(absl::string_view method) {
+  static const absl::flat_hash_set<absl::string_view> kValidMethods{
+      "ACL",       "BIND",    "CHECKOUT", "CONNECT", "COPY",       "DELETE",     "GET",
+      "HEAD",      "LINK",    "LOCK",     "MERGE",   "MKACTIVITY", "MKCALENDAR", "MKCOL",
+      "MOVE",      "MSEARCH", "NOTIFY",   "OPTIONS", "PATCH",      "POST",       "PROPFIND",
+      "PROPPATCH", "PURGE",   "PUT",      "REBIND",  "REPORT",     "SEARCH",     "SOURCE",
+      "SUBSCRIBE", "TRACE",   "UNBIND",   "UNLINK",  "UNLOCK",     "UNSUBSCRIBE"};
+
+  return kValidMethods.count(method) == 1;
+}
+
+} // anonymous namespace
 
 BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t max_header_length)
     : connection_(connection) {
@@ -124,10 +139,15 @@ void BalsaParser::ProcessTrailers(const BalsaHeaders& trailer) {
 }
 
 void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
-                                          absl::string_view /*method_input*/,
+                                          absl::string_view method_input,
                                           absl::string_view request_uri,
                                           absl::string_view /*version_input*/) {
   if (status_ == ParserStatus::Error) {
+    return;
+  }
+  if (!isMethodValid(method_input)) {
+    status_ = ParserStatus::Error;
+    error_message_ = "HPE_INVALID_METHOD";
     return;
   }
   status_ = convertResult(connection_->onMessageBegin());

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -26,8 +26,9 @@ bool isMethodValid(absl::string_view method) {
       "PROPPATCH", "PURGE",   "PUT",      "REBIND",  "REPORT",     "SEARCH",     "SOURCE",
       "SUBSCRIBE", "TRACE",   "UNBIND",   "UNLINK",  "UNLOCK",     "UNSUBSCRIBE"};
 
-  return std::binary_search(&kValidMethods[0], &kValidMethods[0] + ABSL_ARRAYSIZE(kValidMethods),
-                            method);
+  const auto* begin = &kValidMethods[0];
+  const auto* end = &kValidMethods[ABSL_ARRAYSIZE(kValidMethods) - 1] + 1;
+  return std::binary_search(begin, end, method);
 }
 
 } // anonymous namespace

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1025,6 +1025,7 @@ TEST_F(Http1ServerConnectionImplTest, RejectInvalidMethod) {
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
+  EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_METHOD");
 }
 
 TEST_F(Http1ServerConnectionImplTest, BadRequestStartedStream) {


### PR DESCRIPTION
This fixes Http1ServerConnectionImplTest.RejectInvalidMethod, and also
tightens up the test by adding one expectation.

Tested by patching in #22039 and running

bazel test //test/common/http/http1:codec_impl_test
  --test_arg=--runtime-feature-override-for-tests=envoy.reloadable_features.http1_use_balsa_parser

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
