### PR TITLE
tls: set BIO::num to the underlying socket file descriptor

### DIFF
--- a/source/extensions/transport_sockets/tls/io_handle_bio.cc
+++ b/source/extensions/transport_sockets/tls/io_handle_bio.cc
@@ -133,7 +133,7 @@ BIO* BIO_new_io_handle(Envoy::Network::IoHandle* io_handle) {
   RELEASE_ASSERT(b != nullptr, "");
 
   // Initialize the BIO
-  b->num = -1;
+  b->num = io_handle->fdDoNotUse();
   b->ptr = io_handle;
   b->shutdown = 0;
   b->init = 1;


### PR DESCRIPTION
Signed-off-by: yzhao1012 <yzhao@pixielabs.ai>

Commit Message: Set BIO::num from IoHandle::fdDoNotUse()
Additional Description: This is to make sure it's a tracer can read the file descriptor from BIO::num.
Risk Level: Low
Testing: Manually built envoy and examine the results
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
