### PR TITLE
docs: Improve code-block highlighting

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -147,7 +147,7 @@ pkg_files(
         "root/**/*.rst",
         "root/**/*.svg",
         "root/**/*.yaml",
-    ]),
+    ]) + ["root/_pygments/style.py"],
     strip_prefix = "/docs/root",
 )
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,9 @@ import yaml
 from sphinx.directives.code import CodeBlock
 import sphinx_rtd_theme
 
+# TODO(phlax): move the pygments style to envoy.docs.sphinx_runner and remove this
+sys.path.append(os.path.abspath("./_pygments"))
+
 
 class SphinxConfigError(Exception):
     pass
@@ -317,3 +320,5 @@ htmlhelp_basename = 'envoydoc'
 rediraffe_redirects = "redirects.txt"
 
 intersphinx_mapping = _config("intersphinx_mapping")
+
+pygments_style = "style.EnvoyCodeStyle"

--- a/docs/root/_pygments/style.py
+++ b/docs/root/_pygments/style.py
@@ -2,7 +2,7 @@ from pygments.styles import get_style_by_name
 from pygments.token import Generic
 
 ENVOY_STYLES = {
-    Generic.Output: "#888888",
+    Generic.Output: "#777777",
 }
 
 TangoStyle = get_style_by_name("tango")

--- a/docs/root/_pygments/style.py
+++ b/docs/root/_pygments/style.py
@@ -1,0 +1,15 @@
+from pygments.styles import get_style_by_name
+from pygments.token import Generic
+
+ENVOY_STYLES = {
+    Generic.Output: "#aaaaaa",
+}
+
+TangoStyle = get_style_by_name("tango")
+
+
+class EnvoyCodeStyle(TangoStyle):
+    default_style = "tango"
+    highlight_color = "#f6f5db"
+    styles = TangoStyle.styles.copy()
+    styles.update(ENVOY_STYLES)

--- a/docs/root/_pygments/style.py
+++ b/docs/root/_pygments/style.py
@@ -2,7 +2,7 @@ from pygments.styles import get_style_by_name
 from pygments.token import Generic
 
 ENVOY_STYLES = {
-    Generic.Output: "#aaaaaa",
+    Generic.Output: "#888888",
 }
 
 TangoStyle = get_style_by_name("tango")


### PR DESCRIPTION
Fix #22050 

This PR links docs builds with a selection of pygments themes for code-block highlighting

We can adapt a chosen theme, but the less we have to do so the better

Some changes are easier than others - for example changing the background

I think that a few of the themes might work better if they didnt have a white background

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]


#### pygments previews

https://dt.iki.fi/pygments-gallery


#### good pages to view

- start/quick-start/run-envoy.html
- start/sandboxes/ext_authz.html
- start/sandboxes/wasm-cc.html
- api-v3/config/bootstrap/v3/bootstrap.proto.html#config-bootstrap-v3-bootstrap
- api-v3/config/route/v3/route_components.proto.html
- docs/operations/admin.html
- intro/arch_overview/advanced/matching/matching_listener.html

#### themes currently available in the build

```python
['default', 'emacs', 'friendly', 'friendly_grayscale', 'colorful', 'autumn', 'murphy', 'manni', 
 'material', 'monokai', 'perldoc', 'pastie', 'borland', 'trac', 'native', 'fruity', 'bw', 'vim', 'vs',
 'tango', 'rrt', 'xcode', 'igor', 'paraiso-light', 'paraiso-dark', 'lovelace', 'algol', 'algol_nu',
 'arduino', 'rainbow_dash', 'abap', 'solarized-dark', 'solarized-light', 'sas', 'stata',
 'stata-light', 'stata-dark', 'inkpot', 'zenburn', 'gruvbox-dark', 'gruvbox-light', 'dracula',
 'one-dark', 'lilypond']
```

