### PR TITLE
tracer: fix the coredump when instances of skywalking type tracer wer…

### DIFF
--- a/source/extensions/tracers/skywalking/skywalking_stats.h
+++ b/source/extensions/tracers/skywalking/skywalking_stats.h
@@ -17,7 +17,7 @@ struct SkyWalkingTracerStats {
   SKYWALKING_TRACER_STATS(GENERATE_COUNTER_STRUCT)
 };
 
-using SkyWalkingTracerStatsPtr = std::shared_ptr<SkyWalkingTracerStats>;
+using SkyWalkingTracerStatsSharedPtr = std::shared_ptr<SkyWalkingTracerStats>;
 
 } // namespace SkyWalking
 } // namespace Tracers

--- a/source/extensions/tracers/skywalking/skywalking_stats.h
+++ b/source/extensions/tracers/skywalking/skywalking_stats.h
@@ -17,6 +17,8 @@ struct SkyWalkingTracerStats {
   SKYWALKING_TRACER_STATS(GENERATE_COUNTER_STRUCT)
 };
 
+using SkyWalkingTracerStatsPtr = std::shared_ptr<SkyWalkingTracerStats>;
+
 } // namespace SkyWalking
 } // namespace Tracers
 } // namespace Extensions

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -28,8 +28,9 @@ using cpp2sky::TracerException;
 
 Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
                Server::Configuration::TracerFactoryContext& context)
-    : tracing_stats_{SKYWALKING_TRACER_STATS(
-          POOL_COUNTER_PREFIX(context.serverFactoryContext().scope(), "tracing.skywalking."))},
+    : tracing_stats_(std::make_shared<SkyWalkingTracerStats>(
+          SkyWalkingTracerStats{SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(
+              context.serverFactoryContext().scope(), "tracing.skywalking."))})),
       tls_slot_ptr_(context.serverFactoryContext().threadLocal().allocateSlot()) {
   loadConfig(proto_config.client_config(), context.serverFactoryContext());
   tracing_context_factory_ = std::make_unique<TracingContextFactory>(config_);

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
@@ -43,7 +43,7 @@ private:
   };
 
   TracerConfig config_;
-  SkyWalkingTracerStats tracing_stats_;
+  SkyWalkingTracerStatsPtr tracing_stats_;
   ThreadLocal::SlotPtr tls_slot_ptr_;
   std::unique_ptr<TracingContextFactory> tracing_context_factory_;
 };

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
@@ -43,7 +43,7 @@ private:
   };
 
   TracerConfig config_;
-  SkyWalkingTracerStatsPtr tracing_stats_;
+  SkyWalkingTracerStatsSharedPtr tracing_stats_;
   ThreadLocal::SlotPtr tls_slot_ptr_;
   std::unique_ptr<TracingContextFactory> tracing_context_factory_;
 };

--- a/source/extensions/tracers/skywalking/trace_segment_reporter.cc
+++ b/source/extensions/tracers/skywalking/trace_segment_reporter.cc
@@ -17,7 +17,7 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Request
 TraceSegmentReporter::TraceSegmentReporter(Grpc::AsyncClientFactoryPtr&& factory,
                                            Event::Dispatcher& dispatcher,
                                            Random::RandomGenerator& random_generator,
-                                           SkyWalkingTracerStatsPtr stats,
+                                           SkyWalkingTracerStatsSharedPtr stats,
                                            uint32_t delayed_buffer_size, const std::string& token)
     : tracing_stats_(stats), client_(factory->createUncachedRawAsyncClient()),
       service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(

--- a/source/extensions/tracers/skywalking/trace_segment_reporter.cc
+++ b/source/extensions/tracers/skywalking/trace_segment_reporter.cc
@@ -17,7 +17,7 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Request
 TraceSegmentReporter::TraceSegmentReporter(Grpc::AsyncClientFactoryPtr&& factory,
                                            Event::Dispatcher& dispatcher,
                                            Random::RandomGenerator& random_generator,
-                                           SkyWalkingTracerStats& stats,
+                                           SkyWalkingTracerStatsPtr stats,
                                            uint32_t delayed_buffer_size, const std::string& token)
     : tracing_stats_(stats), client_(factory->createUncachedRawAsyncClient()),
       service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
@@ -48,14 +48,14 @@ void TraceSegmentReporter::report(TracingContextPtr tracing_context) {
   ENVOY_LOG(trace, "Try to report segment to SkyWalking Server:\n{}", request.DebugString());
 
   if (stream_ != nullptr) {
-    tracing_stats_.segments_sent_.inc();
+    tracing_stats_->segments_sent_.inc();
     stream_->sendMessage(request, false);
     return;
   }
   // Null stream_ and cache segment data temporarily.
   delayed_segments_cache_.emplace(request);
   if (delayed_segments_cache_.size() > delayed_buffer_size_) {
-    tracing_stats_.segments_dropped_.inc();
+    tracing_stats_->segments_dropped_.inc();
     delayed_segments_cache_.pop();
   }
 }
@@ -63,12 +63,12 @@ void TraceSegmentReporter::report(TracingContextPtr tracing_context) {
 void TraceSegmentReporter::flushTraceSegments() {
   ENVOY_LOG(debug, "Flush segments in cache to SkyWalking backend service");
   while (!delayed_segments_cache_.empty() && stream_ != nullptr) {
-    tracing_stats_.segments_sent_.inc();
-    tracing_stats_.segments_flushed_.inc();
+    tracing_stats_->segments_sent_.inc();
+    tracing_stats_->segments_flushed_.inc();
     stream_->sendMessage(delayed_segments_cache_.front(), false);
     delayed_segments_cache_.pop();
   }
-  tracing_stats_.cache_flushed_.inc();
+  tracing_stats_->cache_flushed_.inc();
 }
 
 void TraceSegmentReporter::closeStream() {

--- a/source/extensions/tracers/skywalking/trace_segment_reporter.h
+++ b/source/extensions/tracers/skywalking/trace_segment_reporter.h
@@ -23,7 +23,7 @@ class TraceSegmentReporter : public Logger::Loggable<Logger::Id::tracing>,
 public:
   explicit TraceSegmentReporter(Grpc::AsyncClientFactoryPtr&& factory,
                                 Event::Dispatcher& dispatcher, Random::RandomGenerator& random,
-                                SkyWalkingTracerStats& stats, uint32_t delayed_buffer_size,
+                                SkyWalkingTracerStatsPtr stats, uint32_t delayed_buffer_size,
                                 const std::string& token);
   ~TraceSegmentReporter() override;
 
@@ -46,7 +46,7 @@ private:
   void handleFailure();
   void setRetryTimer();
 
-  SkyWalkingTracerStats& tracing_stats_;
+  SkyWalkingTracerStatsPtr tracing_stats_;
   Grpc::AsyncClient<skywalking::v3::SegmentObject, skywalking::v3::Commands> client_;
   Grpc::AsyncStream<skywalking::v3::SegmentObject> stream_{};
   const Protobuf::MethodDescriptor& service_method_;

--- a/source/extensions/tracers/skywalking/trace_segment_reporter.h
+++ b/source/extensions/tracers/skywalking/trace_segment_reporter.h
@@ -23,7 +23,7 @@ class TraceSegmentReporter : public Logger::Loggable<Logger::Id::tracing>,
 public:
   explicit TraceSegmentReporter(Grpc::AsyncClientFactoryPtr&& factory,
                                 Event::Dispatcher& dispatcher, Random::RandomGenerator& random,
-                                SkyWalkingTracerStatsPtr stats, uint32_t delayed_buffer_size,
+                                SkyWalkingTracerStatsSharedPtr stats, uint32_t delayed_buffer_size,
                                 const std::string& token);
   ~TraceSegmentReporter() override;
 
@@ -46,7 +46,7 @@ private:
   void handleFailure();
   void setRetryTimer();
 
-  SkyWalkingTracerStatsPtr tracing_stats_;
+  SkyWalkingTracerStatsSharedPtr tracing_stats_;
   Grpc::AsyncClient<skywalking::v3::SegmentObject, skywalking::v3::Commands> client_;
   Grpc::AsyncStream<skywalking::v3::SegmentObject> stream_{};
   const Protobuf::MethodDescriptor& service_method_;

--- a/test/extensions/tracers/skywalking/trace_segment_reporter_test.cc
+++ b/test/extensions/tracers/skywalking/trace_segment_reporter_test.cc
@@ -68,8 +68,9 @@ protected:
   NiceMock<Event::MockTimer>* timer_;
   Event::TimerCb timer_cb_;
   std::string test_string = "ABCDEFGHIJKLMN";
-  SkyWalkingTracerStats tracing_stats_{
-      SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))};
+  SkyWalkingTracerStatsPtr tracing_stats_{
+      std::make_shared<SkyWalkingTracerStats>(SkyWalkingTracerStats{
+          SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))})};
   TraceSegmentReporterPtr reporter_;
 };
 

--- a/test/extensions/tracers/skywalking/trace_segment_reporter_test.cc
+++ b/test/extensions/tracers/skywalking/trace_segment_reporter_test.cc
@@ -68,7 +68,7 @@ protected:
   NiceMock<Event::MockTimer>* timer_;
   Event::TimerCb timer_cb_;
   std::string test_string = "ABCDEFGHIJKLMN";
-  SkyWalkingTracerStatsPtr tracing_stats_{
+  SkyWalkingTracerStatsSharedPtr tracing_stats_{
       std::make_shared<SkyWalkingTracerStats>(SkyWalkingTracerStats{
           SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))})};
   TraceSegmentReporterPtr reporter_;

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -64,8 +64,9 @@ protected:
   NiceMock<Stats::MockIsolatedStatsStore>& mock_scope_ = context_.server_factory_context_.scope_;
   std::unique_ptr<NiceMock<Grpc::MockAsyncStream>> mock_stream_ptr_{nullptr};
   std::string test_string = "ABCDEFGHIJKLMN";
-  SkyWalkingTracerStats tracing_stats_{
-      SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))};
+  SkyWalkingTracerStatsPtr tracing_stats_{
+      std::make_shared<SkyWalkingTracerStats>(SkyWalkingTracerStats{
+          SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))})};
   TracerPtr tracer_;
 };
 

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -64,7 +64,7 @@ protected:
   NiceMock<Stats::MockIsolatedStatsStore>& mock_scope_ = context_.server_factory_context_.scope_;
   std::unique_ptr<NiceMock<Grpc::MockAsyncStream>> mock_stream_ptr_{nullptr};
   std::string test_string = "ABCDEFGHIJKLMN";
-  SkyWalkingTracerStatsPtr tracing_stats_{
+  SkyWalkingTracerStatsSharedPtr tracing_stats_{
       std::make_shared<SkyWalkingTracerStats>(SkyWalkingTracerStats{
           SKYWALKING_TRACER_STATS(POOL_COUNTER_PREFIX(mock_scope_, "tracing.skywalking."))})};
   TracerPtr tracer_;


### PR DESCRIPTION
…e destructed in TLS.

The reason for the crash is that the main thread posts function to each worker thread and does not wait for the worker thread to finish executing.  Let's assume that the main thread executes faster than the worker thread has had time to execute, and the main thread continues to execute, destructing the Envoy::Extensions::Tracers::SkyWalking::Driver class, and the tracing_stats_ member in the Driver class is also destructed.  At this point, if the worker thread starts executing, the reference to the tracing_stats_ member held by the worker thread is invalidated.

Signed-off-by: zhouyu <zhouyu-jt@163.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
