### PR TITLE
`envoy.filters.http.oauth2`: Change to `%REQ(x-forwarded-proto)%`

### DIFF
--- a/docs/root/configuration/http/http_filters/oauth2_filter.rst
+++ b/docs/root/configuration/http/http_filters/oauth2_filter.rst
@@ -61,7 +61,7 @@ The following is an example configuring the filter.
       uri: oauth.com/token
       timeout: 3s
     authorization_endpoint: https://oauth.com/oauth/authorize/
-    redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+    redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
     redirect_path_matcher:
       path:
         exact: /callback
@@ -118,7 +118,7 @@ Below is a complete code example of how we employ the filter as one of
                     uri: oauth.com/token
                     timeout: 3s
                   authorization_endpoint: https://oauth.com/oauth/authorize/
-                  redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+                  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
                   redirect_path_matcher:
                     path:
                       exact: /callback

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -39,7 +39,7 @@ config:
     hmac_secret:
       name: hmac
   authorization_endpoint: https://oauth.com/oauth/authorize/
-  redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
   redirect_path_matcher:
     path:
       exact: /callback
@@ -92,7 +92,7 @@ config:
       oauth_hmac: OauthHMAC
       oauth_expires: OauthExpires
   authorization_endpoint: https://oauth.com/oauth/authorize/
-  redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
   redirect_path_matcher:
     path:
       exact: /callback
@@ -168,7 +168,7 @@ config:
     cookie_names:
       bearer_token: "?"
   authorization_endpoint: https://oauth.com/oauth/authorize/
-  redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
   redirect_path_matcher:
     path:
       exact: /callback

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -101,7 +101,7 @@ typed_config:
       uri: oauth.com/token
       timeout: 3s
     authorization_endpoint: https://oauth.com/oauth/authorize/
-    redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+    redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
     redirect_path_matcher:
       path:
         exact: /callback
@@ -225,7 +225,7 @@ typed_config:
       uri: oauth.com/token
       timeout: 3s
     authorization_endpoint: https://oauth.com/oauth/authorize/
-    redirect_uri: "%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"
+    redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
     redirect_path_matcher:
       path:
         exact: /callback


### PR DESCRIPTION
`redirect_uri` should not be `"%REQ(:x-forwarded-proto)%://%REQ(:authority)%/callback"` in the files below:

* `test/extensions/filters/http/oauth2/config_test.cc`
* `test/extensions/filters/http/oauth2/oauth_integration_test.cc`

Signed-off-by: Mohamed Bana <mohamed@bana.io>