### PR TITLE
tcp_stats: fix when kernel doesn't provide all stats

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -1,4 +1,4 @@
-1.22.3 (July 27, 2022)
+1.22.4 (Pending)
 ======================
 
 Incompatible Behavior Changes
@@ -14,6 +14,7 @@ Bug Fixes
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
 * repo: fix version to resolve release issue.
+* transport_socket: fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.
 
 Removed Config or Runtime
 -------------------------

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -79,7 +79,7 @@ absl::optional<struct tcp_info> TcpStatsSocket::querySocketInfo() {
   memset(&info, 0, sizeof(info));
   socklen_t optlen = sizeof(info);
   const auto result = callbacks_->ioHandle().getOption(IPPROTO_TCP, TCP_INFO, &info, &optlen);
-  if ((result.return_value_ != 0) || (optlen < sizeof(info))) {
+  if (result.return_value_ != 0) {
     ENVOY_LOG(debug, "Failed getsockopt(IPPROTO_TCP, TCP_INFO): rc {} errno {} optlen {}",
               result.return_value_, result.errno_, optlen);
     return absl::nullopt;

--- a/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
+++ b/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
@@ -122,25 +122,6 @@ TEST_F(TcpStatsTest, CloseSocket) {
   EXPECT_EQ(0, gaugeValue("cx_tx_unacked_segments"));
 }
 
-TEST_F(TcpStatsTest, SyscallFailureShortRead) {
-  initialize(true);
-  tcp_info_.tcpi_notsent_bytes = 42;
-  EXPECT_CALL(io_handle_, getOption(IPPROTO_TCP, TCP_INFO, _, _))
-      .WillOnce(Invoke([this](int, int, void* optval, socklen_t* optlen) {
-        *optlen = *optlen - 1;
-        memcpy(optval, &tcp_info_, sizeof(*optlen));
-        return Api::SysCallIntResult{0, 0};
-      }));
-  EXPECT_LOG_CONTAINS(
-      "debug",
-      fmt::format("Failed getsockopt(IPPROTO_TCP, TCP_INFO): rc 0 errno 0 optlen {}",
-                  sizeof(tcp_info_) - 1),
-      timer_->callback_());
-
-  // Not updated on failed syscall.
-  EXPECT_EQ(0, gaugeValue("cx_tx_unsent_bytes"));
-}
-
 TEST_F(TcpStatsTest, SyscallFailureReturnCode) {
   initialize(true);
   tcp_info_.tcpi_notsent_bytes = 42;


### PR DESCRIPTION
Fix cases when the running kernel has an older version of
`struct tcp_info` than the kernel headers Envoy was compiled with.

Backport of https://github.com/envoyproxy/envoy/pull/22433

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>
