### PR TITLE
vscode: add target for contrib compdb

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,12 @@
       "type": "shell",
       "command": "tools/vscode/refresh_compdb.sh",
       "problemMatcher": []
+    },
+    {
+      "label": "Refresh Compilation Database Exclude Contrib",
+      "type": "shell",
+      "command": "EXCLUDE_CONTRIB=true tools/vscode/refresh_compdb.sh",
+      "problemMatcher": []
     }
   ]
 }

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -5,8 +5,10 @@
 bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
+[[ -z "${EXCLUDE_CONTRIB}" ]] || opts="--exclude_contrib"
+
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk --exclude_contrib
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk ${opts}
 
 # Kill clangd to reload the compilation database
 pkill clangd || :


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

Now refresh compilation database excludes contrib as default, so add it as an option.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
