### PR TITLE
http: making http11 connect proxy work with HTTP/3 auto_config

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -684,9 +684,13 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   const bool can_send_early_data =
       conn_pool_new_stream_with_early_data_and_http3_ &&
       route_entry_->earlyDataPolicy().allowsEarlyDataForRequest(*downstream_headers_);
-  UpstreamRequestPtr upstream_request =
-      std::make_unique<UpstreamRequest>(*this, std::move(generic_conn_pool), can_send_early_data,
-                                        /*can_use_http3=*/true);
+  // Set initial HTTP/3 use based on the presence of HTTP/1.1 proxy config.
+  // For retries etc, HTTP/3 usability may transition from true to false, but
+  // will never transition from false to true.
+  bool can_use_http3 =
+      !transport_socket_options_ || !transport_socket_options_->http11ProxyInfo().has_value();
+  UpstreamRequestPtr upstream_request = std::make_unique<UpstreamRequest>(
+      *this, std::move(generic_conn_pool), can_send_early_data, can_use_http3);
   LinkedList::moveIntoList(std::move(upstream_request), upstream_requests_);
   upstream_requests_.front()->acceptHeadersFromRouter(end_stream);
   if (end_stream) {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -17,6 +17,7 @@
 #include "source/common/config/well_known_names.h"
 #include "source/common/http/context_impl.h"
 #include "source/common/network/application_protocol.h"
+#include "source/common/network/filter_state_proxy_info.h"
 #include "source/common/network/socket_option_factory.h"
 #include "source/common/network/upstream_server_name.h"
 #include "source/common/network/upstream_socket_options_filter_state.h"
@@ -86,7 +87,7 @@ public:
     EXPECT_CALL(callbacks_, activeSpan()).WillRepeatedly(ReturnRef(span_));
   };
 
-  void testRequestResponseSize(bool with_trailers) {
+  void testRequestResponse(bool with_trailers, bool can_use_http3 = true) {
     NiceMock<Http::MockRequestEncoder> encoder;
     Http::ResponseDecoder* response_decoder = nullptr;
 
@@ -96,7 +97,7 @@ public:
                        const Http::ConnectionPool::Instance::StreamOptions& options)
                        -> Http::ConnectionPool::Cancellable* {
               EXPECT_FALSE(options.can_send_early_data_);
-              EXPECT_TRUE(options.can_use_http3_);
+              EXPECT_EQ(options.can_use_http3_, can_use_http3);
               response_decoder = &decoder;
               callbacks.onPoolReady(encoder, cm_.thread_local_cluster_.conn_pool_.host_,
                                     upstream_stream_info_, Http::Protocol::Http10);
@@ -6040,11 +6041,21 @@ TEST_F(RouterTest, NotSetDynamicMaxStreamDurationIfZero) {
 }
 
 // Test that request/response header/body sizes are properly recorded.
-TEST_F(RouterTest, RequestResponseSize) { testRequestResponseSize(false); }
+TEST_F(RouterTest, RequestResponseSize) { testRequestResponse(false); }
 
 // Test that request/response header/body sizes are properly recorded
 // when there are trailers in both the request/response.
-TEST_F(RouterTest, RequestResponseSizeWithTrailers) { testRequestResponseSize(true); }
+TEST_F(RouterTest, RequestResponseSizeWithTrailers) { testRequestResponse(true); }
+
+TEST_F(RouterTest, Http3DisabledForHttp11Proxies) {
+  auto address = Network::Utility::parseInternetAddressAndPort("127.0.0.1:20");
+  std::string hostname = "www.lyft.com";
+  callbacks_.stream_info_.filterState()->setData(
+      Network::Http11ProxyInfoFilterState::key(),
+      std::make_unique<Network::Http11ProxyInfoFilterState>(hostname, address),
+      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  testRequestResponse(true, false);
+}
 
 TEST_F(RouterTest, ExpectedUpstreamTimeoutUpdatedDuringRetries) {
   auto retry_options_predicate = std::make_shared<MockRetryOptionsPredicate>();

--- a/test/extensions/filters/http/alternate_protocols_cache/BUILD
+++ b/test/extensions/filters/http/alternate_protocols_cache/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test(
         "//test/common/http:common_lib",
         "//test/integration:http_integration_lib",
         "//test/integration:http_protocol_integration_lib",
+        "//test/integration/filters:header_to_proxy_filter_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/common/key_value/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -144,6 +144,47 @@ TEST_P(FilterIntegrationTest, AltSvc) {
   test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_http3_total", 1);
 }
 
+TEST_P(FilterIntegrationTest, AltSvcIgnoredWithProxyConfig) {
+  config_helper_.addFilter("{ name: header-to-proxy-filter }");
+  const uint64_t request_size = 0;
+  const uint64_t response_size = 0;
+  const std::chrono::milliseconds timeout = TestUtility::DefaultTimeout;
+
+  initialize();
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "POST"},       {":path", "/test/long/url"},
+      {":scheme", "http"},       {":authority", "sni.lyft.com"},
+      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
+  int port = fake_upstreams_[1]->localAddress()->ip()->port();
+  std::string alt_svc = absl::StrCat("h3=\":", port, "\"; ma=86400");
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"alt-svc", alt_svc}};
+
+  // First request should go out over HTTP/2 (upstream index 0). The response includes an
+  // Alt-Svc header.
+  auto response = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
+                                                response_size, 0, timeout);
+  checkSimpleRequestSuccess(request_size, response_size, response.get());
+
+  // Close the connection so the HTTP/2 connection will not be used.
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_http2_total", 1);
+  ASSERT_TRUE(fake_upstream_connection_->close());
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_destroy", 1);
+  fake_upstream_connection_.reset();
+
+  absl::string_view upstream_address(fake_upstreams_[0]->localAddress()->asStringView());
+  request_headers.setCopy(Envoy::Http::LowerCaseString("connect-proxy"), upstream_address);
+
+  // Second request will still go to the HTTP/2 cluster, due to the presence of proxy config
+  // and will go over TCP/TLS due to proxy config.
+  auto response2 = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
+                                                 response_size, 0, timeout);
+  checkSimpleRequestSuccess(request_size, response_size, response2.get());
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_http2_total", 2);
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_http3_total", 0);
+}
+
 TEST_P(FilterIntegrationTest, RetryAfterHttp3ZeroRttHandshakeFailed) {
   const uint64_t response_size = 0;
   const std::chrono::milliseconds timeout = TestUtility::DefaultTimeout;


### PR DESCRIPTION
the connect proxy code was originally only designed to work with explicit HTTP/1.1 upstreams.
It happened to work for auto_config with TCP, and this allows it to work with auto_config and TCP or QUIC.

Risk Level: low
Testing: new unit, integration tests
Docs Changes: n/a
Release Notes: n/a