### PR TITLE
bazel: disable uring with compilation database

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -11,7 +11,10 @@ configure_make(
     name = "liburing",
     configure_in_place = True,
     lib_source = "@com_github_axboe_liburing//:all",
-    tags = ["skip_on_windows"],
+    tags = [
+        "nocompdb",
+        "skip_on_windows",
+    ],
 )
 
 # autotools packages are unusable on Windows as-is

--- a/source/common/io/BUILD
+++ b/source/common/io/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "io_uring_impl.h",
     ],
     external_deps = ["uring"],
+    tags = ["nocompdb"],
     deps = [
         ":io_uring_interface",
     ],

--- a/test/common/io/BUILD
+++ b/test/common/io/BUILD
@@ -11,7 +11,10 @@ envoy_package()
 envoy_cc_test(
     name = "io_uring_impl_test",
     srcs = ["io_uring_impl_test.cc"],
-    tags = ["skip_on_windows"],
+    tags = [
+        "nocompdb",
+        "skip_on_windows",
+    ],
     deps = [
         "//source/common/io:io_uring_impl_lib",
         "//test/mocks/server:server_mocks",


### PR DESCRIPTION
This is a workaround for
https://github.com/envoyproxy/envoy/issues/22217 with the downside that
it disables it for all platforms.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>