### PR TITLE
Disable upstream filters by default

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -33,7 +33,6 @@ RUNTIME_GUARD(envoy_reloadable_features_admin_stats_filter_use_re2);
 RUNTIME_GUARD(envoy_reloadable_features_allow_adding_content_type_in_local_replies);
 RUNTIME_GUARD(envoy_reloadable_features_allow_concurrency_for_alpn_pool);
 RUNTIME_GUARD(envoy_reloadable_features_allow_multiple_dns_addresses);
-RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_filters);
 RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_inline_write);
 RUNTIME_GUARD(envoy_reloadable_features_append_or_truncate);
 RUNTIME_GUARD(envoy_reloadable_features_append_to_accept_content_encoding_only_once);
@@ -94,6 +93,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 // TODO(mattklein123): Also unit test this if this sticks and this becomes the default for Apple &
 // Android.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_always_use_v6);
+// TODO(yanavlasov): disable upstream filters by default
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_filters);
 
 // Block of non-boolean flags. These are deprecated. Do not add more.
 ABSL_FLAG(uint64_t, envoy_headermap_lazy_map_min_size, 3, "");  // NOLINT

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -451,6 +451,7 @@ envoy_cc_test(
         "//source/common/router:router_lib",
         "//test/common/http:common_lib",
         "//test/mocks/router:router_filter_interface",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/common/http/common.h"
 #include "test/mocks/router/router_filter_interface.h"
+#include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -72,6 +73,8 @@ TEST_F(UpstreamRequestTest, TestAccessors) {
 
 // Test sending headers from the router to upstream.
 TEST_F(UpstreamRequestTest, AcceptRouterHeaders) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.allow_upstream_filters", "true"}});
   std::shared_ptr<Http::MockStreamDecoderFilter> filter(
       new NiceMock<Http::MockStreamDecoderFilter>());
 

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -41,6 +41,7 @@ TEST_P(BufferIntegrationTest, RouterRequestAndResponseWithZeroByteBodyBuffer) {
 }
 
 TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_upstream_filters", "true");
   config_helper_.prependFilter(ConfigHelper::defaultBufferFilter(), testing_downstream_filter_);
   initialize();
 
@@ -68,6 +69,7 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
 }
 
 TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLengthOnTrailers) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_upstream_filters", "true");
   config_helper_.prependFilter(ConfigHelper::defaultBufferFilter(), testing_downstream_filter_);
   initialize();
 
@@ -97,6 +99,7 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLengthOnTrailers) {
 }
 
 TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_upstream_filters", "true");
   // Make sure the connection isn't closed during request upload.
   // Without a large drain-close it's possible that the local reply will be sent
   // during request upload, and continued upload will result in TCP reset before

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -21,7 +21,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/network/dns_resolver:90.7"  # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
 "source/common/protobuf:94.8"
 "source/common/quic:91.8"
-"source/common/router:96.3"
+"source/common/router:95.8" # Bump to 96.3 after 22879 is addressed
 "source/common/runtime:96.4"
 "source/common/secret:94.9"
 "source/common/signal:86.9" # Death tests don't report LCOV


### PR DESCRIPTION
Commit Message:
Temporarily disable by default upstream filters introduced in #22553

Risk Level: Low, disabled new feature
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes commit #22553

Signed-off-by: Yan Avlasov <yavlasov@google.com>
