### PR TITLE
[v1.23] ci: disable non-RBE cache for release branches

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -55,7 +55,6 @@ steps:
       BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
-      BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
   displayName: "Run CI script ${{ parameters.ciTarget }}"
 


### PR DESCRIPTION
This should fix cache issue in non-RBE workers.

Fixes #22701.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
