### PR TITLE
Fix the analisys of getsockopt() syscall

### DIFF
--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -78,8 +78,14 @@ absl::optional<struct tcp_info> TcpStatsSocket::querySocketInfo() {
   struct tcp_info info;
   memset(&info, 0, sizeof(info));
   socklen_t optlen = sizeof(info);
+
+  // Minimal supported size of the `struct tcp_info`. We rely on that field at build time, so it
+  // must be present in the kernel at runtime.
+  size_t size = offsetof(struct tcp_info, LAST_TCP_INFO_FIELD_WE_USE) +
+                sizeof(info.LAST_TCP_INFO_FIELD_WE_USE);
+
   const auto result = callbacks_->ioHandle().getOption(IPPROTO_TCP, TCP_INFO, &info, &optlen);
-  if ((result.return_value_ != 0) || (optlen < sizeof(info))) {
+  if ((result.return_value_ != 0) || (optlen < size)) {
     ENVOY_LOG(debug, "Failed getsockopt(IPPROTO_TCP, TCP_INFO): rc {} errno {} optlen {}",
               result.return_value_, result.errno_, optlen);
     return absl::nullopt;

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -15,6 +15,12 @@
 // Defined in /usr/include/linux/tcp.h.
 struct tcp_info;
 
+// Contains the last field in the `struct tcp_info` that is we actually use.
+// This is necessary so that at runtime we require a kernel that offers a struct
+// of this size at minimal.
+// This define must be updated whenever we use a field with a higher offset in that struct.
+#define LAST_TCP_INFO_FIELD_WE_USE tcpi_data_segs_out
+
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -15,12 +15,6 @@
 // Defined in /usr/include/linux/tcp.h.
 struct tcp_info;
 
-// Contains the last field in the `struct tcp_info` that is we actually use.
-// This is necessary so that at runtime we require a kernel that offers a struct
-// of this size at minimal.
-// This define must be updated whenever we use a field with a higher offset in that struct.
-#define LAST_TCP_INFO_FIELD_WE_USE tcpi_data_segs_out
-
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
@@ -49,6 +43,10 @@ public:
 
   TcpStats stats_;
   const absl::optional<std::chrono::milliseconds> update_period_;
+
+  // Minimal size of the `struct tcp_info`.
+  // Holds the size of this struct up to the last field we use.
+  size_t tcp_info_min_size_;
 
 private:
   TcpStats generateStats(Stats::Scope& scope);

--- a/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
+++ b/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
@@ -127,14 +127,14 @@ TEST_F(TcpStatsTest, SyscallFailureShortRead) {
   tcp_info_.tcpi_notsent_bytes = 42;
   EXPECT_CALL(io_handle_, getOption(IPPROTO_TCP, TCP_INFO, _, _))
       .WillOnce(Invoke([this](int, int, void* optval, socklen_t* optlen) {
-        *optlen = *optlen - 1;
-        memcpy(optval, &tcp_info_, sizeof(*optlen));
+        *optlen = offsetof(struct tcp_info, LAST_TCP_INFO_FIELD_WE_USE);
+        memcpy(optval, &tcp_info_, *optlen);
         return Api::SysCallIntResult{0, 0};
       }));
   EXPECT_LOG_CONTAINS(
       "debug",
       fmt::format("Failed getsockopt(IPPROTO_TCP, TCP_INFO): rc 0 errno 0 optlen {}",
-                  sizeof(tcp_info_) - 1),
+                  offsetof(struct tcp_info, LAST_TCP_INFO_FIELD_WE_USE)),
       timer_->callback_());
 
   // Not updated on failed syscall.


### PR DESCRIPTION
The syscall might change the optlen value to hold the actual value of
the resturned value in optval. In my case it's reducing that value to 192,
and thus some tests are failing.

We can relax this comparison by comparing the result with the value that
we actually use. If the runtime kernel has a shorter tcp_info struct
than what we need, then we must fail. Otherwise, it's fine.

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>
