### PR TITLE
http2: guarding against stream reset before stream creation

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -882,6 +882,10 @@ void ConnectionImpl::StreamImpl::resetStream(StreamResetReason reason) {
 }
 
 void ConnectionImpl::StreamImpl::resetStreamWorker(StreamResetReason reason) {
+  if (stream_id_ == -1) {
+    // Handle the case where client streams are reset before headers are created.
+    return;
+  }
   if (parent_.use_new_codec_wrapper_) {
     parent_.adapter_->SubmitRst(stream_id_,
                                 static_cast<http2::adapter::Http2ErrorCode>(reasonToReset(reason)));

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1307,6 +1307,13 @@ TEST_P(Http2CodecImplTest, ConnectionKeepaliveJitter) {
   EXPECT_EQ(max_observed.count(), max_expected.count());
 }
 
+TEST_P(Http2CodecImplTest, EarlyReset) {
+  initialize();
+
+  // Reset the stream before sending headers to make sure this corner case is handled.
+  request_encoder_->getStream().resetStream(StreamResetReason::LocalReset);
+}
+
 TEST_P(Http2CodecImplTest, IdlePing) {
   client_http2_options_.mutable_connection_keepalive()
       ->mutable_connection_idle_interval()


### PR DESCRIPTION
Right now if we call newStream and then reset the stream before sending headers, we attempt to have the codec send a reset stream to stream_id -1.  nghttp2 appears to silently swallow this without complaint. oghttp2 will soon as well but either way it doesn't make sense to reset the stream before a stream id has been assigned.

Risk Level: low
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a