### PR TITLE
connection handler: correct the handling of listener update

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -24,6 +24,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: listener
+  change: |
+    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a memory leak.
 - area: transport_socket
   change: |
     fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -110,12 +110,12 @@ void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_list
           !address->ip()->ipv6()->v6only()) {
         if (address->ip()->isAnyAddress()) {
           // Since both "::" with ipv4_compat and "0.0.0.0" can be supported.
-          // If there already one and it isn't shutdown for compatible addr,
-          // then won't insert a new one.
+          // Only override the listener when this is an update of the existing listener by
+          // checking the address.
           auto ipv4_any_address = Network::Address::Ipv4Instance(address->ip()->port()).asString();
           auto ipv4_any_listener = tcp_listener_map_by_address_.find(ipv4_any_address);
           if (ipv4_any_listener == tcp_listener_map_by_address_.end() ||
-              ipv4_any_listener->second->listener_->listener() == nullptr) {
+              *ipv4_any_listener->second->address_ == *address) {
             tcp_listener_map_by_address_.insert_or_assign(ipv4_any_address, per_address_details);
           }
         } else {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -111,7 +111,8 @@ void ConnectionHandlerImpl::addListener(absl::optional<uint64_t> overridden_list
         if (address->ip()->isAnyAddress()) {
           // Since both "::" with ipv4_compat and "0.0.0.0" can be supported.
           // Only override the listener when this is an update of the existing listener by
-          // checking the address.
+          // checking the address, this ensures the Ipv4 address listener won't be override
+          // by the listener which has the same IPv4-mapped address.
           auto ipv4_any_address = Network::Address::Ipv4Instance(address->ip()->port()).asString();
           auto ipv4_any_listener = tcp_listener_map_by_address_.find(ipv4_any_address);
           if (ipv4_any_listener == tcp_listener_map_by_address_.end() ||

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -1786,10 +1786,9 @@ TEST_F(ConnectionHandlerTest, MatchhIpv4WhenBothIpv4AndIPv6WithIpv4CompatFlag2) 
   EXPECT_CALL(*access_log_, log(_, _, _, _));
 }
 
-// This test the case of there is stopped "0.0.0.0" listener, then add
-// "::" listener with ipv4_compat. Ensure the ipv6 listener will take over the
-// ipv4 listener.
-TEST_F(ConnectionHandlerTest, AddIpv4MappedListenerAfterIpv4ListenerStopped) {
+// This test the case of an update for listener which listening
+// on an Ipv4-mapped Ipv6 address.
+TEST_F(ConnectionHandlerTest, UpdateIpv4MappedListener) {
   // Listener1 is response for redirect the connection.
   Network::TcpListenerCallbacks* listener_callbacks1;
   auto listener1 = new NiceMock<Network::MockListener>();
@@ -1799,36 +1798,30 @@ TEST_F(ConnectionHandlerTest, AddIpv4MappedListenerAfterIpv4ListenerStopped) {
       addListener(1, true, true, "test_listener1", listener1, &listener_callbacks1, normal_address);
   handler_->addListener(absl::nullopt, *test_listener1, runtime_);
 
-  // Listener2 is listening on an Ipv4 address.
-  auto ipv4_overridden_filter_chain_manager =
+  // Listener2 is listening on an Ipv4-mapped Ipv6 address.
+  auto listener2_overridden_filter_chain_manager =
       std::make_shared<NiceMock<Network::MockFilterChainManager>>();
-  Network::TcpListenerCallbacks* ipv4_listener_callbacks;
+  Network::TcpListenerCallbacks* listener2_listener_callbacks;
   auto listener2 = new NiceMock<Network::MockListener>();
-  Network::Address::InstanceConstSharedPtr ipv4_address(
-      new Network::Address::Ipv4Instance("0.0.0.0", 80, nullptr));
-  TestListener* ipv4_listener =
-      addListener(2, false, false, "ipv4_test_listener", listener2, &ipv4_listener_callbacks,
-                  ipv4_address, nullptr, nullptr, Network::Socket::Type::Stream,
-                  std::chrono::milliseconds(15000), false, ipv4_overridden_filter_chain_manager);
-  handler_->addListener(absl::nullopt, *ipv4_listener, runtime_);
-
-  EXPECT_CALL(*listener2, onDestroy());
-  // Stop the ipv4 listener.
-  handler_->stopListeners(2);
-
-  // Listener3 is listening on an Ipv4-mapped Ipv6 address.
-  auto ipv6_overridden_filter_chain_manager =
-      std::make_shared<NiceMock<Network::MockFilterChainManager>>();
-  Network::TcpListenerCallbacks* ipv6_any_listener_callbacks;
-  auto listener3 = new NiceMock<Network::MockListener>();
   // Set the ipv6only as false.
   Network::Address::InstanceConstSharedPtr ipv4_mapped_ipv6_address(
       new Network::Address::Ipv6Instance("::", 80, nullptr, false));
-  TestListener* ipv6_listener =
-      addListener(3, false, false, "ipv6_test_listener", listener3, &ipv6_any_listener_callbacks,
-                  ipv4_mapped_ipv6_address, nullptr, nullptr, Network::Socket::Type::Stream,
-                  std::chrono::milliseconds(15000), false, ipv6_overridden_filter_chain_manager);
-  handler_->addListener(absl::nullopt, *ipv6_listener, runtime_);
+  TestListener* origin_ipv4_mapped_listener = addListener(
+      2, false, false, "ipv4_mapped_test_listener", listener2, &listener2_listener_callbacks,
+      ipv4_mapped_ipv6_address, nullptr, nullptr, Network::Socket::Type::Stream,
+      std::chrono::milliseconds(15000), false, listener2_overridden_filter_chain_manager);
+  handler_->addListener(absl::nullopt, *origin_ipv4_mapped_listener, runtime_);
+
+  // Listener3 is an update of listener2.
+  auto listener3_overridden_filter_chain_manager =
+      std::make_shared<NiceMock<Network::MockFilterChainManager>>();
+  Network::TcpListenerCallbacks* listener3_any_listener_callbacks;
+  auto listener3 = new NiceMock<Network::MockListener>();
+  TestListener* updated_ipv4_mapped_listener = addListener(
+      3, false, false, "ipv4_mapped_test_listener", listener3, &listener3_any_listener_callbacks,
+      ipv4_mapped_ipv6_address, nullptr, nullptr, Network::Socket::Type::Stream,
+      std::chrono::milliseconds(15000), false, listener3_overridden_filter_chain_manager);
+  handler_->addListener(absl::nullopt, *updated_ipv4_mapped_listener, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1855,10 +1848,10 @@ TEST_F(ConnectionHandlerTest, AddIpv4MappedListenerAfterIpv4ListenerStopped) {
 
   // The listener1 will balance the request to listener2.
   EXPECT_CALL(manager_, findFilterChain(_)).Times(0);
-  // The listener2 won't get the connection since it is stopped.
-  EXPECT_CALL(*ipv4_overridden_filter_chain_manager, findFilterChain(_)).Times(0);
+  // The listener2 won't get the connection since it is override by the listener3.
+  EXPECT_CALL(*listener2_overridden_filter_chain_manager, findFilterChain(_)).Times(0);
   // The listener3 gets the connection.
-  EXPECT_CALL(*ipv6_overridden_filter_chain_manager, findFilterChain(_))
+  EXPECT_CALL(*listener3_overridden_filter_chain_manager, findFilterChain(_))
       .WillOnce(Return(filter_chain_.get()));
 
   auto* connection = new NiceMock<Network::MockServerConnection>();
@@ -1868,6 +1861,7 @@ TEST_F(ConnectionHandlerTest, AddIpv4MappedListenerAfterIpv4ListenerStopped) {
   EXPECT_EQ(1UL, handler_->numConnections());
 
   EXPECT_CALL(*listener3, onDestroy());
+  EXPECT_CALL(*listener2, onDestroy());
   EXPECT_CALL(*listener1, onDestroy());
   EXPECT_CALL(*access_log_, log(_, _, _, _));
 }


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: connection handler: correct the handling of listener update
Additional Description:
To balance the IPv4 mapped address request to IPv4-mapped IPv6 address listener, inserting a mapping item into `tcp_listener_map_by_address_` using IPv4 mapped address as the key.

There can be a chance to override the mapping with the same key(the IP address key). The override cases are:
1. a listener using the same IPv4 address with a listener which has the same IPv4 mapped address.
2. an update of IPv4 mapped address listener.

Currently, the override checks only allow the stopped listener can be overridden, since it prevents the IPv4 listener was override by the listener which has the same IPv4-mapped address.
https://github.com/envoyproxy/envoy/blob/a866dceb91d0ae0d2f1b45f116463bd33d1a9310/source/server/connection_handler_impl.cc#L117-L118

But this will lead to a memory leak when an update happened on an IPv4-mapped IPv6 listener.

When updating a listener, the old listener mapping will be left in the `tcp_listener_map_by_address_` since the old listener will be stopped after updated new listener. After draining the old listener, the old listener will be stopped and removed, then the old listener's left mapping item in the `tcp_listener_map_by_address_` still reference the old listener resource, which leads to segment fault.

This PR changes to check the listening address, it also can prevent the IPv4 listener was override by the listener which has the same IPv4-mapped address, and also allow the IPv4-mapped listener to update the old mapping item.

Risk Level: high
Testing: unittest added
Docs Changes: n/a
Release Notes: an item for bug fixes added.
Fixes #22449

