### PR TITLE
bazel: add target_compatible_with to envoy_cc_library

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -101,7 +101,8 @@ def envoy_cc_library(
         strip_include_prefix = None,
         include_prefix = None,
         textual_hdrs = None,
-        defines = []):
+        defines = [],
+        target_compatible_with = None):
     if tcmalloc_dep:
         deps += tcmalloc_external_deps(repository)
 
@@ -127,6 +128,7 @@ def envoy_cc_library(
         strip_include_prefix = strip_include_prefix,
         include_prefix = include_prefix,
         defines = defines,
+        target_compatible_with = target_compatible_with,
     )
 
     # Intended for usage by external consumers. This allows them to disambiguate
@@ -140,6 +142,7 @@ def envoy_cc_library(
         deps = [":" + name],
         strip_include_prefix = strip_include_prefix,
         include_prefix = include_prefix,
+        target_compatible_with = target_compatible_with,
     )
 
 # Used to specify a library that only builds on POSIX

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -11,10 +11,8 @@ configure_make(
     name = "liburing",
     configure_in_place = True,
     lib_source = "@com_github_axboe_liburing//:all",
-    tags = [
-        "nocompdb",
-        "skip_on_windows",
-    ],
+    tags = ["skip_on_windows"],
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 # autotools packages are unusable on Windows as-is

--- a/source/common/io/BUILD
+++ b/source/common/io/BUILD
@@ -27,7 +27,7 @@ envoy_cc_library(
         "io_uring_impl.h",
     ],
     external_deps = ["uring"],
-    tags = ["nocompdb"],
+    target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":io_uring_interface",
     ],


### PR DESCRIPTION
This attribute allows us to specify what constraints a library is
compatible with, such as only usable on linux, or not windows etc. It
is viral in that any targets that explicitly depend on it up the tree
will respect those constraints, and not be built, unless they're
specified explicitly on the command line, in which case bazel will fail
instead. This helps us a fix a problem with the compilation database
script where it virtually does `bazel build //...`, but some libraries
don't build at all on some platforms. Theoretically we could also solve
this case by marking those libraries as `manual`, but that would have
other side effects in that they wouldn't be built on the platforms that
they support either (unless they were somehow otherwise part of the
dependency tree, since unlike this attribute, the `manual` tag is not
viral).

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>