### PR TITLE
fm: handling decode data better

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -187,6 +187,9 @@ private:
     void decodeData(Buffer::Instance& data, bool end_stream) override;
     void decodeMetadata(MetadataMapPtr&&) override;
 
+    // Mark that the last downstream byte is received, and the downstream stream is complete.
+    void maybeEndDecode(bool end_stream);
+
     // Http::RequestDecoder
     void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override;
     void decodeTrailers(RequestTrailerMapPtr&& trailers) override;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -783,7 +783,6 @@ void FilterManager::decodeMetadata(ActiveStreamDecoderFilter* filter, MetadataMa
   }
 }
 
-
 void FilterManager::disarmRequestTimeout() { filter_manager_callbacks_.disarmRequestTimeout(); }
 
 std::list<ActiveStreamEncoderFilterPtr>::iterator

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -783,13 +783,6 @@ void FilterManager::decodeMetadata(ActiveStreamDecoderFilter* filter, MetadataMa
   }
 }
 
-void FilterManager::maybeEndDecode(bool end_stream) {
-  // If recreateStream is called, the HCM rewinds state and may send more encodeData calls.
-  if (end_stream && !remoteDecodeComplete()) {
-    stream_info_.downstreamTiming().onLastDownstreamRxByteReceived(dispatcher_.timeSource());
-    ENVOY_STREAM_LOG(debug, "request end stream", *this);
-  }
-}
 
 void FilterManager::disarmRequestTimeout() { filter_manager_callbacks_.disarmRequestTimeout(); }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -749,12 +749,6 @@ public:
   void disarmRequestTimeout();
 
   /**
-   * If end_stream is true, marks decoding as complete. This is a noop if end_stream is false.
-   * @param end_stream whether decoding is complete.
-   */
-  void maybeEndDecode(bool end_stream);
-
-  /**
    * If end_stream is true, marks encoding as complete. This is a noop if end_stream is false.
    * @param end_stream whether encoding is complete.
    */


### PR DESCRIPTION
moving filter end decode from the FM (an upstream /downstream concept) to HCM as it should only be done once.

Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/10455
