### PR TITLE
[balsa] Reject NUL in first line, headers and trailers.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -163,8 +163,19 @@ void BalsaParser::OnBodyChunkInput(absl::string_view input) {
   connection_->bufferBody(input.data(), input.size());
 }
 
-void BalsaParser::OnHeaderInput(absl::string_view /*input*/) {}
-void BalsaParser::OnTrailerInput(absl::string_view /*input*/) {}
+void BalsaParser::OnHeaderInput(absl::string_view input) {
+  // NUL character is not allowed anywhere in the start line or in the header section.
+  if (input.find(absl::string_view("\0", 1)) != absl::string_view::npos) {
+    HandleError(BalsaFrameEnums::INVALID_HEADER_CHARACTER);
+  }
+}
+
+void BalsaParser::OnTrailerInput(absl::string_view input) {
+  // NUL character is not allowed anywhere in the trailers section.
+  if (input.find(absl::string_view("\0", 1)) != absl::string_view::npos) {
+    HandleError(BalsaFrameEnums::INVALID_HEADER_CHARACTER);
+  }
+}
 
 void BalsaParser::OnHeader(absl::string_view key, absl::string_view value) {
   if (status_ == ParserStatus::Error) {

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -165,14 +165,14 @@ void BalsaParser::OnBodyChunkInput(absl::string_view input) {
 
 void BalsaParser::OnHeaderInput(absl::string_view input) {
   // NUL character is not allowed anywhere in the start line or in the header section.
-  if (input.find(absl::string_view("\0", 1)) != absl::string_view::npos) {
+  if (absl::StrContains(input, '\0')) {
     HandleError(BalsaFrameEnums::INVALID_HEADER_CHARACTER);
   }
 }
 
 void BalsaParser::OnTrailerInput(absl::string_view input) {
   // NUL character is not allowed anywhere in the trailers section.
-  if (input.find(absl::string_view("\0", 1)) != absl::string_view::npos) {
+  if (absl::StrContains(input, '\0')) {
     HandleError(BalsaFrameEnums::INVALID_HEADER_CHARACTER);
   }
 }


### PR DESCRIPTION
Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: Reject NUL in first line, headers and trailers.
Additional Description: Protected by default-false runtime flag.
Risk Level: n/a
Testing: //test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a