### PR TITLE
[test/integration] Remove duplicate log message

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -209,7 +209,6 @@ public:
       }
     }
     decodeGrpcFrame(message);
-    ENVOY_LOG(debug, "Received gRPC message: {}", message.DebugString());
     return AssertionSuccess();
   }
 


### PR DESCRIPTION
Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>

In logs for integration tests same log message is logged twice. As decoded grpc message can be quite large it spams logs a lot. Message is logged inside the call to `decodeGrpcFrame` and straight after the call to `decodeGrpcFrame`.  `message` data is not mutated inside `decodeGrpcFrame`, log content is identical.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
