### PR TITLE
wasm: fix crash in gRPC/HTTP handlers calling proxy_done

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1809,10 +1809,14 @@ void Context::onHttpCallSuccess(uint32_t token, Envoy::Http::ResponseMessagePtr&
   }
   http_call_response_ = &response;
   uint32_t body_size = response->body().length();
-  onHttpCallResponse(token, response->headers().size(), body_size,
-                     headerSize(response->trailers()));
-  http_call_response_ = nullptr;
-  http_request_.erase(handler);
+  // Deferred "after VM call" actions are going to be executed upon returning from
+  // ContextBase::*, which might include deleting Context object via proxy_done().
+  wasm()->addAfterVmCallAction([this, handler] {
+    http_call_response_ = nullptr;
+    http_request_.erase(handler);
+  });
+  ContextBase::onHttpCallResponse(token, response->headers().size(), body_size,
+                                  headerSize(response->trailers()));
 }
 
 void Context::onHttpCallFailure(uint32_t token, Http::AsyncClient::FailureReason reason) {
@@ -1829,9 +1833,13 @@ void Context::onHttpCallFailure(uint32_t token, Http::AsyncClient::FailureReason
   // This is the only value currently.
   ASSERT(reason == Http::AsyncClient::FailureReason::Reset);
   status_message_ = "reset";
-  onHttpCallResponse(token, 0, 0, 0);
-  status_message_ = "";
-  http_request_.erase(handler);
+  // Deferred "after VM call" actions are going to be executed upon returning from
+  // ContextBase::*, which might include deleting Context object via proxy_done().
+  wasm()->addAfterVmCallAction([this, handler] {
+    status_message_ = "";
+    http_request_.erase(handler);
+  });
+  ContextBase::onHttpCallResponse(token, 0, 0, 0);
 }
 
 void Context::onGrpcReceiveWrapper(uint32_t token, ::Envoy::Buffer::InstancePtr response) {
@@ -1844,13 +1852,13 @@ void Context::onGrpcReceiveWrapper(uint32_t token, ::Envoy::Buffer::InstancePtr 
     wasm()->addAfterVmCallAction([this, token] {
       grpc_receive_buffer_.reset();
       if (wasm()->isGrpcCallId(token)) {
-       grpc_call_request_.erase(token);
+        grpc_call_request_.erase(token);
       }
     });
     ContextBase::onGrpcReceive(token, response_size);
   } else {
     if (wasm()->isGrpcCallId(token)) {
-     grpc_call_request_.erase(token);
+      grpc_call_request_.erase(token);
     }
   }
 }
@@ -1864,21 +1872,30 @@ void Context::onGrpcCloseWrapper(uint32_t token, const Grpc::Status::GrpcStatus&
     });
     return;
   }
+  auto cleanup = [this, token] {
+    if (wasm()->isGrpcCallId(token)) {
+      grpc_call_request_.erase(token);
+    } else if (wasm()->isGrpcStreamId(token)) {
+      auto it = grpc_stream_.find(token);
+      if (it != grpc_stream_.end()) {
+        if (it->second.local_closed_) {
+          grpc_stream_.erase(token);
+        }
+      }
+    }
+  };
   if (wasm()->on_grpc_close_) {
     status_code_ = static_cast<uint32_t>(status);
     status_message_ = toAbslStringView(message);
-    onGrpcClose(token, status_code_);
-    status_message_ = "";
-  }
-  if (wasm()->isGrpcCallId(token)) {
-    grpc_call_request_.erase(token);
-  } else if (wasm()->isGrpcStreamId(token)) {
-    auto it = grpc_stream_.find(token);
-    if (it != grpc_stream_.end()) {
-      if (it->second.local_closed_) {
-        grpc_stream_.erase(token);
-      }
-    }
+    // Deferred "after VM call" actions are going to be executed upon returning from
+    // ContextBase::*, which might include deleting Context object via proxy_done().
+    wasm()->addAfterVmCallAction([this, cleanup] {
+      status_message_ = "";
+      cleanup();
+    });
+    ContextBase::onGrpcClose(token, status_code_);
+  } else {
+    cleanup();
   }
 }
 

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1836,17 +1836,21 @@ void Context::onHttpCallFailure(uint32_t token, Http::AsyncClient::FailureReason
 
 void Context::onGrpcReceiveWrapper(uint32_t token, ::Envoy::Buffer::InstancePtr response) {
   ASSERT(proxy_wasm::current_context_ == nullptr); // Non-reentrant.
-  if (wasm()->isGrpcCallId(token)) {
-    grpc_call_request_.erase(token);
-  }
   if (wasm()->on_grpc_receive_) {
     grpc_receive_buffer_ = std::move(response);
     uint32_t response_size = grpc_receive_buffer_->length();
-    wasm()->addAfterVmCallAction([this] {
+    wasm()->addAfterVmCallAction([this, token] {
       grpc_receive_buffer_.reset();
+      if (wasm()->isGrpcCallId(token)) {
+       grpc_call_request_.erase(token);
+      }
     });
     // on_grpc_receive_ may indirectly delete Context via proxy_done().
     ContextBase::onGrpcReceive(token, response_size);
+  } else {
+    if (wasm()->isGrpcCallId(token)) {
+     grpc_call_request_.erase(token);
+    }
   }
 }
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1255,13 +1255,13 @@ TEST_P(WasmHttpFilterTest, GrpcCallClose) {
 }
 
 TEST_P(WasmHttpFilterTest, GrpcCallAfterDestroyed) {
-  std::vector<std::string> proto_or_cluster;
-  proto_or_cluster.push_back("grpc_call");
+  std::vector<std::pair<std::string, bool>> proto_or_cluster;
+  proto_or_cluster.emplace_back("grpc_call", true);
   if (std::get<1>(GetParam()) == "cpp") {
     // cluster definition passed as a protobuf is only supported in C++ SDK.
-    proto_or_cluster.push_back("grpc_call_proto");
+    proto_or_cluster.emplace_back("grpc_call_proto", false);
   }
-  for (const auto& id : proto_or_cluster) {
+  for (const auto& [id, success] : proto_or_cluster) {
     setupTest(id);
     setupFilter();
 
@@ -1309,23 +1309,41 @@ TEST_P(WasmHttpFilterTest, GrpcCallAfterDestroyed) {
     EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
               filter().decodeHeaders(request_headers, false));
 
-    EXPECT_CALL(request, cancel()).WillOnce([&]() { callbacks = nullptr; });
+    if (std::get<1>(GetParam()) == "rust") {
+      EXPECT_CALL(request, cancel()).WillOnce([&]() { callbacks = nullptr; });
 
-    // Destroy the Context, Plugin and VM.
-    context_.reset();
-    plugin_.reset();
-    plugin_handle_.reset();
-    wasm_.reset();
+      // Destroy the Context, Plugin and VM.
+      context_.reset();
+      plugin_.reset();
+      plugin_handle_.reset();
+      wasm_.reset();
+    } else {
+      rootContext().onQueueReady(2);
+
+      // Start shutdown sequence.
+      wasm_->wasm()->startShutdown();
+      plugin_.reset();
+      plugin_handle_.reset();
+      wasm_.reset();
+    }
 
     ProtobufWkt::Value value;
     value.set_string_value("response");
     std::string response_string;
     EXPECT_TRUE(value.SerializeToString(&response_string));
     auto response = std::make_unique<Buffer::OwnedImpl>(response_string);
-    EXPECT_EQ(callbacks, nullptr);
+    if (std::get<1>(GetParam()) == "rust") {
+      EXPECT_EQ(callbacks, nullptr);
+    } else {
+      EXPECT_NE(callbacks, nullptr);
+    }
     NiceMock<Tracing::MockSpan> span;
     if (callbacks) {
-      callbacks->onSuccessRaw(std::move(response), span);
+      if (success) {
+        callbacks->onSuccessRaw(std::move(response), span);
+      } else {
+        callbacks->onFailure(Grpc::Status::WellKnownGrpcStatus::Canceled, "bad", span);
+      }
     }
   }
 }

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -35,7 +35,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/exe:92.6"
 "source/extensions/common:95.8"
 "source/extensions/common/tap:92.9"
-"source/extensions/common/wasm:95.0" # flaky: be careful adjusting
+"source/extensions/common/wasm:94.9" # flaky: be careful adjusting
 "source/extensions/common/wasm/ext:92.0"
 "source/extensions/filters/common:96.1"
 "source/extensions/filters/common/expr:96.2"


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: A fix to address an issue in istio/proxy. There's a major problem in ABI implementation dealing with `proxy_done`. The code is written so that `ContextBase` may delete `Context` while executing methods on `Context`. This PR addresses known use of `proxy_done` when called from gRPC handler by wrapping continuation into deferred actions before calling `ContextBase`.
Risk Level: low
Testing: manual verification, regression test
Docs Changes:
Release Notes: