### PR TITLE
Add tests for Quiche protocol flags

### DIFF
--- a/source/common/quic/platform/quiche_flags_impl.h
+++ b/source/common/quic/platform/quiche_flags_impl.h
@@ -21,15 +21,6 @@ const std::string EnvoyQuicheReloadableFlagPrefix =
     "envoy.reloadable_features.FLAGS_quic_reloadable_flag_";
 const std::string EnvoyFeaturePrefix = "envoy.reloadable_features.";
 
-// TODO(mpwarres): implement. Lower priority since only used by QUIC command-line tools.
-inline std::vector<std::string> quicParseCommandLineFlagsImpl(const char* /*usage*/, int /*argc*/,
-                                                              const char* const* /*argv*/) {
-  return {};
-}
-
-// TODO(mpwarres): implement. Lower priority since only used by QUIC command-line tools.
-inline void quicPrintCommandLineFlagHelpImpl(const char* /*usage*/) {}
-
 // Concrete class for QUICHE protocol and feature flags, templated by flag type.
 template <typename T> class TypedFlag {
 public:

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -490,6 +490,10 @@ TEST_F(QuicPlatformTest, QuicFlags) {
     SetQuicRestartFlag(quic_testonly_default_false, true);
     EXPECT_TRUE(GetQuicRestartFlag(quic_testonly_default_false));
 
+    EXPECT_FALSE(GetQuicheFlag(FLAGS_quiche_oghttp2_debug_trace));
+    SetQuicheFlag(FLAGS_quiche_oghttp2_debug_trace, true);
+    EXPECT_TRUE(GetQuicheFlag(FLAGS_quiche_oghttp2_debug_trace));
+
     EXPECT_EQ(200, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
     SetQuicFlag(FLAGS_quic_time_wait_list_seconds, 100);
     EXPECT_EQ(100, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
@@ -499,6 +503,7 @@ TEST_F(QuicPlatformTest, QuicFlags) {
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_FALSE(GetQuicRestartFlag(quic_testonly_default_false));
   EXPECT_EQ(200, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
+  EXPECT_FALSE(GetQuicheFlag(FLAGS_quiche_oghttp2_debug_trace));
 }
 
 TEST_F(QuicPlatformTest, UpdateReloadableFlags) {

--- a/test/common/quic/platform/quiche_test_impl.h
+++ b/test/common/quic/platform/quiche_test_impl.h
@@ -23,6 +23,10 @@ public:
 #include "quiche/quic/core/quic_protocol_flags_list.h"
 #undef QUIC_PROTOCOL_FLAG
 
+#define QUICHE_PROTOCOL_FLAG(type, flag, ...) saved_##flag##_ = GetQuicheFlagImpl(FLAGS_##flag);
+#include "quiche/common/quiche_protocol_flags_list.h"
+#undef QUICHE_PROTOCOL_FLAG
+
 #define QUIC_FLAG(flag, ...) saved_##flag##_ = GetQuicheFlagImpl(FLAGS_##flag);
 #include "quiche/quic/core/quic_flags_list.h"
 #undef QUIC_FLAG
@@ -34,6 +38,10 @@ public:
 #include "quiche/quic/core/quic_protocol_flags_list.h"
 #undef QUIC_PROTOCOL_FLAG
 
+#define QUICHE_PROTOCOL_FLAG(type, flag, ...) SetQuicheFlagImpl(FLAGS_##flag, saved_##flag##_);
+#include "quiche/common/quiche_protocol_flags_list.h"
+#undef QUICHE_PROTOCOL_FLAG
+
 #define QUIC_FLAG(flag, ...) SetQuicheFlagImpl(FLAGS_##flag, saved_##flag##_);
 #include "quiche/quic/core/quic_flags_list.h"
 #undef QUIC_FLAG
@@ -44,6 +52,10 @@ private:
 #define QUIC_PROTOCOL_FLAG(type, flag, ...) type saved_##flag##_;
 #include "quiche/quic/core/quic_protocol_flags_list.h"
 #undef QUIC_PROTOCOL_FLAG
+
+#define QUICHE_PROTOCOL_FLAG(type, flag, ...) type saved_##flag##_;
+#include "quiche/common/quiche_protocol_flags_list.h"
+#undef QUICHE_PROTOCOL_FLAG
 
 #define QUIC_FLAG(flag, ...) bool saved_##flag##_;
 #include "quiche/quic/core/quic_flags_list.h"


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@google.com>

Commit Message: Address leftover comments from https://github.com/envoyproxy/envoy/pull/22588
Additional Description: With the recent quiche changes, I think we no longer need those empty impl functions. I removed them and we can add them back when needed.
Added unit tests for the new QUICHE protocol flags.
Risk Level: Low
Testing: Unit tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
