### PR TITLE
WiP tracing: dubbo proxy tracing #17601

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/BUILD
@@ -110,6 +110,7 @@ envoy_cc_extension(
         "//source/extensions/filters/network/dubbo_proxy/router:rds_lib",
         "//source/extensions/filters/network/dubbo_proxy/router:route_matcher",
         "//source/extensions/filters/network/dubbo_proxy/router:router_lib",
+        "//source/extensions/filters/network/dubbo_proxy/tracer:config",
         "@envoy_api//envoy/extensions/filters/network/dubbo_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/network/dubbo_proxy/active_message.cc
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.cc
@@ -102,6 +102,11 @@ const Network::Connection* ActiveMessageFilterBase::connection() const {
 
 Router::RouteConstSharedPtr ActiveMessageFilterBase::route() { return parent_.route(); }
 
+Tracer::Config& ActiveMessageFilterBase::tracerConfig() {
+  return parent_.tracerConfig();
+}
+
+
 SerializationType ActiveMessageFilterBase::serializationType() const {
   return parent_.serializationType();
 }
@@ -303,6 +308,10 @@ DubboProxy::Router::RouteConstSharedPtr ActiveMessage::route() {
   }
 
   return nullptr;
+}
+
+Tracer::Config& ActiveMessage::tracerConfig() {
+  return parent_.config().tracerConfig();
 }
 
 FilterStatus ActiveMessage::applyDecoderFilters(ActiveMessageDecoderFilter* filter,

--- a/source/extensions/filters/network/dubbo_proxy/active_message.h
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.h
@@ -71,6 +71,7 @@ public:
   uint64_t streamId() const override;
   const Network::Connection* connection() const override;
   DubboProxy::Router::RouteConstSharedPtr route() override;
+  Tracer::Config& tracerConfig() override;
   SerializationType serializationType() const override;
   ProtocolType protocolType() const override;
   StreamInfo::StreamInfo& streamInfo() override;
@@ -164,6 +165,7 @@ public:
   ProtocolType protocolType() const;
   StreamInfo::StreamInfo& streamInfo();
   Router::RouteConstSharedPtr route();
+  Tracer::Config& tracerConfig();
   void sendLocalReply(const DubboFilters::DirectResponse& response, bool end_stream);
   void startUpstreamResponse();
   DubboFilters::UpstreamResponseStatus upstreamData(Buffer::Instance& buffer);

--- a/source/extensions/filters/network/dubbo_proxy/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/config.cc
@@ -2,9 +2,14 @@
 
 #include "envoy/extensions/filters/network/dubbo_proxy/v3/dubbo_proxy.pb.h"
 #include "envoy/extensions/filters/network/dubbo_proxy/v3/dubbo_proxy.pb.validate.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.validate.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/config/utility.h"
+#include "source/common/tracing/custom_tag_impl.h"
+#include "source/common/tracing/http_tracer_manager_impl.h"
+#include "source/common/tracing/tracer_config_impl.h"
 #include "source/extensions/filters/network/dubbo_proxy/conn_manager.h"
 #include "source/extensions/filters/network/dubbo_proxy/filters/factory_base.h"
 #include "source/extensions/filters/network/dubbo_proxy/router/rds.h"
@@ -12,6 +17,7 @@
 #include "source/extensions/filters/network/dubbo_proxy/stats.h"
 
 #include "absl/container/flat_hash_map.h"
+#include <memory>
 
 namespace Envoy {
 namespace Extensions {
@@ -19,6 +25,7 @@ namespace NetworkFilters {
 namespace DubboProxy {
 
 SINGLETON_MANAGER_REGISTRATION(dubbo_route_config_provider_manager);
+SINGLETON_MANAGER_REGISTRATION(dubbo_tracer_config_manager);
 
 Network::FilterFactoryCb DubboProxyFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::network::dubbo_proxy::v3::DubboProxy& proto_config,
@@ -28,9 +35,15 @@ Network::FilterFactoryCb DubboProxyFilterConfigFactory::createFilterFactoryFromP
           SINGLETON_MANAGER_REGISTERED_NAME(dubbo_route_config_provider_manager), [&context] {
             return std::make_shared<Router::RouteConfigProviderManagerImpl>(context.admin());
           });
+  auto tracer_config_manager = context.singletonManager().getTyped<Tracing::HttpTracerManagerImpl>(
+      SINGLETON_MANAGER_REGISTERED_NAME(dubbo_tracer_config_manager), [&context] {
+        return std::make_shared<Tracing::HttpTracerManagerImpl>(
+            std::make_unique<Tracing::TracerFactoryContextImpl>(
+                context.getServerFactoryContext(), context.messageValidationVisitor()));
+      });
 
-  std::shared_ptr<Config> filter_config(
-      std::make_shared<ConfigImpl>(proto_config, context, *route_config_provider_manager));
+  std::shared_ptr<Config> filter_config(std::make_shared<ConfigImpl>(
+      proto_config, context, *route_config_provider_manager, *tracer_config_manager));
 
   return [route_config_provider_manager, filter_config,
           &context](Network::FilterManager& filter_manager) -> void {
@@ -89,7 +102,8 @@ private:
 // class ConfigImpl.
 ConfigImpl::ConfigImpl(const DubboProxyConfig& config,
                        Server::Configuration::FactoryContext& context,
-                       Router::RouteConfigProviderManager& route_config_provider_manager)
+                       Router::RouteConfigProviderManager& route_config_provider_manager,
+                       Tracing::HttpTracerManager& tracing_config_manager)
     : context_(context), stats_prefix_(fmt::format("dubbo.{}.", config.stat_prefix())),
       stats_(DubboFilterStats::generateStats(stats_prefix_, context_.scope())),
       serialization_type_(
@@ -125,17 +139,86 @@ ConfigImpl::ConfigImpl(const DubboProxyConfig& config,
         multiple_route_config, context_.getServerFactoryContext());
   }
 
+  InitTracerCallback callback =
+      [this, &context, &tracing_config_manager](const Protobuf::Message& message) -> void {
+    this->initTracingConfig(message, context, tracing_config_manager);
+  };
+
   if (config.dubbo_filters().empty()) {
     ENVOY_LOG(debug, "using default router filter");
 
     envoy::extensions::filters::network::dubbo_proxy::v3::DubboFilter router_config;
     router_config.set_name("envoy.filters.dubbo.router");
-    registerFilter(router_config);
+    registerFilter(router_config, callback);
   } else {
     for (const auto& filter_config : config.dubbo_filters()) {
-      registerFilter(filter_config);
+      registerFilter(filter_config, callback);
     }
   }
+}
+
+std::unique_ptr<Http::TracingConnectionManagerConfig>
+ConfigImpl::createTracingConfig(const envoy::extensions::filters::network::http_connection_manager::
+                                    v3::HttpConnectionManager::Tracing& proto,
+                                Server::Configuration::FactoryContext& context) {
+
+  Tracing::OperationName tracing_operation_name;
+
+  // Listener level traffic direction overrides the operation name
+  switch (context.direction()) {
+    PANIC_ON_PROTO_ENUM_SENTINEL_VALUES;
+  case envoy::config::core::v3::UNSPECIFIED: {
+    // Continuing legacy behavior; if unspecified, we treat this as ingress.
+    tracing_operation_name = Tracing::OperationName::Ingress;
+    break;
+  }
+  case envoy::config::core::v3::INBOUND:
+    tracing_operation_name = Tracing::OperationName::Ingress;
+    break;
+  case envoy::config::core::v3::OUTBOUND:
+    tracing_operation_name = Tracing::OperationName::Egress;
+    break;
+  }
+
+  Tracing::CustomTagMap custom_tags;
+  for (const auto& tag : proto.custom_tags()) {
+    custom_tags.emplace(tag.tag(), Tracing::CustomTagUtility::createCustomTag(tag));
+  }
+
+  envoy::type::v3::FractionalPercent client_sampling;
+  client_sampling.set_numerator(proto.has_client_sampling() ? proto.client_sampling().value()
+                                                            : 100);
+  envoy::type::v3::FractionalPercent random_sampling;
+  // TODO: Random sampling historically was an integer and default to out of 10,000. We should
+  // deprecate that and move to a straight fractional percent config.
+  uint64_t random_sampling_numerator{
+      PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(proto, random_sampling, 10000, 10000)};
+  random_sampling.set_numerator(random_sampling_numerator);
+  random_sampling.set_denominator(envoy::type::v3::FractionalPercent::TEN_THOUSAND);
+  envoy::type::v3::FractionalPercent overall_sampling;
+  uint64_t overall_sampling_numerator{
+      PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(proto, overall_sampling, 10000, 10000)};
+  overall_sampling.set_numerator(overall_sampling_numerator);
+  overall_sampling.set_denominator(envoy::type::v3::FractionalPercent::TEN_THOUSAND);
+
+  const uint32_t max_path_tag_length =
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto, max_path_tag_length, Tracing::DefaultMaxPathTagLength);
+
+  return std::make_unique<Http::TracingConnectionManagerConfig>(
+      Http::TracingConnectionManagerConfig{tracing_operation_name, custom_tags, client_sampling,
+                                           random_sampling, overall_sampling, proto.verbose(),
+                                           max_path_tag_length});
+}
+
+void ConfigImpl::initTracingConfig(const Protobuf::Message& message,
+                                   Server::Configuration::FactoryContext& context,
+                                   Tracing::HttpTracerManager& tracing_config_manager) {
+  auto tracing_proto = MessageUtil::downcastAndValidate<const TracingProtoConfig&>(
+      message, context.messageValidationVisitor());
+  ASSERT(tracing_proto.has_provider());
+  auto tracer = tracing_config_manager.getOrCreateHttpTracer(&tracing_proto.provider());
+  auto tracing_config = createTracingConfig(tracing_proto, context);
+  tracer_config_ = std::make_unique<Tracer::TracerConfigImpl>(std::move(tracing_config), tracer);
 }
 
 void ConfigImpl::createFilterChain(DubboFilters::FilterChainFactoryCallbacks& callbacks) {
@@ -154,7 +237,8 @@ ProtocolPtr ConfigImpl::createProtocol() {
   return NamedProtocolConfigFactory::getFactory(protocol_type_).createProtocol(serialization_type_);
 }
 
-void ConfigImpl::registerFilter(const DubboFilterConfig& proto_config) {
+void ConfigImpl::registerFilter(const DubboFilterConfig& proto_config,
+                                InitTracerCallback tracer_callback) {
   const auto& string_name = proto_config.name();
   ENVOY_LOG(debug, "    dubbo filter #{}", filter_factories_.size());
   ENVOY_LOG(debug, "      name: {}", string_name);
@@ -167,6 +251,9 @@ void ConfigImpl::registerFilter(const DubboFilterConfig& proto_config) {
   ProtobufTypes::MessagePtr message = factory.createEmptyConfigProto();
   Envoy::Config::Utility::translateOpaqueConfig(proto_config.config(),
                                                 context_.messageValidationVisitor(), *message);
+  if (string_name == "envoy.filters.dubbo.tracer") {
+    tracer_callback(*message);
+  }
   DubboFilters::FilterFactoryCb callback =
       factory.createFilterFactoryFromProto(*message, stats_prefix_, context_);
 

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.h
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.h
@@ -34,6 +34,7 @@ public:
   virtual DubboFilterStats& stats() PURE;
   virtual ProtocolPtr createProtocol() PURE;
   virtual Router::Config& routerConfig() PURE;
+  virtual Tracer::Config& tracerConfig() PURE;
 };
 
 // class ActiveMessagePtr;

--- a/source/extensions/filters/network/dubbo_proxy/filters/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/filters/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
         "//source/extensions/filters/network/dubbo_proxy:serializer_interface",
         "//source/extensions/filters/network/dubbo_proxy/router:router_interface",
+        "//source/extensions/filters/network/dubbo_proxy/tracer:tracer_interface",
     ],
 )
 

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter.h
@@ -13,6 +13,7 @@
 #include "source/extensions/filters/network/dubbo_proxy/metadata.h"
 #include "source/extensions/filters/network/dubbo_proxy/protocol.h"
 #include "source/extensions/filters/network/dubbo_proxy/router/router.h"
+#include "source/extensions/filters/network/dubbo_proxy/tracer/tracer.h"
 #include "source/extensions/filters/network/dubbo_proxy/serializer.h"
 
 namespace Envoy {
@@ -83,6 +84,8 @@ public:
    * @return RouteConstSharedPtr the route for the current request.
    */
   virtual DubboProxy::Router::RouteConstSharedPtr route() PURE;
+
+  virtual Tracer::Config& tracerConfig() PURE;
 
   /**
    * @return SerializationType the originating protocol.

--- a/source/extensions/filters/network/dubbo_proxy/router/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/router/BUILD
@@ -69,6 +69,7 @@ envoy_cc_library(
         "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
         "//source/extensions/filters/network/dubbo_proxy:serializer_interface",
         "//source/extensions/filters/network/dubbo_proxy/filters:filter_interface",
+        "//source/extensions/filters/network/dubbo_proxy/tracer:tracer_util",
     ],
 )
 

--- a/source/extensions/filters/network/dubbo_proxy/router/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/config.cc
@@ -16,7 +16,7 @@ DubboFilters::FilterFactoryCb RouterFilterConfig::createFilterFactoryFromProtoTy
     const envoy::extensions::filters::network::dubbo_proxy::router::v3::Router&, const std::string&,
     Server::Configuration::FactoryContext& context) {
   return [&context](DubboFilters::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addFilter(std::make_shared<Router>(context.clusterManager()));
+    callbacks.addFilter(std::make_shared<Router>(context.clusterManager(), context.api().randomGenerator(), context.runtime()));
   };
 }
 

--- a/source/extensions/filters/network/dubbo_proxy/tracer/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/BUILD
@@ -1,0 +1,79 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "tracer_interface",
+    hdrs = ["tracer.h"],
+    deps = [
+        "//source/common/http:conn_manager_config_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "tracer_lib",
+    srcs = ["tracer_impl.cc"],
+    hdrs = ["tracer_impl.h"],
+    deps = [
+        "//envoy/tcp:conn_pool_interface",
+        "//envoy/upstream:cluster_manager_interface",
+        "//envoy/upstream:load_balancer_interface",
+        "//envoy/upstream:thread_local_cluster_interface",
+        "//source/common/common:logger_lib",
+        "//source/common/http:conn_manager_config_interface",
+        "//source/common/http:header_utility_lib",
+        "//source/common/tracing:http_tracer_lib",
+        "//source/common/upstream:load_balancer_lib",
+        "//source/extensions/filters/network/dubbo_proxy/filters:filter_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":tracer_lib",
+        "//envoy/registry",
+        "//envoy/singleton:instance_interface",
+        "//source/common/tracing:custom_tag_lib",
+        "//source/common/tracing:http_tracer_lib",
+        "//source/common/tracing:http_tracer_manager_lib",
+        "//source/common/tracing:tracer_config_lib",
+        "//source/extensions/filters/network/dubbo_proxy/filters:factory_base_lib",
+        "//source/extensions/filters/network/dubbo_proxy/filters:filter_config_interface",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "skywalking_specialization",
+    srcs = ["skywalking_specialization.cc"],
+    hdrs = ["skywalking_specialization.h"],
+    external_deps = [
+        "cpp2sky",
+    ],
+    deps = [
+        "//envoy/tracing:trace_driver_interface",
+        "//source/extensions/tracers/skywalking:skywalking_tracer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "tracer_util",
+    srcs = ["tracer_util.cc"],
+    hdrs = ["tracer_util.h"],
+    deps = [
+        ":skywalking_specialization",
+        "//envoy/tracing:trace_driver_interface",
+        "//source/extensions/request_id/uuid:config",
+        "//source/extensions/filters/network/dubbo_proxy:message_lib",
+        "//source/extensions/filters/network/dubbo_proxy/filters:filter_interface",
+    ],
+)

--- a/source/extensions/filters/network/dubbo_proxy/tracer/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/config.cc
@@ -1,0 +1,38 @@
+#include "source/extensions/filters/network/dubbo_proxy/tracer/config.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.validate.h"
+#include "envoy/registry/registry.h"
+#include "source/extensions/filters/network/dubbo_proxy/tracer/tracer_impl.h"
+#include "source/common/common/logger.h"
+#include "envoy/singleton/manager.h"
+#include "source/common/tracing/http_tracer_manager_impl.h"
+#include "source/common/tracing/tracer_config_impl.h"
+#include "source/common/tracing/custom_tag_impl.h"
+#include <memory>
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+DubboFilters::FilterFactoryCb TracerFilterConfig::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+        Tracing&,
+    const std::string&, Server::Configuration::FactoryContext&) {
+
+  return [](DubboFilters::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addFilter(std::make_shared<Tracer>());
+  };
+}
+
+/**
+ * Static registration for the router filter. @see RegisterFactory.
+ */
+REGISTER_FACTORY(TracerFilterConfig, DubboFilters::NamedDubboFilterConfigFactory);
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/config.h
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/tracing/http_tracer_manager.h"
+#include "source/common/tracing/http_tracer_impl.h"
+#include "source/extensions/filters/network/dubbo_proxy/filters/factory_base.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+class TracerFilterConfig : public DubboFilters::FactoryBase<
+                               envoy::extensions::filters::network::http_connection_manager::v3::
+                                   HttpConnectionManager::Tracing> {
+public:
+  TracerFilterConfig() : FactoryBase("envoy.filters.dubbo.tracer") {}
+
+private:
+  DubboFilters::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::network::http_connection_manager::v3::
+          HttpConnectionManager::Tracing& proto_config,
+      const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/skywalking_specialization.cc
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/skywalking_specialization.cc
@@ -1,0 +1,23 @@
+#include "source/extensions/filters/network/dubbo_proxy/tracer/skywalking_specialization.h"
+
+#include "source/extensions/tracers/skywalking/tracer.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+void SkyWalkingSpecialization::setSpanLayerToRPCFramework(Tracing::SpanPtr& span) {
+  try {
+    auto& sky_span = dynamic_cast<Tracers::SkyWalking::Span&>(*span);
+    sky_span.spanEntity()->setSpanLayer(skywalking::v3::SpanLayer::RPCFramework);
+  } catch (const std::bad_cast&) {
+  }
+}
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/skywalking_specialization.h
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/skywalking_specialization.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "envoy/tracing/trace_driver.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+class SkyWalkingSpecialization {
+public:
+  static void setSpanLayerToRPCFramework(Tracing::SpanPtr& span);
+};
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/tracer.h
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/tracer.h
@@ -1,0 +1,24 @@
+#include "envoy/common/pure.h"
+#include "envoy/tracing/http_tracer.h"
+#include "source/common/http/conn_manager_config.h"
+#include <memory>
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+class Config : public virtual Tracing::Config {
+public:
+  virtual Tracing::HttpTracerSharedPtr tracer() const PURE;
+  virtual const Http::TracingConnectionManagerConfig* tracingConfig() const PURE;
+};
+
+using ConfigConstSharedPtr = std::shared_ptr<const Config>;
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/tracer_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/tracer_impl.cc
@@ -1,0 +1,61 @@
+#include "source/extensions/filters/network/dubbo_proxy/tracer/tracer_impl.h"
+
+#include "envoy/upstream/cluster_manager.h"
+#include "envoy/upstream/thread_local_cluster.h"
+#include "source/common/tracing/http_tracer_impl.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/extensions/filters/network/dubbo_proxy/message_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+void Tracer::onDestroy() {}
+
+void Tracer::setDecoderFilterCallbacks(DubboFilters::DecoderFilterCallbacks&) {
+}
+
+FilterStatus Tracer::onMessageDecoded(MessageMetadataSharedPtr, ContextSharedPtr) {
+  return FilterStatus::Continue;
+}
+
+void Tracer::setEncoderFilterCallbacks(DubboFilters::EncoderFilterCallbacks&) {
+}
+
+FilterStatus Tracer::onMessageEncoded(MessageMetadataSharedPtr, ContextSharedPtr) {
+  return FilterStatus::Continue;
+}
+
+void Tracer::onUpstreamData(Buffer::Instance&, bool) {
+}
+
+void Tracer::onEvent(Network::ConnectionEvent) {
+}
+
+Tracing::HttpTracerSharedPtr TracerConfigImpl::tracer() const { return tracer_; }
+
+const Http::TracingConnectionManagerConfig* TracerConfigImpl::tracingConfig() const {
+  return tracing_config_.get();
+}
+
+Tracing::OperationName TracerConfigImpl::operationName() const {
+  return tracing_config_->operation_name_;
+}
+
+const Tracing::CustomTagMap* TracerConfigImpl::customTags() const {
+  return &tracing_config_->custom_tags_; // http can specify tags with route filters
+}
+
+bool TracerConfigImpl::verbose() const { return tracing_config_->verbose_; }
+
+uint32_t TracerConfigImpl::maxPathTagLength() const {
+  return tracing_config_->max_path_tag_length_;
+}
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/tracer_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/tracer_impl.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/tcp/conn_pool.h"
+#include "envoy/tracing/trace_config.h"
+#include "envoy/tracing/http_tracer.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/config/well_known_names.h"
+#include "source/common/upstream/load_balancer_impl.h"
+#include "source/common/http/conn_manager_config.h"
+#include "source/common/tracing/http_tracer_impl.h"
+#include "source/extensions/filters/network/dubbo_proxy/filters/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+class Tracer : public Tcp::ConnectionPool::UpstreamCallbacks,
+               public DubboFilters::CodecFilter {
+public:
+  Tracer() = default;
+  ~Tracer() override = default;
+
+  // DubboFilters::DecoderFilter
+  void onDestroy() override;
+  void setDecoderFilterCallbacks(DubboFilters::DecoderFilterCallbacks& callbacks) override;
+
+  FilterStatus onMessageDecoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) override;
+
+  // DubboFilter::EncoderFilter
+  void setEncoderFilterCallbacks(DubboFilters::EncoderFilterCallbacks& callbacks) override;
+  FilterStatus onMessageEncoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) override;
+
+  // Tcp::ConnectionPool::UpstreamCallbacks
+  void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
+  void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+};
+
+class TracerConfigImpl : public Config,
+                         public Logger::Loggable<Logger::Id::dubbo> {
+public:
+  TracerConfigImpl(Http::TracingConnectionManagerConfigPtr&& tracing_config,
+                   Tracing::HttpTracerSharedPtr tracer)
+      : tracing_config_(std::move(tracing_config)), tracer_(tracer) {}
+  Tracing::HttpTracerSharedPtr tracer() const override;
+  const Http::TracingConnectionManagerConfig* tracingConfig() const override;
+
+  // Tracing::Config
+  Tracing::OperationName operationName() const override;
+  const Tracing::CustomTagMap* customTags() const override;
+  bool verbose() const override;
+  uint32_t maxPathTagLength() const override;
+
+private:
+  Http::TracingConnectionManagerConfigPtr tracing_config_;
+  Tracing::HttpTracerSharedPtr tracer_;
+};
+
+class NullTracerConfig : public Config {
+public:
+  Tracing::HttpTracerSharedPtr tracer() const override { return nullptr; }
+  const Http::TracingConnectionManagerConfig* tracingConfig() const override {return nullptr; }
+
+  // Tracing::Config
+  Tracing::OperationName operationName() const override { return Tracing::OperationName(); }
+  const Tracing::CustomTagMap* customTags() const override { return nullptr; }
+  bool verbose() const override { return false; }
+  uint32_t maxPathTagLength() const override { return 0UL;}
+};
+
+using TracerConfigImplPtr = std::unique_ptr<Config>;
+
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/tracer_util.cc
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/tracer_util.cc
@@ -1,0 +1,164 @@
+#include "source/extensions/filters/network/dubbo_proxy/tracer/tracer_util.h"
+#include "source/extensions/filters/network/dubbo_proxy/tracer/skywalking_specialization.h"
+
+#include <memory>
+
+#include "source/common/tracing/http_tracer_impl.h"
+
+#include "source/extensions/request_id/uuid/config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+void DubboTracerUtility::prepareStreamInfoTraceReason(
+    const Config& config, const std::unique_ptr<Http::RequestHeaderMapImpl>& attachment,
+    StreamInfo::StreamInfo& stream_info, Random::RandomGenerator& random_generator,
+    Envoy::Runtime::Loader& runtime) {
+
+  auto rid_extension = std::make_unique<Extensions::RequestId::UUIDRequestIDExtension>(
+      envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(), random_generator);
+  auto final_reason = Tracing::Reason::NotTraceable;
+  rid_extension->set(*attachment, false);
+  if (!rid_extension->useRequestIdForTraceSampling()) {
+    final_reason = Tracing::Reason::Sampling;
+  } else {
+    const auto rid_to_integer = rid_extension->toInteger(*attachment);
+    if (rid_to_integer.has_value()) {
+      const uint64_t result = rid_to_integer.value() % 10000;
+      const envoy::type::v3::FractionalPercent* client_sampling =
+          &config.tracingConfig()->client_sampling_;
+      const envoy::type::v3::FractionalPercent* random_sampling =
+          &config.tracingConfig()->random_sampling_;
+      const envoy::type::v3::FractionalPercent* overall_sampling =
+          &config.tracingConfig()->overall_sampling_;
+      final_reason = rid_extension->getTraceReason(*attachment);
+      if (Tracing::Reason::NotTraceable == final_reason) {
+        if (attachment->ClientTraceId() &&
+            runtime.snapshot().featureEnabled("tracing.client_enabled", *client_sampling)) {
+          final_reason = Tracing::Reason::ClientForced;
+          rid_extension->setTraceReason(*attachment, final_reason);
+        } else if (attachment->EnvoyForceTrace()) {
+          final_reason = Tracing::Reason::ServiceForced;
+          rid_extension->setTraceReason(*attachment, final_reason);
+        } else if (runtime.snapshot().featureEnabled("tracing.random_sampling", *random_sampling,
+                                                     result)) {
+          final_reason = Tracing::Reason::Sampling;
+          rid_extension->setTraceReason(*attachment, final_reason);
+        }
+      }
+      if (final_reason != Tracing::Reason::NotTraceable &&
+          !runtime.snapshot().featureEnabled("tracing.global_enabled", *overall_sampling, result)) {
+        final_reason = Tracing::Reason::NotTraceable;
+        rid_extension->setTraceReason(*attachment, final_reason);
+      }
+    }
+  }
+  stream_info.setTraceReason(final_reason);
+}
+
+Tracing::SpanPtr DubboTracerUtility::createDownstreamSpan(
+    const Tracing::HttpTracerSharedPtr tracer, const Config& config,
+    const std::unique_ptr<Http::RequestHeaderMapImpl>& attachment, const RpcInvocation& invocation,
+    const StreamInfo::StreamInfo& stream_info) {
+
+  const auto tracing_decision = Tracing::HttpTracerUtility::shouldTraceRequest(stream_info);
+  attachment->setPath(invocation.serviceName() + "." + invocation.methodName());
+  auto span = tracer->startSpan(config, *attachment, stream_info, tracing_decision);
+  SkyWalkingSpecialization::setSpanLayerToRPCFramework(span);
+  return span;
+}
+
+Tracing::SpanPtr DubboTracerUtility::createUpstreamSpan(const Tracing::SpanPtr& downstream_span,
+                                                        const Config& config,
+                                                        const std::string& cluster_name,
+                                                        const SystemTime& system_time) {
+
+  auto span =
+      downstream_span->spawnChild(config, "router " + cluster_name + " egress", system_time);
+  SkyWalkingSpecialization::setSpanLayerToRPCFramework(span);
+  return span;
+}
+
+void DubboTracerUtility::updateUpstreamRequestAttachment(
+    const Tracing::SpanPtr& upstream_span, const Upstream::HostDescriptionConstSharedPtr& host,
+    const RpcInvocationImpl* invocation) {
+  auto& attachment = invocation->mutableAttachment();
+  auto context = Http::createHeaderMap<Http::RequestHeaderMapImpl>(attachment->headers());
+  context->setPath(invocation->serviceName() + "." + invocation->methodName());
+  upstream_span->injectContext(*context, host);
+  context->forEach([&attachment](absl::string_view key, absl::string_view val) -> bool {
+    auto k = std::string(key);
+    auto value = std::string(val);
+    attachment->remove(k);
+    attachment->insert(k, value);
+    return true;
+  });
+}
+
+void DubboTracerUtility::finalizeDownstreamSpan(
+    const Tracing::SpanPtr& span, const std::unique_ptr<Http::RequestHeaderMapImpl>& attachment,
+    const StreamInfo::StreamInfo& stream_info, const Network::Connection* connection,
+    const Tracing::Config& config) {
+
+  if (attachment->RequestId()) {
+    span->setTag(Tracing::Tags::get().GuidXRequestId, attachment->getRequestIdValue());
+  }
+
+  const auto& remote_address = connection->connectionInfoProvider().directRemoteAddress();
+  if (remote_address->type() == Network::Address::Type::Ip) {
+    const auto remote_ip = remote_address->ip();
+    span->setTag(Tracing::Tags::get().PeerAddress, remote_ip->addressAsString());
+  } else {
+    span->setTag(Tracing::Tags::get().PeerAddress, remote_address->logicalName());
+  }
+
+  if (attachment->ClientTraceId()) {
+    span->setTag(Tracing::Tags::get().GuidXClientTraceId, attachment->getClientTraceIdValue());
+  }
+
+  Tracing::CustomTagContext ctx{attachment.get(), stream_info};
+  const Tracing::CustomTagMap* custom_tag_map = config.customTags();
+  if (custom_tag_map) {
+    for (const auto& it : *custom_tag_map) {
+      it.second->applySpan(*span, ctx);
+    }
+  }
+
+  span->setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
+
+  if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
+    span->setTag(Tracing::Tags::get().UpstreamCluster,
+                 stream_info.upstreamInfo()->upstreamHost()->cluster().name());
+    span->setTag(Tracing::Tags::get().UpstreamClusterName,
+                 stream_info.upstreamInfo()->upstreamHost()->cluster().observabilityName());
+  }
+
+  span->finishSpan();
+}
+
+void DubboTracerUtility::finalizeUpstreamSpan(const Tracing::SpanPtr& span,
+                                              const StreamInfo::StreamInfo&,
+                                              const Upstream::HostDescriptionConstSharedPtr host,
+                                              const Tracing::Config&) {
+
+  if (host) {
+    auto upstream_address = host->address();
+    span->setTag(Tracing::Tags::get().UpstreamAddress, upstream_address->asStringView());
+    span->setTag(Tracing::Tags::get().PeerAddress, upstream_address->asStringView());
+    span->setTag(Tracing::Tags::get().UpstreamCluster, host->cluster().name());
+    span->setTag(Tracing::Tags::get().UpstreamClusterName, host->cluster().observabilityName());
+  }
+
+  span->setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
+
+  span->finishSpan();
+}
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/tracer/tracer_util.h
+++ b/source/extensions/filters/network/dubbo_proxy/tracer/tracer_util.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/common/random_generator.h"
+#include "envoy/network/address.h"
+
+#include "source/extensions/filters/network/dubbo_proxy/message_impl.h"
+#include "source/extensions/filters/network/dubbo_proxy/filters/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Tracer {
+
+class DubboTracerUtility {
+public:
+  static void prepareStreamInfoTraceReason(
+      const Config& config, const std::unique_ptr<Http::RequestHeaderMapImpl>& attachment,
+      StreamInfo::StreamInfo& stream_info, Random::RandomGenerator& random_generator,
+      Envoy::Runtime::Loader& runtime);
+
+  static Tracing::SpanPtr
+  createDownstreamSpan(const Tracing::HttpTracerSharedPtr tracer, const Config& config,
+                       const std::unique_ptr<Http::RequestHeaderMapImpl>& attachment,
+                       const RpcInvocation& invocation, const StreamInfo::StreamInfo& stream_info);
+
+  static Tracing::SpanPtr createUpstreamSpan(const Tracing::SpanPtr& downstream_span,
+                                             const Config& config, const std::string& cluster_name,
+                                             const SystemTime& system_time);
+
+  static void updateUpstreamRequestAttachment(const Tracing::SpanPtr& upstream_span,
+                                              const Upstream::HostDescriptionConstSharedPtr& host,
+                                              const RpcInvocationImpl* invocation);
+
+  static void finalizeDownstreamSpan(const Tracing::SpanPtr& span,
+                                     const std::unique_ptr<Http::RequestHeaderMapImpl>& attachment,
+                                     const StreamInfo::StreamInfo& stream_info,
+                                     const Network::Connection* connection,
+                                     const Tracing::Config& config);
+
+  static void finalizeUpstreamSpan(const Tracing::SpanPtr& span,
+                                   const StreamInfo::StreamInfo& stream_info,
+                                   const Upstream::HostDescriptionConstSharedPtr host,
+                                   const Tracing::Config& config);
+};
+
+} // namespace Tracer
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

<!--
This is my first PR for envoy. I'm worried about whether I'm dealing with this issue #17601 in a complete wrong way.
So, currently even I'm not finished, I'm opening this PR for review purpose.
It built, and ran. Didn't make service call to step in the tracing logic. I will do this the next step, to debug through, to make sure this PR works.

I found it's looks not possible to implement tracing in a isolate filter without a large scale refactor, neither the `http_connection_manger` nor the `router` filter of `dubbo_proxy` do. The dubbo router still coupling with dubbo's connection manager and active message.

Meanwhile, `Http::createHeaderMap<Http::RequestHeaderMapImpl>(invocation_impl->attachment().headers());` should not work,
mainly because dubbo's attachment dosen't have keys like `authority` or `method`. It's need some extra logic to reuse http's tracing classes and methods.
Also the occasion of span manipulations may need to adjust.
-->


Commit Message: Add tracing support for dubbo proxy
Additional Description: #17601 
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
