### PR TITLE
http: unifying reset APIs

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -202,7 +202,9 @@ public:
   /**
    * Reset the underlying stream.
    */
-  virtual void resetStream() PURE;
+  virtual void
+  resetStream(Http::StreamResetReason reset_reason = Http::StreamResetReason::LocalReset,
+              absl::string_view transport_failure_reason = "") PURE;
 
   /**
    * Returns the route for the current request. The assumption is that the implementation can do

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -243,7 +243,7 @@ void AsyncStreamImpl::cleanup() {
   }
 }
 
-void AsyncStreamImpl::resetStream() {
+void AsyncStreamImpl::resetStream(Http::StreamResetReason, absl::string_view) {
   stream_callbacks_.onReset();
   cleanup();
 }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -343,7 +343,8 @@ private:
   // Http::StreamDecoderFilterCallbacks
   OptRef<const Network::Connection> connection() override { return {}; }
   Event::Dispatcher& dispatcher() override { return parent_.dispatcher_; }
-  void resetStream() override;
+  void resetStream(Http::StreamResetReason reset_reason = Http::StreamResetReason::LocalReset,
+                   absl::string_view transport_failure_reason = "") override;
   Router::RouteConstSharedPtr route() override { return route_; }
   Router::RouteConstSharedPtr route(const Router::RouteCallback&) override { return nullptr; }
   void setRoute(Router::RouteConstSharedPtr) override {}

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1799,7 +1799,7 @@ void ConnectionManagerImpl::ActiveStream::onResponseDataTooLarge() {
   connection_manager_.stats_.named_.rs_too_large_.inc();
 }
 
-void ConnectionManagerImpl::ActiveStream::resetStream() {
+void ConnectionManagerImpl::ActiveStream::resetStream(Http::StreamResetReason, absl::string_view) {
   connection_manager_.stats_.named_.downstream_rq_tx_reset_.inc();
   connection_manager_.doEndStream(*this);
 }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -273,7 +273,8 @@ private:
     void disarmRequestTimeout() override;
     void resetIdleTimer() override;
     void recreateStream(StreamInfo::FilterStateSharedPtr filter_state) override;
-    void resetStream() override;
+    void resetStream(Http::StreamResetReason reset_reason = Http::StreamResetReason::LocalReset,
+                     absl::string_view transport_failure_reason = "") override;
     const Router::RouteEntry::UpgradeMap* upgradeMap() override;
     Upstream::ClusterInfoConstSharedPtr clusterInfo() override;
     Router::RouteConstSharedPtr route(const Router::RouteCallback& cb) override;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -865,7 +865,7 @@ void DownstreamFilterManager::sendLocalReply(
   if (data.reset_imminent_) {
     ENVOY_STREAM_LOG(debug, "Resetting stream due to {}. onLocalReply requested reset.", *this,
                      details);
-    filter_manager_callbacks_.resetStream();
+    filter_manager_callbacks_.resetStream(Http::StreamResetReason::LocalReset, "");
     return;
   }
 
@@ -1587,7 +1587,10 @@ void ActiveStreamEncoderFilter::responseDataDrained() {
   onEncoderFilterBelowWriteBufferLowWatermark();
 }
 
-void ActiveStreamFilterBase::resetStream() { parent_.filter_manager_callbacks_.resetStream(); }
+void ActiveStreamFilterBase::resetStream(Http::StreamResetReason reset_reason,
+                                         absl::string_view transport_failure_reason) {
+  parent_.filter_manager_callbacks_.resetStream(reset_reason, transport_failure_reason);
+}
 
 uint64_t ActiveStreamFilterBase::streamId() const { return parent_.streamId(); }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -61,7 +61,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   // Buffers provided_data.
   void commonHandleBufferData(Buffer::Instance& provided_data);
 
-  // If i,teration has stopped for all frame types, calls this function to buffer the data before
+  // If iteration has stopped for all frame types, calls this function to buffer the data before
   // the filter processes data. The function also updates streaming state.
   void commonBufferDataIfStopAll(Buffer::Instance& provided_data, bool& buffer_was_streaming);
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -61,7 +61,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   // Buffers provided_data.
   void commonHandleBufferData(Buffer::Instance& provided_data);
 
-  // If iteration has stopped for all frame types, calls this function to buffer the data before
+  // If i,teration has stopped for all frame types, calls this function to buffer the data before
   // the filter processes data. The function also updates streaming state.
   void commonBufferDataIfStopAll(Buffer::Instance& provided_data, bool& buffer_was_streaming);
 
@@ -85,7 +85,8 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   // Http::StreamFilterCallbacks
   OptRef<const Network::Connection> connection() override;
   Event::Dispatcher& dispatcher() override;
-  void resetStream() override;
+  void resetStream(Http::StreamResetReason reset_reason,
+                   absl::string_view transport_failure_reason) override;
   Router::RouteConstSharedPtr route() override;
   Router::RouteConstSharedPtr route(const Router::RouteCallback& cb) override;
   void setRoute(Router::RouteConstSharedPtr route) override;
@@ -456,7 +457,9 @@ public:
   /**
    * Called when the stream should be reset.
    */
-  virtual void resetStream() PURE;
+  virtual void
+  resetStream(Http::StreamResetReason reset_reason = Http::StreamResetReason::LocalReset,
+              absl::string_view transport_failure_reason = "") PURE;
 
   /**
    * Returns the upgrade map for the current route entry.

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 
+using testing::_;
 using testing::InSequence;
 using testing::Return;
 
@@ -218,7 +219,7 @@ TEST_F(FilterManagerTest, OnLocalReply) {
             EXPECT_THAT(local_reply_data.grpc_status_, testing::Optional(Grpc::Status::Internal));
             return Http::LocalErrorStatus::Continue;
           }));
-  EXPECT_CALL(filter_manager_callbacks_, resetStream());
+  EXPECT_CALL(filter_manager_callbacks_, resetStream(_, _));
   decoder_filter->callbacks_->sendLocalReply(Code::InternalServerError, "body", nullptr,
                                              Grpc::Status::Internal, "details");
 

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -983,7 +983,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryWithInvalidHttpBodyAsOutput
   response_data.add("\x10\x80");
   Grpc::Common::prependGrpcFrameHeader(response_data);
 
-  EXPECT_CALL(encoder_callbacks_, resetStream());
+  EXPECT_CALL(encoder_callbacks_, resetStream(_, _));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
             filter_.encodeData(response_data, false));
 }

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -8,6 +8,7 @@
 #include "test/mocks/router/mocks.h"
 #include "test/test_common/wasm_base.h"
 
+using testing::_;
 using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
@@ -2069,7 +2070,7 @@ TEST_P(WasmHttpFilterTest, CloseRequest) {
   filter().setDecoderFilterCallbacks(decoder_callbacks);
   EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
   EXPECT_CALL(stream_info, setResponseCodeDetails("wasm_close_stream"));
-  EXPECT_CALL(decoder_callbacks, resetStream());
+  EXPECT_CALL(decoder_callbacks, resetStream(_, _));
 
   // Create in-VM context.
   filter().onCreate();
@@ -2084,7 +2085,7 @@ TEST_P(WasmHttpFilterTest, CloseResponse) {
   filter().setEncoderFilterCallbacks(encoder_callbacks);
   EXPECT_CALL(encoder_callbacks, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
   EXPECT_CALL(stream_info, setResponseCodeDetails("wasm_close_stream"));
-  EXPECT_CALL(encoder_callbacks, resetStream());
+  EXPECT_CALL(encoder_callbacks, resetStream(_, _));
 
   // Create in-VM context.
   filter().onCreate();

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -92,7 +92,8 @@ public:
   MOCK_METHOD(void, disarmRequestTimeout, ());
   MOCK_METHOD(void, resetIdleTimer, ());
   MOCK_METHOD(void, recreateStream, (StreamInfo::FilterStateSharedPtr filter_state));
-  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(void, resetStream,
+              (Http::StreamResetReason reset_reason, absl::string_view transport_failure_reason));
   MOCK_METHOD(const Router::RouteEntry::UpgradeMap*, upgradeMap, ());
   MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, clusterInfo, ());
   MOCK_METHOD(Router::RouteConstSharedPtr, route, (const Router::RouteCallback& cb));
@@ -224,7 +225,8 @@ public:
   // Http::StreamFilterCallbacks
   MOCK_METHOD(OptRef<const Network::Connection>, connection, ());
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
-  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(void, resetStream,
+              (Http::StreamResetReason reset_reason, absl::string_view transport_failure_reason));
   MOCK_METHOD(void, resetIdleTimer, ());
   MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, clusterInfo, ());
   MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
@@ -320,7 +322,8 @@ public:
   // Http::StreamFilterCallbacks
   MOCK_METHOD(OptRef<const Network::Connection>, connection, ());
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
-  MOCK_METHOD(void, resetStream, ());
+  MOCK_METHOD(void, resetStream,
+              (Http::StreamResetReason reset_reason, absl::string_view transport_failure_reason));
   MOCK_METHOD(void, resetIdleTimer, ());
   MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, clusterInfo, ());
   MOCK_METHOD(void, requestRouteConfigUpdate, (std::function<void()>));


### PR DESCRIPTION
This allows the upstream filter chain to reset without losing details.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
https://github.com/envoyproxy/envoy/issues/10455