### PR TITLE
CacheFilter: update cachefilter logs type

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -212,9 +212,9 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
       case FilterState::DecodeServingFromCache:
         ABSL_FALLTHROUGH_INTENDED;
       case FilterState::Destroyed:
-        ENVOY_BUG(false, absl::StrCat("Unexpected filter state in requestCacheStatus: cache lookup "
-                                      "response required validation, but filter state is ",
-                                      filter_state));
+        IS_ENVOY_BUG(absl::StrCat("Unexpected filter state in requestCacheStatus: cache lookup "
+                                  "response required validation, but filter state is ",
+                                  filter_state));
       }
       return LookupStatus::Unknown;
     }
@@ -225,10 +225,9 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
     case CacheEntryStatus::LookupError:
       return LookupStatus::LookupError;
     }
-    ENVOY_BUG(false,
-              absl::StrCat(
-                  "Unhandled CacheEntryStatus encountered when retrieving request cache status: " +
-                  std::to_string(static_cast<int>(filter_state))));
+    IS_ENVOY_BUG(absl::StrCat(
+        "Unhandled CacheEntryStatus encountered when retrieving request cache status: " +
+        std::to_string(static_cast<int>(filter_state))));
     return LookupStatus::Unknown;
   }
   // Either decodeHeaders decided not to do a cache lookup (because the

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -227,8 +227,8 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
     }
     ENVOY_BUG(false,
               absl::StrCat(
-                  "Unhandled CacheEntryStatus encountered when retrieving request cache status: ",
-                  filter_state));
+                  "Unhandled CacheEntryStatus encountered when retrieving request cache status: " +
+                  std::to_string(static_cast<int>(filter_state))));
     return LookupStatus::Unknown;
   }
   // Either decodeHeaders decided not to do a cache lookup (because the

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -249,7 +249,7 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
   case FilterState::ResponseServedFromCache:
     ABSL_FALLTHROUGH_INTENDED;
   case FilterState::Destroyed:
-    ENVOY_BUG(false, absl::StrCat("Unexpected filter state in requestCacheStatus: "
+    ENVOY_LOG(error, absl::StrCat("Unexpected filter state in requestCacheStatus: "
                                   "lookup_result_ is empty but filter state is ",
                                   filter_state));
   }
@@ -458,7 +458,7 @@ void CacheFilter::handleCacheHit() {
 
 void CacheFilter::handleCacheHitWithRangeRequest() {
   if (!lookup_result_->range_details_.has_value()) {
-    ENVOY_BUG(false, "handleCacheHitWithRangeRequest() should not be called without "
+    ENVOY_LOG(error, "handleCacheHitWithRangeRequest() should not be called without "
                      "range_details being populated in lookup_result_");
     return;
   }

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -212,9 +212,7 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
       case FilterState::DecodeServingFromCache:
         ABSL_FALLTHROUGH_INTENDED;
       case FilterState::Destroyed:
-        // TODO (capoferro): ENVOY_BUG prevents code coverage from working. When we fix that, we
-        // should convert this to an ENVOY_BUG.
-        ENVOY_LOG(error, absl::StrCat("Unexpected filter state in requestCacheStatus: cache lookup "
+        ENVOY_BUG(false, absl::StrCat("Unexpected filter state in requestCacheStatus: cache lookup "
                                       "response required validation, but filter state is ",
                                       filter_state));
       }
@@ -227,12 +225,10 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
     case CacheEntryStatus::LookupError:
       return LookupStatus::LookupError;
     }
-    // TODO (capoferro): ENVOY_BUG prevents code coverage from working. When we fix that, we should
-    // convert this to an ENVOY_BUG.
-    ENVOY_LOG(error,
+    ENVOY_BUG(false,
               absl::StrCat(
-                  "Unhandled CacheEntryStatus encountered when retrieving request cache status: " +
-                  std::to_string(static_cast<int>(filter_state))));
+                  "Unhandled CacheEntryStatus encountered when retrieving request cache status: ",
+                  filter_state));
     return LookupStatus::Unknown;
   }
   // Either decodeHeaders decided not to do a cache lookup (because the
@@ -253,7 +249,7 @@ CacheFilter::resolveLookupStatus(absl::optional<CacheEntryStatus> cache_entry_st
   case FilterState::ResponseServedFromCache:
     ABSL_FALLTHROUGH_INTENDED;
   case FilterState::Destroyed:
-    ENVOY_LOG(error, absl::StrCat("Unexpected filter state in requestCacheStatus: "
+    ENVOY_BUG(false, absl::StrCat("Unexpected filter state in requestCacheStatus: "
                                   "lookup_result_ is empty but filter state is ",
                                   filter_state));
   }
@@ -462,7 +458,7 @@ void CacheFilter::handleCacheHit() {
 
 void CacheFilter::handleCacheHitWithRangeRequest() {
   if (!lookup_result_->range_details_.has_value()) {
-    ENVOY_LOG(error, "handleCacheHitWithRangeRequest() should not be called without "
+    ENVOY_BUG(false, "handleCacheHitWithRangeRequest() should not be called without "
                      "range_details being populated in lookup_result_");
     return;
   }


### PR DESCRIPTION
ENVOY_BUG should be used here as ENVOY_BUG no longer crashes when running code coverage.

Signed-off-by: Jiayu Wu <jiayu1.wu@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
