### PR TITLE
build: ensure gold linker is used by the gcc compiler

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -66,6 +66,9 @@ build:clang --linkopt=-fuse-ld=lld
 build:clang-pch --spawn_strategy=local
 build:clang-pch --define=ENVOY_CLANG_PCH=1
 
+# Use gold linker for gcc compiler.
+build:gcc --linkopt=-fuse-ld=gold
+
 # Basic ASAN/UBSAN that works for gcc
 build:asan --action_env=ENVOY_ASAN=1
 build:asan --config=sanitizer

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -30,6 +30,9 @@ function setup_gcc_toolchain() {
     echo "gcc toolchain doesn't support ${ENVOY_STDLIB}."
     exit 1
   fi
+
+  BAZEL_BUILD_OPTIONS=("--config=gcc" "${BAZEL_BUILD_OPTIONS[@]}")
+
   if [[ -z "${ENVOY_RBE}" ]]; then
     export CC=gcc
     export CXX=g++


### PR DESCRIPTION
Commit Message: build: ensure gold linker is used by the gcc compiler
Additional Description:

The `build_setup.sh` will export `/opt/llvm/bin` to the `$PATH`. And the bazel will use the lld linker first. This PR will ensure the gold linker is used by the gcc compiler.

Risk Level: Low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
