### PR TITLE
expr: add SHA256 certificate digest

### DIFF
--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -119,6 +119,7 @@ RBAC):
    connection.dns_san_peer_certificate, string, The first DNS entry in the SAN field of the peer certificate in the downstream TLS connection
    connection.uri_san_local_certificate, string, The first URI entry in the SAN field of the local certificate in the downstream TLS connection
    connection.uri_san_peer_certificate, string, The first URI entry in the SAN field of the peer certificate in the downstream TLS connection
+   connection.sha256_peer_certificate_digest, SHA256 digest of the peer certificate in the downstream TLS connection if present
 
 The following additional attributes are available upon the downstream connection termination:
 
@@ -146,6 +147,7 @@ The following attributes are available once the upstream connection is establish
    upstream.dns_san_peer_certificate, string, The first DNS entry in the SAN field of the peer certificate in the upstream TLS connection
    upstream.uri_san_local_certificate, string, The first URI entry in the SAN field of the local certificate in the upstream TLS connection
    upstream.uri_san_peer_certificate, string, The first URI entry in the SAN field of the peer certificate in the upstream TLS connection
+   upstream.sha256_peer_certificate_digest, SHA256 digest of the peer certificate in the upstream TLS connection if present
    upstream.local_address, string, The local address of the upstream connection
    upstream.transport_failure_reason, string, The upstream transport failure reason e.g. certificate validation failed
 

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -63,6 +63,10 @@ absl::optional<CelValue> extractSslInfo(const Ssl::ConnectionInfo& ssl_info,
     if (!ssl_info.dnsSansPeerCertificate().empty()) {
       return CelValue::CreateString(&ssl_info.dnsSansPeerCertificate()[0]);
     }
+  } else if (value == SHA256PeerCertificateDigest) {
+    if (!ssl_info.sha256PeerCertificateDigest().empty()) {
+      return CelValue::CreateString(&ssl_info.sha256PeerCertificateDigest());
+    }
   }
   return {};
 }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -71,6 +71,7 @@ constexpr absl::string_view URISanLocalCertificate = "uri_san_local_certificate"
 constexpr absl::string_view URISanPeerCertificate = "uri_san_peer_certificate";
 constexpr absl::string_view DNSSanLocalCertificate = "dns_san_local_certificate";
 constexpr absl::string_view DNSSanPeerCertificate = "dns_san_peer_certificate";
+constexpr absl::string_view SHA256PeerCertificateDigest = "sha256_peer_certificate_digest";
 
 // Source properties
 // New symbols must be added to WrapperFieldValues.

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -124,6 +124,7 @@ public:
       CelValue::CreateStringView(URISanPeerCertificate),
       CelValue::CreateStringView(DNSSanLocalCertificate),
       CelValue::CreateStringView(DNSSanPeerCertificate),
+      CelValue::CreateStringView(SHA256PeerCertificateDigest),
   }};
   const ContainerBackedListImpl Upstream{{
       CelValue::CreateStringView(Address),
@@ -137,6 +138,7 @@ public:
       CelValue::CreateStringView(URISanPeerCertificate),
       CelValue::CreateStringView(DNSSanLocalCertificate),
       CelValue::CreateStringView(DNSSanPeerCertificate),
+      CelValue::CreateStringView(SHA256PeerCertificateDigest),
   }};
   const ContainerBackedListImpl Peer{{
       CelValue::CreateStringView(Address),

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -516,6 +516,11 @@ TEST(Context, ConnectionAttributes) {
   EXPECT_CALL(*downstream_ssl_info, subjectPeerCertificate())
       .WillRepeatedly(ReturnRef(subject_peer));
   EXPECT_CALL(*upstream_ssl_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject_peer));
+  const std::string peer_certificate_digest = "c58ccaf8e9276ebd095652e56e89c7d56e92e6c0";
+  EXPECT_CALL(*downstream_ssl_info, sha256PeerCertificateDigest())
+      .WillRepeatedly(ReturnRef(peer_certificate_digest));
+  EXPECT_CALL(*upstream_ssl_info, sha256PeerCertificateDigest())
+      .WillRepeatedly(ReturnRef(peer_certificate_digest));
 
   EXPECT_EQ(11, connection.size());
   EXPECT_FALSE(connection.empty());
@@ -655,6 +660,13 @@ TEST(Context, ConnectionAttributes) {
   }
 
   {
+    auto value = connection[CelValue::CreateStringView(SHA256PeerCertificateDigest)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ(peer_certificate_digest, value.value().StringOrDie().value());
+  }
+
+  {
     auto value = connection[CelValue::CreateStringView(ID)];
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsUint64());
@@ -715,6 +727,13 @@ TEST(Context, ConnectionAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsString());
     EXPECT_EQ(subject_peer, value.value().StringOrDie().value());
+  }
+
+  {
+    auto value = upstream[CelValue::CreateStringView(SHA256PeerCertificateDigest)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ(peer_certificate_digest, value.value().StringOrDie().value());
   }
 
   {

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -522,10 +522,10 @@ TEST(Context, ConnectionAttributes) {
   EXPECT_CALL(*upstream_ssl_info, sha256PeerCertificateDigest())
       .WillRepeatedly(ReturnRef(peer_certificate_digest));
 
-  EXPECT_EQ(11, connection.size());
+  EXPECT_EQ(12, connection.size());
   EXPECT_FALSE(connection.empty());
 
-  EXPECT_EQ(11, upstream.size());
+  EXPECT_EQ(12, upstream.size());
   EXPECT_FALSE(connection.empty());
 
   EXPECT_EQ(2, source.size());


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Add SHA256 digest to Cel/Wasm context
Risk Level: low
Testing: unit 
Docs Changes: yes 
Release Notes: none
Fixes: https://github.com/envoyproxy/envoy/issues/14229