### PR TITLE
socket: allow restoring SSL info

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -165,11 +165,6 @@ public:
   virtual void setSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
 
   /**
-   * @param connection_info restores the downstream ssl connection in case transport socket is internal.
-   */
-  virtual void restoreSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
-  
-  /**
    * @param JA3 fingerprint.
    */
   virtual void setJA3Hash(const absl::string_view ja3_hash) PURE;

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -63,10 +63,6 @@ public:
   }
   Ssl::ConnectionInfoConstSharedPtr sslConnection() const override { return ssl_info_; }
   void setSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) override {
-    ASSERT(!ssl_info_);
-    ssl_info_ = ssl_connection_info;
-  }
-  void restoreSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) override {
     ssl_info_ = ssl_connection_info;
   }
   absl::string_view ja3Hash() const override { return ja3_hash_; }


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Permit changing SSL info in extensions and not just from the transport socket SSL info. 
Additional Description: This is needed when using internal sockets since they are raw_buffer but are upstream from TLS streams.
We would like to override TLS info on the internal connection in a custom extension.
Risk Level: low (removal of debug assertion)
Testing: regression
Docs Changes: none
Release Notes: none