### PR TITLE
check_format: Fix related test

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -33,6 +33,7 @@ stages:
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
         GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
+        AZP_BRANCH: $(Build.SourceBranch)
       displayName: "Run format checks"
     - task: PublishBuildArtifacts@1
       inputs:

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -221,9 +221,6 @@ def run_checks():
     errors += check_unfixable_error("clang_format_double_off.cc", "clang-format nested off")
     errors += check_unfixable_error("clang_format_trailing_off.cc", "clang-format remains off")
     errors += check_unfixable_error("clang_format_double_on.cc", "clang-format nested on")
-    errors += fix_file_expecting_failure(
-        "api/missing_package.proto",
-        "Unable to find package name for proto file: ./api/missing_package.proto")
     errors += check_unfixable_error(
         "proto_enum_mangling.cc", "Don't use mangled Protobuf names for enum constants")
     errors += check_unfixable_error(


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:

This removes the protobuf test from this script test as the script no longer provides this functionality

It also (correctly) enables the test in CI

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
