### PR TITLE
bazel: fix googletest bazel_tools use

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -732,11 +732,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_url = "https://github.com/google/googletest",
         # Pick up fix for MOCK_METHOD compilation with clang-cl for Windows (resolved after 1.10.0)
         # see https://github.com/google/googletest/issues/2490
-        version = "a4ab0abb93620ce26efad9de9296b73b16e88588",
-        sha256 = "7897bfaa5ad39a479177cfb5c3ce010184dbaee22a7c3727b212282871918751",
+        version = "5c08f92c881b666998a4f7852c3cf9e393bf33a7",
+        sha256 = "9733972d9bee45170be9a9194b3387d6a5a9524975cd80a11e69e654ca934663",
         strip_prefix = "googletest-{version}",
         urls = ["https://github.com/google/googletest/archive/{version}.tar.gz"],
-        release_date = "2020-09-10",
+        release_date = "2021-03-15",
         use_category = ["test_only"],
         cpe = "cpe:2.3:a:google:google_test:*",
     ),


### PR DESCRIPTION
This doesn't update to the latest version because of other new
incompatibilities, https://github.com/envoyproxy/envoy/pull/22779

This should fix the last issue with https://github.com/envoyproxy/envoy/issues/22758

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>