### PR TITLE
lua: support setting http call options by table

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -122,6 +122,11 @@ new_features:
 - area: listener
   change: |
     allow network filters other than HTTP Connection Manager to be created for QUIC listeners.
+- area: lua
+  change: |
+    added an alternative function signature to `httpCall()` with `options` as an argument. This allows to skip sampling the produced trace span
+    by setting `{["sampled"] = false}` as the `options`. And this allows to return multiple header values for same header name by setting
+    `{["multiple"] = true}` as the `options`.
 
 deprecated:
 - area: http

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -126,7 +126,7 @@ new_features:
   change: |
     added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span
     by setting ``{["trace_sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
-    ``{["allows_repeat"] = true}`` as the ``options``.
+    ``{["return_duplicate_headers"] = true}`` as the ``options``.
 
 deprecated:
 - area: http

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -124,9 +124,9 @@ new_features:
     allow network filters other than HTTP Connection Manager to be created for QUIC listeners.
 - area: lua
   change: |
-    added an alternative function signature to `httpCall()` with `options` as an argument. This allows to skip sampling the produced trace span
-    by setting `{["sampled"] = false}` as the `options`. And this allows to return multiple header values for same header name by setting
-    `{["multiple"] = true}` as the `options`.
+    added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span
+    by setting ``{["sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
+    ``{["multiple"] = true}`` as the ``options``.
 
 deprecated:
 - area: http

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -125,8 +125,8 @@ new_features:
 - area: lua
   change: |
     added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span
-    by setting ``{["sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
-    ``{["multiple"] = true}`` as the ``options``.
+    by setting ``{["trace_sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
+    ``{["allows_repeat"] = true}`` as the ``options``.
 
 deprecated:
 - area: http

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -12,7 +12,7 @@ if [[ "$1" == "format" || "$1" == "fix_proto_format" || "$1" == "check_proto_for
           || "$1" == "verify_distro" ]]; then
     build_setup_args="-nofetch"
 fi
-build_setup_args="-nofetch"
+
 # TODO(phlax): Clarify and/or integrate SRCDIR and ENVOY_SRCDIR
 export SRCDIR="${SRCDIR:-$PWD}"
 export ENVOY_SRCDIR="${ENVOY_SRCDIR:-$PWD}"
@@ -225,10 +225,10 @@ if [[ "$CI_TARGET" == "bazel.release" ]]; then
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" -c opt "${TEST_TARGETS[@]}"
 
   echo "bazel release build..."
-  # bazel_envoy_binary_build release
+  bazel_envoy_binary_build release
 
   echo "bazel contrib release build..."
-  # bazel_contrib_binary_build release
+  bazel_contrib_binary_build release
 
   exit 0
 elif [[ "$CI_TARGET" == "bazel.distribution" ]]; then

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -12,7 +12,7 @@ if [[ "$1" == "format" || "$1" == "fix_proto_format" || "$1" == "check_proto_for
           || "$1" == "verify_distro" ]]; then
     build_setup_args="-nofetch"
 fi
-
+build_setup_args="-nofetch"
 # TODO(phlax): Clarify and/or integrate SRCDIR and ENVOY_SRCDIR
 export SRCDIR="${SRCDIR:-$PWD}"
 export ENVOY_SRCDIR="${ENVOY_SRCDIR:-$PWD}"
@@ -225,10 +225,10 @@ if [[ "$CI_TARGET" == "bazel.release" ]]; then
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" -c opt "${TEST_TARGETS[@]}"
 
   echo "bazel release build..."
-  bazel_envoy_binary_build release
+  # bazel_envoy_binary_build release
 
   echo "bazel contrib release build..."
-  bazel_contrib_binary_build release
+  # bazel_contrib_binary_build release
 
   exit 0
 elif [[ "$CI_TARGET" == "bazel.distribution" ]]; then

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -425,7 +425,7 @@ the supported keys are:
 - *timeout* is an integer that specifies the call timeout in milliseconds.
   It refers to the same *timeout* argument as the first function signature.
 - *sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
-- *multiple* is boolean flag that decides whether the returned headers could has multiple values for same header name.
+- *multiple* is boolean flag that decides whether the returned headers could have multiple values for same header name.
 
 Some examples of specifying *request_options* are shown below:
 

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -444,7 +444,7 @@ the supported keys are:
 
   Then if *allows_repeat* is set to false, the returned headers will be:
 
-  -- code-block:: lua
+  .. code-block:: lua
 
     {
       [":status"] = "200",

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -399,7 +399,7 @@ httpCall()
 
 .. code-block:: lua
 
-  local headers, body = handle:httpCall(cluster, headers, body, timeout, async)
+  local headers, body = handle:httpCall(cluster, headers, body, timeout_ms, asynchronous)
 
   -- Alternative function signature.
   local headers, body = handle:httpCall(cluster, headers, body, options)
@@ -407,9 +407,9 @@ httpCall()
 Makes an HTTP call to an upstream host. *cluster* is a string which maps to a configured cluster manager cluster. *headers*
 is a table of key/value pairs to send (the value can be a string or table of strings). Note that
 the *:method*, *:path*, and *:authority* headers must be set. *body* is an optional string of body
-data to send. *timeout* is an integer that specifies the call timeout in milliseconds.
+data to send. *timeout_ms* is an integer that specifies the call timeout in milliseconds.
 
-*async* is a boolean flag. If async is set to true, Envoy will make the HTTP request and continue,
+*asynchronous* is a boolean flag. If async is set to true, Envoy will make the HTTP request and continue,
 regardless of the response success or failure. If this is set to false, or not set, Envoy will suspend executing the script
 until the call completes or has an error.
 
@@ -420,31 +420,67 @@ body. May be nil if there is no body.
 The alternative function signature allows caller to specify *options* as a table. Currently,
 the supported keys are:
 
-- *async* is a boolean flag that controls the asynchronicity of the HTTP call.
-  It refers to the same *async* flag as the first function signature.
-- *timeout* is an integer that specifies the call timeout in milliseconds.
-  It refers to the same *timeout* argument as the first function signature.
-- *sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
-- *multiple* is boolean flag that decides whether the returned headers could have multiple values for same header name.
+- *asynchronous* is a boolean flag that controls the asynchronicity of the HTTP call.
+  It refers to the same *asynchronous* flag as the first function signature.
+- *timeout_ms* is an integer that specifies the call timeout in milliseconds.
+  It refers to the same *timeout_ms* argument as the first function signature.
+- *trace_sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
+- *allows_repeat* is boolean flag that decides whether the repeated headers are allowed in response headers.
+  If the *allows_repeat* is set to false (default), the returned *headers* is table with value type of string.
+  If the *allows_repeat* is set to true, the returned *headers* is table with value type of string or value type
+  of table.
 
-Some examples of specifying *request_options* are shown below:
+  For example, the following upstream response headers have repeated headers.
+
+  .. code-block:: none
+
+    {
+      { ":status", "200" },
+      { "foo", "bar" },
+      { "key", "value_0" },
+      { "key", "value_1" },
+      { "key", "value_2" },
+    }
+
+  Then if *allows_repeat* is set to false, the returned headers will be:
+
+  -- code-block:: lua
+
+    {
+      [":status"] = "200",
+      ["foo"] = "bar",
+      ["key"] = "value_2",
+    }
+
+  If *allows_repeat* is set to true, the returned *headers* will be:
+
+  .. code-block:: lua
+
+    {
+      [":status"] = "200",
+      ["foo"] = "bar",
+      ["key"] = { "value_0", "value_1", "value_2" },
+    }
+
+
+Some examples of specifying *options* are shown below:
 
 .. code-block:: lua
 
   -- Create a fire-and-forget HTTP call.
-  local request_options = {["async"] = true}
+  local request_options = {["asynchronous"] = true}
 
   -- Create a synchronous HTTP call with 1000 ms timeout.
-  local request_options = {["timeout"] = 1000}
+  local request_options = {["timeout_ms"] = 1000}
 
   -- Create a synchronous HTTP call, but do not sample the trace span.
-  local request_options = {["sampled"] = false}
+  local request_options = {["trace_sampled"] = false}
 
-  -- The same as above, but explicitly set the "async" flag to false.
-  local request_options = {["async"] = false, ["sampled"] = false }
+  -- The same as above, but explicitly set the "asynchronous" flag to false.
+  local request_options = {["asynchronous"] = false, ["trace_sampled"] = false }
 
   -- The same as above, but with 1000 ms timeout.
-  local request_options = {["async"] = false, ["sampled"] = false }
+  local request_options = {["asynchronous"] = false, ["trace_sampled"] = false, ["timeout_ms"] = 1000 }
 
 
 respond()

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -399,19 +399,53 @@ httpCall()
 
 .. code-block:: lua
 
-  local headers, body = handle:httpCall(cluster, headers, body, timeout, asynchronous)
+  local headers, body = handle:httpCall(cluster, headers, body, timeout, async)
+
+  -- Alternative function signature.
+  local headers, body = handle:httpCall(cluster, headers, body, options)
 
 Makes an HTTP call to an upstream host. *cluster* is a string which maps to a configured cluster manager cluster. *headers*
 is a table of key/value pairs to send (the value can be a string or table of strings). Note that
 the *:method*, *:path*, and *:authority* headers must be set. *body* is an optional string of body
 data to send. *timeout* is an integer that specifies the call timeout in milliseconds.
 
-*asynchronous* is a boolean flag. If asynchronous is set to true, Envoy will make the HTTP request and continue,
+*async* is a boolean flag. If asynchronous is set to true, Envoy will make the HTTP request and continue,
 regardless of the response success or failure. If this is set to false, or not set, Envoy will suspend executing the script
 until the call completes or has an error.
 
 Returns *headers* which is a table of response headers. Returns *body* which is the string response
 body. May be nil if there is no body.
+
+
+The alternative function signature allows caller to specify *options* as a table. Currently,
+the supported keys are:
+
+- *async* is a boolean flag that controls the asynchronicity of the HTTP call.
+  It refers to the same *async* flag as the first function signature.
+- *timeout* is an integer that specifies the call timeout in milliseconds.
+  It refers to the same *timeout* argument as the first function signature.
+- *sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
+- *multiple* is boolean flag that decides whether the returned header value could has multiple value for same header name.
+
+Some examples of specifying *request_options* are shown below:
+
+.. code-block:: lua
+
+  -- Create a fire-and-forget HTTP call.
+  local request_options = {["async"] = true}
+
+  -- Create a synchronous HTTP call with 1000 ms timeout.
+  local request_options = {["timeout"] = 1000}
+
+  -- Create a synchronous HTTP call, but do not sample the trace span.
+  local request_options = {["sampled"] = false}
+
+  -- The same as above, but explicitly set the "async" flag to false.
+  local request_options = {["async"] = false, ["sampled"] = false }
+
+  -- The same as above, but with 1000 ms timeout.
+  local request_options = {["async"] = false, ["sampled"] = false }
+
 
 respond()
 ^^^^^^^^^^

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -409,7 +409,7 @@ is a table of key/value pairs to send (the value can be a string or table of str
 the *:method*, *:path*, and *:authority* headers must be set. *body* is an optional string of body
 data to send. *timeout* is an integer that specifies the call timeout in milliseconds.
 
-*async* is a boolean flag. If asynchronous is set to true, Envoy will make the HTTP request and continue,
+*async* is a boolean flag. If async is set to true, Envoy will make the HTTP request and continue,
 regardless of the response success or failure. If this is set to false, or not set, Envoy will suspend executing the script
 until the call completes or has an error.
 

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -425,7 +425,7 @@ the supported keys are:
 - *timeout* is an integer that specifies the call timeout in milliseconds.
   It refers to the same *timeout* argument as the first function signature.
 - *sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
-- *multiple* is boolean flag that decides whether the returned header value could has multiple value for same header name.
+- *multiple* is boolean flag that decides whether the returned headers could has multiple values for same header name.
 
 Some examples of specifying *request_options* are shown below:
 

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -425,9 +425,9 @@ the supported keys are:
 - *timeout_ms* is an integer that specifies the call timeout in milliseconds.
   It refers to the same *timeout_ms* argument as the first function signature.
 - *trace_sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
-- *allows_repeat* is boolean flag that decides whether the repeated headers are allowed in response headers.
-  If the *allows_repeat* is set to false (default), the returned *headers* is table with value type of string.
-  If the *allows_repeat* is set to true, the returned *headers* is table with value type of string or value type
+- *return_duplicate_headers* is boolean flag that decides whether the repeated headers are allowed in response headers.
+  If the *return_duplicate_headers* is set to false (default), the returned *headers* is table with value type of string.
+  If the *return_duplicate_headers* is set to true, the returned *headers* is table with value type of string or value type
   of table.
 
   For example, the following upstream response headers have repeated headers.
@@ -442,7 +442,7 @@ the supported keys are:
       { "key", "value_2" },
     }
 
-  Then if *allows_repeat* is set to false, the returned headers will be:
+  Then if *return_duplicate_headers* is set to false, the returned headers will be:
 
   .. code-block:: lua
 
@@ -452,7 +452,7 @@ the supported keys are:
       ["key"] = "value_2",
     }
 
-  If *allows_repeat* is set to true, the returned *headers* will be:
+  If *return_duplicate_headers* is set to true, the returned *headers* will be:
 
   .. code-block:: lua
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -366,6 +366,7 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
     options.is_async_request_ = lua_toboolean(state, AsyncFlagIndex);
   }
 
+  options.request_options_.setParentSpan(callbacks_.activeSpan());
   return doHttpCall(state, options);
 }
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -23,10 +23,73 @@ namespace Lua {
 
 namespace {
 
+constexpr int AsyncFlagIndex = 6;
+constexpr int HttpCallOptionsIndex = 5;
+
+constexpr absl::string_view SampledOption{"sampled"};
+constexpr absl::string_view TimeoutOPtion{"timeout"};
+constexpr absl::string_view AsyncOption{"async"};
+constexpr absl::string_view MultipleOption{"multiple"};
+
 struct HttpResponseCodeDetailValues {
   const absl::string_view LuaResponse = "lua_response";
 };
 using HttpResponseCodeDetails = ConstSingleton<HttpResponseCodeDetailValues>;
+
+// Parse http call options by inspecting the provided table.
+void parseOptionsFromTable(lua_State* state, int index,
+                           StreamHandleWrapper::HttpCallOptions& options) {
+  lua_pushnil(state);
+  while (lua_next(state, index) != 0) {
+    // Uses 'key' (at index -2) and 'value' (at index -1). We only care for string keys.
+    size_t key_length = 0;
+    const char* key = luaL_checklstring(state, -2, &key_length);
+    if (key == nullptr) {
+      continue;
+    }
+    if (key_length == 0) {
+      luaL_error(state, "empty string is not a valid key for httpCall() options");
+    }
+
+    switch (*key) {
+    case 's': {
+      // Handle the case when the table has: {["sampled"] = <boolean>} entry.
+      ASSERT(absl::string_view(key, key_length) == SampledOption);
+      const bool sampled = lua_toboolean(state, -1);
+      options.request_options_.setSampled(sampled);
+      break;
+    }
+    case 't': {
+      ASSERT(absl::string_view(key, key_length) == TimeoutOPtion);
+      // Handle the case when the table has: {["timeout"] = <int>} entry.
+      const int timeout_ms = luaL_checkint(state, -1);
+      if (timeout_ms < 0) {
+        luaL_error(state, "http call timeout must be >= 0");
+      } else {
+        options.request_options_.setTimeout(std::chrono::milliseconds(timeout_ms));
+      }
+      break;
+    }
+    case 'a': {
+      ASSERT(absl::string_view(key, key_length) == AsyncOption);
+      // Handle the case when the table has: {["async"] = <boolean>} entry.
+      options.is_async_request_ = lua_toboolean(state, -1);
+      break;
+    }
+    case 'm': {
+      ASSERT(absl::string_view(key, key_length) == MultipleOption);
+      // Handle the case when the table has: {["multiple_headers"] = <boolean>} entry.
+      options.return_multiple_ = lua_toboolean(state, -1);
+      break;
+    }
+    default:
+      luaL_error(state, "\"%s\" is not a valid key for httpCall() options", key);
+    }
+
+    // Pop value of key/value pair.
+    lua_pop(state, 1);
+  }
+}
 
 const ProtobufWkt::Struct& getMetadata(Http::StreamFilterCallbacks* callbacks) {
   if (callbacks->route() == nullptr) {
@@ -77,16 +140,10 @@ void buildHeadersFromTable(Http::HeaderMap& headers, lua_State* state, int table
 }
 
 Http::AsyncClient::Request* makeHttpCall(lua_State* state, Filter& filter,
-                                         Tracing::Span& parent_span,
+                                         const Http::AsyncClient::RequestOptions& options,
                                          Http::AsyncClient::Callbacks& callbacks) {
   const std::string cluster = luaL_checkstring(state, 2);
   luaL_checktype(state, 3, LUA_TTABLE);
-  size_t body_size;
-  const char* body = luaL_optlstring(state, 4, nullptr, &body_size);
-  int timeout_ms = luaL_checkint(state, 5);
-  if (timeout_ms < 0) {
-    luaL_error(state, "http call timeout must be >= 0");
-  }
 
   const auto thread_local_cluster = filter.clusterManager().getThreadLocalCluster(cluster);
   if (thread_local_cluster == nullptr) {
@@ -102,19 +159,16 @@ Http::AsyncClient::Request* makeHttpCall(lua_State* state, Filter& filter,
   if (message->headers().Path() == nullptr || message->headers().Method() == nullptr ||
       message->headers().Host() == nullptr) {
     luaL_error(state, "http call headers must include ':path', ':method', and ':authority'");
+    return nullptr;
   }
 
+  size_t body_size;
+  const char* body = luaL_optlstring(state, 4, nullptr, &body_size);
   if (body != nullptr) {
     message->body().add(body, body_size);
     message->headers().setContentLength(body_size);
   }
 
-  absl::optional<std::chrono::milliseconds> timeout;
-  if (timeout_ms > 0) {
-    timeout = std::chrono::milliseconds(timeout_ms);
-  }
-
-  auto options = Http::AsyncClient::RequestOptions().setTimeout(timeout).setParentSpan(parent_span);
   return thread_local_cluster->httpAsyncClient().send(std::move(message), callbacks, options);
 }
 
@@ -284,33 +338,45 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
 int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   ASSERT(state_ == State::Running);
 
-  const int async_flag_index = 6;
-  if (!lua_isnone(state, async_flag_index) && !lua_isboolean(state, async_flag_index)) {
-    luaL_error(state, "http call asynchronous flag must be 'true', 'false', or empty");
+  StreamHandleWrapper::HttpCallOptions options;
+
+  // Check if the last argument is table of options. For example:
+  // handle:httpCall(cluster, headers, body, {["timeout"] = 200, ...}).
+  if (const bool has_options = lua_istable(state, HttpCallOptionsIndex); has_options) {
+    parseOptionsFromTable(state, HttpCallOptionsIndex, options);
+  } else {
+    if (!lua_isnone(state, AsyncFlagIndex) && !lua_isboolean(state, AsyncFlagIndex)) {
+      luaL_error(state, "http call asynchronous flag must be 'true', 'false', or empty");
+    }
+
+    // When the last argument is not option table, the timeout is provided at the 5th index.
+    int timeout_ms = luaL_checkint(state, 5);
+    if (timeout_ms < 0) {
+      luaL_error(state, "http call timeout must be >= 0");
+    }
+    options.request_options_.setTimeout(std::chrono::milliseconds(timeout_ms));
+    options.is_async_request_ = lua_toboolean(state, AsyncFlagIndex);
   }
 
-  if (lua_toboolean(state, async_flag_index)) {
-    return doAsynchronousHttpCall(state, callbacks_.activeSpan());
-  } else {
-    return doSynchronousHttpCall(state, callbacks_.activeSpan());
-  }
+  return doHttpCall(state, options);
 }
 
-int StreamHandleWrapper::doSynchronousHttpCall(lua_State* state, Tracing::Span& span) {
-  http_request_ = makeHttpCall(state, filter_, span, *this);
+int StreamHandleWrapper::doHttpCall(lua_State* state, const HttpCallOptions& options) {
+  if (options.is_async_request_) {
+    makeHttpCall(state, filter_, options.request_options_, noopCallbacks());
+    return 0;
+  }
+
+  http_request_ = makeHttpCall(state, filter_, options.request_options_, *this);
   if (http_request_ != nullptr) {
     state_ = State::HttpCall;
+    return_multiple_ = options.return_multiple_;
     return lua_yield(state, 0);
   } else {
     // Immediate failure case. The return arguments are already on the stack.
     ASSERT(lua_gettop(state) >= 2);
     return 2;
   }
-}
-
-int StreamHandleWrapper::doAsynchronousHttpCall(lua_State* state, Tracing::Span& span) {
-  makeHttpCall(state, filter_, span, noopCallbacks());
-  return 0;
 }
 
 void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
@@ -321,15 +387,45 @@ void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
 
   // We need to build a table with the headers as return param 1. The body will be return param 2.
   lua_newtable(coroutine_.luaState());
-  response->headers().iterate([lua_State = coroutine_.luaState()](
-                                  const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
-    lua_pushlstring(lua_State, header.key().getStringView().data(),
-                    header.key().getStringView().size());
-    lua_pushlstring(lua_State, header.value().getStringView().data(),
-                    header.value().getStringView().size());
-    lua_settable(lua_State, -3);
-    return Http::HeaderMap::Iterate::Continue;
-  });
+
+  if (return_multiple_) {
+    absl::flat_hash_map<absl::string_view, absl::InlinedVector<absl::string_view, 1>> headers;
+    headers.reserve(response->headers().size());
+
+    response->headers().iterate([&headers](const Http::HeaderEntry& header) {
+      headers[header.key().getStringView()].push_back(header.value().getStringView());
+      return Http::HeaderMap::Iterate::Continue;
+    });
+
+    auto lua_state = coroutine_.luaState();
+    for (const auto& header : headers) {
+      lua_pushlstring(lua_state, header.first.data(), header.first.size());
+      ASSERT(!header.second.empty());
+      // If there are multiple values for same header name then create table for these values.
+      if (header.second.size() > 1) {
+        lua_newtable(lua_state);
+        for (size_t i = 0; i < header.second.size(); i++) {
+          lua_pushinteger(lua_state, i + 1);
+          lua_pushlstring(lua_state, header.second[i].data(), header.second[i].size());
+          lua_settable(lua_state, -3);
+        }
+      } else {
+        lua_pushlstring(lua_state, header.second[0].data(), header.second[0].size());
+      }
+
+      lua_settable(lua_state, -3);
+    }
+  } else {
+    response->headers().iterate([lua_State = coroutine_.luaState()](
+                                    const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+      lua_pushlstring(lua_State, header.key().getStringView().data(),
+                      header.key().getStringView().size());
+      lua_pushlstring(lua_State, header.value().getStringView().data(),
+                      header.value().getStringView().size());
+      lua_settable(lua_State, -3);
+      return Http::HeaderMap::Iterate::Continue;
+    });
+  }
 
   // TODO(mattklein123): Avoid double copy here.
   if (response->body().length() > 0) {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -146,7 +146,7 @@ public:
   struct HttpCallOptions {
     Http::AsyncClient::RequestOptions request_options_;
     bool is_async_request_{false};
-    bool return_multiple_{false};
+    bool return_duplicate_headers_{false};
   };
 
   StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
@@ -338,7 +338,7 @@ private:
   bool headers_continued_{};
   bool buffered_body_{};
   bool saw_body_{};
-  bool return_multiple_{};
+  bool return_duplicate_headers_{};
   Filter& filter_;
   FilterCallbacks& callbacks_;
   Http::HeaderMap* trailers_{};

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -143,6 +143,12 @@ public:
     Responded
   };
 
+  struct HttpCallOptions {
+    Http::AsyncClient::RequestOptions request_options_;
+    bool is_async_request_{false};
+    bool return_multiple_{false};
+  };
+
   StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
                       Http::RequestOrResponseHeaderMap& headers, bool end_stream, Filter& filter,
                       FilterCallbacks& callbacks, TimeSource& time_source);
@@ -306,8 +312,7 @@ private:
 
   enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
 
-  int doSynchronousHttpCall(lua_State* state, Tracing::Span& span);
-  int doAsynchronousHttpCall(lua_State* state, Tracing::Span& span);
+  int doHttpCall(lua_State* state, const HttpCallOptions& options);
 
   // Filters::Common::Lua::BaseLuaObject
   void onMarkDead() override {
@@ -333,6 +338,7 @@ private:
   bool headers_continued_{};
   bool buffered_body_{};
   bool saw_body_{};
+  bool return_multiple_{};
   Filter& filter_;
   FilterCallbacks& callbacks_;
   Http::HeaderMap* trailers_{};

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -895,6 +895,68 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
 }
 
+// HTTP request flow with multiple header values for same header name.
+TEST_F(LuaHttpFilterTest, HttpCallWithMultipleHeaders) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      local headers, body = request_handle:httpCall(
+        "cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "foo",
+        },
+        "hello world",
+        {
+          ["multiple"] = true
+        })
+      for key, value in pairs(headers) do
+        if type(value) == "table" then
+          request_handle:logTrace(key .. " " .. table.concat(value, ","))
+        else
+          request_handle:logTrace(key .. " " .. value)
+        end
+      end
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::MockAsyncClientRequest request(&cluster_manager_.thread_local_cluster_.async_client_);
+  Http::AsyncClient::Callbacks* callbacks;
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(Eq("cluster")));
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_, httpAsyncClient());
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.async_client_, send_(_, _, _))
+      .WillOnce(
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            callbacks = &cb;
+            return &request;
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
+
+  Http::ResponseMessagePtr response_message(
+      new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
+          new Http::TestResponseHeaderMapImpl{{"key", "value"}, {"key", "second_value"}}}));
+
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("key value,second_value")));
+
+  EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  callbacks->onBeforeFinalizeUpstreamSpan(child_span_, &response_message->headers());
+  callbacks->onSuccess(request, std::move(response_message));
+  EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
+}
+
 // Basic HTTP request flow. Asynchronous flag set to false.
 TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
   const std::string SCRIPT{R"EOF(
@@ -975,6 +1037,59 @@ TEST_F(LuaHttpFilterTest, HttpCallAsynchronous) {
             "hello world",
             5000,
             true)
+        end
+      )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::MockAsyncClientRequest request(&cluster_manager_.thread_local_cluster_.async_client_);
+  Http::AsyncClient::Callbacks* callbacks;
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(Eq("cluster")));
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_, httpAsyncClient());
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.async_client_, send_(_, _, _))
+      .WillOnce(
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            const Http::TestRequestHeaderMapImpl expected_headers{
+                {":path", "/"},
+                {":method", "POST"},
+                {":authority", "foo"},
+                {"set-cookie", "flavor=chocolate; Path=/"},
+                {"set-cookie", "variant=chewy; Path=/"},
+                {"content-length", "11"}};
+            EXPECT_THAT(&message->headers(), HeaderMapEqualIgnoreOrder(&expected_headers));
+            callbacks = &cb;
+            return &request;
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
+  EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
+}
+
+// Basic asynchronous, fire-and-forget HTTP request flow.
+TEST_F(LuaHttpFilterTest, HttpCallAsynchronousInOptions) {
+  const std::string SCRIPT{R"EOF(
+        function envoy_on_request(request_handle)
+          local headers, body = request_handle:httpCall(
+            "cluster",
+            {
+              [":method"] = "POST",
+              [":path"] = "/",
+              [":authority"] = "foo",
+              ["set-cookie"] = { "flavor=chocolate; Path=/", "variant=chewy; Path=/" }
+            },
+            "hello world",
+            {
+              ["async"] = true
+            })
         end
       )EOF"};
 
@@ -1450,6 +1565,60 @@ TEST_F(LuaHttpFilterTest, HttpCallInvalidCluster) {
                 StrEq("[string \"...\"]:3: http call cluster invalid. Must be configured")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ(1, stats_store_.counter("test.lua.errors").value());
+}
+
+// HTTP request flow with timeout and sampled flag in options.
+TEST_F(LuaHttpFilterTest, HttpCallWithTimeoutAndSampledInOptions) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      local headers, body = request_handle:httpCall(
+        "cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "foo",
+        },
+        "hello world",
+        {
+          ["timeout"] = 5000,
+          ["sampled"] = false,
+        })
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::MockAsyncClientRequest request(&cluster_manager_.thread_local_cluster_.async_client_);
+  Http::AsyncClient::Callbacks* callbacks;
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(Eq("cluster")));
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_, httpAsyncClient());
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.async_client_, send_(_, _, _))
+      .WillOnce(Invoke(
+          [&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
+              const Http::AsyncClient::RequestOptions& options) -> Http::AsyncClient::Request* {
+            EXPECT_EQ(options.timeout->count(), 5000);
+            EXPECT_EQ(options.sampled_.value(), false);
+            callbacks = &cb;
+            return &request;
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
+
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
+  EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  callbacks->onBeforeFinalizeUpstreamSpan(child_span_, &response_message->headers());
+  callbacks->onSuccess(request, std::move(response_message));
+  EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
 }
 
 // Invalid HTTP call headers.

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -896,7 +896,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
 }
 
 // HTTP request flow with multiple header values for same header name.
-TEST_F(LuaHttpFilterTest, HttpCallWithMultipleHeaders) {
+TEST_F(LuaHttpFilterTest, HttpCallWithRepeatedHeaders) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_request(request_handle)
       local headers, body = request_handle:httpCall(
@@ -908,7 +908,7 @@ TEST_F(LuaHttpFilterTest, HttpCallWithMultipleHeaders) {
         },
         "hello world",
         {
-          ["multiple"] = true
+          ["allows_repeat"] = true
         })
       for key, value in pairs(headers) do
         if type(value) == "table" then
@@ -1088,7 +1088,7 @@ TEST_F(LuaHttpFilterTest, HttpCallAsynchronousInOptions) {
             },
             "hello world",
             {
-              ["async"] = true
+              ["asynchronous"] = true
             })
         end
       )EOF"};
@@ -1580,8 +1580,8 @@ TEST_F(LuaHttpFilterTest, HttpCallWithTimeoutAndSampledInOptions) {
         },
         "hello world",
         {
-          ["timeout"] = 5000,
-          ["sampled"] = false,
+          ["timeout_ms"] = 5000,
+          ["trace_sampled"] = false,
         })
     end
   )EOF"};


### PR DESCRIPTION

Commit Message: lua: support setting http call options by table
Additional Description:

A new `httpCall` signature is added. We can set http call options by named key in options table.
To close both #14785 and #22173.

This PR is inherited from #14882. Thanks for all these great work of @dio.

Risk Level: Low. Only updates for lua filter.
Testing: Added.
Docs Changes: Added.
Release Notes: Added.
Platform Specific Features: n/a.