### PR TITLE
matching: fix regex engine initialization order

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -9,7 +9,7 @@ minor_behavior_changes:
 bug_fixes:
 - area: matching
   change: |
-    Fixed bootstrap crash when config contains stats_config configuration.
+    fixed bootstrap crash when config contains ``stats_config`` configuration.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -9,7 +9,7 @@ minor_behavior_changes:
 bug_fixes:
 - area: matching
   change: |
-    Fixed bootstrap crash when config contains `stats_config` configuration.
+    Fixed bootstrap crash when config contains stats_config configuration.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -7,7 +7,9 @@ minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
 
 bug_fixes:
-# *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: matching
+  change: |
+    Fixed bootstrap crash when config contains `stats_config` configuration.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -445,6 +445,21 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
               absl::StrJoin(info.registered_headers_, ","));
   }
 
+  // Initialize the regex engine and inject to singleton.
+  if (bootstrap_.has_default_regex_engine()) {
+    const auto& default_regex_engine = bootstrap_.default_regex_engine();
+    Regex::EngineFactory& factory =
+        Config::Utility::getAndCheckFactory<Regex::EngineFactory>(default_regex_engine);
+    auto config = Config::Utility::translateAnyToFactoryConfig(
+        default_regex_engine.typed_config(), messageValidationContext().staticValidationVisitor(),
+        factory);
+    regex_engine_ = factory.createEngine(*config, serverFactoryContext());
+  } else {
+    regex_engine_ = std::make_shared<Regex::GoogleReEngine>();
+  }
+  Regex::EngineSingleton::clear();
+  Regex::EngineSingleton::initialize(regex_engine_.get());
+
   // Needs to happen as early as possible in the instantiation to preempt the objects that require
   // stats.
   stats_store_.setTagProducer(Config::Utility::createTagProducer(bootstrap_, options_.statsTags()));
@@ -591,21 +606,6 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
       Network::SocketInterfaceSingleton::initialize(sock);
     }
   }
-
-  // Initialize the regex engine and inject to singleton.
-  if (bootstrap_.has_default_regex_engine()) {
-    const auto& default_regex_engine = bootstrap_.default_regex_engine();
-    Regex::EngineFactory& factory =
-        Config::Utility::getAndCheckFactory<Regex::EngineFactory>(default_regex_engine);
-    auto config = Config::Utility::translateAnyToFactoryConfig(
-        default_regex_engine.typed_config(), messageValidationContext().staticValidationVisitor(),
-        factory);
-    regex_engine_ = factory.createEngine(*config, serverFactoryContext());
-  } else {
-    regex_engine_ = std::make_shared<Regex::GoogleReEngine>();
-  }
-  Regex::EngineSingleton::clear();
-  Regex::EngineSingleton::initialize(regex_engine_.get());
 
   // Workers get created first so they register for thread local updates.
   listener_manager_ =


### PR DESCRIPTION
Commit Message: matching: fix regex engine initialization order
Additional Description: When Envoy is started with stats_config.histogram_bucket_settings in bootstrap configuration, it asserts/exits on startup.
Risk Level: Low
Testing: Manual, unit/integration testing
Docs Changes: Done
Release Notes: 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #22258 ]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
