### PR TITLE
fuzz: fix http health-check when connection is closed

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -289,6 +289,10 @@ Http::Protocol codecClientTypeToProtocol(Http::CodecType codec_client_type) {
   PANIC_DUE_TO_CORRUPT_ENUM
 }
 
+Http::Protocol HttpHealthCheckerImpl::protocol() const {
+  return codecClientTypeToProtocol(codec_client_type_);
+}
+
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSession(
     HttpHealthCheckerImpl& parent, const HostSharedPtr& host)
     : ActiveHealthCheckSession(parent, host), parent_(parent),

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -114,6 +114,9 @@ public:
                         Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
                         Random::RandomGenerator& random, HealthCheckEventLoggerPtr&& event_logger);
 
+  // Returns the HTTP protocol used for the health checker.
+  Http::Protocol protocol() const;
+
   /**
    * Utility class checking if given http status matches configured expectations.
    */

--- a/test/common/upstream/health_check_corpus/http_headers-with-proxy-connection-close
+++ b/test/common/upstream/health_check_corpus/http_headers-with-proxy-connection-close
@@ -1,0 +1,43 @@
+health_check_config {
+  timeout {
+    seconds: 11
+  }
+  interval {
+    seconds: 1
+  }
+  unhealthy_threshold {
+    value: 2
+  }
+  healthy_threshold {
+    value: 2
+  }
+  http_health_check {
+    path: "close"
+  }
+}
+actions {
+  respond {
+    http_respond {
+      headers {
+        headers {
+          key: "proxy-connection"
+          value: "ulose"
+        }
+        headers {
+          key: "proxy-connection"
+          value: "close"
+        }
+      }
+    }
+    tcp_respond {
+    }
+    grpc_respond {
+      grpc_respond_headers {
+      }
+    }
+  }
+}
+actions {
+  trigger_interval_timer {
+  }
+}

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -144,16 +144,8 @@ void HttpHealthCheckFuzz::respond(test::common::upstream::Respond respond, bool 
   response_headers->setStatus(status);
 
   // Responding with http can cause client to close, if so create a new one.
-  bool client_will_close = false;
-  if (response_headers->Connection()) {
-    client_will_close =
-        absl::EqualsIgnoreCase(response_headers->Connection()->value().getStringView(),
-                               Http::Headers::get().ConnectionValues.Close);
-  } else if (response_headers->ProxyConnection()) {
-    client_will_close =
-        absl::EqualsIgnoreCase(response_headers->ProxyConnection()->value().getStringView(),
-                               Http::Headers::get().ConnectionValues.Close);
-  }
+  bool client_will_close =
+      Http::HeaderUtility::shouldCloseConnection(health_checker_->protocol(), *response_headers);
 
   // Check if there is a response body.
   bool has_response_body = !respond.http_respond().body().empty();

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -144,7 +144,7 @@ void HttpHealthCheckFuzz::respond(test::common::upstream::Respond respond, bool 
   response_headers->setStatus(status);
 
   // Responding with http can cause client to close, if so create a new one.
-  bool client_will_close =
+  const bool client_will_close =
       Http::HeaderUtility::shouldCloseConnection(health_checker_->protocol(), *response_headers);
 
   // Check if there is a response body.


### PR DESCRIPTION
Commit Message: fuzz: fix http health-check when connection is closed
Additional Description:
The http health-check fuzzer only handled a case where a "proxy-connection:close" header key-value was passed, but should have handled cases where one of the values is close.

Risk Level: Low (fuzzer only)
Testing: Fixed fuzz test.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
