### PR TITLE
build: fix `-Wnonnull` errors

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1392,12 +1392,12 @@ PathTemplateRouteEntryImpl::PathTemplateRouteEntryImpl(
 
 void PathTemplateRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                                    bool insert_envoy_original_path) const {
-  finalizePathHeader(headers, nullptr, insert_envoy_original_path);
+  finalizePathHeader(headers, "", insert_envoy_original_path);
 }
 
 absl::optional<std::string> PathTemplateRouteEntryImpl::currentUrlPathAfterRewrite(
     const Http::RequestHeaderMap& headers) const {
-  return currentUrlPathAfterRewriteWithMatchedPath(headers, nullptr);
+  return currentUrlPathAfterRewriteWithMatchedPath(headers, "");
 }
 
 RouteConstSharedPtr PathTemplateRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,


### PR DESCRIPTION
Fixes the following build errors when `-Wnonnull` is enabled:

```
source/common/router/config_impl.cc:1395:31: error: null passed to a callee that requires a non-null argument [-Werror,-Wnonnull]
  finalizePathHeader(headers, nullptr, insert_envoy_original_path);
                              ^~~~~~~
source/common/router/config_impl.cc:1400:61: error: null passed to a callee that requires a non-null argument [-Werror,-Wnonnull]
  return currentUrlPathAfterRewriteWithMatchedPath(headers, nullptr);
                                                            ^~~~~~~
```

It's my understanding from reading the implementations of `finalizePathHeader` and `currentUrlPathAfterRewriteWithMatchedPath` that passing empty strings should have the same behavior.

Commit Message: build: fix `-Wnonnull` errors
Risk Level: Moderate
Testing: Unit tests & CI
Docs Changes: None
Release Notes: None
Platform Specific Features: None