### PR TITLE
bazel: replace bazel_tools//platforms use

### DIFF
--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -3,8 +3,8 @@ load(":contrib_build_config.bzl", "CONTRIB_EXTENSIONS")
 # linter requires indirection for @bazel_tools definitions
 def envoy_contrib_linux_x86_64_constraints():
     return [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ]
 
 ARM64_SKIP_CONTRIB_TARGETS = [


### PR DESCRIPTION
This is going away in newer bazel versions

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>