### PR TITLE
http: making http1StreamEncoderOptions a decoder function

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -317,6 +317,12 @@ public:
    */
   virtual void traversePerFilterConfig(
       std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const PURE;
+
+  /**
+   * Return the HTTP/1 stream encoder options if applicable. If the stream is not HTTP/1 returns
+   * absl::nullopt.
+   */
+  virtual Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() PURE;
 };
 
 /**
@@ -923,12 +929,6 @@ public:
    * @return the buffer limit the filter should apply.
    */
   virtual uint32_t encoderBufferLimit() PURE;
-
-  /**
-   * Return the HTTP/1 stream encoder options if applicable. If the stream is not HTTP/1 returns
-   * absl::nullopt.
-   */
-  virtual Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() PURE;
 };
 
 /**

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -420,6 +420,7 @@ private:
   }
   void traversePerFilterConfig(
       std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+  Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return {}; }
   void requestRouteConfigUpdate(Http::RouteConfigUpdatedCallbackSharedPtr) override {}
   void resetIdleTimer() override {}
   void setUpstreamOverrideHost(absl::string_view) override {}

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -314,6 +314,12 @@ void ActiveStreamFilterBase::traversePerFilterConfig(
   route->traversePerFilterConfig(filter_context_.filter_name, cb);
 }
 
+Http1StreamEncoderOptionsOptRef ActiveStreamFilterBase::http1StreamEncoderOptions() {
+  // TODO(mattklein123): At some point we might want to actually wrap this interface but for now
+  // we give the filter direct access to the encoder options.
+  return parent_.filter_manager_callbacks_.http1StreamEncoderOptions();
+}
+
 bool ActiveStreamDecoderFilter::canContinue() {
   // It is possible for the connection manager to respond directly to a request even while
   // a filter is trying to continue. If a response has already happened, we should not
@@ -1556,12 +1562,6 @@ void ActiveStreamEncoderFilter::sendLocalReply(
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
   parent_.sendLocalReply(code, body, modify_headers, grpc_status, details);
-}
-
-Http1StreamEncoderOptionsOptRef ActiveStreamEncoderFilter::http1StreamEncoderOptions() {
-  // TODO(mattklein123): At some point we might want to actually wrap this interface but for now
-  // we give the filter direct access to the encoder options.
-  return parent_.filter_manager_callbacks_.http1StreamEncoderOptions();
 }
 
 void ActiveStreamEncoderFilter::responseDataTooLarge() {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -101,6 +101,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override;
   void traversePerFilterConfig(
       std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const override;
+  Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
 
   // Functions to set or get iteration state.
   bool canIterate() { return iteration_state_ == IterationState::Continue; }
@@ -307,7 +308,6 @@ struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                       absl::string_view details) override;
-  Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
 
   void responseDataTooLarge();
   void responseDataDrained();

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -250,6 +250,7 @@ public:
   MOCK_METHOD(const Router::RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (), (const));
   MOCK_METHOD(void, traversePerFilterConfig,
               (std::function<void(const Router::RouteSpecificFilterConfig&)> cb), (const));
+  MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
 
   // Http::StreamDecoderFilterCallbacks
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -340,6 +341,7 @@ public:
   MOCK_METHOD(const Router::RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (), (const));
   MOCK_METHOD(void, traversePerFilterConfig,
               (std::function<void(const Router::RouteSpecificFilterConfig&)> cb), (const));
+  MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
 
   // Http::StreamEncoderFilterCallbacks
   MOCK_METHOD(void, addEncodedData, (Buffer::Instance & data, bool streaming));
@@ -354,7 +356,6 @@ public:
                std::function<void(ResponseHeaderMap& headers)> modify_headers,
                const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                absl::string_view details));
-  MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
 
   Buffer::InstancePtr buffer_;
   testing::NiceMock<Tracing::MockSpan> active_span_;


### PR DESCRIPTION
will be used to allow upstream filters to set downstream chunked encoding options.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
part of https://github.com/envoyproxy/envoy/issues/10455