### PR TITLE
docs: Fix the documentation of tcp_proxy.tunneling_config.hostname

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -80,7 +80,7 @@ message TcpProxy {
     //
     // Example: dynamically set hostname using dynamic metadata
     //
-    // .. code-block: yaml
+    // .. code-block:: yaml
     //
     //    tunneling_config:
     //      hostname: "%DYNAMIC_METADATA(tunnel:address)%"


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jacek.ewertowski1@gmail.com>

This change fixes displaying a code block with an example of dynamically set `tunneling_config.hostname`.
You can see [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto#envoy-v3-api-field-extensions-filters-network-tcp-proxy-v3-tcpproxy-tunnelingconfig-hostname) that the second code block is not visible.

Commit Message: docs: Fix the documentation of tcp_proxy.tunneling_config.hostname
Additional Description:
Risk Level: None
Testing: Not needed
Docs Changes:
Release Notes: Not needed
Platform Specific Features: None