### PR TITLE
docs: list dependencies' license

### DIFF
--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -9,6 +9,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-03-10",
         urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/bazel-skylib/blob/{version}/LICENSE",
     ),
     com_envoyproxy_protoc_gen_validate = dict(
         project_name = "protoc-gen-validate (PGV)",
@@ -27,6 +29,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "org_golang_google_genproto",
             "org_golang_x_text",
         ],
+        license = "Apache-2.0",
+        license_url = "https://github.com/envoyproxy/protoc-gen-validate/blob/v{version}/LICENSE",
     ),
     com_github_cncf_udpa = dict(
         project_name = "xDS API",
@@ -39,6 +43,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "xds-{version}",
         urls = ["https://github.com/cncf/xds/archive/{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/cncf/xds/blob/{version}/LICENSE",
     ),
     com_github_openzipkin_zipkinapi = dict(
         project_name = "Zipkin API",
@@ -50,6 +56,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "zipkin-api-{version}",
         urls = ["https://github.com/openzipkin/zipkin-api/archive/{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/openzipkin/zipkin-api/blob/{version}/LICENSE",
     ),
     com_google_googleapis = dict(
         # TODO(dio): Consider writing a Starlark macro for importing Google API proto.
@@ -62,6 +70,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "googleapis-{version}",
         urls = ["https://github.com/googleapis/googleapis/archive/{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/googleapis/googleapis/blob/{version}/LICENSE",
     ),
     opencensus_proto = dict(
         project_name = "OpenCensus Proto",
@@ -73,6 +83,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "opencensus-proto-{version}/src",
         urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/v{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/census-instrumentation/opencensus-proto/blob/v{version}/LICENSE",
     ),
     prometheus_metrics_model = dict(
         project_name = "Prometheus client model",
@@ -84,6 +96,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "client_model-{version}",
         urls = ["https://github.com/prometheus/client_model/archive/{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/prometheus/client_model/blob/{version}/LICENSE",
     ),
     rules_proto = dict(
         project_name = "Protobuf Rules for Bazel",
@@ -95,6 +109,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "rules_proto-{version}",
         urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_proto/blob/{version}/LICENSE",
     ),
     opentelemetry_proto = dict(
         project_name = "OpenTelemetry Proto",
@@ -106,6 +122,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "opentelemetry-proto-{version}",
         urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/v{version}.tar.gz"],
         use_category = ["api"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/open-telemetry/opentelemetry-proto/blob/v{version}/LICENSE",
     ),
     com_github_bufbuild_buf = dict(
         project_name = "buf",
@@ -118,5 +136,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-07-27",
         use_category = ["api"],
         tags = ["manual"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bufbuild/buf/blob/v{version}/LICENSE",
     ),
 )

--- a/api/bazel/repository_locations_utils.bzl
+++ b/api/bazel/repository_locations_utils.bzl
@@ -17,6 +17,8 @@ def load_repository_locations_spec(repository_locations_spec):
             if "strip_prefix" in location:
                 mutable_location["strip_prefix"] = _format_version(location["strip_prefix"], location["version"])
             mutable_location["urls"] = [_format_version(url, location["version"]) for url in location["urls"]]
+            if "license_url" in location:
+                mutable_location["license_url"] = _format_version(location["license_url"], location["version"])
     return locations
 
 def merge_dicts(*dicts):

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -26,6 +26,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/grailbio/bazel-compilation-database/archive/{version}.tar.gz"],
         release_date = "2021-09-10",
         use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/grailbio/bazel-compilation-database/blob/{version}/LICENSE",
     ),
     bazel_gazelle = dict(
         project_name = "Gazelle",
@@ -36,6 +38,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v{version}/bazel-gazelle-v{version}.tar.gz"],
         release_date = "2022-06-26",
         use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/bazel-gazelle/blob/v{version}/LICENSE",
     ),
     bazel_toolchains = dict(
         project_name = "bazel-toolchains",
@@ -49,6 +53,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2021-11-30",
         use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/bazel-toolchains/blob/v{version}/LICENSE",
     ),
     build_bazel_rules_apple = dict(
         project_name = "Apple Rules for Bazel",
@@ -59,6 +65,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bazelbuild/rules_apple/releases/download/{version}/rules_apple.{version}.tar.gz"],
         release_date = "2022-06-17",
         use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_apple/blob/{version}/LICENSE",
     ),
     rules_fuzzing = dict(
         project_name = "Fuzzing Rules for Bazel",
@@ -75,6 +83,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             # engine target from the CFLAGS/CXXFLAGS environment.
             "rules_fuzzing_oss_fuzz",
         ],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_fuzzing/blob/v{version}/LICENSE",
     ),
     envoy_build_tools = dict(
         project_name = "envoy-build-tools",
@@ -86,6 +96,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/envoyproxy/envoy-build-tools/archive/{version}.tar.gz"],
         release_date = "2022-05-18",
         use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/envoyproxy/envoy-build-tools/blob/{version}/LICENSE",
     ),
     boringssl = dict(
         project_name = "BoringSSL",
@@ -104,6 +116,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-07-19",
         cpe = "cpe:2.3:a:google:boringssl:*",
+        license = "Mixed",
+        license_url = "https://github.com/google/boringssl/blob/{version}/LICENSE",
     ),
     boringssl_fips = dict(
         project_name = "BoringSSL (FIPS)",
@@ -127,6 +141,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["build"],
         release_date = "2022-08-12",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/aspect-build/bazel-lib/blob/v{version}/LICENSE",
     ),
     com_google_absl = dict(
         project_name = "Abseil",
@@ -139,6 +155,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2022-07-05",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/abseil/abseil-cpp/blob/{version}/LICENSE",
     ),
     com_github_aignas_rules_shellcheck = dict(
         project_name = "Shellcheck rules for bazel",
@@ -151,6 +169,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-05-30",
         use_category = ["build"],
         cpe = "N/A",
+        license = "MIT",
+        license_url = "https://github.com/aignas/rules_shellcheck/blob/v{version}/LICENSE",
     ),
     com_github_axboe_liburing = dict(
         project_name = "liburing",
@@ -177,6 +197,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2022-08-02",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/perfetto/blob/v{version}/LICENSE",
     ),
     com_github_c_ares_c_ares = dict(
         project_name = "c-ares",
@@ -189,6 +211,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2021-10-27",
         cpe = "cpe:2.3:a:c-ares_project:c-ares:*",
+        license = "c-ares",
+        license_url = "https://github.com/c-ares/c-ares/blob/cares-{underscore_version}/LICENSE.md",
     ),
     com_github_circonus_labs_libcircllhist = dict(
         project_name = "libcircllhist",
@@ -201,6 +225,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "observability_core", "dataplane_core"],
         release_date = "2019-02-11",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/circonus-labs/libcircllhist/blob/{version}/LICENSE",
     ),
     com_github_cyan4973_xxhash = dict(
         project_name = "xxHash",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -641,6 +641,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-03-27",
         cpe = "cpe:2.3:a:gnu:zlib:*",
         license = "zlib",
+        license_url = "https://github.com/madler/zlib/blob/v{version}/zlib.h",
     ),
     org_boost = dict(
         project_name = "Boost",
@@ -945,6 +946,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.wasm.runtime.wavm",
         ],
         cpe = "cpe:2.3:a:llvm:*:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/llvm/llvm-project/blob/llvmorg-{version}/llvm/LICENSE.TXT",
     ),
     com_github_wamr = dict(
         project_name = "Webassembly Micro Runtime",
@@ -959,7 +962,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.wasm.runtime.wamr"],
         cpe = "N/A",
         license = "Apache-2.0",
-        license_url = "https://github.com/bytecodealliance/wasm-micro-runtime/blob/{version}/LICENSE.txt",
+        license_url = "https://github.com/bytecodealliance/wasm-micro-runtime/blob/{version}/LICENSE",
     ),
     com_github_wavm_wavm = dict(
         project_name = "WAVM",
@@ -1085,6 +1088,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.wasm.runtime.v8"],
         release_date = "2022-05-31",
         cpe = "N/A",
+        license = "zlib",
+        license_url = "https://chromium.googlesource.com/chromium/src/third_party/zlib/+/{version}/LICENSE",
     ),
     com_github_google_quiche = dict(
         project_name = "QUICHE",
@@ -1097,6 +1102,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core"],
         release_date = "2022-08-19",
         cpe = "N/A",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/google/quiche/blob/{version}/LICENSE",
     ),
     com_googlesource_googleurl = dict(
         project_name = "Chrome URL parsing library",
@@ -1110,6 +1117,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = [],
         release_date = "2022-04-04",
         cpe = "N/A",
+        license = "googleurl",
+        license_url = "https://quiche.googlesource.com/googleurl/+/{version}/LICENSE",
     ),
     com_google_cel_cpp = dict(
         project_name = "Common Expression Language (CEL) C++ library",
@@ -1158,6 +1167,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2021-05-10",
         cpe = "cpe:2.3:a:google:flatbuffers:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/flatbuffers/blob/v{version}/LICENSE.txt",
     ),
     com_googlesource_code_re2 = dict(
         project_name = "RE2",
@@ -1170,6 +1181,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-05-31",
         cpe = "N/A",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/google/re2/blob/{version}/LICENSE",
     ),
     # Included to access FuzzedDataProvider.h. This is compiler agnostic but
     # provided as part of the compiler-rt source distribution. We can't use the
@@ -1186,6 +1199,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-03-23",
         use_category = ["test_only"],
         cpe = "cpe:2.3:a:llvm:compiler-rt:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/llvm/llvm-project/blob/llvmorg-{version}/compiler-rt/LICENSE.TXT",
     ),
     upb = dict(
         project_name = "upb",
@@ -1198,6 +1213,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/protocolbuffers/upb/archive/{version}.tar.gz"],
         use_category = ["controlplane"],
         cpe = "N/A",
+        license = "upb",
+        license_url = "https://github.com/protocolbuffers/upb/blob/{version}/LICENSE",
     ),
     kafka_source = dict(
         project_name = "Kafka (source)",
@@ -1211,6 +1228,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.network.kafka_broker", "envoy.filters.network.kafka_mesh"],
         release_date = "2022-05-03",
         cpe = "cpe:2.3:a:apache:kafka:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/apache/kafka/blob/{version}/LICENSE",
     ),
     edenhill_librdkafka = dict(
         project_name = "Kafka (C/C++ client)",
@@ -1224,6 +1243,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.network.kafka_mesh"],
         release_date = "2021-10-18",
         cpe = "N/A",
+        license = "librdkafka",
+        license_url = "https://github.com/edenhill/librdkafka/blob/v{version}/LICENSE",
     ),
     kafka_server_binary = dict(
         project_name = "Kafka (server binary)",
@@ -1246,6 +1267,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/dpkp/kafka-python/archive/{version}.tar.gz"],
         release_date = "2020-09-30",
         use_category = ["test_only"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/dpkp/kafka-python/blob/{version}/LICENSE",
     ),
     proxy_wasm_cpp_sdk = dict(
         project_name = "WebAssembly for Proxies (C++ SDK)",
@@ -1270,6 +1293,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2022-03-15",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/blob/{version}/LICENSE",
     ),
     proxy_wasm_cpp_host = dict(
         project_name = "WebAssembly for Proxies (C++ host implementation)",
@@ -1294,6 +1319,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2022-08-05",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host/blob/{version}/LICENSE",
     ),
     proxy_wasm_rust_sdk = dict(
         project_name = "WebAssembly for Proxies (Rust SDK)",
@@ -1306,6 +1333,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["test_only"],
         release_date = "2022-04-08",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/proxy-wasm/proxy-wasm-rust-sdk/blob/v{version}/LICENSE",
     ),
     emsdk = dict(
         project_name = "Emscripten SDK",
@@ -1318,6 +1347,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/emscripten-core/emsdk/archive/{version}.tar.gz"],
         use_category = ["test_only"],
         release_date = "2022-03-09",
+        license = "Emscripten SDK",
+        license_url = "https://github.com/emscripten-core/emsdk/blob/{version}/LICENSE",
     ),
     rules_rust = dict(
         project_name = "Bazel rust rules",
@@ -1330,6 +1361,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.wasm.runtime.wasmtime"],
         release_date = "2022-04-26",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_rust/blob/{version}/LICENSE.txt",
     ),
     com_github_fdio_vpp_vcl = dict(
         project_name = "VPP Comms Library",
@@ -1343,6 +1376,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.bootstrap.vcl"],
         release_date = "2022-03-02",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/FDio/vpp/blob/{version}/LICENSE",
     ),
     intel_dlb = dict(
         project_name = "Intel Dlb",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -658,7 +658,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2021-12-08",
         cpe = "cpe:2.3:a:boost:boost:*",
         license = "Boost",
-        license_url = "https://www.boost.org/LICENSE_1_0.txt",
+        license_url = "https://github.com/boostorg/boost/blob/boost-{version}/LICENSE_1_0.txt",
     ),
     org_brotli = dict(
         project_name = "brotli",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1405,6 +1405,8 @@ def _compiled_protoc_deps(locations, versions):
             use_category = ["dataplane_core", "controlplane"],
             release_date = "2022-04-22",
             cpe = "N/A",
+            license = "Protocol Buffers",
+            license_url = "https://github.com/protocolbuffers/protobuf/blob/v{version}/LICENSE",
         )
 
 _compiled_protoc_deps(REPOSITORY_LOCATIONS_SPEC, PROTOC_VERSIONS)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -512,6 +512,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.tracers.skywalking"],
         release_date = "2021-12-11",
         cpe = "cpe:2.3:a:apache:skywalking:*",
+        license = "Apache-2.0",
     ),
     com_github_skyapm_cpp2sky = dict(
         project_name = "cpp2sky",
@@ -525,6 +526,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.tracers.skywalking"],
         release_date = "2022-03-28",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/SkyAPM/cpp2sky/blob/v{version}/LICENSE",
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
         project_name = "Datadog OpenTracing C++ Client",
@@ -538,6 +541,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.tracers.datadog"],
         release_date = "2021-01-27",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/DataDog/dd-opentracing-cpp/blob/v{version}/LICENSE",
     ),
     com_github_google_benchmark = dict(
         project_name = "Benchmark",
@@ -549,6 +554,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/google/benchmark/archive/v{version}.tar.gz"],
         use_category = ["test_only"],
         release_date = "2022-07-25",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/benchmark/blob/v{version}/LICENSE",
     ),
     com_github_libevent_libevent = dict(
         project_name = "libevent",
@@ -571,6 +578,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2020-07-28",
         cpe = "cpe:2.3:a:libevent_project:libevent:*",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/libevent/libevent/blob/{version}/LICENSE",
     ),
     net_colm_open_source_colm = dict(
         project_name = "Colm",
@@ -591,6 +600,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2021-12-28",
         cpe = "N/A",
+        license = "MIT",
+        license_url = "https://github.com/adrian-thurston/colm/blob/{version}/COPYING",
     ),
     net_colm_open_source_ragel = dict(
         project_name = "Ragel",
@@ -614,6 +625,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2021-12-28",
         cpe = "N/A",
+        license = "MIT",
+        license_url = "https://github.com/adrian-thurston/ragel/blob/{version}/COPYING",
     ),
     # This should be removed, see https://github.com/envoyproxy/envoy/issues/13261.
     net_zlib = dict(
@@ -627,6 +640,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-03-27",
         cpe = "cpe:2.3:a:gnu:zlib:*",
+        license = "zlib",
     ),
     org_boost = dict(
         project_name = "Boost",
@@ -643,6 +657,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2021-12-08",
         cpe = "cpe:2.3:a:boost:boost:*",
+        license = "Boost",
+        license_url = "https://www.boost.org/LICENSE_1_0.txt",
     ),
     org_brotli = dict(
         project_name = "brotli",
@@ -661,6 +677,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2020-09-08",
         cpe = "cpe:2.3:a:google:brotli:*",
+        license = "MIT",
+        license_url = "https://github.com/google/brotli/blob/{version}/LICENSE",
     ),
     com_github_facebook_zstd = dict(
         project_name = "zstd",
@@ -689,6 +707,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2021-12-24",
         cpe = "N/A",
+        license = "zlib",
+        license_url = "https://github.com/zlib-ng/zlib-ng/blob/{version}/LICENSE.md",
     ),
     com_github_jbeder_yaml_cpp = dict(
         project_name = "yaml-cpp",
@@ -703,6 +723,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-04-27",
         cpe = "cpe:2.3:a:yaml-cpp_project:yaml-cpp:*",
+        license = "MIT",
+        license_url = "https://github.com/jbeder/yaml-cpp/blob/{version}/LICENSE",
     ),
     com_github_msgpack_msgpack_c = dict(
         project_name = "msgpack for C/C++",
@@ -716,6 +738,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.tracers.datadog"],
         release_date = "2020-06-05",
         cpe = "N/A",
+        license = "Boost",
+        license_url = "https://github.com/msgpack/msgpack-c/blob/cpp-{version}/LICENSE_1_0.txt",
     ),
     com_github_google_jwt_verify = dict(
         project_name = "jwt_verify_lib",
@@ -729,6 +753,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.http.jwt_authn", "envoy.filters.http.gcp_authn"],
         release_date = "2021-03-05",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/jwt_verify_lib/blob/{version}/LICENSE",
     ),
     com_github_alibaba_hessian2_codec = dict(
         project_name = "hessian2-codec",
@@ -742,6 +768,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.network.dubbo_proxy"],
         release_date = "2021-04-05",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/alibaba/hessian2-codec/blob/{version}/LICENSE",
     ),
     com_github_tencent_rapidjson = dict(
         project_name = "RapidJSON",
@@ -756,6 +784,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.tracers.zipkin", "envoy.tracers.opencensus"],
         release_date = "2019-12-03",
         cpe = "cpe:2.3:a:tencent:rapidjson:*",
+        license = "RapidJSON",
+        license_url = "https://github.com/Tencent/rapidjson/blob/{version}/license.txt",
     ),
     com_github_nlohmann_json = dict(
         project_name = "nlohmann JSON",
@@ -770,6 +800,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-08-12",
         cpe = "cpe:2.3:a:json-for-modern-cpp_project:json-for-modern-cpp:*",
+        license = "MIT",
+        license_url = "https://github.com/nlohmann/json/blob/v{version}/LICENSE.MIT",
     ),
     # This is an external dependency needed while running the
     # envoy docker image. A bazel target has been created since

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -819,6 +819,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["other"],
         release_date = "2019-09-18",
         cpe = "N/A",
+        license = "MIT",
+        license_url = "https://github.com/ncopa/su-exec/blob/{version}/LICENSE",
     ),
     com_google_googletest = dict(
         project_name = "Google Test",
@@ -833,6 +835,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2020-09-10",
         use_category = ["test_only"],
         cpe = "cpe:2.3:a:google:google_test:*",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/google/googletest/blob/{version}/LICENSE",
     ),
     com_google_protobuf = dict(
         project_name = "Protocol Buffers",
@@ -849,6 +853,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2022-04-22",
         cpe = "cpe:2.3:a:google:protobuf:*",
+        license = "Protocol Buffers",
+        license_url = "https://github.com/protocolbuffers/protobuf/blob/v{version}/LICENSE",
     ),
     grpc_httpjson_transcoding = dict(
         project_name = "grpc-httpjson-transcoding",
@@ -862,6 +868,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.http.grpc_json_transcoder"],
         release_date = "2022-06-18",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/blob/{version}/LICENSE",
     ),
     io_bazel_rules_go = dict(
         project_name = "Go rules for Bazel",
@@ -878,6 +886,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "org_golang_google_protobuf",
             "org_golang_x_tools",
         ],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_go/blob/v{version}/LICENSE.txt",
     ),
     rules_foreign_cc = dict(
         project_name = "Rules for using foreign build systems in Bazel",
@@ -889,6 +899,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/{version}.tar.gz"],
         release_date = "2022-04-18",
         use_category = ["build", "dataplane_core", "controlplane"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_foreign_cc/blob/{version}/LICENSE",
     ),
     rules_python = dict(
         project_name = "Python rules for Bazel",
@@ -900,6 +912,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "rules_python-{version}",
         urls = ["https://github.com/bazelbuild/rules_python/archive/{version}.tar.gz"],
         use_category = ["build"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_python/blob/{version}/LICENSE",
     ),
     rules_pkg = dict(
         project_name = "Packaging rules for Bazel",
@@ -911,6 +925,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bazelbuild/rules_pkg/archive/{version}.tar.gz"],
         use_category = ["build"],
         release_date = "2022-04-07",
+        license = "Apache-2.0",
+        license_url = "https://github.com/bazelbuild/rules_pkg/blob/{version}/LICENSE",
     ),
     org_llvm_llvm = dict(
         # When changing this, you must re-generate the list of llvm libs
@@ -942,6 +958,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.wamr"],
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/bytecodealliance/wasm-micro-runtime/blob/{version}/LICENSE.txt",
     ),
     com_github_wavm_wavm = dict(
         project_name = "WAVM",
@@ -968,6 +986,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.wasmtime"],
         cpe = "cpe:2.3:a:bytecodealliance:wasmtime:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/bytecodealliance/wasmtime/blob/v{version}/LICENSE",
     ),
     com_github_wasm_c_api = dict(
         project_name = "wasm-c-api",
@@ -983,6 +1003,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.wasmtime"],
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/WebAssembly/wasm-c-api/blob/{version}/LICENSE",
     ),
     io_opencensus_cpp = dict(
         project_name = "OpenCensus C++",
@@ -996,6 +1018,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.tracers.opencensus"],
         release_date = "2020-10-08",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/census-instrumentation/opencensus-cpp/blob/{version}/LICENSE",
     ),
     # This should be removed, see https://github.com/envoyproxy/envoy/issues/11816.
     com_github_curl = dict(
@@ -1015,6 +1039,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2022-06-27",
         cpe = "cpe:2.3:a:haxx:libcurl:*",
+        license = "curl",
+        license_url = "https://github.com/curl/curl/blob/curl-{underscore_version}/COPYING",
     ),
     v8 = dict(
         project_name = "V8",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -239,6 +239,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2021-11-29",
         cpe = "N/A",
+        license = "BSD-2-Clause",
+        license_url = "https://github.com/Cyan4973/xxHash/blob/v{version}/LICENSE",
     ),
     com_github_envoyproxy_sqlparser = dict(
         project_name = "C++ SQL Parser Library",
@@ -255,6 +257,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2020-06-10",
         cpe = "N/A",
+        license = "MIT",
+        license_url = "https://github.com/envoyproxy/sql-parser/blob/{version}/LICENSE",
     ),
     com_github_mirror_tclap = dict(
         project_name = "tclap",
@@ -267,6 +271,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2021-11-01",
         use_category = ["other"],
         cpe = "cpe:2.3:a:tclap_project:tclap:*",
+        license = "MIT",
+        license_url = "https://github.com/mirror/tclap/blob/v{version}/COPYING",
     ),
     com_github_fmtlib_fmt = dict(
         project_name = "fmt",
@@ -279,6 +285,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2022-01-06",
         cpe = "cpe:2.3:a:fmt:fmt:*",
+        license = "fmt",
+        license_url = "https://github.com/fmtlib/fmt/blob/{version}/LICENSE.rst",
     ),
     com_github_gabime_spdlog = dict(
         project_name = "spdlog",
@@ -291,6 +299,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2021-08-12",
         cpe = "N/A",
+        license = "MIT",
+        license_url = "https://github.com/gabime/spdlog/blob/v{version}/LICENSE",
     ),
     com_github_google_libprotobuf_mutator = dict(
         project_name = "libprotobuf-mutator",
@@ -302,6 +312,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/google/libprotobuf-mutator/archive/v{version}.tar.gz"],
         release_date = "2020-11-13",
         use_category = ["test_only"],
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/libprotobuf-mutator/blob/v{version}/LICENSE",
     ),
     com_github_google_libsxg = dict(
         project_name = "libsxg",
@@ -315,6 +327,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.http.sxg"],
         release_date = "2021-07-08",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/libsxg/blob/{version}/LICENSE",
     ),
     com_github_google_tcmalloc = dict(
         project_name = "tcmalloc",
@@ -327,6 +341,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2022-08-06",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/google/tcmalloc/blob/{version}/LICENSE",
     ),
     com_github_gperftools_gperftools = dict(
         project_name = "gperftools",
@@ -339,6 +355,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2022-05-31",
         use_category = ["dataplane_core", "controlplane"],
         cpe = "cpe:2.3:a:gperftools_project:gperftools:*",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/gperftools/gperftools/blob/gperftools-{version}/COPYING",
     ),
     com_github_grpc_grpc = dict(
         project_name = "gRPC",
@@ -351,6 +369,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_core", "controlplane"],
         release_date = "2022-08-18",
         cpe = "cpe:2.3:a:grpc:grpc:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/grpc/grpc/blob/v{version}/LICENSE",
     ),
     com_github_unicode_org_icu = dict(
         project_name = "ICU Library",
@@ -364,6 +384,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.http.language"],
         release_date = "2022-04-06",
         cpe = "N/A",
+        license = "ICU",
+        license_url = "https://github.com/unicode-org/icu/blob/release-{version}/icu4c/LICENSE",
     ),
     com_github_intel_ipp_crypto_crypto_mb = dict(
         project_name = "libipp-crypto",
@@ -377,6 +399,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_ext"],
         extensions = ["envoy.tls.key_providers.cryptomb"],
         cpe = "cpe:2.3:a:intel:cryptography_for_intel_integrated_performance_primitives:*",
+        license = "Apache-2.0",
+        license_url = "https://github.com/intel/ipp-crypto/blob/ippcp_{version}/LICENSE",
     ),
     com_github_intel_qatlib = dict(
         project_name = "qatlib",
@@ -390,6 +414,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2021-11-10",
         extensions = ["envoy.tls.key_providers.qat"],
         cpe = "N/A",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/intel/qatlib/blob/{version}/LICENSE",
     ),
     com_github_luajit_luajit = dict(
         project_name = "LuaJIT",
@@ -405,6 +431,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["dataplane_ext"],
         extensions = ["envoy.filters.http.lua"],
         cpe = "cpe:2.3:a:luajit:luajit:*",
+        license = "MIT",
+        license_url = "https://github.com/LuaJIT/LuaJIT/blob/{version}/COPYRIGHT",
     ),
     com_github_moonjit_moonjit = dict(
         project_name = "Moonjit",
@@ -418,6 +446,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         extensions = ["envoy.filters.http.lua"],
         release_date = "2020-01-14",
         cpe = "cpe:2.3:a:moonjit_project:moonjit:*",
+        license = "moonjit",
+        license_url = "https://github.com/moonjit/moonjit/blob/{version}/COPYRIGHT",
     ),
     com_github_nghttp2_nghttp2 = dict(
         project_name = "Nghttp2",
@@ -430,6 +460,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         use_category = ["controlplane", "dataplane_core"],
         release_date = "2022-06-24",
         cpe = "cpe:2.3:a:nghttp2:nghttp2:*",
+        license = "MIT",
+        license_url = "https://github.com/nghttp2/nghttp2/blob/v{version}/LICENSE",
     ),
     io_hyperscan = dict(
         project_name = "Hyperscan",
@@ -446,6 +478,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2021-01-13",
         cpe = "N/A",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/intel/hyperscan/blob/v{version}/LICENSE",
     ),
     io_opentracing_cpp = dict(
         project_name = "OpenTracing",
@@ -462,6 +496,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         ],
         release_date = "2019-01-16",
         cpe = "N/A",
+        license = "Apache-2.0",
+        license_url = "https://github.com/opentracing/opentracing-cpp/blob/v{version}/LICENSE",
     ),
     skywalking_data_collect_protocol = dict(
         project_name = "skywalking-data-collect-protocol",

--- a/tools/docs/generate_external_deps_rst.py
+++ b/tools/docs/generate_external_deps_rst.py
@@ -127,8 +127,6 @@ def main():
         version = rst_link(render_version(v['version']), get_version_url(v))
         release_date = v['release_date']
         license = v.get('license', '')
-        if license == 'N/A':
-            license = ''
         if license:
             license_url = v.get('license_url', '')
             if license_url:

--- a/tools/docs/generate_external_deps_rst.py
+++ b/tools/docs/generate_external_deps_rst.py
@@ -101,7 +101,7 @@ def get_version_url(metadata):
 
 
 def csv_row(dep):
-    return [dep.name, dep.version, dep.release_date, dep.cpe]
+    return [dep.name, dep.version, dep.release_date, dep.cpe, dep.license]
 
 
 def main():
@@ -112,7 +112,7 @@ def main():
 
     pathlib.Path(security_rst_root).mkdir(parents=True, exist_ok=True)
 
-    Dep = namedtuple('Dep', ['name', 'sort_name', 'version', 'cpe', 'release_date'])
+    Dep = namedtuple('Dep', ['name', 'sort_name', 'version', 'cpe', 'release_date', 'license'])
     use_categories = defaultdict(lambda: defaultdict(list))
     # Bin rendered dependencies into per-use category lists.
     for k, v in repository_locations.items():
@@ -126,7 +126,14 @@ def main():
         name = rst_link(project_name, project_url)
         version = rst_link(render_version(v['version']), get_version_url(v))
         release_date = v['release_date']
-        dep = Dep(name, project_name.lower(), version, cpe, release_date)
+        license = v.get('license', '')
+        if license == 'N/A':
+            license = ''
+        if license:
+            license_url = v.get('license_url', '')
+            if license_url:
+                license = rst_link(license, license_url)
+        dep = Dep(name, project_name.lower(), version, cpe, release_date, license)
         for category in v['use_category']:
             for ext in v.get('extensions', ['core']):
                 use_categories[category][ext].append(dep)
@@ -141,7 +148,7 @@ def main():
             if ext_name != 'core':
                 content += render_title(ext_name)
             output_path = pathlib.Path(security_rst_root, f'external_dep_{category}.rst')
-            content += csv_table(['Name', 'Version', 'Release date', 'CPE'], [2, 1, 1, 2],
+            content += csv_table(['Name', 'Version', 'Release date', 'CPE', 'License'], [2, 1, 1, 2, 1],
                                  [csv_row(dep) for dep in sorted(deps, key=lambda d: d.sort_name)])
         output_path.write_text(content)
 

--- a/tools/docs/generate_external_deps_rst.py
+++ b/tools/docs/generate_external_deps_rst.py
@@ -148,7 +148,8 @@ def main():
             if ext_name != 'core':
                 content += render_title(ext_name)
             output_path = pathlib.Path(security_rst_root, f'external_dep_{category}.rst')
-            content += csv_table(['Name', 'Version', 'Release date', 'CPE', 'License'], [2, 1, 1, 2, 1],
+            content += csv_table(['Name', 'Version', 'Release date', 'CPE', 'License'],
+                                 [2, 1, 1, 2, 1],
                                  [csv_row(dep) for dep in sorted(deps, key=lambda d: d.sort_name)])
         output_path.write_text(content)
 


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: docs: list dependencies' license
Additional Description:

TODO:

- BoringSSL (FIPS): unknown repo
- liburing: dual license needs to be chosen by code owners
- skywalking-data-collect-protocol: license in README only
- zstd: dual license needs to be chosen by code owners
- wavm: version not found
- V8: unknown repo
- Chromium's trace event headers: license not found
- Common Expression Language (CEL) C++ library: version not found
- Kafka (server binary): unknown repo
- Intel Dlb: unknown repo

Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A
Partial fix for #22874 
