### PR TITLE
http.lua: allow setting HTTP1 reason phrase

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -130,6 +130,9 @@ new_features:
     Added :ref:`response_buffer_size <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.response_buffer_size>` to configure the maximum HTTP health check response buffer size.
 - area: lua
   change: |
+    added new headers method "setHttp1ReasonPhrase" for lua filter, please see :ref:`lua header wrapper <config_http_filters_lua_header_wrapper>`.
+- area: lua
+  change: |
     added stats for lua filter, please see :ref:`lua filter stats <config_http_filters_lua_stats>`.
 - area: subset load balancer
   change: |

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -629,8 +629,9 @@ setHttp1ReasonPhrase()
 
   headers:setHttp1ReasonPhrase(reasonPhrase)
 
-Sets a custom HTTP1 response reason phrase. This call is *only valid in the response flow*.
-*reasonPhrase* is a string that supplies the reason phrase value.
+Sets a custom HTTP/1 response reason phrase. This call is *only valid in the response flow*.
+*reasonPhrase* is a string that supplies the reason phrase value. Additionally this call only
+effects HTTP/1 connections. It will have no effect if the client is HTTP/2 or HTTP/3.
 
 .. _config_http_filters_lua_buffer_wrapper:
 

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -622,6 +622,16 @@ replace()
 Replaces a header. *key* is a string that supplies the header key. *value* is a string that supplies
 the header value. If the header does not exist, it is added as per the *add()* function.
 
+setHttp1ReasonPhrase()
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  headers:setHttp1ReasonPhrase(reasonPhrase)
+
+Sets a custom HTTP1 response reason phrase. This call is *only valid in the response flow*.
+*reasonPhrase* is a string that supplies the reason phrase value.
+
 .. _config_http_filters_lua_buffer_wrapper:
 
 Buffer API

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -45,6 +45,7 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/extensions/filters/common/lua:lua_lib",
         "//source/extensions/filters/common/lua:wrappers_lib",
+        "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
     ],
 )
 

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -1,8 +1,10 @@
 #include "source/extensions/filters/http/lua/wrappers.h"
 
+#include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
 #include "source/extensions/filters/common/lua/wrappers.h"
+#include "source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -11,10 +13,11 @@ namespace Lua {
 
 HeaderMapIterator::HeaderMapIterator(HeaderMapWrapper& parent) : parent_(parent) {
   entries_.reserve(parent_.headers_.size());
-  parent_.headers_.iterate([this](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
-    entries_.push_back(&header);
-    return Http::HeaderMap::Iterate::Continue;
-  });
+  parent_.headers_.iterate(
+      [this](const ::Envoy::Http::HeaderEntry& header) -> ::Envoy::Http::HeaderMap::Iterate {
+        entries_.push_back(&header);
+        return ::Envoy::Http::HeaderMap::Iterate::Continue;
+      });
 }
 
 int HeaderMapIterator::luaPairsIterator(lua_State* state) {
@@ -36,14 +39,15 @@ int HeaderMapWrapper::luaAdd(lua_State* state) {
 
   const char* key = luaL_checkstring(state, 2);
   const char* value = luaL_checkstring(state, 3);
-  headers_.addCopy(Http::LowerCaseString(key), value);
+  headers_.addCopy(::Envoy::Http::LowerCaseString(key), value);
   return 0;
 }
 
 int HeaderMapWrapper::luaGet(lua_State* state) {
   absl::string_view key = Filters::Common::Lua::getStringViewFromLuaString(state, 2);
-  const Http::HeaderUtility::GetAllOfHeaderAsStringResult value =
-      Http::HeaderUtility::getAllOfHeaderAsString(headers_, Http::LowerCaseString(key));
+  const ::Envoy::Http::HeaderUtility::GetAllOfHeaderAsStringResult value =
+      ::Envoy::Http::HeaderUtility::getAllOfHeaderAsString(headers_,
+                                                           ::Envoy::Http::LowerCaseString(key));
   if (value.result().has_value()) {
     lua_pushlstring(state, value.result().value().data(), value.result().value().size());
     return 1;
@@ -55,7 +59,8 @@ int HeaderMapWrapper::luaGet(lua_State* state) {
 int HeaderMapWrapper::luaGetAtIndex(lua_State* state) {
   absl::string_view key = Filters::Common::Lua::getStringViewFromLuaString(state, 2);
   const int index = luaL_checknumber(state, 3);
-  const Http::HeaderMap::GetResult header_value = headers_.get(Http::LowerCaseString(key));
+  const ::Envoy::Http::HeaderMap::GetResult header_value =
+      headers_.get(::Envoy::Http::LowerCaseString(key));
   if (index >= 0 && header_value.size() > static_cast<uint64_t>(index)) {
     absl::string_view value = header_value[index]->value().getStringView();
     lua_pushlstring(state, value.data(), value.size());
@@ -66,7 +71,8 @@ int HeaderMapWrapper::luaGetAtIndex(lua_State* state) {
 
 int HeaderMapWrapper::luaGetNumValues(lua_State* state) {
   absl::string_view key = Filters::Common::Lua::getStringViewFromLuaString(state, 2);
-  const Http::HeaderMap::GetResult header_value = headers_.get(Http::LowerCaseString(key));
+  const ::Envoy::Http::HeaderMap::GetResult header_value =
+      headers_.get(::Envoy::Http::LowerCaseString(key));
   lua_pushnumber(state, header_value.size());
   return 1;
 }
@@ -93,7 +99,7 @@ int HeaderMapWrapper::luaReplace(lua_State* state) {
 
   const char* key = luaL_checkstring(state, 2);
   const char* value = luaL_checkstring(state, 3);
-  const Http::LowerCaseString lower_key(key);
+  const ::Envoy::Http::LowerCaseString lower_key(key);
 
   headers_.setCopy(lower_key, value);
 
@@ -104,7 +110,7 @@ int HeaderMapWrapper::luaRemove(lua_State* state) {
   checkModifiable(state);
 
   const char* key = luaL_checkstring(state, 2);
-  headers_.remove(Http::LowerCaseString(key));
+  headers_.remove(::Envoy::Http::LowerCaseString(key));
   return 0;
 }
 
@@ -118,8 +124,38 @@ void HeaderMapWrapper::checkModifiable(lua_State* state) {
   }
 }
 
+int HeaderMapWrapper::luaSetHttp1ReasonPhrase(lua_State* state) {
+  checkModifiable(state);
+
+  const char* phrase = luaL_checkstring(state, 2);
+
+  ::Envoy::Http::StatefulHeaderKeyFormatterOptRef formatter(headers_.formatter());
+
+  if (!formatter.has_value()) {
+    using envoy::extensions::http::header_formatters::preserve_case::v3::
+        PreserveCaseFormatterConfig;
+    using ::Envoy::Http::ResponseHeaderMapImpl;
+    using ::Envoy::Http::StatefulHeaderKeyFormatter;
+    using Http::HeaderFormatters::PreserveCase::PreserveCaseHeaderFormatter;
+
+    try {
+      ResponseHeaderMapImpl& map = dynamic_cast<ResponseHeaderMapImpl&>(headers_);
+      std::unique_ptr<StatefulHeaderKeyFormatter> fmt =
+          std::make_unique<PreserveCaseHeaderFormatter>(true, PreserveCaseFormatterConfig::DEFAULT);
+      fmt->setReasonPhrase(absl::string_view(std::string(phrase)));
+      map.setFormatter(std::move(fmt));
+    } catch (const std::bad_cast&) {
+    }
+  } else {
+    formatter->setReasonPhrase(absl::string_view(std::string(phrase)));
+  }
+
+  return 0;
+}
+
 int StreamInfoWrapper::luaProtocol(lua_State* state) {
-  const std::string& protocol = Http::Utility::getProtocolString(stream_info_.protocol().value());
+  const std::string& protocol =
+      ::Envoy::Http::Utility::getProtocolString(stream_info_.protocol().value());
   lua_pushlstring(state, protocol.data(), protocol.size());
   return 1;
 }

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -139,6 +139,7 @@ int HeaderMapWrapper::luaSetHttp1ReasonPhrase(lua_State* state) {
     using Envoy::Http::StatefulHeaderKeyFormatter;
     using Http::HeaderFormatters::PreserveCase::PreserveCaseHeaderFormatter;
 
+    // Casting here to make sure the call is in the right (response) context
     ResponseHeaderMapImpl* map = dynamic_cast<ResponseHeaderMapImpl*>(&headers_);
     if (map) {
       std::unique_ptr<StatefulHeaderKeyFormatter> fmt =

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -143,11 +143,11 @@ int HeaderMapWrapper::luaSetHttp1ReasonPhrase(lua_State* state) {
     if (map) {
       std::unique_ptr<StatefulHeaderKeyFormatter> fmt =
           std::make_unique<PreserveCaseHeaderFormatter>(true, PreserveCaseFormatterConfig::DEFAULT);
-      fmt->setReasonPhrase(absl::string_view(std::string(phrase)));
+      fmt->setReasonPhrase(absl::string_view(phrase, input_size));
       map->setFormatter(std::move(fmt));
     }
   } else {
-    formatter->setReasonPhrase(absl::string_view(std::string(phrase, input_size)));
+    formatter->setReasonPhrase(absl::string_view(phrase, input_size));
   }
 
   return 0;

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -50,6 +50,7 @@ public:
             {"getNumValues", static_luaGetNumValues},
             {"remove", static_luaRemove},
             {"replace", static_luaReplace},
+            {"setHttp1ReasonPhrase", static_luaSetHttp1ReasonPhrase},
             {"__pairs", static_luaPairs}};
   }
 
@@ -104,6 +105,13 @@ private:
    * @return nothing.
    */
   DECLARE_LUA_FUNCTION(HeaderMapWrapper, luaReplace);
+
+  /**
+   * Set a HTTP1 reason phrase
+   * @param 1 (string): reason phrase
+   * @return nothing.
+   */
+  DECLARE_LUA_FUNCTION(HeaderMapWrapper, luaSetHttp1ReasonPhrase);
 
   void checkModifiable(lua_State* state);
 


### PR DESCRIPTION
:wave: 

Note:
This is a PoC PR to ensure the validity of the approach and the feasibility of the eventual upstream merge.
All the missing parts (docs, tests) will be added later if maintainers find the approach acceptable. 

This PR is somewhat complementary to https://github.com/envoyproxy/envoy/pull/18997/files and uses some machinery established in it.
Essentially, we'd need to be able to customize HTTP1 reason phrase based on the responses from `ext_authz` filter. 
Currently it's possible to override the code but the reason phrase (being HTTP1-specific) is set to the default value.

The approach in this PR adds a lua function to override reason phrase. It is done by injecting a stateful header formatter into the response headers map if it hasn't been set yet and setting the reason phrase, which will be used by the encoder.