### PR TITLE
upstream: plumbing server factory context through to upstream

### DIFF
--- a/envoy/upstream/cluster_factory.h
+++ b/envoy/upstream/cluster_factory.h
@@ -96,7 +96,8 @@ public:
    *         balancer if this cluster has an integrated load balancer.
    */
   virtual std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr>
-  create(const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context) PURE;
+  create(Server::Configuration::ServerFactoryContext& server_context,
+         const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.clusters"; }
 };

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -533,6 +533,7 @@ public:
    * Parameters for createClusterInfo().
    */
   struct CreateClusterInfoParams {
+    Server::Configuration::ServerFactoryContext& server_context_;
     Server::Admin& admin_;
     Runtime::Loader& runtime_;
     const envoy::config::cluster::v3::Cluster& cluster_;
@@ -546,7 +547,6 @@ public:
     Singleton::Manager& singleton_manager_;
     ThreadLocal::SlotAllocator& tls_;
     ProtobufMessage::ValidationVisitor& validation_visitor_;
-    Api::Api& api_;
     const Server::Options& options_;
     AccessLog::AccessLogManager& access_log_manager_;
   };

--- a/source/common/upstream/cluster_factory_impl.h
+++ b/source/common/upstream/cluster_factory_impl.h
@@ -116,8 +116,10 @@ public:
   /**
    * Static method to get the registered cluster factory and create an instance of cluster.
    */
+  // TODO(alyssawilk) clean up redundant members.
   static std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr>
-  create(const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cluster_manager,
+  create(Server::Configuration::ServerFactoryContext& server_context,
+         const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cluster_manager,
          Stats::Store& stats, ThreadLocal::Instance& tls,
          Network::DnsResolverSharedPtr dns_resolver, Ssl::ContextManager& ssl_context_manager,
          Runtime::Loader& runtime, Event::Dispatcher& dispatcher,
@@ -136,7 +138,8 @@ public:
 
   // Upstream::ClusterFactory
   std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr>
-  create(const envoy::config::cluster::v3::Cluster& cluster,
+  create(Server::Configuration::ServerFactoryContext& server_context,
+         const envoy::config::cluster::v3::Cluster& cluster,
          ClusterFactoryContext& context) override;
   std::string name() const override { return name_; }
 
@@ -148,6 +151,7 @@ private:
    * Create an instance of ClusterImplBase.
    */
   virtual std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) PURE;
@@ -172,6 +176,7 @@ protected:
 
 private:
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override {
@@ -179,13 +184,14 @@ private:
     Config::Utility::translateOpaqueConfig(cluster.cluster_type().typed_config(),
                                            socket_factory_context.messageValidationVisitor(),
                                            *config);
-    return createClusterWithConfig(cluster,
+    return createClusterWithConfig(server_context, cluster,
                                    MessageUtil::downcastAndValidate<const ConfigProto&>(
                                        *config, context.messageValidationVisitor()),
                                    context, socket_factory_context, std::move(stats_scope));
   }
 
   virtual std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterWithConfig(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, const ConfigProto& proto_config,
       ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1948,9 +1948,9 @@ std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr> ProdClusterManagerFactor
     const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cm,
     Outlier::EventLoggerSharedPtr outlier_event_logger, bool added_via_api) {
   return ClusterFactoryImplBase::create(
-      cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_, context_.runtime(),
-      context_.mainThreadDispatcher(), log_manager_, context_.localInfo(), admin_,
-      singleton_manager_, outlier_event_logger, added_via_api,
+      server_context_, cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_,
+      context_.runtime(), context_.mainThreadDispatcher(), log_manager_, context_.localInfo(),
+      admin_, singleton_manager_, outlier_event_logger, added_via_api,
       added_via_api ? validation_context_.dynamicValidationVisitor()
                     : validation_context_.staticValidationVisitor(),
       context_.api(), context_.options());

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -48,19 +48,18 @@ namespace Upstream {
  */
 class ProdClusterManagerFactory : public ClusterManagerFactory {
 public:
-  ProdClusterManagerFactory(Server::Admin& admin, Runtime::Loader& runtime, Stats::Store& stats,
-                            ThreadLocal::Instance& tls, Network::DnsResolverSharedPtr dns_resolver,
-                            Ssl::ContextManager& ssl_context_manager,
-                            Event::Dispatcher& main_thread_dispatcher,
-                            const LocalInfo::LocalInfo& local_info,
-                            Secret::SecretManager& secret_manager,
-                            ProtobufMessage::ValidationContext& validation_context, Api::Api& api,
-                            Http::Context& http_context, Grpc::Context& grpc_context,
-                            Router::Context& router_context,
-                            AccessLog::AccessLogManager& log_manager,
-                            Singleton::Manager& singleton_manager, const Server::Options& options,
-                            Quic::QuicStatNames& quic_stat_names, const Server::Instance& server)
-      : context_(options, main_thread_dispatcher, api, local_info, admin, runtime,
+  ProdClusterManagerFactory(
+      Server::Configuration::ServerFactoryContext& server_context, Server::Admin& admin,
+      Runtime::Loader& runtime, Stats::Store& stats, ThreadLocal::Instance& tls,
+      Network::DnsResolverSharedPtr dns_resolver, Ssl::ContextManager& ssl_context_manager,
+      Event::Dispatcher& main_thread_dispatcher, const LocalInfo::LocalInfo& local_info,
+      Secret::SecretManager& secret_manager, ProtobufMessage::ValidationContext& validation_context,
+      Api::Api& api, Http::Context& http_context, Grpc::Context& grpc_context,
+      Router::Context& router_context, AccessLog::AccessLogManager& log_manager,
+      Singleton::Manager& singleton_manager, const Server::Options& options,
+      Quic::QuicStatNames& quic_stat_names, const Server::Instance& server)
+      : server_context_(server_context),
+        context_(options, main_thread_dispatcher, api, local_info, admin, runtime,
                  singleton_manager, validation_context.staticValidationVisitor(), stats, tls),
         validation_context_(validation_context), http_context_(http_context),
         grpc_context_(grpc_context), router_context_(router_context), admin_(admin), stats_(stats),
@@ -99,6 +98,7 @@ public:
   Singleton::Manager& singletonManager() override { return singleton_manager_; }
 
 protected:
+  Server::Configuration::ServerFactoryContext& server_context_;
   Server::FactoryContextBaseImpl context_;
   ProtobufMessage::ValidationContext& validation_context_;
   Http::Context& http_context_;

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -30,7 +30,8 @@ class EdsClusterImpl
     : public BaseDynamicClusterImpl,
       Envoy::Config::SubscriptionBase<envoy::config::endpoint::v3::ClusterLoadAssignment> {
 public:
-  EdsClusterImpl(const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
+  EdsClusterImpl(Server::Configuration::ServerFactoryContext& server_context,
+                 const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
                  Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                  Stats::ScopeSharedPtr&& stats_scope, bool added_via_api);
 
@@ -113,6 +114,7 @@ public:
 
 private:
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override;

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -47,8 +47,8 @@ public:
 class HdsCluster : public Cluster, Logger::Loggable<Logger::Id::upstream> {
 public:
   static ClusterSharedPtr create();
-  HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
-             envoy::config::cluster::v3::Cluster cluster,
+  HdsCluster(Server::Configuration::ServerFactoryContext& server_context, Server::Admin& admin,
+             Runtime::Loader& runtime, envoy::config::cluster::v3::Cluster cluster,
              const envoy::config::core::v3::BindConfig& bind_config, Stats::Store& stats,
              Ssl::ContextManager& ssl_context_manager, bool added_via_api,
              ClusterInfoFactory& info_factory, ClusterManager& cm,
@@ -89,6 +89,7 @@ protected:
 private:
   std::function<void()> initialization_complete_callback_;
 
+  Server::Configuration::ServerFactoryContext& server_context_;
   Runtime::Loader& runtime_;
   envoy::config::cluster::v3::Cluster cluster_;
   const envoy::config::core::v3::BindConfig& bind_config_;
@@ -148,8 +149,9 @@ struct HdsDelegateStats {
 class HdsDelegate : Grpc::AsyncStreamCallbacks<envoy::service::health::v3::HealthCheckSpecifier>,
                     Logger::Loggable<Logger::Id::upstream> {
 public:
-  HdsDelegate(Stats::Scope& scope, Grpc::RawAsyncClientPtr async_client,
-              Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Envoy::Stats::Store& stats,
+  HdsDelegate(Server::Configuration::ServerFactoryContext& server_context, Stats::Scope& scope,
+              Grpc::RawAsyncClientPtr async_client, Event::Dispatcher& dispatcher,
+              Runtime::Loader& runtime, Envoy::Stats::Store& stats,
               Ssl::ContextManager& ssl_context_manager, ClusterInfoFactory& info_factory,
               AccessLog::AccessLogManager& access_log_manager, ClusterManager& cm,
               const LocalInfo::LocalInfo& local_info, Server::Admin& admin,
@@ -191,6 +193,7 @@ private:
   Grpc::AsyncStream<envoy::service::health::v3::HealthCheckRequestOrEndpointHealthResponse>
       stream_{};
   Event::Dispatcher& dispatcher_;
+  Server::Configuration::ServerFactoryContext& server_context_;
   Runtime::Loader& runtime_;
   Envoy::Stats::Store& store_stats_;
   Ssl::ContextManager& ssl_context_manager_;

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -45,12 +45,13 @@ convertPriority(const envoy::config::endpoint::v3::ClusterLoadAssignment& load_a
 } // namespace
 
 LogicalDnsCluster::LogicalDnsCluster(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
     Network::DnsResolverSharedPtr dns_resolver,
     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api)
-    : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api,
-                      factory_context.mainThreadDispatcher().timeSource()),
+    : ClusterImplBase(server_context, cluster, runtime, factory_context, std::move(stats_scope),
+                      added_via_api, factory_context.mainThreadDispatcher().timeSource()),
       dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(cluster, dns_refresh_rate, 5000))),
@@ -179,13 +180,14 @@ void LogicalDnsCluster::startResolve() {
 
 std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>
 LogicalDnsClusterFactory::createClusterImpl(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
     Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
     Stats::ScopeSharedPtr&& stats_scope) {
   auto selected_dns_resolver = selectDnsResolver(cluster, context);
 
   return std::make_pair(std::make_shared<LogicalDnsCluster>(
-                            cluster, context.runtime(), selected_dns_resolver,
+                            server_context, cluster, context.runtime(), selected_dns_resolver,
                             socket_factory_context, std::move(stats_scope), context.addedViaApi()),
                         nullptr);
 }

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -33,7 +33,8 @@ namespace Upstream {
  */
 class LogicalDnsCluster : public ClusterImplBase {
 public:
-  LogicalDnsCluster(const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
+  LogicalDnsCluster(Server::Configuration::ServerFactoryContext& server_context,
+                    const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
                     Network::DnsResolverSharedPtr dns_resolver,
                     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api);
@@ -84,6 +85,7 @@ public:
 
 private:
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override;

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -107,11 +107,12 @@ OriginalDstCluster::LoadBalancer::requestOverrideHost(LoadBalancerContext* conte
 }
 
 OriginalDstCluster::OriginalDstCluster(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api)
-    : ClusterImplBase(config, runtime, factory_context, std::move(stats_scope), added_via_api,
-                      factory_context.mainThreadDispatcher().timeSource()),
+    : ClusterImplBase(server_context, config, runtime, factory_context, std::move(stats_scope),
+                      added_via_api, factory_context.mainThreadDispatcher().timeSource()),
       dispatcher_(factory_context.mainThreadDispatcher()),
       cleanup_interval_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, cleanup_interval, 5000))),
@@ -192,6 +193,7 @@ void OriginalDstCluster::cleanup() {
 
 std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>
 OriginalDstClusterFactory::createClusterImpl(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
     Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
     Stats::ScopeSharedPtr&& stats_scope) {
@@ -206,9 +208,9 @@ OriginalDstClusterFactory::createClusterImpl(
   // TODO(mattklein123): The original DST load balancer type should be deprecated and instead
   //                     the cluster should directly supply the load balancer. This will remove
   //                     a special case and allow this cluster to be compiled out as an extension.
-  auto new_cluster =
-      std::make_shared<OriginalDstCluster>(cluster, context.runtime(), socket_factory_context,
-                                           std::move(stats_scope), context.addedViaApi());
+  auto new_cluster = std::make_shared<OriginalDstCluster>(
+      server_context, cluster, context.runtime(), socket_factory_context, std::move(stats_scope),
+      context.addedViaApi());
   auto lb = std::make_unique<OriginalDstCluster::ThreadAwareLoadBalancer>(new_cluster);
   return std::make_pair(new_cluster, std::move(lb));
 }

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -29,7 +29,8 @@ using HostMapConstSharedPtr = std::shared_ptr<const HostMap>;
  */
 class OriginalDstCluster : public ClusterImplBase {
 public:
-  OriginalDstCluster(const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
+  OriginalDstCluster(Server::Configuration::ServerFactoryContext& server_context,
+                     const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
                      Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                      Stats::ScopeSharedPtr&& stats_scope, bool added_via_api);
 
@@ -137,6 +138,7 @@ public:
 
 private:
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override;

--- a/source/common/upstream/static_cluster.cc
+++ b/source/common/upstream/static_cluster.cc
@@ -8,11 +8,12 @@ namespace Envoy {
 namespace Upstream {
 
 StaticClusterImpl::StaticClusterImpl(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api)
-    : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api,
-                      factory_context.mainThreadDispatcher().timeSource()),
+    : ClusterImplBase(server_context, cluster, runtime, factory_context, std::move(stats_scope),
+                      added_via_api, factory_context.mainThreadDispatcher().timeSource()),
       priority_state_manager_(
           new PriorityStateManager(*this, factory_context.localInfo(), nullptr)) {
   const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment =
@@ -63,13 +64,14 @@ void StaticClusterImpl::startPreInit() {
 
 std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>
 StaticClusterFactory::createClusterImpl(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
     Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
     Stats::ScopeSharedPtr&& stats_scope) {
-  return std::make_pair(
-      std::make_shared<StaticClusterImpl>(cluster, context.runtime(), socket_factory_context,
-                                          std::move(stats_scope), context.addedViaApi()),
-      nullptr);
+  return std::make_pair(std::make_shared<StaticClusterImpl>(
+                            server_context, cluster, context.runtime(), socket_factory_context,
+                            std::move(stats_scope), context.addedViaApi()),
+                        nullptr);
 }
 
 /**

--- a/source/common/upstream/static_cluster.h
+++ b/source/common/upstream/static_cluster.h
@@ -14,7 +14,8 @@ namespace Upstream {
  */
 class StaticClusterImpl : public ClusterImplBase {
 public:
-  StaticClusterImpl(const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
+  StaticClusterImpl(Server::Configuration::ServerFactoryContext& server_context,
+                    const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
                     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api);
 
@@ -38,6 +39,7 @@ public:
 
 private:
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override;

--- a/source/common/upstream/strict_dns_cluster.h
+++ b/source/common/upstream/strict_dns_cluster.h
@@ -15,7 +15,8 @@ namespace Upstream {
  */
 class StrictDnsClusterImpl : public BaseDynamicClusterImpl {
 public:
-  StrictDnsClusterImpl(const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
+  StrictDnsClusterImpl(Server::Configuration::ServerFactoryContext& server_context,
+                       const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
                        Network::DnsResolverSharedPtr dns_resolver,
                        Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                        Stats::ScopeSharedPtr&& stats_scope, bool added_via_api);
@@ -81,6 +82,7 @@ public:
 
 private:
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -801,7 +801,7 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 }
 
 ClusterInfoImpl::ClusterInfoImpl(
-    const envoy::config::cluster::v3::Cluster& config,
+    Server::Configuration::ServerFactoryContext&, const envoy::config::cluster::v3::Cluster& config,
     const envoy::config::core::v3::BindConfig& bind_config, Runtime::Loader& runtime,
     TransportSocketMatcherPtr&& socket_matcher, Stats::ScopeSharedPtr&& stats_scope,
     bool added_via_api, Server::Configuration::TransportSocketFactoryContext& factory_context)
@@ -1081,6 +1081,7 @@ ClusterInfoImpl::upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_
 }
 
 ClusterImplBase::ClusterImplBase(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api, TimeSource& time_source)
@@ -1101,8 +1102,8 @@ ClusterImplBase::ClusterImplBase(
   const bool matcher_supports_alpn = socket_matcher->allMatchesSupportAlpn();
   auto& dispatcher = factory_context.mainThreadDispatcher();
   info_ = std::shared_ptr<const ClusterInfoImpl>(
-      new ClusterInfoImpl(cluster, factory_context.clusterManager().bindConfig(), runtime,
-                          std::move(socket_matcher), std::move(stats_scope), added_via_api,
+      new ClusterInfoImpl(server_context, cluster, factory_context.clusterManager().bindConfig(),
+                          runtime, std::move(socket_matcher), std::move(stats_scope), added_via_api,
                           factory_context),
       [&dispatcher](const ClusterInfoImpl* self) {
         ENVOY_LOG(trace, "Schedule destroy cluster info {}", self->name());

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -605,7 +605,8 @@ class ClusterInfoImpl : public ClusterInfo,
 public:
   using HttpProtocolOptionsConfigImpl =
       Envoy::Extensions::Upstreams::Http::ProtocolOptionsConfigImpl;
-  ClusterInfoImpl(const envoy::config::cluster::v3::Cluster& config,
+  ClusterInfoImpl(Server::Configuration::ServerFactoryContext& server_context,
+                  const envoy::config::cluster::v3::Cluster& config,
                   const envoy::config::core::v3::BindConfig& bind_config, Runtime::Loader& runtime,
                   TransportSocketMatcherPtr&& socket_matcher, Stats::ScopeSharedPtr&& stats_scope,
                   bool added_via_api, Server::Configuration::TransportSocketFactoryContext&);
@@ -916,7 +917,8 @@ public:
   void initialize(std::function<void()> callback) override;
 
 protected:
-  ClusterImplBase(const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
+  ClusterImplBase(Server::Configuration::ServerFactoryContext& server_context,
+                  const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
                   Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                   Stats::ScopeSharedPtr&& stats_scope, bool added_via_api, TimeSource& time_source);
 

--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -12,14 +12,16 @@ namespace Extensions {
 namespace Clusters {
 namespace Aggregate {
 
-Cluster::Cluster(const envoy::config::cluster::v3::Cluster& cluster,
+Cluster::Cluster(Server::Configuration::ServerFactoryContext& server_context,
+                 const envoy::config::cluster::v3::Cluster& cluster,
                  const envoy::extensions::clusters::aggregate::v3::ClusterConfig& config,
                  Upstream::ClusterManager& cluster_manager, Runtime::Loader& runtime,
                  Random::RandomGenerator& random,
                  Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                  Stats::ScopeSharedPtr&& stats_scope, bool added_via_api)
-    : Upstream::ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope),
-                                added_via_api, factory_context.mainThreadDispatcher().timeSource()),
+    : Upstream::ClusterImplBase(server_context, cluster, runtime, factory_context,
+                                std::move(stats_scope), added_via_api,
+                                factory_context.mainThreadDispatcher().timeSource()),
       cluster_manager_(cluster_manager), runtime_(runtime), random_(random),
       clusters_(std::make_shared<ClusterSet>(config.clusters().begin(), config.clusters().end())) {}
 
@@ -208,15 +210,16 @@ AggregateClusterLoadBalancer::lifetimeCallbacks() {
 
 std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>
 ClusterFactory::createClusterWithConfig(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster,
     const envoy::extensions::clusters::aggregate::v3::ClusterConfig& proto_config,
     Upstream::ClusterFactoryContext& context,
     Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
     Stats::ScopeSharedPtr&& stats_scope) {
-  auto new_cluster =
-      std::make_shared<Cluster>(cluster, proto_config, context.clusterManager(), context.runtime(),
-                                context.api().randomGenerator(), socket_factory_context,
-                                std::move(stats_scope), context.addedViaApi());
+  auto new_cluster = std::make_shared<Cluster>(
+      server_context, cluster, proto_config, context.clusterManager(), context.runtime(),
+      context.api().randomGenerator(), socket_factory_context, std::move(stats_scope),
+      context.addedViaApi());
   auto lb = std::make_unique<AggregateThreadAwareLoadBalancer>(*new_cluster);
   return std::make_pair(new_cluster, std::move(lb));
 }

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -39,7 +39,8 @@ using ClusterSetConstSharedPtr = std::shared_ptr<const ClusterSet>;
 
 class Cluster : public Upstream::ClusterImplBase {
 public:
-  Cluster(const envoy::config::cluster::v3::Cluster& cluster,
+  Cluster(Server::Configuration::ServerFactoryContext& server_context,
+          const envoy::config::cluster::v3::Cluster& cluster,
           const envoy::extensions::clusters::aggregate::v3::ClusterConfig& config,
           Upstream::ClusterManager& cluster_manager, Runtime::Loader& runtime,
           Random::RandomGenerator& random,
@@ -170,6 +171,7 @@ public:
 private:
   std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>
   createClusterWithConfig(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster,
       const envoy::extensions::clusters::aggregate::v3::ClusterConfig& proto_config,
       Upstream::ClusterFactoryContext& context,

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -18,6 +18,7 @@ namespace Clusters {
 namespace DynamicForwardProxy {
 
 Cluster::Cluster(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster,
     const envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig& config,
     Runtime::Loader& runtime,
@@ -25,8 +26,8 @@ Cluster::Cluster(
     const LocalInfo::LocalInfo& local_info,
     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
     Stats::ScopeSharedPtr&& stats_scope, bool added_via_api)
-    : Upstream::BaseDynamicClusterImpl(cluster, runtime, factory_context, std::move(stats_scope),
-                                       added_via_api,
+    : Upstream::BaseDynamicClusterImpl(server_context, cluster, runtime, factory_context,
+                                       std::move(stats_scope), added_via_api,
                                        factory_context.mainThreadDispatcher().timeSource()),
       dns_cache_manager_(cache_manager_factory.get()),
       dns_cache_(dns_cache_manager_->getCache(config.dns_cache_config())),
@@ -247,6 +248,7 @@ void Cluster::LoadBalancer::onConnectionDraining(Envoy::Http::ConnectionPool::In
 
 std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>
 ClusterFactory::createClusterWithConfig(
+    Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& cluster,
     const envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig& proto_config,
     Upstream::ClusterFactoryContext& context,
@@ -264,8 +266,8 @@ ClusterFactory::createClusterWithConfig(
   }
 
   auto new_cluster = std::make_shared<Cluster>(
-      cluster_config, proto_config, context.runtime(), cache_manager_factory, context.localInfo(),
-      socket_factory_context, std::move(stats_scope), context.addedViaApi());
+      server_context, cluster_config, proto_config, context.runtime(), cache_manager_factory,
+      context.localInfo(), socket_factory_context, std::move(stats_scope), context.addedViaApi());
 
   auto& options = new_cluster->info()->upstreamHttpProtocolOptions();
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -18,7 +18,8 @@ namespace DynamicForwardProxy {
 class Cluster : public Upstream::BaseDynamicClusterImpl,
                 public Extensions::Common::DynamicForwardProxy::DnsCache::UpdateCallbacks {
 public:
-  Cluster(const envoy::config::cluster::v3::Cluster& cluster,
+  Cluster(Server::Configuration::ServerFactoryContext& server_context,
+          const envoy::config::cluster::v3::Cluster& cluster,
           const envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig& config,
           Runtime::Loader& runtime,
           Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactory& cache_manager_factory,
@@ -166,6 +167,7 @@ public:
 private:
   std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>
   createClusterWithConfig(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster,
       const envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig& proto_config,
       Upstream::ClusterFactoryContext& context,

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -90,7 +90,8 @@ namespace Redis {
 
 class RedisCluster : public Upstream::BaseDynamicClusterImpl {
 public:
-  RedisCluster(const envoy::config::cluster::v3::Cluster& cluster,
+  RedisCluster(Server::Configuration::ServerFactoryContext& server_context,
+               const envoy::config::cluster::v3::Cluster& cluster,
                const envoy::extensions::clusters::redis::v3::RedisClusterConfig& redis_cluster,
                NetworkFilters::Common::Redis::Client::ClientFactory& client_factory,
                Upstream::ClusterManager& cluster_manager, Runtime::Loader& runtime, Api::Api& api,
@@ -301,6 +302,7 @@ private:
 
   std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>
   createClusterWithConfig(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster,
       const envoy::extensions::clusters::redis::v3::RedisClusterConfig& proto_config,
       Upstream::ClusterFactoryContext& context,

--- a/source/server/config_validation/cluster_manager.h
+++ b/source/server/config_validation/cluster_manager.h
@@ -31,6 +31,7 @@ public:
       const Server::Options& options, Quic::QuicStatNames& quic_stat_names,
       Server::Instance& server)
       : ProdClusterManagerFactory(
+            const_cast<Server::Configuration::ServerFactoryContext&>(server.serverFactoryContext()),
             admin, runtime, stats, tls, dns_resolver, ssl_context_manager, main_thread_dispatcher,
             local_info, secret_manager, validation_context, api, http_context, grpc_context,
             router_context, log_manager, singleton_manager, options, quic_stat_names, server),

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -681,10 +681,10 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
       dns_resolver_factory.createDnsResolver(dispatcher(), api(), typed_dns_resolver_config);
 
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
-      *admin_, runtime(), stats_store_, thread_local_, dns_resolver_, *ssl_context_manager_,
-      *dispatcher_, *local_info_, *secret_manager_, messageValidationContext(), *api_,
-      http_context_, grpc_context_, router_context_, access_log_manager_, *singleton_manager_,
-      options_, quic_stat_names_, *this);
+      serverFactoryContext(), *admin_, runtime(), stats_store_, thread_local_, dns_resolver_,
+      *ssl_context_manager_, *dispatcher_, *local_info_, *secret_manager_,
+      messageValidationContext(), *api_, http_context_, grpc_context_, router_context_,
+      access_log_manager_, *singleton_manager_, options_, quic_stat_names_, *this);
 
   // Now the configuration gets parsed. The configuration may start setting
   // thread local data per above. See MainImpl::initialize() for why ConfigImpl
@@ -759,7 +759,7 @@ void InstanceImpl::onRuntimeReady() {
     TRY_ASSERT_MAIN_THREAD {
       Config::Utility::checkTransportVersion(hds_config);
       hds_delegate_ = std::make_unique<Upstream::HdsDelegate>(
-          stats_store_,
+          serverFactoryContext(), stats_store_,
           Config::Utility::factoryForGrpcApiConfigSource(*async_client_manager_, hds_config,
                                                          stats_store_, false)
               ->createUncachedRawAsyncClient(),

--- a/test/common/upstream/cluster_factory_impl_test.cc
+++ b/test/common/upstream/cluster_factory_impl_test.cc
@@ -41,11 +41,12 @@ public:
   TestStaticClusterFactory() : ClusterFactoryImplBase("envoy.clusters.test_static") {}
 
   std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr> createClusterImpl(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster, ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override {
     return std::make_pair(std::make_shared<CustomStaticCluster>(
-                              cluster, context.runtime(), socket_factory_context,
+                              server_context, cluster, context.runtime(), socket_factory_context,
                               std::move(stats_scope), context.addedViaApi(), 1, "127.0.0.1", 80),
                           nullptr);
   }
@@ -58,6 +59,7 @@ protected:
     dns_resolver_ = std::make_shared<Network::MockDnsResolver>();
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   NiceMock<Server::MockAdmin> admin_;
   Ssl::MockContextManager ssl_context_manager_;
   NiceMock<MockClusterManager> cm_;
@@ -99,9 +101,9 @@ TEST_F(TestStaticClusterImplTest, CreateWithoutConfig) {
 
   const envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
   auto create_result = ClusterFactoryImplBase::create(
-      cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_, dispatcher_,
-      log_manager_, local_info_, admin_, singleton_manager_, std::move(outlier_event_logger_),
-      false, validation_visitor_, *api_, options_);
+      server_context_, cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_,
+      runtime_, dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
+      std::move(outlier_event_logger_), false, validation_visitor_, *api_, options_);
   auto cluster = create_result.first;
   cluster->initialize([] {});
 
@@ -144,9 +146,9 @@ TEST_F(TestStaticClusterImplTest, CreateWithStructConfig) {
 
   const envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
   auto create_result = ClusterFactoryImplBase::create(
-      cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_, dispatcher_,
-      log_manager_, local_info_, admin_, singleton_manager_, std::move(outlier_event_logger_),
-      false, validation_visitor_, *api_, options_);
+      server_context_, cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_,
+      runtime_, dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
+      std::move(outlier_event_logger_), false, validation_visitor_, *api_, options_);
   auto cluster = create_result.first;
   cluster->initialize([] {});
 
@@ -187,9 +189,9 @@ TEST_F(TestStaticClusterImplTest, CreateWithTypedConfig) {
 
   const envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
   auto create_result = ClusterFactoryImplBase::create(
-      cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_, dispatcher_,
-      log_manager_, local_info_, admin_, singleton_manager_, std::move(outlier_event_logger_),
-      false, validation_visitor_, *api_, options_);
+      server_context_, cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_,
+      runtime_, dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
+      std::move(outlier_event_logger_), false, validation_visitor_, *api_, options_);
   auto cluster = create_result.first;
   cluster->initialize([] {});
 
@@ -230,8 +232,8 @@ TEST_F(TestStaticClusterImplTest, UnsupportedClusterType) {
       {
         const envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
         ClusterFactoryImplBase::create(
-            cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_,
-            dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
+            server_context_, cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_,
+            runtime_, dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
             std::move(outlier_event_logger_), false, validation_visitor_, *api_, options_);
       },
       EnvoyException,
@@ -263,8 +265,8 @@ TEST_F(TestStaticClusterImplTest, HostnameWithoutDNS) {
       {
         const envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
         ClusterFactoryImplBase::create(
-            cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_,
-            dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
+            server_context_, cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_,
+            runtime_, dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
             std::move(outlier_event_logger_), false, validation_visitor_, *api_, options_);
       },
       EnvoyException,

--- a/test/common/upstream/eds_speed_test.cc
+++ b/test/common/upstream/eds_speed_test.cc
@@ -89,8 +89,8 @@ public:
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    cluster_ = std::make_shared<EdsClusterImpl>(eds_cluster_, runtime_, factory_context,
-                                                std::move(scope), false);
+    cluster_ = std::make_shared<EdsClusterImpl>(server_context_, eds_cluster_, runtime_,
+                                                factory_context, std::move(scope), false);
     EXPECT_EQ(initialize_phase, cluster_->initializePhase());
     eds_callbacks_ = cm_.subscription_factory_.callbacks_;
     subscription_ = std::make_unique<Config::GrpcSubscriptionImpl>(
@@ -152,6 +152,7 @@ public:
            num_hosts);
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   State& state_;
   bool use_unified_mux_;
   const std::string type_url_;

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -131,8 +131,8 @@ public:
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    cluster_ = std::make_shared<EdsClusterImpl>(eds_cluster_, runtime_.loader(), factory_context,
-                                                std::move(scope), false);
+    cluster_ = std::make_shared<EdsClusterImpl>(server_context_, eds_cluster_, runtime_.loader(),
+                                                factory_context, std::move(scope), false);
     EXPECT_EQ(initialize_phase, cluster_->initializePhase());
     eds_callbacks_ = cm_.subscription_factory_.callbacks_;
   }
@@ -149,6 +149,7 @@ public:
     VERBOSE_EXPECT_NO_THROW(eds_callbacks_->onConfigUpdate(decoded_resources.refvec_, ""));
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   bool initialized_{};
   Stats::TestUtil::TestStore stats_;
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -93,9 +93,9 @@ protected:
         .WillRepeatedly(testing::ReturnNew<NiceMock<Event::MockTimer>>());
 
     hds_delegate_ = std::make_unique<HdsDelegate>(
-        stats_store_, Grpc::RawAsyncClientPtr(async_client_), dispatcher_, runtime_, stats_store_,
-        ssl_context_manager_, test_factory_, log_manager_, cm_, local_info_, admin_,
-        singleton_manager_, tls_, validation_visitor_, *api_, options_);
+        server_context_, stats_store_, Grpc::RawAsyncClientPtr(async_client_), dispatcher_,
+        runtime_, stats_store_, ssl_context_manager_, test_factory_, log_manager_, cm_, local_info_,
+        admin_, singleton_manager_, tls_, validation_visitor_, *api_, options_);
   }
 
   void expectCreateClientConnection() {
@@ -229,6 +229,7 @@ transport_socket_match_criteria:
         TestUtility::parseYaml<envoy::config::core::v3::HealthCheck>(criteria_yaml));
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Event::SimulatedTimeSystem time_system_;
   envoy::config::core::v3::Node node_;
   Event::MockDispatcher dispatcher_;
@@ -586,7 +587,8 @@ TEST_F(HdsTest, TestSocketContext) {
         Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
             params.admin_, params.ssl_context_manager_, *scope, params.cm_, params.local_info_,
             params.dispatcher_, params.stats_, params.singleton_manager_, params.tls_,
-            params.validation_visitor_, params.api_, params.options_, params.access_log_manager_);
+            params.validation_visitor_, params.server_context_.api(), params.options_,
+            params.access_log_manager_);
 
         // Create a mock socket_factory for the scope of this unit test.
         std::unique_ptr<Envoy::Network::UpstreamTransportSocketFactory> socket_factory =
@@ -1038,7 +1040,8 @@ TEST_F(HdsTest, TestUpdateSocketContext) {
         Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
             params.admin_, params.ssl_context_manager_, *scope, params.cm_, params.local_info_,
             params.dispatcher_, params.stats_, params.singleton_manager_, params.tls_,
-            params.validation_visitor_, params.api_, params.options_, params.access_log_manager_);
+            params.validation_visitor_, params.server_context_.api(), params.options_,
+            params.access_log_manager_);
 
         // Create a mock socket_factory for the scope of this unit test.
         std::unique_ptr<Envoy::Network::UpstreamTransportSocketFactory> socket_factory =

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -55,8 +55,9 @@ protected:
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm, local_info_, dispatcher_, stats_store_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    cluster_ = std::make_shared<LogicalDnsCluster>(cluster_config, runtime_, dns_resolver_,
-                                                   factory_context, std::move(scope), false);
+    cluster_ = std::make_shared<LogicalDnsCluster>(server_context_, cluster_config, runtime_,
+                                                   dns_resolver_, factory_context, std::move(scope),
+                                                   false);
     priority_update_cb_ = cluster_->prioritySet().addPriorityUpdateCb(
         [&](uint32_t, const HostVector&, const HostVector&) -> void {
           membership_updated_.ready();
@@ -196,6 +197,7 @@ protected:
     tls_.shutdownThread();
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
   std::shared_ptr<NiceMock<Network::MockDnsResolver>> dns_resolver_{

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -81,8 +81,8 @@ public:
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm, local_info_, dispatcher_, stats_store_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    cluster_ = std::make_shared<OriginalDstCluster>(cluster_config, runtime_, factory_context,
-                                                    std::move(scope), false);
+    cluster_ = std::make_shared<OriginalDstCluster>(server_context_, cluster_config, runtime_,
+                                                    factory_context, std::move(scope), false);
     priority_update_cb_ = cluster_->prioritySet().addPriorityUpdateCb(
         [&](uint32_t, const HostVector&, const HostVector&) -> void {
           membership_updated_.ready();
@@ -90,6 +90,7 @@ public:
     cluster_->initialize([&]() -> void { initialized_.ready(); });
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
   NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -68,8 +68,8 @@ public:
                 Outlier::EventLoggerSharedPtr outlier_event_logger,
                 bool added_via_api) -> std::pair<ClusterSharedPtr, ThreadAwareLoadBalancer*> {
               auto result = ClusterFactoryImplBase::create(
-                  cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_,
-                  dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
+                  server_context_, cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_,
+                  runtime_, dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
                   outlier_event_logger, added_via_api, validation_visitor_, *api_, options_);
               // Convert from load balancer unique_ptr -> raw pointer -> unique_ptr.
               return std::make_pair(result.first, result.second.release());
@@ -130,6 +130,7 @@ public:
                Outlier::EventLoggerSharedPtr outlier_event_logger, bool added_via_api));
   MOCK_METHOD(CdsApi*, createCds_, ());
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   std::shared_ptr<NiceMock<Network::MockDnsResolver>> dns_resolver_{

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -64,6 +64,7 @@ class UpstreamImplTestBase {
 protected:
   UpstreamImplTestBase() : api_(Api::createApiForTest(stats_, random_)) {}
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   NiceMock<Server::MockAdmin> admin_;
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   NiceMock<MockClusterManager> cm_;
@@ -199,8 +200,8 @@ TEST_P(StrictDnsParamTest, ImmediateResolve) {
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
 
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver,
+                               factory_context, std::move(scope), false);
   cluster.initialize([&]() -> void { initialized.ready(); });
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -232,8 +233,8 @@ TEST_F(StrictDnsClusterImplTest, ZeroHostsIsInializedImmediately) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   EXPECT_CALL(initialized, ready());
   cluster.initialize([&]() -> void { initialized.ready(); });
   EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->hosts().size());
@@ -267,8 +268,8 @@ TEST_F(StrictDnsClusterImplTest, ZeroHostsHealthChecker) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   std::shared_ptr<MockHealthChecker> health_checker(new MockHealthChecker());
   EXPECT_CALL(*health_checker, start());
   EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
@@ -313,8 +314,8 @@ TEST_F(StrictDnsClusterImplTest, DontWaitForDNSOnInit) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
 
   ReadyWatcher initialized;
 
@@ -393,8 +394,8 @@ TEST_F(StrictDnsClusterImplTest, Basic) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   EXPECT_CALL(runtime_.snapshot_, getInteger("circuit_breakers.name.default.max_connections", 43))
       .Times(AnyNumber());
   EXPECT_EQ(43U, cluster.info()->resourceManager(ResourcePriority::Default).connections().max());
@@ -559,8 +560,8 @@ TEST_F(StrictDnsClusterImplTest, HostRemovalActiveHealthSkipped) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   std::shared_ptr<MockHealthChecker> health_checker(new MockHealthChecker());
   EXPECT_CALL(*health_checker, start());
   EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
@@ -620,8 +621,8 @@ TEST_F(StrictDnsClusterImplTest, HostRemovalAfterHcFail) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   std::shared_ptr<MockHealthChecker> health_checker(new MockHealthChecker());
   EXPECT_CALL(*health_checker, start());
   EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
@@ -747,8 +748,8 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("circuit_breakers.name.default.max_connections", 43));
   EXPECT_EQ(43U, cluster.info()->resourceManager(ResourcePriority::Default).connections().max());
@@ -985,8 +986,8 @@ TEST_F(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   ReadyWatcher membership_updated;
   auto priority_update_cb = cluster.prioritySet().addPriorityUpdateCb(
       [&](uint32_t, const HostVector&, const HostVector&) -> void { membership_updated.ready(); });
@@ -1101,10 +1102,11 @@ TEST_F(StrictDnsClusterImplTest, CustomResolverFails) {
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
 
-  EXPECT_THROW_WITH_MESSAGE(
-      std::make_unique<StrictDnsClusterImpl>(cluster_config, runtime_, dns_resolver_,
-                                             factory_context, std::move(scope), false),
-      EnvoyException, "STRICT_DNS clusters must NOT have a custom resolver name set");
+  EXPECT_THROW_WITH_MESSAGE(std::make_unique<StrictDnsClusterImpl>(
+                                server_context_, cluster_config, runtime_, dns_resolver_,
+                                factory_context, std::move(scope), false),
+                            EnvoyException,
+                            "STRICT_DNS clusters must NOT have a custom resolver name set");
 }
 
 TEST_F(StrictDnsClusterImplTest, FailureRefreshRateBackoffResetsWhenSuccessHappens) {
@@ -1136,8 +1138,8 @@ TEST_F(StrictDnsClusterImplTest, FailureRefreshRateBackoffResetsWhenSuccessHappe
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   cluster.initialize([] {});
 
   // Failing response kicks the failure refresh backoff strategy.
@@ -1185,8 +1187,8 @@ TEST_F(StrictDnsClusterImplTest, TtlAsDnsRefreshRate) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver_, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver_,
+                               factory_context, std::move(scope), false);
   ReadyWatcher membership_updated;
   auto priority_update_cb = cluster.prioritySet().addPriorityUpdateCb(
       [&](uint32_t, const HostVector&, const HostVector&) -> void { membership_updated.ready(); });
@@ -1266,8 +1268,8 @@ TEST_F(StrictDnsClusterImplTest, Http2UserDefinedSettingsParametersValidation) {
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
   EXPECT_THROW_WITH_REGEX(
-      StrictDnsClusterImpl(cluster_config, runtime_, dns_resolver_, factory_context,
-                           std::move(scope), false),
+      StrictDnsClusterImpl(server_context_, cluster_config, runtime_, dns_resolver_,
+                           factory_context, std::move(scope), false),
       EnvoyException,
       R"(the \{hpack_table_size\} HTTP/2 SETTINGS parameter\(s\) can not be configured through)"
       " both");
@@ -1494,7 +1496,8 @@ TEST_F(StaticClusterImplTest, InitialHosts) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -1529,7 +1532,8 @@ TEST_F(StaticClusterImplTest, LoadAssignmentEmptyHostname) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -1564,7 +1568,8 @@ TEST_F(StaticClusterImplTest, LoadAssignmentNonEmptyHostname) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -1599,7 +1604,8 @@ TEST_F(StaticClusterImplTest, LoadAssignmentNonEmptyHostnameWithHealthChecks) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -1652,7 +1658,8 @@ TEST_F(StaticClusterImplTest, LoadAssignmentMultiplePriorities) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -1697,7 +1704,8 @@ TEST_F(StaticClusterImplTest, LoadAssignmentLocality) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   auto& hosts = cluster.prioritySet().hostSetsPerPriority()[0]->hosts();
@@ -1743,7 +1751,8 @@ TEST_F(StaticClusterImplTest, LoadAssignmentEdsHealth) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
@@ -1775,7 +1784,8 @@ TEST_F(StaticClusterImplTest, AltStatName) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
   // Increment a stat and verify it is emitted with alt_stat_name
   cluster.info()->stats().upstream_rq_total_.inc();
@@ -1805,7 +1815,8 @@ TEST_F(StaticClusterImplTest, RingHash) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), true);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), true);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -1843,7 +1854,8 @@ TEST_F(StaticClusterImplTest, RoundRobinWithSlowStart) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), true);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), true);
   cluster.initialize([] {});
 
   EXPECT_EQ(LoadBalancerType::RoundRobin, cluster.info()->lbType());
@@ -1885,7 +1897,8 @@ TEST_F(StaticClusterImplTest, LeastRequestWithSlowStart) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), true);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), true);
   cluster.initialize([] {});
 
   EXPECT_EQ(LoadBalancerType::LeastRequest, cluster.info()->lbType());
@@ -1925,7 +1938,8 @@ TEST_F(StaticClusterImplTest, OutlierDetector) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
 
   Outlier::MockDetector* detector = new Outlier::MockDetector();
   EXPECT_CALL(*detector, addChangedStateCb(_));
@@ -1983,7 +1997,8 @@ TEST_F(StaticClusterImplTest, HealthyStat) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
 
   Outlier::MockDetector* outlier_detector = new NiceMock<Outlier::MockDetector>();
   cluster.setOutlierDetector(Outlier::DetectorSharedPtr{outlier_detector});
@@ -2124,7 +2139,8 @@ TEST_F(StaticClusterImplTest, UrlConfig) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(1024U, cluster.info()->resourceManager(ResourcePriority::Default).connections().max());
@@ -2177,8 +2193,8 @@ TEST_F(StaticClusterImplTest, UnsupportedLBType) {
         Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
             admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
             singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-        StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope),
-                                  false);
+        StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                                  std::move(scope), false);
       },
       EnvoyException, "invalid value \"fakelbtype\"");
 }
@@ -2218,7 +2234,8 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithLbPolicy) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), true);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), true);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -2262,7 +2279,8 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithOtherLbPolicy) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), true);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), true);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -2304,7 +2322,8 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithoutLbPolicy) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), true);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), true);
   cluster.initialize([] {});
 
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -2334,11 +2353,11 @@ TEST_F(StaticClusterImplTest, MalformedHostIP) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  EXPECT_THROW_WITH_MESSAGE(
-      StaticClusterImpl(cluster_config, runtime_, factory_context, std::move(scope), false),
-      EnvoyException,
-      "malformed IP address: foo.bar.com. Consider setting resolver_name or "
-      "setting cluster type to 'STRICT_DNS' or 'LOGICAL_DNS'");
+  EXPECT_THROW_WITH_MESSAGE(StaticClusterImpl(server_context_, cluster_config, runtime_,
+                                              factory_context, std::move(scope), false),
+                            EnvoyException,
+                            "malformed IP address: foo.bar.com. Consider setting resolver_name or "
+                            "setting cluster type to 'STRICT_DNS' or 'LOGICAL_DNS'");
 }
 
 // Test for oss-fuzz issue #11329
@@ -2361,7 +2380,8 @@ TEST_F(StaticClusterImplTest, NoHostsTest) {
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-  StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false);
+  StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                            std::move(scope), false);
   cluster.initialize([] {});
 
   EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -2380,7 +2400,8 @@ TEST_F(StaticClusterImplTest, SourceAddressPriority) {
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    StaticClusterImpl cluster(config, runtime_, factory_context, std::move(scope), false);
+    StaticClusterImpl cluster(server_context_, config, runtime_, factory_context, std::move(scope),
+                              false);
     EXPECT_EQ("1.2.3.5:0", cluster.info()->sourceAddress()->asString());
   }
 
@@ -2393,7 +2414,8 @@ TEST_F(StaticClusterImplTest, SourceAddressPriority) {
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    StaticClusterImpl cluster(config, runtime_, factory_context, std::move(scope), false);
+    StaticClusterImpl cluster(server_context_, config, runtime_, factory_context, std::move(scope),
+                              false);
     EXPECT_EQ(cluster_address, cluster.info()->sourceAddress()->ip()->addressAsString());
   }
 
@@ -2405,7 +2427,8 @@ TEST_F(StaticClusterImplTest, SourceAddressPriority) {
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
-    StaticClusterImpl cluster(config, runtime_, factory_context, std::move(scope), false);
+    StaticClusterImpl cluster(server_context_, config, runtime_, factory_context, std::move(scope),
+                              false);
     EXPECT_EQ(cluster_address, cluster.info()->sourceAddress()->ip()->addressAsString());
   }
 }
@@ -2431,7 +2454,8 @@ TEST_F(StaticClusterImplTest, LedsUnsupported) {
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
   EXPECT_THROW_WITH_MESSAGE(
-      StaticClusterImpl cluster(cluster_config, runtime_, factory_context, std::move(scope), false),
+      StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                                std::move(scope), false),
       EnvoyException,
       "LEDS is only supported when EDS is used. Static cluster staticcluster cannot use LEDS.");
 }
@@ -2467,8 +2491,8 @@ TEST_F(ClusterImplTest, CloseConnectionsOnHostHealthFailure) {
       admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_,
       singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
 
-  StrictDnsClusterImpl cluster(cluster_config, runtime_, dns_resolver, factory_context,
-                               std::move(scope), false);
+  StrictDnsClusterImpl cluster(server_context_, cluster_config, runtime_, dns_resolver,
+                               factory_context, std::move(scope), false);
   EXPECT_TRUE(cluster.info()->features() &
               ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE);
 }
@@ -2673,8 +2697,9 @@ public:
         admin_, ssl_context_manager_, *scope_, cm_, local_info_, dispatcher_, stats_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
 
-    return std::make_unique<StrictDnsClusterImpl>(cluster_config_, runtime_, dns_resolver_,
-                                                  *factory_context_, std::move(scope_), false);
+    return std::make_unique<StrictDnsClusterImpl>(server_context_, cluster_config_, runtime_,
+                                                  dns_resolver_, *factory_context_,
+                                                  std::move(scope_), false);
   }
 
   class RetryBudgetTestClusterInfo : public ClusterInfoImpl {
@@ -2685,6 +2710,7 @@ public:
     }
   };
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_;
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   std::shared_ptr<Network::MockDnsResolver> dns_resolver_{new NiceMock<Network::MockDnsResolver>()};

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -101,9 +101,9 @@ public:
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_store_,
         singleton_manager_, tls_, validation_visitor_, *api_, options_, access_log_manager_);
 
-    cluster_ =
-        std::make_shared<Cluster>(cluster_config, config, cm_, runtime_, api_->randomGenerator(),
-                                  factory_context, std::move(scope), false);
+    cluster_ = std::make_shared<Cluster>(server_context_, cluster_config, config, cm_, runtime_,
+                                         api_->randomGenerator(), factory_context, std::move(scope),
+                                         false);
 
     cm_.initializeThreadLocalClusters({"primary", "secondary"});
     primary_.cluster_.info_->name_ = "primary";
@@ -123,6 +123,7 @@ public:
     lb_ = lb_factory_->create();
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
   NiceMock<Upstream::MockClusterManager> cm_;

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -52,8 +52,8 @@ public:
     // actually correct. It's possible this will have to change in the future.
     EXPECT_CALL(*dns_cache_manager_->dns_cache_, addUpdateCallbacks_(_))
         .WillOnce(DoAll(SaveArgAddress(&update_callbacks_), Return(nullptr)));
-    cluster_ = std::make_shared<Cluster>(cluster_config, config, runtime_, *this, local_info_,
-                                         factory_context, std::move(scope), false);
+    cluster_ = std::make_shared<Cluster>(server_context_, cluster_config, config, runtime_, *this,
+                                         local_info_, factory_context, std::move(scope), false);
     thread_aware_lb_ = std::make_unique<Cluster::ThreadAwareLoadBalancer>(*cluster_);
     lb_factory_ = thread_aware_lb_->factory();
     refreshLb();
@@ -132,6 +132,7 @@ public:
   MOCK_METHOD(void, onMemberUpdateCb,
               (const Upstream::HostVector& hosts_added, const Upstream::HostVector& hosts_removed));
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
   NiceMock<Upstream::MockClusterManager> cm_;
@@ -589,10 +590,11 @@ protected:
     std::unique_ptr<Upstream::ClusterFactory> cluster_factory = std::make_unique<ClusterFactory>();
 
     std::tie(cluster_, thread_aware_lb_) =
-        cluster_factory->create(cluster_config, cluster_factory_context);
+        cluster_factory->create(server_context_, cluster_config, cluster_factory_context);
   }
 
 private:
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_store_;
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;
   NiceMock<Upstream::MockClusterManager> cm_;

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -113,7 +113,7 @@ protected:
                                            ProtobufMessage::getStrictValidationVisitor(), config);
     cluster_callback_ = std::make_shared<NiceMock<MockClusterSlotUpdateCallBack>>();
     cluster_ = std::make_shared<RedisCluster>(
-        cluster_config,
+        server_context_, cluster_config,
         TestUtility::downcastAndValidate<
             const envoy::extensions::clusters::redis::v3::RedisClusterConfig&>(config),
         *this, cm, runtime_, *api_, dns_resolver_, factory_context, std::move(scope), false,
@@ -150,8 +150,8 @@ protected:
         std::move(outlier_event_logger), false, validation_visitor_, api, options_);
 
     RedisClusterFactory factory = RedisClusterFactory();
-    factory.createClusterWithConfig(cluster_config, config, cluster_factory_context,
-                                    factory_context, std::move(scope));
+    factory.createClusterWithConfig(server_context_, cluster_config, config,
+                                    cluster_factory_context, factory_context, std::move(scope));
   }
 
   void expectResolveDiscovery(Network::DnsLookupFamily dns_lookup_family,
@@ -662,6 +662,7 @@ protected:
     EXPECT_CALL(active_dns_query_, cancel(Network::ActiveDnsQuery::CancelReason::QueryAbandoned));
   }
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
   std::shared_ptr<NiceMock<Network::MockDnsResolver>> dns_resolver_{

--- a/test/integration/clusters/custom_static_cluster.h
+++ b/test/integration/clusters/custom_static_cluster.h
@@ -24,12 +24,13 @@ namespace Envoy {
 
 class CustomStaticCluster : public Upstream::ClusterImplBase {
 public:
-  CustomStaticCluster(const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
+  CustomStaticCluster(Server::Configuration::ServerFactoryContext& server_context,
+                      const envoy::config::cluster::v3::Cluster& cluster, Runtime::Loader& runtime,
                       Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
                       Stats::ScopeSharedPtr&& stats_scope, bool added_via_api, uint32_t priority,
                       std::string address, uint32_t port)
-      : ClusterImplBase(cluster, runtime, factory_context, std::move(stats_scope), added_via_api,
-                        factory_context.mainThreadDispatcher().timeSource()),
+      : ClusterImplBase(server_context, cluster, runtime, factory_context, std::move(stats_scope),
+                        added_via_api, factory_context.mainThreadDispatcher().timeSource()),
         priority_(priority), address_(std::move(address)), port_(port), host_(makeHost()) {}
 
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
@@ -59,13 +60,14 @@ protected:
 private:
   std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>
   createClusterWithConfig(
+      Server::Configuration::ServerFactoryContext& server_context,
       const envoy::config::cluster::v3::Cluster& cluster,
       const test::integration::clusters::CustomStaticConfig& proto_config,
       Upstream::ClusterFactoryContext& context,
       Server::Configuration::TransportSocketFactoryContextImpl& socket_factory_context,
       Stats::ScopeSharedPtr&& stats_scope) override {
     auto new_cluster = std::make_shared<CustomStaticCluster>(
-        cluster, context.runtime(), socket_factory_context, std::move(stats_scope),
+        server_context, cluster, context.runtime(), socket_factory_context, std::move(stats_scope),
         context.addedViaApi(), proto_config.priority(), proto_config.address(),
         proto_config.port_value());
     return std::make_pair(new_cluster, create_lb_ ? new_cluster->threadAwareLb() : nullptr);

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -61,12 +61,12 @@ protected:
   ConfigurationImplTest()
       : api_(Api::createApiForTest()),
         cluster_manager_factory_(
-            server_.admin(), server_.runtime(), server_.stats(), server_.threadLocal(),
-            server_.dnsResolver(), server_.sslContextManager(), server_.dispatcher(),
-            server_.localInfo(), server_.secretManager(), server_.messageValidationContext(), *api_,
-            server_.httpContext(), server_.grpcContext(), server_.routerContext(),
-            server_.accessLogManager(), server_.singletonManager(), server_.options(),
-            server_.quic_stat_names_, server_) {}
+            server_context_, server_.admin(), server_.runtime(), server_.stats(),
+            server_.threadLocal(), server_.dnsResolver(), server_.sslContextManager(),
+            server_.dispatcher(), server_.localInfo(), server_.secretManager(),
+            server_.messageValidationContext(), *api_, server_.httpContext(), server_.grpcContext(),
+            server_.routerContext(), server_.accessLogManager(), server_.singletonManager(),
+            server_.options(), server_.quic_stat_names_, server_) {}
 
   void addStatsdFakeClusterConfig(envoy::config::metrics::v3::StatsSink& sink) {
     envoy::config::metrics::v3::StatsdSink statsd_sink;
@@ -75,6 +75,7 @@ protected:
   }
 
   Api::ApiPtr api_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   NiceMock<Server::MockInstance> server_;
   Upstream::ProdClusterManagerFactory cluster_manager_factory_;
 };


### PR DESCRIPTION
Adding the server factory context in this PR.
I plan to do a follow-up series to remove the multiple subclasses factory context impls, after https://github.com/envoyproxy/envoy/pull/22134 lands, but plumbing this now helps upstream filters.

Risk Level: low (new member unused)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/10455

