### PR TITLE
router: add 500 cluster not found response code

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -724,6 +724,9 @@ message RouteAction {
 
     // HTTP status code - 404 Not Found.
     NOT_FOUND = 1;
+
+    // HTTP status code - 500 Internal Server Error.
+    INTERNAL_SERVER_ERROR = 2;
   }
 
   // Configures :ref:`internal redirect <arch_overview_internal_redirects>` behavior.

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -143,6 +143,8 @@ Http::Code ConfigUtility::parseClusterNotFoundResponseCode(
     return Http::Code::ServiceUnavailable;
   case envoy::config::route::v3::RouteAction::NOT_FOUND:
     return Http::Code::NotFound;
+  case envoy::config::route::v3::RouteAction::INTERNAL_SERVER_ERROR:
+    return Http::Code::InternalServerError;
   }
   PANIC_DUE_TO_CORRUPT_ENUM;
 }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3856,6 +3856,27 @@ virtual_hosts:
             config.route(headers, 0)->routeEntry()->clusterNotFoundResponseCode());
 }
 
+TEST_F(RouteMatcherTest, ClusterNotFoundResponseCodeConfig500) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+  - name: "www2"
+    domains: ["www.lyft.com"]
+    routes:
+      - match: { prefix: "/"}
+        route:
+          cluster: "not_found"
+          cluster_not_found_response_code: INTERNAL_SERVER_ERROR
+  )EOF";
+
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, false);
+
+  Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+
+  EXPECT_EQ("not_found", config.route(headers, 0)->routeEntry()->clusterName());
+  EXPECT_EQ(Http::Code::InternalServerError,
+            config.route(headers, 0)->routeEntry()->clusterNotFoundResponseCode());
+}
+
 TEST_F(RouteMatcherTest, ClusterNotFoundResponseCodeConfig404) {
   const std::string yaml = R"EOF(
 virtual_hosts:


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: add 500 as response code when the cluster is missing.
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none
Fixes: https://github.com/envoyproxy/envoy/issues/21930