### PR TITLE
tools: fix print_dependencies.py target error

### DIFF
--- a/tools/print_dependencies.py
+++ b/tools/print_dependencies.py
@@ -39,7 +39,8 @@ if __name__ == '__main__':
 
     # Bazel target to print
     target = sys.argv[1]
-    output = subprocess.check_output(['bazel', 'query', 'deps(%s)' % target])
+    output = subprocess.check_output(['bazel', 'query', 'deps(%s)' % target],
+                                     text=True)
 
     repos = set()
 
@@ -50,5 +51,5 @@ if __name__ == '__main__':
         if match:
             repos.add(match.group(1))
 
-    deps = filter(lambda dep: dep['identifier'] in repos, deps)
+    deps = list(filter(lambda dep: dep['identifier'] in repos, deps))
     print_deps(deps)


### PR DESCRIPTION
Fix error if target is passed to tools/print_dependencies.py

For example:
$ tools/print_dependencies.py //envoy/ssl:handshaker_interface
Traceback (most recent call last):
  File "/envoy/envoy/tools/print_dependencies.py", line 48, in <module>
    for line in output.split('\n'):
TypeError: a bytes-like object is required, not 'str'

Signed-off-by: Ruslan Mstoi <ruslan.mstoi@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
