### PR TITLE
http inspector: fix incorrect protocol detection

### DIFF
--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -76,8 +76,6 @@ public:
 private:
   static const absl::string_view HTTP2_CONNECTION_PREFACE;
 
-  void onMessageBegin() { parsing_begin_ = true; }
-
   void done(bool success);
   ParseState parseHttpHeader(absl::string_view data);
 
@@ -88,7 +86,6 @@ private:
   Network::ListenerFilterCallbacks* cb_{nullptr};
   absl::string_view protocol_;
   http_parser parser_;
-  bool parsing_begin_{false};
   static http_parser_settings settings_;
 };
 

--- a/source/extensions/filters/listener/http_inspector/http_inspector.h
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.h
@@ -76,6 +76,8 @@ public:
 private:
   static const absl::string_view HTTP2_CONNECTION_PREFACE;
 
+  void onMessageBegin() { parsing_begin_ = true; }
+
   void done(bool success);
   ParseState parseHttpHeader(absl::string_view data);
 
@@ -86,6 +88,7 @@ private:
   Network::ListenerFilterCallbacks* cb_{nullptr};
   absl::string_view protocol_;
   http_parser parser_;
+  bool parsing_begin_{false};
   static http_parser_settings settings_;
 };
 

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -166,7 +166,7 @@ public:
       }));
 
       if (alpn == Http::Utility::AlpnNames::get().Http2c) {
-        for (size_t i = 1; i <= 24; i++) {
+        for (size_t i = 0; i <= 24; i++) {
           EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
               .WillOnce(Invoke(
                   [&data, i](os_fd_t, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -176,7 +176,7 @@ public:
                   }));
         }
       } else {
-        for (size_t i = 1; i <= header.size(); i++) {
+        for (size_t i = 0; i <= header.size(); i++) {
           EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
               .WillOnce(Invoke([&header, i](os_fd_t, void* buffer, size_t length,
                                             int) -> Api::SysCallSizeResult {

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -421,6 +421,16 @@ TEST_F(HttpInspectorTest, InvalidRequestLine2) {
   testHttpInspectNotFound(header);
 }
 
+TEST_F(HttpInspectorTest, InvalidRequestLine3) {
+  const absl::string_view header = "\r\n\r\n\r\n BAD";
+  testHttpInspectNotFound(header);
+}
+
+TEST_F(HttpInspectorTest, InvalidRequestLine4) {
+  const absl::string_view header = "\r\nGET /anything HTTP/1.1\r\n";
+  testHttpInspectNotFound(header);
+}
+
 TEST_F(HttpInspectorTest, InspectHttp2) {
   const std::string header =
       "505249202a20485454502f322e300d0a0d0a534d0d0a0d0a00000c04000000000000041000000000020000000000"

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -416,6 +416,11 @@ TEST_F(HttpInspectorTest, InvalidRequestLine) {
   testHttpInspectNotFound(header);
 }
 
+TEST_F(HttpInspectorTest, InvalidRequestLine2) {
+  const absl::string_view header = "\r\n\r\n\r\n";
+  testHttpInspectNotFound(header);
+}
+
 TEST_F(HttpInspectorTest, InspectHttp2) {
   const std::string header =
       "505249202a20485454502f322e300d0a0d0a534d0d0a0d0a00000c04000000000000041000000000020000000000"


### PR DESCRIPTION

Commit Message: http inspector: fix incorrect protocol detection
Additional Description: 

The http inspector will search first `\r\n` in the buffer and decode the data before the `\r\n`  with http parser. If there is no parsing error, the message will treated as http message.

**However, the message that contains only `\r\n` or started with `\r\n` will be inspected as http message also.** For example, `\r\n\r\n\r\n LS`.

This PR fix this problem.

Risk Level: Low.
Testing: Added.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
