### PR TITLE
upstream: Expose the `drainConnections` method on the connection pool.

### DIFF
--- a/envoy/upstream/thread_local_cluster.h
+++ b/envoy/upstream/thread_local_cluster.h
@@ -33,6 +33,7 @@ public:
    * See documentation of Envoy::ConnectionPool::Instance.
    */
   void addIdleCallback(ConnectionPool::Instance::IdleCb cb) { pool_->addIdleCallback(cb); };
+  void drainConnections(ConnectionPool::DrainBehavior drain_behavior){ pool_->drainConnections(drain_behavior); };
 
   Upstream::HostDescriptionConstSharedPtr host() const { return pool_->host(); }
 

--- a/envoy/upstream/thread_local_cluster.h
+++ b/envoy/upstream/thread_local_cluster.h
@@ -33,7 +33,9 @@ public:
    * See documentation of Envoy::ConnectionPool::Instance.
    */
   void addIdleCallback(ConnectionPool::Instance::IdleCb cb) { pool_->addIdleCallback(cb); };
-  void drainConnections(ConnectionPool::DrainBehavior drain_behavior){ pool_->drainConnections(drain_behavior); };
+  void drainConnections(ConnectionPool::DrainBehavior drain_behavior) {
+    pool_->drainConnections(drain_behavior);
+  };
 
   Upstream::HostDescriptionConstSharedPtr host() const { return pool_->host(); }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -4248,6 +4248,10 @@ TEST_F(ClusterManagerImplTest, HttpPoolDataForwardsCallsToConnectionPool) {
   ConnectionPool::Instance::IdleCb drained_cb = []() {};
   EXPECT_CALL(*pool_mock, addIdleCallback(_));
   opt_cp.value().addIdleCallback(drained_cb);
+
+
+  EXPECT_CALL(*pool_mock, drainConnections(ConnectionPool::DrainBehavior::DrainAndDelete));
+  opt_cp.value().drainConnections(ConnectionPool::DrainBehavior::DrainAndDelete);
 }
 
 // Test that the read only cross-priority host map in the main thread is correctly synchronized to

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -4249,7 +4249,6 @@ TEST_F(ClusterManagerImplTest, HttpPoolDataForwardsCallsToConnectionPool) {
   EXPECT_CALL(*pool_mock, addIdleCallback(_));
   opt_cp.value().addIdleCallback(drained_cb);
 
-
   EXPECT_CALL(*pool_mock, drainConnections(ConnectionPool::DrainBehavior::DrainAndDelete));
   opt_cp.value().drainConnections(ConnectionPool::DrainBehavior::DrainAndDelete);
 }


### PR DESCRIPTION
Exposing the `drainConnections` method on the connection pool, so that [Nighthawk](https://github.com/envoyproxy/nighthawk) can correctly drain the connection pools used by its individual workers.

Fixes #22527.
Works on https://github.com/envoyproxy/nighthawk/issues/873.

/cc @alyssawilk 

Risk Level: low, existing functionality isn't affected.
Testing: unit tests.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.

Signed-off-by: Jakub Sobon <mumak@google.com>
