### PR TITLE
nghttp: update code comments

### DIFF
--- a/source/common/http/http2/nghttp2.cc
+++ b/source/common/http/http2/nghttp2.cc
@@ -14,7 +14,7 @@ namespace Http {
 namespace Http2 {
 
 void initializeNghttp2Logging() {
-  // Event when ENVOY_NGHTTP2_TRACE is not set, we install a debug logger, to prevent nghttp2
+  // When ENVOY_NGHTTP2_TRACE is set, we install a debug logger, to prevent nghttp2
   // logging directly to stdout at -l trace.
   nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
     if (std::getenv("ENVOY_NGHTTP2_TRACE") != nullptr) {


### PR DESCRIPTION
Signed-off-by: Loong Dai <loong.dai@intel.com>

The current code flow is that install logger when ENVOY_NGHTTP2_TRACE is set, while the comment is the opposite.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
