### PR TITLE
listener: fix flaky listener integration test

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -824,9 +824,7 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterInPlaceUpdate) {
   auto codec1 =
       makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
   // The socket are closed asynchronously, so waiting the connection closed here.
-  while (codec1->connected()) {
-    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-  }
+  ASSERT_TRUE(codec1->waitForDisconnect());
 
   // Test the connection again to ensure the socket is closed.
   auto codec2 =
@@ -918,9 +916,7 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterMultipleInPlaceUpdate) {
   auto codec1 =
       makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
   // The socket are closed asynchronously, so waiting the connection closed here.
-  while (codec1->connected()) {
-    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-  }
+  ASSERT_TRUE(codec1->waitForDisconnect());
 
   // Test the connection again to ensure the socket is closed.
   auto codec2 =

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -821,10 +821,18 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterInPlaceUpdate) {
 
   // All the listen socket are closed. include the sockets in the active listener and
   // the sockets in the filter chain draining listener. The new connection should be reset.
-  auto codec =
+  auto codec1 =
       makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  EXPECT_FALSE(codec->connected());
-  EXPECT_THAT(codec->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+  // The socket are closed asynchronously, so waiting the connection closed here.
+  while (codec1->connected()) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  // Test the connection again to ensure the socket is closed.
+  auto codec2 =
+      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
+  EXPECT_FALSE(codec2->connected());
+  EXPECT_THAT(codec2->connection()->transportFailureReason(), StartsWith("delayed connect error"));
 
   // Ensure the old listener is still in filter chain draining.
   test_server_->waitForGaugeEq("listener_manager.total_filter_chains_draining", 1);
@@ -907,10 +915,18 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterMultipleInPlaceUpdate) {
 
   // All the listen socket are closed. include the sockets in the active listener and
   // the sockets in the filter chain draining listener. The new connection should be reset.
-  auto codec =
+  auto codec1 =
       makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  EXPECT_FALSE(codec->connected());
-  EXPECT_THAT(codec->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+  // The socket are closed asynchronously, so waiting the connection closed here.
+  while (codec1->connected()) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  // Test the connection again to ensure the socket is closed.
+  auto codec2 =
+      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
+  EXPECT_FALSE(codec2->connected());
+  EXPECT_THAT(codec2->connection()->transportFailureReason(), StartsWith("delayed connect error"));
 
   // Ensure the old listener is still in filter chain draining.
   test_server_->waitForGaugeEq("listener_manager.total_filter_chains_draining", 2);


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: listener: fix flaky listener integration test
Additional Description:
The listener socket is closed async https://github.com/envoyproxy/envoy/blob/3f0efa989f9776a8e1fcff3b1d1464da66aecb7e/source/server/listener_manager_impl.cc#L561-L567

So there can be a chance the listener was removed, but the socket doesn't remove yet.

Risk Level: low
Testing: integration test
Docs Changes: n/a 
Release Notes: n/a
Platform Specific Features: n/a
Fixes #22348

