### PR TITLE
deps: Bump com_google_cel_cpp release date to 2022-07-21

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1012,7 +1012,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.stat_sinks.wasm",
             "envoy.rbac.matchers.upstream_ip_port",
         ],
-        release_date = "2022-07-20",
+        release_date = "2022-07-21",
         cpe = "N/A",
     ),
     com_github_google_flatbuffers = dict(


### PR DESCRIPTION
Commit Message: Bump com_google_cel_cpp release date to 2022-07-21
Additional Description: Noticed the following error in the pipeline ([link](https://dev.azure.com/cncf/envoy/_build/results?buildId=115138&view=logs&j=1c04237c-5f52-5959-5f83-5522b3556331&t=db3f3889-c922-566b-fa2e-4bc4948bc467)):

```
DependencyChecker ERROR ERRORS Summary [release_dates]:
--------------------------------------------------------------------------------
Mismatch: com_google_cel_cpp 2022-07-20 != 2022-07-21
```

Looks like the version was bumped in https://github.com/envoyproxy/envoy/pull/22315, and I noticed this on a separate PR after that was submitted.

Risk Level: Very low, just dev.