### PR TITLE
grpc_json_transcoder: add newline-delimited streaming option

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -45,6 +45,7 @@ message GrpcJsonTranscoder {
     ALL_CHARACTERS = 2;
   }
 
+  // [#next-free-field: 6]
   message PrintOptions {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder.PrintOptions";
@@ -68,6 +69,9 @@ message GrpcJsonTranscoder {
     // generate JSON field names using the ``json_name`` option, or lower camel case,
     // in that order. Setting this flag will preserve the original field names. Defaults to false.
     bool preserve_proto_field_names = 4;
+
+    // If true, return all streams as newline-delimited JSON messages instead of as a comma-separated array
+    bool stream_newline_delimited = 5;
   }
 
   message RequestValidationOptions {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -253,6 +253,9 @@ new_features:
 - area: grpc_json_transcoder
   change: |
     added support for parsing enum value case insensitively enabled by the config :ref:`case_insensitive_enum_parsing <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.case_insensitive_enum_parsing>`.
+- area: grpc_json_transcoder
+  change: |
+    added support for newline-delimited streams in :ref:`stream_newline_delimited <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.PrintOptions.stream_newline_delimited>`.
 
 deprecated:
 - area: http

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -217,10 +217,14 @@ JsonTranscoderConfig::JsonTranscoderConfig(
   path_matcher_ = pmb.Build();
 
   const auto& print_config = proto_config.print_options();
-  print_options_.add_whitespace = print_config.add_whitespace();
-  print_options_.always_print_primitive_fields = print_config.always_print_primitive_fields();
-  print_options_.always_print_enums_as_ints = print_config.always_print_enums_as_ints();
-  print_options_.preserve_proto_field_names = print_config.preserve_proto_field_names();
+  response_translate_options_.json_print_options.add_whitespace = print_config.add_whitespace();
+  response_translate_options_.json_print_options.always_print_primitive_fields =
+      print_config.always_print_primitive_fields();
+  response_translate_options_.json_print_options.always_print_enums_as_ints =
+      print_config.always_print_enums_as_ints();
+  response_translate_options_.json_print_options.preserve_proto_field_names =
+      print_config.preserve_proto_field_names();
+  response_translate_options_.stream_newline_delimited = print_config.stream_newline_delimited();
 
   match_incoming_request_route_ = proto_config.match_incoming_request_route();
   ignore_unknown_query_parameters_ = proto_config.ignore_unknown_query_parameters();
@@ -386,7 +390,7 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
       Grpc::Common::typeUrl(method_info->descriptor_->output_type()->full_name());
   ResponseToJsonTranslatorPtr response_translator{new ResponseToJsonTranslator(
       type_helper_->Resolver(), response_type_url, method_info->descriptor_->server_streaming(),
-      &response_input, {print_options_, false})};
+      &response_input, response_translate_options_)};
 
   transcoder = std::make_unique<TranscoderImpl>(std::move(request_translator),
                                                 std::move(json_request_translator),
@@ -414,7 +418,7 @@ JsonTranscoderConfig::translateProtoMessageToJson(const Protobuf::Message& messa
                                                   std::string* json_out) const {
   return ProtobufUtil::BinaryToJsonString(
       type_helper_->Resolver(), Grpc::Common::typeUrl(message.GetDescriptor()->full_name()),
-      message.SerializeAsString(), json_out, print_options_);
+      message.SerializeAsString(), json_out, response_translate_options_.json_print_options);
 }
 
 JsonTranscoderFilter::JsonTranscoderFilter(const JsonTranscoderConfig& config) : config_(config) {}

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -15,6 +15,7 @@
 #include "google/api/http.pb.h"
 #include "grpc_transcoding/path_matcher.h"
 #include "grpc_transcoding/request_message_translator.h"
+#include "grpc_transcoding/response_to_json_translator.h"
 #include "grpc_transcoding/transcoder.h"
 #include "grpc_transcoding/type_helper.h"
 
@@ -128,7 +129,7 @@ private:
   Protobuf::DescriptorPool descriptor_pool_;
   google::grpc::transcoding::PathMatcherPtr<MethodInfoSharedPtr> path_matcher_;
   std::unique_ptr<google::grpc::transcoding::TypeHelper> type_helper_;
-  Protobuf::util::JsonPrintOptions print_options_;
+  google::grpc::transcoding::JsonResponseTranslateOptions response_translate_options_;
 
   bool match_incoming_request_route_{false};
   bool ignore_unknown_query_parameters_{false};

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -176,11 +176,27 @@ protected:
     if (!expected_response_body.empty()) {
       const bool isJsonResponse = response->headers().getContentTypeValue() == "application/json";
       if (full_response && isJsonResponse) {
-        const bool isStreamingResponse = response->body()[0] == '[';
-        EXPECT_TRUE(TestUtility::jsonStringEqual(response->body(), expected_response_body,
-                                                 isStreamingResponse))
-            << "Response mismatch. \nGot : " << response->body()
-            << "\nWant: " << expected_response_body;
+        const bool isArray = response->body()[0] == '[';
+
+        // test each line of the response for equality
+        std::stringstream response_body_stream(response->body());
+        std::stringstream expected_response_stream(expected_response_body);
+        std::string response_body_chunk;
+        std::string expected_response_chunk;
+        char delimiter = '\n';
+
+        while (std::getline(response_body_stream, response_body_chunk, delimiter)) {
+          std::getline(expected_response_stream, expected_response_chunk, delimiter);
+
+          EXPECT_TRUE(
+              TestUtility::jsonStringEqual(response_body_chunk, expected_response_chunk, isArray))
+              << "Response mismatch. \nGot : " << response_body_chunk
+              << "\nWant: " << expected_response_chunk;
+        }
+
+        // verify that both streams have been fully tested
+        EXPECT_EQ(response_body_stream.rdbuf()->in_avail(), 0);
+        EXPECT_EQ(expected_response_stream.rdbuf()->in_avail(), 0);
       } else if (full_response) {
         EXPECT_EQ(response->body(), expected_response_body);
       } else {
@@ -459,6 +475,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, TestEnumValueCaseMatch) {
 // After enable the "case_insensitive_enum_parsing" flag,
 // JSON enum value string can be in any case.
 TEST_P(GrpcJsonTranscoderIntegrationTest, TestEnumValueIgnoreCase) {
+
   // Enable case_insensitive_enum_parsing flag
   const std::string filter =
       R"EOF(
@@ -496,6 +513,38 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, TestEnumValueIgnoreCase) {
                                       {"content-length", "31"},
                                       {"grpc-status", "0"}},
       R"({"id":"1234","gender":"FEMALE"})");
+}
+
+// Test newline-delimited stream translation.
+// By default, streams are aggregated into a JSON Array.
+// Newline-delimited streams return each message with a newline termination instead.
+TEST_P(GrpcJsonTranscoderIntegrationTest, ServerStreamingNewlineDelimitedGet) {
+  // Enable stream_newline_delimited flag
+  const std::string filter =
+      R"EOF(
+            name: grpc_json_transcoder
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
+              proto_descriptor : "{}"
+              services : "bookstore.Bookstore"
+              print_options :
+                stream_newline_delimited : true
+            )EOF";
+  config_helper_.prependFilter(
+      fmt::format(filter, TestEnvironment::runfilesPath("test/proto/bookstore.descriptor")));
+  HttpIntegrationTest::initialize();
+
+  testTranscoding<bookstore::ListBooksRequest, bookstore::Book>(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/shelves/1/books"}, {":authority", "host"}},
+      "", {"shelf: 1"},
+      {R"(id: 1 author: "Neal Stephenson" title: "Reamde")",
+       R"(id: 2 author: "George R.R. Martin" title: "A Game of Thrones")"},
+      Status(),
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-type", "application/json"}},
+      R"({"id":"1","author":"Neal Stephenson","title":"Reamde"})"
+      "\n"
+      R"({"id":"2","author":"George R.R. Martin","title":"A Game of Thrones"})");
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryGet) {


### PR DESCRIPTION
Commit Message: updated `grpc-httpjson-transcoding` to include the newlin-delimited streaming option.
Additional Description: this PR pulls in the work in [this upstream PR](https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/pull/73) that is required to enable newline-delimited streaming for transcoded gRPC streams.
Risk Level: Low
Testing: Integration Tests
Docs Changes: documentation is inline in `transcoder.proto`
Release Notes: Add newline-delimited streaming option for gRPC JSON transcoder.
Platform Specific Features: N/A
