### PR TITLE
[WIP] Fix URL parsing to handle schemes allowed by RFC 3986

### DIFF
--- a/bazel/external/http_parser/http_parser.c
+++ b/bazel/external/http_parser/http_parser.c
@@ -513,7 +513,7 @@ parse_url_char(enum state s, const char ch)
         return s_req_path;
       }
 
-      if (IS_ALPHANUM(ch) || ch == '+' || ch == '-' || '.') {
+      if (IS_ALPHANUM(ch) || ch == '+' || ch == '-' || ch == '.') {
         return s_req_schema;
       }
 

--- a/bazel/external/http_parser/http_parser.c
+++ b/bazel/external/http_parser/http_parser.c
@@ -513,7 +513,7 @@ parse_url_char(enum state s, const char ch)
         return s_req_path;
       }
 
-      if (IS_ALPHA(ch)) {
+      if (IS_ALPHANUM(ch) || ch == '+' || ch == '-' || '.') {
         return s_req_schema;
       }
 

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -54,7 +54,7 @@ bool isUrlValid(absl::string_view url, bool is_connect) {
   if (!is_connect) {
     // Scheme must start with alpha and be non-empty.
     auto it = url.begin();
-    if (!std::isalpha(it)) {
+    if (!std::isalpha(*it)) {
       return false;
     }
     ++it;

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -62,7 +62,7 @@ bool isUrlValid(absl::string_view url, bool is_connect) {
     const auto is_scheme_suffix = [](char c) {
       return std::isalpha(c) || std::isdigit(c) || c == '+' || c == '-' || c == '.';
     };
-    it = std::find_if_not(it, url.end(), [](char c) { return std::isalpha(c); });
+    it = std::find_if_not(it, url.end(), is_scheme_suffix);
     url.remove_prefix(it - url.begin());
     if (!absl::StartsWith(url, kColonSlashSlash)) {
       return false;

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -52,11 +52,17 @@ bool isUrlValid(absl::string_view url, bool is_connect) {
 
   // If method is not CONNECT, parse scheme.
   if (!is_connect) {
-    // Scheme must be alpha and non-empty.
-    auto it = std::find_if_not(url.begin(), url.end(), [](char c) { return std::isalpha(c); });
-    if (it == url.begin()) {
+    // Scheme must start with alpha and be non-empty.
+    auto it = url.begin();
+    if (!std::isalpha(it)) {
       return false;
     }
+    ++it;
+    // Scheme started with an alpha character and the rest of it is alpha, digit, '+', '-' or '.'
+    const auto is_scheme_suffix = [](char c) {
+      return std::isalpha(c) || std::isdigit(c) || c == '+' || c == '-' || c == '.';
+    };
+    it = std::find_if_not(it, url.end(), [](char c) { return std::isalpha(c); });
     url.remove_prefix(it - url.begin());
     if (!absl::StartsWith(url, kColonSlashSlash)) {
       return false;

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -58,7 +58,7 @@ bool isUrlValid(absl::string_view url, bool is_connect) {
       return false;
     }
     ++it;
-    // Scheme started with an alpha character and the rest of it is alpha, digit, '+', '-' or '.'
+    // Scheme started with an alpha character and the rest of it is alpha, digit, '+', '-' or '.'.
     const auto is_scheme_suffix = [](char c) {
       return std::isalpha(c) || std::isdigit(c) || c == '+' || c == '-' || c == '.';
     };

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -274,10 +274,10 @@ TEST_F(ConnectionManagerUtilityTest, AlphaNumCharRefererPassesSanitization) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
-  TestRequestHeaderMapImpl headers{{"referer", "android-app+1://example.com/"}};
+  TestRequestHeaderMapImpl headers{{"referer", "android-app+1.0://example.com/"}};
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true, Tracing::Reason::NotTraceable}),
             callMutateRequestHeaders(headers, Protocol::Http2));
-  EXPECT_EQ("android-app+1://example.com/",
+  EXPECT_EQ("android-app+1.0://example.com/",
             headers.get(Http::CustomHeaders::get().Referer)[0]->value().getStringView());
 }
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -270,6 +270,17 @@ TEST_F(ConnectionManagerUtilityTest, ValidRefererPassesSanitization) {
             headers.get(Http::CustomHeaders::get().Referer)[0]->value().getStringView());
 }
 
+TEST_F(ConnectionManagerUtilityTest, AlphaNumCharRefererPassesSanitization) {
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
+      std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1"));
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  TestRequestHeaderMapImpl headers{{"referer", "android-app+1://example.com/"}};
+  EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ("android-app+1://example.com/",
+            headers.get(Http::CustomHeaders::get().Referer)[0]->value().getStringView());
+}
+
 // Verify that we don't append XFF when skipXffAppend(), even if using remote
 // address and where the address is external.
 TEST_F(ConnectionManagerUtilityTest, SkipXffAppendUseRemoteAddress) {


### PR DESCRIPTION
Signed-off-by: James Fish <jfish@pinterest.com>

Commit Message: Fix URL parsing to handle schemes allowed by RFC 3986
Additional Description: The URI RFC allows schemas to include digits . - + (as well as alphabetical characters) but currently the validation only allows schemes to have alphabetical characters, otherwise if enabled will sanitize the header.
scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
Risk Level: low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
Fixes #22062
