### PR TITLE
[balsa] Fix Http1ServerConnectionImplTest.Http11InvalidTrailerPost.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -268,12 +268,19 @@ void BalsaParser::HandleError(BalsaFrameEnums::ErrorCode error_code) {
   case BalsaFrameEnums::HEADERS_TOO_LONG:
     error_message_ = "size exceeds limit";
     break;
+  case BalsaFrameEnums::TRAILER_MISSING_COLON:
+    error_message_ = "HPE_INVALID_HEADER_TOKEN";
+    break;
   default:
     error_message_ = BalsaFrameEnums::ErrorCodeToString(error_code);
   }
 }
 
-void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode /*error_code*/) {}
+void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode error_code) {
+  if (error_code == BalsaFrameEnums::TRAILER_MISSING_COLON) {
+    HandleError(error_code);
+  }
+}
 
 ParserStatus BalsaParser::convertResult(CallbackResult result) const {
   return result == CallbackResult::Error ? ParserStatus::Error : status_;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -935,11 +935,6 @@ TEST_P(Http1ServerConnectionImplTest, Http11InvalidRequest) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   initialize();
 
   MockRequestDecoder decoder;
@@ -962,6 +957,7 @@ TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
   EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _));
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
+  EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_HEADER_TOKEN");
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http11AbsolutePathNoSlash) {


### PR DESCRIPTION
Also add test expectation for status.message().

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: Fix Http1ServerConnectionImplTest.Http11InvalidTrailerPost.
Additional Description:
Risk Level: low
Testing: Http1ServerConnectionImplTest.Http11InvalidTrailerPost
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a