### PR TITLE
main: declare MainThread in MainCommonBase in addition to MainCommon.

### DIFF
--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -85,6 +85,8 @@ protected:
 private:
   void configureComponentLogLevels();
   void configureHotRestarter(Random::RandomGenerator& random_generator);
+
+  Thread::MainThread main_thread_;
 };
 
 // TODO(jmarantz): consider removing this class; I think it'd be more useful to


### PR DESCRIPTION
Commit Message: Currently, the MainThread is declared in the MainCommon constructor, but not MainCommonBase. Validation mode occurs in MainCommonBase though, without MainThread, so declare it in both.

MainThread can be declared at multiple points in the same thread, so this is not a problem.

We can't *move* the declaration out of MainCommon because it needs to be declared before OptionsImpl is instantiated, so it needs to stay in both places.
Additional Description:
Risk Level: low
Testing: //test/....
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features:

