### PR TITLE
http: add max response headers size config

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -173,7 +173,7 @@ message AlternateProtocolsCacheOptions {
   repeated AlternateProtocolsCacheEntry prepopulated_entries = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message HttpProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HttpProtocolOptions";
@@ -223,6 +223,11 @@ message HttpProtocolOptions {
   // and the connection will be force-closed after the drain period. See :ref:`drain_timeout
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
   google.protobuf.Duration max_connection_duration = 3;
+
+  // The maximum response headers size allowed from the upstream server. If not set, the default max response headers
+  // size allowed is 80 KiB. Response that exceed this limit would fail with a protocol error.
+  google.protobuf.UInt32Value max_response_headers_kb = 7
+      [(validate.rules).uint32 = {lte: 8192 gt: 0}];
 
   // The maximum number of headers. If unconfigured, the default
   // maximum number of request headers allowed is 100. Requests that exceed this limit will receive

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -65,8 +65,12 @@ new_features:
 - area: http
   change: |
     added default-false ``envoy.reloadable_features.http1_use_balsa_parser`` for experimental BalsaParser.
+- area: http
   change: |
     added ``envoy.reloadable_features.allow_upstream_filters`` for experimental upstream filters.
+- area: http
+  change: |
+    added :ref:`max_response_headers_kb setting <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_response_headers_kb>` to control the max size of the response headers. The default max headers size is 80K.
 - area: dns_resolver
   change: |
     added DNS stats for c-ares DNS resolver. Detailed documentation is available :ref:`here <arch_overview_dns_resolution>`.

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -36,6 +36,8 @@ struct CodecStats;
 
 // Legacy default value of 60K is safely under both codec default limits.
 static constexpr uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
+// The default limit of 80KiB is the vanilla http_parser behaviour.
+static constexpr uint32_t DEFAULT_MAX_RESPONSE_HEADERS_KB = 80;
 // Default maximum number of headers.
 static constexpr uint32_t DEFAULT_MAX_HEADERS_COUNT = 100;
 

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -913,6 +913,11 @@ public:
   virtual uint64_t maxRequestsPerConnection() const PURE;
 
   /**
+   * @return uint32_t the maximum size of the response headers in KB. The default value is 80.
+   */
+  virtual uint32_t maxResponseHeadersSizeKb() const PURE;
+
+  /**
    * @return uint32_t the maximum number of response headers. The default value is 100. Results in a
    * reset if the number of headers exceeds this value.
    */

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -192,13 +192,14 @@ NoConnectCodecClientProd::NoConnectCodecClientProd(
     }
     codec_ = std::make_unique<Http1::ClientConnectionImpl>(
         *connection_, host->cluster().http1CodecStats(), *this, host->cluster().http1Settings(),
-        host->cluster().maxResponseHeadersCount(), proxied);
+        host->cluster().maxResponseHeadersSizeKb(), host->cluster().maxResponseHeadersCount(),
+        proxied);
     break;
   }
   case CodecType::HTTP2: {
     codec_ = std::make_unique<Http2::ClientConnectionImpl>(
         *connection_, *this, host->cluster().http2CodecStats(), random_generator,
-        host->cluster().http2Options(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
+        host->cluster().http2Options(), host->cluster().maxResponseHeadersSizeKb(),
         host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
     break;
   }
@@ -207,7 +208,7 @@ NoConnectCodecClientProd::NoConnectCodecClientProd(
     auto& quic_session = dynamic_cast<Quic::EnvoyQuicClientSession&>(*connection_);
     codec_ = std::make_unique<Quic::QuicHttpClientConnectionImpl>(
         quic_session, *this, host->cluster().http3CodecStats(), host->cluster().http3Options(),
-        Http::DEFAULT_MAX_REQUEST_HEADERS_KB, host->cluster().maxResponseHeadersCount());
+        host->cluster().maxResponseHeadersSizeKb(), host->cluster().maxResponseHeadersCount());
     // Initialize the session after max request header size is changed in above http client
     // connection creation.
     quic_session.Initialize();

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1349,9 +1349,10 @@ void ServerConnectionImpl::ActiveRequest::dumpState(std::ostream& os, int indent
 
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, CodecStats& stats,
                                            ConnectionCallbacks&, const Http1Settings& settings,
+                                           uint32_t max_response_headers_kb,
                                            const uint32_t max_response_headers_count,
                                            bool passing_through_proxy)
-    : ConnectionImpl(connection, stats, settings, MessageType::Response, MAX_RESPONSE_HEADERS_KB,
+    : ConnectionImpl(connection, stats, settings, MessageType::Response, max_response_headers_kb,
                      max_response_headers_count),
       owned_output_buffer_(connection.dispatcher().getWatermarkFactory().createBuffer(
           [&]() -> void { this->onBelowLowWatermark(); },

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -564,7 +564,7 @@ class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, CodecStats& stats,
                        ConnectionCallbacks& callbacks, const Http1Settings& settings,
-                       const uint32_t max_response_headers_count,
+                       uint32_t max_response_headers_kb, const uint32_t max_response_headers_count,
                        bool passing_through_proxy = false);
   // Http::ClientConnection
   RequestEncoder& newStream(ResponseDecoder& response_decoder) override;
@@ -655,9 +655,6 @@ private:
   // detected while parsing the first trailer field (if trailers are enabled). The variant is reset
   // to null headers on message complete for assertion purposes.
   absl::variant<ResponseHeaderMapPtr, ResponseTrailerMapPtr> headers_or_trailers_;
-
-  // The default limit of 80 KiB is the vanilla http_parser behaviour.
-  static constexpr uint32_t MAX_RESPONSE_HEADERS_KB = 80;
 
   // True if the upstream connection is pointed at an HTTP/1.1 proxy, and
   // plaintext HTTP should be sent with fully qualified URLs.

--- a/source/common/quic/codec_impl.cc
+++ b/source/common/quic/codec_impl.cc
@@ -62,13 +62,13 @@ QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
     EnvoyQuicClientSession& session, Http::ConnectionCallbacks& callbacks,
     Http::Http3::CodecStats& stats,
     const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
-    const uint32_t max_request_headers_kb, const uint32_t max_response_headers_count)
+    const uint32_t max_response_headers_kb, const uint32_t max_response_headers_count)
     : QuicHttpConnectionImplBase(session, stats), quic_client_session_(session) {
   session.setCodecStats(stats);
   session.setHttp3Options(http3_options);
   session.setHttpConnectionCallbacks(callbacks);
   session.setMaxIncomingHeadersCount(max_response_headers_count);
-  session.set_max_inbound_header_list_size(max_request_headers_kb * 1024);
+  session.set_max_inbound_header_list_size(max_response_headers_kb * 1024);
 }
 
 void QuicHttpClientConnectionImpl::goAway() {

--- a/source/common/quic/codec_impl.h
+++ b/source/common/quic/codec_impl.h
@@ -65,7 +65,7 @@ public:
   QuicHttpClientConnectionImpl(EnvoyQuicClientSession& session,
                                Http::ConnectionCallbacks& callbacks, Http::Http3::CodecStats& stats,
                                const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
-                               const uint32_t max_request_headers_kb,
+                               const uint32_t max_response_headers_kb,
                                const uint32_t max_response_headers_count);
 
   // Http::ClientConnection

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -861,6 +861,9 @@ ClusterInfoImpl::ClusterInfoImpl(
       max_requests_per_connection_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           http_protocol_options_->common_http_protocol_options_, max_requests_per_connection,
           config.max_requests_per_connection().value())),
+      max_response_headers_size_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          http_protocol_options_->common_http_protocol_options_, max_response_headers_kb,
+          Http::DEFAULT_MAX_RESPONSE_HEADERS_KB)),
       max_response_headers_count_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           http_protocol_options_->common_http_protocol_options_, max_headers_count,
           runtime_.snapshot().getInteger(Http::MaxResponseHeadersCountOverrideKey,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -712,6 +712,7 @@ public:
   }
   bool maintenanceMode() const override;
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  uint32_t maxResponseHeadersSizeKb() const override { return max_response_headers_size_kb_; }
   uint32_t maxResponseHeadersCount() const override { return max_response_headers_count_; }
   const std::string& name() const override { return name_; }
   const std::string& observabilityName() const override { return observability_name_; }
@@ -824,6 +825,7 @@ private:
       extension_protocol_options_;
   const std::shared_ptr<const HttpProtocolOptionsConfigImpl> http_protocol_options_;
   const uint64_t max_requests_per_connection_;
+  const uint32_t max_response_headers_size_kb_;
   const uint32_t max_response_headers_count_;
   const std::chrono::milliseconds connect_timeout_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -556,6 +556,7 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
   NiceMock<MockConnectionManagerConfig> conn_manager_config;
   uint32_t max_request_headers_kb = Http::DEFAULT_MAX_REQUEST_HEADERS_KB;
   uint32_t max_request_headers_count = Http::DEFAULT_MAX_HEADERS_COUNT;
+  uint32_t max_response_headers_kb = Http::DEFAULT_MAX_RESPONSE_HEADERS_KB;
   uint32_t max_response_headers_count = Http::DEFAULT_MAX_HEADERS_COUNT;
   const envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action = envoy::config::core::v3::HttpProtocolOptions::ALLOW;
@@ -593,12 +594,12 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
   if (http2) {
     client = std::make_unique<Http2::ClientConnectionImpl>(
         client_connection, client_callbacks, Http2::CodecStats::atomicGet(http2_stats, stats_store),
-        random, client_http2_options, max_request_headers_kb, max_response_headers_count,
+        random, client_http2_options, max_response_headers_kb, max_response_headers_count,
         Http2::ProdNghttp2SessionFactory::get());
   } else {
     client = std::make_unique<Http1::ClientConnectionImpl>(
         client_connection, Http1::CodecStats::atomicGet(http1_stats, stats_store), client_callbacks,
-        client_http1settings, max_response_headers_count);
+        client_http1settings, max_response_headers_kb, max_response_headers_count);
   }
 
   if (http2) {

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -534,13 +534,13 @@ TEST_P(MultiplexedUpstreamIntegrationTest, ManyResponseHeadersAccepted) {
   EXPECT_TRUE(response->complete());
 }
 
-// Tests that HTTP/2 response headers over 60 kB are rejected and result in a stream reset.
+// Tests that HTTP/2 response headers over 80KB are rejected and result in a stream reset.
 TEST_P(MultiplexedUpstreamIntegrationTest, LargeResponseHeadersRejected) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   Http::TestResponseHeaderMapImpl large_headers(default_response_headers_);
-  large_headers.addCopy("large", std::string(60 * 1024, 'a'));
+  large_headers.addCopy("large", std::string(80 * 1024, 'a'));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();
 

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -74,6 +74,8 @@ MockClusterInfo::MockClusterInfo()
   ON_CALL(*this, commonHttpProtocolOptions())
       .WillByDefault(ReturnRef(common_http_protocol_options_));
   ON_CALL(*this, extensionProtocolOptions(_)).WillByDefault(Return(extension_protocol_options_));
+  ON_CALL(*this, maxResponseHeadersSizeKb())
+      .WillByDefault(ReturnPointee(&max_response_headers_kb_));
   ON_CALL(*this, maxResponseHeadersCount())
       .WillByDefault(ReturnPointee(&max_response_headers_count_));
   ON_CALL(*this, maxRequestsPerConnection())

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -132,6 +132,7 @@ public:
   MOCK_METHOD(const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&, upstreamConfig,
               (), (const));
   MOCK_METHOD(bool, maintenanceMode, (), (const));
+  MOCK_METHOD(uint32_t, maxResponseHeadersSizeKb, (), (const));
   MOCK_METHOD(uint32_t, maxResponseHeadersCount, (), (const));
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
   MOCK_METHOD(const std::string&, name, (), (const));
@@ -182,6 +183,7 @@ public:
   envoy::config::core::v3::HttpProtocolOptions common_http_protocol_options_;
   ProtocolOptionsConfigConstSharedPtr extension_protocol_options_;
   uint64_t max_requests_per_connection_{};
+  uint32_t max_response_headers_kb_{Http::DEFAULT_MAX_RESPONSE_HEADERS_KB};
   uint32_t max_response_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStatNames stat_names_;


### PR DESCRIPTION
### Background

Currently, there seems to be no easy way to configure the max limit on the response headers and it's hard-coded to **80 KiB** for HTTP/1.1 and **60K** for HTTP/2 & HTTP/3.

### Changes

This PR adds a new field called `max_response_headers_kb` to make this limit configurable.

---
**Commit Message:** add a new config to override the max response headers size.
**Additional Description:** See Background Section.
**Risk Level:** Low
**Testing:** Unit Tests
**Docs Changes:** Added the description of the new proto field. 
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>