### PR TITLE
api: expose eds_service_name to admin response of clusters

### DIFF
--- a/api/envoy/admin/v3/clusters.proto
+++ b/api/envoy/admin/v3/clusters.proto
@@ -85,7 +85,7 @@ message ClusterStatus {
   // Observability name of the cluster.
   string observability_name = 7;
 
-  // eds_service_name from EDS config of the cluster.
+  // The :ref:`EDS service name <envoy_v3_api_field_config.cluster.v3.Cluster.EdsClusterConfig.service_name>` if the cluster is an EDS cluster.
   string eds_service_name = 8;
 }
 

--- a/api/envoy/admin/v3/clusters.proto
+++ b/api/envoy/admin/v3/clusters.proto
@@ -84,6 +84,9 @@ message ClusterStatus {
 
   // Observability name of the cluster.
   string observability_name = 7;
+
+  // eds_service_name from EDS config of the cluster.
+  string eds_service_name = 8;
 }
 
 // Current state of a particular host.

--- a/api/envoy/admin/v3/clusters.proto
+++ b/api/envoy/admin/v3/clusters.proto
@@ -30,7 +30,7 @@ message Clusters {
 }
 
 // Details an individual cluster's current status.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message ClusterStatus {
   option (udpa.annotations.versioning).previous_message_type = "envoy.admin.v2alpha.ClusterStatus";
 

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -115,6 +115,10 @@ void ClustersHandler::writeClustersAsJson(Buffer::Instance& response) {
     envoy::admin::v3::ClusterStatus& cluster_status = *clusters.add_cluster_statuses();
     cluster_status.set_name(cluster_info->name());
     cluster_status.set_observability_name(cluster_info->observabilityName());
+    auto eds_service_name = cluster_info->edsServiceName();
+    if (eds_service_name.has_value()) {
+      cluster_status.set_eds_service_name(*eds_service_name);
+    }
 
     addCircuitBreakerSettingsAsJson(
         envoy::config::core::v3::RoutingPriority::DEFAULT,

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -115,7 +115,7 @@ void ClustersHandler::writeClustersAsJson(Buffer::Instance& response) {
     envoy::admin::v3::ClusterStatus& cluster_status = *clusters.add_cluster_statuses();
     cluster_status.set_name(cluster_info->name());
     cluster_status.set_observability_name(cluster_info->observabilityName());
-    auto eds_service_name = cluster_info->edsServiceName();
+    const auto& eds_service_name = cluster_info->edsServiceName();
     if (eds_service_name.has_value()) {
       cluster_status.set_eds_service_name(*eds_service_name);
     }
@@ -216,7 +216,7 @@ void ClustersHandler::writeClustersAsText(Buffer::Instance& response) {
 
     response.add(
         fmt::format("{}::added_via_api::{}\n", cluster_name, cluster.info()->addedViaApi()));
-    auto eds_service_name = cluster.info()->edsServiceName();
+    const auto& eds_service_name = cluster.info()->edsServiceName();
     if (eds_service_name.has_value()) {
       response.add(fmt::format("{}::eds_service_name::{}\n", cluster_name, *eds_service_name));
     }

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -216,6 +216,11 @@ void ClustersHandler::writeClustersAsText(Buffer::Instance& response) {
 
     response.add(
         fmt::format("{}::added_via_api::{}\n", cluster_name, cluster.info()->addedViaApi()));
+    auto eds_service_name = cluster.info()->edsServiceName();
+    if (eds_service_name.has_value()) {
+      response.add(
+          fmt::format("{}::eds_service_name::{}\n", cluster_name, *eds_service_name));
+    }
     for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
       for (auto& host : host_set->hosts()) {
         const std::string& host_address = host->address()->asString();

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -218,8 +218,7 @@ void ClustersHandler::writeClustersAsText(Buffer::Instance& response) {
         fmt::format("{}::added_via_api::{}\n", cluster_name, cluster.info()->addedViaApi()));
     auto eds_service_name = cluster.info()->edsServiceName();
     if (eds_service_name.has_value()) {
-      response.add(
-          fmt::format("{}::eds_service_name::{}\n", cluster_name, *eds_service_name));
+      response.add(fmt::format("{}::eds_service_name::{}\n", cluster_name, *eds_service_name));
     }
     for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
       for (auto& host : host_set->hosts()) {

--- a/test/server/admin/clusters_handler_test.cc
+++ b/test/server/admin/clusters_handler_test.cc
@@ -13,7 +13,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-TEST_P(AdminInstanceTest, ClustersJson) {
+TEST_P(AdminInstanceTest, ClustersJsonAndText) {
   Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
   ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_maps));
 

--- a/test/server/admin/clusters_handler_test.cc
+++ b/test/server/admin/clusters_handler_test.cc
@@ -32,6 +32,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
       .WillByDefault(Return(9.0));
 
   ON_CALL(*cluster.info_, addedViaApi()).WillByDefault(Return(true));
+  ON_CALL(*cluster.info_, edsServiceName()).WillByDefault(Return("potato_launcher"));
 
   Upstream::MockHostSet* host_set = cluster.priority_set_.getMockHostSet(0);
   auto host = std::make_shared<NiceMock<Upstream::MockHost>>();
@@ -107,6 +108,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   {
    "name": "fake_cluster",
    "observability_name": "observability_name",
+   "eds_service_name": "potato_launcher",
    "success_rate_ejection_threshold": {
     "value": 6
    },
@@ -218,6 +220,7 @@ fake_cluster::high_priority::max_pending_requests::1024
 fake_cluster::high_priority::max_requests::1024
 fake_cluster::high_priority::max_retries::1
 fake_cluster::added_via_api::true
+fake_cluster::eds_service_name::potato_launcher
 fake_cluster::1.2.3.4:80::arest_counter::5
 fake_cluster::1.2.3.4:80::atest_gauge::10
 fake_cluster::1.2.3.4:80::rest_counter::10


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Expose eds_service_name as an optional string to the ClusterStatus proto, and adding populating logic.
Additional Description: The data is already available in the ClusterInfo class. ([getter function](https://github.com/envoyproxy/envoy/blob/main/source/common/upstream/upstream_impl.h#L770); [data generation](https://github.com/envoyproxy/envoy/blob/main/source/common/upstream/upstream_impl.cc#L997-L1002))
Risk Level: Low
Testing: Unit Test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] [22903](https://github.com/envoyproxy/envoy/issues/22903)
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
