### PR TITLE
bazel: disable incompatible flag for now

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,8 @@ run --color=yes
 
 build --color=yes
 build --workspace_status_command="bash bazel/get_workspace_status"
+# TODO: https://github.com/envoyproxy/envoy/issues/22758
+build --incompatible_use_platforms_repo_for_constraints=false
 build --incompatible_strict_action_env
 build --host_force_python=PY3
 build --java_runtime_version=remotejdk_11


### PR DESCRIPTION
This depends on https://github.com/envoyproxy/envoy-build-tools/pull/181
which currently requires some unknown fixes for windows.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>