### PR TITLE
examples: Add `--remove-orphans` when bringing down examples

### DIFF
--- a/examples/verify-common.sh
+++ b/examples/verify-common.sh
@@ -57,7 +57,7 @@ cleanup_stack () {
     local path
     path="$1"
     run_log "Cleanup ($path)"
-    "$DOCKER_COMPOSE" down
+    "$DOCKER_COMPOSE" down --remove-orphans
 }
 
 cleanup () {


### PR DESCRIPTION
This might resolve a very infrequent CI bug in which docker doesnt
clean up containers before removing the network.

This relates to a very long-standing docker bug that never seems to
have been fully resolved.

cf https://github.com/moby/moby/issues/17217

Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
