### PR TITLE
hcm: fix switch-case scopes in config

### DIFF
--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -595,8 +595,8 @@ Http::ServerConnectionPtr
 HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
                                          const Buffer::Instance& data,
                                          Http::ServerConnectionCallbacks& callbacks) {
-  switch (codec_type_)
-  case CodecType::HTTP1: {
+  switch (codec_type_) {
+  case CodecType::HTTP1:
     return std::make_unique<Http::Http1::ServerConnectionImpl>(
         connection, Http::Http1::CodecStats::atomicGet(http1_codec_stats_, context_.scope()),
         callbacks, http1_settings_, maxRequestHeadersKb(), maxRequestHeadersCount(),
@@ -623,7 +623,7 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
         http1_codec_stats_, http2_codec_stats_, http1_settings_, http2_options_,
         maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction());
   }
-    PANIC_DUE_TO_CORRUPT_ENUM;
+  PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
 void HttpConnectionManagerConfig::createFilterChain(Http::FilterChainManager& manager) {


### PR DESCRIPTION
Commit Message: hcm: fix switch-case scopes in config
Additional Description:
Fixing a strange curly-brackets scopes in a switch statement that was introduced in #22301.
This doesn't seem to impact the behavior after compilation, but fixes the readability of the code.

Risk Level: Low
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>