### PR TITLE
grpc_transcoder: check response transcoder error

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -131,6 +131,9 @@ minor_behavior_changes:
     remove unnecessary "spawnChild" annotations in OpenCensus tracer.
 
 bug_fixes:
+- area: grpc_json_transcoder
+  change: |
+    Response with a error messsage if a proto message is too deep (>64). Before the fix the response is an empty JSON.
 - area: http
   change: |
     Fixed HTTP/2 CONNECT to be RFC compliant, rather than following the abandoned extended connect draft.

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -768,7 +768,7 @@ bool JsonTranscoderFilter::checkAndRejectIfResponseTranscoderFailed() {
     ENVOY_LOG(debug, "Transcoding response error {}", response_status.ToString());
     error_ = true;
     encoder_callbacks_->sendLocalReply(
-        Http::Code::InternalServerError,
+        Http::Code::BadGateway,
         absl::string_view(response_status.message().data(), response_status.message().size()),
         nullptr, absl::nullopt,
         absl::StrCat(

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -170,6 +170,7 @@ public:
 
 private:
   bool checkIfTranscoderFailed(const std::string& details);
+  bool checkIfResponseTranscoderFailed();
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
   void maybeSendHttpBodyRequestMessage();
   /**

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -169,8 +169,8 @@ public:
   void onDestroy() override {}
 
 private:
-  bool checkIfTranscoderFailed(const std::string& details);
-  bool checkIfResponseTranscoderFailed();
+  bool checkAndRejectIfRequestTranscoderFailed(const std::string& details);
+  bool checkAndRejectIfResponseTranscoderFailed();
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
   void maybeSendHttpBodyRequestMessage();
   /**

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -1355,6 +1355,61 @@ TEST_F(GrpcJsonTranscoderFilterReportCollisionTest, CreateShelfBodyWildcard) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_.decodeData(request_data, true));
 }
 
+bookstore::EchoStructReqResp createDeepStruct(int level) {
+  bookstore::EchoStructReqResp msg;
+  auto* field_map = msg.mutable_content()->mutable_fields();
+  for (int i = 0; i < level; ++i) {
+    (*field_map)["level"] = ValueUtil::numberValue(i);
+    Envoy::ProtobufWkt::Struct s;
+    (*field_map)["struct"] = ValueUtil::structValue(s);
+    field_map = (*field_map)["struct"].mutable_struct_value()->mutable_fields();
+  }
+  return msg;
+}
+
+class GrpcJsonTranscoderFilterEchoStructTest : public GrpcJsonTranscoderFilterTest {
+public:
+  GrpcJsonTranscoderFilterEchoStructTest() : GrpcJsonTranscoderFilterTest(bookstoreProtoConfig()) {}
+
+  void SetUp() override {
+    EXPECT_CALL(decoder_callbacks_, clearRouteCache());
+
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"content-type", "application/json"}, {":method", "POST"}, {":path", "/echoStruct"}};
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+
+    Http::TestResponseHeaderMapImpl response_headers{{"content-type", "application/grpc"},
+                                                     {":status", "200"}};
+    EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+              filter_.encodeHeaders(response_headers, false));
+  }
+};
+
+TEST_F(GrpcJsonTranscoderFilterEchoStructTest, TranscodingOKWithNotDeepProtoMessage) {
+  // If less than 64 deep, grpc response transcoder should be fine.
+  // But loadFromJson() only can convert up to 32 level deep.
+  auto response_message = createDeepStruct(30);
+  auto response_data = Grpc::Common::serializeToGrpcFrame(response_message);
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
+            filter_.encodeData(*response_data, false));
+
+  bookstore::EchoStructReqResp response_out;
+  TestUtility::loadFromJson(response_data->toString(), response_out);
+  EXPECT_TRUE(TestUtility::protoEqual(response_message, response_out));
+}
+
+TEST_F(GrpcJsonTranscoderFilterEchoStructTest, TranscodingFailedWithTooDeepProtoMessage) {
+  // If more than 64 deep, grpc response transcoder will fail.
+  auto response_message = createDeepStruct(65);
+  auto response_data = Grpc::Common::serializeToGrpcFrame(response_message);
+
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_.encodeData(*response_data, false));
+}
+
 class GrpcJsonTranscoderFilterGrpcStatusTest : public GrpcJsonTranscoderFilterTest {
 public:
   GrpcJsonTranscoderFilterGrpcStatusTest(

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -1404,7 +1404,7 @@ TEST_F(GrpcJsonTranscoderFilterEchoStructTest, TranscodingFailedWithTooDeepProto
   auto response_message = createDeepStruct(65);
   auto response_data = Grpc::Common::serializeToGrpcFrame(response_message);
 
-  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _, _));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::BadGateway, _, _, _, _));
 
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
             filter_.encodeData(*response_data, false));


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix https://github.com/envoyproxy/envoy/issues/21490

grpc response transcoder will fail with error if the proto message is too deep (>64),  but grpc_transcoder filter encodeData() function did not check the error status.  This pr adds code to check the error status and adds a test.

Risk Level:  Low
Testing:  Unit-test
Docs Changes: No
Release Notes: Yes
