### PR TITLE
bazel: switch to using new-style platform constraints

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -395,8 +395,8 @@ config_setting(
 config_setting(
     name = "boringssl_fips",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     values = {"define": "boringssl=fips"},
 )
@@ -409,7 +409,7 @@ config_setting(
 config_setting(
     name = "zlib_ng",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
+        "@platforms//os:linux",
     ],
     values = {"define": "zlib=ng"},
 )


### PR DESCRIPTION
The old style will stop working in Bazel 6.0 (see https://github.com/bazelbuild/bazel/commit/3469784a4935c91b4ac22bcfed6be52e6dfec878)

Signed-off-by: Xùdōng Yáng <wyverald@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: see above
Additional Description: N/A
Risk Level: low
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
