### PR TITLE
ConnectionHandlerImpl: refactor to share common code

### DIFF
--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -329,7 +329,7 @@ ConnectionHandlerImpl::getBalancedHandlerByTag(uint64_t listener_tag,
   if (active_listener.has_value()) {
     // If the tag matches this must be a TCP listener.
     ASSERT(active_listener->get().tcpListener().has_value());
-    return active_listener->get().tcpListener();
+    return active_listener->get().tcpListener().value().get();
   }
   return absl::nullopt;
 }

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -185,21 +185,32 @@ void ConnectionHandlerImpl::removeListeners(uint64_t listener_tag) {
   }
 }
 
-Network::UdpListenerCallbacksOptRef
-ConnectionHandlerImpl::getUdpListenerCallbacks(uint64_t listener_tag,
-                                               const Network::Address::Instance& address) {
-  auto listener = findActiveListenerByTag(listener_tag);
-  if (listener.has_value()) {
+ConnectionHandlerImpl::PerAddressActiveListenerDetailsOptRef
+ConnectionHandlerImpl::findPerAddressActiveListenerDetails(
+    const ConnectionHandlerImpl::ActiveListenerDetailsOptRef active_listener_details,
+    const Network::Address::Instance& address) {
+  if (active_listener_details.has_value()) {
     // If the tag matches this must be a UDP listener.
-    for (auto& details : listener->get().per_address_details_list_) {
+    for (auto& details : active_listener_details->get().per_address_details_list_) {
       if (*details->address_ == address) {
-        auto udp_listener = details->udpListener();
-        ASSERT(udp_listener.has_value());
-        return details->udpListener();
+        return *details;
       }
     }
   }
 
+  return absl::nullopt;
+}
+
+Network::UdpListenerCallbacksOptRef
+ConnectionHandlerImpl::getUdpListenerCallbacks(uint64_t listener_tag,
+                                               const Network::Address::Instance& address) {
+  auto listener =
+      findPerAddressActiveListenerDetails(findActiveListenerByTag(listener_tag), address);
+  if (listener.has_value()) {
+    // If the tag matches this must be a UDP listener.
+    ASSERT(listener->get().udpListener().has_value());
+    return listener->get().udpListener();
+  }
   return absl::nullopt;
 }
 
@@ -313,16 +324,12 @@ ConnectionHandlerImpl::findActiveListenerByTag(uint64_t listener_tag) {
 Network::BalancedConnectionHandlerOptRef
 ConnectionHandlerImpl::getBalancedHandlerByTag(uint64_t listener_tag,
                                                const Network::Address::Instance& address) {
-  auto active_listener = findActiveListenerByTag(listener_tag);
+  auto active_listener =
+      findPerAddressActiveListenerDetails(findActiveListenerByTag(listener_tag), address);
   if (active_listener.has_value()) {
-    for (auto& details : active_listener->get().per_address_details_list_) {
-      if (*details->address_ == address) {
-        ASSERT(absl::holds_alternative<std::reference_wrapper<ActiveTcpListener>>(
-                   details->typed_listener_) &&
-               details->listener_->listener() != nullptr);
-        return {details->tcpListener().value().get()};
-      }
-    }
+    // If the tag matches this must be a TCP listener.
+    ASSERT(active_listener->get().tcpListener().has_value());
+    return active_listener->get().tcpListener();
   }
   return absl::nullopt;
 }

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -132,6 +132,12 @@ private:
   using ActiveListenerDetailsOptRef = absl::optional<std::reference_wrapper<ActiveListenerDetails>>;
   ActiveListenerDetailsOptRef findActiveListenerByTag(uint64_t listener_tag);
 
+  using PerAddressActiveListenerDetailsOptRef =
+      absl::optional<std::reference_wrapper<PerAddressActiveListenerDetails>>;
+  PerAddressActiveListenerDetailsOptRef
+  findPerAddressActiveListenerDetails(const ActiveListenerDetailsOptRef active_listener_details,
+                                      const Network::Address::Instance& address);
+
   // This has a value on worker threads, and no value on the main thread.
   const absl::optional<uint32_t> worker_index_;
   Event::Dispatcher& dispatcher_;


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: ConnectionHandlerImpl: refactor to share common code
Additional Description:
Both `getUdpListenerCallbacks` and `getBalancedHandlerByTag` are doing the similar thing. create a common method `findPerAddressActiveListenerDetails` for finding the specific address listener details.

Risk Level: low
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
