### PR TITLE
Execute hot-restarter using python3

### DIFF
--- a/restarter/hot-restarter.py
+++ b/restarter/hot-restarter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import os


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing: None (research how envoy is currently running on modern systems reveals people are using hacks like the package [python-is-python3](https://askubuntu.com/questions/1296790/python-is-python3-package-in-ubuntu-20-04-what-is-it-and-what-does-it-actually))
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

As brought up in https://github.com/envoyproxy/envoy/issues/4552#issuecomment-1224654557 I've submitted a PR. Pinging @phlax as suggested.

Note that this MR *will* break envoy on Platforms that are still using Python2 and don't offer Python3 at all. 

I've done a quick test on what I consider the most up-2-date linux (archlinux) to see what the result was when calling `/usr/bin/env python` and `/usr/bin/env python3`. There, they point to the same file. This PR is primarily to correct the behaviour for Debian-based platforms. If you consider this PR to be wrong, you likely want to change your Debian package to require `python-is-python3` for Bullseye (and up?).