### PR TITLE
thrift: bidirectional and encoder filter config validation

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/filters/filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/filter.h
@@ -170,8 +170,7 @@ public:
    * @param reset_imminent True if the downstream connection should be closed after this response
    * @param LocalErrorStatus the action to take after onLocalError completes.
    */
-  virtual LocalErrorStatus onLocalReply(const MessageMetadata& metadata,
-                                        bool end_stream) {
+  virtual LocalErrorStatus onLocalReply(const MessageMetadata& metadata, bool end_stream) {
     UNREFERENCED_PARAMETER(metadata);
     UNREFERENCED_PARAMETER(end_stream);
     return LocalErrorStatus::Continue;

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -204,6 +204,11 @@ thrift_filters:
       "@type": type.googleapis.com/google.protobuf.Struct
       value:
         key: value
+  - name: envoy.filters.thrift.mock_encoder_filter
+    typed_config:
+      "@type": type.googleapis.com/google.protobuf.Struct
+      value:
+        key: value
   - name: envoy.filters.thrift.mock_bidirectional_filter
     typed_config:
       "@type": type.googleapis.com/google.protobuf.Struct

--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -174,7 +174,9 @@ MockBidirectionalFilter::MockBidirectionalFilter() {
 }
 MockBidirectionalFilter::~MockBidirectionalFilter() = default;
 
-MockDecoderFilterConfigFactory::MockDecoderFilterConfigFactory() : name_("envoy.filters.thrift.mock_decoder_filter") {
+// MockDecoderFilterConfigFactory
+MockDecoderFilterConfigFactory::MockDecoderFilterConfigFactory()
+    : name_("envoy.filters.thrift.mock_decoder_filter") {
   mock_filter_ = std::make_shared<NiceMock<MockDecoderFilter>>();
 }
 
@@ -193,7 +195,28 @@ FilterFactoryCb MockDecoderFilterConfigFactory::createFilterFactoryFromProto(
   };
 }
 
-MockBidirectionalFilterConfigFactory::MockBidirectionalFilterConfigFactory() : name_("envoy.filters.thrift.mock_bidirectional_filter") {
+MockEncoderFilterConfigFactory::MockEncoderFilterConfigFactory()
+    : name_("envoy.filters.thrift.mock_encoder_filter") {
+  mock_filter_ = std::make_shared<NiceMock<MockEncoderFilter>>();
+}
+
+MockEncoderFilterConfigFactory::~MockEncoderFilterConfigFactory() = default;
+
+FilterFactoryCb MockEncoderFilterConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message& proto_config, const std::string& stats_prefix,
+    Server::Configuration::FactoryContext& context) {
+  UNREFERENCED_PARAMETER(context);
+
+  config_struct_ = dynamic_cast<const ProtobufWkt::Struct&>(proto_config);
+  config_stat_prefix_ = stats_prefix;
+
+  return [this](FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addEncoderFilter(mock_filter_);
+  };
+}
+
+MockBidirectionalFilterConfigFactory::MockBidirectionalFilterConfigFactory()
+    : name_("envoy.filters.thrift.mock_bidirectional_filter") {
   mock_filter_ = std::make_shared<NiceMock<MockBidirectionalFilter>>();
 }
 

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -429,6 +429,30 @@ private:
   const std::string name_;
 };
 
+class MockEncoderFilterConfigFactory : public NamedThriftFilterConfigFactory {
+public:
+  MockEncoderFilterConfigFactory();
+  ~MockEncoderFilterConfigFactory() override;
+
+  FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ProtobufWkt::Struct>();
+  }
+
+  std::string name() const override { return name_; }
+
+  ProtobufWkt::Struct config_struct_;
+  std::string config_stat_prefix_;
+
+private:
+  std::shared_ptr<MockEncoderFilter> mock_filter_;
+  const std::string name_;
+};
+
 class MockBidirectionalFilterConfigFactory : public NamedThriftFilterConfigFactory {
 public:
   MockBidirectionalFilterConfigFactory();


### PR DESCRIPTION
Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>

Commit Message:
More test coverage for bidirectional and encoder filter config.

Additional Description:
Risk Level: low
Testing: unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
