### PR TITLE
original_dst: fix leak of hosts in pools

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -178,16 +178,6 @@ public:
    * envoy.api.v2.endpoint.Endpoint.load_balancing_weight).
    */
   virtual void weight(uint32_t new_weight) PURE;
-
-  /**
-   * @return the current boolean value of host being in use.
-   */
-  virtual bool used() const PURE;
-
-  /**
-   * @param new_used supplies the new value of host being in use to be stored.
-   */
-  virtual void used(bool new_used) PURE;
 };
 
 using HostConstSharedPtr = std::shared_ptr<const Host>;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -230,8 +230,7 @@ public:
            uint32_t priority, const envoy::config::core::v3::HealthStatus health_status,
            TimeSource& time_source)
       : HostDescriptionImpl(cluster, hostname, address, metadata, locality, health_check_config,
-                            priority, time_source),
-        used_(true) {
+                            priority, time_source) {
     setEdsHealthFlag(health_status);
     HostImpl::weight(initial_weight);
   }
@@ -285,8 +284,6 @@ public:
 
   uint32_t weight() const override { return weight_; }
   void weight(uint32_t new_weight) override;
-  bool used() const override { return used_; }
-  void used(bool new_used) override { used_ = new_used; }
 
 protected:
   static CreateConnectionData
@@ -303,7 +300,6 @@ private:
 
   std::atomic<uint32_t> health_flags_{};
   std::atomic<uint32_t> weight_;
-  std::atomic<bool> used_;
 };
 
 class HostsPerLocalityImpl : public HostsPerLocality {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -196,8 +196,6 @@ public:
   MOCK_METHOD(LoadMetricStats&, loadMetricStats, (), (const));
   MOCK_METHOD(uint32_t, weight, (), (const));
   MOCK_METHOD(void, weight, (uint32_t new_weight));
-  MOCK_METHOD(bool, used, (), (const));
-  MOCK_METHOD(void, used, (bool new_used));
   MOCK_METHOD(const envoy::config::core::v3::Locality&, locality, (), (const));
   MOCK_METHOD(uint32_t, priority, (), (const));
   MOCK_METHOD(void, priority, (uint32_t));


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Address memory leak in concurrent host additions in ORIGINAL_DST clusters.
Additional Description: This is an attempt to avoid a global mutex on the cluster. The idea is to collect synthetic hosts for the same address and manage them collectively. Unfortunately, there's another issue present: GC might delete a host and post drain request before the connection to that host is fully established and violate an assertion (GC sees unset `used_` right before `chooseHost` returns it).

Risk Level: high
Testing: manual so far, fixes memory leak but another issue uncovered
Docs Changes: none
Release Notes: none