### PR TITLE
Initialize regex engine for fuzz test.

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_corpus/no_regex_engine
+++ b/test/extensions/filters/http/ext_authz/ext_authz_corpus/no_regex_engine
@@ -1,0 +1,22 @@
+
+config {
+  clear_route_cache: true
+  include_peer_certificate: true
+  stat_prefix: "C"
+  filter_enabled_metadata {
+    filter: ";"
+    path {
+      key: "V"
+    }
+    value {
+      string_match {
+        safe_regex {
+          regex: "/envoy.config.route.v3.Route"
+        }
+      }
+    }
+  }
+  bootstrap_metadata_labels_key: "\000\000\000\000\000\000\000\000\000\000\000\000\000"
+}
+request_data {
+}

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
@@ -80,6 +80,7 @@ DEFINE_PROTO_FUZZER(const envoy::extensions::filters::http::ext_authz::ExtAuthzT
 
   static FuzzerMocks mocks;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store;
+  static ScopedInjectableLoader<Regex::Engine> engine(std::make_unique<Regex::GoogleReEngine>());
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   Http::ContextImpl http_context(stats_store.symbolTable());
 


### PR DESCRIPTION
Signed-off-by: Pradeep Rao <pcrao@google.com>

Commit Message:
Additional Description:
#21633 deprecated the `google_re2` field. This change is needed to register a regex engine for a corpus with config that doesn't contain that field.

Risk Level: low
Testing: test fix
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

