### PR TITLE
spelling: Replace 'getiffaddrs' with 'getifaddrs'

### DIFF
--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -638,7 +638,7 @@ absl::optional<std::string> IoSocketHandleImpl::interfaceName() {
 
   Api::InterfaceAddressVector interface_addresses{};
   const Api::SysCallIntResult rc = os_syscalls_singleton.getifaddrs(interface_addresses);
-  RELEASE_ASSERT(!rc.return_value_, fmt::format("getiffaddrs error: {}", rc.errno_));
+  RELEASE_ASSERT(!rc.return_value_, fmt::format("getifaddrs error: {}", rc.errno_));
 
   absl::optional<std::string> selected_interface_name{};
   for (const auto& interface_address : interface_addresses) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -200,7 +200,7 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
 
     const Api::SysCallIntResult rc =
         Api::OsSysCallsSingleton::get().getifaddrs(interface_addresses);
-    RELEASE_ASSERT(!rc.return_value_, fmt::format("getiffaddrs error: {}", rc.errno_));
+    RELEASE_ASSERT(!rc.return_value_, fmt::format("getifaddrs error: {}", rc.errno_));
 
     // man getifaddrs(3)
     for (const auto& interface_address : interface_addresses) {

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -455,7 +455,7 @@ DnsResolverImpl::AddrInfoPendingResolution::availableInterfaces() {
   Api::InterfaceAddressVector interface_addresses{};
   const Api::SysCallIntResult rc = Api::OsSysCallsSingleton::get().getifaddrs(interface_addresses);
   if (rc.return_value_ != 0) {
-    ENVOY_LOG_EVENT(debug, "cares_getiffaddrs_error",
+    ENVOY_LOG_EVENT(debug, "cares_getifaddrs_error",
                     "dns resolution for {} could not obtain interface information with error={}",
                     dns_name_, rc.errno_);
     // Maintain no-op behavior if the system encountered an error while providing interface

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -856,7 +856,7 @@ public:
                            const DnsResolver::ResolutionStatus resolution_status =
                                DnsResolver::ResolutionStatus::Success,
                            const bool getifaddrs_supported = true,
-                           const bool getiffaddrs_success = true) {
+                           const bool getifaddrs_success = true) {
     server_->addHosts("some.good.domain", {"201.134.56.7"}, RecordType::A);
     server_->addHosts("some.good.domain", {"1::2"}, RecordType::AAAA);
 
@@ -866,7 +866,7 @@ public:
 
     EXPECT_CALL(os_sys_calls, supportsGetifaddrs()).WillOnce(Return(getifaddrs_supported));
     if (getifaddrs_supported) {
-      if (getiffaddrs_success) {
+      if (getifaddrs_success) {
         EXPECT_CALL(os_sys_calls, getifaddrs(_))
             .WillOnce(Invoke([&](Api::InterfaceAddressVector& vector) -> Api::SysCallIntResult {
               for (uint32_t i = 0; i < ifaddrs.size(); i++) {
@@ -1716,12 +1716,12 @@ TEST_P(DnsImplFilterUnroutableFamiliesTest, FilterAllV6) {
   testFilterAddresses({"1.2.3.4:80"}, DnsLookupFamily::All, {"201.134.56.7"});
 }
 
-TEST_P(DnsImplFilterUnroutableFamiliesTest, DontFilterIfGetiffaddrsIsNotSupported) {
+TEST_P(DnsImplFilterUnroutableFamiliesTest, DontFilterIfGetifaddrsIsNotSupported) {
   testFilterAddresses({}, DnsLookupFamily::All, {"201.134.56.7", "1::2"},
                       DnsResolver::ResolutionStatus::Success, false /* getifaddrs_supported */);
 }
 
-TEST_P(DnsImplFilterUnroutableFamiliesTest, DontFilterIfThereIsAGetiffaddrsFailure) {
+TEST_P(DnsImplFilterUnroutableFamiliesTest, DontFilterIfThereIsAGetifaddrsFailure) {
   testFilterAddresses({}, DnsLookupFamily::All, {"201.134.56.7", "1::2"},
                       DnsResolver::ResolutionStatus::Success, true /* getifaddrs_supported */,
                       false /* getifaddrs_success */);


### PR DESCRIPTION
Signed-off-by: Michael Kaufmann <michael.kaufmann@ergon.ch>

Additional Description: Only some error messages are affected.
Risk Level: Low