### PR TITLE
filter:manager change metadata and downstream APIs.

### DIFF
--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -729,6 +729,14 @@ public:
     upstream_info.setDownstreamBytesMeter(downstream_info.getDownstreamBytesMeter());
   }
 
+  /**
+   * Dump the info to the specified ostream.
+   *
+   * @param os the ostream to dump state to
+   * @param indent_level the depth, for pretty-printing.
+   *
+   * This function is called on Envoy fatal errors so should avoid memory allocation.
+   */
   virtual void dumpState(std::ostream& os, int indent_level = 0) const PURE;
 };
 

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -728,6 +728,8 @@ public:
     downstream_info.setUpstreamBytesMeter(upstream_info.getUpstreamBytesMeter());
     upstream_info.setDownstreamBytesMeter(downstream_info.getDownstreamBytesMeter());
   }
+
+  virtual void dumpState(std::ostream& os, int indent_level = 0) const PURE;
 };
 
 // An enum representation of the Proxy-Status error space.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1527,9 +1527,11 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ResponseTrailerMap& tra
   response_encoder_->encodeTrailers(trailers);
 }
 
-void ConnectionManagerImpl::ActiveStream::encodeMetadata(MetadataMapVector& metadata) {
-  ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, metadata);
-  response_encoder_->encodeMetadata(metadata);
+void ConnectionManagerImpl::ActiveStream::encodeMetadata(MetadataMapPtr&& metadata) {
+  MetadataMapVector metadata_map_vector;
+  metadata_map_vector.emplace_back(std::move(metadata));
+  ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, metadata_map_vector);
+  response_encoder_->encodeMetadata(metadata_map_vector);
 }
 
 void ConnectionManagerImpl::ActiveStream::onDecoderFilterBelowWriteBufferLowWatermark() {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -220,7 +220,7 @@ private:
     void encode1xxHeaders(ResponseHeaderMap& response_headers) override;
     void encodeData(Buffer::Instance& data, bool end_stream) override;
     void encodeTrailers(ResponseTrailerMap& trailers) override;
-    void encodeMetadata(MetadataMapVector& metadata) override;
+    void encodeMetadata(MetadataMapPtr&& metadata) override;
     void setRequestTrailers(Http::RequestTrailerMapPtr&& request_trailers) override {
       ASSERT(!request_trailers_);
       request_trailers_ = std::move(request_trailers);
@@ -365,7 +365,7 @@ private:
 
     // Note: The FM must outlive the above headers, as they are possibly accessed during filter
     // destruction.
-    FilterManager filter_manager_;
+    DownstreamFilterManager filter_manager_;
 
     Router::ConfigConstSharedPtr snapped_route_config_;
     Router::ScopedConfigConstSharedPtr snapped_scoped_routes_config_;

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -30,6 +30,7 @@ namespace Envoy {
 namespace Http {
 
 class FilterManager;
+class DownstreamFilterManager;
 
 struct ActiveStreamFilterBase;
 
@@ -354,7 +355,7 @@ public:
    * Called when the provided metadata has been encoded by all filters in the chain.
    * @param trailers the encoded trailers.
    */
-  virtual void encodeMetadata(MetadataMapVector& metadata) PURE;
+  virtual void encodeMetadata(MetadataMapPtr&& metadata) PURE;
 
   /**
    * Injects request trailers into a stream that originally did not have request trailers.
@@ -612,16 +613,11 @@ public:
   FilterManager(FilterManagerCallbacks& filter_manager_callbacks, Event::Dispatcher& dispatcher,
                 const Network::Connection& connection, uint64_t stream_id,
                 Buffer::BufferMemoryAccountSharedPtr account, bool proxy_100_continue,
-                uint32_t buffer_limit, FilterChainFactory& filter_chain_factory,
-                const LocalReply::LocalReply& local_reply, Http::Protocol protocol,
-                TimeSource& time_source, StreamInfo::FilterStateSharedPtr parent_filter_state,
-                StreamInfo::FilterState::LifeSpan filter_state_life_span)
+                uint32_t buffer_limit, FilterChainFactory& filter_chain_factory)
       : filter_manager_callbacks_(filter_manager_callbacks), dispatcher_(dispatcher),
         connection_(connection), stream_id_(stream_id), account_(std::move(account)),
         proxy_100_continue_(proxy_100_continue), buffer_limit_(buffer_limit),
-        filter_chain_factory_(filter_chain_factory), local_reply_(local_reply),
-        stream_info_(protocol, time_source, connection.connectionInfoProviderSharedPtr(),
-                     parent_filter_state, filter_state_life_span) {}
+        filter_chain_factory_(filter_chain_factory) {}
   ~FilterManager() override {
     ASSERT(state_.destroyed_);
     ASSERT(state_.filter_call_state_ == 0);
@@ -636,7 +632,7 @@ public:
     DUMP_DETAILS(filter_manager_callbacks_.requestTrailers());
     DUMP_DETAILS(filter_manager_callbacks_.responseHeaders());
     DUMP_DETAILS(filter_manager_callbacks_.responseTrailers());
-    DUMP_DETAILS(&stream_info_);
+    DUMP_DETAILS(&streamInfo());
   }
 
   void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) {
@@ -684,7 +680,7 @@ public:
     }
 
     for (const auto& log_handler : access_log_handlers_) {
-      log_handler->log(request_headers, response_headers, response_trailers, stream_info_);
+      log_handler->log(request_headers, response_headers, response_trailers, streamInfo());
     }
   }
 
@@ -754,33 +750,10 @@ public:
    */
   void maybeEndEncode(bool end_stream);
 
-  /**
-   * Called before local reply is made by the filter manager.
-   * @param data the data associated with the local reply.
-   */
-  void onLocalReply(StreamFilterBase::LocalReplyData& data);
-
-  void sendLocalReply(Code code, absl::string_view body,
-                      const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
-                      absl::string_view details);
-  /**
-   * Sends a local reply by constructing a response and passing it through all the encoder
-   * filters. The resulting response will be passed out via the FilterManagerCallbacks.
-   */
-  void sendLocalReplyViaFilterChain(
-      bool is_grpc_request, Code code, absl::string_view body,
-      const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
-      const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details);
-
-  /**
-   * Sends a local reply by constructing a response and skipping the encoder filters. The
-   * resulting response will be passed out via the FilterManagerCallbacks.
-   */
-  void sendDirectLocalReply(Code code, absl::string_view body,
-                            const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                            bool is_head_request,
-                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status);
+  virtual void sendLocalReply(Code code, absl::string_view body,
+                              const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
+                              const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                              absl::string_view details) PURE;
 
   // Possibly increases buffer_limit_ to the value of limit.
   void setBufferLimit(uint32_t limit);
@@ -818,8 +791,8 @@ public:
    * Whether remote processing has been marked as complete.
    */
   bool remoteDecodeComplete() const {
-    return stream_info_.downstreamTiming() &&
-           stream_info_.downstreamTiming()->lastDownstreamRxByteReceived().has_value();
+    return streamInfo().downstreamTiming() &&
+           streamInfo().downstreamTiming()->lastDownstreamRxByteReceived().has_value();
   }
 
   /**
@@ -831,13 +804,8 @@ public:
     state_.created_filter_chain_ = true;
   }
 
-  // TODO(snowp): This should probably return a StreamInfo instead of the impl.
-  StreamInfo::StreamInfoImpl& streamInfo() { return stream_info_; }
-  const StreamInfo::StreamInfoImpl& streamInfo() const { return stream_info_; }
-  void setDownstreamRemoteAddress(
-      const Network::Address::InstanceConstSharedPtr& downstream_remote_address) {
-    stream_info_.setDownstreamRemoteAddress(downstream_remote_address);
-  }
+  virtual StreamInfo::StreamInfo& streamInfo() PURE;
+  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
 
   // Set up the Encoder/Decoder filter chain.
   bool createFilterChain();
@@ -854,6 +822,7 @@ public:
   void onDownstreamReset() { state_.saw_downstream_reset_ = true; }
 
 private:
+  friend class DownstreamFilterManager;
   class FilterChainFactoryCallbacksImpl : public Http::FilterChainFactoryCallbacks {
   public:
     FilterChainFactoryCallbacksImpl(FilterManager& manager, const Http::FilterContext& context)
@@ -977,8 +946,6 @@ private:
   absl::optional<absl::string_view> upstream_override_host_;
 
   FilterChainFactory& filter_chain_factory_;
-  const LocalReply::LocalReply& local_reply_;
-  OverridableRemoteConnectionInfoSetterStreamInfo stream_info_;
   // TODO(snowp): Once FM has been moved to its own file we'll make these private classes of FM,
   // at which point they no longer need to be friends.
   friend ActiveStreamFilterBase;
@@ -1050,6 +1017,68 @@ private:
   };
 
   State state_;
+};
+
+// The DownstreamFilterManager has explicit handling to send local replies.
+// The UpstreamFilterManager will not, and will instead defer local reply
+// management to the DownstreamFilterManager.
+class DownstreamFilterManager : public FilterManager {
+public:
+  DownstreamFilterManager(FilterManagerCallbacks& filter_manager_callbacks,
+                          Event::Dispatcher& dispatcher, const Network::Connection& connection,
+                          uint64_t stream_id, Buffer::BufferMemoryAccountSharedPtr account,
+                          bool proxy_100_continue, uint32_t buffer_limit,
+                          FilterChainFactory& filter_chain_factory,
+                          const LocalReply::LocalReply& local_reply, Http::Protocol protocol,
+                          TimeSource& time_source,
+                          StreamInfo::FilterStateSharedPtr parent_filter_state,
+                          StreamInfo::FilterState::LifeSpan filter_state_life_span)
+      : FilterManager(filter_manager_callbacks, dispatcher, connection, stream_id, account,
+                      proxy_100_continue, buffer_limit, filter_chain_factory),
+        stream_info_(protocol, time_source, connection.connectionInfoProviderSharedPtr(),
+                     parent_filter_state, filter_state_life_span),
+        local_reply_(local_reply) {}
+
+  // TODO(snowp): This should probably return a StreamInfo instead of the impl.
+  StreamInfo::StreamInfoImpl& streamInfo() override { return stream_info_; }
+  const StreamInfo::StreamInfoImpl& streamInfo() const override { return stream_info_; }
+
+  void setDownstreamRemoteAddress(
+      const Network::Address::InstanceConstSharedPtr& downstream_remote_address) {
+    stream_info_.setDownstreamRemoteAddress(downstream_remote_address);
+  }
+
+  /**
+   * Called before local reply is made by the filter manager.
+   * @param data the data associated with the local reply.
+   */
+  void onLocalReply(StreamFilterBase::LocalReplyData& data);
+
+  void sendLocalReply(Code code, absl::string_view body,
+                      const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
+                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      absl::string_view details) override;
+  /**
+   * Sends a local reply by constructing a response and passing it through all the encoder
+   * filters. The resulting response will be passed out via the FilterManagerCallbacks.
+   */
+  void sendLocalReplyViaFilterChain(
+      bool is_grpc_request, Code code, absl::string_view body,
+      const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
+      const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details);
+
+  /**
+   * Sends a local reply by constructing a response and skipping the encoder filters. The
+   * resulting response will be passed out via the FilterManagerCallbacks.
+   */
+  void sendDirectLocalReply(Code code, absl::string_view body,
+                            const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
+                            bool is_head_request,
+                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status);
+
+private:
+  OverridableRemoteConnectionInfoSetterStreamInfo stream_info_;
+  const LocalReply::LocalReply& local_reply_;
 };
 
 } // namespace Http

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -260,7 +260,7 @@ struct StreamInfoImpl : public StreamInfo {
   void setTraceReason(Tracing::Reason reason) override { trace_reason_ = reason; }
   Tracing::Reason traceReason() const override { return trace_reason_; }
 
-  void dumpState(std::ostream& os, int indent_level = 0) const {
+  void dumpState(std::ostream& os, int indent_level = 0) const override {
     const char* spaces = spacesForLevel(indent_level);
     os << spaces << "StreamInfoImpl " << this << DUMP_OPTIONAL_MEMBER(protocol_)
        << DUMP_OPTIONAL_MEMBER(response_code_) << DUMP_OPTIONAL_MEMBER(response_code_details_)

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -27,7 +27,7 @@ namespace {
 class FilterManagerTest : public testing::Test {
 public:
   void initialize() {
-    filter_manager_ = std::make_unique<FilterManager>(
+    filter_manager_ = std::make_unique<DownstreamFilterManager>(
         filter_manager_callbacks_, dispatcher_, connection_, 0, nullptr, true, 10000,
         filter_factory_, local_reply_, protocol_, time_source_, filter_state_,
         StreamInfo::FilterState::LifeSpan::Connection);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -62,7 +62,7 @@ public:
   MOCK_METHOD(void, encode1xxHeaders, (ResponseHeaderMap&));
   MOCK_METHOD(void, encodeData, (Buffer::Instance&, bool));
   MOCK_METHOD(void, encodeTrailers, (ResponseTrailerMap&));
-  MOCK_METHOD(void, encodeMetadata, (MetadataMapVector&));
+  MOCK_METHOD(void, encodeMetadata, (MetadataMapPtr &&));
   MOCK_METHOD(void, chargeStats, (const ResponseHeaderMap&));
   MOCK_METHOD(void, setRequestTrailers, (RequestTrailerMapPtr &&));
   MOCK_METHOD(void, setInformationalHeaders_, (ResponseHeaderMap&));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -130,6 +130,7 @@ public:
   MOCK_METHOD(const BytesMeterSharedPtr&, getDownstreamBytesMeter, (), (const));
   MOCK_METHOD(void, setUpstreamBytesMeter, (const BytesMeterSharedPtr&));
   MOCK_METHOD(void, setDownstreamBytesMeter, (const BytesMeterSharedPtr&));
+  MOCK_METHOD(void, dumpState, (std::ostream & os, int indent_level), (const));
   Envoy::Event::SimulatedTimeSystem ts_;
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;


### PR DESCRIPTION
Signed-off-by: Alyssa Wilk <alyssar@chromium.org>
This PR does two things.  

1) it moves the translation of metadata map types to the HCM, so we consistently use MetadataMapPtr&& everywhere in between the upstream codec and the downstream codec and
2) start moving downstream-only code out of the generic FM base class into a downstream-specific base class.  Specifically I'm claiming (and documenting) that if an upstream filter sends a local reply, as the response is not generated by the cluster so should only traverse the downstream filter chain, so UpstreamFM sendLocal Reply will just forward sendLocalReply to the DownstreamFM and HCM. 

Risk Level: low (minor refactors)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/10455