### PR TITLE
Improve stack_decode.py exit code if binary terminated by signal

### DIFF
--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -128,7 +128,8 @@ if __name__ == "__main__":
         # if so, add 128 to signal value to follow convention.
         # sys.exit casts to unsigned int so a negative value leads
         # to unexpected exit code.
-        sys.exit(returncode if returncode >= 0 else 128 + abs(returncode))  # Pass back test pass/fail result
+        exitcode = returncode if returncode >= 0 else 128 + abs(returncode)
+        sys.exit(exitcode)  # Pass back test pass/fail result
     else:
         print("Usage (execute subprocess): stack_decode.py executable_file [additional args]")
         print("Usage (read from stdin): stack_decode.py -s executable_file")

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -123,8 +123,12 @@ if __name__ == "__main__":
             sys.argv[1:], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
         offset = find_address_offset(rununder.pid)
         decode_stacktrace_log(sys.argv[1], ignore_decoding_errors(rununder.stdout), offset)
-        rununder.wait()
-        sys.exit(rununder.returncode)  # Pass back test pass/fail result
+        returncode = rununder.wait()
+        # negative return code means process terminated by signal
+        # if so, add 128 to signal value to follow convention.
+        # sys.exit casts to unsigned int so a negative value leads
+        # to unexpected exit code.
+        sys.exit(returncode if returncode >= 0 else 128 + abs(returncode))  # Pass back test pass/fail result
     else:
         print("Usage (execute subprocess): stack_decode.py executable_file [additional args]")
         print("Usage (read from stdin): stack_decode.py -s executable_file")


### PR DESCRIPTION
Commit Message: Improve stack_decode.py exit code if binary terminated by signal
Additional Description: Pythons subprocess returncode is negative if process terminated by signal, which leads to unexpected exit code if passed directly to sys.exit. For example sigkill leads to sys.exit(-9) which becomes 247 on unix as -9 signed int is cast to unsigned 8bit int. Bash and docker will convert the exit to 128 + signal int, e.g. 137 in the above example. Therefore follow that convention for more obvious exit codes.
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
