### PR TITLE
docs: fix incorrect punctuation

### DIFF
--- a/api/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
+++ b/api/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
@@ -79,7 +79,7 @@ message LocalRateLimit {
   // on. The rate limit descriptor is selected by the first full match from the
   // request descriptors.
   //
-  // Example on how to use ::ref:`this <config_http_filters_local_rate_limit_descriptors>`
+  // Example on how to use :ref:`this <config_http_filters_local_rate_limit_descriptors>`.
   //
   // .. note::
   //


### PR DESCRIPTION
Commit Message: fixing a typo in the docs (removing an extra `:` and adding a `.`)
Additional Description:
Risk Level: Low
Testing: built and confirmed the docs locally 
Docs Changes: Yes
Release Notes: 
Platform Specific Features: N/A