### PR TITLE
build: Fix call to std::min for newer compiler

### DIFF
--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -119,7 +119,8 @@ public:
     uint64_t size_copied = 0;
     uint64_t num_slices_copied = 0;
     while (size_copied < length && num_slices_copied < num_slices) {
-      auto copy_length = std::min((length - size_copied), static_cast<unsigned long long>(slices[num_slices_copied].len_));
+      auto copy_length = std::min((length - size_copied), 
+                                  static_cast<unsigned long long>(slices[num_slices_copied].len_));
       ::memcpy(slices[num_slices_copied].mem_, this->start(), copy_length);
       size_copied += copy_length;
       if (copy_length == slices[num_slices_copied].len_) {

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -119,7 +119,7 @@ public:
     uint64_t size_copied = 0;
     uint64_t num_slices_copied = 0;
     while (size_copied < length && num_slices_copied < num_slices) {
-      auto copy_length = std::min((length - size_copied), 
+      auto copy_length = std::min((length - size_copied),
                                   static_cast<unsigned long long>(slices[num_slices_copied].len_));
       ::memcpy(slices[num_slices_copied].mem_, this->start(), copy_length);
       size_copied += copy_length;

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -119,7 +119,7 @@ public:
     uint64_t size_copied = 0;
     uint64_t num_slices_copied = 0;
     while (size_copied < length && num_slices_copied < num_slices) {
-      auto copy_length = std::min((length - size_copied), slices[num_slices_copied].len_);
+      auto copy_length = std::min((length - size_copied), static_cast<unsigned long long>(slices[num_slices_copied].len_));
       ::memcpy(slices[num_slices_copied].mem_, this->start(), copy_length);
       size_copied += copy_length;
       if (copy_length == slices[num_slices_copied].len_) {


### PR DESCRIPTION
Signed-off-by: Andrew Duerig <duerig.andrew@gmail.com>

std::min needs to explicitly have the same types, build errors with this:
```
test/common/buffer/buffer_fuzz.cc:123:26: error: no matching function for call to 'min'
      auto copy_length = std::min((length - size_copied), slices[num_slices_copied].len_);
                         ^~~~~~~~
/Applications/Xcode_13.4.0_fb.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/min.h:39:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned long long' vs. 'unsigned long')
min(const _Tp& __a, const _Tp& __b)
```