### PR TITLE
[balsa] Reject invalid characters.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -95,6 +95,7 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   framer_.set_balsa_trailer(&trailers_);
   framer_.set_balsa_visitor(this);
   framer_.set_max_header_length(max_header_length);
+  framer_.set_invalid_chars_level(quiche::BalsaFrame::InvalidCharsLevel::kError);
 
   switch (type) {
   case MessageType::Request:
@@ -270,6 +271,9 @@ void BalsaParser::HandleError(BalsaFrameEnums::ErrorCode error_code) {
     break;
   case BalsaFrameEnums::TRAILER_MISSING_COLON:
     error_message_ = "HPE_INVALID_HEADER_TOKEN";
+    break;
+  case BalsaFrameEnums::INVALID_HEADER_CHARACTER:
+    error_message_ = "header value contains invalid chars";
     break;
   default:
     error_message_ = BalsaFrameEnums::ErrorCodeToString(error_code);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -687,7 +687,12 @@ Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t 
 
   const ParserStatus status = parser_->getStatus();
   if (status != ParserStatus::Ok && status != ParserStatus::Paused) {
-    RETURN_IF_ERROR(sendProtocolError(Http1ResponseCodeDetails::get().HttpCodecError));
+    absl::string_view error = Http1ResponseCodeDetails::get().HttpCodecError;
+    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_use_balsa_parser") &&
+        parser_->errorMessage() == "header value contains invalid chars") {
+      error = Http1ResponseCodeDetails::get().InvalidCharacters;
+    }
+    RETURN_IF_ERROR(sendProtocolError(error));
     // Avoid overwriting the codec_status_ set in the callbacks.
     ASSERT(codec_status_.ok());
     codec_status_ =


### PR DESCRIPTION
Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Reject invalid characters.
Additional Description: Protected by default-false runtime flag.
Risk Level: low
Testing: //test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a