### PR TITLE
bazel: Remove uses of `depset.to_list` where possible

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -179,14 +179,10 @@ def api_proto_package(
 
     # Because RBAC proro depends on googleapis syntax.proto and checked.proto,
     # which share the same go proto library, it causes duplicative dependencies.
-    # Thus, we use depset().to_list() to remove duplicated depenencies.
-    go_proto_library(
-        name = name + _GO_PROTO_SUFFIX,
-        compilers = compilers,
-        importpath = _GO_IMPORTPATH_PREFIX + native.package_name(),
-        proto = name,
-        visibility = ["//visibility:public"],
-        deps = depset([_go_proto_mapping(dep) for dep in deps] + [
+    # Thus, we use a dictionary below to simulate a set and remove duplicated dependencies.
+    deps = (
+        [_go_proto_mapping(dep) for dep in deps] +
+        [
             "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
             "@com_github_golang_protobuf//ptypes:go_default_library_gen",
             "@go_googleapis//google/api:annotations_go_proto",
@@ -196,5 +192,13 @@ def api_proto_package(
             "@io_bazel_rules_go//proto/wkt:struct_go_proto",
             "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
             "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
-        ]).to_list(),
+        ]
+    )
+    go_proto_library(
+        name = name + _GO_PROTO_SUFFIX,
+        compilers = compilers,
+        importpath = _GO_IMPORTPATH_PREFIX + native.package_name(),
+        proto = name,
+        visibility = ["//visibility:public"],
+        deps = {dep: True for dep in deps}.keys(),
     )

--- a/source/extensions/all_extensions.bzl
+++ b/source/extensions/all_extensions.bzl
@@ -20,7 +20,7 @@ def envoy_all_extensions(denylist = []):
     all_extensions = dicts.add(_required_extensions, EXTENSIONS)
 
     # These extensions can be removed on a site specific basis.
-    return depset([_selected_extension_target(v) for k, v in all_extensions.items() if not k in denylist]).to_list()
+    return {_selected_extension_target(v): True for k, v in all_extensions.items() if k not in denylist}.keys()
 
 # Core extensions needed to run Envoy's integration tests.
 _core_extensions = [
@@ -41,14 +41,14 @@ def envoy_all_core_extensions():
     all_extensions = dicts.add(_required_extensions, EXTENSIONS)
 
     # These extensions can be removed on a site specific basis.
-    return depset([v for k, v in all_extensions.items() if k in _core_extensions]).to_list()
+    return {_selected_extension_target(v): True for k, v in all_extensions.items() if k in _core_extensions}.keys()
 
 _http_filter_prefix = "envoy.filters.http"
 
 def envoy_all_http_filters():
     all_extensions = dicts.add(_required_extensions, EXTENSIONS)
 
-    return [_selected_extension_target(v) for k, v in all_extensions.items() if k.startswith(_http_filter_prefix)]
+    return {_selected_extension_target(v): True for k, v in all_extensions.items() if k.startswith(_http_filter_prefix)}.keys()
 
 # All network-layer filters are extensions with names that have the following prefix.
 _network_filter_prefix = "envoy.filters.network"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Use of depsets, and `to_list` are recomended against unless actually necessary (https://docs.bazel.build/versions/main/skylark/performance.html)

The recommended advice to simulate a set in starlark is to use dictionary keys (https://docs.bazel.build/versions/main/skylark/lib/depset.html)

> The elements of a depset must be hashable and all of the same type (as defined by the built-in type(x) function), but depsets are not simply hash sets and do not support fast membership tests. If you need a general set datatype, you can simulate one using a dictionary where all keys map to True.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
