### PR TITLE
[ext_proc]: verify that header entry removal is applied before header entry append

### DIFF
--- a/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
+++ b/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
@@ -69,6 +69,10 @@ TEST(MutationUtils, TestApplyMutations) {
   s->mutable_header()->set_key("x-append-this");
   s->mutable_header()->set_value("3");
   s = mutation.add_set_headers();
+  s->mutable_append()->set_value(true);
+  s->mutable_header()->set_key("x-remove-and-append-this");
+  s->mutable_header()->set_value("4");
+  s = mutation.add_set_headers();
   s->mutable_append()->set_value(false);
   s->mutable_header()->set_key("x-replace-this");
   s->mutable_header()->set_value("no");
@@ -84,6 +88,8 @@ TEST(MutationUtils, TestApplyMutations) {
   mutation.add_set_headers();
 
   mutation.add_remove_headers("x-remove-this");
+  // remove is applied before append, so the header entry will be in the final headers.
+  mutation.add_remove_headers("x-remove-and-append-this");
   // Attempts to remove ":" and "host" headers should be ignored
   mutation.add_remove_headers("host");
   mutation.add_remove_headers(":method");
@@ -138,6 +144,7 @@ TEST(MutationUtils, TestApplyMutations) {
       {"x-append-this", "1"},
       {"x-append-this", "2"},
       {"x-append-this", "3"},
+      {"x-remove-and-append-this", "4"},
       {"x-replace-this", "nope"},
       {"x-envoy-strange-thing", "No"},
   };


### PR DESCRIPTION
Signed-off-by: chaoqin-li1123 <chaoqinli@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add a test case to verify filter behavior
Additional Description:
Risk Level: low, only testing
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
