### PR TITLE
http: fixing auto_rewrite for upstream filters

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -480,21 +480,6 @@ void UpstreamRequest::acceptHeadersFromRouter(bool end_stream) {
 
   auto* headers = parent_.downstreamHeaders();
 
-  const auto* route_entry = parent_.route()->routeEntry();
-  if (route_entry->autoHostRewrite() && !upstream_host_->hostname().empty()) {
-    Http::Utility::updateAuthority(*parent_.downstreamHeaders(), upstream_host_->hostname(),
-                                   route_entry->appendXfh());
-  }
-
-  if (span_ != nullptr) {
-    span_->injectContext(*parent_.downstreamHeaders(), upstream_host_);
-  } else {
-    // No independent child span for current upstream request then inject the parent span's tracing
-    // context into the request headers.
-    // The injectContext() of the parent span may be called repeatedly when the request is retried.
-    parent_.callbacks()->activeSpan().injectContext(*parent_.downstreamHeaders(), upstream_host_);
-  }
-
   // Make sure that when we are forwarding CONNECT payload we do not do so until
   // the upstream has accepted the CONNECT request.
   if (headers->getMethodValue() == Http::Headers::get().MethodValues.Connect) {
@@ -799,15 +784,6 @@ void UpstreamRequest::onPoolReady(
     max_stream_duration_timer_->enableTimer(*max_stream_duration);
   }
 
-  if (allow_upstream_filters_) {
-    // Make sure the local filter manager will do the same.
-    codec_filter_->callbacks_->addDownstreamWatermarkCallbacks(downstream_watermark_manager_);
-    codec_filter_->shipHeadersIfPaused(*parent_.downstreamHeaders());
-    return;
-  }
-
-  calling_encode_headers_ = true;
-  auto* headers = parent_.downstreamHeaders();
   const auto* route_entry = parent_.route()->routeEntry();
   if (route_entry->autoHostRewrite() && !host->hostname().empty()) {
     Http::Utility::updateAuthority(*parent_.downstreamHeaders(), host->hostname(),
@@ -822,6 +798,17 @@ void UpstreamRequest::onPoolReady(
     // The injectContext() of the parent span may be called repeatedly when the request is retried.
     parent_.callbacks()->activeSpan().injectContext(*parent_.downstreamHeaders(), host);
   }
+
+  if (allow_upstream_filters_) {
+    // Make sure the local filter manager will inform the downstream watermark manager if downstream
+    // buffers are overrun.
+    codec_filter_->callbacks_->addDownstreamWatermarkCallbacks(downstream_watermark_manager_);
+    codec_filter_->shipHeadersIfPaused(*parent_.downstreamHeaders());
+    return;
+  }
+
+  calling_encode_headers_ = true;
+  auto* headers = parent_.downstreamHeaders();
 
   upstreamTiming().onFirstUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -76,6 +76,12 @@ TEST_P(ProtocolIntegrationTest, LogicalDns) {
     cluster.set_type(envoy::config::cluster::v3::Cluster::LOGICAL_DNS);
     cluster.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
   });
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
+        route->mutable_route()->mutable_auto_host_rewrite()->set_value(true);
+      });
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response =


### PR DESCRIPTION
Fixing a bug in upstream filters where the host was accessed before it was set (iff auto_rewrite was configured)

Risk Level: low
Testing: new integration test
Docs Changes: n/a
Release Notes: n/a

Part of https://github.com/envoyproxy/envoy/issues/10455