### PR TITLE
tracing: Add common tag name, to specify app protocol

### DIFF
--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -73,7 +73,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config&, Tracing::TraceContext
     }
   }
 
-  return tracer.startSpan(trace_context.path(), tracing_context);
+  return tracer.startSpan(trace_context.path(), trace_context.protocol(), tracing_context);
 }
 
 void Driver::loadConfig(const envoy::config::trace::v3::ClientConfig& client_config,

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -64,8 +64,8 @@ void Span::injectContext(Tracing::TraceContext& trace_context,
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string&, SystemTime) {
   // Reuse operation name of parent span by default.
-  return std::make_unique<Span>(span_entity_->operationName(), *this, tracing_context_,
-                                parent_tracer_);
+  return std::make_unique<Span>(span_entity_->operationName(), span_entity_->spanLayer(), *this,
+                                tracing_context_, parent_tracer_);
 }
 
 Tracer::Tracer(TraceSegmentReporterPtr reporter) : reporter_(std::move(reporter)) {}
@@ -77,8 +77,9 @@ void Tracer::sendSegment(TracingContextPtr segment_context) {
   }
 }
 
-Tracing::SpanPtr Tracer::startSpan(absl::string_view name, TracingContextPtr tracing_context) {
-  return std::make_unique<Span>(name, tracing_context, *this);
+Tracing::SpanPtr Tracer::startSpan(absl::string_view name, absl::string_view protocol,
+                                   TracingContextPtr tracing_context) {
+  return std::make_unique<Span>(name, protocol, tracing_context, *this);
 }
 } // namespace SkyWalking
 } // namespace Tracers

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -62,8 +62,8 @@ public:
       // TraceContext.protocol of http is parsed from http message, which value could be HTTP/1.1,
       // etc.
       layer = skywalking::v3::SpanLayer::Http;
-    } else {
-      skywalking::v3::SpanLayer_Parse(std::string(protocol), &layer);
+    } else if (!skywalking::v3::SpanLayer_Parse(std::string(protocol), &layer)) {
+      layer = skywalking::v3::SpanLayer::Unknown;
     }
     span_entity_->setSpanLayer(layer);
   }

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -41,7 +41,8 @@ public:
    *
    * @return The unique ptr to the newly created span.
    */
-  Tracing::SpanPtr startSpan(absl::string_view name, TracingContextPtr tracing_context);
+  Tracing::SpanPtr startSpan(absl::string_view name, absl::string_view protocol,
+                             TracingContextPtr tracing_context);
 
 private:
   TraceSegmentReporterPtr reporter_;
@@ -51,16 +52,27 @@ using TracerPtr = std::unique_ptr<Tracer>;
 
 class Span : public Tracing::Span {
 public:
-  Span(absl::string_view name, TracingContextPtr tracing_context, Tracer& parent_tracer)
+  Span(absl::string_view name, absl::string_view protocol, TracingContextPtr tracing_context,
+       Tracer& parent_tracer)
       : parent_tracer_(parent_tracer), tracing_context_(tracing_context),
         span_entity_(tracing_context_->createEntrySpan()) {
     span_entity_->startSpan({name.data(), name.size()});
+    skywalking::v3::SpanLayer layer;
+    if (absl::StrContains(protocol, "HTTP")) {
+      // TraceContext.protocol of http is parsed from http message, which value could be HTTP/1.1,
+      // etc.
+      layer = skywalking::v3::SpanLayer::Http;
+    } else {
+      skywalking::v3::SpanLayer_Parse(std::string(protocol), &layer);
+    }
+    span_entity_->setSpanLayer(layer);
   }
-  Span(absl::string_view name, Span& parent_span, TracingContextPtr tracing_context,
-       Tracer& parent_tracer)
+  Span(absl::string_view name, const skywalking::v3::SpanLayer& span_layer, Span& parent_span,
+       TracingContextPtr tracing_context, Tracer& parent_tracer)
       : parent_tracer_(parent_tracer), tracing_context_(tracing_context),
         span_entity_(tracing_context_->createExitSpan(parent_span.spanEntity())) {
     span_entity_->startSpan({name.data(), name.size()});
+    span_entity_->setSpanLayer(span_layer);
   }
 
   // Tracing::Span

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -67,7 +67,7 @@ public:
     }
     span_entity_->setSpanLayer(layer);
   }
-  Span(absl::string_view name, const skywalking::v3::SpanLayer& span_layer, Span& parent_span,
+  Span(absl::string_view name, skywalking::v3::SpanLayer span_layer, Span& parent_span,
        TracingContextPtr tracing_context, Tracer& parent_tracer)
       : parent_tracer_(parent_tracer), tracing_context_(tracing_context),
         span_entity_(tracing_context_->createExitSpan(parent_span.spanEntity())) {

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -137,6 +137,23 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   }
 
   {
+    Envoy::Tracing::SpanPtr org_span =
+        tracer_->startSpan("io.envoyproxy.rpc.demo.Service", "RPCFramework", segment_context);
+    Span* span = dynamic_cast<Span*>(org_span.get());
+    EXPECT_TRUE(span->spanEntity()->spanLayer() == skywalking::v3::SpanLayer::RPCFramework);
+    EXPECT_EQ(span->spanEntity()->operationName(), "io.envoyproxy.rpc.demo.Service");
+  }
+
+  {
+    // When protocol is not known by "skywalking", the span layer will be Unknown
+    Envoy::Tracing::SpanPtr org_span = tracer_->startSpan(
+        "com.company.department.business.Service", "InternalPrivateFramework", segment_context);
+    Span* span = dynamic_cast<Span*>(org_span.get());
+    EXPECT_TRUE(span->spanEntity()->spanLayer() == skywalking::v3::SpanLayer::Unknown);
+    EXPECT_EQ(span->spanEntity()->operationName(), "com.company.department.business.Service");
+  }
+
+  {
     Envoy::Tracing::SpanPtr org_first_child_span =
         org_span->spawnChild(mock_tracing_config_, "TestChild", mock_time_source_.systemTime());
 

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -137,23 +137,6 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   }
 
   {
-    Envoy::Tracing::SpanPtr org_span =
-        tracer_->startSpan("io.envoyproxy.rpc.demo.Service", "RPCFramework", segment_context);
-    Span* span = dynamic_cast<Span*>(org_span.get());
-    EXPECT_TRUE(span->spanEntity()->spanLayer() == skywalking::v3::SpanLayer::RPCFramework);
-    EXPECT_EQ(span->spanEntity()->operationName(), "io.envoyproxy.rpc.demo.Service");
-  }
-
-  {
-    // When protocol is not known by "skywalking", the span layer will be Unknown
-    Envoy::Tracing::SpanPtr org_span = tracer_->startSpan(
-        "com.company.department.business.Service", "InternalPrivateFramework", segment_context);
-    Span* span = dynamic_cast<Span*>(org_span.get());
-    EXPECT_TRUE(span->spanEntity()->spanLayer() == skywalking::v3::SpanLayer::Unknown);
-    EXPECT_EQ(span->spanEntity()->operationName(), "com.company.department.business.Service");
-  }
-
-  {
     Envoy::Tracing::SpanPtr org_first_child_span =
         org_span->spawnChild(mock_tracing_config_, "TestChild", mock_time_source_.systemTime());
 
@@ -249,6 +232,26 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   EXPECT_EQ(0U, mock_scope_.counter("tracing.skywalking.segments_dropped").value());
   EXPECT_EQ(0U, mock_scope_.counter("tracing.skywalking.cache_flushed").value());
   EXPECT_EQ(0U, mock_scope_.counter("tracing.skywalking.segments_flushed").value());
+
+  {
+    auto rpc_context = SkyWalkingTestHelper::createSegmentContext(true, "CURR", "");
+    Envoy::Tracing::SpanPtr org_rpc_span =
+        tracer_->startSpan("io.envoyproxy.rpc.demo.Service", "RPCFramework", rpc_context);
+    Span* rpc_span = dynamic_cast<Span*>(org_rpc_span.get());
+    EXPECT_TRUE(rpc_span->spanEntity()->spanLayer() == skywalking::v3::SpanLayer::RPCFramework);
+    EXPECT_EQ(rpc_span->spanEntity()->operationName(), "io.envoyproxy.rpc.demo.Service");
+  }
+
+  {
+    // When protocol is not known by "skywalking", the span layer will be Unknown
+    auto unknown_context = SkyWalkingTestHelper::createSegmentContext(true, "CURR", "");
+    Envoy::Tracing::SpanPtr org_unknown_span = tracer_->startSpan(
+        "com.company.department.business.Service", "InternalPrivateFramework", unknown_context);
+    Span* unknown_span = dynamic_cast<Span*>(org_unknown_span.get());
+    EXPECT_TRUE(unknown_span->spanEntity()->spanLayer() == skywalking::v3::SpanLayer::Unknown);
+    EXPECT_EQ(unknown_span->spanEntity()->operationName(),
+              "com.company.department.business.Service");
+  }
 }
 
 } // namespace

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -79,7 +79,8 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   // Create a new SegmentContext.
   auto segment_context = SkyWalkingTestHelper::createSegmentContext(true, "CURR", "");
 
-  Envoy::Tracing::SpanPtr org_span = tracer_->startSpan("/downstream/path", segment_context);
+  Envoy::Tracing::SpanPtr org_span =
+      tracer_->startSpan("/downstream/path", "HTTP", segment_context);
   Span* span = dynamic_cast<Span*>(org_span.get());
 
   {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add common tag name, to specify app protocol
Additional Description: #22594 Span of skywalking has a field called `spanLayer`, indicate it's http, rpc, db and so on. Currently this field is hardcoded to http as it's default value in ctor. Other telemetry impls may also have similar concept, so it's better introduce a common tag key,  to specify app protocol through `setTag`, to achieve protocol independent.

Why not add something like `setSpanLayer` to `Tracing::Span` interface:
\- Because, the parameter type varies and coupling with impl, e.g. `skywalking::v3::SpanLayer`. And there are impls without this concept, currently among tracers that envoy supported, only skywalking comes with this. On the other hand, opentelemetry comes with `kind` indicating it's server or client, xray comes with `direction` stands for it's ingress or egress, both of kind and direction could be set using `operation_name`. Meanwhile operation name of skywalking is set to `path` due to #21199 .


Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
