### PR TITLE
docs: fix typo in matching API

### DIFF
--- a/docs/root/intro/arch_overview/advanced/matching/matching_api.rst
+++ b/docs/root/intro/arch_overview/advanced/matching/matching_api.rst
@@ -69,8 +69,8 @@ These input functions are available for matching TCP connections and HTTP reques
 * :ref:`DNS SAN <extension_envoy.matching.inputs.dns_san>`.
 * :ref:`Subject <extension_envoy.matching.inputs.subject>`.
 
-Common Input Functons
-*********************
+Common Input Functions
+**********************
 
 These input functions are available in any context:
 


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: docs: fix typo in matching API
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: Matching API
Release Notes: N/A
Platform Specific Features: N/A
