### PR TITLE
http: support ignoring host port on filter processing

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -36,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 51]
+// [#next-free-field: 52]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -720,7 +720,7 @@ message HttpConnectionManager {
   // Without setting this option, incoming requests with host ``example:443`` will not match against
   // route with :ref:`domains<envoy_v3_api_field_config.route.v3.VirtualHost.domains>` match set to ``example``. Defaults to ``false``. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  // Only one of ``strip_matching_host_port`` or ``strip_any_host_port`` can be set.
+  // Only one of ``strip_matching_host_port``, ``strip_any_host_port`` or ``ignore_any_host_port`` can be set.
   bool strip_matching_host_port = 39
       [(udpa.annotations.field_migrate).oneof_promotion = "strip_port_mode"];
 
@@ -732,8 +732,13 @@ message HttpConnectionManager {
     // Without setting this option, incoming requests with host ``example:443`` will not match against
     // route with :ref:`domains<envoy_v3_api_field_config.route.v3.VirtualHost.domains>` match set to ``example``. Defaults to ``false``. Note that port removal is not part
     // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-    // Only one of ``strip_matching_host_port`` or ``strip_any_host_port`` can be set.
+    // Only one of ``strip_matching_host_port``, ``strip_any_host_port`` or ``ignore_any_host_port`` can be set.
     bool strip_any_host_port = 42;
+
+    // Determines if the port part should be ignored from host/authority header before any processing
+    // of request by HTTP filters or routing.
+    // Only one of ``strip_matching_host_port``, ``strip_any_host_port`` or ``ignore_any_host_port`` can be set.
+    bool ignore_any_host_port = 51;
   }
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -181,6 +181,8 @@ enum class StripPortType {
   MatchingHost,
   // Removes any port from host/authority header.
   Any,
+  // Ignores any port from host/authority header.
+  Ignore,
   // Keeps the port in host/authority header as is.
   None
 };

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1065,13 +1065,14 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   }
 
   ASSERT(action == ConnectionManagerUtility::NormalizePathAction::Continue);
-  auto optional_port = ConnectionManagerUtility::maybeNormalizeHost(
+  auto result = ConnectionManagerUtility::maybeNormalizeHost(
       *request_headers_, connection_manager_.config_, localPort());
-  if (optional_port.has_value() &&
-      requestWasConnect(request_headers_, connection_manager_.codec_->protocol())) {
+  if (result.port_.has_value() &&
+      (result.should_store_ ||
+       requestWasConnect(request_headers_, connection_manager_.codec_->protocol()))) {
     filter_manager_.streamInfo().filterState()->setData(
         Router::OriginalConnectPort::key(),
-        std::make_unique<Router::OriginalConnectPort>(optional_port.value()),
+        std::make_unique<Router::OriginalConnectPort>(result.port_.value()),
         StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Request);
   }
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -586,18 +586,22 @@ ConnectionManagerUtility::maybeNormalizePath(RequestHeaderMap& request_headers,
   return final_action;
 }
 
-absl::optional<uint32_t>
+ConnectionManagerUtility::NormalizeHostResult
 ConnectionManagerUtility::maybeNormalizeHost(RequestHeaderMap& request_headers,
                                              const ConnectionManagerConfig& config, uint32_t port) {
   if (config.shouldStripTrailingHostDot()) {
     HeaderUtility::stripTrailingHostDot(request_headers);
   }
-  if (config.stripPortType() == Http::StripPortType::Any) {
-    return HeaderUtility::stripPortFromHost(request_headers, absl::nullopt);
-  } else if (config.stripPortType() == Http::StripPortType::MatchingHost) {
-    return HeaderUtility::stripPortFromHost(request_headers, port);
+  switch (config.stripPortType()) {
+  case Http::StripPortType::Any:
+    return {HeaderUtility::stripPortFromHost(request_headers, absl::nullopt), false};
+  case Http::StripPortType::Ignore:
+    return {HeaderUtility::stripPortFromHost(request_headers, absl::nullopt), true};
+  case Http::StripPortType::MatchingHost:
+    return {HeaderUtility::stripPortFromHost(request_headers, port), false};
+  case Http::StripPortType::None:
+    return {absl::nullopt, false};
   }
-  return absl::nullopt;
 }
 
 } // namespace Http

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -123,9 +123,17 @@ public:
   static NormalizePathAction maybeNormalizePath(RequestHeaderMap& request_headers,
                                                 const ConnectionManagerConfig& config);
 
-  static absl::optional<uint32_t> maybeNormalizeHost(RequestHeaderMap& request_headers,
-                                                     const ConnectionManagerConfig& config,
-                                                     uint32_t port);
+  struct NormalizeHostResult {
+    // The stripped port.
+    absl::optional<uint32_t> port_;
+
+    // The result if the port should be forced restoring when finalize request headers.
+    bool should_store_;
+  };
+
+  static NormalizeHostResult maybeNormalizeHost(RequestHeaderMap& request_headers,
+                                                const ConnectionManagerConfig& config,
+                                                uint32_t port);
 
   /**
    * Mutate request headers if request needs to be traced.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -782,7 +782,9 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::RequestHeaderMap& headers,
     header_parser->evaluateHeaders(headers, stream_info);
   }
 
-  // Restore the port if this was a CONNECT request.
+  // Restore the port if this was a stored original connect port. The original connect port will
+  // be stored if it is getting stripped by strip_matching_host_port or strip_any_host_port on
+  // CONNECT requests, and by ignore_any_host_port on any requests.
   // Note this will restore the port for HTTP/2 CONNECT-upgrades as well as as HTTP/1.1 style
   // CONNECT requests.
   if (Http::HeaderUtility::getPortStart(headers.getHostValue()) == absl::string_view::npos) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -1600,6 +1600,14 @@ TEST_F(ConnectionManagerUtilityTest, RemovePort) {
   ConnectionManagerUtility::maybeNormalizeHost(header_map_any, config_, 7777);
   EXPECT_EQ(header_map_any.getHostValue(), "host");
 
+  ON_CALL(config_, stripPortType()).WillByDefault(Return(Http::StripPortType::Ignore));
+  TestRequestHeaderMapImpl original_headers_ignore;
+  original_headers_ignore.setHost("host:9999");
+
+  TestRequestHeaderMapImpl header_map_ignore(original_headers_ignore);
+  ConnectionManagerUtility::maybeNormalizeHost(header_map_ignore, config_, 7777);
+  EXPECT_EQ(header_map_ignore.getHostValue(), "host");
+
   ON_CALL(config_, stripPortType()).WillByDefault(Return(Http::StripPortType::None));
   TestRequestHeaderMapImpl original_headers_none;
   original_headers_none.setHost("host:9999");


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: http: support ignoring host port on filter processing
Additional Description:
Risk Level: Low
Testing: WIP
Docs Changes: N/A
Release Notes: WIP
Platform Specific Features: N/A
Fixes #22664 
