### PR TITLE
Fix brittle tests that depend on the contents of Protobuf JSON error messages

### DIFF
--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -289,7 +289,6 @@ TEST_F(ProtobufUtilityTest, JsonConvertAnyUnknownMessageType) {
   source_any.set_value("asdf");
   auto status = MessageUtil::getJsonStringFromMessage(source_any, true).status();
   EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.ToString(), testing::HasSubstr("bad.type.url"));
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertKnownGoodMessage) {
@@ -303,14 +302,15 @@ TEST_F(ProtobufUtilityTest, JsonConvertOrErrorAnyWithUnknownMessageType) {
   ProtobufWkt::Any source_any;
   source_any.set_type_url("type.googleapis.com/bad.type.url");
   source_any.set_value("asdf");
-  EXPECT_THAT(MessageUtil::getJsonStringFromMessageOrError(source_any), HasSubstr("unknown type"));
+  EXPECT_THAT(MessageUtil::getJsonStringFromMessageOrError(source_any),
+              HasSubstr("Failed to convert"));
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertOrDieAnyWithUnknownMessageType) {
   ProtobufWkt::Any source_any;
   source_any.set_type_url("type.googleapis.com/bad.type.url");
   source_any.set_value("asdf");
-  EXPECT_DEATH(MessageUtil::getJsonStringFromMessageOrDie(source_any), "bad.type.url");
+  EXPECT_DEATH(MessageUtil::getJsonStringFromMessageOrDie(source_any), "");
 }
 
 TEST_F(ProtobufUtilityTest, LoadBinaryProtoFromFile) {
@@ -1483,9 +1483,9 @@ TEST_F(ProtobufUtilityTest, UnpackToNoThrowWrongType) {
 // MessageUtility::loadFromJson() throws on garbage JSON.
 TEST_F(ProtobufUtilityTest, LoadFromJsonGarbage) {
   envoy::config::cluster::v3::Cluster dst;
-  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromJson("{drain_connections_on_host_removal: true", dst,
-                                                    ProtobufMessage::getNullValidationVisitor()),
-                          EnvoyException, "Unable to parse JSON as proto.*after key:value pair.");
+  EXPECT_THROW(MessageUtil::loadFromJson("{drain_connections_on_host_removal: true", dst,
+                                         ProtobufMessage::getNullValidationVisitor()),
+               EnvoyException);
 }
 
 // MessageUtility::loadFromJson() with API message works at same version.
@@ -1519,10 +1519,9 @@ TEST_F(ProtobufUtilityTest, LoadFromJsonSameVersion) {
 // MessageUtility::loadFromJson() avoids boosting when version specified.
 TEST_F(ProtobufUtilityTest, LoadFromJsonNoBoosting) {
   envoy::config::cluster::v3::Cluster dst;
-  EXPECT_THROW_WITH_REGEX(
-      MessageUtil::loadFromJson("{drain_connections_on_host_removal: true}", dst,
-                                ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "INVALID_ARGUMENT:drain_connections_on_host_removal: Cannot find field.");
+  EXPECT_THROW(MessageUtil::loadFromJson("{drain_connections_on_host_removal: true}", dst,
+                                         ProtobufMessage::getStrictValidationVisitor()),
+               EnvoyException);
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertSuccess) {
@@ -1549,10 +1548,7 @@ TEST_F(ProtobufUtilityTest, JsonConvertFail) {
   std::string expected_duration_text = R"pb(seconds: -281474976710656)pb";
   ProtobufWkt::Duration expected_duration_proto;
   Protobuf::TextFormat::ParseFromString(expected_duration_text, &expected_duration_proto);
-  EXPECT_THROW_WITH_REGEX(TestUtility::jsonConvert(source_duration, dest_struct), EnvoyException,
-                          fmt::format("Unable to convert protobuf message to JSON string.*"
-                                      "seconds exceeds limit for field:  {}",
-                                      expected_duration_proto.DebugString()));
+  EXPECT_THROW(TestUtility::jsonConvert(source_duration, dest_struct), EnvoyException);
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/3665.
@@ -1616,11 +1612,8 @@ TEST_F(ProtobufUtilityTest, YamlLoadFromStringFail) {
   EXPECT_THROW_WITH_MESSAGE(TestUtility::loadFromYaml("/home/configs/config.yaml", bootstrap),
                             EnvoyException,
                             "Unable to convert YAML as JSON: /home/configs/config.yaml");
-  // Verify loadFromYaml throws error when the input leads to an Array. This error message is
-  // arguably more useful than only "Unable to convert YAML as JSON".
-  EXPECT_THROW_WITH_REGEX(TestUtility::loadFromYaml("- node: { id: node1 }", bootstrap),
-                          EnvoyException,
-                          "Unable to parse JSON as proto.*Root element must be a message.*");
+  // Verify loadFromYaml throws error when the input leads to an Array.
+  EXPECT_THROW(TestUtility::loadFromYaml("- node: { id: node1 }", bootstrap), EnvoyException);
 }
 
 TEST_F(ProtobufUtilityTest, GetFlowYamlStringFromMessage) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6387,22 +6387,8 @@ virtual_hosts:
       cluster: www2
   )EOF";
 
-#ifndef GTEST_USES_SIMPLE_RE
-  EXPECT_THROW_WITH_REGEX(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set. Cannot set '(prefix|path)' "
-      "for "
-      "type oneof");
-#else
-  EXPECT_THAT_THROWS_MESSAGE(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      ::testing::AnyOf(::testing::ContainsRegex("invalid value oneof field 'path_specifier' is "
-                                                "already set. Cannot set 'prefix' for "
-                                                "type oneof"),
-                       ::testing::ContainsRegex("invalid value oneof field 'path_specifier' is "
-                                                "already set. Cannot set 'path' for "
-                                                "type oneof")));
-#endif
+  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
+               EnvoyException);
 }
 
 TEST_F(BadHttpRouteConfigurationsTest, BadRouteEntryConfigMissingPathSpecifier) {
@@ -6436,22 +6422,8 @@ virtual_hosts:
       cluster: www2
   )EOF";
 
-#ifndef GTEST_USES_SIMPLE_RE
-  EXPECT_THROW_WITH_REGEX(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set. Cannot set '(prefix|safe_regex)' "
-      "for "
-      "type oneof");
-#else
-  EXPECT_THAT_THROWS_MESSAGE(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      ::testing::AnyOf(::testing::ContainsRegex("invalid value oneof field 'path_specifier' is "
-                                                "already set. Cannot set 'prefix' for "
-                                                "type oneof"),
-                       ::testing::ContainsRegex("invalid value oneof field 'path_specifier' is "
-                                                "already set. Cannot set 'safe_regex' for "
-                                                "type oneof")));
-#endif
+  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
+               EnvoyException);
 }
 
 TEST_F(BadHttpRouteConfigurationsTest, BadRouteEntryConfigNoAction) {
@@ -6484,23 +6456,8 @@ virtual_hosts:
     route:
       cluster: www2
   )EOF";
-
-#ifndef GTEST_USES_SIMPLE_RE
-  EXPECT_THROW_WITH_REGEX(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set. Cannot set '(path|safe_regex)' "
-      "for "
-      "type oneof");
-#else
-  EXPECT_THAT_THROWS_MESSAGE(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      ::testing::AnyOf(::testing::ContainsRegex("invalid value oneof field 'path_specifier' is "
-                                                "already set. Cannot set 'path' for "
-                                                "type oneof"),
-                       ::testing::ContainsRegex("invalid value oneof field 'path_specifier' is "
-                                                "already set. Cannot set 'safe_regex' for "
-                                                "type oneof")));
-#endif
+  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
+               EnvoyException);
 }
 
 TEST_F(BadHttpRouteConfigurationsTest, BadRouteEntryConfigPrefixAndPathAndRegex) {
@@ -6519,9 +6476,8 @@ virtual_hosts:
       cluster: www2
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(
-      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
-      "invalid value oneof field 'path_specifier' is already set.");
+  EXPECT_THROW(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
+               EnvoyException);
 }
 
 TEST_F(RouteMatcherTest, TestOpaqueConfig) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2183,7 +2183,7 @@ TEST_F(StaticClusterImplTest, UnsupportedLBType) {
               socket_address: { address: 192.168.1.2, port_value: 44 }
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(
+  EXPECT_THROW(
       {
         envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
         Envoy::Stats::ScopeSharedPtr scope =
@@ -2196,7 +2196,7 @@ TEST_F(StaticClusterImplTest, UnsupportedLBType) {
         StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
                                   std::move(scope), false);
       },
-      EnvoyException, "invalid value \"fakelbtype\"");
+      EnvoyException);
 }
 
 // load_balancing_policy should be used when lb_policy is set to LOAD_BALANCING_POLICY_CONFIG.

--- a/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
+++ b/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
@@ -614,18 +614,12 @@ TEST_P(DecompressorFilterTest, NoResponseDecompressionNoTransformPresentInList) 
 }
 
 TEST_P(DecompressorFilterTest, DecompressionLibraryNotRegistered) {
-  EXPECT_THROW_WITH_MESSAGE(
-      setUpFilter(R"EOF(
+  EXPECT_THROW(setUpFilter(R"EOF(
 decompressor_library:
   typed_config:
     "@type": "type.googleapis.com/envoy.extensions.compression.does_not_exist"
 )EOF"),
-      EnvoyException,
-      "Unable to parse JSON as proto (INVALID_ARGUMENT:(decompressor_library.typed_config): "
-      "invalid value Invalid type URL, unknown type: envoy.extensions.compression.does_not_exist "
-      "for type Any): "
-      "{\"decompressor_library\":{\"typed_config\":{\"@type\":\"type.googleapis.com/"
-      "envoy.extensions.compression.does_not_exist\"}}}");
+               EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -51,8 +51,7 @@ TEST(HealthCheckFilterConfig, BadHealthCheckFilterConfig) {
   )EOF";
 
   envoy::extensions::filters::http::health_check::v3::HealthCheck proto_config;
-  EXPECT_THROW_WITH_REGEX(TestUtility::loadFromYaml(yaml_string, proto_config), EnvoyException,
-                          "status: Cannot find field");
+  EXPECT_THROW(TestUtility::loadFromYaml(yaml_string, proto_config), EnvoyException);
 }
 
 TEST(HealthCheckFilterConfig, FailsWhenNotPassThroughButTimeoutSetYaml) {

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -76,8 +76,7 @@ TEST(RateLimitFilterConfigTest, BadRateLimitFilterConfig) {
   )EOF";
 
   envoy::extensions::filters::http::ratelimit::v3::RateLimit proto_config{};
-  EXPECT_THROW_WITH_REGEX(TestUtility::loadFromYamlAndValidate(yaml, proto_config), EnvoyException,
-                          "route_key: Cannot find field");
+  EXPECT_THROW(TestUtility::loadFromYamlAndValidate(yaml, proto_config), EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/router/config_test.cc
+++ b/test/extensions/filters/http/router/config_test.cc
@@ -43,8 +43,7 @@ TEST(RouterFilterConfigTest, BadRouterFilterConfig) {
   )EOF";
 
   envoy::extensions::filters::http::router::v3::Router proto_config;
-  EXPECT_THROW_WITH_REGEX(TestUtility::loadFromYaml(yaml_string, proto_config), EnvoyException,
-                          "route: Cannot find field");
+  EXPECT_THROW(TestUtility::loadFromYaml(yaml_string, proto_config), EnvoyException);
 }
 
 TEST(RouterFilterConfigTest, RouterFilterWithUnsupportedStrictHeaderCheck) {

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1590,8 +1590,7 @@ access_log:
   filter: []
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(parseHttpConnectionManagerFromYaml(yaml_string), EnvoyException,
-                          "filter: Proto field is not repeating, cannot start list.");
+  EXPECT_THROW(parseHttpConnectionManagerFromYaml(yaml_string), EnvoyException);
 }
 
 TEST_F(HttpConnectionManagerConfigTest, BadAccessLogType) {
@@ -1619,8 +1618,7 @@ access_log:
     bad_type: {}
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(parseHttpConnectionManagerFromYaml(yaml_string), EnvoyException,
-                          "bad_type: Cannot find field");
+  EXPECT_THROW(parseHttpConnectionManagerFromYaml(yaml_string), EnvoyException);
 }
 
 TEST_F(HttpConnectionManagerConfigTest, BadAccessLogNestedTypes) {
@@ -1656,8 +1654,7 @@ access_log:
       - not_health_check_filter: {}
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(parseHttpConnectionManagerFromYaml(yaml_string), EnvoyException,
-                          "bad_type: Cannot find field");
+  EXPECT_THROW(parseHttpConnectionManagerFromYaml(yaml_string), EnvoyException);
 }
 
 // Validates that HttpConnectionManagerConfig construction succeeds when there are no collisions

--- a/test/extensions/http/header_formatters/preserve_case/config_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/config_test.cc
@@ -48,10 +48,7 @@ TEST(PreserveCaseFormatterFactoryConfigTest, InvalidfFormatterTypeOnEnvoyHeaders
         forward_reason_phrase: true
         formatter_type_on_envoy_headers: INVALID
 )EOF";
-  EXPECT_THROW_WITH_REGEX(
-      TestUtility::loadFromYaml(yaml, typed_config);
-      , EnvoyException,
-      "Unable to parse JSON as proto \\(INVALID_ARGUMENT:\\(formatter_type_on_envoy_headers\\):.*");
+  EXPECT_THROW(TestUtility::loadFromYaml(yaml, typed_config);, EnvoyException);
 }
 
 TEST(PreserveCaseFormatterFactoryConfigTest, PreserveCaseFormatterFactoryConfig_DEFAULT) {

--- a/test/tools/schema_validator/test/schema_validator_test.cc
+++ b/test/tools/schema_validator/test/schema_validator_test.cc
@@ -51,9 +51,8 @@ TEST_F(SchemaValidatorTest, LdsFailOnDeprecated) {
 
 // Unknown field.
 TEST_F(SchemaValidatorTest, LdsUnknownField) {
-  EXPECT_THROW_WITH_REGEX(
-      run("schema_validator_tool -c {} -t discovery_response", "lds_unknown.yaml"), EnvoyException,
-      "reason INVALID_ARGUMENT:foo: Cannot find field.");
+  EXPECT_THROW(run("schema_validator_tool -c {} -t discovery_response", "lds_unknown.yaml"),
+               EnvoyException);
 }
 
 // Invalid type struct URL cases.


### PR DESCRIPTION
(on behalf of protobuf-team)

Protobuf does not guarantee the contents of these messages, so these
tests may be broken by upgrades if not fixed.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>