### PR TITLE
Update Transcoding Lib API

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -415,7 +415,7 @@ JsonTranscoderConfig::translateProtoMessageToJson(const Protobuf::Message& messa
       message.SerializeAsString(), json_out, print_options_);
 }
 
-JsonTranscoderFilter::JsonTranscoderFilter(JsonTranscoderConfig& config) : config_(config) {}
+JsonTranscoderFilter::JsonTranscoderFilter(const JsonTranscoderConfig& config) : config_(config) {}
 
 void JsonTranscoderFilter::initPerRouteConfig() {
   const auto* route_local =

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -476,6 +476,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, EmptyRoute) {
 
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers, false));
+  EXPECT_FALSE(filter_.shouldTranscodeResponse());
 }
 
 TEST_F(GrpcJsonTranscoderFilterTest, EmptyRouteEntry) {
@@ -483,6 +484,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, EmptyRouteEntry) {
 
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers, false));
+  EXPECT_FALSE(filter_.shouldTranscodeResponse());
 }
 
 TEST_F(GrpcJsonTranscoderFilterTest, PerRouteDisabledConfigOverride) {
@@ -495,6 +497,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, PerRouteDisabledConfigOverride) {
       .WillByDefault(Return(&route_config));
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers, false));
+  EXPECT_FALSE(filter_.shouldTranscodeResponse());
 }
 
 TEST_F(GrpcJsonTranscoderFilterTest, NoTranscoding) {
@@ -520,6 +523,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, NoTranscoding) {
 
   Http::TestRequestTrailerMapImpl request_trailers;
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
+  EXPECT_FALSE(filter_.shouldTranscodeResponse());
 
   Http::TestResponseHeaderMapImpl response_headers{{"content-type", "application/grpc"},
                                                    {":status", "200"}};
@@ -588,6 +592,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPost) {
   bookstore::Shelf response;
   response.set_id(20);
   response.set_theme("Children");
+  EXPECT_TRUE(filter_.shouldTranscodeResponse());
 
   auto response_data = Grpc::Common::serializeToGrpcFrame(response);
 
@@ -638,7 +643,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPostWithPackageServiceMetho
 
   EXPECT_EQ(expected_request.ByteSize(), frames[0].length_);
   EXPECT_TRUE(MessageDifferencer::Equals(expected_request, request));
-
+  EXPECT_TRUE(filter_.shouldTranscodeResponse());
   Http::TestResponseHeaderMapImpl continue_headers{{":status", "000"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encode1xxHeaders(continue_headers));
 


### PR DESCRIPTION
Commit Message: this PR updates the  gRPC JSON transcoding API so that allows transcode the gRPC response status in other format. The details are:
- have another filter wrapping the JsonTranscoder filter object and intercept the response if it is gRPC error response
- JsonTranscoderConfig can be updated with additional proto info for the wrapping filter where JsonTranscoderConfig is also used

For more context, see https://github.com/envoyproxy/envoy/pull/22456. 

Risk Level:low

