### PR TITLE
c++: provide type to std::weak_ptr template

### DIFF
--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -399,9 +399,10 @@ bool FileSystemBufferFilter::maybeStorage(BufferedStreamState& state,
       // We can't use getSafeDispatcher here because we need to close the file if the filter
       // was deleted before the callback, not just do nothing.
       cancel_in_flight_async_action_ = config_->asyncFileManager().createAnonymousFile(
-          config_->storageBufferPath(), [this, me = std::weak_ptr(shared_from_this()),
-                                         dispatcher = &request_callbacks_->dispatcher(),
-                                         &state](absl::StatusOr<AsyncFileHandle> file_handle) {
+          config_->storageBufferPath(),
+          [this, me = std::weak_ptr<FileSystemBufferFilter>(shared_from_this()),
+           dispatcher = &request_callbacks_->dispatcher(),
+           &state](absl::StatusOr<AsyncFileHandle> file_handle) {
             dispatcher->post([this, me = std::move(me), &state, file_handle]() {
               if (!me.lock()) {
                 // If we opened a file but the filter went away in the meantime, close the file


### PR DESCRIPTION
Commit Message:
provide type to std::weak_ptr template

Additional Description:
Most compilers do not have problems deducing type for `std::weak_ptr` without explicit type
`std::weak_ptr(shared_from_this())`, but lack of the type breaks a build on macos 10.15: https://github.com/Homebrew/homebrew-core/pull/105900

Risk Level: Low
Testing: Use existing unit tests.
Docs Changes: No
Release Notes: No 
Platform Specific Features: No

