### PR TITLE
Make TypedLoadBalancerFactory a TypedFactory

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -218,7 +218,7 @@ using ThreadAwareLoadBalancerPtr = std::unique_ptr<ThreadAwareLoadBalancer>;
  * load_balancing_policy must be registered with Envoy. Envoy will use the first policy for which
  * it has a registered factory.
  */
-class TypedLoadBalancerFactory : public Config::UntypedFactory {
+class TypedLoadBalancerFactory : public Config::TypedFactory {
 public:
   ~TypedLoadBalancerFactory() override = default;
 

--- a/test/integration/load_balancers/BUILD
+++ b/test/integration/load_balancers/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
     "envoy_package",
+    "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
@@ -17,8 +18,14 @@ envoy_cc_test_library(
         "custom_lb_policy.h",
     ],
     deps = [
+        ":config_cc_proto",
         "//envoy/upstream:load_balancer_interface",
         "//source/common/upstream:load_balancer_factory_base_lib",
         "//test/test_common:registry_lib",
     ],
+)
+
+envoy_proto_library(
+    name = "config",
+    srcs = [":config.proto"],
 )

--- a/test/integration/load_balancers/config.proto
+++ b/test/integration/load_balancers/config.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package test.integration.custom_lb;
+
+message CustomLbConfig {
+}

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -4,6 +4,7 @@
 
 #include "source/common/upstream/load_balancer_factory_base.h"
 
+#include "test/integration/load_balancers/config.pb.h"
 #include "test/test_common/registry.h"
 
 namespace Envoy {
@@ -56,6 +57,10 @@ private:
 class CustomLbFactory : public Upstream::TypedLoadBalancerFactoryBase {
 public:
   CustomLbFactory() : TypedLoadBalancerFactoryBase("envoy.load_balancers.custom_lb") {}
+
+  Envoy::ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return Envoy::ProtobufTypes::MessagePtr{new ::test::integration::custom_lb::CustomLbConfig()};
+  }
 
   Upstream::ThreadAwareLoadBalancerPtr
   create(const Upstream::PrioritySet&, Upstream::ClusterStats&, Stats::Scope&, Runtime::Loader&,

--- a/test/mocks/upstream/typed_load_balancer_factory.h
+++ b/test/mocks/upstream/typed_load_balancer_factory.h
@@ -18,6 +18,12 @@ public:
               (const PrioritySet& priority_set, ClusterStats& stats, Stats::Scope& stats_scope,
                Runtime::Loader& runtime, Random::RandomGenerator& random,
                const ::envoy::config::cluster::v3::LoadBalancingPolicy_Policy& lb_policy));
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    // Using Struct instead of a custom per-filter empty config proto
+    // This is only allowed in tests.
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Struct()};
+  }
 };
 } // namespace Upstream
 } // namespace Envoy


### PR DESCRIPTION
Note: this is a breaking change for any TypedLoadBalancerFactory that does not currently implement `createEmptyConfigProto()`.

Signed-off-by: Eugene Chan <eugenechan@google.com>

Commit Message: Make TypedLoadBalancerFactory a TypedFactory
Additional Description: It's currently an UntypedFactory.
Risk Level: low
Testing: modified the existing CI tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a