### PR TITLE
http: refactoring all the templates to allow for the creation of upst…

### DIFF
--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -5,7 +5,7 @@
 set -e
 
 # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-ENVOY_FILTER_EXAMPLE_GITSHA="ac6a66a4a1c08138ccc03c23aafc9637b2df55a1"
+ENVOY_FILTER_EXAMPLE_GITSHA="a8a9ad118dc701f33e97b11aa59523ef5237163b"
 ENVOY_FILTER_EXAMPLE_SRCDIR="${BUILD_DIR}/envoy-filter-example"
 
 # shellcheck disable=SC2034

--- a/contrib/sip_proxy/filters/network/test/config_test.cc
+++ b/contrib/sip_proxy/filters/network/test/config_test.cc
@@ -33,7 +33,7 @@ public:
   void testConfig(envoy::extensions::filters::network::sip_proxy::v3alpha::SipProxy& config) {
     Network::FilterFactoryCb cb;
     EXPECT_NO_THROW({ cb = factory_.createFilterFactoryFromProto(config, context_); });
-    EXPECT_TRUE(factory_.isTerminalFilterByProto(config, context_));
+    EXPECT_TRUE(factory_.isTerminalFilterByProto(config, context_.getServerFactoryContext()));
 
     Network::MockConnection connection;
     EXPECT_CALL(connection, addReadFilter(_));

--- a/envoy/filter/config_provider_manager.h
+++ b/envoy/filter/config_provider_manager.h
@@ -46,7 +46,8 @@ public:
    */
   virtual DynamicFilterConfigProviderPtr<FactoryCb> createDynamicFilterConfigProvider(
       const envoy::config::core::v3::ExtensionConfigSource& config_source,
-      const std::string& filter_config_name, FactoryCtx& factory_context,
+      const std::string& filter_config_name, Server::Configuration::ServerFactoryContext& server_context,
+      FactoryCtx& factory_context,
       const std::string& stat_prefix, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher) PURE;

--- a/envoy/filter/config_provider_manager.h
+++ b/envoy/filter/config_provider_manager.h
@@ -46,8 +46,8 @@ public:
    */
   virtual DynamicFilterConfigProviderPtr<FactoryCb> createDynamicFilterConfigProvider(
       const envoy::config::core::v3::ExtensionConfigSource& config_source,
-      const std::string& filter_config_name, Server::Configuration::ServerFactoryContext& server_context,
-      FactoryCtx& factory_context,
+      const std::string& filter_config_name,
+      Server::Configuration::ServerFactoryContext& server_context, FactoryCtx& factory_context,
       const std::string& stat_prefix, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher) PURE;

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -132,7 +132,9 @@ public:
   /**
    * @return bool true if this filter must be the last filter in a filter chain, false otherwise.
    */
-  virtual bool isTerminalFilterByProto(const Protobuf::Message&, ServerFactoryContext&) { return false; }
+  virtual bool isTerminalFilterByProto(const Protobuf::Message&, ServerFactoryContext&) {
+    return false;
+  }
 };
 
 /**
@@ -166,7 +168,6 @@ using MatchingRequirementsPtr =
 class HttpFilterConfigFactoryBase : public ProtocolOptionsFactory {
 public:
   ~HttpFilterConfigFactoryBase() override = default;
-
 
   /**
    * @return ProtobufTypes::MessagePtr create an empty virtual host, route, or weighted
@@ -228,7 +229,10 @@ public:
   /**
    * @return bool true if this filter must be the last filter in a filter chain, false otherwise.
    */
-  virtual bool isTerminalFilterByProto(const Protobuf::Message&, Server::Configuration::ServerFactoryContext&) { return false; }
+  virtual bool isTerminalFilterByProto(const Protobuf::Message&,
+                                       Server::Configuration::ServerFactoryContext&) {
+    return false;
+  }
 };
 
 class NamedHttpFilterConfigFactory : public virtual HttpFilterConfigFactoryBase {
@@ -243,10 +247,9 @@ public:
    * @param context supplies the filter's context.
    * @return Http::FilterFactoryCb the factory creation function.
    */
-  virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
-                                                             const std::string& stat_prefix,
-                                                             Server::Configuration::FactoryContext& context) PURE;
-
+  virtual Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
+                               Server::Configuration::FactoryContext& context) PURE;
 };
 
 class UpstreamHttpFilterConfigFactory : public virtual HttpFilterConfigFactoryBase {
@@ -261,9 +264,9 @@ public:
    * @param context supplies the filter's context.
    * @return Http::FilterFactoryCb the factory creation function.
    */
-  virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
-                                                             const std::string& stat_prefix,
-                                                             Server::Configuration::ServerFactoryContext& context) PURE;
+  virtual Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
+                               Server::Configuration::ServerFactoryContext& context) PURE;
 };
 
 } // namespace Configuration

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -132,7 +132,7 @@ public:
   /**
    * @return bool true if this filter must be the last filter in a filter chain, false otherwise.
    */
-  virtual bool isTerminalFilterByProto(const Protobuf::Message&, FactoryContext&) { return false; }
+  virtual bool isTerminalFilterByProto(const Protobuf::Message&, ServerFactoryContext&) { return false; }
 };
 
 /**
@@ -163,23 +163,10 @@ using MatchingRequirementsPtr =
  * Implemented by each HTTP filter and registered via Registry::registerFactory or the
  * convenience class RegisterFactory.
  */
-class NamedHttpFilterConfigFactory : public ProtocolOptionsFactory {
+class HttpFilterConfigFactoryBase : public ProtocolOptionsFactory {
 public:
-  ~NamedHttpFilterConfigFactory() override = default;
+  ~HttpFilterConfigFactoryBase() override = default;
 
-  /**
-   * Create a particular http filter factory implementation. If the implementation is unable to
-   * produce a factory with the provided parameters, it should throw an EnvoyException. The returned
-   * callback should always be initialized.
-   * @param config supplies the general Protobuf message to be marshaled into a filter-specific
-   * configuration.
-   * @param stat_prefix prefix for stat logging
-   * @param context supplies the filter's context.
-   * @return Http::FilterFactoryCb the factory creation function.
-   */
-  virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
-                                                             const std::string& stat_prefix,
-                                                             FactoryContext& context) PURE;
 
   /**
    * @return ProtobufTypes::MessagePtr create an empty virtual host, route, or weighted
@@ -203,11 +190,6 @@ public:
   }
 
   std::string category() const override { return "envoy.filters.http"; }
-
-  /**
-   * @return bool true if this filter must be the last filter in a filter chain, false otherwise.
-   */
-  virtual bool isTerminalFilterByProto(const Protobuf::Message&, FactoryContext&) { return false; }
 
   /**
    * @return FilterDependenciesPtr specification of dependencies required or
@@ -242,6 +224,46 @@ public:
 
     return config_types;
   }
+
+  /**
+   * @return bool true if this filter must be the last filter in a filter chain, false otherwise.
+   */
+  virtual bool isTerminalFilterByProto(const Protobuf::Message&, Server::Configuration::ServerFactoryContext&) { return false; }
+};
+
+class NamedHttpFilterConfigFactory : public virtual HttpFilterConfigFactoryBase {
+public:
+  /**
+   * Create a particular http filter factory implementation. If the implementation is unable to
+   * produce a factory with the provided parameters, it should throw an EnvoyException. The returned
+   * callback should always be initialized.
+   * @param config supplies the general Protobuf message to be marshaled into a filter-specific
+   * configuration.
+   * @param stat_prefix prefix for stat logging
+   * @param context supplies the filter's context.
+   * @return Http::FilterFactoryCb the factory creation function.
+   */
+  virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
+                                                             const std::string& stat_prefix,
+                                                             Server::Configuration::FactoryContext& context) PURE;
+
+};
+
+class UpstreamHttpFilterConfigFactory : public virtual HttpFilterConfigFactoryBase {
+public:
+  /**
+   * Create a particular http filter factory implementation. If the implementation is unable to
+   * produce a factory with the provided parameters, it should throw an EnvoyException. The returned
+   * callback should always be initialized.
+   * @param config supplies the general Protobuf message to be marshaled into a filter-specific
+   * configuration.
+   * @param stat_prefix prefix for stat logging
+   * @param context supplies the filter's context.
+   * @return Http::FilterFactoryCb the factory creation function.
+   */
+  virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
+                                                             const std::string& stat_prefix,
+                                                             Server::Configuration::ServerFactoryContext& context) PURE;
 };
 
 } // namespace Configuration

--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -176,7 +176,7 @@ void FilterConfigSubscription::incrementConflictCounter() { stats_.config_confli
 
 std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImplBase::getSubscription(
     const envoy::config::core::v3::ConfigSource& config_source, const std::string& name,
-    Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix) {
+    Server::Configuration::ServerFactoryContext& server_context, const std::string& stat_prefix) {
   // FilterConfigSubscriptions are unique based on their config source and filter config name
   // combination.
   // TODO(https://github.com/envoyproxy/envoy/issues/11967) Hash collision can cause subscription
@@ -185,7 +185,7 @@ std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImplBase::g
   auto it = subscriptions_.find(subscription_id);
   if (it == subscriptions_.end()) {
     auto subscription = std::make_shared<FilterConfigSubscription>(
-        config_source, name, factory_context.getServerFactoryContext(), stat_prefix, *this,
+        config_source, name, server_context, stat_prefix, *this,
         subscription_id);
     subscriptions_.insert({subscription_id, std::weak_ptr<FilterConfigSubscription>(subscription)});
     return subscription;

--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -185,8 +185,7 @@ std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImplBase::g
   auto it = subscriptions_.find(subscription_id);
   if (it == subscriptions_.end()) {
     auto subscription = std::make_shared<FilterConfigSubscription>(
-        config_source, name, server_context, stat_prefix, *this,
-        subscription_id);
+        config_source, name, server_context, stat_prefix, *this, subscription_id);
     subscriptions_.insert({subscription_id, std::weak_ptr<FilterConfigSubscription>(subscription)});
     return subscription;
   } else {

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -172,6 +172,8 @@ struct NamedHttpFilterFactoryCb {
 };
 
 // Implementation of a HTTP dynamic filter config provider.
+// NeutralHttpFilterConfigFactory can either be a NamedHttpFilterConfigFactory
+// or an UpstreamHttpFilterConfigFactory.
 template <class FactoryCtx, class NeutralHttpFilterConfigFactory>
 class HttpDynamicFilterConfigProviderImpl
     : public DynamicFilterConfigProviderImpl<NamedHttpFilterFactoryCb> {

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -71,7 +71,7 @@ public:
   DynamicFilterConfigProviderImpl(
       FilterConfigSubscriptionSharedPtr& subscription,
       const absl::flat_hash_set<std::string>& require_type_urls,
-      Server::Configuration::FactoryContext& factory_context,
+      ThreadLocal::SlotAllocator& tls,
       ProtobufTypes::MessagePtr&& default_config, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type, absl::string_view stat_prefix,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher)
@@ -79,7 +79,7 @@ public:
                                             last_filter_in_filter_chain, filter_chain_type),
         listener_filter_matcher_(listener_filter_matcher), stat_prefix_(stat_prefix),
         main_config_(std::make_shared<MainConfig>()),
-        default_configuration_(std::move(default_config)), tls_(factory_context.threadLocal()) {
+        default_configuration_(std::move(default_config)), tls_(tls) {
     tls_.set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalConfig>(); });
   };
 
@@ -173,26 +173,28 @@ struct NamedHttpFilterFactoryCb {
 };
 
 // Implementation of a HTTP dynamic filter config provider.
+template <class FactoryCtx, class NeutralHttpFilterConfigFactory>
 class HttpDynamicFilterConfigProviderImpl
     : public DynamicFilterConfigProviderImpl<NamedHttpFilterFactoryCb> {
 public:
   HttpDynamicFilterConfigProviderImpl(
       FilterConfigSubscriptionSharedPtr& subscription,
       const absl::flat_hash_set<std::string>& require_type_urls,
-      Server::Configuration::FactoryContext& factory_context,
+      Server::Configuration::ServerFactoryContext& server_context,
+      FactoryCtx& factory_context,
       ProtobufTypes::MessagePtr&& default_config, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type, absl::string_view stat_prefix,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher)
-      : DynamicFilterConfigProviderImpl(subscription, require_type_urls, factory_context,
+      : DynamicFilterConfigProviderImpl(subscription, require_type_urls, factory_context.threadLocal(),
                                         std::move(default_config), last_filter_in_filter_chain,
                                         filter_chain_type, stat_prefix, listener_filter_matcher),
-        factory_context_(factory_context) {}
+        server_context_(server_context), factory_context_(factory_context) {}
   void validateMessage(const std::string& config_name, const Protobuf::Message& message,
                        const std::string& factory_name) const override {
     auto* factory =
-        Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
+        Registry::FactoryRegistry<NeutralHttpFilterConfigFactory>::getFactory(
             factory_name);
-    const bool is_terminal_filter = factory->isTerminalFilterByProto(message, factory_context_);
+    const bool is_terminal_filter = factory->isTerminalFilterByProto(message, server_context_);
     Config::Utility::validateTerminalFilters(config_name, factory_name, filter_chain_type_,
                                              is_terminal_filter, last_filter_in_filter_chain_);
   }
@@ -200,13 +202,14 @@ public:
 private:
   NamedHttpFilterFactoryCb
   instantiateFilterFactory(const Protobuf::Message& message) const override {
-    auto* factory = Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::
+    auto* factory = Registry::FactoryRegistry<NeutralHttpFilterConfigFactory>::
         getFactoryByType(message.GetTypeName());
     return {factory->name(),
             factory->createFilterFactoryFromProto(message, getStatPrefix(), factory_context_)};
   }
 
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::Configuration::ServerFactoryContext& server_context_;
+  FactoryCtx& factory_context_;
 };
 
 // Implementation of a listener dynamic filter config provider.
@@ -216,12 +219,13 @@ public:
   ListenerDynamicFilterConfigProviderImpl(
       FilterConfigSubscriptionSharedPtr& subscription,
       const absl::flat_hash_set<std::string>& require_type_urls,
+      Server::Configuration::ServerFactoryContext&,
       Server::Configuration::ListenerFactoryContext& factory_context,
       ProtobufTypes::MessagePtr&& default_config, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type, absl::string_view stat_prefix,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher)
       : DynamicFilterConfigProviderImpl<FactoryCb>(
-            subscription, require_type_urls, factory_context, std::move(default_config),
+            subscription, require_type_urls, factory_context.threadLocal(), std::move(default_config),
             last_filter_in_filter_chain, filter_chain_type, stat_prefix, listener_filter_matcher),
         factory_context_(factory_context) {}
 
@@ -373,7 +377,7 @@ public:
 protected:
   std::shared_ptr<FilterConfigSubscription>
   getSubscription(const envoy::config::core::v3::ConfigSource& config_source,
-                  const std::string& name, Server::Configuration::FactoryContext& factory_context,
+                  const std::string& name, Server::Configuration::ServerFactoryContext& server_context,
                   const std::string& stat_prefix);
   void applyLastOrDefaultConfig(std::shared_ptr<FilterConfigSubscription>& subscription,
                                 DynamicFilterConfigProviderImplBase& provider,
@@ -399,7 +403,7 @@ class FilterConfigProviderManagerImpl : public FilterConfigProviderManagerImplBa
 public:
   DynamicFilterConfigProviderPtr<FactoryCb> createDynamicFilterConfigProvider(
       const envoy::config::core::v3::ExtensionConfigSource& config_source,
-      const std::string& filter_config_name, FactoryCtx& factory_context,
+      const std::string& filter_config_name, Server::Configuration::ServerFactoryContext& server_context, FactoryCtx& factory_context,
       const std::string& stat_prefix, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher) override {
@@ -416,7 +420,7 @@ public:
     }
 
     auto subscription = getSubscription(config_source.config_source(), filter_config_name,
-                                        factory_context, subscription_stat_prefix);
+                                        server_context, subscription_stat_prefix);
     // For warming, wait until the subscription receives the first response to indicate readiness.
     // Otherwise, mark ready immediately and start the subscription on initialization. A default
     // config is expected in the latter case.
@@ -432,12 +436,12 @@ public:
     ProtobufTypes::MessagePtr default_config;
     if (config_source.has_default_config()) {
       default_config =
-          getDefaultConfig(config_source.default_config(), filter_config_name, factory_context,
+          getDefaultConfig(config_source.default_config(), filter_config_name, server_context, factory_context,
                            last_filter_in_filter_chain, filter_chain_type, require_type_urls);
     }
 
-    auto provider = createFilterConfigProviderImpl(subscription, require_type_urls, factory_context,
-                                                   std::move(default_config),
+    auto provider = createFilterConfigProviderImpl(subscription, require_type_urls, server_context,
+                                                   factory_context, std::move(default_config),
                                                    last_filter_in_filter_chain, filter_chain_type,
                                                    provider_stat_prefix, listener_filter_matcher);
 
@@ -470,11 +474,11 @@ public:
 protected:
   virtual void validateFilters(const std::string&, const std::string&, const std::string&, bool,
                                bool) const {};
-  virtual bool isTerminalFilter(Factory*, Protobuf::Message&, FactoryCtx&) const { return false; }
+  virtual bool isTerminalFilter(Factory*, Protobuf::Message&, Server::Configuration::ServerFactoryContext&) const { return false; }
 
   ProtobufTypes::MessagePtr
   getDefaultConfig(const ProtobufWkt::Any& proto_config, const std::string& filter_config_name,
-                   FactoryCtx& factory_context, bool last_filter_in_filter_chain,
+                   Server::Configuration::ServerFactoryContext& server_context, FactoryCtx& factory_context, bool last_filter_in_filter_chain,
                    const std::string& filter_chain_type,
                    const absl::flat_hash_set<std::string>& require_type_urls) const {
     auto* default_factory = Config::Utility::getFactoryByType<Factory>(proto_config);
@@ -484,7 +488,7 @@ protected:
     ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
         proto_config, factory_context.messageValidationVisitor(), *default_factory);
     validateFilters(filter_config_name, default_factory->name(), filter_chain_type,
-                    isTerminalFilter(default_factory, *message, factory_context),
+                    isTerminalFilter(default_factory, *message, server_context),
                     last_filter_in_filter_chain);
     return message;
   }
@@ -492,12 +496,13 @@ protected:
 private:
   std::unique_ptr<DynamicFilterConfigProviderImpl<FactoryCb>> createFilterConfigProviderImpl(
       FilterConfigSubscriptionSharedPtr& subscription,
-      const absl::flat_hash_set<std::string>& require_type_urls, FactoryCtx& factory_context,
+      const absl::flat_hash_set<std::string>& require_type_urls, Server::Configuration::ServerFactoryContext& server_context,
+      FactoryCtx& factory_context,
       ProtobufTypes::MessagePtr&& default_config, bool last_filter_in_filter_chain,
       const std::string& filter_chain_type, absl::string_view stat_prefix,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher) {
     return std::make_unique<DynamicFilterConfigImpl>(
-        subscription, require_type_urls, factory_context, std::move(default_config),
+        subscription, require_type_urls, server_context, factory_context, std::move(default_config),
         last_filter_in_filter_chain, filter_chain_type, stat_prefix, listener_filter_matcher);
   }
 };
@@ -506,14 +511,36 @@ private:
 class HttpFilterConfigProviderManagerImpl
     : public FilterConfigProviderManagerImpl<
           Server::Configuration::NamedHttpFilterConfigFactory, NamedHttpFilterFactoryCb,
-          Server::Configuration::FactoryContext, HttpDynamicFilterConfigProviderImpl> {
+          Server::Configuration::FactoryContext, HttpDynamicFilterConfigProviderImpl<Server::Configuration::FactoryContext, Server::Configuration::NamedHttpFilterConfigFactory>> {
 public:
   absl::string_view statPrefix() const override { return "http_filter."; }
 
 protected:
   bool isTerminalFilter(Server::Configuration::NamedHttpFilterConfigFactory* default_factory,
                         Protobuf::Message& message,
-                        Server::Configuration::FactoryContext& factory_context) const override {
+                        Server::Configuration::ServerFactoryContext& factory_context) const override {
+    return default_factory->isTerminalFilterByProto(message, factory_context);
+  }
+  void validateFilters(const std::string& filter_config_name, const std::string& filter_type,
+                       const std::string& filter_chain_type, bool is_terminal_filter,
+                       bool last_filter_in_filter_chain) const override {
+    Config::Utility::validateTerminalFilters(filter_config_name, filter_type, filter_chain_type,
+                                             is_terminal_filter, last_filter_in_filter_chain);
+  }
+};
+
+// HTTP filter
+class UpstreamHttpFilterConfigProviderManagerImpl
+    : public FilterConfigProviderManagerImpl<
+          Server::Configuration::UpstreamHttpFilterConfigFactory, NamedHttpFilterFactoryCb,
+          Server::Configuration::ServerFactoryContext, HttpDynamicFilterConfigProviderImpl<Server::Configuration::ServerFactoryContext, Server::Configuration::UpstreamHttpFilterConfigFactory>> {
+public:
+  absl::string_view statPrefix() const override { return "http_filter."; }
+
+protected:
+  bool isTerminalFilter(Server::Configuration::UpstreamHttpFilterConfigFactory* default_factory,
+                        Protobuf::Message& message,
+                        Server::Configuration::ServerFactoryContext& factory_context) const override {
     return default_factory->isTerminalFilterByProto(message, factory_context);
   }
   void validateFilters(const std::string& filter_config_name, const std::string& filter_type,

--- a/source/common/http/filter_chain_helper.cc
+++ b/source/common/http/filter_chain_helper.cc
@@ -55,6 +55,8 @@ void FilterChainUtility::createFilterChainForFactories(
   }
 }
 
+void FilterChainUtility::throwError(std::string message) { throw EnvoyException(message); }
+
 SINGLETON_MANAGER_REGISTRATION(downstream_filter_config_provider_manager);
 SINGLETON_MANAGER_REGISTRATION(upstream_filter_config_provider_manager);
 

--- a/source/common/http/filter_chain_helper.cc
+++ b/source/common/http/filter_chain_helper.cc
@@ -31,9 +31,9 @@ static Http::FilterFactoryCb MissingConfigFilterFactory =
       cb.addStreamDecoderFilter(std::make_shared<MissingConfigFilter>());
     };
 
-void FilterChainHelper::createFilterChainForFactories(
+void FilterChainUtility::createFilterChainForFactories(
     Http::FilterChainManager& manager,
-    const FilterChainHelper::FilterFactoriesList& filter_factories) {
+    const FilterChainUtility::FilterFactoriesList& filter_factories) {
   bool added_missing_config_filter = false;
   for (const auto& filter_config_provider : filter_factories) {
     auto config = filter_config_provider->config();
@@ -55,99 +55,27 @@ void FilterChainHelper::createFilterChainForFactories(
   }
 }
 
-void FilterChainHelper::processFilters(const FiltersList& filters, const std::string& prefix,
-                                       const std::string& filter_chain_type,
-                                       FilterFactoriesList& filter_factories) {
-  DependencyManager dependency_manager;
-  for (int i = 0; i < filters.size(); i++) {
-    processFilter(filters[i], i, prefix, filter_chain_type, i == filters.size() - 1,
-                  filter_factories, dependency_manager);
-  }
-  // TODO(auni53): Validate encode dependencies too.
-  auto status = dependency_manager.validDecodeDependencies();
-  if (!status.ok()) {
-    throw EnvoyException(std::string(status.message()));
-  }
-}
+SINGLETON_MANAGER_REGISTRATION(downstream_filter_config_provider_manager);
+SINGLETON_MANAGER_REGISTRATION(upstream_filter_config_provider_manager);
 
-void FilterChainHelper::processFilter(
-    const envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter&
-        proto_config,
-    int i, const std::string& prefix, const std::string& filter_chain_type,
-    bool last_filter_in_current_config, FilterFactoriesList& filter_factories,
-    DependencyManager& dependency_manager) {
-  ENVOY_LOG(debug, "    {} filter #{}", prefix, i);
-  if (proto_config.config_type_case() ==
-      envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter::ConfigTypeCase::
-          kConfigDiscovery) {
-    processDynamicFilterConfig(proto_config.name(), proto_config.config_discovery(),
-                               filter_factories, filter_chain_type, last_filter_in_current_config);
-    return;
-  }
-
-  // Now see if there is a factory that will accept the config.
-  auto* factory =
-      Config::Utility::getAndCheckFactory<Server::Configuration::NamedHttpFilterConfigFactory>(
-          proto_config, proto_config.is_optional());
-  // null pointer returned only when the filter is optional, then skip all the processes.
-  if (factory == nullptr) {
-    ENVOY_LOG(warn, "Didn't find a registered factory for the optional http filter {}",
-              proto_config.name());
-    return;
-  }
-  ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
-      proto_config, factory_context_.messageValidationVisitor(), *factory);
-  Http::FilterFactoryCb callback =
-      factory->createFilterFactoryFromProto(*message, stats_prefix_, factory_context_);
-  dependency_manager.registerFilter(factory->name(), *factory->dependencies());
-  bool is_terminal = factory->isTerminalFilterByProto(*message, factory_context_);
-  Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(), filter_chain_type,
-                                           is_terminal, last_filter_in_current_config);
-  auto filter_config_provider = filter_config_provider_manager_.createStaticFilterConfigProvider(
-      {factory->name(), callback}, proto_config.name());
-  ENVOY_LOG(debug, "      name: {}", filter_config_provider->name());
-  ENVOY_LOG(debug, "    config: {}",
-            MessageUtil::getJsonStringFromMessageOrError(
-                static_cast<const Protobuf::Message&>(proto_config.typed_config())));
-  filter_factories.push_back(std::move(filter_config_provider));
-}
-
-void FilterChainHelper::processDynamicFilterConfig(
-    const std::string& name, const envoy::config::core::v3::ExtensionConfigSource& config_discovery,
-    FilterFactoriesList& filter_factories, const std::string& filter_chain_type,
-    bool last_filter_in_current_config) {
-  ENVOY_LOG(debug, "      dynamic filter name: {}", name);
-  if (config_discovery.apply_default_config_without_warming() &&
-      !config_discovery.has_default_config()) {
-    throw EnvoyException(fmt::format(
-        "Error: filter config {} applied without warming but has no default config.", name));
-  }
-  for (const auto& type_url : config_discovery.type_urls()) {
-    auto factory_type_url = TypeUtil::typeUrlToDescriptorFullName(type_url);
-    auto* factory = Registry::FactoryRegistry<
-        Server::Configuration::NamedHttpFilterConfigFactory>::getFactoryByType(factory_type_url);
-    if (factory == nullptr) {
-      throw EnvoyException(
-          fmt::format("Error: no factory found for a required type URL {}.", factory_type_url));
-    }
-  }
-
-  auto filter_config_provider = filter_config_provider_manager_.createDynamicFilterConfigProvider(
-      config_discovery, name, factory_context_, stats_prefix_, last_filter_in_current_config,
-      filter_chain_type, nullptr);
-  filter_factories.push_back(std::move(filter_config_provider));
-}
-
-SINGLETON_MANAGER_REGISTRATION(filter_config_provider_manager);
-
-std::shared_ptr<FilterConfigProviderManager>
-FilterChainHelper::createSingletonFilterConfigProviderManager(
+std::shared_ptr<UpstreamFilterConfigProviderManager>
+FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(
     Server::Configuration::ServerFactoryContext& context) {
-  std::shared_ptr<FilterConfigProviderManager> filter_config_provider_manager =
-      context.singletonManager().getTyped<FilterConfigProviderManager>(
-          SINGLETON_MANAGER_REGISTERED_NAME(filter_config_provider_manager),
+  std::shared_ptr<UpstreamFilterConfigProviderManager> upstream_filter_config_provider_manager =
+      context.singletonManager().getTyped<Http::UpstreamFilterConfigProviderManager>(
+          SINGLETON_MANAGER_REGISTERED_NAME(upstream_filter_config_provider_manager),
+          [] { return std::make_shared<Filter::UpstreamHttpFilterConfigProviderManagerImpl>(); });
+  return upstream_filter_config_provider_manager;
+}
+
+std::shared_ptr<Http::DownstreamFilterConfigProviderManager>
+FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(
+    Server::Configuration::ServerFactoryContext& context) {
+  std::shared_ptr<Http::DownstreamFilterConfigProviderManager> downstream_filter_config_provider_manager =
+      context.singletonManager().getTyped<Http::DownstreamFilterConfigProviderManager>(
+          SINGLETON_MANAGER_REGISTERED_NAME(upstream_filter_config_provider_manager),
           [] { return std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>(); });
-  return filter_config_provider_manager;
+  return downstream_filter_config_provider_manager;
 }
 
 } // namespace Http

--- a/source/common/http/filter_chain_helper.cc
+++ b/source/common/http/filter_chain_helper.cc
@@ -71,10 +71,11 @@ FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(
 std::shared_ptr<Http::DownstreamFilterConfigProviderManager>
 FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(
     Server::Configuration::ServerFactoryContext& context) {
-  std::shared_ptr<Http::DownstreamFilterConfigProviderManager> downstream_filter_config_provider_manager =
-      context.singletonManager().getTyped<Http::DownstreamFilterConfigProviderManager>(
-          SINGLETON_MANAGER_REGISTERED_NAME(upstream_filter_config_provider_manager),
-          [] { return std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>(); });
+  std::shared_ptr<Http::DownstreamFilterConfigProviderManager>
+      downstream_filter_config_provider_manager =
+          context.singletonManager().getTyped<Http::DownstreamFilterConfigProviderManager>(
+              SINGLETON_MANAGER_REGISTERED_NAME(upstream_filter_config_provider_manager),
+              [] { return std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>(); });
   return downstream_filter_config_provider_manager;
 }
 

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -21,7 +21,7 @@ using UpstreamFilterConfigProviderManager =
                                         Server::Configuration::ServerFactoryContext>;
 
 class FilterChainUtility : Logger::Loggable<Logger::Id::config> {
- public:
+public:
   using FilterFactoriesList =
       std::list<Filter::FilterConfigProviderPtr<Filter::NamedHttpFilterFactoryCb>>;
   using FiltersList = Protobuf::RepeatedPtrField<
@@ -31,10 +31,12 @@ class FilterChainUtility : Logger::Loggable<Logger::Id::config> {
                                             const FilterFactoriesList& filter_factories);
 
   static std::shared_ptr<DownstreamFilterConfigProviderManager>
-  createSingletonDownstreamFilterConfigProviderManager(Server::Configuration::ServerFactoryContext& context);
+  createSingletonDownstreamFilterConfigProviderManager(
+      Server::Configuration::ServerFactoryContext& context);
 
   static std::shared_ptr<UpstreamFilterConfigProviderManager>
-  createSingletonUpstreamFilterConfigProviderManager(Server::Configuration::ServerFactoryContext& context);
+  createSingletonUpstreamFilterConfigProviderManager(
+      Server::Configuration::ServerFactoryContext& context);
 };
 
 template <class FilterCtx, class NeutralNamedHttpFilterFactory>
@@ -43,15 +45,14 @@ public:
   using FilterFactoriesList =
       std::list<Filter::FilterConfigProviderPtr<Filter::NamedHttpFilterFactoryCb>>;
   using FilterConfigProviderManager =
-      Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
-                                        FilterCtx>;
+      Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb, FilterCtx>;
 
   FilterChainHelper(FilterConfigProviderManager& filter_config_provider_manager,
                     Server::Configuration::ServerFactoryContext& server_context,
-                    FilterCtx& factory_context,
-                    const std::string& stats_prefix)
+                    FilterCtx& factory_context, const std::string& stats_prefix)
       : filter_config_provider_manager_(filter_config_provider_manager),
-        server_context_(server_context), factory_context_(factory_context), stats_prefix_(stats_prefix) {}
+        server_context_(server_context), factory_context_(factory_context),
+        stats_prefix_(stats_prefix) {}
 
   using FiltersList = Protobuf::RepeatedPtrField<
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>;
@@ -80,17 +81,17 @@ private:
                 DependencyManager& dependency_manager) {
     ENVOY_LOG(debug, "    {} filter #{}", prefix, i);
     if (proto_config.config_type_case() ==
-        envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter::ConfigTypeCase::
-        kConfigDiscovery) {
+        envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter::
+            ConfigTypeCase::kConfigDiscovery) {
       processDynamicFilterConfig(proto_config.name(), proto_config.config_discovery(),
-                                 filter_factories, filter_chain_type, last_filter_in_current_config);
+                                 filter_factories, filter_chain_type,
+                                 last_filter_in_current_config);
       return;
     }
 
     // Now see if there is a factory that will accept the config.
-    auto* factory =
-        Config::Utility::getAndCheckFactory<NeutralNamedHttpFilterFactory>(
-            proto_config, proto_config.is_optional());
+    auto* factory = Config::Utility::getAndCheckFactory<NeutralNamedHttpFilterFactory>(
+        proto_config, proto_config.is_optional());
     // null pointer returned only when the filter is optional, then skip all the processes.
     if (factory == nullptr) {
       ENVOY_LOG(warn, "Didn't find a registered factory for the optional http filter {}",
@@ -102,9 +103,11 @@ private:
     Http::FilterFactoryCb callback =
         factory->createFilterFactoryFromProto(*message, stats_prefix_, factory_context_);
     dependency_manager.registerFilter(factory->name(), *factory->dependencies());
-//    bool is_terminal = factory->isTerminalFilterByProto(*message, server_context_);
-//    Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(), filter_chain_type,
-//FIXME                                             is_terminal, last_filter_in_current_config);
+    //    bool is_terminal = factory->isTerminalFilterByProto(*message, server_context_);
+    //    Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(),
+    //    filter_chain_type,
+    // FIXME                                             is_terminal,
+    // last_filter_in_current_config);
     auto filter_config_provider = filter_config_provider_manager_.createStaticFilterConfigProvider(
         {factory->name(), callback}, proto_config.name());
     ENVOY_LOG(debug, "      name: {}", filter_config_provider->name());
@@ -128,8 +131,8 @@ private:
     }
     for (const auto& type_url : config_discovery.type_urls()) {
       auto factory_type_url = TypeUtil::typeUrlToDescriptorFullName(type_url);
-      auto* factory = Registry::FactoryRegistry<
-          NeutralNamedHttpFilterFactory>::getFactoryByType(factory_type_url);
+      auto* factory = Registry::FactoryRegistry<NeutralNamedHttpFilterFactory>::getFactoryByType(
+          factory_type_url);
       if (factory == nullptr) {
         throw EnvoyException(
             fmt::format("Error: no factory found for a required type URL {}.", factory_type_url));
@@ -137,11 +140,10 @@ private:
     }
 
     auto filter_config_provider = filter_config_provider_manager_.createDynamicFilterConfigProvider(
-        config_discovery, name, server_context_, factory_context_, stats_prefix_, last_filter_in_current_config,
-        filter_chain_type, nullptr);
+        config_discovery, name, server_context_, factory_context_, stats_prefix_,
+        last_filter_in_current_config, filter_chain_type, nullptr);
     filter_factories.push_back(std::move(filter_config_provider));
   }
-
 
   FilterConfigProviderManager& filter_config_provider_manager_;
   Server::Configuration::ServerFactoryContext& server_context_;

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -103,11 +103,10 @@ private:
     Http::FilterFactoryCb callback =
         factory->createFilterFactoryFromProto(*message, stats_prefix_, factory_context_);
     dependency_manager.registerFilter(factory->name(), *factory->dependencies());
-    //    bool is_terminal = factory->isTerminalFilterByProto(*message, server_context_);
-    //    Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(),
-    //    filter_chain_type,
-    // FIXME                                             is_terminal,
-    // last_filter_in_current_config);
+    bool is_terminal = factory->isTerminalFilterByProto(*message, server_context_);
+    Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(),
+                                             filter_chain_type, is_terminal,
+                                             last_filter_in_current_config);
     auto filter_config_provider = filter_config_provider_manager_.createStaticFilterConfigProvider(
         {factory->name(), callback}, proto_config.name());
     ENVOY_LOG(debug, "      name: {}", filter_config_provider->name());

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -13,31 +13,63 @@
 namespace Envoy {
 namespace Http {
 
-using FilterConfigProviderManager =
+using DownstreamFilterConfigProviderManager =
     Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
                                         Server::Configuration::FactoryContext>;
+using UpstreamFilterConfigProviderManager =
+    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
+                                        Server::Configuration::ServerFactoryContext>;
 
+class FilterChainUtility : Logger::Loggable<Logger::Id::config> {
+ public:
+  using FilterFactoriesList =
+      std::list<Filter::FilterConfigProviderPtr<Filter::NamedHttpFilterFactoryCb>>;
+  using FiltersList = Protobuf::RepeatedPtrField<
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>;
+
+  static void createFilterChainForFactories(Http::FilterChainManager& manager,
+                                            const FilterFactoriesList& filter_factories);
+
+  static std::shared_ptr<DownstreamFilterConfigProviderManager>
+  createSingletonDownstreamFilterConfigProviderManager(Server::Configuration::ServerFactoryContext& context);
+
+  static std::shared_ptr<UpstreamFilterConfigProviderManager>
+  createSingletonUpstreamFilterConfigProviderManager(Server::Configuration::ServerFactoryContext& context);
+};
+
+template <class FilterCtx, class NeutralNamedHttpFilterFactory>
 class FilterChainHelper : Logger::Loggable<Logger::Id::config> {
 public:
   using FilterFactoriesList =
       std::list<Filter::FilterConfigProviderPtr<Filter::NamedHttpFilterFactoryCb>>;
-  static void createFilterChainForFactories(Http::FilterChainManager& manager,
-                                            const FilterFactoriesList& filter_factories);
-
-  static std::shared_ptr<FilterConfigProviderManager>
-  createSingletonFilterConfigProviderManager(Server::Configuration::ServerFactoryContext& context);
+  using FilterConfigProviderManager =
+      Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
+                                        FilterCtx>;
 
   FilterChainHelper(FilterConfigProviderManager& filter_config_provider_manager,
-                    Server::Configuration::FactoryContext& factory_context,
+                    Server::Configuration::ServerFactoryContext& server_context,
+                    FilterCtx& factory_context,
                     const std::string& stats_prefix)
       : filter_config_provider_manager_(filter_config_provider_manager),
-        factory_context_(factory_context), stats_prefix_(stats_prefix) {}
+        server_context_(server_context), factory_context_(factory_context), stats_prefix_(stats_prefix) {}
 
   using FiltersList = Protobuf::RepeatedPtrField<
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>;
 
-  void processFilters(const FiltersList& list, const std::string& prefix,
-                      const std::string& filter_chain_type, FilterFactoriesList& filter_factories);
+  void processFilters(const FiltersList& filters, const std::string& prefix,
+                      const std::string& filter_chain_type, FilterFactoriesList& filter_factories) {
+
+    DependencyManager dependency_manager;
+    for (int i = 0; i < filters.size(); i++) {
+      processFilter(filters[i], i, prefix, filter_chain_type, i == filters.size() - 1,
+                    filter_factories, dependency_manager);
+    }
+    // TODO(auni53): Validate encode dependencies too.
+    auto status = dependency_manager.validDecodeDependencies();
+    if (!status.ok()) {
+      throw EnvoyException(std::string(status.message()));
+    }
+  }
 
 private:
   void
@@ -45,16 +77,75 @@ private:
                     proto_config,
                 int i, const std::string& prefix, const std::string& filter_chain_type,
                 bool last_filter_in_current_config, FilterFactoriesList& filter_factories,
-                DependencyManager& dependency_manager);
+                DependencyManager& dependency_manager) {
+    ENVOY_LOG(debug, "    {} filter #{}", prefix, i);
+    if (proto_config.config_type_case() ==
+        envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter::ConfigTypeCase::
+        kConfigDiscovery) {
+      processDynamicFilterConfig(proto_config.name(), proto_config.config_discovery(),
+                                 filter_factories, filter_chain_type, last_filter_in_current_config);
+      return;
+    }
+
+    // Now see if there is a factory that will accept the config.
+    auto* factory =
+        Config::Utility::getAndCheckFactory<NeutralNamedHttpFilterFactory>(
+            proto_config, proto_config.is_optional());
+    // null pointer returned only when the filter is optional, then skip all the processes.
+    if (factory == nullptr) {
+      ENVOY_LOG(warn, "Didn't find a registered factory for the optional http filter {}",
+                proto_config.name());
+      return;
+    }
+    ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+        proto_config, factory_context_.messageValidationVisitor(), *factory);
+    Http::FilterFactoryCb callback =
+        factory->createFilterFactoryFromProto(*message, stats_prefix_, factory_context_);
+    dependency_manager.registerFilter(factory->name(), *factory->dependencies());
+//    bool is_terminal = factory->isTerminalFilterByProto(*message, server_context_);
+//    Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(), filter_chain_type,
+//FIXME                                             is_terminal, last_filter_in_current_config);
+    auto filter_config_provider = filter_config_provider_manager_.createStaticFilterConfigProvider(
+        {factory->name(), callback}, proto_config.name());
+    ENVOY_LOG(debug, "      name: {}", filter_config_provider->name());
+    ENVOY_LOG(debug, "    config: {}",
+              MessageUtil::getJsonStringFromMessageOrError(
+                  static_cast<const Protobuf::Message&>(proto_config.typed_config())));
+    filter_factories.push_back(std::move(filter_config_provider));
+  }
+
   void
   processDynamicFilterConfig(const std::string& name,
                              const envoy::config::core::v3::ExtensionConfigSource& config_discovery,
                              FilterFactoriesList& filter_factories,
                              const std::string& filter_chain_type,
-                             bool last_filter_in_current_config);
+                             bool last_filter_in_current_config) {
+    ENVOY_LOG(debug, "      dynamic filter name: {}", name);
+    if (config_discovery.apply_default_config_without_warming() &&
+        !config_discovery.has_default_config()) {
+      throw EnvoyException(fmt::format(
+          "Error: filter config {} applied without warming but has no default config.", name));
+    }
+    for (const auto& type_url : config_discovery.type_urls()) {
+      auto factory_type_url = TypeUtil::typeUrlToDescriptorFullName(type_url);
+      auto* factory = Registry::FactoryRegistry<
+          NeutralNamedHttpFilterFactory>::getFactoryByType(factory_type_url);
+      if (factory == nullptr) {
+        throw EnvoyException(
+            fmt::format("Error: no factory found for a required type URL {}.", factory_type_url));
+      }
+    }
+
+    auto filter_config_provider = filter_config_provider_manager_.createDynamicFilterConfigProvider(
+        config_discovery, name, server_context_, factory_context_, stats_prefix_, last_filter_in_current_config,
+        filter_chain_type, nullptr);
+    filter_factories.push_back(std::move(filter_config_provider));
+  }
+
 
   FilterConfigProviderManager& filter_config_provider_manager_;
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::Configuration::ServerFactoryContext& server_context_;
+  FilterCtx& factory_context_;
   const std::string& stats_prefix_;
 };
 

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -17,7 +17,7 @@ namespace BufferFilter {
 
 Http::FilterFactoryCb BufferFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config, const std::string&,
-    Server::Configuration::FactoryContext&) {
+    Server::Configuration::ServerFactoryContext&) {
   ASSERT(proto_config.has_max_request_bytes());
 
   BufferFilterConfigSharedPtr filter_config(new BufferFilterConfig(proto_config));
@@ -33,11 +33,14 @@ BufferFilterFactory::createRouteSpecificFilterConfigTyped(
   return std::make_shared<const BufferFilterSettings>(proto_config);
 }
 
+
 /**
  * Static registration for the buffer filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(BufferFilterFactory,
                  Server::Configuration::NamedHttpFilterConfigFactory){"envoy.buffer"};
+REGISTER_FACTORY(UpstreamBufferFilterFactory,
+                 Server::Configuration::UpstreamHttpFilterConfigFactory){"envoy.buffer"};
 
 } // namespace BufferFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -33,7 +33,6 @@ BufferFilterFactory::createRouteSpecificFilterConfigTyped(
   return std::make_shared<const BufferFilterSettings>(proto_config);
 }
 
-
 /**
  * Static registration for the buffer filter. @see RegisterFactory.
  */

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -14,22 +14,25 @@ namespace BufferFilter {
  * Config registration for the buffer filter.
  */
 class BufferFilterFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::buffer::v3::Buffer,
+    : public Common::DualFactoryBase<envoy::extensions::filters::http::buffer::v3::Buffer,
                                  envoy::extensions::filters::http::buffer::v3::BufferPerRoute> {
 public:
-  BufferFilterFactory() : FactoryBase("envoy.filters.http.buffer") {}
+  BufferFilterFactory() : DualFactoryBase("envoy.filters.http.buffer") {}
 
 private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::buffer::v3::BufferPerRoute&,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 };
 
+using UpstreamBufferFilterFactory = BufferFilterFactory;
+
 DECLARE_FACTORY(BufferFilterFactory);
+DECLARE_FACTORY(UpstreamBufferFilterFactory);
 
 } // namespace BufferFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -15,14 +15,15 @@ namespace BufferFilter {
  */
 class BufferFilterFactory
     : public Common::DualFactoryBase<envoy::extensions::filters::http::buffer::v3::Buffer,
-                                 envoy::extensions::filters::http::buffer::v3::BufferPerRoute> {
+                                     envoy::extensions::filters::http::buffer::v3::BufferPerRoute> {
 public:
   BufferFilterFactory() : DualFactoryBase("envoy.filters.http.buffer") {}
 
 private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
-      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) override;
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::buffer::v3::BufferPerRoute&,

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -44,6 +44,7 @@ public:
                                             Server::Configuration::ServerFactoryContext&) {
     return false;
   }
+
 protected:
   CommonFactoryBase(const std::string& name) : name_(name) {}
 
@@ -57,8 +58,9 @@ protected:
   const std::string name_;
 };
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
-class FactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>, public Server::Configuration::NamedHttpFilterConfigFactory {
- public:
+class FactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
+                    public Server::Configuration::NamedHttpFilterConfigFactory {
+public:
   FactoryBase(const std::string& name) : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
 
   Http::FilterFactoryCb
@@ -73,13 +75,15 @@ class FactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>, pub
   createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) PURE;
-
 };
 
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
-class DualFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>, public Server::Configuration::NamedHttpFilterConfigFactory, public Server::Configuration::UpstreamHttpFilterConfigFactory {
- public:
-  DualFactoryBase(const std::string& name) : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
+class DualFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
+                        public Server::Configuration::NamedHttpFilterConfigFactory,
+                        public Server::Configuration::UpstreamHttpFilterConfigFactory {
+public:
+  DualFactoryBase(const std::string& name)
+      : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
 
   Http::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -12,17 +12,8 @@ namespace Common {
  * boilerplate.
  */
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
-class FactoryBase : public Server::Configuration::NamedHttpFilterConfigFactory {
+class CommonFactoryBase : public virtual Server::Configuration::HttpFilterConfigFactoryBase {
 public:
-  Http::FilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                               const std::string& stats_prefix,
-                               Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
-                                                 proto_config, context.messageValidationVisitor()),
-                                             stats_prefix, context);
-  }
-
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ConfigProto>();
   }
@@ -43,24 +34,18 @@ public:
   std::string name() const override { return name_; }
 
   bool isTerminalFilterByProto(const Protobuf::Message& proto_config,
-                               Server::Configuration::FactoryContext& context) override {
+                               Server::Configuration::ServerFactoryContext& context) override {
     return isTerminalFilterByProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
                                             proto_config, context.messageValidationVisitor()),
                                         context);
   }
 
-protected:
-  FactoryBase(const std::string& name) : name_(name) {}
-
-private:
   virtual bool isTerminalFilterByProtoTyped(const ConfigProto&,
-                                            Server::Configuration::FactoryContext&) {
+                                            Server::Configuration::ServerFactoryContext&) {
     return false;
   }
-  virtual Http::FilterFactoryCb
-  createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                    const std::string& stats_prefix,
-                                    Server::Configuration::FactoryContext& context) PURE;
+protected:
+  CommonFactoryBase(const std::string& name) : name_(name) {}
 
   virtual Router::RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfigTyped(const RouteConfigProto&,
@@ -70,6 +55,54 @@ private:
   }
 
   const std::string name_;
+};
+template <class ConfigProto, class RouteConfigProto = ConfigProto>
+class FactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>, public Server::Configuration::NamedHttpFilterConfigFactory {
+ public:
+  FactoryBase(const std::string& name) : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
+
+  Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             stats_prefix, context);
+  }
+  virtual Http::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                    const std::string& stats_prefix,
+                                    Server::Configuration::FactoryContext& context) PURE;
+
+};
+
+template <class ConfigProto, class RouteConfigProto = ConfigProto>
+class DualFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>, public Server::Configuration::NamedHttpFilterConfigFactory, public Server::Configuration::UpstreamHttpFilterConfigFactory {
+ public:
+  DualFactoryBase(const std::string& name) : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
+
+  Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             stats_prefix, context.getServerFactoryContext());
+  }
+
+  Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::ServerFactoryContext& context) override {
+    return createFilterFactoryFromProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
+                                                 proto_config, context.messageValidationVisitor()),
+                                             stats_prefix, context);
+  }
+
+  virtual Http::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                    const std::string& stats_prefix,
+                                    Server::Configuration::ServerFactoryContext& context) PURE;
 };
 
 } // namespace Common

--- a/source/extensions/filters/http/router/config.h
+++ b/source/extensions/filters/http/router/config.h
@@ -22,7 +22,7 @@ public:
 
 private:
   bool isTerminalFilterByProtoTyped(const envoy::extensions::filters::http::router::v3::Router&,
-                                    Server::Configuration::FactoryContext&) override {
+                                    Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/network/common/factory_base.h
+++ b/source/extensions/filters/network/common/factory_base.h
@@ -45,7 +45,7 @@ public:
   std::string name() const override { return name_; }
 
   bool isTerminalFilterByProto(const Protobuf::Message& proto_config,
-                               Server::Configuration::FactoryContext& context) override {
+                               Server::Configuration::ServerFactoryContext& context) override {
     return isTerminalFilterByProtoTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(
                                             proto_config, context.messageValidationVisitor()),
                                         context);
@@ -57,7 +57,7 @@ protected:
 
 private:
   virtual bool isTerminalFilterByProtoTyped(const ConfigProto&,
-                                            Server::Configuration::FactoryContext&) {
+                                            Server::Configuration::ServerFactoryContext&) {
     return is_terminal_filter_;
   }
   virtual Network::FilterFactoryCb

--- a/source/extensions/filters/network/direct_response/config.cc
+++ b/source/extensions/filters/network/direct_response/config.cc
@@ -33,7 +33,7 @@ private:
 
   bool isTerminalFilterByProtoTyped(
       const envoy::extensions::filters::network::direct_response::v3::Config&,
-      Server::Configuration::FactoryContext&) override {
+      Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
 };

--- a/source/extensions/filters/network/echo/config.cc
+++ b/source/extensions/filters/network/echo/config.cc
@@ -30,7 +30,7 @@ private:
   }
 
   bool isTerminalFilterByProtoTyped(const envoy::extensions::filters::network::echo::v3::Echo&,
-                                    Server::Configuration::FactoryContext&) override {
+                                    Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
 };

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -164,8 +164,8 @@ Utility::Singletons Utility::createSingletons(Server::Configuration::FactoryCont
                 context.getServerFactoryContext(), context.messageValidationVisitor()));
       });
 
-  std::shared_ptr<FilterConfigProviderManager> filter_config_provider_manager =
-      Http::FilterChainHelper::createSingletonFilterConfigProviderManager(
+  std::shared_ptr<Http::DownstreamFilterConfigProviderManager> filter_config_provider_manager =
+      Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(
           context.getServerFactoryContext());
 
   return {date_provider, route_config_provider_manager, scoped_routes_config_provider_manager,
@@ -560,7 +560,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     throw EnvoyException("Non-HTTP/3 codec configured on QUIC listener.");
   }
 
-  Http::FilterChainHelper helper(filter_config_provider_manager_, context_, stats_prefix_);
+  Http::FilterChainHelper<Server::Configuration::FactoryContext, Server::Configuration::NamedHttpFilterConfigFactory> helper(filter_config_provider_manager_, context_.getServerFactoryContext(), context_, stats_prefix_);
   helper.processFilters(config.http_filters(), "http", "http", filter_factories_);
 
   for (const auto& upgrade_config : config.upgrade_configs()) {
@@ -627,7 +627,7 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
 }
 
 void HttpConnectionManagerConfig::createFilterChain(Http::FilterChainManager& manager) {
-  Http::FilterChainHelper::createFilterChainForFactories(manager, filter_factories_);
+  Http::FilterChainUtility::createFilterChainForFactories(manager, filter_factories_);
 }
 
 bool HttpConnectionManagerConfig::createUpgradeFilterChain(
@@ -658,7 +658,7 @@ bool HttpConnectionManagerConfig::createUpgradeFilterChain(
     filters_to_use = it->second.filter_factories.get();
   }
 
-  Http::FilterChainHelper::createFilterChainForFactories(callbacks, *filters_to_use);
+  Http::FilterChainUtility::createFilterChainForFactories(callbacks, *filters_to_use);
   return true;
 }
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -560,7 +560,10 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     throw EnvoyException("Non-HTTP/3 codec configured on QUIC listener.");
   }
 
-  Http::FilterChainHelper<Server::Configuration::FactoryContext, Server::Configuration::NamedHttpFilterConfigFactory> helper(filter_config_provider_manager_, context_.getServerFactoryContext(), context_, stats_prefix_);
+  Http::FilterChainHelper<Server::Configuration::FactoryContext,
+                          Server::Configuration::NamedHttpFilterConfigFactory>
+      helper(filter_config_provider_manager_, context_.getServerFactoryContext(), context_,
+             stats_prefix_);
   helper.processFilters(config.http_filters(), "http", "http", filter_factories_);
 
   for (const auto& upgrade_config : config.upgrade_configs()) {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -100,7 +100,8 @@ ProdListenerComponentFactory::createNetworkFilterFactoryListImpl(
         proto_config, filter_chain_factory_context.messageValidationVisitor(), factory);
     Config::Utility::validateTerminalFilters(
         filters[i].name(), factory.name(), "network",
-        factory.isTerminalFilterByProto(*message, filter_chain_factory_context.getServerFactoryContext()),
+        factory.isTerminalFilterByProto(*message,
+                                        filter_chain_factory_context.getServerFactoryContext()),
         i == filters.size() - 1);
     Network::FilterFactoryCb callback =
         factory.createFilterFactoryFromProto(*message, filter_chain_factory_context);
@@ -143,8 +144,8 @@ ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
         }
       }
       auto filter_config_provider = config_provider_manager.createDynamicFilterConfigProvider(
-          config_discovery, name, context.getServerFactoryContext(), context,"tcp_listener.", false, "listener",
-          createListenerFilterMatcher(proto_config));
+          config_discovery, name, context.getServerFactoryContext(), context, "tcp_listener.",
+          false, "listener", createListenerFilterMatcher(proto_config));
       ret.push_back(std::move(filter_config_provider));
     } else {
       ENVOY_LOG(debug, "  config: {}",

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -100,7 +100,7 @@ ProdListenerComponentFactory::createNetworkFilterFactoryListImpl(
         proto_config, filter_chain_factory_context.messageValidationVisitor(), factory);
     Config::Utility::validateTerminalFilters(
         filters[i].name(), factory.name(), "network",
-        factory.isTerminalFilterByProto(*message, filter_chain_factory_context),
+        factory.isTerminalFilterByProto(*message, filter_chain_factory_context.getServerFactoryContext()),
         i == filters.size() - 1);
     Network::FilterFactoryCb callback =
         factory.createFilterFactoryFromProto(*message, filter_chain_factory_context);
@@ -143,7 +143,7 @@ ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
         }
       }
       auto filter_config_provider = config_provider_manager.createDynamicFilterConfigProvider(
-          config_discovery, name, context, "tcp_listener.", false, "listener",
+          config_discovery, name, context.getServerFactoryContext(), context,"tcp_listener.", false, "listener",
           createListenerFilterMatcher(proto_config));
       ret.push_back(std::move(filter_config_provider));
     } else {

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -104,8 +104,8 @@ public:
     }
 
     return filter_config_provider_manager_->createDynamicFilterConfigProvider(
-        config_source, name, factory_context_, "xds.", last_filter_config, getFilterType(),
-        getMatcher());
+        config_source, name, factory_context_.getServerFactoryContext(), factory_context_, "xds.",
+        last_filter_config, getFilterType(), getMatcher());
   }
 
   void setup(bool warm = true, bool default_configuration = false, bool last_filter_config = true) {
@@ -458,7 +458,8 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, WrongDefaultConfig) {
       "type.googleapis.com/test.integration.filters.Bogus");
   EXPECT_THROW_WITH_MESSAGE(
       config_discovery_test.filter_config_provider_manager_->createDynamicFilterConfigProvider(
-          config_source, "foo", config_discovery_test.factory_context_, "xds.", true,
+          config_source, "foo", config_discovery_test.factory_context_.getServerFactoryContext(),
+          config_discovery_test.factory_context_, "xds.", true,
           config_discovery_test.getFilterType(), config_discovery_test.getMatcher()),
       EnvoyException,
       "Error: cannot find filter factory foo for default filter "

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -46,6 +46,18 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProto) {
   cb(filter_callback);
 }
 
+TEST(BufferFilterFactoryTest, BufferFilterCorrectProtoUpstreamFactory) {
+  envoy::extensions::filters::http::buffer::v3::Buffer config;
+  config.mutable_max_request_bytes()->set_value(1028);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  BufferFilterFactory factory;
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
 TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
   BufferFilterFactory factory;
   auto empty_proto = factory.createEmptyConfigProto();

--- a/test/extensions/filters/network/dubbo_proxy/config_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/config_test.cc
@@ -76,7 +76,7 @@ TEST_F(DubboFilterConfigTest, ValidProtoConfiguration) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   DubboProxyFilterConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, context);
-  EXPECT_TRUE(factory.isTerminalFilterByProto(config, context));
+  EXPECT_TRUE(factory.isTerminalFilterByProto(config, context.getServerFactoryContext()));
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1537,7 +1537,7 @@ http_filters:
   EXPECT_CALL(context_.thread_local_, allocateSlot());
   Network::FilterFactoryCb cb1 = factory.createFilterFactoryFromProto(proto_config, context_);
   Network::FilterFactoryCb cb2 = factory.createFilterFactoryFromProto(proto_config, context_);
-  EXPECT_TRUE(factory.isTerminalFilterByProto(proto_config, context_));
+  EXPECT_TRUE(factory.isTerminalFilterByProto(proto_config, context_.getServerFactoryContext()));
 }
 
 TEST_F(HttpConnectionManagerConfigTest, BadHttpConnectionMangerConfig) {

--- a/test/extensions/filters/network/redis_proxy/config_test.cc
+++ b/test/extensions/filters/network/redis_proxy/config_test.cc
@@ -81,7 +81,7 @@ settings:
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
-  EXPECT_TRUE(factory.isTerminalFilterByProto(proto_config, context));
+  EXPECT_TRUE(factory.isTerminalFilterByProto(proto_config, context.getServerFactoryContext()));
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);

--- a/test/extensions/filters/network/redis_proxy/config_test.cc
+++ b/test/extensions/filters/network/redis_proxy/config_test.cc
@@ -142,7 +142,7 @@ settings:
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
-  EXPECT_TRUE(factory.isTerminalFilterByProto(proto_config, context));
+  EXPECT_TRUE(factory.isTerminalFilterByProto(proto_config, context.getServerFactoryContext()));
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -60,7 +60,7 @@ TEST(ConfigTest, ConfigTest) {
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
 
-  EXPECT_TRUE(factory.isTerminalFilterByProto(config, context));
+  EXPECT_TRUE(factory.isTerminalFilterByProto(config, context.getServerFactoryContext()));
 
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, context);
   Network::MockConnection connection;

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -63,7 +63,7 @@ public:
   void testConfig(envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy& config) {
     Network::FilterFactoryCb cb;
     EXPECT_NO_THROW({ cb = factory_.createFilterFactoryFromProto(config, context_); });
-    EXPECT_TRUE(factory_.isTerminalFilterByProto(config, context_));
+    EXPECT_TRUE(factory_.isTerminalFilterByProto(config, context_.getServerFactoryContext()));
 
     Network::MockConnection connection;
     EXPECT_CALL(connection, addReadFilter(_));

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -136,7 +136,7 @@ public:
                                              Network::ConnectionCallbacks& upstream_callbacks)
       : FactoryBase(name), upstream_callbacks_(&upstream_callbacks) {}
   bool isTerminalFilterByProtoTyped(const test::integration::starttls::StartTlsFilterConfig&,
-                                    Server::Configuration::FactoryContext&) override {
+                                    Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
 

--- a/test/integration/filters/set_is_terminal_filter.cc
+++ b/test/integration/filters/set_is_terminal_filter.cc
@@ -33,7 +33,7 @@ private:
   }
   bool isTerminalFilterByProtoTyped(
       const test::integration::filters::SetIsTerminalFilterConfig& proto_config,
-      Server::Configuration::FactoryContext&) override {
+      Server::Configuration::ServerFactoryContext&) override {
     return proto_config.is_terminal_filter();
   }
 };

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -102,7 +102,7 @@ public:
 
   std::string name() const override { CONSTRUCT_ON_FIRST_USE(std::string, "envoy.test.router"); }
   bool isTerminalFilterByProto(const Protobuf::Message&,
-                               Server::Configuration::FactoryContext&) override {
+                               Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
 };

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -687,7 +687,7 @@ public:
   std::string name() const override { return "stats_test"; }
 
   bool isTerminalFilterByProto(const Protobuf::Message&,
-                               Server::Configuration::FactoryContext&) override {
+                               Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
 


### PR DESCRIPTION
Changing the filter factory classes to allow for upstream http factories, which take a ServerFactoryContext rather than a FactoryContext.

This also changes the type of isTerminalFilter.* which is not strictly speaking necessary, but makes for less copy-pasted template code.

Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/10455
