### PR TITLE
Fix the analisys of getsockopt() call

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -12,6 +12,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: transport_socket
+  change: |
+    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -79,7 +79,7 @@ absl::optional<struct tcp_info> TcpStatsSocket::querySocketInfo() {
   memset(&info, 0, sizeof(info));
   socklen_t optlen = sizeof(info);
   const auto result = callbacks_->ioHandle().getOption(IPPROTO_TCP, TCP_INFO, &info, &optlen);
-  if ((result.return_value_ != 0) || (optlen < sizeof(info))) {
+  if (result.return_value_ != 0) {
     ENVOY_LOG(debug, "Failed getsockopt(IPPROTO_TCP, TCP_INFO): rc {} errno {} optlen {}",
               result.return_value_, result.errno_, optlen);
     return absl::nullopt;

--- a/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
+++ b/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
@@ -122,25 +122,6 @@ TEST_F(TcpStatsTest, CloseSocket) {
   EXPECT_EQ(0, gaugeValue("cx_tx_unacked_segments"));
 }
 
-TEST_F(TcpStatsTest, SyscallFailureShortRead) {
-  initialize(true);
-  tcp_info_.tcpi_notsent_bytes = 42;
-  EXPECT_CALL(io_handle_, getOption(IPPROTO_TCP, TCP_INFO, _, _))
-      .WillOnce(Invoke([this](int, int, void* optval, socklen_t* optlen) {
-        *optlen = *optlen - 1;
-        memcpy(optval, &tcp_info_, sizeof(*optlen));
-        return Api::SysCallIntResult{0, 0};
-      }));
-  EXPECT_LOG_CONTAINS(
-      "debug",
-      fmt::format("Failed getsockopt(IPPROTO_TCP, TCP_INFO): rc 0 errno 0 optlen {}",
-                  sizeof(tcp_info_) - 1),
-      timer_->callback_());
-
-  // Not updated on failed syscall.
-  EXPECT_EQ(0, gaugeValue("cx_tx_unsent_bytes"));
-}
-
 TEST_F(TcpStatsTest, SyscallFailureReturnCode) {
   initialize(true);
   tcp_info_.tcpi_notsent_bytes = 42;


### PR DESCRIPTION
The syscall might change the optlen value to hold the actual value of
the resturned value in optval.

In my case it's reducing that value to 192, and thus some tests are
failing.

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>
