### PR TITLE
clarify resource warming docs in xds protocol

### DIFF
--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -669,13 +669,15 @@ Resource warming
 go through warming before they can serve requests. This process
 happens both during :ref:`Envoy initialization <arch_overview_initialization>`
 and when the ``Cluster`` or ``Listener`` is updated. Warming of
-``Cluster`` is completed only when a ``ClusterLoadAssignment`` response
-is supplied by management server. Similarly, warming of ``Listener`` is
-completed only when a ``RouteConfiguration`` is supplied by management
-server if the listener refers to an RDS configuration. Management server
-is expected to provide the EDS/RDS updates during warming. If management
-server does not provide EDS/RDS responses, Envoy will not initialize
-itself during the initialization phase and the updates sent via CDS/LDS
+``Cluster`` is completed only when a new ``ClusterLoadAssignment`` response
+is supplied by management server even though there is no change in endpoints.
+Similarly, warming of ``Listener`` is completed only when a ``RouteConfiguration``
+is supplied by management server if the listener refers to an RDS configuration.
+If Envoy is already aware of ``RouteConfiguration`` referenced by ``Listener``,
+it will use it otherwise Envoy will initiate a new RDS request with the new 
+route name referenced by ``Listener``. Management server is expected to provide
+the EDS/RDS updates during warming. If management server does not provide EDS/RDS responses, 
+Envoy will not initialize itself during the initialization phase and the updates sent via CDS/LDS
 will not take effect until EDS/RDS responses are supplied.
 
 .. _xds_protocol_eventual_consistency_considerations:

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -680,14 +680,14 @@ will not take effect until EDS/RDS responses are supplied.
 
 .. note::
 
-   Envoy specific implementation note: Warming of ``Cluster`` is completed only
-   when a new ``ClusterLoadAssignment`` response is supplied by management server
-   even if there is no change in endpoints. 
-   Warming of ``Listener`` is completed even if management server does not send a 
-   response for ``RouteConfiguration`` referenced by ``Listener``. Envoy will use the
-   previously sent ``RouteConfiguration`` to finish ``Listener`` warming. Management Server
-   has to send the ``RouteConfiguration`` response only if it has changed or it was never 
-   sent in the past.
+   Envoy specific implementation notes: 
+   * Warming of ``Cluster`` is completed only when a new ``ClusterLoadAssignment``
+     response is supplied by management server even if there is no change in endpoints.
+   * Warming of ``Listener`` is completed even if management server does not send a
+     response for ``RouteConfiguration`` referenced by ``Listener``. Envoy will use the
+     previously sent ``RouteConfiguration`` to finish ``Listener`` warming. Management Server
+     has to send the ``RouteConfiguration`` response only if it has changed or it was never
+     sent in the past.
 
 .. _xds_protocol_eventual_consistency_considerations:
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -679,12 +679,11 @@ itself during the initialization phase and the updates sent via CDS/LDS
 will not take effect until EDS/RDS responses are supplied.
 
 .. note::
-   Envoy specific implementation note: Warming of
-``Cluster`` is completed only when a new ``ClusterLoadAssignment`` response
-is supplied by management server even though there is no change in endpoints.
-However, If Envoy is already aware of ``RouteConfiguration`` referenced by ``Listener``,
-it will use it otherwise Envoy will initiate a new RDS request with the new
-route name referenced by ``Listener``.
+Envoy specific implementation note: Warming of ``Cluster`` is completed only
+when a new ``ClusterLoadAssignment`` response is supplied by management server
+even though there is no change in endpoints. However, If Envoy is already aware of
+``RouteConfiguration`` referenced by ``Listener``, it will use it otherwise Envoy will
+initiate a new RDS request with the new route name referenced by ``Listener``.
 
 .. _xds_protocol_eventual_consistency_considerations:
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -680,10 +680,11 @@ will not take effect until EDS/RDS responses are supplied.
 
 .. note::
 
-   Envoy specific implementation notes: 
-   * Warming of ``Cluster`` is completed only when a new ``ClusterLoadAssignment``
+   Envoy specific implementation notes:
+   
+   - Warming of ``Cluster`` is completed only when a new ``ClusterLoadAssignment``
      response is supplied by management server even if there is no change in endpoints.
-   * Warming of ``Listener`` is completed even if management server does not send a
+   - Warming of ``Listener`` is completed even if management server does not send a
      response for ``RouteConfiguration`` referenced by ``Listener``. Envoy will use the
      previously sent ``RouteConfiguration`` to finish ``Listener`` warming. Management Server
      has to send the ``RouteConfiguration`` response only if it has changed or it was never

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -682,9 +682,11 @@ will not take effect until EDS/RDS responses are supplied.
 
    Envoy specific implementation note: Warming of ``Cluster`` is completed only
    when a new ``ClusterLoadAssignment`` response is supplied by management server
-   even though there is no change in endpoints. However, If Envoy is already aware of
-   ``RouteConfiguration`` referenced by ``Listener``, it will use it otherwise Envoy will
-   initiate a new RDS request with the new route name referenced by ``Listener``.
+   even if there is no change in endpoints. 
+   Warming of ``Listener`` is completed even if management server does not send a 
+   response for ``RouteConfiguration`` referenced by ``Listener``. Envoy will use the
+   previously sent ``RouteConfiguration`` to finish ``Listener`` warming. Management Server
+   has to send the ``RouteConfiguration`` only if has changed or it was never sent in the past.
 
 .. _xds_protocol_eventual_consistency_considerations:
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -679,11 +679,12 @@ itself during the initialization phase and the updates sent via CDS/LDS
 will not take effect until EDS/RDS responses are supplied.
 
 .. note::
-Envoy specific implementation note: Warming of ``Cluster`` is completed only
-when a new ``ClusterLoadAssignment`` response is supplied by management server
-even though there is no change in endpoints. However, If Envoy is already aware of
-``RouteConfiguration`` referenced by ``Listener``, it will use it otherwise Envoy will
-initiate a new RDS request with the new route name referenced by ``Listener``.
+
+   Envoy specific implementation note: Warming of ``Cluster`` is completed only
+   when a new ``ClusterLoadAssignment`` response is supplied by management server
+   even though there is no change in endpoints. However, If Envoy is already aware of
+   ``RouteConfiguration`` referenced by ``Listener``, it will use it otherwise Envoy will
+   initiate a new RDS request with the new route name referenced by ``Listener``.
 
 .. _xds_protocol_eventual_consistency_considerations:
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -686,7 +686,8 @@ will not take effect until EDS/RDS responses are supplied.
    Warming of ``Listener`` is completed even if management server does not send a 
    response for ``RouteConfiguration`` referenced by ``Listener``. Envoy will use the
    previously sent ``RouteConfiguration`` to finish ``Listener`` warming. Management Server
-   has to send the ``RouteConfiguration`` only if has changed or it was never sent in the past.
+   has to send the ``RouteConfiguration`` response only if it has changed or it was never 
+   sent in the past.
 
 .. _xds_protocol_eventual_consistency_considerations:
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -674,9 +674,9 @@ is supplied by management server even though there is no change in endpoints.
 Similarly, warming of ``Listener`` is completed only when a ``RouteConfiguration``
 is supplied by management server if the listener refers to an RDS configuration.
 If Envoy is already aware of ``RouteConfiguration`` referenced by ``Listener``,
-it will use it otherwise Envoy will initiate a new RDS request with the new 
+it will use it otherwise Envoy will initiate a new RDS request with the new
 route name referenced by ``Listener``. Management server is expected to provide
-the EDS/RDS updates during warming. If management server does not provide EDS/RDS responses, 
+the EDS/RDS updates during warming. If management server does not provide EDS/RDS responses,
 Envoy will not initialize itself during the initialization phase and the updates sent via CDS/LDS
 will not take effect until EDS/RDS responses are supplied.
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -669,16 +669,22 @@ Resource warming
 go through warming before they can serve requests. This process
 happens both during :ref:`Envoy initialization <arch_overview_initialization>`
 and when the ``Cluster`` or ``Listener`` is updated. Warming of
+``Cluster`` is completed only when a ``ClusterLoadAssignment`` response
+is supplied by management server. Similarly, warming of ``Listener`` is
+completed only when a ``RouteConfiguration`` is supplied by management
+server if the listener refers to an RDS configuration. Management server
+is expected to provide the EDS/RDS updates during warming. If management
+server does not provide EDS/RDS responses, Envoy will not initialize
+itself during the initialization phase and the updates sent via CDS/LDS
+will not take effect until EDS/RDS responses are supplied.
+
+.. note::
+   Envoy specific implementation note: Warming of
 ``Cluster`` is completed only when a new ``ClusterLoadAssignment`` response
 is supplied by management server even though there is no change in endpoints.
-Similarly, warming of ``Listener`` is completed only when a ``RouteConfiguration``
-is supplied by management server if the listener refers to an RDS configuration.
-If Envoy is already aware of ``RouteConfiguration`` referenced by ``Listener``,
+However, If Envoy is already aware of ``RouteConfiguration`` referenced by ``Listener``,
 it will use it otherwise Envoy will initiate a new RDS request with the new
-route name referenced by ``Listener``. Management server is expected to provide
-the EDS/RDS updates during warming. If management server does not provide EDS/RDS responses,
-Envoy will not initialize itself during the initialization phase and the updates sent via CDS/LDS
-will not take effect until EDS/RDS responses are supplied.
+route name referenced by ``Listener``.
 
 .. _xds_protocol_eventual_consistency_considerations:
 

--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -681,7 +681,7 @@ will not take effect until EDS/RDS responses are supplied.
 .. note::
 
    Envoy specific implementation notes:
-   
+
    - Warming of ``Cluster`` is completed only when a new ``ClusterLoadAssignment``
      response is supplied by management server even if there is no change in endpoints.
    - Warming of ``Listener`` is completed even if management server does not send a


### PR DESCRIPTION
Clusters expect EDS response even if they do not change so EDS response is mandatory to finish warming. But listener use route configuration that Envoy is aware of and response is only needed for new routes. This PR clarifies that part in resource warming docs.

Commit Message:clarify resource warming docs in xds protocol
Additional Description:clarify resource warming docs in xds protocol
Risk Level:N/A
Testing:N/A
Docs Changes:N/A
Release Notes:N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
