### PR TITLE
json: avoid testing a 3-byte utf8 code-point that mismatches expectations in a future protobuf library upgrade

### DIFF
--- a/test/common/json/json_sanitizer_test_util.cc
+++ b/test/common/json/json_sanitizer_test_util.cc
@@ -34,6 +34,12 @@ public:
     // sanitizer() will catch that an do simple escapes on the string.
     invalid_3byte_intervals_.insert(0xd800, 0xe000);
 
+    // Version 3.21.5 of the protobuf library appears to handle the unicode
+    // point 0xfffd differently from the nlohmann library, so exclude it. Note
+    // that Envoy does not depend on this version of the protobuf library yet,
+    // but this 1-code-point exclusion will simplify the update process.
+    invalid_3byte_intervals_.insert(0xfffd, 0xfffe);
+
     // Avoid differential testing of Unicode ranges generated from 4-byte utf-8
     // where protobuf serialization generates two small Unicode values instead
     // of the correct one. This must be a protobuf serialization issue.


### PR DESCRIPTION
Commit Message: The next protobuf upgrade will break a few JSON-related tests, mostly due to brittle dependence on error-message syntax. However this one is a consistency check for serializing 3-byte utf-8 code-points, and there is one that is serialized differently in the new version of the protobuf library than the previous one.
Additional Description:
Risk Level: low
Testing: test/common/json/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

