### PR TITLE
Fully qualify namespace so ENVOY_BUG can be used outside of Envoy namespace

### DIFF
--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -265,7 +265,7 @@ void resetEnvoyBugCountersForTest();
       ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,    \
                           "envoy bug failure: {}.{}{}", CONDITION_STR,                             \
                           details.empty() ? "" : " Details: ", details);                           \
-      Assert::EnvoyBugStackTrace st;                                                               \
+      Envoy::Assert::EnvoyBugStackTrace st;                                                        \
       st.capture();                                                                                \
       st.logStackTrace();                                                                          \
       ACTION;                                                                                      \


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
