### PR TITLE
config: refactoring opaque resource decoder to be a unique-ptr

### DIFF
--- a/envoy/config/grpc_mux.h
+++ b/envoy/config/grpc_mux.h
@@ -100,7 +100,7 @@ public:
   virtual GrpcMuxWatchPtr addWatch(const std::string& type_url,
                                    const absl::flat_hash_set<std::string>& resources,
                                    SubscriptionCallbacks& callbacks,
-                                   OpaqueResourceDecoder& resource_decoder,
+                                   OpaqueResourceDecoderPtr resource_decoder,
                                    const SubscriptionOptions& options) PURE;
 
   virtual void requestOnDemandUpdate(const std::string& type_url,

--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -83,6 +83,8 @@ public:
   virtual std::string resourceName(const Protobuf::Message& resource) PURE;
 };
 
+using OpaqueResourceDecoderPtr = std::unique_ptr<OpaqueResourceDecoder>;
+
 /**
  * Subscription to DecodedResources.
  */

--- a/envoy/config/subscription_factory.h
+++ b/envoy/config/subscription_factory.h
@@ -39,7 +39,7 @@ public:
   virtual SubscriptionPtr subscriptionFromConfigSource(
       const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
       Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-      OpaqueResourceDecoder& resource_decoder, const SubscriptionOptions& options) PURE;
+      OpaqueResourceDecoderPtr resource_decoder, const SubscriptionOptions& options) PURE;
 
   /**
    * Collection subscription factory interface for xDS-TP URLs.
@@ -60,7 +60,7 @@ public:
                                 const envoy::config::core::v3::ConfigSource& config,
                                 absl::string_view type_url, Stats::Scope& scope,
                                 SubscriptionCallbacks& callbacks,
-                                OpaqueResourceDecoder& resource_decoder) PURE;
+                                OpaqueResourceDecoderPtr resource_decoder) PURE;
 };
 
 } // namespace Config

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -26,7 +26,7 @@ public:
   FilesystemSubscriptionImpl(Event::Dispatcher& dispatcher,
                              const envoy::config::core::v3::PathConfigSource& path_config_source,
                              SubscriptionCallbacks& callbacks,
-                             OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
+                             OpaqueResourceDecoderPtr resource_decoder, SubscriptionStats stats,
                              ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api);
 
   // Config::Subscription
@@ -48,7 +48,7 @@ protected:
   std::unique_ptr<Filesystem::Watcher> file_watcher_;
   WatchedDirectoryPtr directory_watcher_;
   SubscriptionCallbacks& callbacks_;
-  OpaqueResourceDecoder& resource_decoder_;
+  OpaqueResourceDecoderPtr resource_decoder_;
   SubscriptionStats stats_;
   Api::Api& api_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
@@ -61,7 +61,7 @@ public:
   FilesystemCollectionSubscriptionImpl(
       Event::Dispatcher& dispatcher,
       const envoy::config::core::v3::PathConfigSource& path_config_source,
-      SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+      SubscriptionCallbacks& callbacks, OpaqueResourceDecoderPtr resource_decoder,
       SubscriptionStats stats, ProtobufMessage::ValidationVisitor& validation_visitor,
       Api::Api& api);
 

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -59,7 +59,7 @@ public:
   GrpcMuxWatchPtr addWatch(const std::string& type_url,
                            const absl::flat_hash_set<std::string>& resources,
                            SubscriptionCallbacks& callbacks,
-                           OpaqueResourceDecoder& resource_decoder,
+                           OpaqueResourceDecoderPtr resource_decoder,
                            const SubscriptionOptions& options) override;
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {
@@ -89,10 +89,10 @@ private:
 
   struct GrpcMuxWatchImpl : public GrpcMuxWatch {
     GrpcMuxWatchImpl(const absl::flat_hash_set<std::string>& resources,
-                     SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+                     SubscriptionCallbacks& callbacks, OpaqueResourceDecoderPtr resource_decoder,
                      const std::string& type_url, GrpcMuxImpl& parent)
-        : callbacks_(callbacks), resource_decoder_(resource_decoder), type_url_(type_url),
-          parent_(parent), watches_(parent.apiStateFor(type_url).watches_) {
+        : callbacks_(callbacks), resource_decoder_(std::move(resource_decoder)),
+          type_url_(type_url), parent_(parent), watches_(parent.apiStateFor(type_url).watches_) {
       std::copy(resources.begin(), resources.end(), std::inserter(resources_, resources_.begin()));
       iter_ = watches_.emplace(watches_.begin(), this);
     }
@@ -119,7 +119,7 @@ private:
     // Maintain deterministic wire ordering via ordered std::set.
     std::set<std::string> resources_;
     SubscriptionCallbacks& callbacks_;
-    OpaqueResourceDecoder& resource_decoder_;
+    OpaqueResourceDecoderPtr resource_decoder_;
     const std::string type_url_;
     GrpcMuxImpl& parent_;
 
@@ -210,7 +210,7 @@ public:
   }
 
   GrpcMuxWatchPtr addWatch(const std::string&, const absl::flat_hash_set<std::string>&,
-                           SubscriptionCallbacks&, OpaqueResourceDecoder&,
+                           SubscriptionCallbacks&, OpaqueResourceDecoderPtr,
                            const SubscriptionOptions&) override {
     ExceptionUtil::throwEnvoyException("ADS must be configured to support an ADS config source");
   }

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -22,7 +22,7 @@ class GrpcSubscriptionImpl : public Subscription,
                              Logger::Loggable<Logger::Id::config> {
 public:
   GrpcSubscriptionImpl(GrpcMuxSharedPtr grpc_mux, SubscriptionCallbacks& callbacks,
-                       OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
+                       OpaqueResourceDecoderPtr resource_decoder, SubscriptionStats stats,
                        absl::string_view type_url, Event::Dispatcher& dispatcher,
                        std::chrono::milliseconds init_fetch_timeout, bool is_aggregated,
                        const SubscriptionOptions& options);
@@ -49,7 +49,7 @@ private:
 
   GrpcMuxSharedPtr grpc_mux_;
   SubscriptionCallbacks& callbacks_;
-  OpaqueResourceDecoder& resource_decoder_;
+  OpaqueResourceDecoderPtr resource_decoder_;
   SubscriptionStats stats_;
   const std::string type_url_;
   GrpcMuxWatchPtr watch_;
@@ -75,7 +75,7 @@ class GrpcCollectionSubscriptionImpl : public GrpcSubscriptionImpl {
 public:
   GrpcCollectionSubscriptionImpl(const xds::core::v3::ResourceLocator& collection_locator,
                                  GrpcMuxSharedPtr grpc_mux, SubscriptionCallbacks& callbacks,
-                                 OpaqueResourceDecoder& resource_decoder, SubscriptionStats stats,
+                                 OpaqueResourceDecoderPtr resource_decoder, SubscriptionStats stats,
                                  Event::Dispatcher& dispatcher,
                                  std::chrono::milliseconds init_fetch_timeout, bool is_aggregated,
                                  const SubscriptionOptions& options);

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -27,7 +27,7 @@ public:
                        Random::RandomGenerator& random, std::chrono::milliseconds refresh_interval,
                        std::chrono::milliseconds request_timeout,
                        const Protobuf::MethodDescriptor& service_method, absl::string_view type_url,
-                       SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+                       SubscriptionCallbacks& callbacks, OpaqueResourceDecoderPtr resource_decoder,
                        SubscriptionStats stats, std::chrono::milliseconds init_fetch_timeout,
                        ProtobufMessage::ValidationVisitor& validation_visitor);
 
@@ -53,7 +53,7 @@ private:
   Protobuf::RepeatedPtrField<std::string> resources_;
   envoy::service::discovery::v3::DiscoveryRequest request_;
   Config::SubscriptionCallbacks& callbacks_;
-  Config::OpaqueResourceDecoder& resource_decoder_;
+  Config::OpaqueResourceDecoderPtr resource_decoder_;
   SubscriptionStats stats_;
   Event::Dispatcher& dispatcher_;
   std::chrono::milliseconds init_fetch_timeout_;

--- a/source/common/config/new_grpc_mux_impl.h
+++ b/source/common/config/new_grpc_mux_impl.h
@@ -50,7 +50,7 @@ public:
   GrpcMuxWatchPtr addWatch(const std::string& type_url,
                            const absl::flat_hash_set<std::string>& resources,
                            SubscriptionCallbacks& callbacks,
-                           OpaqueResourceDecoder& resource_decoder,
+                           OpaqueResourceDecoderPtr resource_decoder,
                            const SubscriptionOptions& options) override;
 
   void requestOnDemandUpdate(const std::string& type_url,
@@ -83,8 +83,10 @@ public:
   struct SubscriptionStuff {
     SubscriptionStuff(const std::string& type_url, const LocalInfo::LocalInfo& local_info,
                       const bool use_namespace_matching, Event::Dispatcher& dispatcher,
-                      CustomConfigValidators& config_validators)
-        : watch_map_(use_namespace_matching, type_url, config_validators),
+                      CustomConfigValidators& config_validators,
+                      OpaqueResourceDecoderPtr resource_decoder)
+        : watch_map_(use_namespace_matching, type_url, config_validators,
+                     std::move(resource_decoder)),
           sub_state_(type_url, watch_map_, local_info, dispatcher) {}
 
     WatchMap watch_map_;
@@ -139,7 +141,8 @@ private:
                    const SubscriptionOptions& options);
 
   // Adds a subscription for the type_url to the subscriptions map and order list.
-  void addSubscription(const std::string& type_url, bool use_namespace_matching);
+  void addSubscription(const std::string& type_url, bool use_namespace_matching,
+                       OpaqueResourceDecoderPtr resource_decoder);
 
   void trySendDiscoveryRequests();
 

--- a/source/common/config/subscription_base.h
+++ b/source/common/config/subscription_base.h
@@ -12,12 +12,13 @@ template <typename Current> struct SubscriptionBase : public Config::Subscriptio
 public:
   SubscriptionBase(ProtobufMessage::ValidationVisitor& validation_visitor,
                    absl::string_view name_field)
-      : resource_decoder_(validation_visitor, name_field) {}
+      : resource_decoder_(std::make_unique<Config::OpaqueResourceDecoderImpl<Current>>(
+            validation_visitor, name_field)) {}
 
   std::string getResourceName() const { return Envoy::Config::getResourceName<Current>(); }
 
 protected:
-  Config::OpaqueResourceDecoderImpl<Current> resource_decoder_;
+  Config::OpaqueResourceDecoderPtr resource_decoder_;
 };
 
 } // namespace Config

--- a/source/common/config/subscription_factory_impl.h
+++ b/source/common/config/subscription_factory_impl.h
@@ -25,14 +25,14 @@ public:
   SubscriptionPtr subscriptionFromConfigSource(const envoy::config::core::v3::ConfigSource& config,
                                                absl::string_view type_url, Stats::Scope& scope,
                                                SubscriptionCallbacks& callbacks,
-                                               OpaqueResourceDecoder& resource_decoder,
+                                               OpaqueResourceDecoderPtr resource_decoder,
                                                const SubscriptionOptions& options) override;
   SubscriptionPtr
   collectionSubscriptionFromUrl(const xds::core::v3::ResourceLocator& collection_locator,
                                 const envoy::config::core::v3::ConfigSource& config,
                                 absl::string_view resource_type, Stats::Scope& scope,
                                 SubscriptionCallbacks& callbacks,
-                                OpaqueResourceDecoder& resource_decoder) override;
+                                OpaqueResourceDecoderPtr resource_decoder) override;
 
 private:
   const LocalInfo::LocalInfo& local_info_;

--- a/source/common/config/watch_map.cc
+++ b/source/common/config/watch_map.cc
@@ -21,9 +21,10 @@ std::string namespaceFromName(const std::string& resource_name) {
 }
 } // namespace
 
-Watch* WatchMap::addWatch(SubscriptionCallbacks& callbacks,
-                          OpaqueResourceDecoder& resource_decoder) {
-  auto watch = std::make_unique<Watch>(callbacks, resource_decoder);
+Watch* WatchMap::addWatch(SubscriptionCallbacks& callbacks) {
+  // TODO(adisuissa): there isn't a real need to pass the resource decoder to
+  // the Watch. Need to clean this in the future.
+  auto watch = std::make_unique<Watch>(callbacks, *resource_decoder_);
   Watch* watch_ptr = watch.get();
   wildcard_watches_.insert(watch_ptr);
   watches_.insert(std::move(watch));

--- a/source/common/config/watch_map.h
+++ b/source/common/config/watch_map.h
@@ -62,14 +62,14 @@ struct Watch {
 class WatchMap : public UntypedConfigUpdateCallbacks, public Logger::Loggable<Logger::Id::config> {
 public:
   WatchMap(const bool use_namespace_matching, const std::string& type_url,
-           CustomConfigValidators& config_validators)
+           CustomConfigValidators& config_validators, OpaqueResourceDecoderPtr resource_decoder)
       : use_namespace_matching_(use_namespace_matching), type_url_(type_url),
-        config_validators_(config_validators) {}
+        config_validators_(config_validators), resource_decoder_(std::move(resource_decoder)) {}
 
   // Adds 'callbacks' to the WatchMap, with every possible resource being watched.
   // (Use updateWatchInterest() to narrow it down to some specific names).
   // Returns the newly added watch, to be used with updateWatchInterest and removeWatch.
-  Watch* addWatch(SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder);
+  Watch* addWatch(SubscriptionCallbacks& callbacks);
 
   // Updates the set of resource names that the given watch should watch.
   // Returns any resource name additions/removals that are unique across all watches. That is:
@@ -133,6 +133,7 @@ private:
   const bool use_namespace_matching_;
   const std::string type_url_;
   CustomConfigValidators& config_validators_;
+  OpaqueResourceDecoderPtr resource_decoder_;
 };
 
 } // namespace Config

--- a/source/common/config/xds_mux/grpc_mux_impl.h
+++ b/source/common/config/xds_mux/grpc_mux_impl.h
@@ -81,7 +81,7 @@ public:
   Config::GrpcMuxWatchPtr addWatch(const std::string& type_url,
                                    const absl::flat_hash_set<std::string>& resources,
                                    SubscriptionCallbacks& callbacks,
-                                   OpaqueResourceDecoder& resource_decoder,
+                                   OpaqueResourceDecoderPtr resource_decoder,
                                    const SubscriptionOptions& options) override;
   void updateWatch(const std::string& type_url, Watch* watch,
                    const absl::flat_hash_set<std::string>& resources,
@@ -252,7 +252,7 @@ public:
   }
 
   Config::GrpcMuxWatchPtr addWatch(const std::string&, const absl::flat_hash_set<std::string>&,
-                                   SubscriptionCallbacks&, OpaqueResourceDecoder&,
+                                   SubscriptionCallbacks&, OpaqueResourceDecoderPtr,
                                    const SubscriptionOptions&) override;
 
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {

--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -74,8 +74,8 @@ FilterConfigSubscription::FilterConfigSubscription(
   const auto resource_name = getResourceName();
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
-          config_source, Grpc::Common::typeUrl(resource_name), *scope_, *this, resource_decoder_,
-          {});
+          config_source, Grpc::Common::typeUrl(resource_name), *scope_, *this,
+          std::move(resource_decoder_), {});
 }
 
 void FilterConfigSubscription::start() {

--- a/source/common/rds/rds_route_config_subscription.cc
+++ b/source/common/rds/rds_route_config_subscription.cc
@@ -8,7 +8,7 @@ namespace Rds {
 
 RdsRouteConfigSubscription::RdsRouteConfigSubscription(
     RouteConfigUpdatePtr&& config_update,
-    std::unique_ptr<Envoy::Config::OpaqueResourceDecoder>&& resource_decoder,
+    Envoy::Config::OpaqueResourceDecoderPtr&& resource_decoder,
     const envoy::config::core::v3::ConfigSource& config_source,
     const std::string& route_config_name, const uint64_t manager_identifier,
     Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
@@ -28,13 +28,12 @@ RdsRouteConfigSubscription::RdsRouteConfigSubscription(
       stat_prefix_(stat_prefix), rds_type_(rds_type),
       stats_({ALL_RDS_STATS(POOL_COUNTER(*scope_), POOL_GAUGE(*scope_))}),
       route_config_provider_manager_(route_config_provider_manager),
-      manager_identifier_(manager_identifier), config_update_info_(std::move(config_update)),
-      resource_decoder_(std::move(resource_decoder)) {
+      manager_identifier_(manager_identifier), config_update_info_(std::move(config_update)) {
   const auto resource_type = route_config_provider_manager_.protoTraits().resourceType();
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
           config_source, Envoy::Grpc::Common::typeUrl(resource_type), *scope_, *this,
-          *resource_decoder_, {});
+          std::move(resource_decoder), {});
   local_init_manager_.add(local_init_target_);
 }
 

--- a/source/common/rds/rds_route_config_subscription.h
+++ b/source/common/rds/rds_route_config_subscription.h
@@ -43,13 +43,14 @@ struct RdsStats {
 class RdsRouteConfigSubscription : Envoy::Config::SubscriptionCallbacks,
                                    protected Logger::Loggable<Logger::Id::rds> {
 public:
-  RdsRouteConfigSubscription(
-      RouteConfigUpdatePtr&& config_update,
-      std::unique_ptr<Envoy::Config::OpaqueResourceDecoder>&& resource_decoder,
-      const envoy::config::core::v3::ConfigSource& config_source,
-      const std::string& route_config_name, const uint64_t manager_identifier,
-      Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
-      const std::string& rds_type, RouteConfigProviderManager& route_config_provider_manager);
+  RdsRouteConfigSubscription(RouteConfigUpdatePtr&& config_update,
+                             Envoy::Config::OpaqueResourceDecoderPtr&& resource_decoder,
+                             const envoy::config::core::v3::ConfigSource& config_source,
+                             const std::string& route_config_name,
+                             const uint64_t manager_identifier,
+                             Server::Configuration::ServerFactoryContext& factory_context,
+                             const std::string& stat_prefix, const std::string& rds_type,
+                             RouteConfigProviderManager& route_config_provider_manager);
 
   ~RdsRouteConfigSubscription() override;
 
@@ -99,7 +100,6 @@ protected:
   const uint64_t manager_identifier_;
   absl::optional<RouteConfigProvider*> route_config_provider_opt_;
   RouteConfigUpdatePtr config_update_info_;
-  std::unique_ptr<Envoy::Config::OpaqueResourceDecoder> resource_decoder_;
 };
 
 using RdsRouteConfigSubscriptionSharedPtr = std::shared_ptr<RdsRouteConfigSubscription>;

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -154,14 +154,14 @@ ScopedRdsConfigSubscription::ScopedRdsConfigSubscription(
     subscription_ =
         factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
             scoped_rds.scoped_rds_config_source(), Grpc::Common::typeUrl(resource_name), *scope_,
-            *this, resource_decoder_, {});
+            *this, std::move(resource_decoder_), {});
   } else {
     const auto srds_resources_locator =
         Envoy::Config::XdsResourceIdentifier::decodeUrl(scoped_rds.srds_resources_locator());
     subscription_ =
         factory_context.clusterManager().subscriptionFactory().collectionSubscriptionFromUrl(
             srds_resources_locator, scoped_rds.scoped_rds_config_source(), resource_name, *scope_,
-            *this, resource_decoder_);
+            *this, std::move(resource_decoder_));
   }
 
   initialize([scope_key_builder]() -> Envoy::Config::ConfigProvider::ConfigConstSharedPtr {

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -51,7 +51,8 @@ VhdsSubscription::VhdsSubscription(
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().subscriptionFromConfigSource(
           config_update_info_->protobufConfigurationCast().vhds().config_source(),
-          Grpc::Common::typeUrl(resource_name), *scope_, *this, resource_decoder_, options);
+          Grpc::Common::typeUrl(resource_name), *scope_, *this, std::move(resource_decoder_),
+          options);
 }
 
 void VhdsSubscription::updateOnDemand(const std::string& with_route_config_name_prefix) {

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -476,8 +476,8 @@ RtdsSubscription::RtdsSubscription(
 void RtdsSubscription::createSubscription() {
   const auto resource_name = getResourceName();
   subscription_ = parent_.cm_->subscriptionFactory().subscriptionFromConfigSource(
-      config_source_, Grpc::Common::typeUrl(resource_name), *stats_scope_, *this, resource_decoder_,
-      {});
+      config_source_, Grpc::Common::typeUrl(resource_name), *stats_scope_, *this,
+      std::move(resource_decoder_), {});
 }
 
 void RtdsSubscription::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& resources,

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -32,7 +32,8 @@ SdsApi::SdsApi(envoy::config::core::v3::ConfigSource sds_config, absl::string_vi
   const auto resource_name = getResourceName();
   // This has to happen here (rather than in initialize()) as it can throw exceptions.
   subscription_ = subscription_factory_.subscriptionFromConfigSource(
-      sds_config_, Grpc::Common::typeUrl(resource_name), *scope_, *this, resource_decoder_, {});
+      sds_config_, Grpc::Common::typeUrl(resource_name), *scope_, *this,
+      std::move(resource_decoder_), {});
 }
 
 void SdsApi::resolveDataSource(const FileContentMap& files,

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -26,10 +26,12 @@ CdsApiImpl::CdsApiImpl(const envoy::config::core::v3::ConfigSource& cds_config,
   const auto resource_name = getResourceName();
   if (cds_resources_locator == nullptr) {
     subscription_ = cm_.subscriptionFactory().subscriptionFromConfigSource(
-        cds_config, Grpc::Common::typeUrl(resource_name), *scope_, *this, resource_decoder_, {});
+        cds_config, Grpc::Common::typeUrl(resource_name), *scope_, *this,
+        std::move(resource_decoder_), {});
   } else {
     subscription_ = cm.subscriptionFactory().collectionSubscriptionFromUrl(
-        *cds_resources_locator, cds_config, resource_name, *scope_, *this, resource_decoder_);
+        *cds_resources_locator, cds_config, resource_name, *scope_, *this,
+        std::move(resource_decoder_));
   }
 }
 

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -90,6 +90,10 @@ private:
   Server::Configuration::TransportSocketFactoryContextImpl factory_context_;
   const LocalInfo::LocalInfo& local_info_;
   const std::string cluster_name_;
+  // TODO(adisuissa): This is an internal resource decoder that is used when an
+  // assignment becomes stale, and a timeout event occurs.
+  Config::OpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
+      resource_decoder_for_timeout_;
   std::vector<LocalityWeightsMap> locality_weights_map_;
   Event::TimerPtr assignment_timeout_;
   InitializePhase initialize_phase_;

--- a/source/common/upstream/leds.cc
+++ b/source/common/upstream/leds.cc
@@ -26,7 +26,7 @@ LedsSubscription::LedsSubscription(
   subscription_ =
       factory_context.clusterManager().subscriptionFactory().collectionSubscriptionFromUrl(
           leds_resource_locator, leds_config.leds_config(), resource_name, *stats_scope_, *this,
-          resource_decoder_);
+          std::move(resource_decoder_));
   subscription_->start({});
 }
 

--- a/source/common/upstream/od_cds_api_impl.cc
+++ b/source/common/upstream/od_cds_api_impl.cc
@@ -31,10 +31,12 @@ OdCdsApiImpl::OdCdsApiImpl(const envoy::config::core::v3::ConfigSource& odcds_co
   const auto resource_name = getResourceName();
   if (!odcds_resources_locator.has_value()) {
     subscription_ = cm_.subscriptionFactory().subscriptionFromConfigSource(
-        odcds_config, Grpc::Common::typeUrl(resource_name), *scope_, *this, resource_decoder_, {});
+        odcds_config, Grpc::Common::typeUrl(resource_name), *scope_, *this,
+        std::move(resource_decoder_), {});
   } else {
     subscription_ = cm.subscriptionFactory().collectionSubscriptionFromUrl(
-        *odcds_resources_locator, odcds_config, resource_name, *scope_, *this, resource_decoder_);
+        *odcds_resources_locator, odcds_config, resource_name, *scope_, *this,
+        std::move(resource_decoder_));
   }
 }
 

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -31,10 +31,12 @@ LdsApiImpl::LdsApiImpl(const envoy::config::core::v3::ConfigSource& lds_config,
   const auto resource_name = getResourceName();
   if (lds_resources_locator == nullptr) {
     subscription_ = cm.subscriptionFactory().subscriptionFromConfigSource(
-        lds_config, Grpc::Common::typeUrl(resource_name), *scope_, *this, resource_decoder_, {});
+        lds_config, Grpc::Common::typeUrl(resource_name), *scope_, *this,
+        std::move(resource_decoder_), {});
   } else {
     subscription_ = cm.subscriptionFactory().collectionSubscriptionFromUrl(
-        *lds_resources_locator, lds_config, resource_name, *scope_, *this, resource_decoder_);
+        *lds_resources_locator, lds_config, resource_name, *scope_, *this,
+        std::move(resource_decoder_));
   }
   init_manager.add(init_target_);
 }

--- a/test/common/config/delta_subscription_impl_test.cc
+++ b/test/common/config/delta_subscription_impl_test.cc
@@ -140,7 +140,8 @@ TEST_P(DeltaSubscriptionNoGrpcStreamTest, NoGrpcStream) {
   NiceMock<Random::MockRandomGenerator> random;
   Envoy::Config::RateLimitSettings rate_limit_settings;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks;
-  NiceMock<Config::MockOpaqueResourceDecoder> resource_decoder;
+  OpaqueResourceDecoderPtr resource_decoder{
+      std::make_unique<NiceMock<Config::MockOpaqueResourceDecoder>>()};
   auto* async_client = new Grpc::MockAsyncClient();
 
   const Protobuf::MethodDescriptor* method_descriptor =
@@ -160,8 +161,9 @@ TEST_P(DeltaSubscriptionNoGrpcStreamTest, NoGrpcStream) {
   }
 
   GrpcSubscriptionImplPtr subscription = std::make_unique<GrpcSubscriptionImpl>(
-      xds_context, callbacks, resource_decoder, stats, Config::TypeUrl::get().ClusterLoadAssignment,
-      dispatcher, std::chrono::milliseconds(12345), false, SubscriptionOptions());
+      xds_context, callbacks, std::move(resource_decoder), stats,
+      Config::TypeUrl::get().ClusterLoadAssignment, dispatcher, std::chrono::milliseconds(12345),
+      false, SubscriptionOptions());
 
   EXPECT_CALL(*async_client, startRaw(_, _, _, _)).WillOnce(Return(nullptr));
 

--- a/test/common/config/delta_subscription_test_harness.h
+++ b/test/common/config/delta_subscription_test_harness.h
@@ -56,8 +56,11 @@ public:
           random_, stats_store_, rate_limit_settings_, local_info_,
           std::make_unique<NiceMock<MockCustomConfigValidators>>());
     }
+    OpaqueResourceDecoderPtr resource_decoder(
+        std::make_unique<TestUtility::TestOpaqueResourceDecoderImpl<
+            envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name"));
     subscription_ = std::make_unique<GrpcSubscriptionImpl>(
-        xds_context_, callbacks_, resource_decoder_, stats_,
+        xds_context_, callbacks_, std::move(resource_decoder), stats_,
         Config::TypeUrl::get().ClusterLoadAssignment, dispatcher_, init_fetch_timeout, false,
         SubscriptionOptions());
     EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
@@ -227,8 +230,6 @@ public:
   Event::MockTimer* init_timeout_timer_;
   envoy::config::core::v3::Node node_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
   std::queue<std::string> nonce_acks_required_;
   std::queue<std::string> nonce_acks_sent_;
   bool subscription_started_{};

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -34,8 +34,10 @@ public:
   FilesystemSubscriptionTestHarness()
       : path_(makePathConfigSource(TestEnvironment::temporaryPath("eds.json"))),
         api_(Api::createApiForTest(stats_store_, simTime())), dispatcher_(setupDispatcher()),
-        subscription_(*dispatcher_, path_, callbacks_, resource_decoder_, stats_,
-                      validation_visitor_, *api_) {}
+        subscription_(*dispatcher_, path_, callbacks_,
+                      std::make_unique<TestUtility::TestOpaqueResourceDecoderImpl<
+                          envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name"),
+                      stats_, validation_visitor_, *api_) {}
 
   ~FilesystemSubscriptionTestHarness() override { TestEnvironment::removePath(path_.path()); }
 
@@ -133,8 +135,6 @@ public:
   Event::DispatcherPtr dispatcher_;
   Filesystem::Watcher::OnChangedCb on_changed_cb_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
   FilesystemSubscriptionImpl subscription_;
   bool file_at_start_{false};
 };

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -63,9 +63,13 @@ public:
           *method_descriptor_, random_, stats_store_, rate_limit_settings_, true,
           std::move(config_validators_));
     }
+    OpaqueResourceDecoderPtr resource_decoder{
+        std::make_unique<TestUtility::TestOpaqueResourceDecoderImpl<
+            envoy::config::endpoint::v3::ClusterLoadAssignment>>("cluster_name")};
     subscription_ = std::make_unique<GrpcSubscriptionImpl>(
-        mux_, callbacks_, resource_decoder_, stats_, Config::TypeUrl::get().ClusterLoadAssignment,
-        dispatcher_, init_fetch_timeout, false, SubscriptionOptions());
+        mux_, callbacks_, std::move(resource_decoder), stats_,
+        Config::TypeUrl::get().ClusterLoadAssignment, dispatcher_, init_fetch_timeout, false,
+        SubscriptionOptions());
   }
 
   ~GrpcSubscriptionTestHarness() override {
@@ -221,8 +225,6 @@ public:
   Event::MockTimer* ttl_timer_;
   envoy::config::core::v3::Node node_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{"cluster_name"};
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   CustomConfigValidatorsPtr config_validators_;
   NiceMock<Grpc::MockAsyncStream> async_stream_;

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -50,7 +50,7 @@ public:
   subscriptionFromConfigSource(const envoy::config::core::v3::ConfigSource& config) {
     return subscription_factory_.subscriptionFromConfigSource(
         config, Config::TypeUrl::get().ClusterLoadAssignment, stats_store_, callbacks_,
-        resource_decoder_, {});
+        std::make_unique<MockOpaqueResourceDecoder>(), {});
   }
 
   SubscriptionPtr
@@ -59,14 +59,13 @@ public:
     const auto resource_locator = XdsResourceIdentifier::decodeUrl(xds_url);
     return subscription_factory_.collectionSubscriptionFromUrl(
         resource_locator, config, "envoy.config.endpoint.v3.ClusterLoadAssignment", stats_store_,
-        callbacks_, resource_decoder_);
+        callbacks_, std::make_unique<MockOpaqueResourceDecoder>());
   }
 
   Upstream::MockClusterManager cm_;
   Event::MockDispatcher dispatcher_;
   NiceMock<Random::MockRandomGenerator> random_;
   MockSubscriptionCallbacks callbacks_;
-  MockOpaqueResourceDecoder resource_decoder_;
   Http::MockAsyncClientRequest http_request_;
   Stats::MockIsolatedStatsStore stats_store_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
@@ -433,7 +432,7 @@ TEST_F(SubscriptionFactoryTest, LogWarningOnDeprecatedV2Transport) {
 
   EXPECT_THROW_WITH_REGEX(subscription_factory_.subscriptionFromConfigSource(
                               config, Config::TypeUrl::get().ClusterLoadAssignment, stats_store_,
-                              callbacks_, resource_decoder_, {}),
+                              callbacks_, std::make_unique<MockOpaqueResourceDecoder>(), {}),
                           EnvoyException,
                           "V2 .and AUTO. xDS transport protocol versions are deprecated in");
 }
@@ -455,7 +454,7 @@ TEST_F(SubscriptionFactoryTest, LogWarningOnDeprecatedAutoTransport) {
 
   EXPECT_THROW_WITH_REGEX(subscription_factory_.subscriptionFromConfigSource(
                               config, Config::TypeUrl::get().ClusterLoadAssignment, stats_store_,
-                              callbacks_, resource_decoder_, {}),
+                              callbacks_, std::make_unique<MockOpaqueResourceDecoder>(), {}),
                           EnvoyException,
                           "V2 .and AUTO. xDS transport protocol versions are deprecated in");
 }

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -350,7 +350,7 @@ protected:
         .WillRepeatedly(
             Invoke([this](const envoy::config::core::v3::ConfigSource&, absl::string_view,
                           Stats::Scope&, Envoy::Config::SubscriptionCallbacks& callbacks,
-                          Envoy::Config::OpaqueResourceDecoder&,
+                          Envoy::Config::OpaqueResourceDecoderPtr,
                           const Envoy::Config::SubscriptionOptions&) {
               auto ret = std::make_unique<NiceMock<Envoy::Config::MockSubscription>>();
               rds_subscription_by_config_subscription_[ret.get()] = &callbacks;

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -875,7 +875,7 @@ public:
     ON_CALL(cm_.subscription_factory_, subscriptionFromConfigSource(_, _, _, _, _, _))
         .WillByDefault(testing::Invoke(
             [this](const envoy::config::core::v3::ConfigSource&, absl::string_view, Stats::Scope&,
-                   Config::SubscriptionCallbacks& callbacks, Config::OpaqueResourceDecoder&,
+                   Config::SubscriptionCallbacks& callbacks, Config::OpaqueResourceDecoderPtr,
                    const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
               auto ret = std::make_unique<testing::NiceMock<Config::MockSubscription>>();
               rtds_subscriptions_.push_back(ret.get());

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -100,8 +100,9 @@ TEST_F(SdsApiTest, InitManagerInitialised) {
   const std::string sds_config_path = TestEnvironment::writeStringToFileForTest(
       "sds.yaml", TestEnvironment::substitute(sds_config), false);
   NiceMock<Config::MockSubscriptionCallbacks> callbacks;
-  TestUtility::TestOpaqueResourceDecoderImpl<envoy::extensions::transport_sockets::tls::v3::Secret>
-      resource_decoder("name");
+  Config::OpaqueResourceDecoderPtr resource_decoder{
+      std::make_unique<TestUtility::TestOpaqueResourceDecoderImpl<
+          envoy::extensions::transport_sockets::tls::v3::Secret>>("name")};
   Config::SubscriptionStats stats(Config::Utility::generateStats(stats_));
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
   envoy::config::core::v3::ConfigSource config_source;
@@ -110,11 +111,11 @@ TEST_F(SdsApiTest, InitManagerInitialised) {
       .WillOnce(Invoke([this, &sds_config_path, &resource_decoder,
                         &stats](const envoy::config::core::v3::ConfigSource&, absl::string_view,
                                 Stats::Scope&, Config::SubscriptionCallbacks& cbs,
-                                Config::OpaqueResourceDecoder&,
+                                Config::OpaqueResourceDecoderPtr,
                                 const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
         return std::make_unique<Config::FilesystemSubscriptionImpl>(
-            *dispatcher_, Config::makePathConfigSource(sds_config_path), cbs, resource_decoder,
-            stats, validation_visitor_, *api_);
+            *dispatcher_, Config::makePathConfigSource(sds_config_path), cbs,
+            std::move(resource_decoder), stats, validation_visitor_, *api_);
       }));
 
   auto init_manager = Init::ManagerImpl("testing");

--- a/test/common/upstream/eds_speed_test.cc
+++ b/test/common/upstream/eds_speed_test.cc
@@ -93,9 +93,12 @@ public:
                                                 factory_context, std::move(scope), false);
     EXPECT_EQ(initialize_phase, cluster_->initializePhase());
     eds_callbacks_ = cm_.subscription_factory_.callbacks_;
+    Config::OpaqueResourceDecoderPtr resource_decoder{std::make_unique<
+        Config::OpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>>(
+        validation_visitor_, "cluster_name")};
     subscription_ = std::make_unique<Config::GrpcSubscriptionImpl>(
-        grpc_mux_, *eds_callbacks_, resource_decoder_, subscription_stats_, type_url_, dispatcher_,
-        std::chrono::milliseconds(), false, Config::SubscriptionOptions());
+        grpc_mux_, *eds_callbacks_, std::move(resource_decoder), subscription_stats_, type_url_,
+        dispatcher_, std::chrono::milliseconds(), false, Config::SubscriptionOptions());
   }
 
   // Set up an EDS config with multiple priorities, localities, weights and make sure
@@ -166,8 +169,6 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   EdsClusterImplSharedPtr cluster_;
   Config::SubscriptionCallbacks* eds_callbacks_{};
-  Config::OpaqueResourceDecoderImpl<envoy::config::endpoint::v3::ClusterLoadAssignment>
-      resource_decoder_{validation_visitor_, "cluster_name"};
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;

--- a/test/common/upstream/leds_test.cc
+++ b/test/common/upstream/leds_test.cc
@@ -105,7 +105,7 @@ public:
             [this, &leds_config](const xds::core::v3::ResourceLocator& locator_url,
                                  const envoy::config::core::v3::ConfigSource&, absl::string_view,
                                  Stats::Scope&, Envoy::Config::SubscriptionCallbacks& callbacks,
-                                 Envoy::Config::OpaqueResourceDecoder&) {
+                                 Envoy::Config::OpaqueResourceDecoderPtr) {
               // Verify that the locator is correct.
               Config::XdsResourceIdentifier::EncodeOptions encode_options;
               encode_options.sort_context_params_ = true;

--- a/test/mocks/config/mocks.cc
+++ b/test/mocks/config/mocks.cc
@@ -15,7 +15,7 @@ MockSubscriptionFactory::MockSubscriptionFactory() {
   ON_CALL(*this, subscriptionFromConfigSource(_, _, _, _, _, _))
       .WillByDefault(
           Invoke([this](const envoy::config::core::v3::ConfigSource&, absl::string_view,
-                        Stats::Scope&, SubscriptionCallbacks& callbacks, OpaqueResourceDecoder&,
+                        Stats::Scope&, SubscriptionCallbacks& callbacks, OpaqueResourceDecoderPtr,
                         const SubscriptionOptions&) -> SubscriptionPtr {
             auto ret = std::make_unique<NiceMock<MockSubscription>>();
             subscription_ = ret.get();

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -82,12 +82,12 @@ public:
   MOCK_METHOD(SubscriptionPtr, subscriptionFromConfigSource,
               (const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
                Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-               OpaqueResourceDecoder& resource_decoder, const SubscriptionOptions& options));
+               OpaqueResourceDecoderPtr resource_decoder, const SubscriptionOptions& options));
   MOCK_METHOD(SubscriptionPtr, collectionSubscriptionFromUrl,
               (const xds::core::v3::ResourceLocator& collection_locator,
                const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
                Stats::Scope& scope, SubscriptionCallbacks& callbacks,
-               OpaqueResourceDecoder& resource_decoder));
+               OpaqueResourceDecoderPtr resource_decoder));
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
 
   MockSubscription* subscription_{};
@@ -120,7 +120,7 @@ public:
 
   MOCK_METHOD(GrpcMuxWatchPtr, addWatch,
               (const std::string& type_url, const absl::flat_hash_set<std::string>& resources,
-               SubscriptionCallbacks& callbacks, OpaqueResourceDecoder& resource_decoder,
+               SubscriptionCallbacks& callbacks, OpaqueResourceDecoderPtr resource_decoder,
                const SubscriptionOptions& options));
 
   MOCK_METHOD(void, requestOnDemandUpdate,


### PR DESCRIPTION
Commit Message: refactoring opaque resource decoder to be a unique-ptr
Additional Description:
Prior to this PR the OpaqueResourceDecoder was owned by each of the Subscriptions, and a reference to it was used by the GrpcMux's. This can cause an issue if the Mux outlives the subscription, as can happen in the newly added test ValidResourceDecoderAfterRemoval, and in the unified Mux implementation.
This PR converts the OpaqueResourceDecoder to a unique pointer, that can be used by both.
Followup by request in #22596.

Risk Level: Low/Medium - modifying many places in the config-plane codebase, but the refactor switches from a reference to a unique pointer.
Testing: Added a unit test that fails if non-unique pointer is used.
Docs Changes: N/A.
Release Notes: TBD.
Platform Specific Features: N/A
Signed-off-by: Adi Suissa-Peleg <adip@google.com>