### PR TITLE
comptiable with openmetrics that removing blank line on prometheus metrics 

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -9,9 +9,9 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
-- area: prometheus stats
+- area: prometheus_stats
   change: |
-    removed blank line for comptiable with openmetrics
+    removed blank line for being compatible with OpenMetrics.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -9,6 +9,9 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: prometheus stats
+  change: |
+    removed blank line for comptiable with openmetrics
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/server/admin/prometheus_stats.cc
+++ b/source/server/admin/prometheus_stats.cc
@@ -158,7 +158,6 @@ uint64_t outputStatType(
     for (const auto& metric : group.second) {
       response.add(generate_output(*metric, prefixed_tag_extracted_name.value()));
     }
-    response.add("\n");
   }
   return result;
 }

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -473,16 +473,12 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithTextReadoutsInGaugeFormat) {
 
   const std::string expected_output = R"EOF(# TYPE envoy_cluster_upstream_cx_total_count counter
 envoy_cluster_upstream_cx_total_count{cluster="c1"} 0
-
 # TYPE envoy_cluster_upstream_cx_total gauge
 envoy_cluster_upstream_cx_total{cluster="c1"} 0
-
 # TYPE envoy_control_plane_identifier gauge
 envoy_control_plane_identifier{cluster="c1",text_value="CP-1"} 0
-
 # TYPE envoy_invalid_tag_values gauge
 envoy_invalid_tag_values{tag1="\\",tag2="\n",tag3="\"",text_value="test"} 0
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -256,7 +256,6 @@ envoy_histogram1_bucket{le="3600000"} 0
 envoy_histogram1_bucket{le="+Inf"} 0
 envoy_histogram1_sum{} 0
 envoy_histogram1_count{} 0
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());
@@ -325,7 +324,6 @@ envoy_histogram1_bucket{le="1"} 2
 envoy_histogram1_bucket{le="+Inf"} 3
 envoy_histogram1_sum{} 2.2599999999999997868371792719699
 envoy_histogram1_count{} 3
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());
@@ -377,7 +375,6 @@ envoy_histogram1_bucket{le="3600000"} 101100000
 envoy_histogram1_bucket{le="+Inf"} 101100000
 envoy_histogram1_sum{} 105105105000
 envoy_histogram1_count{} 101100000
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());
@@ -419,22 +416,16 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithAllMetricTypes) {
 
   const std::string expected_output = R"EOF(# TYPE envoy_cluster_test_1_upstream_cx_total counter
 envoy_cluster_test_1_upstream_cx_total{a_tag_name="a.tag-value"} 0
-
 # TYPE envoy_cluster_test_2_upstream_cx_total counter
 envoy_cluster_test_2_upstream_cx_total{another_tag_name="another_tag-value"} 0
-
 # TYPE myapp_test_foo counter
 myapp_test_foo{tag_name="tag-value"} 0
-
 # TYPE envoy_cluster_test_3_upstream_cx_total gauge
 envoy_cluster_test_3_upstream_cx_total{another_tag_name_3="another_tag_3-value"} 0
-
 # TYPE envoy_cluster_test_4_upstream_cx_total gauge
 envoy_cluster_test_4_upstream_cx_total{another_tag_name_4="another_tag_4-value"} 0
-
 # TYPE MYAPP_test_bar gauge
 MYAPP_test_bar{tag_name="tag-value"} 0
-
 # TYPE envoy_cluster_test_1_upstream_rq_time histogram
 envoy_cluster_test_1_upstream_rq_time_bucket{key1="value1",key2="value2",le="0.5"} 0
 envoy_cluster_test_1_upstream_rq_time_bucket{key1="value1",key2="value2",le="1"} 0
@@ -458,7 +449,6 @@ envoy_cluster_test_1_upstream_rq_time_bucket{key1="value1",key2="value2",le="360
 envoy_cluster_test_1_upstream_rq_time_bucket{key1="value1",key2="value2",le="+Inf"} 7
 envoy_cluster_test_1_upstream_rq_time_sum{key1="value1",key2="value2"} 5532
 envoy_cluster_test_1_upstream_rq_time_count{key1="value1",key2="value2"} 7
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());
@@ -537,22 +527,18 @@ TEST_F(PrometheusStatsFormatterTest, OutputSortedByMetricName) {
 envoy_cluster_upstream_cx_connect_fail{cluster="aaa"} 0
 envoy_cluster_upstream_cx_connect_fail{cluster="bbb"} 0
 envoy_cluster_upstream_cx_connect_fail{cluster="ccc"} 0
-
 # TYPE envoy_cluster_upstream_cx_total counter
 envoy_cluster_upstream_cx_total{cluster="aaa"} 0
 envoy_cluster_upstream_cx_total{cluster="bbb"} 0
 envoy_cluster_upstream_cx_total{cluster="ccc"} 0
-
 # TYPE envoy_cluster_upstream_cx_active gauge
 envoy_cluster_upstream_cx_active{cluster="aaa"} 0
 envoy_cluster_upstream_cx_active{cluster="bbb"} 0
 envoy_cluster_upstream_cx_active{cluster="ccc"} 0
-
 # TYPE envoy_cluster_upstream_rq_active gauge
 envoy_cluster_upstream_rq_active{cluster="aaa"} 0
 envoy_cluster_upstream_rq_active{cluster="bbb"} 0
 envoy_cluster_upstream_rq_active{cluster="ccc"} 0
-
 # TYPE envoy_cluster_upstream_response_time histogram
 envoy_cluster_upstream_response_time_bucket{cluster="aaa",le="0.5"} 0
 envoy_cluster_upstream_response_time_bucket{cluster="aaa",le="1"} 0
@@ -620,7 +606,6 @@ envoy_cluster_upstream_response_time_bucket{cluster="ccc",le="3600000"} 7
 envoy_cluster_upstream_response_time_bucket{cluster="ccc",le="+Inf"} 7
 envoy_cluster_upstream_response_time_sum{cluster="ccc"} 5532
 envoy_cluster_upstream_response_time_count{cluster="ccc"} 7
-
 # TYPE envoy_cluster_upstream_rq_time histogram
 envoy_cluster_upstream_rq_time_bucket{cluster="aaa",le="0.5"} 0
 envoy_cluster_upstream_rq_time_bucket{cluster="aaa",le="1"} 0
@@ -688,7 +673,6 @@ envoy_cluster_upstream_rq_time_bucket{cluster="ccc",le="3600000"} 7
 envoy_cluster_upstream_rq_time_bucket{cluster="ccc",le="+Inf"} 7
 envoy_cluster_upstream_rq_time_sum{cluster="ccc"} 5532
 envoy_cluster_upstream_rq_time_count{cluster="ccc"} 7
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());
@@ -747,7 +731,6 @@ envoy_cluster_test_1_upstream_rq_time_bucket{key1="value1",key2="value2",le="360
 envoy_cluster_test_1_upstream_rq_time_bucket{key1="value1",key2="value2",le="+Inf"} 7
 envoy_cluster_test_1_upstream_rq_time_sum{key1="value1",key2="value2"} 5532
 envoy_cluster_test_1_upstream_rq_time_count{key1="value1",key2="value2"} 7
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());
@@ -814,7 +797,6 @@ TEST_F(PrometheusStatsFormatterTest, OutputWithRegexp) {
   const std::string expected_output =
       R"EOF(# TYPE envoy_cluster_test_1_upstream_cx_total counter
 envoy_cluster_test_1_upstream_cx_total{a_tag_name="a.tag-value"} 0
-
 )EOF";
   {
     Buffer::OwnedImpl response;

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -286,7 +286,6 @@ envoy_histogram1_bucket{le="20"} 0
 envoy_histogram1_bucket{le="+Inf"} 0
 envoy_histogram1_sum{} 0
 envoy_histogram1_count{} 0
-
 )EOF";
 
   EXPECT_EQ(expected_output, response.toString());

--- a/test/server/admin/stats_handler_test.cc
+++ b/test/server/admin/stats_handler_test.cc
@@ -1292,11 +1292,9 @@ TEST_P(StatsHandlerPrometheusDefaultTest, StatsHandlerPrometheusDefaultTest) {
   const std::string expected_response = R"EOF(# TYPE envoy_cluster_upstream_cx_total counter
 envoy_cluster_upstream_cx_total{cluster="c1"} 10
 envoy_cluster_upstream_cx_total{cluster="c2"} 20
-
 # TYPE envoy_cluster_upstream_cx_active gauge
 envoy_cluster_upstream_cx_active{cluster="c1"} 11
 envoy_cluster_upstream_cx_active{cluster="c2"} 12
-
 )EOF";
 
   const CodeResponse code_response = handlerStats(url);
@@ -1337,14 +1335,11 @@ TEST_P(StatsHandlerPrometheusWithTextReadoutsTest, StatsHandlerPrometheusWithTex
   const std::string expected_response = R"EOF(# TYPE envoy_cluster_upstream_cx_total counter
 envoy_cluster_upstream_cx_total{cluster="c1"} 10
 envoy_cluster_upstream_cx_total{cluster="c2"} 20
-
 # TYPE envoy_cluster_upstream_cx_active gauge
 envoy_cluster_upstream_cx_active{cluster="c1"} 11
 envoy_cluster_upstream_cx_active{cluster="c2"} 12
-
 # TYPE envoy_control_plane_identifier gauge
 envoy_control_plane_identifier{cluster="c1",text_value="cp-1"} 0
-
 )EOF";
 
   const CodeResponse code_response = handlerStats(url);


### PR DESCRIPTION
Signed-off-by: 白泽 <patrickjiang0530@gmail.com>

Commit Message:
Additional Description: comptiable with openmetrics that removing blank line on prometheus metrics 
Risk Level: Low
Testing: Unit Tests
Docs Changes: None
Release Notes: Added
Platform Specific Features:
