### PR TITLE
Support allowlisting request headers for both gRPC and HTTP authorization servers

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 17]
+// [#next-free-field: 18]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -153,6 +153,22 @@ message ExtAuthz {
   // :ref:`destination<envoy_v3_api_field_service.auth.v3.AttributeContext.destination>`.
   // The labels will be read from :ref:`metadata<envoy_v3_api_msg_config.core.v3.Node>` with the specified key.
   string bootstrap_metadata_labels_key = 15;
+
+  // Check request to authorization server will include the client request headers that have a correspondent match
+  // in the :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>`. Note that in addition to the
+  // user's supplied matchers:
+  //
+  // 1. In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //
+  // 2. For requestst to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
+  // authorization server will not have a message body. However, the check request can include the buffered 
+  // client request body (controlled by :ref:`with_request_body
+  // <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.with_request_body>` setting),
+  // consequently the value of *Content-Length* of the authorization request reflects the size of
+  // its payload size.
+  //
+  type.matcher.v3.ListStringMatcher allowed_headers = 17;
 }
 
 // Configuration for buffering the request data.
@@ -246,7 +262,9 @@ message AuthorizationRequest {
   //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
   //   setting) hence the value of its ``Content-Length`` reflects the size of its payload size.
   //
-  type.matcher.v3.ListStringMatcher allowed_headers = 1;
+  //   This field has been deprecated in favor of :ref:`allowed_headers
+  //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.
+  type.matcher.v3.ListStringMatcher allowed_headers = 1 [deprecated = true];
 
   // Sets a list of headers that will be included to the request to authorization service. Note that
   // client request of the same key will be overridden.

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -162,7 +162,7 @@ message ExtAuthz {
   // 1. In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
   //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
   //
-  // 2. For requestst to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
+  // 2. For requests to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
   // authorization server will not have a message body. However, the check request can include the buffered
   // client request body (controlled by :ref:`with_request_body
   // <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.with_request_body>` setting),

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -156,11 +156,13 @@ message ExtAuthz {
   string bootstrap_metadata_labels_key = 15;
 
   // Check request to authorization server will include the client request headers that have a correspondent match
-  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`.
+  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. If this option isn't specified, then
+  // all client request headers are included in the check request to a gRPC authorization server, whereas no client request headers
+  // (besides the ones allowed by default - see note below) are included in the check request to an HTTP authorization server.
   //
   // .. note::
   //
-  //  1. In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //  1. For requests to an HTTP authorization server: in addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
   //     ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
   //
   // .. note::

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -159,11 +159,12 @@ message ExtAuthz {
   // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. If this option isn't specified, then
   // all client request headers are included in the check request to a gRPC authorization server, whereas no client request headers
   // (besides the ones allowed by default - see note below) are included in the check request to an HTTP authorization server.
+  // This inconsistency between gRPC and HTTP servers is to maintain backwards compatibility with legacy behavior.
   //
   // .. note::
   //
   //  1. For requests to an HTTP authorization server: in addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
-  //     ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //     ``Content-Length``, and ``Authorization`` are **additionally included** in the list.
   //
   // .. note::
   //

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -10,6 +10,7 @@ import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -162,7 +163,7 @@ message ExtAuthz {
   //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
   //
   // 2. For requestst to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
-  // authorization server will not have a message body. However, the check request can include the buffered 
+  // authorization server will not have a message body. However, the check request can include the buffered
   // client request body (controlled by :ref:`with_request_body
   // <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.with_request_body>` setting),
   // consequently the value of *Content-Length* of the authorization request reflects the size of
@@ -264,7 +265,8 @@ message AuthorizationRequest {
   //
   //   This field has been deprecated in favor of :ref:`allowed_headers
   //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.
-  type.matcher.v3.ListStringMatcher allowed_headers = 1 [deprecated = true];
+  type.matcher.v3.ListStringMatcher allowed_headers = 1
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Sets a list of headers that will be included to the request to authorization service. Note that
   // client request of the same key will be overridden.

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -156,19 +156,21 @@ message ExtAuthz {
   string bootstrap_metadata_labels_key = 15;
 
   // Check request to authorization server will include the client request headers that have a correspondent match
-  // in the :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>`. Note that in addition to the
-  // user's supplied matchers:
+  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`.
   //
-  // 1. In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
-  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  // .. note::
   //
-  // 2. For requests to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
-  // authorization server will not have a message body. However, the check request can include the buffered
-  // client request body (controlled by :ref:`with_request_body
-  // <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.with_request_body>` setting),
-  // consequently the value of *Content-Length* of the authorization request reflects the size of
-  // its payload size.
+  //  1. In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //     ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
   //
+  // .. note::
+  //
+  //  2. For requests to an HTTP authorization server: *Content-Length* will be set to 0 and the request to the
+  //  authorization server will not have a message body. However, the check request can include the buffered
+  //  client request body (controlled by :ref:`with_request_body
+  //  <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
+  //  consequently the value of *Content-Length* of the authorization request reflects the size of
+  //  its payload size.
   type.matcher.v3.ListStringMatcher allowed_headers = 17;
 }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -2,47 +2,6 @@ date: Pending
 
 behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
-- area: build
-  change: |
-    official released binary is now built on Ubuntu 20.04, requires glibc >= 2.30.
-- area: stats http local_rate_limit
-  change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    envoy_http_local_rate_limit_myprefix_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_http_ratelimit_prefix="myprefix"}.
-- area: stats network local_rate_limit
-  change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    envoy_local_rate_limit_myprefix_rate_limited{} to envoy_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix="myprefix"}.
-- area: http
-  change: |
-    Envoy no longer adds ``content-length: 0`` header when proxying UPGRADE requests without ``content-length`` and ``transfer-encoding`` headers.
-    This behavior change can be reverted by setting the ``envoy.reloadable_features.http_skip_adding_content_length_to_upgrade`` runtime flag to false.
-- area: tls
-  change: |
-    Change TLS and QUIC transport sockets to support asynchronous cert validation extension. This behavior change can be reverted by setting runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` to false.
-- area: gcp_authn
-  change: |
-    Add GCP Authentication filter which can be used to fetch authentication tokens from Google Compute Engine(GCE) metadata server.
-- area: http
-  change: |
-    For HTTP/2 and HTTP/3 codecs, all clients now continue sending data upstream after receiving an end of the server
-    stream. This supports the server half-close semantics for TCP tunneling with CONNECT as well as bi-directional
-    streaming calls. This behavior change can be reverted by setting the
-    ``envoy.reloadable_features.http_response_half_close`` runtime flag to false.
-- area: original_dst
-  change: |
-    ORIGINAL_DST cluster will not attempt to remove and drain the stale hosts during cleanup if they are still used by
-    the connection pools. For HTTP pools, please set :ref:`idle_timeout <faq_configuration_connection_timeouts>` to
-    limit the duration of the upstream connections (the default value is 1h, and the recommended value is 5min). This
-    behavior change can be reverted by setting runtime guard
-    ``envoy.reloadable_features.original_dst_rely_on_idle_timeout``.
-- area: config
-  change: |
-    Fixed resource tracking when using the Incremental (Delta-xDS) protocol. The protocol state will be updated after
-    the resources are successfully ingested and an ACK is sent. This behavior change can be reverted by setting the
-    ``envoy.reloadable_features.delta_xds_subscription_state_tracking_fix`` runtime flag to false.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
@@ -74,8 +33,6 @@ new_features:
 - area: http
   change: |
     allowing the dynamic forward proxy cluster to :ref:`allow_coalesced_connections <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_coalesced_connections>`  for HTTP/2 and HTTP/3 connections.
-    added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check for HTTP health check.
-    Added :ref:`response_buffer_size <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.response_buffer_size>` to configure the maximum HTTP health check response buffer size.
 
 - area: ext_authz
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -43,9 +43,6 @@ behavior_changes:
     Fixed resource tracking when using the Incremental (Delta-xDS) protocol. The protocol state will be updated after
     the resources are successfully ingested and an ACK is sent. This behavior change can be reverted by setting the
     ``envoy.reloadable_features.delta_xds_subscription_state_tracking_fix`` runtime flag to false.
-- area: ext_auth
-  change: |
-    Client request headers to be included in the check request to the authorization server (gRPC) are matched against a list of allowed headers.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
@@ -134,8 +131,5 @@ new_features:
   change: |
     Added :ref:`HeaderBasedSessionState <envoy_v3_api_msg_extensions.http.stateful_session.header.v3.HeaderBasedSessionState>` to manage
     :ref:`StatefulSession State <envoy_v3_api_msg_extensions.filters.http.stateful_session.v3.StatefulSession>` via request/response header.
-- area: ext_authz
-  change: |
-    added support to allowlist headers included in the check request to gRPC authorization server.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -76,60 +76,9 @@ new_features:
     allowing the dynamic forward proxy cluster to :ref:`allow_coalesced_connections <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_coalesced_connections>`  for HTTP/2 and HTTP/3 connections.
     added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check for HTTP health check.
     Added :ref:`response_buffer_size <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.response_buffer_size>` to configure the maximum HTTP health check response buffer size.
-- area: lua
-  change: |
-    added new headers method "setHttp1ReasonPhrase" for lua filter, please see :ref:`lua header wrapper <config_http_filters_lua_header_wrapper>`.
-- area: lua
-  change: |
-    added stats for lua filter, please see :ref:`lua filter stats <config_http_filters_lua_stats>`.
-- area: subset load balancer
-  change: |
-    added multiple keys or multiple selectors support for :ref:`single host per subset mode <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector.single_host_per_subset>`.
-- area: listener
-  change: |
-    allow network filters other than HTTP Connection Manager to be created for QUIC listeners.
+
 - area: ext_authz
   change: |
     added support to allowlist headers included in the check request to gRPC authorization server (previously only available for HTTP authorization server).
-- area: lua
-  change: |
-    added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span
-    by setting ``{["trace_sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
-    ``{["return_duplicate_headers"] = true}`` as the ``options``.
-- area: zipkin
-  change: |
-    added :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>` to make Envoy appear
-    as an independent hop for zipkin tracing.
-- area: cluster
-  change: |
-    added support to override original destination port via setting :ref:`upstream_port_override <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.upstream_port_override>`.
-- area: generic_proxy
-  change: |
-    added an new network filter :ref:`generic_proxy filter <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
-- area: redis
-  change: |
-    added support for quit command to the redis proxy.
-- area: tcp_proxy
-  change: |
-    added support for propagating the response headers in :ref:`TunnelingConfig
-    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_headers>` to
-    the downstream info filter state.
-- area: access_log
-  change: |
-    log ``duration``, ``upstream_request_attempt_count``, ``connection_termination_details`` and tls ``ja3`` field in the grpc access log
-    and also log the tls ``sni`` and ``ja3`` field in the grpc access log when envoy is configured as a tls forward proxy.
-- area: grpc_json_transcoder
-  change: |
-    added support for parsing enum value case insensitively enabled by the config :ref:`case_insensitive_enum_parsing <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.case_insensitive_enum_parsing>`.
-- area: grpc_json_transcoder
-  change: |
-    added support for newline-delimited streams in :ref:`stream_newline_delimited <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.PrintOptions.stream_newline_delimited>`.
-- area: grpc_stats
-  change: |
-    added support for replacing dots of gRPC service name with underscores in the gRPC stats by the config :ref:`replace_dots_in_grpc_service_name <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.replace_dots_in_grpc_service_name>`.
-- area: http
-  change: |
-    Added :ref:`HeaderBasedSessionState <envoy_v3_api_msg_extensions.http.stateful_session.header.v3.HeaderBasedSessionState>` to manage
-    :ref:`StatefulSession State <envoy_v3_api_msg_extensions.filters.http.stateful_session.v3.StatefulSession>` via request/response header.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -2,6 +2,50 @@ date: Pending
 
 behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+- area: build
+  change: |
+    official released binary is now built on Ubuntu 20.04, requires glibc >= 2.30.
+- area: stats http local_rate_limit
+  change: |
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
+    is properly extracted. This changes the Prometheus name from
+    envoy_http_local_rate_limit_myprefix_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_http_ratelimit_prefix="myprefix"}.
+- area: stats network local_rate_limit
+  change: |
+    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
+    is properly extracted. This changes the Prometheus name from
+    envoy_local_rate_limit_myprefix_rate_limited{} to envoy_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix="myprefix"}.
+- area: http
+  change: |
+    Envoy no longer adds ``content-length: 0`` header when proxying UPGRADE requests without ``content-length`` and ``transfer-encoding`` headers.
+    This behavior change can be reverted by setting the ``envoy.reloadable_features.http_skip_adding_content_length_to_upgrade`` runtime flag to false.
+- area: tls
+  change: |
+    Change TLS and QUIC transport sockets to support asynchronous cert validation extension. This behavior change can be reverted by setting runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` to false.
+- area: gcp_authn
+  change: |
+    Add GCP Authentication filter which can be used to fetch authentication tokens from Google Compute Engine(GCE) metadata server.
+- area: http
+  change: |
+    For HTTP/2 and HTTP/3 codecs, all clients now continue sending data upstream after receiving an end of the server
+    stream. This supports the server half-close semantics for TCP tunneling with CONNECT as well as bi-directional
+    streaming calls. This behavior change can be reverted by setting the
+    ``envoy.reloadable_features.http_response_half_close`` runtime flag to false.
+- area: original_dst
+  change: |
+    ORIGINAL_DST cluster will not attempt to remove and drain the stale hosts during cleanup if they are still used by
+    the connection pools. For HTTP pools, please set :ref:`idle_timeout <faq_configuration_connection_timeouts>` to
+    limit the duration of the upstream connections (the default value is 1h, and the recommended value is 5min). This
+    behavior change can be reverted by setting runtime guard
+    ``envoy.reloadable_features.original_dst_rely_on_idle_timeout``.
+- area: config
+  change: |
+    Fixed resource tracking when using the Incremental (Delta-xDS) protocol. The protocol state will be updated after
+    the resources are successfully ingested and an ACK is sent. This behavior change can be reverted by setting the
+    ``envoy.reloadable_features.delta_xds_subscription_state_tracking_fix`` runtime flag to false.
+- area: ext_auth
+  change: |
+    Client request headers to be included in the check request to the authorization server (gRPC) are matched against a list of allowed headers.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
@@ -33,5 +77,62 @@ new_features:
 - area: http
   change: |
     allowing the dynamic forward proxy cluster to :ref:`allow_coalesced_connections <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_coalesced_connections>`  for HTTP/2 and HTTP/3 connections.
+    added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check for HTTP health check.
+    Added :ref:`response_buffer_size <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.response_buffer_size>` to configure the maximum HTTP health check response buffer size.
+- area: lua
+  change: |
+    added new headers method "setHttp1ReasonPhrase" for lua filter, please see :ref:`lua header wrapper <config_http_filters_lua_header_wrapper>`.
+- area: lua
+  change: |
+    added stats for lua filter, please see :ref:`lua filter stats <config_http_filters_lua_stats>`.
+- area: subset load balancer
+  change: |
+    added multiple keys or multiple selectors support for :ref:`single host per subset mode <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector.single_host_per_subset>`.
+- area: listener
+  change: |
+    allow network filters other than HTTP Connection Manager to be created for QUIC listeners.
+- area: lua
+  change: |
+    added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span
+    by setting ``{["trace_sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
+    ``{["return_duplicate_headers"] = true}`` as the ``options``.
+- area: zipkin
+  change: |
+    added :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>` to make Envoy appear
+    as an independent hop for zipkin tracing.
+- area: cluster
+  change: |
+    added support to override original destination port via setting :ref:`upstream_port_override <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.upstream_port_override>`.
+- area: generic_proxy
+  change: |
+    added an new network filter :ref:`generic_proxy filter <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
+- area: redis
+  change: |
+    added support for quit command to the redis proxy.
+- area: tcp_proxy
+  change: |
+    added support for propagating the response headers in :ref:`TunnelingConfig
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_headers>` to
+    the downstream info filter state.
+- area: access_log
+  change: |
+    log ``duration``, ``upstream_request_attempt_count``, ``connection_termination_details`` and tls ``ja3`` field in the grpc access log
+    and also log the tls ``sni`` and ``ja3`` field in the grpc access log when envoy is configured as a tls forward proxy.
+- area: grpc_json_transcoder
+  change: |
+    added support for parsing enum value case insensitively enabled by the config :ref:`case_insensitive_enum_parsing <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.case_insensitive_enum_parsing>`.
+- area: grpc_json_transcoder
+  change: |
+    added support for newline-delimited streams in :ref:`stream_newline_delimited <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.PrintOptions.stream_newline_delimited>`.
+- area: grpc_stats
+  change: |
+    added support for replacing dots of gRPC service name with underscores in the gRPC stats by the config :ref:`replace_dots_in_grpc_service_name <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.replace_dots_in_grpc_service_name>`.
+- area: http
+  change: |
+    Added :ref:`HeaderBasedSessionState <envoy_v3_api_msg_extensions.http.stateful_session.header.v3.HeaderBasedSessionState>` to manage
+    :ref:`StatefulSession State <envoy_v3_api_msg_extensions.filters.http.stateful_session.v3.StatefulSession>` via request/response header.
+- area: ext_authz
+  change: |
+    added support to allowlist headers included in the check request to gRPC authorization server.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -37,5 +37,7 @@ new_features:
 - area: ext_authz
   change: |
     added support to allowlist headers included in the check request to gRPC authorization server (previously only available for HTTP authorization server).
+    Pre-existing field :ref:`allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationRequest.allowed_headers>` is deprecated in favour
+    of the new field :ref:`allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -91,6 +91,9 @@ new_features:
 - area: listener
   change: |
     allow network filters other than HTTP Connection Manager to be created for QUIC listeners.
+- area: ext_authz
+  change: |
+    added support to allowlist headers included in the check request to gRPC authorization server (previously only available for HTTP authorization server).
 - area: lua
   change: |
     added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -240,18 +240,22 @@ void CheckRequestUtils::createTcpCheck(
 }
 
 MatcherSharedPtr
-CheckRequestUtils::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  const std::vector<Http::LowerCaseString> keys{
-      {Http::CustomHeaders::get().Authorization, Http::Headers::get().Method,
-       Http::Headers::get().Path, Http::Headers::get().Host}};
-
+CheckRequestUtils::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
+                                     bool add_http_headers) {
   std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
-  for (const auto& key : keys) {
-    envoy::type::matcher::v3::StringMatcher matcher;
-    matcher.set_exact(key.get());
-    matchers.push_back(
-        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
-            matcher));
+
+  if (add_http_headers) {
+    const std::vector<Http::LowerCaseString> keys{
+        {Http::CustomHeaders::get().Authorization, Http::Headers::get().Method,
+         Http::Headers::get().Path, Http::Headers::get().Host}};
+
+    for (const auto& key : keys) {
+      envoy::type::matcher::v3::StringMatcher matcher;
+      matcher.set_exact(key.get());
+      matchers.push_back(
+          std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
+              matcher));
+    }
   }
 
   return std::make_shared<HeaderKeyMatcher>(std::move(matchers));

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -127,10 +127,7 @@ void CheckRequestUtils::setHttpRequest(
       const std::string key(e.key().getStringView());
 
       if (request_header_matchers != nullptr) {
-
-        ENVOY_LOG_MISC(trace, "request header matchers are set");
         if (request_header_matchers->matches(key)) {
-          ENVOY_LOG_MISC(trace, "found a match for key {}", key);
           if (mutable_headers->find(key) == mutable_headers->end()) {
             (*mutable_headers)[key] = std::string(e.value().getStringView());
           } else {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -30,6 +30,20 @@ namespace Filters {
 namespace Common {
 namespace ExtAuthz {
 
+// Matchers
+HeaderKeyMatcher::HeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list)
+    : matchers_(std::move(list)) {}
+
+bool HeaderKeyMatcher::matches(absl::string_view key) const {
+  return std::any_of(matchers_.begin(), matchers_.end(),
+                     [&key](auto& matcher) { return matcher->match(key); });
+}
+
+NotHeaderKeyMatcher::NotHeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list)
+    : matcher_(std::move(list)) {}
+
+bool NotHeaderKeyMatcher::matches(absl::string_view key) const { return !matcher_.matches(key); }
+
 void CheckRequestUtils::setAttrContextPeer(envoy::service::auth::v3::AttributeContext::Peer& peer,
                                            const Network::Connection& connection,
                                            const std::string& service, const bool local,

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -105,7 +105,8 @@ void CheckRequestUtils::setRequestTime(envoy::service::auth::v3::AttributeContex
 void CheckRequestUtils::setHttpRequest(
     envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq, uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
-    const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes) {
+    const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
+    const MatcherSharedPtr& request_header_matchers) {
   httpreq.set_id(std::to_string(stream_id));
   httpreq.set_method(getHeaderStr(headers.Method()));
   httpreq.set_path(getHeaderStr(headers.Path()));
@@ -119,15 +120,31 @@ void CheckRequestUtils::setHttpRequest(
 
   // Fill in the headers.
   auto* mutable_headers = httpreq.mutable_headers();
-  headers.iterate([mutable_headers](const Envoy::Http::HeaderEntry& e) {
+
+  headers.iterate([request_header_matchers, mutable_headers](const Envoy::Http::HeaderEntry& e) {
     // Skip any client EnvoyAuthPartialBody header, which could interfere with internal use.
     if (e.key().getStringView() != Headers::get().EnvoyAuthPartialBody.get()) {
       const std::string key(e.key().getStringView());
-      if (mutable_headers->find(key) == mutable_headers->end()) {
-        (*mutable_headers)[key] = std::string(e.value().getStringView());
+
+      if (request_header_matchers != nullptr) {
+
+        ENVOY_LOG_MISC(trace, "request header matchers are set");
+        if (request_header_matchers->matches(key)) {
+          ENVOY_LOG_MISC(trace, "found a match for key {}", key);
+          if (mutable_headers->find(key) == mutable_headers->end()) {
+            (*mutable_headers)[key] = std::string(e.value().getStringView());
+          } else {
+            // Merge duplicate headers.
+            (*mutable_headers)[key].append(",").append(std::string(e.value().getStringView()));
+          }
+        }
       } else {
-        // Merge duplicate headers.
-        (*mutable_headers)[key].append(",").append(std::string(e.value().getStringView()));
+        if (mutable_headers->find(key) == mutable_headers->end()) {
+          (*mutable_headers)[key] = std::string(e.value().getStringView());
+        } else {
+          // Merge duplicate headers.
+          (*mutable_headers)[key].append(",").append(std::string(e.value().getStringView()));
+        }
       }
     }
     return Envoy::Http::HeaderMap::Iterate::Continue;
@@ -157,10 +174,11 @@ void CheckRequestUtils::setHttpRequest(
 void CheckRequestUtils::setAttrContextRequest(
     envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
-    const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes) {
+    const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
+    const MatcherSharedPtr& request_header_matchers) {
   setRequestTime(req, stream_info);
   setHttpRequest(*req.mutable_http(), stream_id, stream_info, decoding_buffer, headers,
-                 max_request_bytes, pack_as_bytes);
+                 max_request_bytes, pack_as_bytes, request_header_matchers);
 }
 
 void CheckRequestUtils::createHttpCheck(
@@ -170,7 +188,8 @@ void CheckRequestUtils::createHttpCheck(
     envoy::config::core::v3::Metadata&& metadata_context,
     envoy::service::auth::v3::CheckRequest& request, uint64_t max_request_bytes, bool pack_as_bytes,
     bool include_peer_certificate,
-    const Protobuf::Map<std::string, std::string>& destination_labels) {
+    const Protobuf::Map<std::string, std::string>& destination_labels,
+    const MatcherSharedPtr& request_header_matchers) {
 
   auto attrs = request.mutable_attributes();
   const std::string service = getHeaderStr(headers.EnvoyDownstreamServiceCluster());
@@ -183,7 +202,8 @@ void CheckRequestUtils::createHttpCheck(
   setAttrContextPeer(*attrs->mutable_destination(), *cb->connection(), EMPTY_STRING, true,
                      include_peer_certificate);
   setAttrContextRequest(*attrs->mutable_request(), cb->streamId(), cb->streamInfo(),
-                        cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes);
+                        cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes,
+                        request_header_matchers);
 
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
   // Fill in the context extensions and metadata context.
@@ -206,6 +226,35 @@ void CheckRequestUtils::createTcpCheck(
   setAttrContextPeer(*attrs->mutable_destination(), cb->connection(), server_name, true,
                      include_peer_certificate);
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
+}
+
+MatcherSharedPtr
+CheckRequestUtils::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
+  const std::vector<Http::LowerCaseString> keys{
+      {Http::CustomHeaders::get().Authorization, Http::Headers::get().Method,
+       Http::Headers::get().Path, Http::Headers::get().Host}};
+
+  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
+  for (const auto& key : keys) {
+    envoy::type::matcher::v3::StringMatcher matcher;
+    matcher.set_exact(key.get());
+    matchers.push_back(
+        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
+            matcher));
+  }
+
+  return std::make_shared<HeaderKeyMatcher>(std::move(matchers));
+}
+
+std::vector<Matchers::StringMatcherPtr>
+CheckRequestUtils::createStringMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
+  std::vector<Matchers::StringMatcherPtr> matchers;
+  for (const auto& matcher : list.patterns()) {
+    matchers.push_back(
+        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
+            matcher));
+  }
+  return matchers;
 }
 
 } // namespace ExtAuthz

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -140,16 +140,7 @@ void CheckRequestUtils::setHttpRequest(
     if (e.key().getStringView() != Headers::get().EnvoyAuthPartialBody.get()) {
       const std::string key(e.key().getStringView());
 
-      if (request_header_matchers != nullptr) {
-        if (request_header_matchers->matches(key)) {
-          if (mutable_headers->find(key) == mutable_headers->end()) {
-            (*mutable_headers)[key] = std::string(e.value().getStringView());
-          } else {
-            // Merge duplicate headers.
-            (*mutable_headers)[key].append(",").append(std::string(e.value().getStringView()));
-          }
-        }
-      } else {
+      if (request_header_matchers == nullptr || request_header_matchers->matches(key)) {
         if (mutable_headers->find(key) == mutable_headers->end()) {
           (*mutable_headers)[key] = std::string(e.value().getStringView());
         } else {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -110,8 +110,8 @@ public:
                              bool include_peer_certificate,
                              const Protobuf::Map<std::string, std::string>& destination_labels);
 
-  static MatcherSharedPtr
-  toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
+  static MatcherSharedPtr toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
+                                            bool add_http_headers);
   static std::vector<Matchers::StringMatcherPtr>
   createStringMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
 

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -19,6 +19,7 @@
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/common/common/logger.h"
 #include "source/common/http/async_client_impl.h"
 #include "source/common/singleton/const_singleton.h"
 
@@ -27,6 +28,44 @@ namespace Extensions {
 namespace Filters {
 namespace Common {
 namespace ExtAuthz {
+
+class Matcher;
+using MatcherSharedPtr = std::shared_ptr<Matcher>;
+
+/**
+ *  Matchers describe the rules for matching authorization request and response headers.
+ */
+class Matcher {
+public:
+  virtual ~Matcher() = default;
+
+  /**
+   * Returns whether or not the header key matches the rules of the matcher.
+   *
+   * @param key supplies the header key to be evaluated.
+   */
+  virtual bool matches(absl::string_view key) const PURE;
+};
+
+class HeaderKeyMatcher : public Matcher {
+public:
+  HeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list);
+
+  bool matches(absl::string_view key) const override;
+
+private:
+  const std::vector<Matchers::StringMatcherPtr> matchers_;
+};
+
+class NotHeaderKeyMatcher : public Matcher {
+public:
+  NotHeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list);
+
+  bool matches(absl::string_view key) const override;
+
+private:
+  const HeaderKeyMatcher matcher_;
+};
 
 /**
  * For creating ext_authz.proto (authorization) request.
@@ -56,7 +95,8 @@ public:
                               envoy::service::auth::v3::CheckRequest& request,
                               uint64_t max_request_bytes, bool pack_as_bytes,
                               bool include_peer_certificate,
-                              const Protobuf::Map<std::string, std::string>& destination_labels);
+                              const Protobuf::Map<std::string, std::string>& destination_labels,
+                              const MatcherSharedPtr& request_header_matchers);
 
   /**
    * createTcpCheck is used to extract the attributes from the network layer and fill them up
@@ -70,6 +110,11 @@ public:
                              bool include_peer_certificate,
                              const Protobuf::Map<std::string, std::string>& destination_labels);
 
+  static MatcherSharedPtr
+  toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
+  static std::vector<Matchers::StringMatcherPtr>
+  createStringMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
+
 private:
   static void setAttrContextPeer(envoy::service::auth::v3::AttributeContext::Peer& peer,
                                  const Network::Connection& connection, const std::string& service,
@@ -80,13 +125,15 @@ private:
                              const uint64_t stream_id, const StreamInfo::StreamInfo& stream_info,
                              const Buffer::Instance* decoding_buffer,
                              const Envoy::Http::RequestHeaderMap& headers,
-                             uint64_t max_request_bytes, bool pack_as_bytes);
+                             uint64_t max_request_bytes, bool pack_as_byte,
+                             const MatcherSharedPtr& request_header_matchers);
   static void setAttrContextRequest(envoy::service::auth::v3::AttributeContext::Request& req,
                                     const uint64_t stream_id,
                                     const StreamInfo::StreamInfo& stream_info,
                                     const Buffer::Instance* decoding_buffer,
                                     const Envoy::Http::RequestHeaderMap& headers,
-                                    uint64_t max_request_bytes, bool pack_as_bytes);
+                                    uint64_t max_request_bytes, bool pack_as_bytes,
+                                    const MatcherSharedPtr& request_header_matchers);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);
 };

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -14,6 +14,7 @@
 
 #include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
+#include "check_request_utils.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -98,17 +99,6 @@ struct SuccessResponse {
   ResponsePtr response_;
 };
 
-std::vector<Matchers::StringMatcherPtr>
-createStringMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  std::vector<Matchers::StringMatcherPtr> matchers;
-  for (const auto& matcher : list.patterns()) {
-    matchers.push_back(
-        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
-            matcher));
-  }
-  return matchers;
-}
-
 } // namespace
 
 // Matchers
@@ -128,9 +118,7 @@ bool NotHeaderKeyMatcher::matches(absl::string_view key) const { return !matcher
 // Config
 ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& config,
                            uint32_t timeout, absl::string_view path_prefix)
-    : request_header_matchers_(
-          toRequestMatchers(config.http_service().authorization_request().allowed_headers())),
-      client_header_matchers_(toClientMatchers(
+    : client_header_matchers_(toClientMatchers(
           config.http_service().authorization_response().allowed_client_headers())),
       client_header_on_success_matchers_(toClientMatchersOnSuccess(
           config.http_service().authorization_response().allowed_client_headers_on_success())),
@@ -144,42 +132,39 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
       path_prefix_(path_prefix),
       tracing_name_(fmt::format("async {} egress", config.http_service().server_uri().cluster())),
       request_headers_parser_(Router::HeaderParser::configure(
+<<<<<<< HEAD
           config.http_service().authorization_request().headers_to_add(),
           envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD)) {}
+=======
+          config.http_service().authorization_request().headers_to_add(), false)) {
+>>>>>>> f6fddbff01 (Add support for allowlisting request headers sent in check)
 
-MatcherSharedPtr
-ClientConfig::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  const std::vector<Http::LowerCaseString> keys{
-      {Http::CustomHeaders::get().Authorization, Http::Headers::get().Method,
-       Http::Headers::get().Path, Http::Headers::get().Host}};
-
-  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
-  for (const auto& key : keys) {
-    envoy::type::matcher::v3::StringMatcher matcher;
-    matcher.set_exact(key.get());
-    matchers.push_back(
-        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
-            matcher));
+  if (config.has_allowed_headers() &&
+      config.http_service().authorization_request().has_allowed_headers()) {
+    throw EnvoyException("Invalid duplicate configuration for allowed_headers.");
   }
 
-  return std::make_shared<HeaderKeyMatcher>(std::move(matchers));
+  if (config.http_service().authorization_request().has_allowed_headers()) {
+    request_header_matchers_ = CheckRequestUtils::toRequestMatchers(
+        config.http_service().authorization_request().allowed_headers());
+  }
 }
 
 MatcherSharedPtr
 ClientConfig::toClientMatchersOnSuccess(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
+  std::vector<Matchers::StringMatcherPtr> matchers(CheckRequestUtils::createStringMatchers(list));
   return std::make_shared<HeaderKeyMatcher>(std::move(matchers));
 }
 
 MatcherSharedPtr
 ClientConfig::toDynamicMetadataMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
+  std::vector<Matchers::StringMatcherPtr> matchers(CheckRequestUtils::createStringMatchers(list));
   return std::make_shared<HeaderKeyMatcher>(std::move(matchers));
 }
 
 MatcherSharedPtr
 ClientConfig::toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
+  std::vector<Matchers::StringMatcherPtr> matchers(CheckRequestUtils::createStringMatchers(list));
 
   // If list is empty, all authorization response headers, except Host, should be added to
   // the client response.
@@ -212,7 +197,7 @@ ClientConfig::toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher
 
 MatcherSharedPtr
 ClientConfig::toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
-  return std::make_unique<HeaderKeyMatcher>(createStringMatchers(list));
+  return std::make_unique<HeaderKeyMatcher>(CheckRequestUtils::createStringMatchers(list));
 }
 
 RawHttpClientImpl::RawHttpClientImpl(Upstream::ClusterManager& cm, ClientConfigSharedPtr config)
@@ -245,17 +230,30 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
 
   for (const auto& header : request.attributes().request().http().headers()) {
     const Http::LowerCaseString key{header.first};
+
     // Skip setting content-length header since it is already configured at initialization.
     if (key == Http::Headers::get().ContentLength) {
       continue;
     }
 
-    if (config_->requestHeaderMatchers()->matches(key.get())) {
-      if (key == Http::Headers::get().Path && !config_->pathPrefix().empty()) {
+    // path header: override in case a specific path prefix has been configured
+    if (key == Http::Headers::get().Path) {
+      if (!config_->pathPrefix().empty()) {
         headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
       } else {
         headers->addCopy(key, header.second);
       }
+      continue;
+    }
+
+    // for all other headers: check whether it's allowed or not
+    if (config_->requestHeaderMatchers() != nullptr) {
+      if (config_->requestHeaderMatchers()->matches(key.get())) {
+        headers->addCopy(key, header.second);
+      }
+    } else {
+      // header is allowed
+      headers->addCopy(key, header.second);
     }
   }
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -132,12 +132,8 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
       path_prefix_(path_prefix),
       tracing_name_(fmt::format("async {} egress", config.http_service().server_uri().cluster())),
       request_headers_parser_(Router::HeaderParser::configure(
-<<<<<<< HEAD
           config.http_service().authorization_request().headers_to_add(),
-          envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD)) {}
-=======
-          config.http_service().authorization_request().headers_to_add(), false)) {
->>>>>>> f6fddbff01 (Add support for allowlisting request headers sent in check)
+          envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD)) {
 
   if (config.has_allowed_headers() &&
       config.http_service().authorization_request().has_allowed_headers()) {

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -207,17 +207,11 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
       continue;
     }
 
-    // path header: override in case a specific path prefix has been configured
-    if (key == Http::Headers::get().Path) {
-      if (!config_->pathPrefix().empty()) {
-        headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
-      } else {
-        headers->addCopy(key, header.second);
-      }
-      continue;
+    if (key == Http::Headers::get().Path && !config_->pathPrefix().empty()) {
+      headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
+    } else {
+      headers->addCopy(key, header.second);
     }
-
-    headers->addCopy(key, header.second);
   }
 
   config_->requestHeaderParser().evaluateHeaders(*headers, stream_info);

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -119,18 +119,7 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
       tracing_name_(fmt::format("async {} egress", config.http_service().server_uri().cluster())),
       request_headers_parser_(Router::HeaderParser::configure(
           config.http_service().authorization_request().headers_to_add(),
-          envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD)) {
-
-  if (config.has_allowed_headers() &&
-      config.http_service().authorization_request().has_allowed_headers()) {
-    throw EnvoyException("Invalid duplicate configuration for allowed_headers.");
-  }
-
-  if (config.http_service().authorization_request().has_allowed_headers()) {
-    request_header_matchers_ = CheckRequestUtils::toRequestMatchers(
-        config.http_service().authorization_request().allowed_headers());
-  }
-}
+          envoy::config::core::v3::HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD)) {}
 
 MatcherSharedPtr
 ClientConfig::toClientMatchersOnSuccess(const envoy::type::matcher::v3::ListStringMatcher& list) {
@@ -228,15 +217,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
       continue;
     }
 
-    // for all other headers: check whether it's allowed or not
-    if (config_->requestHeaderMatchers() != nullptr) {
-      if (config_->requestHeaderMatchers()->matches(key.get())) {
-        headers->addCopy(key, header.second);
-      }
-    } else {
-      // header is allowed
-      headers->addCopy(key, header.second);
-    }
+    headers->addCopy(key, header.second);
   }
 
   config_->requestHeaderParser().evaluateHeaders(*headers, stream_info);

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -101,20 +101,6 @@ struct SuccessResponse {
 
 } // namespace
 
-// Matchers
-HeaderKeyMatcher::HeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list)
-    : matchers_(std::move(list)) {}
-
-bool HeaderKeyMatcher::matches(absl::string_view key) const {
-  return std::any_of(matchers_.begin(), matchers_.end(),
-                     [&key](auto& matcher) { return matcher->match(key); });
-}
-
-NotHeaderKeyMatcher::NotHeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list)
-    : matcher_(std::move(list)) {}
-
-bool NotHeaderKeyMatcher::matches(absl::string_view key) const { return !matcher_.matches(key); }
-
 // Config
 ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& config,
                            uint32_t timeout, absl::string_view path_prefix)

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -95,7 +95,7 @@ private:
   static MatcherSharedPtr
   toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
 
-  MatcherSharedPtr request_header_matchers_;
+  const MatcherSharedPtr request_header_matchers_;
   const MatcherSharedPtr client_header_matchers_;
   const MatcherSharedPtr client_header_on_success_matchers_;
   const MatcherSharedPtr to_dynamic_metadata_matchers_;

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -43,12 +43,6 @@ public:
   const std::chrono::milliseconds& timeout() const { return timeout_; }
 
   /**
-   * Returns a list of matchers used for selecting the request headers that should be sent to the
-   * authorization server.
-   */
-  const MatcherSharedPtr& requestHeaderMatchers() const { return request_header_matchers_; }
-
-  /**
    * Returns a list of matchers used for selecting the authorization response headers that
    * should be send back to the client.
    */

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -10,6 +10,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/common/matchers.h"
 #include "source/common/router/header_parser.h"
+#include "source/extensions/filters/common/ext_authz/check_request_utils.h"
 #include "source/extensions/filters/common/ext_authz/ext_authz.h"
 
 namespace Envoy {
@@ -17,44 +18,6 @@ namespace Extensions {
 namespace Filters {
 namespace Common {
 namespace ExtAuthz {
-
-class Matcher;
-using MatcherSharedPtr = std::shared_ptr<Matcher>;
-
-/**
- *  Matchers describe the rules for matching authorization request and response headers.
- */
-class Matcher {
-public:
-  virtual ~Matcher() = default;
-
-  /**
-   * Returns whether or not the header key matches the rules of the matcher.
-   *
-   * @param key supplies the header key to be evaluated.
-   */
-  virtual bool matches(absl::string_view key) const PURE;
-};
-
-class HeaderKeyMatcher : public Matcher {
-public:
-  HeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list);
-
-  bool matches(absl::string_view key) const override;
-
-private:
-  const std::vector<Matchers::StringMatcherPtr> matchers_;
-};
-
-class NotHeaderKeyMatcher : public Matcher {
-public:
-  NotHeaderKeyMatcher(std::vector<Matchers::StringMatcherPtr>&& list);
-
-  bool matches(absl::string_view key) const override;
-
-private:
-  const HeaderKeyMatcher matcher_;
-};
 
 /**
  * HTTP client configuration for the HTTP authorization (ext_authz) filter.
@@ -130,8 +93,6 @@ public:
   const Router::HeaderParser& requestHeaderParser() const { return *request_headers_parser_; }
 
 private:
-  static MatcherSharedPtr
-  toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
   static MatcherSharedPtr toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
   static MatcherSharedPtr
   toClientMatchersOnSuccess(const envoy::type::matcher::v3::ListStringMatcher& list);
@@ -140,7 +101,7 @@ private:
   static MatcherSharedPtr
   toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& list);
 
-  const MatcherSharedPtr request_header_matchers_;
+  MatcherSharedPtr request_header_matchers_;
   const MatcherSharedPtr client_header_matchers_;
   const MatcherSharedPtr client_header_on_success_matchers_;
   const MatcherSharedPtr to_dynamic_metadata_matchers_;

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -68,7 +68,8 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   Filters::Common::ExtAuthz::CheckRequestUtils::createHttpCheck(
       decoder_callbacks_, headers, std::move(context_extensions), std::move(metadata_context),
       check_request_, config_->maxRequestBytes(), config_->packAsBytes(),
-      config_->includePeerCertificate(), config_->destinationLabels());
+      config_->includePeerCertificate(), config_->destinationLabels(),
+      config_->requestHeaderMatchers());
 
   ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server", *decoder_callbacks_);
   // Store start time of ext_authz filter call

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -16,6 +16,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/matchers.h"
+#include "source/common/common/utility.h"
 #include "source/common/http/codes.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/runtime/runtime_protos.h"
@@ -98,7 +99,7 @@ public:
 
     if (config.has_allowed_headers() &&
         config.http_service().authorization_request().has_allowed_headers()) {
-      throw EnvoyException("Invalid duplicate configuration for allowed_headers.");
+      ExceptionUtil::throwEnvoyException("Invalid duplicate configuration for allowed_headers.");
     }
 
     if (config.has_grpc_service() && config.has_allowed_headers()) {

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -102,6 +102,11 @@ public:
       ExceptionUtil::throwEnvoyException("Invalid duplicate configuration for allowed_headers.");
     }
 
+    // An unset request_headers_matchers_ means that all client request headers are allowed through
+    // to the authz server; this is to preserve backwards compatibility when introducing
+    // allowlisting of request headers for gRPC authz servers. Pre-existing support is for
+    // HTTP authz servers only and defaults to blocking all but a few headers (i.e. Authorization,
+    // Method, Path and Host).
     if (config.has_grpc_service() && config.has_allowed_headers()) {
       request_header_matchers_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
           config.allowed_headers(), false);

--- a/test/extensions/filters/common/ext_authz/BUILD
+++ b/test/extensions/filters/common/ext_authz/BUILD
@@ -22,6 +22,7 @@ envoy_cc_test(
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/ext_authz/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/auth/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -106,7 +106,7 @@ public:
     ext_autz_proto_.mutable_allowed_headers()->add_patterns()->set_exact("foo");
     ext_autz_proto_.mutable_allowed_headers()->add_patterns()->set_exact("hello");
     ext_autz_proto_.mutable_allowed_headers()->add_patterns()->set_exact("duplicate");
-    return CheckRequestUtils::toRequestMatchers(ext_autz_proto_.allowed_headers());
+    return CheckRequestUtils::toRequestMatchers(ext_autz_proto_.allowed_headers(), false);
   }
 
   Network::Address::InstanceConstSharedPtr addr_;
@@ -193,7 +193,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttp) {
 }
 
 // Verify that check request merges the duplicate headers.
-TEST_F(CheckRequestUtilsTest, BasicHttpWithLegacyAllowlistedHeaders) {
+TEST_F(CheckRequestUtilsTest, BasicHttpWithDuplicateHeaders) {
   const uint64_t size = 0;
   envoy::service::auth::v3::CheckRequest request_;
 
@@ -222,7 +222,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithLegacyAllowlistedHeaders) {
 
 // Verify that check request only contains allowlisted headers,
 // and that duplicate headers are merged.
-TEST_F(CheckRequestUtilsTest, BasicHttpWithAllowlistedHeaders) {
+TEST_F(CheckRequestUtilsTest, BasicHttpWithRequestHeaderMatchers) {
   const uint64_t size = 0;
   envoy::service::auth::v3::CheckRequest request_;
 

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -54,15 +54,6 @@ public:
             timeout: 0.25s
 
           authorization_request:
-            allowed_headers:
-              patterns:
-              - exact: Baz
-                ignore_case: true
-              - prefix: "X-"
-                ignore_case: true
-              - safe_regex:
-                  google_re2: {}
-                  regex: regex-foo.?
             headers_to_add:
             - key: "x-authz-header1"
               value: "value"
@@ -191,18 +182,8 @@ public:
 // Test HTTP client config default values.
 TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
   const Http::LowerCaseString foo{"foo"};
-  const Http::LowerCaseString baz{"baz"};
   const Http::LowerCaseString bar{"bar"};
   const Http::LowerCaseString alice{"alice"};
-
-  // Check allowed request headers.
-  EXPECT_TRUE(config_->requestHeaderMatchers() != nullptr);
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Method.get()));
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Host.get()));
-  EXPECT_TRUE(
-      config_->requestHeaderMatchers()->matches(Http::CustomHeaders::get().Authorization.get()));
-  EXPECT_FALSE(config_->requestHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(baz.get()));
 
   // Check allowed client headers.
   EXPECT_TRUE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Status.get()));
@@ -248,61 +229,6 @@ TEST_F(ExtAuthzHttpClientTest, TestDefaultAllowedClientAndUpstreamHeaders) {
       config_->upstreamHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
 }
 
-TEST_F(ExtAuthzHttpClientTest, NoRequestHeaderMatchersByDefault) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-  failure_mode_allow: true
-  )EOF";
-
-  initialize(yaml);
-  EXPECT_TRUE(config_->requestHeaderMatchers() == nullptr);
-}
-
-TEST_F(ExtAuthzHttpClientTest, NoRequestHeaderMatchersForNewAllowedHeadersConfig) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-  allowed_headers:
-    patterns:
-    - exact: Foo
-      ignore_case: true
-  failure_mode_allow: true
-  )EOF";
-
-  initialize(yaml);
-
-  EXPECT_TRUE(config_->requestHeaderMatchers() == nullptr);
-}
-
-TEST_F(ExtAuthzHttpClientTest, DuplicateAllowedHeadersConfigIsInvalid) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-    authorization_request:
-      allowed_headers:
-        patterns:
-        - exact: Foo
-          ignore_case: true
-  allowed_headers:
-    patterns:
-    - exact: Bar
-      ignore_case: true
-  failure_mode_allow: true
-  )EOF";
-
-  EXPECT_THROW(initialize(yaml), EnvoyException);
-}
-
 // Verify client response when the authorization server returns a 200 OK and path_prefix is
 // configured.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithPathRewrite) {
@@ -337,8 +263,6 @@ TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZeroWithAllowedHeaders) {
   )EOF";
 
   initialize(yaml);
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Method.get()));
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
 
   Http::RequestMessagePtr message_ptr =
       sendRequest({{Http::Headers::get().ContentLength.get(), std::string{"47"}},
@@ -346,35 +270,6 @@ TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZeroWithAllowedHeaders) {
 
   EXPECT_EQ(message_ptr->headers().getContentLengthValue(), "0");
   EXPECT_EQ(message_ptr->headers().getMethodValue(), "POST");
-}
-
-// Test the client when a request contains headers in the prefix matchers.
-TEST_F(ExtAuthzHttpClientTest, AllowedRequestHeadersPrefix) {
-  const Http::LowerCaseString regexFood{"regex-food"};
-  const Http::LowerCaseString regexFool{"regex-fool"};
-  Http::RequestMessagePtr message_ptr =
-      sendRequest({{Http::Headers::get().XContentTypeOptions.get(), "foobar"},
-                   {Http::Headers::get().XSquashDebug.get(), "foo"},
-                   {Http::Headers::get().ContentType.get(), "bar"},
-                   {regexFood.get(), "food"},
-                   {regexFool.get(), "fool"}});
-
-  EXPECT_TRUE(message_ptr->headers().get(Http::Headers::get().ContentType).empty());
-  const auto x_squash = message_ptr->headers().get(Http::Headers::get().XSquashDebug);
-  ASSERT_FALSE(x_squash.empty());
-  EXPECT_EQ(x_squash[0]->value().getStringView(), "foo");
-
-  const auto x_content_type = message_ptr->headers().get(Http::Headers::get().XContentTypeOptions);
-  ASSERT_FALSE(x_content_type.empty());
-  EXPECT_EQ(x_content_type[0]->value().getStringView(), "foobar");
-
-  const auto food = message_ptr->headers().get(regexFood);
-  ASSERT_FALSE(food.empty());
-  EXPECT_EQ(food[0]->value().getStringView(), "food");
-
-  const auto fool = message_ptr->headers().get(regexFool);
-  ASSERT_FALSE(fool.empty());
-  EXPECT_EQ(fool[0]->value().getStringView(), "fool");
 }
 
 // Verify client response when authorization server returns a 200 OK.

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -116,17 +116,16 @@ TEST_F(ExtAuthzFilterHttpTest, ExtAuthzFilterFactoryTestHttp) {
   const std::string ext_authz_config_yaml = R"EOF(
   stat_prefix: "wall"
   transport_api_version: V3
+  allowed_headers:
+      patterns:
+      - exact: baz
+      - prefix: x-
   http_service:
     server_uri:
       uri: "ext_authz:9000"
       cluster: "ext_authz"
       timeout: 0.25s
-
     authorization_request:
-      allowed_headers:
-        patterns:
-        - exact: baz
-        - prefix: x-
       headers_to_add:
       - key: foo
         value: bar

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -812,7 +812,8 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ExtAuthzHttpIntegrationTest,
 
 // Verifies that by default HTTP service uses the case-sensitive string matcher
 // (uses legacy config for allowed_headers).
-TEST_P(ExtAuthzHttpIntegrationTest, LegacyDefaultCaseSensitiveStringMatcher) {
+TEST_P(ExtAuthzHttpIntegrationTest,
+       DEPRECATED_FEATURE_TEST(LegacyDefaultCaseSensitiveStringMatcher)) {
   setup();
   const auto header_entry = ext_authz_request_->headers().get(case_sensitive_header_name_);
   ASSERT_TRUE(header_entry.empty());

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -453,7 +453,7 @@ attributes:
       - prefix: allowed-prefix
       - safe_regex:
           google_re2: {}
-          regex: regex-foo.? 
+          regex: regex-foo.?
 
     with_request_body:
       max_request_bytes: 1024
@@ -660,7 +660,7 @@ public:
         - prefix: allowed-prefix
         - safe_regex:
             google_re2: {}
-            regex: regex-foo.? 
+            regex: regex-foo.?
 
     authorization_response:
       allowed_upstream_headers:
@@ -684,7 +684,7 @@ public:
     - prefix: allowed-prefix
     - safe_regex:
         google_re2: {}
-        regex: regex-foo.? 
+        regex: regex-foo.?
 
   http_service:
     server_uri:

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -549,7 +549,7 @@ public:
   }
 
   void initializeConfig(bool legacy_allowed_headers = true) {
-    config_helper_.addConfigModifier([this, &legacy_allowed_headers](
+    config_helper_.addConfigModifier([this, legacy_allowed_headers](
                                          envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
       ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -452,7 +452,6 @@ attributes:
       - exact: x-duplicate
       - prefix: allowed-prefix
       - safe_regex:
-          google_re2: {}
           regex: regex-foo.?
 
     with_request_body:
@@ -659,7 +658,6 @@ public:
         - exact: x-duplicate
         - prefix: allowed-prefix
         - safe_regex:
-            google_re2: {}
             regex: regex-foo.?
 
     authorization_response:
@@ -683,7 +681,6 @@ public:
     - exact: x-duplicate
     - prefix: allowed-prefix
     - safe_regex:
-        google_re2: {}
         regex: regex-foo.?
 
   http_service:

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -817,7 +817,7 @@ TEST_P(ExtAuthzHttpIntegrationTest,
 }
 
 // (uses legacy config for allowed_headers).
-TEST_P(ExtAuthzHttpIntegrationTest, LegacyDirectReponse) {
+TEST_P(ExtAuthzHttpIntegrationTest, DEPRECATED_FEATURE_TEST(LegacyDirectReponse)) {
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) {
@@ -838,7 +838,7 @@ TEST_P(ExtAuthzHttpIntegrationTest, LegacyDirectReponse) {
 }
 
 // (uses legacy config for allowed_headers).
-TEST_P(ExtAuthzHttpIntegrationTest, LegacyRedirectResponse) {
+TEST_P(ExtAuthzHttpIntegrationTest, DEPRECATED_FEATURE_TEST(LegacyRedirectResponse)) {
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) {

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -711,30 +711,27 @@ TEST_P(ExtAuthzGrpcIntegrationTest, HTTP1DownstreamRequestWithBody) {
   expectCheckRequestWithBody(Http::CodecType::HTTP1, 4);
 }
 
-// // // Verifies that the request body is included in the CheckRequest when the downstream protocol
-// is
-// // // HTTP/1.1 and the size of the request body is larger than max_request_bytes.
+// Verifies that the request body is included in the CheckRequest when the downstream protocol is
+// HTTP/1.1 and the size of the request body is larger than max_request_bytes.
 TEST_P(ExtAuthzGrpcIntegrationTest, HTTP1DownstreamRequestWithLargeBody) {
   expectCheckRequestWithBody(Http::CodecType::HTTP1, 2048);
 }
 
-// // // Verifies that the request body is included in the CheckRequest when the downstream protocol
-// is
-// // // HTTP/2.
+// Verifies that the request body is included in the CheckRequest when the downstream protocol is
+// HTTP/2.
 TEST_P(ExtAuthzGrpcIntegrationTest, HTTP2DownstreamRequestWithBody) {
   expectCheckRequestWithBody(Http::CodecType::HTTP2, 4);
 }
 
-// // // Verifies that the request body is included in the CheckRequest when the downstream protocol
-// is
-// // // HTTP/2 and the size of the request body is larger than max_request_bytes.
+// Verifies that the request body is included in the CheckRequest when the downstream protocol is
+// HTTP/2 and the size of the request body is larger than max_request_bytes.
 TEST_P(ExtAuthzGrpcIntegrationTest, HTTP2DownstreamRequestWithLargeBody) {
   expectCheckRequestWithBody(Http::CodecType::HTTP2, 2048);
 }
 
-// // Verifies that the original request headers will be added and appended when the authorization
-// // server returns headers_to_add, response_headers_to_add, and headers_to_append in OkResponse
-// // message.
+// Verifies that the original request headers will be added and appended when the authorization
+// server returns headers_to_add, response_headers_to_add, and headers_to_append in OkResponse
+// message.
 TEST_P(ExtAuthzGrpcIntegrationTest, SendHeadersToAddAndToAppendToUpstream) {
   expectCheckRequestWithBodyWithHeaders(
       Http::CodecType::HTTP1, 4,

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1830,7 +1830,8 @@ TEST_F(HttpFilterTestParam, RequestHeaderMatchersForHttpServiceWithAllowedHeader
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(foo.get()));
 }
 
-TEST_F(HttpFilterTestParam, RequestHeaderMatchersForHttpServiceWithLegacyAllowedHeaders) {
+TEST_F(HttpFilterTestParam,
+       DEPRECATED_FEATURE_TEST(RequestHeaderMatchersForHttpServiceWithLegacyAllowedHeaders)) {
   const Http::LowerCaseString foo{"foo"};
   initialize(R"EOF(
     transport_api_version: V3
@@ -1855,7 +1856,7 @@ TEST_F(HttpFilterTestParam, RequestHeaderMatchersForHttpServiceWithLegacyAllowed
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(foo.get()));
 }
 
-TEST_F(HttpFilterTestParam, DuplicateAllowedHeadersConfigIsInvalid) {
+TEST_F(HttpFilterTestParam, DEPRECATED_FEATURE_TEST(DuplicateAllowedHeadersConfigIsInvalid)) {
   EXPECT_THROW(initialize(R"EOF(
   http_service:
     server_uri:


### PR DESCRIPTION
Commit Message: add support for allowlisting request headers included in the check request to the authorization server, be it HTTP or gRPC (currently, this is supported for HTTP only). This patch deprecates the current `allowed_headers` config field (on the `authorization_request` message) and introduces a new one on the `ext_authz` message. To note is that the default behaviour (i.e. no config specified) differs based on the type of authorization server (this is to maintain backwards compatibility).

Additional Description: n/a

Risk Level: low

Testing: updated unit and integration tests

Docs Changes: updated API protos

Release Notes: updated release notes

[Optional Fixes #Issue]: https://github.com/envoyproxy/envoy/issues/21535
