### PR TITLE
tools: bootstrap: add support for symlinks in pwd

### DIFF
--- a/support/bootstrap
+++ b/support/bootstrap
@@ -9,7 +9,7 @@
 # TODO(hausdorff): If compatibility becomes an issue here, come back and do this
 # "the right way". This is hard to do in general, since `realpath` is not
 # standard.
-if [ ! "$PWD" == "$(git rev-parse --show-toplevel)" ]; then
+if [ ! "$(pwd -P)" == "$(git rev-parse --show-toplevel)" ]; then
     cat >&2 <<__EOF__
 ERROR: this script must be run at the root of the envoy source tree
 __EOF__


### PR DESCRIPTION
Currently bootstrap does not support paths with symlinks.

For example:

ln -s envoy/ envoy-symlink
cd envoy-symlink
support/bootstrap
ERROR: this script must be run at the root of the envoy source tree

$ echo $PWD
/envoy-symlink
$ echo "$(git rev-parse --show-toplevel)"
/envoy

Solution is to use pwd -P (physical: avoid all symlinks) instead of $PWD

$ echo "$(pwd -P)"
/envoy

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
