### PR TITLE
OpenTelemetry Tracer: only export OTLP trace span when sampled

### DIFF
--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -46,7 +46,9 @@ void Span::finishSpan() {
   // Call into the parent tracer so we can access the shared exporter.
   span_.set_end_time_unix_nano(
       std::chrono::nanoseconds(time_source_.systemTime().time_since_epoch()).count());
-  parent_tracer_.sendSpan(span_);
+  if (sampled()) {
+    parent_tracer_.sendSpan(span_);
+  }
 }
 
 void Span::injectContext(Tracing::TraceContext& trace_context,


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Export OTLP Trace span only when sampled
Additional Description: Envoy's health checks rely on setting the `sampled` attributed to false for the span for the health check. This should prevent the spurious spans from being created, as we generally don't want to trace every time we health check a cluster.  Before this change, this Tracer just exported them, and it now will check the sampled flag before exporting each span. See https://github.com/envoyproxy/envoy/pull/21893#issuecomment-1167450850 for more context.
Risk Level: Low
Testing: Added a unit test
Part of https://github.com/envoyproxy/envoy/issues/9958
