### PR TITLE
eds: allow duplicate internal addresses

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -41,6 +41,10 @@ message EnvoyInternalAddress {
     // [#not-implemented-hide:] The :ref:`listener name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the destination internal listener.
     string server_listener_name = 1;
   }
+
+  // An optional arbitrary string that can be used to differentiate multiple internal addresses with the same
+  // :ref:`listener name <envoy_v3_api_field_config.core.v3.EnvoyInternalAddress.address_name_specifier>`.
+  string logical_port = 2;
 }
 
 // [#next-free-field: 7]

--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -161,6 +161,7 @@ public:
    * For IPv4 addresses: "1.2.3.4:80"
    * For IPv6 addresses: "[1234:5678::9]:443"
    * For pipe addresses: "/foo"
+   * For internal addresses: "serverListenerName-<hash of metadata>"
    */
   virtual const std::string& asString() const PURE;
 

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -404,10 +404,11 @@ absl::Status PipeInstance::initHelper(const sockaddr_un* address, mode_t mode) {
 }
 
 EnvoyInternalInstance::EnvoyInternalInstance(const std::string& address_id,
-                                             const SocketInterface* sock_interface)
+                                             const SocketInterface* sock_interface,
+                                             const std::string& logical_port)
     : InstanceBase(Type::EnvoyInternal, sockInterfaceOrDefault(sock_interface)),
-      internal_address_(address_id) {
-  friendly_name_ = absl::StrCat("envoy://", address_id);
+      internal_address_(address_id, logical_port) {
+  friendly_name_ = absl::StrCat("envoy://", address_id, ":", logical_port);
 }
 
 bool EnvoyInternalInstance::operator==(const Instance& rhs) const {

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -338,7 +338,8 @@ public:
    * Construct from a string name.
    */
   explicit EnvoyInternalInstance(const std::string& address_id,
-                                 const SocketInterface* sock_interface = nullptr);
+                                 const SocketInterface* sock_interface = nullptr,
+                                 const std::string& logical_port = "");
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
@@ -352,10 +353,13 @@ public:
 
 private:
   struct EnvoyInternalAddressImpl : public EnvoyInternalAddress {
-    explicit EnvoyInternalAddressImpl(const std::string& address_id) : address_id_(address_id) {}
+    explicit EnvoyInternalAddressImpl(const std::string& address_id,
+                                      const std::string& logical_port)
+        : address_id_(address_id), logical_port_(logical_port) {}
     ~EnvoyInternalAddressImpl() override = default;
     const std::string& addressId() const override { return address_id_; }
     const std::string address_id_;
+    const std::string logical_port_;
   };
   EnvoyInternalAddressImpl internal_address_;
 };

--- a/source/common/network/resolver_impl.cc
+++ b/source/common/network/resolver_impl.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/config/core/v3/address.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/resolver.h"
 #include "envoy/registry/registry.h"
@@ -56,7 +57,8 @@ InstanceConstSharedPtr resolveProtoAddress(const envoy::config::core::v3::Addres
     case envoy::config::core::v3::EnvoyInternalAddress::AddressNameSpecifierCase::
         kServerListenerName:
       return std::make_shared<EnvoyInternalInstance>(
-          address.envoy_internal_address().server_listener_name());
+          address.envoy_internal_address().server_listener_name(), nullptr,
+          address.envoy_internal_address().logical_port());
     case envoy::config::core::v3::EnvoyInternalAddress::AddressNameSpecifierCase::
         ADDRESS_NAME_SPECIFIER_NOT_SET:
       break;

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/health_check.pb.h"
@@ -1613,6 +1614,52 @@ TEST_F(EdsTest, EndpointLocalityWeightsIgnored) {
   EXPECT_TRUE(initialized_);
 
   EXPECT_EQ(nullptr, cluster_->prioritySet().hostSetsPerPriority()[0]->localityWeights());
+}
+
+// Validate that onConfigUpdate() with multiple endpoints with the same socket address removes the
+// duplicate hosts.
+TEST_F(EdsTest, EndpointDeduplication) {
+  envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
+  cluster_load_assignment.set_cluster_name("fare");
+  {
+    auto* endpoints = cluster_load_assignment.add_endpoints();
+    for (auto i = 0; i < 3; i++) {
+      auto* endpoint_address = endpoints->add_lb_endpoints()
+                                   ->mutable_endpoint()
+                                   ->mutable_address()
+                                   ->mutable_socket_address();
+      endpoint_address->set_address("1.2.3.4");
+      endpoint_address->set_port_value(80);
+    }
+  }
+  initialize();
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
+  EXPECT_TRUE(initialized_);
+  EXPECT_EQ(1, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+}
+
+// Validate that onConfigUpdate() with endpoints with the same internal address does NOT remove
+// duplicate hosts.
+TEST_F(EdsTest, EndpointInternalAddressNoDeduplication) {
+  envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
+  cluster_load_assignment.set_cluster_name("fare");
+  const auto num_hosts = 3;
+
+  {
+    auto* endpoints = cluster_load_assignment.add_endpoints();
+    for (auto i = 0; i < num_hosts; i++) {
+      auto* endpoint_address = endpoints->add_lb_endpoints()
+                                   ->mutable_endpoint()
+                                   ->mutable_address()
+                                   ->mutable_envoy_internal_address();
+      endpoint_address->set_server_listener_name("internal-listener-addr");
+      endpoint_address->set_logical_port("logical-port-"+std::to_string(i));
+    }
+  }
+  initialize();
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
+  EXPECT_TRUE(initialized_);
+  EXPECT_EQ(num_hosts, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
 }
 
 class EdsLocalityWeightsTest : public EdsTest {


### PR DESCRIPTION


Commit Message: allow duplicate internal endpoints
Additional Description: endpoints that use internal address should not be subject to deduplication as passthrough metadata is usually what distinguishes them
Risk Level: Low
Testing: TODO unit test
Docs Changes: N/A
Release Notes: should I add one? are there releases including internal address at this point? 
Platform Specific Features: N/A

Fixes https://github.com/envoyproxy/envoy/issues/22417

