### PR TITLE
connect: fixing a bug with virtual hosts / happy eyeballs and testing ALPN

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -397,17 +397,17 @@ Host::CreateConnectionData HostImpl::createConnection(
     connection = dispatcher.createClientConnection(
         transport_socket_options->http11ProxyInfo()->proxy_address,
         source_address_fn ? source_address_fn(address) : nullptr,
-        socket_factory.createTransportSocket(transport_socket_options, host),
-        connection_options, transport_socket_options);
+        socket_factory.createTransportSocket(transport_socket_options, host), connection_options,
+        transport_socket_options);
   } else if (address_list.size() > 1) {
     connection = std::make_unique<Network::HappyEyeballsConnectionImpl>(
-        dispatcher, address_list, source_address_fn, socket_factory,
-        transport_socket_options, host, connection_options);
+        dispatcher, address_list, source_address_fn, socket_factory, transport_socket_options, host,
+        connection_options);
   } else {
     connection = dispatcher.createClientConnection(
         address, source_address_fn ? source_address_fn(address) : nullptr,
-        socket_factory.createTransportSocket(transport_socket_options, host),
-        connection_options, transport_socket_options);
+        socket_factory.createTransportSocket(transport_socket_options, host), connection_options,
+        transport_socket_options);
   }
 
   connection->connectionInfoSetter().enableSettingInterfaceName(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -323,15 +323,6 @@ Network::UpstreamTransportSocketFactory& HostDescriptionImpl::resolveTransportSo
 Host::CreateConnectionData HostImpl::createConnection(
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
     Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const {
-  // If the transport socket options indicate the connection should be
-  // redirected to a proxy, create the TCP connection to the proxy's address not
-  // the host's address.
-  if (transport_socket_options && transport_socket_options->http11ProxyInfo().has_value()) {
-    return createConnection(
-        dispatcher, cluster(), transport_socket_options->http11ProxyInfo()->proxy_address,
-        {transport_socket_options->http11ProxyInfo()->proxy_address}, transportSocketFactory(),
-        options, transport_socket_options, shared_from_this());
-  }
   return createConnection(dispatcher, cluster(), address(), addressList(), transportSocketFactory(),
                           options, transport_socket_options, shared_from_this());
 }
@@ -398,15 +389,26 @@ Host::CreateConnectionData HostImpl::createConnection(
 
   auto source_address_fn = cluster.sourceAddressFn();
 
-  Network::ClientConnectionPtr connection =
-      address_list.size() > 1
-          ? std::make_unique<Network::HappyEyeballsConnectionImpl>(
-                dispatcher, address_list, source_address_fn, socket_factory,
-                transport_socket_options, host, connection_options)
-          : dispatcher.createClientConnection(
-                address, source_address_fn ? source_address_fn(address) : nullptr,
-                socket_factory.createTransportSocket(transport_socket_options, host),
-                connection_options, transport_socket_options);
+  Network::ClientConnectionPtr connection;
+  // If the transport socket options indicate the connection should be
+  // redirected to a proxy, create the TCP connection to the proxy's address not
+  // the host's address.
+  if (transport_socket_options && transport_socket_options->http11ProxyInfo().has_value()) {
+    connection = dispatcher.createClientConnection(
+        transport_socket_options->http11ProxyInfo()->proxy_address,
+        source_address_fn ? source_address_fn(address) : nullptr,
+        socket_factory.createTransportSocket(transport_socket_options, host),
+        connection_options, transport_socket_options);
+  } else if (address_list.size() > 1) {
+    connection = std::make_unique<Network::HappyEyeballsConnectionImpl>(
+        dispatcher, address_list, source_address_fn, socket_factory,
+        transport_socket_options, host, connection_options);
+  } else {
+    connection = dispatcher.createClientConnection(
+        address, source_address_fn ? source_address_fn(address) : nullptr,
+        socket_factory.createTransportSocket(transport_socket_options, host),
+        connection_options, transport_socket_options);
+  }
 
   connection->connectionInfoSetter().enableSettingInterfaceName(
       cluster.setLocalInterfaceNameOnUpstreamConnections());

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -19,6 +19,7 @@
 
 #include "source/common/config/metadata.h"
 #include "source/common/network/address_impl.h"
+#include "source/common/network/transport_socket_options_impl.h"
 #include "source/common/network/utility.h"
 #include "source/common/singleton/manager_impl.h"
 #include "source/common/upstream/static_cluster.h"
@@ -1404,6 +1405,55 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballs) {
       host->createConnection(dispatcher, options, transport_socket_options);
   // The created connection will be wrapped in a HappyEyeballsConnectionImpl.
   EXPECT_NE(connection, connection_data.connection_.get());
+}
+
+TEST_F(HostImplTest, ProxyOverridesHappyEyeballs) {
+  MockClusterMockPrioritySet cluster;
+  envoy::config::core::v3::Metadata metadata;
+  Config::Metadata::mutableMetadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
+                                         Config::MetadataEnvoyLbKeys::get().CANARY)
+      .set_bool_value(true);
+  envoy::config::core::v3::Locality locality;
+  locality.set_region("oceania");
+  locality.set_zone("hello");
+  locality.set_sub_zone("world");
+  Network::Address::InstanceConstSharedPtr address =
+      Network::Utility::resolveUrl("tcp://10.0.0.1:1234");
+  Network::Address::InstanceConstSharedPtr proxy_address =
+      Network::Utility::resolveUrl("tcp://10.0.0.1:9999");
+  auto host = std::make_shared<HostImpl>(
+      cluster.info_, "lyft.com", address,
+      std::make_shared<const envoy::config::core::v3::Metadata>(metadata), 1, locality,
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 1,
+      envoy::config::core::v3::UNKNOWN, simTime());
+
+  testing::StrictMock<Event::MockDispatcher> dispatcher;
+  auto proxy_info = std::make_unique<Network::TransportSocketOptions::Http11ProxyInfo>(
+      "www.google.com", proxy_address);
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options =
+      std::make_shared<Network::TransportSocketOptionsImpl>(
+          "name", std::vector<std::string>(), std::vector<std::string>(),
+          std::vector<std::string>(), absl::nullopt, nullptr, std::move(proxy_info));
+  Network::ConnectionSocket::OptionsSharedPtr options;
+  Network::MockTransportSocketFactory socket_factory;
+
+  std::vector<Network::Address::InstanceConstSharedPtr> address_list = {
+      Network::Utility::resolveUrl("tcp://10.0.0.1:1235"),
+      address,
+  };
+  host->setAddressList(address_list);
+  auto connection = new testing::StrictMock<Network::MockClientConnection>();
+  EXPECT_CALL(*connection, setBufferLimits(0));
+  EXPECT_CALL(*connection, connectionInfoSetter());
+  // The underlying connection should be created to the proxy address.
+  EXPECT_CALL(dispatcher, createClientConnection_(proxy_address, _, _, _))
+      .WillOnce(Return(connection));
+
+  Envoy::Upstream::Host::CreateConnectionData connection_data =
+      host->createConnection(dispatcher, options, transport_socket_options);
+  // The created connection will be a raw connection to the proxy address rather
+  // than a happy eyeballs connection.
+  EXPECT_EQ(connection, connection_data.connection_.get());
 }
 
 TEST_F(HostImplTest, HealthFlags) {

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -930,9 +930,12 @@ void ConfigHelper::setProtocolOptions(envoy::config::cluster::v3::Cluster& clust
     HttpProtocolOptions old_options = MessageUtil::anyConvert<ConfigHelper::HttpProtocolOptions>(
         (*cluster.mutable_typed_extension_protocol_options())
             ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]);
-    ASSERT(!old_options.has_auto_config());
+    bool auto_config = old_options.has_auto_config();
     old_options.MergeFrom(protocol_options);
     protocol_options.CopyFrom(old_options);
+    if (auto_config) {
+      protocol_options.mutable_auto_config();
+    }
   }
   (*cluster.mutable_typed_extension_protocol_options())
       ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]

--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -5,8 +5,6 @@
 #include "test/integration/http_integration.h"
 #include "test/integration/integration.h"
 
-using testing::HasSubstr;
-
 namespace Envoy {
 namespace {
 


### PR DESCRIPTION
Fixing a bug where the proxy address was overridden by happy eyeballs addesses
testing HTTP/2 and ALPN for the inner TLS connection

Risk Level: low (config guarded)
Testing: new unit tests, integration
Docs Changes: n/a
Release Notes: n/a