### PR TITLE
bazel: fix android armeabi-v7a constraint

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -707,7 +707,7 @@ platform(
 platform(
     name = "android_armeabi",
     constraint_values = [
-        "@platforms//cpu:arm",  # TODO(keith): This should be armv7 https://github.com/bazelbuild/bazel/issues/14982
+        "@platforms//cpu:armv7",
         "@platforms//os:android",
     ],
 )


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/14982

Risk Level: Low
Testing: Verified by building Envoy Mobile for Android armeabi-v7a
Docs Changes: None
Release Notes: None

Signed-off-by: JP Simard <jp@jpsim.com>