### PR TITLE
Added stacktrace to ENVOY_BUG

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -20,6 +20,8 @@ envoy_cc_library(
     external_deps = [
         "abseil_base",
         "abseil_synchronization",
+        "abseil_stacktrace",
+        "abseil_symbolize",
     ],
     deps = [":minimal_logger_lib"],
 )

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -42,7 +42,7 @@ public:
       if (success) {
         ENVOY_LOG(error, "#{} {} [{}]", i, out, stack_trace_[i]);
       } else {
-        ENVOY_LOG(error, "#{} [{}]", i, stack_trace_[i]);
+        ENVOY_LOG(error, "#{} {} [{}]", i, "UNKNOWN", stack_trace_[i]);
       }
     }
   }

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -4,6 +4,9 @@
 
 #include "source/common/common/logger.h"
 
+#include "absl/debugging/stacktrace.h"
+#include "absl/debugging/symbolize.h"
+
 namespace Envoy {
 namespace Assert {
 
@@ -12,6 +15,47 @@ public:
   virtual ~ActionRegistration() = default;
 };
 using ActionRegistrationPtr = std::unique_ptr<ActionRegistration>;
+
+/*
+ * EnvoyBugStackTrace captures and writes the stack trace to Envoy Bug
+ * to assist with getting additional context for reports
+ */
+class EnvoyBugStackTrace : Logger::Loggable<Logger::Id::envoy_bug> {
+public:
+  EnvoyBugStackTrace() = default;
+  /*
+   * Capture the stack trace
+   * Skip count is one as to skip the last call which is capture()
+   */
+  void capture() {
+    stack_depth_ = stack_depth_ =
+        absl::GetStackTrace(stack_trace_, MaxStackDepth, /* skip_count = */ 1);
+  }
+
+  /*
+   * Logs each row of the captured stack into the envoy_bug log
+   */
+  void logStackTrace() {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,
+                        "stacktrace for envoy bug");
+    for (int i = 0; i < stack_depth_; ++i) {
+      char out[1024];
+      const bool success = absl::Symbolize(stack_trace_[i], out, sizeof(out));
+      if (success) {
+        ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,
+                            "#{} {} [{}]", i, out, stack_trace_[i]);
+      } else {
+        ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,
+                            "#{} [{}]", i, stack_trace_[i]);
+      }
+    }
+  }
+
+private:
+  static const int MaxStackDepth = 16;
+  void* stack_trace_[MaxStackDepth];
+  int stack_depth_{0};
+};
 
 /**
  * Sets an action to be invoked when a debug assertion failure is detected
@@ -225,6 +269,9 @@ void resetEnvoyBugCountersForTest();
       ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,    \
                           "envoy bug failure: {}.{}{}", CONDITION_STR,                             \
                           details.empty() ? "" : " Details: ", details);                           \
+      Assert::EnvoyBugStackTrace st;                                                               \
+      st.capture();                                                                                \
+      st.logStackTrace();                                                                          \
       ACTION;                                                                                      \
     }                                                                                              \
   } while (false)

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -28,8 +28,7 @@ public:
    * Skip count is one as to skip the last call which is capture()
    */
   void capture() {
-    stack_depth_ =
-        absl::GetStackTrace(stack_trace_, MaxStackDepth, /* skip_count = */ 1);
+    stack_depth_ = absl::GetStackTrace(stack_trace_, MaxStackDepth, /* skip_count = */ 1);
   }
 
   /*

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -28,7 +28,7 @@ public:
    * Skip count is one as to skip the last call which is capture()
    */
   void capture() {
-    stack_depth_ = stack_depth_ =
+    stack_depth_ =
         absl::GetStackTrace(stack_trace_, MaxStackDepth, /* skip_count = */ 1);
   }
 

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -84,10 +84,11 @@ TEST(EnvoyBugDeathTest, VariousLogs) {
   EXPECT_ENVOY_BUG({ ENVOY_BUG(false, "With some logs"); },
                    "envoy bug failure: false. Details: With some logs");
   EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "stacktrace for envoy bug");
+  EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "testing::Test::Run()");
 
 #ifdef NDEBUG
-  EXPECT_EQ(4, envoy_bug_fail_count);
-  EXPECT_EQ(4, envoy_bug_fail_count2);
+  EXPECT_EQ(5, envoy_bug_fail_count);
+  EXPECT_EQ(5, envoy_bug_fail_count2);
   // Reset envoy bug count to simplify testing exponential back-off below.
   envoy_bug_fail_count = 0;
   envoy_bug_fail_count2 = 0;

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -83,10 +83,11 @@ TEST(EnvoyBugDeathTest, VariousLogs) {
   EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "envoy bug failure: false.");
   EXPECT_ENVOY_BUG({ ENVOY_BUG(false, "With some logs"); },
                    "envoy bug failure: false. Details: With some logs");
+  EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "stacktrace for envoy bug");
 
 #ifdef NDEBUG
-  EXPECT_EQ(3, envoy_bug_fail_count);
-  EXPECT_EQ(3, envoy_bug_fail_count2);
+  EXPECT_EQ(4, envoy_bug_fail_count);
+  EXPECT_EQ(4, envoy_bug_fail_count2);
   // Reset envoy bug count to simplify testing exponential back-off below.
   envoy_bug_fail_count = 0;
   envoy_bug_fail_count2 = 0;

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -69,6 +69,13 @@ TEST(AssertInReleaseTest, AssertLocation) {
 #endif
 }
 
+TEST(EnvoyBugStackTrace, TestStackTrace) {
+  Assert::EnvoyBugStackTrace st;
+  st.capture();
+  EXPECT_LOG_CONTAINS("error", "stacktrace for envoy bug", st.logStackTrace());
+  EXPECT_LOG_CONTAINS("error", "#0 ", st.logStackTrace());
+}
+
 TEST(EnvoyBugDeathTest, VariousLogs) {
   // Use 2 envoy bug action registrations to verify that action chaining is working correctly.
   int envoy_bug_fail_count = 0;
@@ -84,7 +91,7 @@ TEST(EnvoyBugDeathTest, VariousLogs) {
   EXPECT_ENVOY_BUG({ ENVOY_BUG(false, "With some logs"); },
                    "envoy bug failure: false. Details: With some logs");
   EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "stacktrace for envoy bug");
-  EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "testing::Test::Run()");
+  EXPECT_ENVOY_BUG({ ENVOY_BUG(false, ""); }, "#0 ");
 
 #ifdef NDEBUG
   EXPECT_EQ(5, envoy_bug_fail_count);


### PR DESCRIPTION
Signed-off-by: Alan Diaz <diazalan@google.com>

Commit Message: Added stacktrace to ENVOY_BUG
Additional Description: ENVOY_BUG will now capture a stack trace to log what was called before ENVOY_BUG. This will help provide additional context for errors
Risk Level: Low
Testing: Expanded one of the unit tests to see if the stacktrace was logged and ran all other unit tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA] N/A
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
