### PR TITLE
docs: Use `bazel.release.server_only` for building docker image

### DIFF
--- a/docs/root/start/building/local_docker_build.rst
+++ b/docs/root/start/building/local_docker_build.rst
@@ -14,7 +14,7 @@ This image has all software needed to build Envoy. From your Envoy directory::
 
   $ pwd
   src/envoy
-  $ ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release'
+  $ ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
 
 That command will take some time to run because it is compiling an Envoy binary and running tests.
 

--- a/docs/root/start/building/local_docker_build.rst
+++ b/docs/root/start/building/local_docker_build.rst
@@ -10,13 +10,25 @@ putting that in a clean Ubuntu container.
 **Step 1: Build Envoy**
 
 Using ``envoyproxy/envoy-build`` you will compile Envoy.
-This image has all software needed to build Envoy. From your Envoy directory::
+This image has all software needed to build Envoy. From your Envoy directory:
+
+.. code-block:: console
+
+  $ pwd
+  src/envoy
+  $ ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release'
+
+That command will take some time to run because it is compiling an Envoy binary and running tests.
+
+If your system has limited resources, or you wish to build without running the tests, you can
+also build as follows:
+
+.. code-block:: console
 
   $ pwd
   src/envoy
   $ ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
 
-That command will take some time to run because it is compiling an Envoy binary and running tests.
 
 For more information on building and different build targets, please refer to :repo:`ci/README.md`.
 
@@ -31,7 +43,9 @@ For more information on building and different build targets, please refer to :r
 **Step 2: Build image with only Envoy binary**
 
 In this step we'll build an image that only has the Envoy binary, and none
-of the software used to build it.::
+of the software used to build it.:
+
+.. code-block:: console
 
   $ pwd
   src/envoy/


### PR DESCRIPTION
Fix #21899

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
