### PR TITLE
qat: remove flaking test.

### DIFF
--- a/contrib/qat/private_key_providers/test/ops_test.cc
+++ b/contrib/qat/private_key_providers/test/ops_test.cc
@@ -246,51 +246,6 @@ TEST_F(QatProviderRsaTest, TestQatDeviceInit) {
   delete private_key;
 }
 
-TEST_F(QatProviderRsaTest, TestQatDeviceSetup) {
-  std::string* key_file = new std::string(TestEnvironment::substitute(
-      "{{ test_rundir }}/contrib/qat/private_key_providers/test/test_data/rsa-2048.pem"));
-  envoy::config::core::v3::DataSource* private_key = new envoy::config::core::v3::DataSource();
-  private_key->set_allocated_filename(key_file);
-
-  envoy::extensions::private_key_providers::qat::v3alpha::QatPrivateKeyMethodConfig conf;
-  conf.set_allocated_private_key(private_key);
-
-  std::shared_ptr<QatPrivateKeyMethodProvider> provider;
-
-  // no errors
-  provider = std::make_shared<QatPrivateKeyMethodProvider>(conf, factory_context_, libqat_);
-  EXPECT_NE(provider, nullptr);
-
-  // can't count instances
-  libqat_->cpaCyGetNumInstances_return_value_ = CPA_STATUS_FAIL;
-  EXPECT_THROW_WITH_REGEX(
-      std::make_shared<QatPrivateKeyMethodProvider>(conf, factory_context_, libqat_),
-      EnvoyException, "Failed to start QAT.");
-  libqat_->resetReturnValues();
-
-  // can't list QAT instanecs
-  libqat_->cpaCyGetInstances_return_value_ = CPA_STATUS_FAIL;
-  EXPECT_THROW_WITH_REGEX(
-      std::make_shared<QatPrivateKeyMethodProvider>(conf, factory_context_, libqat_),
-      EnvoyException, "Failed to start QAT.");
-  libqat_->resetReturnValues();
-
-  // instance won't start
-  libqat_->cpaCyStartInstance_return_value_ = CPA_STATUS_FAIL;
-  EXPECT_THROW_WITH_REGEX(
-      std::make_shared<QatPrivateKeyMethodProvider>(conf, factory_context_, libqat_),
-      EnvoyException, "Failed to start QAT.");
-  libqat_->resetReturnValues();
-
-  // no instance info
-  libqat_->cpaCyInstanceGetInfo2_return_value_ = CPA_STATUS_FAIL;
-  EXPECT_THROW_WITH_REGEX(
-      std::make_shared<QatPrivateKeyMethodProvider>(conf, factory_context_, libqat_),
-      EnvoyException, "Failed to start QAT.");
-  libqat_->resetReturnValues();
-  delete private_key;
-}
-
 } // namespace
 } // namespace Qat
 } // namespace PrivateKeyMethodProvider


### PR DESCRIPTION
Remove a test that is causing flakes in CI (https://github.com/envoyproxy/envoy/pull/21984#issuecomment-1188826531). A quick analysis indicates that there is a non-working interaction between MockTransportSocketFactoryContext and MockClusterInfo. Rethink later how to implement the test properly.
