### PR TITLE
Make filter fuzz tester support filters that process off-thread

### DIFF
--- a/test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h
+++ b/test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h
@@ -102,10 +102,6 @@ void HttpFilterFuzzer::runData(FilterType* filter, const test::fuzz::HttpData& d
   ENVOY_LOG_MISC(debug, "Finished with FilterHeadersStatus: {}", static_cast<int>(headersStatus));
   if ((end_stream && headersStatus == Http::FilterHeadersStatus::Continue) || !enabled_) {
     finishFilter(filter);
-  }
-  if ((headersStatus != Http::FilterHeadersStatus::Continue &&
-       headersStatus != Http::FilterHeadersStatus::StopIteration) ||
-      !enabled_) {
     return;
   }
 
@@ -119,11 +115,6 @@ void HttpFilterFuzzer::runData(FilterType* filter, const test::fuzz::HttpData& d
     ENVOY_LOG_MISC(debug, "Finished with FilterDataStatus: {}", static_cast<int>(dataStatus));
     if ((end_stream && dataStatus == Http::FilterDataStatus::Continue) || !enabled_) {
       finishFilter(filter);
-    }
-    if ((dataStatus != Http::FilterDataStatus::Continue &&
-         dataStatus != Http::FilterDataStatus::StopIterationAndBuffer &&
-         dataStatus != Http::FilterDataStatus::StopIterationNoBuffer) ||
-        !enabled_) {
       return;
     }
   }

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -9,7 +9,6 @@
 #include "source/common/protobuf/utility.h"
 
 #include "test/test_common/utility.h"
-#include <chrono>
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -98,8 +98,8 @@ void UberFilterFuzzer::fuzz(
   // Most filters should have finished processing during runData, but filters that
   // rely on an additional thread (e.g. for file system interaction) may need to wait
   // for the worker thread to complete the filter's task.
-  // We can't use a time-based timeout for this, as the linter forbids use of clock
-  // time, and fake time isn't useful for allowing other threads to complete work.
+  // We can't use a time-based timeout for this, as lint forbids use of clock time,
+  // and fake time isn't useful for allowing other threads to complete work.
   int loop_cycles = 5000;
   while (!isFilterFinished() && --loop_cycles > 0) {
     worker_thread_dispatcher_->run(Event::DispatcherImpl::RunType::NonBlock);

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -4,6 +4,7 @@
 
 #include "test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h"
 #include "test/fuzz/utility.h"
+#include "test/mocks/api/mocks.h"
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/factory_context.h"
@@ -57,6 +58,10 @@ private:
   // Mocked callbacks.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+
+  Api::MockApi api_{};
+  Thread::ThreadFactory& thread_factory_;
+  Event::DispatcherPtr worker_thread_dispatcher_;
 
   const Buffer::Instance* decoding_buffer_{};
 };

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -177,6 +177,28 @@ void UberFilterFuzzer::perFilterSetup() {
   ON_CALL(decoder_callbacks_, decodingBuffer()).WillByDefault([this]() -> const Buffer::Instance* {
     return decoding_buffer_;
   });
+  ON_CALL(encoder_callbacks_, dispatcher()).WillByDefault([this]() -> Event::Dispatcher& {
+    return *worker_thread_dispatcher_;
+  });
+  ON_CALL(decoder_callbacks_, dispatcher()).WillByDefault([this]() -> Event::Dispatcher& {
+    return *worker_thread_dispatcher_;
+  });
+  ON_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, true))
+      .WillByDefault([this]() -> void { finishFilter(encoder_filter_.get()); });
+  ON_CALL(encoder_callbacks_, addEncodedData(_, true)).WillByDefault([this]() -> void {
+    finishFilter(encoder_filter_.get());
+  });
+  ON_CALL(encoder_callbacks_, continueEncoding()).WillByDefault([this]() -> void {
+    finishFilter(encoder_filter_.get());
+  });
+  ON_CALL(decoder_callbacks_, injectDecodedDataToFilterChain(_, true))
+      .WillByDefault([this]() -> void { finishFilter(decoder_filter_.get()); });
+  ON_CALL(decoder_callbacks_, addDecodedData(_, true)).WillByDefault([this]() -> void {
+    finishFilter(decoder_filter_.get());
+  });
+  ON_CALL(decoder_callbacks_, continueDecoding()).WillByDefault([this]() -> void {
+    finishFilter(decoder_filter_.get());
+  });
 }
 
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message: Make filter fuzz tester support filters that process off-thread
Additional Description: This is an alternative approach to #21757  
This option also makes the tester verify that filters complete their task - previously a filter could go into a "waiting" mode and stay there, and still pass the fuzz test.
Risk Level: Low (test-only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes Issue: #21726 
