### PR TITLE
fix coredump

### DIFF
--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -199,6 +199,9 @@ void ConnectionManager::continueHandling(const std::string& key, bool try_next_a
             auto ex = AppException(AppExceptionType::InternalError,
                                    fmt::format("envoy can't establish connection to {}", key));
             sendLocalReply(*(metadata), ex, false);
+            setLocalResponseSent(metadata->transactionId().value());
+
+            decoder_->complete();
           }
         } else {
           continueHandling(metadata, decoder_event_handler);
@@ -214,11 +217,7 @@ void ConnectionManager::continueHandling(MessageMetadataSharedPtr metadata,
   } catch (const AppException& ex) {
     ENVOY_LOG(debug, "sip application exception: {}", ex.what());
     sendLocalReply(*(decoder_->metadata()), ex, false);
-
-    absl::string_view k = decoder_->metadata()->transactionId().value();
-    if (transactions_.find(k) != transactions_.end()) {
-      transactions_[k]->setLocalResponseSent(true);
-    }
+    setLocalResponseSent(decoder_->metadata()->transactionId().value());
 
     decoder_->complete();
   } catch (const EnvoyException& ex) {
@@ -235,11 +234,7 @@ void ConnectionManager::dispatch() {
   } catch (const AppException& ex) {
     ENVOY_LOG(debug, "sip application exception: {}", ex.what());
     sendLocalReply(*(decoder_->metadata()), ex, false);
-
-    absl::string_view k = decoder_->metadata()->transactionId().value();
-    if (transactions_.find(k) != transactions_.end()) {
-      transactions_[k]->setLocalResponseSent(true);
-    }
+    setLocalResponseSent(decoder_->metadata()->transactionId().value());
 
     decoder_->complete();
   } catch (const EnvoyException& ex) {
@@ -287,6 +282,12 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectRe
     PANIC("not reached");
   }
   stats_.counterFromElements("", "local-generated-response").inc();
+}
+
+void ConnectionManager::setLocalResponseSent(absl::string_view transaction_id) {
+  if (transactions_.find(transaction_id) != transactions_.end()) {
+    transactions_[transaction_id]->setLocalResponseSent(true);
+  }
 }
 
 void ConnectionManager::doDeferredTransDestroy(ConnectionManager::ActiveTrans& trans) {

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -347,6 +347,7 @@ private:
 
   void dispatch();
   void sendLocalReply(MessageMetadata& metadata, const DirectResponse& response, bool end_stream);
+  void setLocalResponseSent(absl::string_view transaction_id);
   void doDeferredTransDestroy(ActiveTrans& trans);
   void resetAllTrans(bool local_reset);
 

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.h
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.h
@@ -234,19 +234,11 @@ public:
   }
 
   std::shared_ptr<UpstreamRequest> getUpstreamRequest(const std::string& host) {
-    if (tls_->getTyped<ThreadLocalTransactionInfo>().upstream_request_map_.find(host) !=
-        tls_->getTyped<ThreadLocalTransactionInfo>().upstream_request_map_.end()) {
-      return tls_->getTyped<ThreadLocalTransactionInfo>().upstream_request_map_.at(host);
-    } else {
-      return nullptr;
-    }
-#if 0
     try {
       return tls_->getTyped<ThreadLocalTransactionInfo>().upstream_request_map_.at(host);
-    } catch (std::out_of_range const & e) {
+    } catch (std::out_of_range const& e) {
       return nullptr;
     }
-#endif
   }
 
   void deleteUpstreamRequest(const std::string& host) {

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -164,7 +164,9 @@ void GrpcClientImpl::subscribeTrafficRoutingAssistant(const std::string& type,
   callback->stream_ = async_client_->start(service_method, *callback,
                                            Http::AsyncClient::StreamOptions().setParentContext(
                                                Http::AsyncClient::ParentContext{&stream_info}));
-  callback->stream_.sendMessage(request, false);
+  if (!callback->stream_.sendMessage(request, false)) {
+    return;
+  }
   LinkedList::moveIntoList(std::move(callback), stream_callbacks_);
 }
 

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -54,21 +54,8 @@ void GrpcClientImpl::createTrafficRoutingAssistant(
     (*request.mutable_create_request()->mutable_data())[item.first] = item.second;
   }
 
-  if (context.has_value()) {
-    for (auto& item : context.value()) {
-      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
-    }
-  }
-
-  const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-      "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Create");
-
-  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
-  callback->request_ =
-      async_client_->send(service_method, request, *callback, parent_span,
-                          Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
-                              Http::AsyncClient::ParentContext{&stream_info}));
-  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
+  return sendRequest("envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Create",
+                     request, context, parent_span, stream_info);
 }
 
 void GrpcClientImpl::updateTrafficRoutingAssistant(
@@ -82,20 +69,8 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
     (*request.mutable_update_request()->mutable_data())[item.first] = item.second;
   }
 
-  if (context.has_value()) {
-    for (auto& item : context.value()) {
-      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
-    }
-  }
-
-  const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-      "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Update");
-  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
-  callback->request_ =
-      async_client_->send(service_method, request, *callback, parent_span,
-                          Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
-                              Http::AsyncClient::ParentContext{&stream_info}));
-  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
+  return sendRequest("envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Update",
+                     request, context, parent_span, stream_info);
 }
 
 void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
@@ -108,20 +83,8 @@ void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
   request.set_type(type);
   request.mutable_retrieve_request()->set_key(key);
 
-  if (context.has_value()) {
-    for (auto& item : context.value()) {
-      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
-    }
-  }
-
-  const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-      "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Retrieve");
-  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
-  callback->request_ =
-      async_client_->send(service_method, request, *callback, parent_span,
-                          Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
-                              Http::AsyncClient::ParentContext{&stream_info}));
-  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
+  return sendRequest("envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Retrieve",
+                     request, context, parent_span, stream_info);
 }
 
 void GrpcClientImpl::deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
@@ -133,20 +96,8 @@ void GrpcClientImpl::deleteTrafficRoutingAssistant(const std::string& type, cons
   request.set_type(type);
   request.mutable_delete_request()->set_key(key);
 
-  if (context.has_value()) {
-    for (auto& item : context.value()) {
-      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
-    }
-  }
-
-  const auto& service_method = *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-      "envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Delete");
-  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
-  callback->request_ =
-      async_client_->send(service_method, request, *callback, parent_span,
-                          Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
-                              Http::AsyncClient::ParentContext{&stream_info}));
-  LinkedList::moveIntoList(std::move(callback), request_callbacks_);
+  return sendRequest("envoy.extensions.filters.network.sip_proxy.tra.v3alpha.TraService.Delete",
+                     request, context, parent_span, stream_info);
 }
 
 void GrpcClientImpl::subscribeTrafficRoutingAssistant(const std::string& type,
@@ -154,7 +105,6 @@ void GrpcClientImpl::subscribeTrafficRoutingAssistant(const std::string& type,
                                                       const StreamInfo::StreamInfo& stream_info) {
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
 
-  UNREFERENCED_PARAMETER(parent_span);
   request.set_type(type);
   request.mutable_subscribe_request();
 
@@ -164,10 +114,38 @@ void GrpcClientImpl::subscribeTrafficRoutingAssistant(const std::string& type,
   callback->stream_ = async_client_->start(service_method, *callback,
                                            Http::AsyncClient::StreamOptions().setParentContext(
                                                Http::AsyncClient::ParentContext{&stream_info}));
-  if (!callback->stream_.sendMessage(request, false)) {
+  if (callback->stream_ == nullptr) {
+    onFailure(Grpc::Status::WellKnownGrpcStatus::Unavailable,
+              "Unable to establish new stream to tra server", parent_span);
     return;
   }
   LinkedList::moveIntoList(std::move(callback), stream_callbacks_);
+}
+
+void GrpcClientImpl::sendRequest(
+    const std::string& method,
+    envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest& request,
+    absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+    const StreamInfo::StreamInfo& stream_info) {
+
+  if (context.has_value()) {
+    for (auto& item : context.value()) {
+      (*request.mutable_retrieve_request()->mutable_context())[item.first] = item.second;
+    }
+  }
+
+  const auto& service_method =
+      *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(method);
+  std::unique_ptr<AsyncRequestCallbacks> callback = std::make_unique<AsyncRequestCallbacks>(*this);
+  callback->request_ =
+      async_client_->send(service_method, request, *callback, parent_span,
+                          Http::AsyncClient::RequestOptions().setTimeout(timeout_).setParentContext(
+                              Http::AsyncClient::ParentContext{&stream_info}));
+  if (callback->request_ != nullptr) {
+    LinkedList::moveIntoList(std::move(callback), request_callbacks_);
+  }
+
+  // Already invoke `onFailure` asynchronously, no need to call it explicitly here.
 }
 
 void GrpcClientImpl::onSuccess(

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -95,6 +95,13 @@ public:
   };
 
 private:
+  void sendRequest(
+      const std::string& method,
+      envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest& request,
+      absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+      const StreamInfo::StreamInfo& stream_info);
+
+private:
   class AsyncRequestCallbacks
       : public Grpc::AsyncRequestCallbacks<
             envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>,

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -35,8 +35,13 @@ template <typename Request> class AsyncStream /* : public RawAsyncStream */ {
 public:
   AsyncStream() = default;
   AsyncStream(RawAsyncStream* stream) : stream_(stream) {}
-  void sendMessage(const Protobuf::Message& request, bool end_stream) {
-    Internal::sendMessageUntyped(stream_, std::move(request), end_stream);
+  bool sendMessage(const Protobuf::Message& request, bool end_stream) {
+    if (stream_ == nullptr) {
+      return false;
+    } else {
+      Internal::sendMessageUntyped(stream_, std::move(request), end_stream);
+      return true;
+    }
   }
   void closeStream() { stream_->closeStream(); }
   void resetStream() { stream_->resetStream(); }

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -35,13 +35,8 @@ template <typename Request> class AsyncStream /* : public RawAsyncStream */ {
 public:
   AsyncStream() = default;
   AsyncStream(RawAsyncStream* stream) : stream_(stream) {}
-  bool sendMessage(const Protobuf::Message& request, bool end_stream) {
-    if (stream_ == nullptr) {
-      return false;
-    } else {
-      Internal::sendMessageUntyped(stream_, std::move(request), end_stream);
-      return true;
-    }
+  void sendMessage(const Protobuf::Message& request, bool end_stream) {
+    Internal::sendMessageUntyped(stream_, std::move(request), end_stream);
   }
   void closeStream() { stream_->closeStream(); }
   void resetStream() { stream_->resetStream(); }


### PR DESCRIPTION
Commit Message: fix the coredump when stream is nullptr, then return directly instead of still sendMessage
Additional Description: N/A
Testing: MT
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
