### PR TITLE
lua: deprecate inline_code and use default_source_code

### DIFF
--- a/api/envoy/extensions/filters/http/lua/v3/BUILD
+++ b/api/envoy/extensions/filters/http/lua/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/api/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -52,7 +52,7 @@ message Lua {
   //
   map<string, config.core.v3.DataSource> source_codes = 2;
 
-  // The default Lua code that Envoy will execute. If no any per route config is provided
+  // The default Lua code that Envoy will execute. If no per route config is provided
   // for the request, this Lua code will be applied.
   config.core.v3.DataSource default_source_code = 3;
 }

--- a/api/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/api/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -4,6 +4,7 @@ package envoy.extensions.filters.http.lua.v3;
 
 import "envoy/config/core/v3/base.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -26,7 +27,11 @@ message Lua {
   // further loads code from disk if desired. Note that if JSON configuration is used, the code must
   // be properly escaped. YAML configuration may be easier to read since YAML supports multi-line
   // strings so complex scripts can be easily expressed inline in the configuration.
-  string inline_code = 1 [(validate.rules).string = {min_len: 1}];
+  //
+  // This field is deprecated. Please use
+  // :ref:`default_source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>`
+  string inline_code = 1
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Map of named Lua source codes that can be referenced in :ref:`LuaPerRoute
   // <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>`. The Lua source codes can be
@@ -46,6 +51,10 @@ message Lua {
   //       filename: /etc/lua/world.lua
   //
   map<string, config.core.v3.DataSource> source_codes = 2;
+
+  // The default Lua code that Envoy will execute. If no any per route config is provided
+  // for the request, this Lua code will be applied.
+  config.core.v3.DataSource default_source_code = 3;
 }
 
 message LuaPerRoute {

--- a/api/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/api/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -29,7 +29,10 @@ message Lua {
   // strings so complex scripts can be easily expressed inline in the configuration.
   //
   // This field is deprecated. Please use
-  // :ref:`default_source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>`
+  // :ref:`default_source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>`.
+  // Only one of :ref:`inline_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>`
+  // or :ref:`default_source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>`
+  // can be set for the Lua filter.
   string inline_code = 1
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -42,13 +42,6 @@ behavior_changes:
     If there is no entry referred by the filter config name, the canonical filter name
     (e.g., *envoy.filters.http.buffer* for the HTTP buffer filter) will be used for the backwards
     compatibility.
-- area: lua
-  change: |
-    Update all HTTP filters to get per-filter config by the :ref:`HTTP filter config name
-    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-    If there is no entry referred by the filter config name, the canonical filter name
-    (e.g., *envoy.filters.http.buffer* for the HTTP buffer filter) will be used for the backwards
-    compatibility.
 
 minor_behavior_changes:
 - area: thrift

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -42,6 +42,13 @@ behavior_changes:
     If there is no entry referred by the filter config name, the canonical filter name
     (e.g., *envoy.filters.http.buffer* for the HTTP buffer filter) will be used for the backwards
     compatibility.
+- area: lua
+  change: |
+    Update all HTTP filters to get per-filter config by the :ref:`HTTP filter config name
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
+    If there is no entry referred by the filter config name, the canonical filter name
+    (e.g., *envoy.filters.http.buffer* for the HTTP buffer filter) will be used for the backwards
+    compatibility.
 
 minor_behavior_changes:
 - area: thrift
@@ -344,3 +351,7 @@ deprecated:
   change: |
     :ref:`downstream_auth_password <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_password>` has been deprecated. Please use
     :ref:`downstream_auth_passwords <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
+- area: lua
+  change: |
+    :ref:`inline_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>` has been deprecated. Please use
+    :ref:`default_source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>`.

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -59,26 +59,27 @@ Configuration
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.lua.v3.Lua>`
 * This filter should be configured with the name *envoy.filters.http.lua*.
 
-A simple example of configuring Lua HTTP filter that contains only :ref:`inline_code
-<envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>` is as follow:
+A simple example of configuring Lua HTTP filter that contains only :ref:`default source code
+<envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.default_source_code>` is as follow:
 
 .. code-block:: yaml
 
   name: envoy.filters.http.lua
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-    inline_code: |
-      -- Called on the request path.
-      function envoy_on_request(request_handle)
-        -- Do something.
-      end
-      -- Called on the response path.
-      function envoy_on_response(response_handle)
-        -- Do something.
-      end
+    default_source_code:
+      inline_string: |
+        -- Called on the request path.
+        function envoy_on_request(request_handle)
+          -- Do something.
+        end
+        -- Called on the response path.
+        function envoy_on_response(response_handle)
+          -- Do something.
+        end
 
-By default, Lua script defined in ``inline_code`` will be treated as a ``GLOBAL`` script. Envoy will
-execute it for every HTTP request.
+By default, Lua script defined in ``default_source_code`` will be treated as a ``default`` script. Envoy will
+execute it for every HTTP request. This ``default`` script is optional.
 
 Per-Route Configuration
 -----------------------
@@ -87,7 +88,7 @@ The Lua HTTP filter also can be disabled or overridden on a per-route basis by p
 :ref:`LuaPerRoute <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>` configuration
 on the virtual host, route, or weighted cluster.
 
-LuaPerRoute provides two ways of overriding the ``GLOBAL`` Lua script:
+LuaPerRoute provides two ways of overriding the ``default`` Lua script:
 
 * By providing a name reference to the defined :ref:`named Lua source codes map
   <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.source_codes>`.
@@ -102,10 +103,11 @@ As a concrete example, given the following Lua filter configuration:
   name: envoy.filters.http.lua
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-    inline_code: |
-      function envoy_on_request(request_handle)
-        -- do something
-      end
+    default_source_code:
+      inline_string:
+        function envoy_on_request(request_handle)
+          -- do something
+        end
     source_codes:
       hello.lua:
         inline_string: |
@@ -130,7 +132,7 @@ follow:
       disabled: true
 
 We can also refer to a Lua script in the filter configuration by specifying a name in LuaPerRoute.
-The ``GLOBAL`` Lua script will be overridden by the referenced script:
+The ``default`` Lua script will be overridden by the referenced script:
 
 .. code-block:: yaml
 
@@ -139,13 +141,7 @@ The ``GLOBAL`` Lua script will be overridden by the referenced script:
       "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
       name: hello.lua
 
-.. attention::
-
-  The name ``GLOBAL`` is reserved for :ref:`Lua.inline_code
-  <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>`. Therefore, do not use
-  ``GLOBAL`` as name for other Lua scripts.
-
-Or we can define a new Lua script in the LuaPerRoute configuration directly to override the ``GLOBAL``
+Or we can define a new Lua script in the LuaPerRoute configuration directly to override the ``default``
 Lua script as follows:
 
 .. code-block:: yaml

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -27,16 +27,17 @@ static_resources:
           - name: envoy.filters.http.lua
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-              inline_code: |
-                local mylibrary = require("lib.mylibrary")
+              default_source_code:
+                inline_string:
+                  local mylibrary = require("lib.mylibrary")
 
-                function envoy_on_request(request_handle)
-                  request_handle:headers():add("foo", mylibrary.foobar())
-                end
-                function envoy_on_response(response_handle)
-                  body_size = response_handle:body():length()
-                  response_handle:headers():add("response-body-size", tostring(body_size))
-                end
+                  function envoy_on_request(request_handle)
+                    request_handle:headers():add("foo", mylibrary.foobar())
+                  end
+                  function envoy_on_response(response_handle)
+                    body_size = response_handle:body():length()
+                    response_handle:headers():add("response-body-size", tostring(body_size))
+                  end
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -692,8 +692,8 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::lua::v3::Lua&
     : cluster_manager_(cluster_manager) {
   if (proto_config.has_default_source_code()) {
     if (!proto_config.inline_code().empty()) {
-      throw EnvoyException("Error: Only one of `inline_code` or `default_source_code` of can be "
-                           "set for the Lua filter.");
+      throw EnvoyException("Error: Only one of `inline_code` or `default_source_code` can be set "
+                           "for the Lua filter.");
     }
 
     const std::string code =

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -691,6 +691,11 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::lua::v3::Lua&
                            Upstream::ClusterManager& cluster_manager, Api::Api& api)
     : cluster_manager_(cluster_manager) {
   if (proto_config.has_default_source_code()) {
+    if (!proto_config.inline_code().empty()) {
+      throw EnvoyException("Error: Only one of `inline_code` or `default_source_code` of can be "
+                           "set for the Lua filter.");
+    }
+
     const std::string code =
         Config::DataSource::read(proto_config.default_source_code(), true, api);
     default_lua_code_setup_ = std::make_unique<PerLuaCodeSetup>(code, tls);

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -690,9 +690,12 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::lua::v3::Lua&
                            ThreadLocal::SlotAllocator& tls,
                            Upstream::ClusterManager& cluster_manager, Api::Api& api)
     : cluster_manager_(cluster_manager) {
-  auto global_setup_ptr = std::make_unique<PerLuaCodeSetup>(proto_config.inline_code(), tls);
-  if (global_setup_ptr) {
-    per_lua_code_setups_map_[GLOBAL_SCRIPT_NAME] = std::move(global_setup_ptr);
+  if (proto_config.has_default_source_code()) {
+    const std::string code =
+        Config::DataSource::read(proto_config.default_source_code(), true, api);
+    default_lua_code_setup_ = std::make_unique<PerLuaCodeSetup>(code, tls);
+  } else if (!proto_config.inline_code().empty()) {
+    default_lua_code_setup_ = std::make_unique<PerLuaCodeSetup>(proto_config.inline_code(), tls);
   }
 
   for (const auto& source : proto_config.source_codes()) {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -361,8 +361,12 @@ public:
                ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
                Api::Api& api);
 
-  PerLuaCodeSetup* perLuaCodeSetup(const std::string& name) const {
-    const auto iter = per_lua_code_setups_map_.find(name);
+  PerLuaCodeSetup* perLuaCodeSetup(absl::optional<absl::string_view> name = absl::nullopt) const {
+    if (!name.has_value()) {
+      return default_lua_code_setup_.get();
+    }
+
+    const auto iter = per_lua_code_setups_map_.find(name.value());
     if (iter != per_lua_code_setups_map_.end()) {
       return iter->second.get();
     }
@@ -372,6 +376,7 @@ public:
   Upstream::ClusterManager& cluster_manager_;
 
 private:
+  PerLuaCodeSetupPtr default_lua_code_setup_;
   absl::flat_hash_map<std::string, PerLuaCodeSetupPtr> per_lua_code_setups_map_;
 };
 
@@ -432,7 +437,7 @@ PerLuaCodeSetup* getPerLuaCodeSetup(const FilterConfig* filter_config,
     return config_per_route->perLuaCodeSetup();
   }
   ASSERT(filter_config);
-  return filter_config->perLuaCodeSetup(GLOBAL_SCRIPT_NAME);
+  return filter_config->perLuaCodeSetup();
 }
 
 } // namespace

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -15,8 +15,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Lua {
 
-constexpr char GLOBAL_SCRIPT_NAME[] = "GLOBAL";
-
 class PerLuaCodeSetup : Logger::Loggable<Logger::Id::lua> {
 public:
   PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotAllocator& tls);

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -62,7 +62,7 @@ TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCode) {
 
 TEST(LuaFilterConfigTest, LuaFilterWithDeprecatedInlineCode) {
   const std::string yaml_string = R"EOF(
-  inline_code:
+  inline_code: |
     function envoy_on_request(request_handle)
       request_handle:headers():add("code", "code_from_hello")
     end
@@ -85,7 +85,7 @@ TEST(LuaFilterConfigTest, LuaFilterWithBothDeprecatedInlineCodeAndDefaultSourceC
       function envoy_on_request(request_handle)
         request_handle:headers():add("code", "code_from_hello")
       end
-  inline_code:
+  inline_code: |
     function envoy_on_request(request_handle)
       request_handle:headers():add("code", "code_from_hello")
     end

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -21,9 +21,8 @@ namespace {
 
 TEST(LuaFilterConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW(LuaFilterConfig().createFilterFactoryFromProto(
-                   envoy::extensions::filters::http::lua::v3::Lua(), "stats", context),
-               ProtoValidationException);
+  EXPECT_NO_THROW(LuaFilterConfig().createFilterFactoryFromProto(
+      envoy::extensions::filters::http::lua::v3::Lua(), "stats", context));
 }
 
 TEST(LuaFilterConfigTest, LuaFilterInJson) {

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -95,10 +95,9 @@ TEST(LuaFilterConfigTest, LuaFilterWithBothDeprecatedInlineCodeAndDefaultSourceC
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   LuaFilterConfig factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context),
-                            EnvoyException,
-                            "Error: Only one of `inline_code` or `default_source_code` of can be "
-                            "set for the Lua filter.");
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createFilterFactoryFromProto(proto_config, "stats", context), EnvoyException,
+      "Error: Only one of `inline_code` or `default_source_code` can be set for the Lua filter.");
 }
 
 } // namespace

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -41,6 +41,43 @@ TEST(LuaFilterConfigTest, LuaFilterInJson) {
   cb(filter_callback);
 }
 
+TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCode) {
+  const std::string yaml_string = R"EOF(
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:headers():add("code", "code_from_hello")
+      end
+  )EOF";
+
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  LuaFilterConfig factory;
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(LuaFilterConfigTest, LuaFilterWithDeprecatedInlineCode) {
+  const std::string yaml_string = R"EOF(
+  inline_code:
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("code", "code_from_hello")
+    end
+  )EOF";
+
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  LuaFilterConfig factory;
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 } // namespace
 } // namespace Lua
 } // namespace HttpFilters

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -83,7 +83,7 @@ public:
   // test cases, the existing configuration methods must be compatible.
   void setup(const std::string& lua_code) {
     envoy::extensions::filters::http::lua::v3::Lua proto_config;
-    proto_config.set_inline_code(lua_code);
+    proto_config.mutable_default_source_code()->set_inline_string(lua_code);
     envoy::extensions::filters::http::lua::v3::LuaPerRoute per_route_proto_config;
     setupConfig(proto_config, per_route_proto_config);
     setupFilter();
@@ -228,7 +228,7 @@ TEST(LuaHttpFilterConfigTest, BadCode) {
   NiceMock<Api::MockApi> api;
 
   envoy::extensions::filters::http::lua::v3::Lua proto_config;
-  proto_config.set_inline_code(SCRIPT);
+  proto_config.mutable_default_source_code()->set_inline_string(SCRIPT);
 
   EXPECT_THROW_WITH_MESSAGE(FilterConfig(proto_config, tls, cluster_manager, api),
                             Filters::Common::Lua::LuaException,
@@ -2174,7 +2174,7 @@ TEST_F(LuaHttpFilterTest, SignatureVerify) {
 // Test whether the route configuration can properly disable the Lua filter.
 TEST_F(LuaHttpFilterTest, LuaFilterDisabled) {
   envoy::extensions::filters::http::lua::v3::Lua proto_config;
-  proto_config.set_inline_code(ADD_HEADERS_SCRIPT);
+  proto_config.mutable_default_source_code()->set_inline_string(ADD_HEADERS_SCRIPT);
   envoy::extensions::filters::http::lua::v3::LuaPerRoute per_route_proto_config;
   per_route_proto_config.set_disabled(true);
 
@@ -2214,7 +2214,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterRefSourceCodes) {
   )EOF"};
   EXPECT_CALL(decoder_callbacks_, clearRouteCache());
   envoy::extensions::filters::http::lua::v3::Lua proto_config;
-  proto_config.set_inline_code(ADD_HEADERS_SCRIPT);
+  proto_config.mutable_default_source_code()->set_inline_string(ADD_HEADERS_SCRIPT);
   envoy::config::core::v3::DataSource source1, source2;
   source1.set_inline_string(SCRIPT_FOR_ROUTE_ONE);
   source2.set_inline_string(SCRIPT_FOR_ROUTE_TWO);
@@ -2244,7 +2244,7 @@ TEST_F(LuaHttpFilterTest, LuaFilterRefSourceCodeNotExist) {
   )EOF"};
 
   envoy::extensions::filters::http::lua::v3::Lua proto_config;
-  proto_config.set_inline_code(ADD_HEADERS_SCRIPT);
+  proto_config.mutable_default_source_code()->set_inline_string(ADD_HEADERS_SCRIPT);
   envoy::config::core::v3::DataSource source1;
   source1.set_inline_string(SCRIPT_FOR_ROUTE_ONE);
   proto_config.mutable_source_codes()->insert({"route_one.lua", source1});

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1470,7 +1470,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
   setup(SCRIPT);
 
   // Perform a GC and snap bytes currently used by the runtime.
-  auto script_config = config_->perLuaCodeSetup(GLOBAL_SCRIPT_NAME);
+  auto script_config = config_->perLuaCodeSetup();
   script_config->runtimeGC();
   const uint64_t mem_use_at_start = script_config->runtimeBytesUsed();
 

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -238,12 +238,13 @@ TEST_P(LuaIntegrationTest, CallMetadataDuringLocalReply) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_response(response_handle)
-      local metadata = response_handle:metadata():get("foo.bar")
-      if metadata == nil then
+  default_source_code:
+    inline_string: |
+      function envoy_on_response(response_handle)
+        local metadata = response_handle:metadata():get("foo.bar")
+        if metadata == nil then
+        end
       end
-    end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE, "foo");
@@ -263,62 +264,63 @@ TEST_P(LuaIntegrationTest, RequestAndResponse) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      request_handle:logTrace("log test")
-      request_handle:logDebug("log test")
-      request_handle:logInfo("log test")
-      request_handle:logWarn("log test")
-      request_handle:logErr("log test")
-      request_handle:logCritical("log test")
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:logTrace("log test")
+        request_handle:logDebug("log test")
+        request_handle:logInfo("log test")
+        request_handle:logWarn("log test")
+        request_handle:logErr("log test")
+        request_handle:logCritical("log test")
 
-      local metadata = request_handle:metadata():get("foo.bar")
-      local body_length = request_handle:body():length()
+        local metadata = request_handle:metadata():get("foo.bar")
+        local body_length = request_handle:body():length()
 
-      request_handle:streamInfo():dynamicMetadata():set("envoy.lb", "foo", "bar")
-      local dynamic_metadata_value = request_handle:streamInfo():dynamicMetadata():get("envoy.lb")["foo"]
+        request_handle:streamInfo():dynamicMetadata():set("envoy.lb", "foo", "bar")
+        local dynamic_metadata_value = request_handle:streamInfo():dynamicMetadata():get("envoy.lb")["foo"]
 
-      local test_header_value_0 = request_handle:headers():getAtIndex("X-Test-Header", 0)
-      request_handle:headers():add("test_header_value_0", test_header_value_0)
-      local test_header_value_1 = request_handle:headers():getAtIndex("X-TEST-Header", 1)
-      request_handle:headers():add("test_header_value_1", test_header_value_1)
-      local test_header_value_2 = request_handle:headers():getAtIndex("x-test-header", 2)
-      if test_header_value_2 == nil then
-        request_handle:headers():add("test_header_value_2", "nil_value")
+        local test_header_value_0 = request_handle:headers():getAtIndex("X-Test-Header", 0)
+        request_handle:headers():add("test_header_value_0", test_header_value_0)
+        local test_header_value_1 = request_handle:headers():getAtIndex("X-TEST-Header", 1)
+        request_handle:headers():add("test_header_value_1", test_header_value_1)
+        local test_header_value_2 = request_handle:headers():getAtIndex("x-test-header", 2)
+        if test_header_value_2 == nil then
+          request_handle:headers():add("test_header_value_2", "nil_value")
+        end
+        local test_header_value_size = request_handle:headers():getNumValues("x-test-header")
+        request_handle:headers():add("test_header_value_size", test_header_value_size)
+        request_handle:headers():add("cookie_0", request_handle:headers():getAtIndex("set-cookie", 0))
+        request_handle:headers():add("cookie_1", request_handle:headers():getAtIndex("set-cookie", 1))
+        request_handle:headers():add("cookie_size", request_handle:headers():getNumValues("set-cookie"))
+
+        request_handle:headers():add("request_body_size", body_length)
+        request_handle:headers():add("request_metadata_foo", metadata["foo"])
+        request_handle:headers():add("request_metadata_baz", metadata["baz"])
+        if request_handle:connection():ssl() == nil then
+          request_handle:headers():add("request_secure", "false")
+        else
+          request_handle:headers():add("request_secure", "true")
+        end
+        request_handle:headers():add("request_protocol", request_handle:streamInfo():protocol())
+        request_handle:headers():add("request_dynamic_metadata_value", dynamic_metadata_value)
+        request_handle:headers():add("request_downstream_local_address_value",
+          request_handle:streamInfo():downstreamLocalAddress())
+        request_handle:headers():add("request_downstream_directremote_address_value",
+          request_handle:streamInfo():downstreamDirectRemoteAddress())
+        request_handle:headers():add("request_requested_server_name",
+          request_handle:streamInfo():requestedServerName())
       end
-      local test_header_value_size = request_handle:headers():getNumValues("x-test-header")
-      request_handle:headers():add("test_header_value_size", test_header_value_size)
-      request_handle:headers():add("cookie_0", request_handle:headers():getAtIndex("set-cookie", 0))
-      request_handle:headers():add("cookie_1", request_handle:headers():getAtIndex("set-cookie", 1))
-      request_handle:headers():add("cookie_size", request_handle:headers():getNumValues("set-cookie"))
 
-      request_handle:headers():add("request_body_size", body_length)
-      request_handle:headers():add("request_metadata_foo", metadata["foo"])
-      request_handle:headers():add("request_metadata_baz", metadata["baz"])
-      if request_handle:connection():ssl() == nil then
-        request_handle:headers():add("request_secure", "false")
-      else
-        request_handle:headers():add("request_secure", "true")
+      function envoy_on_response(response_handle)
+        local metadata = response_handle:metadata():get("foo.bar")
+        local body_length = response_handle:body():length()
+        response_handle:headers():add("response_metadata_foo", metadata["foo"])
+        response_handle:headers():add("response_metadata_baz", metadata["baz"])
+        response_handle:headers():add("response_body_size", body_length)
+        response_handle:headers():add("request_protocol", response_handle:streamInfo():protocol())
+        response_handle:headers():remove("foo")
       end
-      request_handle:headers():add("request_protocol", request_handle:streamInfo():protocol())
-      request_handle:headers():add("request_dynamic_metadata_value", dynamic_metadata_value)
-      request_handle:headers():add("request_downstream_local_address_value",
-        request_handle:streamInfo():downstreamLocalAddress())
-      request_handle:headers():add("request_downstream_directremote_address_value",
-        request_handle:streamInfo():downstreamDirectRemoteAddress())
-      request_handle:headers():add("request_requested_server_name",
-        request_handle:streamInfo():requestedServerName())
-    end
-
-    function envoy_on_response(response_handle)
-      local metadata = response_handle:metadata():get("foo.bar")
-      local body_length = response_handle:body():length()
-      response_handle:headers():add("response_metadata_foo", metadata["foo"])
-      response_handle:headers():add("response_metadata_baz", metadata["baz"])
-      response_handle:headers():add("response_body_size", body_length)
-      response_handle:headers():add("request_protocol", response_handle:streamInfo():protocol())
-      response_handle:headers():remove("foo")
-    end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -457,21 +459,22 @@ TEST_P(LuaIntegrationTest, UpstreamHttpCall) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      local headers, body = request_handle:httpCall(
-      "lua_cluster",
-      {
-        [":method"] = "POST",
-        [":path"] = "/",
-        [":authority"] = "lua_cluster"
-      },
-      "hello world",
-      5000)
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        local headers, body = request_handle:httpCall(
+        "lua_cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "lua_cluster"
+        },
+        "hello world",
+        5000)
 
-      request_handle:headers():add("upstream_foo", headers["foo"])
-      request_handle:headers():add("upstream_body_size", #body)
-    end
+        request_handle:headers():add("upstream_foo", headers["foo"])
+        request_handle:headers():add("upstream_body_size", #body)
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -515,12 +518,13 @@ TEST_P(LuaIntegrationTest, Respond) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      request_handle:respond(
-        {[":status"] = "403"},
-        "nope")
-    end
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:respond(
+          {[":status"] = "403"},
+          "nope")
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -551,23 +555,24 @@ TEST_P(LuaIntegrationTest, UpstreamCallAndRespond) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      local headers, body = request_handle:httpCall(
-      "lua_cluster",
-      {
-        [":method"] = "POST",
-        [":path"] = "/",
-        [":authority"] = "lua_cluster"
-      },
-      "hello world",
-      5000)
+  default_source_code:
+    inline_string:
+      function envoy_on_request(request_handle)
+        local headers, body = request_handle:httpCall(
+        "lua_cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "lua_cluster"
+        },
+        "hello world",
+        5000)
 
-      request_handle:respond(
-        {[":status"] = "403",
-         ["upstream_foo"] = headers["foo"]},
-        "nope")
-    end
+        request_handle:respond(
+          {[":status"] = "403",
+          ["upstream_foo"] = headers["foo"]},
+          "nope")
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -601,19 +606,20 @@ TEST_P(LuaIntegrationTest, UpstreamAsyncHttpCall) {
 name: envoy.filters.http.lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      local headers, body = request_handle:httpCall(
-      "lua_cluster",
-      {
-        [":method"] = "POST",
-        [":path"] = "/",
-        [":authority"] = "lua_cluster"
-      },
-      "hello world",
-      5000,
-      true)
-    end
+  default_source_code:
+    inline_string:
+      function envoy_on_request(request_handle)
+        local headers, body = request_handle:httpCall(
+        "lua_cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "lua_cluster"
+        },
+        "hello world",
+        5000,
+        true)
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -651,11 +657,12 @@ TEST_P(LuaIntegrationTest, ChangeRoute) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      request_handle:headers():remove(":path")
-      request_handle:headers():add(":path", "/alt/route")
-    end
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:headers():remove(":path")
+        request_handle:headers():add(":path", "/alt/route")
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -685,10 +692,11 @@ TEST_P(LuaIntegrationTest, SurviveMultipleCalls) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      request_handle:streamInfo():dynamicMetadata()
-    end
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:streamInfo():dynamicMetadata()
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -721,58 +729,59 @@ TEST_P(LuaIntegrationTest, SignatureVerification) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function string.fromhex(str)
-      return (str:gsub('..', function (cc)
-        return string.char(tonumber(cc, 16))
-      end))
-    end
-
-    -- decoding
-    function dec(data)
-      local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-      data = string.gsub(data, '[^'..b..'=]', '')
-      return (data:gsub('.', function(x)
-        if (x == '=') then return '' end
-        local r,f='',(b:find(x)-1)
-        for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
-        return r;
-      end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
-        if (#x ~= 8) then return '' end
-        local c=0
-        for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
-        return string.char(c)
-      end))
-    end
-
-    function envoy_on_request(request_handle)
-      local metadata = request_handle:metadata():get("keyset")
-      local keyder = metadata[request_handle:headers():get("keyid")]
-
-      local rawkeyder = dec(keyder)
-      local pubkey = request_handle:importPublicKey(rawkeyder, string.len(rawkeyder)):get()
-
-      if pubkey == nil then
-        request_handle:logErr("log test")
-        request_handle:headers():add("signature_verification", "rejected")
-        return
+  default_source_code:
+    inline_string: |
+      function string.fromhex(str)
+        return (str:gsub('..', function (cc)
+          return string.char(tonumber(cc, 16))
+        end))
       end
 
-      local hash = request_handle:headers():get("hash")
-      local sig = request_handle:headers():get("signature")
-      local rawsig = sig:fromhex()
-      local data = request_handle:headers():get("message")
-      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data))
-
-      if ok then
-        request_handle:headers():add("signature_verification", "approved")
-      else
-        request_handle:logErr(error)
-        request_handle:headers():add("signature_verification", "rejected")
+      -- decoding
+      function dec(data)
+        local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+        data = string.gsub(data, '[^'..b..'=]', '')
+        return (data:gsub('.', function(x)
+          if (x == '=') then return '' end
+          local r,f='',(b:find(x)-1)
+          for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
+          return r;
+        end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+          if (#x ~= 8) then return '' end
+          local c=0
+          for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
+          return string.char(c)
+        end))
       end
 
-      request_handle:headers():add("verification", "done")
-    end
+      function envoy_on_request(request_handle)
+        local metadata = request_handle:metadata():get("keyset")
+        local keyder = metadata[request_handle:headers():get("keyid")]
+
+        local rawkeyder = dec(keyder)
+        local pubkey = request_handle:importPublicKey(rawkeyder, string.len(rawkeyder)):get()
+
+        if pubkey == nil then
+          request_handle:logErr("log test")
+          request_handle:headers():add("signature_verification", "rejected")
+          return
+        end
+
+        local hash = request_handle:headers():get("hash")
+        local sig = request_handle:headers():get("signature")
+        local rawsig = sig:fromhex()
+        local data = request_handle:headers():get("message")
+        local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data))
+
+        if ok then
+          request_handle:headers():add("signature_verification", "approved")
+        else
+          request_handle:logErr(error)
+          request_handle:headers():add("signature_verification", "rejected")
+        end
+
+        request_handle:headers():add("verification", "done")
+      end
 )EOF";
 
   initializeFilter(FILTER_AND_CODE);
@@ -818,10 +827,11 @@ const std::string FILTER_AND_CODE =
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_request(request_handle)
-      request_handle:headers():add("code", "code_from_global")
-    end
+  default_source_code:
+    inline_string: |
+      function envoy_on_request(request_handle)
+        request_handle:headers():add("code", "code_from_global")
+      end
   source_codes:
     hello.lua:
       inline_string: |
@@ -1007,10 +1017,11 @@ TEST_P(LuaIntegrationTest, DirectResponseLuaMetadata) {
   name: lua
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-    inline_code: |
-      function envoy_on_response(response_handle)
-        response_handle:headers():add('foo', response_handle:metadata():get('foo') or 'nil')
-      end
+    default_source_code:
+      inline_string:
+        function envoy_on_response(response_handle)
+          response_handle:headers():add('foo', response_handle:metadata():get('foo') or 'nil')
+        end
 )EOF";
 
   std::string route_config =
@@ -1128,13 +1139,14 @@ TEST_P(LuaIntegrationTest, RewriteResponseBuffer) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_response(response_handle)
-      local content_length = response_handle:body():setBytes("ok")
-      response_handle:logTrace(content_length)
+  default_source_code:
+    inline_string: |
+      function envoy_on_response(response_handle)
+        local content_length = response_handle:body():setBytes("ok")
+        response_handle:logTrace(content_length)
 
-      response_handle:headers():replace("content-length", content_length)
-    end
+        response_handle:headers():replace("content-length", content_length)
+      end
 )EOF";
 
   testRewriteResponse(FILTER_AND_CODE);
@@ -1148,13 +1160,14 @@ TEST_P(LuaIntegrationTest, RewriteResponseBufferWithoutUpstreamBody) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_response(response_handle)
-      local content_length = response_handle:body(true):setBytes("ok")
-      response_handle:logTrace(content_length)
+  default_source_code:
+    inline_string: |
+      function envoy_on_response(response_handle)
+        local content_length = response_handle:body(true):setBytes("ok")
+        response_handle:logTrace(content_length)
 
-      response_handle:headers():replace("content-length", content_length)
-    end
+        response_handle:headers():replace("content-length", content_length)
+      end
 )EOF";
 
   testRewriteResponseWithoutUpstreamBody(FILTER_AND_CODE, true);
@@ -1168,14 +1181,15 @@ TEST_P(LuaIntegrationTest, RewriteResponseBufferWithoutUpstreamBodyAndDisableWra
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_response(response_handle)
-      if response_handle:body(false) then
-        local content_length = response_handle:body():setBytes("ok")
-        response_handle:logTrace(content_length)
-        response_handle:headers():replace("content-length", content_length)
+  default_source_code:
+    inline_string: |
+      function envoy_on_response(response_handle)
+        if response_handle:body(false) then
+          local content_length = response_handle:body():setBytes("ok")
+          response_handle:logTrace(content_length)
+          response_handle:headers():replace("content-length", content_length)
+        end
       end
-    end
 )EOF";
 
   testRewriteResponseWithoutUpstreamBody(FILTER_AND_CODE, false);
@@ -1188,16 +1202,17 @@ TEST_P(LuaIntegrationTest, RewriteChunkedBody) {
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_response(response_handle)
-      response_handle:headers():replace("content-length", 2)
-      local last
-      for chunk in response_handle:bodyChunks() do
-        chunk:setBytes("")
-        last = chunk
+  default_source_code:
+    inline_string: |
+      function envoy_on_response(response_handle)
+        response_handle:headers():replace("content-length", 2)
+        local last
+        for chunk in response_handle:bodyChunks() do
+          chunk:setBytes("")
+          last = chunk
+        end
+        last:setBytes("ok")
       end
-      last:setBytes("ok")
-    end
 )EOF";
 
   testRewriteResponse(FILTER_AND_CODE);
@@ -1209,11 +1224,12 @@ TEST_P(LuaIntegrationTest, RewriteResponseBufferWithoutHeaderReplaceContentLengt
 name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-  inline_code: |
-    function envoy_on_response(response_handle)
-      local content_length = response_handle:body():setBytes("ok")
-      response_handle:logTrace(content_length)
-    end
+  default_source_code:
+    inline_string: |
+      function envoy_on_response(response_handle)
+        local content_length = response_handle:body():setBytes("ok")
+        response_handle:logTrace(content_length)
+      end
 )EOF";
 
   testRewriteResponse(FILTER_AND_CODE);

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -556,7 +556,7 @@ name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
   default_source_code:
-    inline_string:
+    inline_string: |
       function envoy_on_request(request_handle)
         local headers, body = request_handle:httpCall(
         "lua_cluster",
@@ -607,7 +607,7 @@ name: envoy.filters.http.lua
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
   default_source_code:
-    inline_string:
+    inline_string: |
       function envoy_on_request(request_handle)
         local headers, body = request_handle:httpCall(
         "lua_cluster",
@@ -961,7 +961,7 @@ TEST_P(LuaIntegrationTest, BasicTestOfLuaPerRoute) {
     EXPECT_EQ("200", response->headers().getStatusValue());
   };
 
-  // Lua code defined in 'inline_code' will be executed by default.
+  // Lua code defined in 'default_source_code' will be executed by default.
   Http::TestRequestHeaderMapImpl default_headers{{":method", "GET"},
                                                  {":path", "/lua/per/route/default"},
                                                  {":scheme", "http"},
@@ -1018,7 +1018,7 @@ TEST_P(LuaIntegrationTest, DirectResponseLuaMetadata) {
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
     default_source_code:
-      inline_string:
+      inline_string: |
         function envoy_on_response(response_handle)
           response_handle:headers():add('foo', response_handle:metadata():get('foo') or 'nil')
         end
@@ -1046,7 +1046,7 @@ virtual_hosts:
   initializeWithYaml(filter_config, route_config);
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // Lua code defined in 'inline_code' will be executed by default.
+  // Lua code defined in 'default_source_code' will be executed by default.
   Http::TestRequestHeaderMapImpl default_headers{{":method", "GET"},
                                                  {":path", "/lua/direct_response"},
                                                  {":scheme", "http"},


### PR DESCRIPTION


Commit Message: lua: deprecate inline_code and use default_source_code
Additional Description:

Lua source codes map and per route inline source code are supported after #11235 and #12516. However, the `inline_code` field is still necessary for the proto validation.
For users who needn't global/default script, they always need to set a `inline_code` with meaningless code (#14030). This PR will fix this problem.

**This PR will make the `inline_code` optional (remove the `string.min_len` validation) and deprecate it. The  `default_source_code`(of type  `core.v3.DataSource`) will be used to set default/global script.**


Risk Level: Low.
Testing: Updated.
Docs Changes: Updated.
Release Notes: Added.
Platform Specific Features: n/a.