### PR TITLE
connection: propagate set SSL info

### DIFF
--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -82,7 +82,10 @@ public:
     return socket_->connectionInfoProviderSharedPtr();
   }
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;
-  Ssl::ConnectionInfoConstSharedPtr ssl() const override { return transport_socket_->ssl(); }
+  Ssl::ConnectionInfoConstSharedPtr ssl() const override {
+    // SSL info may be overwritten by a filter in the provider.
+    return socket_->connectionInfoProvider().sslConnection();
+  }
   State state() const override;
   bool connecting() const override {
     ENVOY_CONN_LOG_EVENT(debug, "connection_connecting_state", "current connecting state: {}",

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -88,6 +88,7 @@ envoy_cc_test(
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/network:network_mocks",
+        "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -27,6 +27,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
@@ -306,6 +307,15 @@ TEST_P(ConnectionImplTest, UniqueId) {
   uint64_t first_id = client_connection_->id();
   setUpBasicConnection();
   EXPECT_NE(first_id, client_connection_->id());
+  disconnect(false);
+}
+
+TEST_P(ConnectionImplTest, SetSslConnection) {
+  setUpBasicConnection();
+  const Ssl::ConnectionInfoConstSharedPtr ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
+  client_connection_->connectionInfoSetter().setSslConnection(ssl_info);
+  EXPECT_EQ(ssl_info, client_connection_->ssl());
+  EXPECT_EQ(ssl_info, client_connection_->connectionInfoProvider().sslConnection());
   disconnect(false);
 }
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: https://github.com/envoyproxy/envoy/pull/22156 introduced ability to override SSL info. However, `ConnectionImpl` continued to use the original value instead of the new value. This aligns the info provider and `ssl()` method on `ConnectionImpl`.
Risk Level: low, nothing changes unless setSslConnectionInfo is used in a filter
Testing: unit
Docs Changes: none
Release Notes: none
Fixes: https://github.com/envoyproxy/envoy/issues/22617