### PR TITLE
Add a completion callback to insertTrailers in cache_filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -26,7 +26,7 @@ minor_behavior_changes:
     transparent listener can use original_dst filter without nf_conntrack enabled.
 - area: cache_filter
   change: |
-    added a completion callback to insertTrailers in cache interface. Any external cache implementation extensions will need to also add this callback, and call it on completion.
+    added a completion callback to insertHeaders and insertTrailers in cache interface. Any external cache implementation extensions will need to also add this callback, and call it on completion.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -24,6 +24,9 @@ minor_behavior_changes:
 - area: original_dst
   change: |
     transparent listener can use original_dst filter without nf_conntrack enabled.
+- area: cache_filter
+  change: |
+    added a completion callback to insertTrailers in cache interface. Any external cache implementation extensions will need to also add this callback, and call it on completion.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -175,7 +175,7 @@ Http::FilterTrailersStatus CacheFilter::encodeTrailers(Http::ResponseTrailerMap&
   response_has_trailers_ = !trailers.empty();
   if (insert_) {
     ENVOY_STREAM_LOG(debug, "CacheFilter::encodeTrailers inserting trailers", *encoder_callbacks_);
-    insert_->insertTrailers(trailers);
+    insert_->insertTrailers(trailers, [](bool) {});
   }
   insert_status_ = InsertStatus::InsertSucceeded;
 

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -125,7 +125,8 @@ Http::FilterHeadersStatus CacheFilter::encodeHeaders(Http::ResponseHeaderMap& he
     // that an insert has failed. If an insert fails partway, it's better not to send additional
     // chunks to the cache if we're already in a failure state and should abort, but we can only do
     // that if we can communicate failures back to the filter, so we should fix this.
-    insert_->insertHeaders(headers, metadata, end_stream);
+    insert_->insertHeaders(
+        headers, metadata, [](bool) {}, end_stream);
     if (end_stream) {
       insert_status_ = InsertStatus::InsertSucceeded;
     }

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -133,8 +133,12 @@ using InsertCallback = std::function<void(bool success_ready_for_more)>;
 class InsertContext {
 public:
   // Accepts response_headers for caching. Only called once.
+  //
+  // Implementers must call insert_complete(true) on success, or
+  // insert_complete(false) to attempt to abort the insertion.
   virtual void insertHeaders(const Http::ResponseHeaderMap& response_headers,
-                             const ResponseMetadata& metadata, bool end_stream) PURE;
+                             const ResponseMetadata& metadata, InsertCallback insert_complete,
+                             bool end_stream) PURE;
 
   // The insertion is streamed into the cache in chunks whose size is determined
   // by the client, but with a pace determined by the cache. To avoid streaming

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -134,7 +134,7 @@ class InsertContext {
 public:
   // Accepts response_headers for caching. Only called once.
   //
-  // Implementers must call insert_complete(true) on success, or
+  // Implementations must call insert_complete(true) on success, or
   // insert_complete(false) to attempt to abort the insertion.
   virtual void insertHeaders(const Http::ResponseHeaderMap& response_headers,
                              const ResponseMetadata& metadata, InsertCallback insert_complete,

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -148,7 +148,8 @@ public:
                           bool end_stream) PURE;
 
   // Inserts trailers into the cache.
-  virtual void insertTrailers(const Http::ResponseTrailerMap& trailers) PURE;
+  virtual void insertTrailers(const Http::ResponseTrailerMap& trailers,
+                              InsertCallback insert_complete) PURE;
 
   // This routine is called prior to an InsertContext being destroyed. InsertContext is responsible
   // for making sure that any async activities are cleaned up before returning from onDestroy().

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -59,13 +59,15 @@ public:
         cache_(cache) {}
 
   void insertHeaders(const Http::ResponseHeaderMap& response_headers,
-                     const ResponseMetadata& metadata, bool end_stream) override {
+                     const ResponseMetadata& metadata, InsertCallback insert_success,
+                     bool end_stream) override {
     ASSERT(!committed_);
     response_headers_ = Http::createHeaderMap<Http::ResponseHeaderMapImpl>(response_headers);
     metadata_ = metadata;
     if (end_stream) {
       commit();
     }
+    insert_success(true);
   }
 
   void insertBody(const Buffer::Instance& chunk, InsertCallback ready_for_next_chunk,
@@ -76,9 +78,8 @@ public:
     body_.add(chunk);
     if (end_stream) {
       commit();
-    } else {
-      ready_for_next_chunk(true);
     }
+    ready_for_next_chunk(true);
   }
 
   void insertTrailers(const Http::ResponseTrailerMap& trailers,

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -81,10 +81,12 @@ public:
     }
   }
 
-  void insertTrailers(const Http::ResponseTrailerMap& trailers) override {
+  void insertTrailers(const Http::ResponseTrailerMap& trailers,
+                      InsertCallback insert_complete) override {
     ASSERT(!committed_);
     trailers_ = Http::createHeaderMap<Http::ResponseTrailerMapImpl>(trailers);
     commit();
+    insert_complete(true);
   }
 
   void onDestroy() override {}

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
@@ -103,7 +103,7 @@ absl::Status HttpCacheImplementationTest::insert(
     return absl::OkStatus();
   }
   if (body.empty() && trailers.has_value()) {
-    inserter->insertTrailers(trailers.value(), nullptr);
+    inserter->insertTrailers(trailers.value(), [](bool) {});
     return absl::OkStatus();
   }
 


### PR DESCRIPTION
Commit Message: Add a completion callback to insertTrailers in cache_filter
Additional Description: Without this additional callback, an asynchronous cache implementation has no way to signal completion of an insert operation involving trailers. This also changes the cache test implementation to require that the completion callback has been called, before continuing to other parts of the test, where previously it would assume completion as soon as insertTrailers was called.
Risk Level: Low (change to a WIP filter)
Testing: Tests updated
Docs Changes: n/a
Release Notes: added a completion callback to insertTrailers in cache interface. Any external cache implementation extensions will need to also add this callback, and call it on completion.
Platform Specific Features: n/a
