### PR TITLE
bazel: remove external_deps from envoy_proto_library

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -197,7 +197,7 @@ def envoy_cc_win32_library(name, srcs = [], hdrs = [], **kargs):
     )
 
 # Envoy proto targets should be specified with this function.
-def envoy_proto_library(name, external_deps = [], **kwargs):
+def envoy_proto_library(name, **kwargs):
     api_cc_py_proto_library(
         name,
         # Avoid generating .so, we don't need it, can interfere with builds

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -25,7 +25,6 @@ envoy_proto_library(
 envoy_proto_library(
     name = "bookstore_proto",
     srcs = [":bookstore.proto"],
-    external_deps = ["api_httpbody_protos"],
 )
 
 envoy_proto_descriptor(


### PR DESCRIPTION
The usage of this variable was removed in
https://github.com/envoyproxy/envoy/commit/4e858f17fe08224c9c089240908ccd0c518e01a7,
only 1 target provided these today. If more did this would change
behavior since now they're included in kwargs, but I don't think the
intent was to ignore them. Buildifier now flags these as unused.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>