### PR TITLE
[API]xds: Add additional metadata field to Resource wrapper

### DIFF
--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -386,6 +386,5 @@ message Resource {
 
   // The Metadata field can be used to provide additional information for the resource.
   // E.g. the trace data for debugging.
-  // [#not-implemented-hide:]
   config.core.v3.Metadata metadata = 9;
 }

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -332,7 +332,7 @@ message DynamicParameterConstraints {
   }
 }
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
@@ -383,4 +383,9 @@ message Resource {
   // Cache control properties for the resource.
   // [#not-implemented-hide:]
   CacheControl cache_control = 7;
+
+  // The Metadata field can be used to provide additional information for the resource.
+  // E.g. the trace data for debugging.
+  // [#not-implemented-hide:]
+  config.core.v3.Metadata metadata = 9;
 }


### PR DESCRIPTION
Signed-off-by: Boteng Yao <boteng@google.com>

Added  a new metadata to Resources wrapper to unblock the possibility to carry more ad-hoc info, e.g. the trace data for each resources. 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: Low
Testing: 
Docs Changes:
