### PR TITLE
access log: Add context interface with access to listener properties

### DIFF
--- a/envoy/server/access_log_config.h
+++ b/envoy/server/access_log_config.h
@@ -27,6 +27,19 @@ public:
    * @param config the custom configuration for this access log type.
    * @param filter filter to determine whether a particular request should be logged. If no filter
    * was specified in the configuration, argument will be nullptr.
+   * @param context access log context through which persistent resources can be accessed.
+   */
+  virtual AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          AccessLogFactoryContext& context) PURE;
+
+  /**
+   * Create a particular AccessLog::Instance implementation from a config proto. If the
+   * implementation is unable to produce a factory with the provided parameters, it should throw an
+   * EnvoyException. The returned pointer should never be nullptr.
+   * @param config the custom configuration for this access log type.
+   * @param filter filter to determine whether a particular request should be logged. If no filter
+   * was specified in the configuration, argument will be nullptr.
    * @param context general filter context through which persistent resources can be accessed.
    */
   virtual AccessLog::InstanceSharedPtr createAccessLogInstance(const Protobuf::Message& config,

--- a/envoy/server/access_log_config.h
+++ b/envoy/server/access_log_config.h
@@ -31,7 +31,7 @@ public:
    */
   virtual AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          AccessLogFactoryContext& context) PURE;
+                          ListenerAccessLogFactoryContext& context) PURE;
 
   /**
    * Create a particular AccessLog::Instance implementation from a config proto. If the

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -180,11 +180,34 @@ public:
 };
 
 /**
+ * Factory context for access loggers that need access to listener properties.
+ */
+class AccessLogFactoryContext : public virtual CommonFactoryContext {
+public:
+  /**
+   * @return Stats::Scope& the listener's stats scope.
+   */
+  virtual Stats::Scope& listenerScope() PURE;
+
+  /**
+   * @return const envoy::config::core::v3::Metadata& the config metadata associated with this
+   * listener.
+   */
+  virtual const envoy::config::core::v3::Metadata& listenerMetadata() const PURE;
+
+  /**
+   * @return ProcessContextOptRef an optional reference to the
+   * process context. Will be unset when running in validation mode.
+   */
+  virtual ProcessContextOptRef processContext() PURE;
+};
+
+/**
  * Context passed to network and HTTP filters to access server resources.
  * TODO(mattklein123): When we lock down visibility of the rest of the code, filters should only
  * access the rest of the server via interfaces exposed here.
  */
-class FactoryContext : public virtual CommonFactoryContext {
+class FactoryContext : public virtual AccessLogFactoryContext {
 public:
   ~FactoryContext() override = default;
 
@@ -216,20 +239,9 @@ public:
   virtual bool healthCheckFailed() PURE;
 
   /**
-   * @return Stats::Scope& the listener's stats scope.
-   */
-  virtual Stats::Scope& listenerScope() PURE;
-
-  /**
    * @return bool if these filters are created under the scope of a Quic listener.
    */
   virtual bool isQuicListener() const PURE;
-
-  /**
-   * @return const envoy::config::core::v3::Metadata& the config metadata associated with this
-   * listener.
-   */
-  virtual const envoy::config::core::v3::Metadata& listenerMetadata() const PURE;
 
   /**
    * @return const Envoy::Config::TypedMetadata& return the typed metadata provided in the config
@@ -256,12 +268,6 @@ public:
    * @return Router::Context& a reference to the router context.
    */
   virtual Router::Context& routerContext() PURE;
-
-  /**
-   * @return ProcessContextOptRef an optional reference to the
-   * process context. Will be unset when running in validation mode.
-   */
-  virtual ProcessContextOptRef processContext() PURE;
 };
 
 /**

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -181,8 +181,12 @@ public:
 
 /**
  * Factory context for access loggers that need access to listener properties.
+ * This context is supplied to the access log factory when called with the listener context
+ * available, such as from downstream HTTP filters.
+ * NOTE: this interface is used in proprietary access loggers, please do not delete
+ * without reaching to Envoy maintainers first.
  */
-class AccessLogFactoryContext : public virtual CommonFactoryContext {
+class ListenerAccessLogFactoryContext : public virtual CommonFactoryContext {
 public:
   /**
    * @return Stats::Scope& the listener's stats scope.
@@ -207,7 +211,7 @@ public:
  * TODO(mattklein123): When we lock down visibility of the rest of the code, filters should only
  * access the rest of the server via interfaces exposed here.
  */
-class FactoryContext : public virtual AccessLogFactoryContext {
+class FactoryContext : public virtual ListenerAccessLogFactoryContext {
 public:
   ~FactoryContext() override = default;
 

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -308,9 +308,11 @@ bool MetadataFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::Re
   return default_match_;
 }
 
-InstanceSharedPtr
-AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                            Server::Configuration::CommonFactoryContext& context) {
+namespace {
+
+template <typename FactoryContext>
+InstanceSharedPtr makeAccessLogInstance(const envoy::config::accesslog::v3::AccessLog& config,
+                                        FactoryContext& context) {
   FilterPtr filter;
   if (config.has_filter()) {
     filter = FilterFactory::fromProto(config.filter(), context.runtime(),
@@ -324,6 +326,20 @@ AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& confi
       config, context.messageValidationVisitor(), factory);
 
   return factory.createAccessLogInstance(*message, std::move(filter), context);
+}
+
+} // namespace
+
+InstanceSharedPtr
+AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+                            Server::Configuration::AccessLogFactoryContext& context) {
+  return makeAccessLogInstance(config, context);
+}
+
+InstanceSharedPtr
+AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+                            Server::Configuration::CommonFactoryContext& context) {
+  return makeAccessLogInstance(config, context);
 }
 
 } // namespace AccessLog

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -332,7 +332,7 @@ InstanceSharedPtr makeAccessLogInstance(const envoy::config::accesslog::v3::Acce
 
 InstanceSharedPtr
 AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                            Server::Configuration::AccessLogFactoryContext& context) {
+                            Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return makeAccessLogInstance(config, context);
 }
 

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -278,7 +278,15 @@ public:
 class AccessLogFactory {
 public:
   /**
-   * Read a filter definition from proto and instantiate an Instance.
+   * Read a filter definition from proto and instantiate an Instance. This method is used
+   * to create access log instances that need access to listener properties.
+   */
+  static InstanceSharedPtr fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+                                     Server::Configuration::AccessLogFactoryContext& context);
+
+  /**
+   * Read a filter definition from proto and instantiate an Instance. This method does not
+   * have access to listener properties, for example for access loggers of admin interface.
    */
   static InstanceSharedPtr fromProto(const envoy::config::accesslog::v3::AccessLog& config,
                                      Server::Configuration::CommonFactoryContext& context);

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -281,8 +281,9 @@ public:
    * Read a filter definition from proto and instantiate an Instance. This method is used
    * to create access log instances that need access to listener properties.
    */
-  static InstanceSharedPtr fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                                     Server::Configuration::AccessLogFactoryContext& context);
+  static InstanceSharedPtr
+  fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+            Server::Configuration::ListenerAccessLogFactoryContext& context);
 
   /**
    * Read a filter definition from proto and instantiate an Instance. This method does not

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -21,6 +21,14 @@ namespace File {
 
 AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
+
+AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::CommonFactoryContext& context) {
   const auto& fal_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -21,7 +21,7 @@ namespace File {
 
 AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::AccessLogFactoryContext& context) {
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -14,7 +14,7 @@ class FileAccessLogFactory : public Server::Configuration::AccessLogInstanceFact
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
 
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -14,6 +14,10 @@ class FileAccessLogFactory : public Server::Configuration::AccessLogInstanceFact
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -20,6 +20,14 @@ namespace HttpGrpc {
 
 AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
+
+AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::CommonFactoryContext& context) {
   GrpcCommon::validateProtoDescriptors();
 

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -20,7 +20,7 @@ namespace HttpGrpc {
 
 AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::AccessLogFactoryContext& context) {
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));

--- a/source/extensions/access_loggers/grpc/http_config.h
+++ b/source/extensions/access_loggers/grpc/http_config.h
@@ -16,7 +16,7 @@ class HttpGrpcAccessLogFactory : public Server::Configuration::AccessLogInstance
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;

--- a/source/extensions/access_loggers/grpc/http_config.h
+++ b/source/extensions/access_loggers/grpc/http_config.h
@@ -16,6 +16,9 @@ class HttpGrpcAccessLogFactory : public Server::Configuration::AccessLogInstance
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -20,7 +20,7 @@ namespace TcpGrpc {
 
 AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::AccessLogFactoryContext& context) {
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -20,6 +20,14 @@ namespace TcpGrpc {
 
 AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
+
+AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::CommonFactoryContext& context) {
   GrpcCommon::validateProtoDescriptors();
 

--- a/source/extensions/access_loggers/grpc/tcp_config.h
+++ b/source/extensions/access_loggers/grpc/tcp_config.h
@@ -16,7 +16,7 @@ class TcpGrpcAccessLogFactory : public Server::Configuration::AccessLogInstanceF
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
 
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,

--- a/source/extensions/access_loggers/grpc/tcp_config.h
+++ b/source/extensions/access_loggers/grpc/tcp_config.h
@@ -16,6 +16,10 @@ class TcpGrpcAccessLogFactory : public Server::Configuration::AccessLogInstanceF
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -31,10 +31,9 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
       });
 }
 
-::Envoy::AccessLog::InstanceSharedPtr
-AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
-                                          ::Envoy::AccessLog::FilterPtr&& filter,
-                                          Server::Configuration::AccessLogFactoryContext& context) {
+::Envoy::AccessLog::InstanceSharedPtr AccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -34,6 +34,15 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
 ::Envoy::AccessLog::InstanceSharedPtr
 AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
                                           ::Envoy::AccessLog::FilterPtr&& filter,
+                                          Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
+
+::Envoy::AccessLog::InstanceSharedPtr
+AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
+                                          ::Envoy::AccessLog::FilterPtr&& filter,
                                           Server::Configuration::CommonFactoryContext& context) {
   validateProtoDescriptors();
 

--- a/source/extensions/access_loggers/open_telemetry/config.h
+++ b/source/extensions/access_loggers/open_telemetry/config.h
@@ -16,6 +16,10 @@ class AccessLogFactory : public Server::Configuration::AccessLogInstanceFactory 
 public:
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+
+  ::Envoy::AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/open_telemetry/config.h
+++ b/source/extensions/access_loggers/open_telemetry/config.h
@@ -16,7 +16,7 @@ class AccessLogFactory : public Server::Configuration::AccessLogInstanceFactory 
 public:
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
 
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -22,7 +22,7 @@ namespace File {
 
 AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::AccessLogFactoryContext& context) {
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));
@@ -51,7 +51,7 @@ REGISTER_FACTORY(StdoutAccessLogFactory,
 
 AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::AccessLogFactoryContext& context) {
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -22,6 +22,14 @@ namespace File {
 
 AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
+
+AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
     Server::Configuration::CommonFactoryContext& context) {
   return AccessLoggers::createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StdoutAccessLog,
@@ -40,6 +48,14 @@ std::string StdoutAccessLogFactory::name() const { return "envoy.access_loggers.
  */
 REGISTER_FACTORY(StdoutAccessLogFactory,
                  Server::Configuration::AccessLogInstanceFactory){"envoy.stdout_access_log"};
+
+AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
 
 AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,

--- a/source/extensions/access_loggers/stream/config.h
+++ b/source/extensions/access_loggers/stream/config.h
@@ -14,7 +14,7 @@ class StdoutAccessLogFactory : public Server::Configuration::AccessLogInstanceFa
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
 
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
@@ -32,7 +32,7 @@ class StderrAccessLogFactory : public Server::Configuration::AccessLogInstanceFa
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
 
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,

--- a/source/extensions/access_loggers/stream/config.h
+++ b/source/extensions/access_loggers/stream/config.h
@@ -14,6 +14,10 @@ class StdoutAccessLogFactory : public Server::Configuration::AccessLogInstanceFa
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
@@ -26,6 +30,10 @@ public:
  */
 class StderrAccessLogFactory : public Server::Configuration::AccessLogInstanceFactory {
 public:
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -18,6 +18,14 @@ using Common::Wasm::PluginHandleSharedPtrThreadLocal;
 
 AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
+    Server::Configuration::AccessLogFactoryContext& context) {
+  return createAccessLogInstance(
+      proto_config, std::move(filter),
+      static_cast<Server::Configuration::CommonFactoryContext&>(context));
+}
+
+AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
+    const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
     Server::Configuration::CommonFactoryContext& context) {
   const auto& config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::wasm::v3::WasmAccessLog&>(

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -18,7 +18,7 @@ using Common::Wasm::PluginHandleSharedPtrThreadLocal;
 
 AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::AccessLogFactoryContext& context) {
+    Server::Configuration::ListenerAccessLogFactoryContext& context) {
   return createAccessLogInstance(
       proto_config, std::move(filter),
       static_cast<Server::Configuration::CommonFactoryContext&>(context));

--- a/source/extensions/access_loggers/wasm/config.h
+++ b/source/extensions/access_loggers/wasm/config.h
@@ -17,6 +17,10 @@ class WasmAccessLogFactory : public Server::Configuration::AccessLogInstanceFact
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
+                          Server::Configuration::AccessLogFactoryContext& context) override;
+
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
                           Server::Configuration::CommonFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/wasm/config.h
+++ b/source/extensions/access_loggers/wasm/config.h
@@ -17,7 +17,7 @@ class WasmAccessLogFactory : public Server::Configuration::AccessLogInstanceFact
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::AccessLogFactoryContext& context) override;
+                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
 
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -70,7 +70,7 @@ public:
 
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Envoy::AccessLog::MockAccessLogManager> log_manager_;
-  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
 };
 
 TEST_F(AccessLogImplTest, LogMoreData) {
@@ -519,7 +519,7 @@ typed_config:
 }
 
 TEST(AccessLogImplTestCtor, FiltersMissingInOrAndFilter) {
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
 
   {
     const std::string yaml = R"EOF(

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1927,6 +1927,11 @@ envoy_cc_test(
     ],
 )
 
+envoy_proto_library(
+    name = "typed_metadata_integration_proto",
+    srcs = ["typed_metadata_integration_test.proto"],
+)
+
 envoy_cc_test(
     name = "typed_metadata_integration_test",
     srcs = [
@@ -1934,9 +1939,11 @@ envoy_cc_test(
     ],
     deps = [
         ":http_protocol_integration_lib",
+        ":typed_metadata_integration_proto_cc_proto",
         "//source/common/protobuf",
         "//test/integration/filters:listener_typed_metadata_filter_lib",
         "//test/server:utility_lib",
+        "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/integration/typed_metadata_integration_test.cc
+++ b/test/integration/typed_metadata_integration_test.cc
@@ -2,8 +2,11 @@
 
 #include "test/integration/http_protocol_integration.h"
 #include "test/integration/integration.h"
+#include "test/integration/typed_metadata_integration_test.pb.h"
+#include "test/integration/typed_metadata_integration_test.pb.validate.h"
 #include "test/integration/utility.h"
 #include "test/server/utility.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -36,6 +39,69 @@ TEST_P(ListenerTypedMetadataIntegrationTest, Hello) {
   // Here we just ensure the filter was created (so we know those assertions ran).
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 10);
   ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+class MockAccessLog : public AccessLog::Instance {
+public:
+  MOCK_METHOD(void, log,
+              (const Http::RequestHeaderMap*, const Http::ResponseHeaderMap*,
+               const Http::ResponseTrailerMap*, const StreamInfo::StreamInfo&));
+};
+
+class TestAccessLogFactory : public Server::Configuration::AccessLogInstanceFactory {
+public:
+  AccessLog::InstanceSharedPtr createAccessLogInstance(
+      const Protobuf::Message&, AccessLog::FilterPtr&&,
+      Server::Configuration::ListenerAccessLogFactoryContext& context) override {
+    // Check that expected listener metadata is present
+    EXPECT_EQ(1, context.listenerMetadata().typed_filter_metadata().size());
+    const auto iter =
+        context.listenerMetadata().typed_filter_metadata().find("test.listener.typed.metadata");
+    EXPECT_NE(iter, context.listenerMetadata().typed_filter_metadata().end());
+    return std::make_shared<NiceMock<MockAccessLog>>();
+  }
+
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
+                          Server::Configuration::CommonFactoryContext&) override {
+    // This method should never be called in this test
+    ASSERT(false);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new test::integration::typed_metadata::TestAccessLog()};
+  }
+
+  std::string name() const override { return "envoy.access_loggers.test"; }
+};
+
+// Validate that access logger gets the right context with access to listener metadata
+TEST_P(ListenerTypedMetadataIntegrationTest, ListenerMetadataPlumbingToAccessLog) {
+  TestAccessLogFactory factory;
+  Registry::InjectFactory<Server::Configuration::AccessLogInstanceFactory> factory_register(
+      factory);
+
+  // Add some typed metadata to the listener.
+  ProtobufWkt::StringValue value;
+  value.set_value("hello world");
+  ProtobufWkt::Any packed_value;
+  packed_value.PackFrom(value);
+  config_helper_.addListenerTypedMetadata("test.listener.typed.metadata", packed_value);
+
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        test::integration::typed_metadata::TestAccessLog access_log_config;
+        hcm.mutable_access_log(0)->mutable_typed_config()->PackFrom(access_log_config);
+      });
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
 }

--- a/test/integration/typed_metadata_integration_test.cc
+++ b/test/integration/typed_metadata_integration_test.cc
@@ -68,6 +68,7 @@ public:
                           Server::Configuration::CommonFactoryContext&) override {
     // This method should never be called in this test
     ASSERT(false);
+    return nullptr;
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/test/integration/typed_metadata_integration_test.proto
+++ b/test/integration/typed_metadata_integration_test.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package test.integration.typed_metadata;
+
+message TestAccessLog {
+}


### PR DESCRIPTION
Additional Description:
We have internal access loggers that need to get listener properties. This refactor adds creator methods for such access logger with a new factory context interface.

Risk Level: Low,
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
