### PR TITLE
matcher: fix missing HTTP support in IP matcher

### DIFF
--- a/source/extensions/common/matcher/trie_matcher.cc
+++ b/source/extensions/common/matcher/trie_matcher.cc
@@ -11,6 +11,8 @@ REGISTER_FACTORY(NetworkTrieMatcherFactory,
                  ::Envoy::Matcher::CustomMatcherFactory<Network::MatchingData>);
 REGISTER_FACTORY(UdpNetworkTrieMatcherFactory,
                  ::Envoy::Matcher::CustomMatcherFactory<Network::UdpMatchingData>);
+REGISTER_FACTORY(HttpTrieMatcherFactory,
+                 ::Envoy::Matcher::CustomMatcherFactory<Http::HttpMatchingData>);
 
 } // namespace Matcher
 } // namespace Common

--- a/source/extensions/common/matcher/trie_matcher.h
+++ b/source/extensions/common/matcher/trie_matcher.h
@@ -155,6 +155,7 @@ public:
 
 class NetworkTrieMatcherFactory : public TrieMatcherFactoryBase<Network::MatchingData> {};
 class UdpNetworkTrieMatcherFactory : public TrieMatcherFactoryBase<Network::UdpMatchingData> {};
+class HttpTrieMatcherFactory : public TrieMatcherFactoryBase<Http::HttpMatchingData> {};
 
 } // namespace Matcher
 } // namespace Common

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1234,6 +1234,7 @@ envoy.matching.inputs.subject:
   - envoy.extensions.matching.common_inputs.ssl.v3.SubjectInput
 envoy.matching.custom_matchers.trie_matcher:
   categories:
+  - envoy.matching.http.custom_matchers
   - envoy.matching.network.custom_matchers
   security_posture: unknown
   status: alpha

--- a/tools/extensions/extensions_schema.yaml
+++ b/tools/extensions/extensions_schema.yaml
@@ -105,6 +105,7 @@ categories:
 - envoy.access_loggers.extension_filters
 - envoy.http.stateful_session
 - envoy.matching.http.input
+- envoy.matching.http.custom_matchers
 - envoy.matching.network.input
 - envoy.matching.network.custom_matchers
 


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: matcher: fix missing HTTP support in IP matcher
Additional Description:
Risk Level: Low
Testing: Integration
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #22336 
