### PR TITLE
Thrift: enable retrying fetch port in windows integration test

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/driver/generate_fixture.sh
+++ b/test/extensions/filters/network/thrift_proxy/driver/generate_fixture.sh
@@ -70,7 +70,8 @@ if [[ "$OSTYPE" == "msys" ]]; then
         port=$(shuf -n 1 -i 49152-65535)
         netstat -atn | grep -q "$port" >> /dev/null
     do
-    continue
+        echo "Port is used. retrying..."
+        continue
     done
     SOCKET="127.0.0.1:${port}"
 else


### PR DESCRIPTION
Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Test failure only happen on Windows so let's give it a shot to see if it's an port retrying issue

Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #21017
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
