### PR TITLE
[v1.22] ci: disable non-RBE cache for release branches

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -55,7 +55,6 @@ steps:
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
-      BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
   displayName: "Run CI script"
 


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

