### PR TITLE
Explicitly initialize atomics

### DIFF
--- a/source/common/access_log/access_log_manager_impl.h
+++ b/source/common/access_log/access_log_manager_impl.h
@@ -114,8 +114,8 @@ private:
                    // high performance. It is always local to the process.
   Thread::ThreadPtr flush_thread_;
   Thread::CondVar flush_event_;
-  std::atomic<bool> flush_thread_exit_{};
-  std::atomic<bool> reopen_file_{};
+  std::atomic<bool> flush_thread_exit_{false};
+  std::atomic<bool> reopen_file_{false};
   Buffer::OwnedImpl
       flush_buffer_ ABSL_GUARDED_BY(write_lock_); // This buffer is used by multiple threads. It
                                                   // gets filled and then flushed either when max

--- a/source/common/common/basic_resource_impl.h
+++ b/source/common/common/basic_resource_impl.h
@@ -49,7 +49,7 @@ public:
   void resetMax() { max_ = std::numeric_limits<uint64_t>::max(); }
 
 protected:
-  std::atomic<uint64_t> current_{};
+  std::atomic<uint64_t> current_{0};
 
 private:
   uint64_t max_;

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -67,7 +67,7 @@ struct ThreadIds {
 
 private:
   mutable absl::Mutex mutex_;
-  std::atomic<uint32_t> skip_asserts_{};
+  std::atomic<uint32_t> skip_asserts_{0};
   absl::flat_hash_map<std::thread::id, uint32_t>
       main_threads_to_usage_count_ ABSL_GUARDED_BY(mutex_);
 };

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -69,7 +69,7 @@ private:
   // This has to be atomic for alarms which are handled out of thread, for
   // example if the DispatcherImpl::post is called by two threads, they race to
   // both set this to null.
-  std::atomic<const ScopeTrackedObject*> object_{};
+  std::atomic<const ScopeTrackedObject*> object_{nullptr};
 };
 
 } // namespace Event

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -541,9 +541,9 @@ private:
   TagProducerPtr tag_producer_;
   StatsMatcherPtr stats_matcher_;
   HistogramSettingsConstPtr histogram_settings_;
-  std::atomic<bool> threading_ever_initialized_{};
-  std::atomic<bool> shutting_down_{};
-  std::atomic<bool> merge_in_progress_{};
+  std::atomic<bool> threading_ever_initialized_{false};
+  std::atomic<bool> shutting_down_{false};
+  std::atomic<bool> merge_in_progress_{false};
   OptRef<ThreadLocal::Instance> tls_;
 
   NullCounterImpl null_counter_;
@@ -552,7 +552,7 @@ private:
   NullTextReadoutImpl null_text_readout_;
 
   mutable Thread::ThreadSynchronizer sync_;
-  std::atomic<uint64_t> next_scope_id_{};
+  std::atomic<uint64_t> next_scope_id_{0};
   uint64_t next_histogram_id_ ABSL_GUARDED_BY(hist_mutex_) = 0;
 
   StatNameSetPtr well_known_tags_;

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -84,7 +84,7 @@ private:
   std::list<uint32_t> free_slot_indexes_;
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
   Event::Dispatcher* main_thread_dispatcher_{};
-  std::atomic<bool> shutdown_{};
+  std::atomic<bool> shutdown_{false};
 
   // Test only.
   friend class ThreadLocalInstanceImplTest;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -301,7 +301,7 @@ protected:
 private:
   void setEdsHealthFlag(envoy::config::core::v3::HealthStatus health_status);
 
-  std::atomic<uint32_t> health_flags_{};
+  std::atomic<uint32_t> health_flags_{0};
   std::atomic<uint32_t> weight_;
   std::atomic<bool> used_;
 };

--- a/source/extensions/common/redis/cluster_refresh_manager_impl.h
+++ b/source/extensions/common/redis/cluster_refresh_manager_impl.h
@@ -35,10 +35,10 @@ public:
           redirects_threshold_(redirects_threshold), failure_threshold_(failure_threshold),
           host_degraded_threshold_(host_degraded_threshold), cb_(std::move(cb)) {}
     std::string cluster_name_;
-    std::atomic<uint64_t> last_callback_time_ms_{};
-    std::atomic<uint32_t> redirects_count_{};
-    std::atomic<uint32_t> failures_count_{};
-    std::atomic<uint32_t> host_degraded_count_{};
+    std::atomic<uint64_t> last_callback_time_ms_{0};
+    std::atomic<uint32_t> redirects_count_{0};
+    std::atomic<uint32_t> failures_count_{0};
+    std::atomic<uint32_t> host_degraded_count_{0};
     std::chrono::milliseconds min_time_between_triggering_;
     const uint32_t redirects_threshold_;
     const uint32_t failure_threshold_;

--- a/source/extensions/filters/http/health_check/health_check.h
+++ b/source/extensions/filters/http/health_check/health_check.h
@@ -42,9 +42,9 @@ private:
 
   Event::TimerPtr clear_cache_timer_;
   const std::chrono::milliseconds timeout_;
-  std::atomic<bool> use_cached_response_{};
-  std::atomic<Http::Code> last_response_code_{};
-  std::atomic<bool> last_response_degraded_{};
+  std::atomic<bool> use_cached_response_{false};
+  std::atomic<Http::Code> last_response_code_{Http::Code::OK};
+  std::atomic<bool> last_response_degraded_{false};
 };
 
 using HealthCheckCacheManagerSharedPtr = std::shared_ptr<HealthCheckCacheManager>;

--- a/source/server/active_tcp_listener.h
+++ b/source/server/active_tcp_listener.h
@@ -84,7 +84,7 @@ public:
   Network::TcpConnectionHandler& tcp_conn_handler_;
   // The number of connections currently active on this listener. This is typically used for
   // connection balancing across per-handler listeners.
-  std::atomic<uint64_t> num_listener_connections_{};
+  std::atomic<uint64_t> num_listener_connections_{0};
 
   Network::ConnectionBalancer& connection_balancer_;
   // This is the address this listener is listening on. It's used to get the correct listener

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -142,7 +142,7 @@ private:
   absl::flat_hash_map<std::string, std::shared_ptr<PerAddressActiveListenerDetails>>
       internal_listener_map_by_address_;
 
-  std::atomic<uint64_t> num_handler_connections_{};
+  std::atomic<uint64_t> num_handler_connections_{0};
   bool disable_listeners_;
   UnitFloat listener_reject_fraction_{UnitFloat::min()};
 };

--- a/test/extensions/common/redis/cluster_refresh_manager_test.cc
+++ b/test/extensions/common/redis/cluster_refresh_manager_test.cc
@@ -107,9 +107,9 @@ public:
   Event::SimulatedTimeSystem time_system_;
   std::shared_ptr<ClusterRefreshManagerImpl> refresh_manager_;
   ClusterRefreshManager::HandlePtr handle_;
-  std::atomic<uint32_t> callback_count_{};
-  std::atomic<uint32_t> nthreads_waiting_{};
-  std::atomic<uint32_t> nthreads_going_{};
+  std::atomic<uint32_t> callback_count_{0};
+  std::atomic<uint32_t> nthreads_waiting_{0};
+  std::atomic<uint32_t> nthreads_going_{0};
   Thread::CondVar wait_cv_;
   Thread::CondVar setter_wait_cv_;
   Thread::MutexBasicLockable time_mutex_;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -432,7 +432,7 @@ protected:
   Event::Dispatcher& dispatcher_;
   bool initialized_ ABSL_GUARDED_BY(lock_){};
   bool half_closed_ ABSL_GUARDED_BY(lock_){};
-  std::atomic<uint64_t> pending_cbs_{};
+  std::atomic<uint64_t> pending_cbs_{0};
   Event::TestTimeSystem& time_system_;
 };
 

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -105,7 +105,7 @@ private:
   std::set<SimulatedScheduler*> schedulers_ ABSL_GUARDED_BY(mutex_);
   mutable absl::Mutex mutex_;
   uint32_t pending_updates_ ABSL_GUARDED_BY(mutex_);
-  std::atomic<uint32_t> warning_logged_{};
+  std::atomic<uint32_t> warning_logged_{0};
 };
 
 // Represents a simulated time system, where time is advanced by calling


### PR DESCRIPTION
Before C++20 default constructor {} is trivial.
https://en.cppreference.com/w/cpp/atomic/atomic/atomic

It's a standard compliance nit-picking as I failed to reproduce uninitialized value.

Signed-off-by: Vitaly Buka <vitalybuka@google.com>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
