### PR TITLE
unhide custom settings option in protocol options

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -517,7 +517,6 @@ message Http2ProtocolOptions {
   // See `RFC7540, sec. 8.1 <https://tools.ietf.org/html/rfc7540#section-8.1>`_ for details.
   google.protobuf.BoolValue override_stream_error_on_invalid_http_message = 14;
 
-  // [#not-implemented-hide:]
   // Specifies SETTINGS frame parameters to be sent to the peer, with two exceptions:
   //
   // 1. SETTINGS_ENABLE_PUSH (0x2) is not configurable as HTTP/2 server push is not supported by


### PR DESCRIPTION
This has been implemented by https://github.com/envoyproxy/envoy/pull/9964
Commit Message:unhide custom settings option
Additional Description:unhide custom settings option in protocol options
Risk Level:N/A
Testing:N/A
Docs Changes:N/A
Release Notes:N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
