### PR TITLE
multiple addresses listener: remove legacy interface

### DIFF
--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -149,12 +149,6 @@ public:
   virtual FilterChainFactory& filterChainFactory() PURE;
 
   /**
-   * TODO(soulxu): This will be removed when multiple addresses listener implemented.
-   * @return ListenSocketFactory& the factory to create listen socket.
-   */
-  virtual ListenSocketFactory& listenSocketFactory() PURE;
-
-  /**
    * @return std::vector<ListenSocketFactoryPtr>& the factories to create listen sockets.
    */
   virtual std::vector<ListenSocketFactoryPtr>& listenSocketFactories() PURE;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -389,10 +389,6 @@ private:
     // Network::ListenerConfig
     Network::FilterChainManager& filterChainManager() override { return parent_; }
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
-    Network::ListenSocketFactory& listenSocketFactory() override {
-      ASSERT(parent_.socket_factories_.size() == 1);
-      return *parent_.socket_factories_[0];
-    }
     std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
       return parent_.socket_factories_;
     }

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -299,7 +299,6 @@ public:
     return addresses_;
   }
   const envoy::config::listener::v3::Listener& config() const { return config_; }
-  const Network::ListenSocketFactory& getSocketFactory() const { return *socket_factories_[0]; }
   const std::vector<Network::ListenSocketFactoryPtr>& getSocketFactories() const {
     return socket_factories_;
   }

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -324,7 +324,6 @@ public:
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *filter_chain_manager_; }
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
-  Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
   std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
     return socket_factories_;
   }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1044,8 +1044,8 @@ void ListenerManagerImpl::setNewOrDrainingSocketFactory(const std::string& name,
         draining_filter_chains_manager_.cbegin(), draining_filter_chains_manager_.cend(),
         [&listener](const DrainingFilterChainsManager& draining_filter_chain) {
           return draining_filter_chain.getDrainingListener()
-                     .listenSocketFactory()
-                     .getListenSocket(0)
+                     .listenSocketFactories()[0]
+                     ->getListenSocket(0)
                      ->isOpen() &&
                  listener.hasCompatibleAddress(draining_filter_chain.getDrainingListener());
         });

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -92,9 +92,10 @@ protected:
     listen_socket_->addOptions(Network::SocketOptionFactory::buildRxQueueOverFlowOptions());
     ASSERT_TRUE(Network::Socket::applyOptions(listen_socket_->options(), *listen_socket_,
                                               envoy::config::core::v3::SocketOption::STATE_BOUND));
-
-    ON_CALL(listener_config_, listenSocketFactory()).WillByDefault(ReturnRef(socket_factory_));
-    ON_CALL(socket_factory_, getListenSocket(_)).WillByDefault(Return(listen_socket_));
+    EXPECT_CALL(*static_cast<Network::MockListenSocketFactory*>(
+                    listener_config_.socket_factories_[0].get()),
+                getListenSocket(_))
+        .WillRepeatedly(Return(listen_socket_));
 
     // Use UdpGsoBatchWriter to perform non-batched writes for the purpose of this test, if it is
     // supported.
@@ -121,7 +122,7 @@ protected:
     quic_listener_ =
         staticUniquePointerCast<ActiveQuicListener>(listener_factory_->createActiveUdpListener(
             scoped_runtime_.loader(), 0, connection_handler_,
-            listener_config_.listenSocketFactory().getListenSocket(0), *dispatcher_,
+            listener_config_.socket_factories_[0]->getListenSocket(0), *dispatcher_,
             listener_config_));
     quic_dispatcher_ = ActiveQuicListenerPeer::quicDispatcher(*quic_listener_);
     quic::QuicCryptoServerConfig& crypto_config =

--- a/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
+++ b/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
@@ -293,7 +293,6 @@ public:
                                                      : *inline_filter_chain_manager_;
     }
     Network::FilterChainFactory& filterChainFactory() override { return parent_.factory_; }
-    Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
     std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
       return socket_factories_;
     }

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -67,7 +67,6 @@ public:
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
-  Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
   std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
     return socket_factories_;
   }

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -48,7 +48,6 @@ public:
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
-  Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
   std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
     return socket_factories_;
   }

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -84,7 +84,6 @@ public:
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
-  Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
   std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
     return socket_factories_;
   }
@@ -1787,7 +1786,6 @@ public:
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
-  Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
   std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
     return socket_factories_;
   }

--- a/test/extensions/filters/network/echo/echo_integration_test.cc
+++ b/test/extensions/filters/network/echo/echo_integration_test.cc
@@ -78,8 +78,8 @@ filter_chains:
                                    .listenerManager()
                                    .listeners()[1]
                                    .get()
-                                   .listenSocketFactory()
-                                   .localAddress()
+                                   .listenSocketFactories()[0]
+                                   ->localAddress()
                                    ->ip()
                                    ->port();
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -826,9 +826,6 @@ private:
     // Network::ListenerConfig
     Network::FilterChainManager& filterChainManager() override { return parent_; }
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
-    Network::ListenSocketFactory& listenSocketFactory() override {
-      return *parent_.socket_factories_[0];
-    }
     std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
       return parent_.socket_factories_;
     }

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -349,9 +349,10 @@ TEST_P(IntegrationAdminTest, Admin) {
        ++listener_info_it, ++listener_it) {
     auto local_address = (*listener_info_it)->getObject("local_address");
     auto socket_address = local_address->getObject("socket_address");
-    EXPECT_EQ(listener_it->get().listenSocketFactory().localAddress()->ip()->addressAsString(),
-              socket_address->getString("address"));
-    EXPECT_EQ(listener_it->get().listenSocketFactory().localAddress()->ip()->port(),
+    EXPECT_EQ(
+        listener_it->get().listenSocketFactories()[0]->localAddress()->ip()->addressAsString(),
+        socket_address->getString("address"));
+    EXPECT_EQ(listener_it->get().listenSocketFactories()[0]->localAddress()->ip()->port(),
               socket_address->getInteger("port_value"));
 
     std::vector<Json::ObjectSharedPtr> additional_local_addresses =

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -132,7 +132,7 @@ void IntegrationTestServer::start(
   if (tap_path) {
     std::vector<uint32_t> ports;
     for (auto listener : server().listenerManager().listeners()) {
-      const auto listen_addr = listener.get().listenSocketFactory().localAddress();
+      const auto listen_addr = listener.get().listenSocketFactories()[0]->localAddress();
       if (listen_addr->type() == Network::Address::Type::Ip) {
         ports.push_back(listen_addr->ip()->port());
       }

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -36,7 +36,6 @@ MockListenerConfig::MockListenerConfig()
     : socket_(std::make_shared<testing::NiceMock<MockListenSocket>>()) {
   socket_factories_.emplace_back(std::make_unique<MockListenSocketFactory>());
   ON_CALL(*this, filterChainFactory()).WillByDefault(ReturnRef(filter_chain_factory_));
-  ON_CALL(*this, listenSocketFactory()).WillByDefault(ReturnRef(*socket_factories_[0].get()));
   ON_CALL(*this, listenSocketFactories()).WillByDefault(ReturnRef(socket_factories_));
   ON_CALL(*static_cast<MockListenSocketFactory*>(socket_factories_[0].get()), localAddress())
       .WillByDefault(ReturnRef(socket_->connectionInfoProvider().localAddress()));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -426,7 +426,6 @@ public:
 
   MOCK_METHOD(FilterChainManager&, filterChainManager, ());
   MOCK_METHOD(FilterChainFactory&, filterChainFactory, ());
-  MOCK_METHOD(ListenSocketFactory&, listenSocketFactory, ());
   MOCK_METHOD(std::vector<ListenSocketFactoryPtr>&, listenSocketFactories, ());
   MOCK_METHOD(bool, bindToPort, (), (const));
   MOCK_METHOD(bool, handOffRestoredDestinationConnections, (), (const));

--- a/test/mocks/server/worker.cc
+++ b/test/mocks/server/worker.cc
@@ -17,7 +17,7 @@ MockWorker::MockWorker() {
                                    Network::ListenerConfig& config,
                                    AddListenerCompletion completion, Runtime::Loader&) -> void {
         UNREFERENCED_PARAMETER(overridden_listener);
-        config.listenSocketFactory().getListenSocket(0);
+        config.listenSocketFactories()[0]->getListenSocket(0);
         EXPECT_EQ(nullptr, add_listener_completion_);
         add_listener_completion_ = completion;
       }));

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -93,7 +93,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/watchdog:83.3" # Death tests within extensions
 "source/extensions/watchdog/profile_action:83.3"
 "source/server:93.3" # flaky: be careful adjusting. See https://github.com/envoyproxy/envoy/issues/15239
-"source/server/admin:97.4" # TODO(soulxu) try to raise this back to `97.6` when multiple addresses listener implemented and the old interface of Network::ListenerConfig is removed.
+"source/server/admin:97.6"
 "source/server/config_validation:74.8"
 )
 

--- a/test/server/active_udp_listener_test.cc
+++ b/test/server/active_udp_listener_test.cc
@@ -66,8 +66,10 @@ public:
     ASSERT_TRUE(Network::Socket::applyOptions(listen_socket_->options(), *listen_socket_,
                                               envoy::config::core::v3::SocketOption::STATE_BOUND));
 
-    ON_CALL(socket_factory_, getListenSocket(_)).WillByDefault(Return(listen_socket_));
-    EXPECT_CALL(listener_config_, listenSocketFactory()).WillRepeatedly(ReturnRef(socket_factory_));
+    ON_CALL(*static_cast<Network::MockListenSocketFactory*>(
+                listener_config_.socket_factories_[0].get()),
+            getListenSocket(_))
+        .WillByDefault(Return(listen_socket_));
 
     // Use UdpGsoBatchWriter to perform non-batched writes for the purpose of this test, if it is
     // supported.

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -127,7 +127,6 @@ public:
                                                      : *inline_filter_chain_manager_;
     }
     Network::FilterChainFactory& filterChainFactory() override { return parent_.factory_; }
-    Network::ListenSocketFactory& listenSocketFactory() override { return *socket_factories_[0]; }
     std::vector<Network::ListenSocketFactoryPtr>& listenSocketFactories() override {
       return socket_factories_;
     }

--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -142,7 +142,7 @@ filter_chain_matcher:
                    ->listenerFactory()
                    .isTransportConnectionless());
   Network::SocketSharedPtr listen_socket =
-      manager_->listeners().front().get().listenSocketFactory().getListenSocket(0);
+      manager_->listeners().front().get().listenSocketFactories()[0]->getListenSocket(0);
 
   Network::UdpPacketWriterPtr udp_packet_writer =
       manager_->listeners()
@@ -231,7 +231,7 @@ TEST_P(ListenerManagerImplQuicOnlyTest, QuicWriterFromConfig) {
                    ->listenerFactory()
                    .isTransportConnectionless());
   Network::SocketSharedPtr listen_socket =
-      manager_->listeners().front().get().listenSocketFactory().getListenSocket(0);
+      manager_->listeners().front().get().listenSocketFactories()[0]->getListenSocket(0);
 
   Network::UdpPacketWriterFactory& udp_packet_writer_factory =
       manager_->listeners().front().get().udpListenerConfig()->packetWriterFactory();

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -7223,7 +7223,7 @@ address:
   addOrUpdateListener(listener);
   EXPECT_EQ(1U, manager_->listeners().size());
   Network::SocketSharedPtr listen_socket =
-      manager_->listeners().front().get().listenSocketFactory().getListenSocket(0);
+      manager_->listeners().front().get().listenSocketFactories()[0]->getListenSocket(0);
   Network::UdpPacketWriterPtr udp_packet_writer =
       manager_->listeners()
           .front()


### PR DESCRIPTION
Commit Message: multiple addresses listener: remove the legacy interface
Additional Description:
Since the multiple addresses listener is implemented,  all the code moves to use the new multiple socket factories interface, then those old single socket factory interfaces can be removed now.
Risk Level: low
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Fixes #11184
