### PR TITLE
Add grpc reflection to grpc_json_transcoder.

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // gRPC-JSON transcoder :ref:`configuration overview <config_http_filters_grpc_json_transcoder>`.
 // [#extension: envoy.filters.http.grpc_json_transcoder]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 // GrpcJsonTranscoder filter configuration.
 // The filter itself can be used per route / per virtual host or on the general level. The most
 // specific one is being used for a given route. If the list of services is empty - filter
@@ -103,6 +103,17 @@ message GrpcJsonTranscoder {
     bool reject_binding_body_field_collisions = 3;
   }
 
+  message ReflectionConfig {
+    // Supplies the cluster name of the gRPC cluster to use for reflection.
+    // This will typically be the same gRPC cluster that Envoy is forwarding
+    // gRPC traffic to, but it does not need to be.
+    string cluster_name = 1;
+
+    // The amount of time in ms that Envoy should wait for gRPC reflection
+    // requests to return.
+    uint64 request_timeout = 2;
+  }
+
   oneof descriptor_set {
     option (validate.required) = true;
 
@@ -115,6 +126,11 @@ message GrpcJsonTranscoder {
     // :ref:`the proto descriptor set <config_grpc_json_generate_proto_descriptor_set>` for the gRPC
     // services.
     bytes proto_descriptor_bin = 4;
+
+    // Supplies the grpc reflection configuration to fetching the content of
+    // :ref:`the proto descriptor set <config_grpc_json_generate_proto_descriptor_set>` for the gRPC
+    // services.
+    ReflectionConfig reflection_cluster_config = 14;
   }
 
   // A list of strings that

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,6 +21,9 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: grpc_json_transcoder
+  change: |
+    Support grpc reflection for building json transcoding.
 - area: resource_monitors
   change: |
     changed behavior of the fixed heap monitor to count pages allocated to TCMalloc as free memory if it's not used by Envoy. This change can be reverted temporarily by setting the runtime guard ``envoy.reloadable_features.do_not_count_mapped_pages_as_free`` to true.

--- a/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
@@ -104,3 +104,18 @@ gRPC or RESTful JSON requests to localhost:51051.
 
 .. literalinclude:: _include/grpc-transcoder-filter.yaml
     :language: yaml
+
+
+Modified Envoy configuration to use gRPC reflection
+---------------------------------------------------
+Rather than using a statically generated configuration, Envoy can fetch service
+definitions via grpc reflection. This can be done by replacing
+``proto_descriptor`` in the filter's config with the following:
+
+.. code-block:: yaml
+
+  reflection_cluster_config:
+    cluster_name: "<INSERT_GRPC_CLUSTER_NAME_HERE"
+
+Note that reflection must be configured on the target grpc service for this to
+work; the method for doing this is language-specific.

--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -14,10 +14,20 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "json_transcoder_filter_lib",
-    srcs = ["json_transcoder_filter.cc"],
-    hdrs = ["json_transcoder_filter.h"],
+    srcs = [
+        "async_reflection_fetcher.cc",
+        "descriptor_pool_builder.cc",
+        "json_transcoder_filter.cc",
+    ],
+    hdrs = [
+        "async_reflection_fetcher.h",
+        "async_reflection_fetcher_callbacks.h",
+        "descriptor_pool_builder.h",
+        "json_transcoder_filter.h",
+    ],
     external_deps = [
         "path_matcher",
+        "grpc",
         "grpc_transcoding",
         "http_api_protos",
         "api_httpbody_protos",
@@ -26,12 +36,15 @@ envoy_cc_library(
         ":http_body_utils_lib",
         ":transcoder_input_stream_lib",
         "//envoy/http:filter_interface",
+        "//source/common/grpc:async_client_lib",
         "//source/common/grpc:codec_lib",
         "//source/common/grpc:common_lib",
         "//source/common/http:headers_lib",
         "//source/common/protobuf",
         "//source/common/runtime:runtime_features_lib",
+        "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_google_googleapis//google/api:http_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.cc
@@ -1,0 +1,92 @@
+#include "source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.h"
+
+#include "envoy/config/core/v3/grpc_service.pb.h"
+
+#include "source/common/common/lock_guard.h"
+#include "source/common/grpc/async_client_impl.h"
+
+using grpc::reflection::v1alpha::ServerReflection;
+using grpc::reflection::v1alpha::ServerReflectionRequest;
+using grpc::reflection::v1alpha::ServerReflectionResponse;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+void AsyncReflectionFetcher::requestFileDescriptors(
+    std::function<void(Envoy::Protobuf::FileDescriptorSet)> file_descriptors_available) {
+  file_descriptors_available_ = file_descriptors_available;
+  // Register to init_manager, force the listener to wait for completion of the
+  // reflection Rpcs.
+  init_target_ = std::make_unique<Init::TargetImpl>("JsonGrpcFilter: Grpc Reflection Rpcs",
+                                                    [this]() -> void { startReflectionRpcs(); });
+  init_manager_.add(*init_target_);
+}
+
+void AsyncReflectionFetcher::startReflectionRpcs() {
+  envoy::config::core::v3::GrpcService config;
+  config.mutable_envoy_grpc()->set_cluster_name(reflection_cluster_config_.cluster_name());
+
+  const Envoy::Protobuf::MethodDescriptor* server_reflection_method =
+      Envoy::Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+          "grpc.reflection.v1alpha.ServerReflection.ServerReflectionInfo");
+  if (server_reflection_method == nullptr) {
+    ENVOY_LOG(error, "Failed to find MethodDescriptor for ServerReflectionInfo");
+    return;
+  }
+
+  for (size_t i = 0; i < services_.size(); i++) {
+    std::string service = services_[i];
+    Envoy::Grpc::AsyncClient<ServerReflectionRequest, ServerReflectionResponse>& async_client =
+        async_clients_[i];
+
+    AsyncReflectionFetcherCallbacks* callbacks = new AsyncReflectionFetcherCallbacks(
+        [this](AsyncReflectionFetcherCallbacks* callback, ServerReflectionResponsePtr&& message) {
+          this->onRpcCompleted(callback, std::move(message));
+        });
+    callbacks_.emplace(callbacks);
+    remaining_callbacks_.insert(callbacks);
+    Http::AsyncClient::StreamOptions options;
+
+    // Default of 5s is chosen arbitarily.
+    options.setTimeout(std::chrono::milliseconds(reflection_cluster_config_.request_timeout()
+                                                     ? reflection_cluster_config_.request_timeout()
+                                                     : 5000));
+    Envoy::Grpc::AsyncStream<ServerReflectionRequest> async_stream =
+        async_client.start(*server_reflection_method, *callbacks, options);
+
+    ServerReflectionRequest request;
+    request.set_file_containing_symbol(service);
+    async_stream.sendMessage(request, true);
+  }
+}
+
+void AsyncReflectionFetcher::onRpcCompleted(AsyncReflectionFetcherCallbacks* callbacks,
+                                            std::unique_ptr<ServerReflectionResponse>&& message) {
+  Thread::LockGuard guard_(receive_message_mutex_);
+
+  for (const std::string& file_descriptor_bytes :
+       message->file_descriptor_response().file_descriptor_proto()) {
+    if (!file_descriptor_set_.add_file()->ParseFromString(file_descriptor_bytes)) {
+      ENVOY_LOG(error,
+                "transcoding_filter: Unable to parse proto descriptor returned from reflection");
+      return;
+    }
+  }
+
+  // Record that we have already received the response for this Rpc.
+  remaining_callbacks_.erase(callbacks);
+
+  // We have received all the protos we have asked for, so inject them into the
+  // proto config and signal to InitManager that loading is complete.
+  if (remaining_callbacks_.empty()) {
+    file_descriptors_available_(file_descriptor_set_);
+    init_target_->ready();
+  }
+}
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.cc
@@ -49,7 +49,7 @@ void AsyncReflectionFetcher::startReflectionRpcs() {
     remaining_callbacks_.insert(callbacks);
     Http::AsyncClient::StreamOptions options;
 
-    // Default of 5s is chosen arbitarily.
+    // Default of 5s is chosen arbitrarily.
     options.setTimeout(std::chrono::milliseconds(reflection_cluster_config_.request_timeout()
                                                      ? reflection_cluster_config_.request_timeout()
                                                      : 5000));

--- a/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/repeated_field.h>
+
+#include <memory>
+
+#include "envoy/api/api.h"
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
+#include "envoy/http/header_map.h"
+#include "envoy/upstream/cluster_manager.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
+#include "source/common/grpc/typed_async_client.h"
+#include "source/common/init/target_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks.h"
+
+#include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+using ServerReflectionResponsePtr =
+    std::unique_ptr<grpc::reflection::v1alpha::ServerReflectionResponse>;
+
+/**
+ * This class contains the logic for starting gRPC reflection Rpcs and tracking their completion
+ * state.
+ */
+class AsyncReflectionFetcher : public Logger::Loggable<Logger::Id::config> {
+public:
+  /**
+   * Constructor. All arguments are needed for making non-blocking gRpc
+   * requests with the Envoy client.
+   */
+  AsyncReflectionFetcher(const envoy::extensions::filters::http::grpc_json_transcoder::v3::
+                             GrpcJsonTranscoder_ReflectionConfig& reflection_cluster_config,
+                         const Envoy::Protobuf::RepeatedPtrField<std::string>& services,
+                         std::vector<Grpc::RawAsyncClientSharedPtr> async_clients,
+                         Init::Manager& init_manager)
+      : reflection_cluster_config_(reflection_cluster_config), init_manager_(init_manager),
+        services_(std::begin(services), std::end(services)), async_clients_() {
+    // Wrap RawAsyncClient into AsyncClient.
+    for (size_t i = 0; i < async_clients.size(); i++) {
+      async_clients_.emplace_back(async_clients[i]);
+    }
+  }
+
+  /**
+   * Ask this AsyncReflectionFetcher to call descriptor_pool_builder.
+   */
+  void requestFileDescriptors(
+      std::function<void(Envoy::Protobuf::FileDescriptorSet)> file_descriptors_available);
+
+  /**
+   * Kick off reflection Rpcs; invoked by initManager.
+   */
+  void startReflectionRpcs();
+
+  /**
+   * Callback for successful completion of an Rpc.
+   */
+  void onRpcCompleted(AsyncReflectionFetcherCallbacks* callbacks,
+                      ServerReflectionResponsePtr&& message);
+
+  /**
+   * Retrieve remaining callbacks. Used only for unit testing.
+   */
+  absl::flat_hash_set<AsyncReflectionFetcherCallbacks*>& getRemainingCallBacksForTest() {
+    return remaining_callbacks_;
+  }
+
+private:
+  /**
+   * The proto config for talking to the upstream Envoy cluster serving gRPC.
+   */
+  const envoy::extensions::filters::http::grpc_json_transcoder::v3::
+      GrpcJsonTranscoder_ReflectionConfig reflection_cluster_config_;
+
+  /**
+   * Reference to the factory context's init manager, used for deferring
+   * completion of filter initialization until the reflection Rpcs complete.
+   */
+  Init::Manager& init_manager_;
+
+  /**
+   * A function to call when the requested file descriptors are available.
+   */
+  std::function<void(Envoy::Protobuf::FileDescriptorSet)>
+      file_descriptors_available_ ABSL_GUARDED_BY(receive_message_mutex_);
+
+  /**
+   * The fully qualified names of the gRPC services we are requesting protos
+   * for.
+   */
+  std::vector<std::string> services_;
+
+  /**
+   * The callback objects for the remaining Rpcs that we are waiting on
+   * responses for.
+   */
+  absl::flat_hash_set<AsyncReflectionFetcherCallbacks*> remaining_callbacks_;
+
+  /**
+   * The callback objects for all the Rpcs that we have made. This is used to
+   * maintain the lifetime of the callbacks_ object, while remaining_callbacks_
+   * is used to track whether all our Rpcs have completed. We cannot use
+   * remaining_callbacks_ for lifetime because we want to enable the filter
+   * after the last onReceiveMessage is invoked, but cannot delete the callback
+   * object at this time, because this is not the last callback that will be
+   * invoked by the Envoy Grpc Client.
+   *
+   * Additionally, separating ownership from completion tracking avoids the
+   * need to abuse unique_ptr release semantics to erase from a set of
+   * unique_ptrs.
+   */
+  absl::flat_hash_set<std::unique_ptr<AsyncReflectionFetcherCallbacks>> callbacks_;
+
+  /**
+   * The async clients used to make each server reflection request. We are
+   * using multiple clients to send multiple streaming Rpcs in parallel, as
+   * recommended by qiwzhang.
+   */
+  std::vector<Envoy::Grpc::AsyncClient<grpc::reflection::v1alpha::ServerReflectionRequest,
+                                       grpc::reflection::v1alpha::ServerReflectionResponse>>
+      async_clients_;
+
+  /**
+   * The target for the initManager, used to notify the init manager that the
+   * filter has finished initializing.
+   */
+  std::unique_ptr<Init::TargetImpl> init_target_;
+
+  /**
+   * The file descriptors we have received from reflection requests thus far.
+   */
+  Envoy::Protobuf::FileDescriptorSet file_descriptor_set_ ABSL_GUARDED_BY(receive_message_mutex_);
+
+  /**
+   * This mutex protects the data structures manipulated in the
+   * onReceiveMessage callback, since the same object is used for handling all
+   * the callbacks.
+   */
+  Envoy::Thread::MutexBasicLockable receive_message_mutex_;
+};
+
+using AsyncReflectionFetcherSharedPtr = std::shared_ptr<AsyncReflectionFetcher>;
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/http/header_map.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/grpc/typed_async_client.h"
+#include "source/common/protobuf/protobuf.h"
+
+#include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+using ServerReflectionResponsePtr =
+    std::unique_ptr<grpc::reflection::v1alpha::ServerReflectionResponse>;
+
+/**
+ * Instances of this class receive callbacks from gRPC reflection Rpcs.
+ * This class is entirely inlined because all functions are short.
+ */
+class AsyncReflectionFetcherCallbacks
+    : public Envoy::Grpc::AsyncStreamCallbacks<grpc::reflection::v1alpha::ServerReflectionResponse>,
+      public Logger::Loggable<Logger::Id::config> {
+public:
+  /**
+   * Constructor.
+   */
+  AsyncReflectionFetcherCallbacks(
+      std::function<void(AsyncReflectionFetcherCallbacks*, ServerReflectionResponsePtr&&)>
+          on_success_callback)
+      : on_success_callback_(on_success_callback) {}
+
+  /**
+   * Callback for a successful Server Reflection response.
+   */
+  void onReceiveMessage(ServerReflectionResponsePtr&& message) {
+    on_success_callback_(this, std::move(message));
+  }
+
+  /**
+   * See RawAsyncStreamCallbacks for documentation of these methods.
+   */
+  void onCreateInitialMetadata(Http::RequestHeaderMap&) {}
+  void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&){};
+
+  /**
+   * These two are used for detecting unexpected errors.
+   */
+  void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
+  void onRemoteClose(Envoy::Grpc::Status::GrpcStatus status, const std::string& message) override {
+    if (status != Envoy::Grpc::Status::Ok) {
+      ENVOY_LOG(error, "transcoding_filter: server reflection request failed with status {}: {}",
+                status, message);
+    }
+  }
+
+private:
+  std::function<void(AsyncReflectionFetcherCallbacks*, ServerReflectionResponsePtr&&)>
+      on_success_callback_;
+};
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks.h
@@ -37,15 +37,15 @@ public:
   /**
    * Callback for a successful Server Reflection response.
    */
-  void onReceiveMessage(ServerReflectionResponsePtr&& message) {
+  void onReceiveMessage(ServerReflectionResponsePtr&& message) override {
     on_success_callback_(this, std::move(message));
   }
 
   /**
    * See RawAsyncStreamCallbacks for documentation of these methods.
    */
-  void onCreateInitialMetadata(Http::RequestHeaderMap&) {}
-  void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&){};
+  void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
+  void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override{};
 
   /**
    * These two are used for detecting unexpected errors.

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -4,6 +4,8 @@
 #include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.validate.h"
 #include "envoy/registry/registry.h"
 
+#include "source/common/common/assert.h"
+#include "source/common/grpc/async_client_impl.h"
 #include "source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h"
 
 namespace Envoy {
@@ -15,9 +17,8 @@ Http::FilterFactoryCb GrpcJsonTranscoderFilterConfig::createFilterFactoryFromPro
     const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
         proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {
-  JsonTranscoderConfigSharedPtr filter_config =
-      std::make_shared<JsonTranscoderConfig>(proto_config, context.api());
 
+  JsonTranscoderConfigSharedPtr filter_config = createConfig(proto_config, context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<JsonTranscoderFilter>(*filter_config));
   };
@@ -28,8 +29,47 @@ GrpcJsonTranscoderFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
         proto_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+  return createConfig(proto_config, context);
+}
 
-  return std::make_shared<JsonTranscoderConfig>(proto_config, context.api());
+JsonTranscoderConfigSharedPtr GrpcJsonTranscoderFilterConfig::createConfig(
+    const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
+        proto_config,
+    Server::Configuration::CommonFactoryContext& context) {
+  // Construct descriptor_pool_builder differently depending on whether we need
+  // reflection or not.
+  DescriptorPoolBuilderSharedPtr descriptor_pool_builder;
+  if (proto_config.descriptor_set_case() ==
+      envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder::
+          DescriptorSetCase::kReflectionClusterConfig) {
+
+    // Create and inject as many async clients as there are services, since we
+    // need one per service for parallelism, per qiwzhang's suggestion:
+    // https://github.com/envoyproxy/envoy/issues/1182#issuecomment-1026048698
+    envoy::config::core::v3::GrpcService config;
+    config.mutable_envoy_grpc()->set_cluster_name(
+        proto_config.reflection_cluster_config().cluster_name());
+    std::vector<Envoy::Grpc::RawAsyncClientSharedPtr> async_clients;
+    for (int i = 0; i < proto_config.services_size(); i++) {
+      async_clients.push_back(std::make_shared<Envoy::Grpc::AsyncClientImpl>(
+          context.clusterManager(), config, context.api().timeSource()));
+    }
+
+    AsyncReflectionFetcherSharedPtr async_reflection_fetcher =
+        std::make_shared<AsyncReflectionFetcher>(proto_config.reflection_cluster_config(),
+                                                 proto_config.services(), async_clients,
+                                                 context.initManager());
+    // This needs to be injected into descriptor_pool_builder so that it can
+    // transitively stay alive long enough to do its job.
+    descriptor_pool_builder =
+        std::make_shared<DescriptorPoolBuilder>(proto_config, async_reflection_fetcher);
+  } else {
+    // If the descriptor oneof is not set, this will be detected inside
+    // JsonGrpcTranscoder, so we skip the redundant check here.
+    descriptor_pool_builder = std::make_shared<DescriptorPoolBuilder>(proto_config, context.api());
+  }
+
+  return std::make_shared<JsonTranscoderConfig>(proto_config, descriptor_pool_builder);
 }
 
 /**

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -10,6 +10,10 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcJsonTranscoder {
 
+// Forward declaration, to avoid needing to include the entire header.
+class JsonTranscoderConfig;
+using JsonTranscoderConfigSharedPtr = std::shared_ptr<JsonTranscoderConfig>;
+
 /**
  * Config registration for the gRPC JSON transcoder filter. @see NamedHttpFilterConfigFactory.
  */
@@ -29,6 +33,10 @@ private:
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;
+
+  JsonTranscoderConfigSharedPtr createConfig(
+      const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&,
+      Server::Configuration::CommonFactoryContext& context);
 };
 
 } // namespace GrpcJsonTranscoder

--- a/source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.cc
@@ -1,0 +1,156 @@
+#include "source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.h"
+
+using Envoy::Protobuf::FileDescriptorSet;
+using std::string;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+void DescriptorPoolBuilder::requestDescriptorPool(
+    std::function<void(std::unique_ptr<Protobuf::DescriptorPool>&&)> descriptor_pool_available) {
+  descriptor_pool_available_ = descriptor_pool_available;
+  FileDescriptorSet descriptor_set;
+
+  switch (proto_config_.descriptor_set_case()) {
+  case envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder::
+      DescriptorSetCase::kProtoDescriptor:
+    if (!descriptor_set.ParseFromString(
+            api_->fileSystem().fileReadToEnd(proto_config_.proto_descriptor()))) {
+      throw EnvoyException("transcoding_filter: Unable to parse proto descriptor");
+    }
+    loadFileDescriptorProtos(descriptor_set);
+    break;
+  case envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder::
+      DescriptorSetCase::kProtoDescriptorBin:
+    if (!descriptor_set.ParseFromString(proto_config_.proto_descriptor_bin())) {
+      throw EnvoyException("transcoding_filter: Unable to parse proto descriptor");
+    }
+    loadFileDescriptorProtos(descriptor_set);
+    break;
+  case envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder::
+      DescriptorSetCase::kReflectionClusterConfig:
+    // The constructor of this object is responsible for ensuring the async_reflection_fetcher_ is
+    // not null.
+    async_reflection_fetcher_->requestFileDescriptors(
+        [this](Envoy::Protobuf::FileDescriptorSet file_descriptor_set) {
+          this->loadFileDescriptorProtos(file_descriptor_set);
+        });
+    break;
+  case envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder::
+      DescriptorSetCase::DESCRIPTOR_SET_NOT_SET:
+    throw EnvoyException("transcoding_filter: descriptor not set");
+  }
+}
+
+void DescriptorPoolBuilder::loadFileDescriptorProtos(const FileDescriptorSet& file_descriptor_set) {
+  // We dedup the file_descriptor_set because multiple gRPC services can be
+  // defined in a single proto file, and different gRPC services can share
+  // protos. When gRPC refleciton is used, we make a request for the file
+  // descriptors associated with each gRPC service so these can overlap.
+  //
+  // After dedupping, we perform a topological sort on the file_descriptor_set
+  // so that dependencies are always built before the files that depend on
+  // them. This is needed because gRPC server reflection is not guaranteed to
+  // return transitive dependencies in a sorted order.
+  //
+  // Note that the decision to put this logic in this class rather than
+  // AsyncReflectionFetcher makes this class more general-purpose (all sources
+  // of file descriptors no longer need to be pre-processed) at the cost of
+  // additional cycles when the input is already deduped and topologically
+  // sorted. If performance becomes an issue, this decision may need to be
+  // revisited.
+  absl::flat_hash_map<std::string, Envoy::Protobuf::FileDescriptorProto> filename_to_descriptor;
+
+  for (const auto& file : file_descriptor_set.file()) {
+    filename_to_descriptor[file.name()] = file;
+  }
+
+  // Build the dependency graph using file names since they are lighter weight
+  // than protos.
+  absl::flat_hash_map<string, absl::flat_hash_set<string>> incoming_edges;
+  absl::flat_hash_map<string, absl::flat_hash_set<string>> outgoing_edges;
+  absl::flat_hash_set<string> no_incoming_edges;
+
+  for (auto& it : filename_to_descriptor) {
+    const std::string& filename = it.first;
+    const Envoy::Protobuf::FileDescriptorProto& proto = it.second;
+    if (proto.dependency_size() > 0) {
+      if (incoming_edges.find(filename) == incoming_edges.end()) {
+        incoming_edges[filename] = absl::flat_hash_set<string>();
+      }
+      for (auto& dependency : proto.dependency()) {
+        incoming_edges[filename].insert(dependency);
+        if (outgoing_edges.find(dependency) == outgoing_edges.end()) {
+          outgoing_edges[dependency] = absl::flat_hash_set<string>();
+        }
+        outgoing_edges[dependency].insert(filename);
+      }
+    } else {
+      no_incoming_edges.insert(filename);
+    }
+  }
+
+  std::vector<string> top_sorted_filenames;
+  while (!no_incoming_edges.empty()) {
+    std::string node = *no_incoming_edges.begin();
+    top_sorted_filenames.push_back(node);
+    no_incoming_edges.erase(node);
+
+    for (auto dependent_node : outgoing_edges[node]) {
+      incoming_edges[dependent_node].erase(node);
+      if (incoming_edges[dependent_node].size() == 0) {
+        no_incoming_edges.insert(dependent_node);
+      }
+    }
+  }
+
+  // Verify that all files are in among the sorted filenames. If any are
+  // missing, that implies a missing dependency because the topological sort
+  // will only pick up files whose dependencies are available.
+  if (top_sorted_filenames.size() != filename_to_descriptor.size()) {
+    ENVOY_LOG(error,
+              "transcoding_filter: Missing dependencies when building proto descriptor pool");
+    return;
+  }
+
+  std::unique_ptr<Protobuf::DescriptorPool> descriptor_pool =
+      std::make_unique<Protobuf::DescriptorPool>();
+  for (auto filename : top_sorted_filenames) {
+    if (!descriptor_pool->BuildFile(filename_to_descriptor[filename])) {
+      ENVOY_LOG(error, "transcoding_filter: Unable to build proto descriptor pool");
+      return;
+    }
+  }
+
+  bool convert_grpc_status = proto_config_.convert_grpc_status();
+  if (convert_grpc_status) {
+    // Add built-in symbols
+    for (auto& symbol_name : {"google.protobuf.Any", "google.rpc.Status"}) {
+      if (descriptor_pool->FindFileContainingSymbol(symbol_name) != nullptr) {
+        continue;
+      }
+
+      auto* builtin_pool = Protobuf::DescriptorPool::generated_pool();
+      if (!builtin_pool) {
+        continue;
+      }
+
+      Protobuf::DescriptorPoolDatabase pool_database(*builtin_pool);
+      Protobuf::FileDescriptorProto file_proto;
+      pool_database.FindFileContainingSymbol(symbol_name, &file_proto);
+      if (!descriptor_pool->BuildFile(file_proto)) {
+        ENVOY_LOG(error, "transcoding_filter: Unable to build proto descriptor pool");
+        return;
+      }
+    }
+  }
+
+  descriptor_pool_available_(std::move(descriptor_pool));
+}
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.cc
@@ -47,18 +47,18 @@ void DescriptorPoolBuilder::requestDescriptorPool(
 void DescriptorPoolBuilder::loadFileDescriptorProtos(const FileDescriptorSet& file_descriptor_set) {
   // We dedup the file_descriptor_set because multiple gRPC services can be
   // defined in a single proto file, and different gRPC services can share
-  // protos. When gRPC refleciton is used, we make a request for the file
+  // protos. When gRPC reflection is used, we make a request for the file
   // descriptors associated with each gRPC service so these can overlap.
   //
-  // After dedupping, we perform a topological sort on the file_descriptor_set
-  // so that dependencies are always built before the files that depend on
-  // them. This is needed because gRPC server reflection is not guaranteed to
-  // return transitive dependencies in a sorted order.
+  // After deduplication, we perform a topological sort on the
+  // file_descriptor_set so that dependencies are always built before the files
+  // that depend on them. This is needed because gRPC server reflection is not
+  // guaranteed to return transitive dependencies in a sorted order.
   //
   // Note that the decision to put this logic in this class rather than
   // AsyncReflectionFetcher makes this class more general-purpose (all sources
   // of file descriptors no longer need to be pre-processed) at the cost of
-  // additional cycles when the input is already deduped and topologically
+  // additional cycles when the input is already deduplicated and topologically
   // sorted. If performance becomes an issue, this decision may need to be
   // revisited.
   absl::flat_hash_map<std::string, Envoy::Protobuf::FileDescriptorProto> filename_to_descriptor;

--- a/source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/repeated_field.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/grpcpp.h>
+
+#include <memory>
+
+#include "envoy/api/api.h"
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
+#include "envoy/http/header_map.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/grpc/typed_async_client.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+/**
+ * This class contains the logic for building a protobuf descriptor pool from a
+ * set of FileDescriptorProtos.
+ */
+class DescriptorPoolBuilder : public Logger::Loggable<Logger::Id::config> {
+public:
+  /**
+   * Constructor for the non-reflection usage.
+   */
+  DescriptorPoolBuilder(
+      const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
+          proto_config,
+      Api::Api& api)
+      : proto_config_(proto_config), api_(&api) {}
+
+  /**
+   * Constructor. The async_reflection_fetcher is injected rather than
+   * constructed internally for easier unit testing.
+   */
+  DescriptorPoolBuilder(
+      const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
+          proto_config,
+      AsyncReflectionFetcherSharedPtr async_reflection_fetcher)
+      : proto_config_(proto_config), async_reflection_fetcher_(async_reflection_fetcher) {}
+
+  /**
+   * Ask this DescriptorPoolBuilder to compute a descriptor pool and call the given callback
+   * when the descriptor pool is ready.
+   */
+  virtual void requestDescriptorPool(
+      std::function<void(std::unique_ptr<Protobuf::DescriptorPool>&&)> descriptor_pool_available);
+
+  /**
+   * Convert the given FileDescriptorSet into a descriptor pool and pass it
+   * into the descriptor_pool_available function passed to
+   * requestDescriptorPool.
+   */
+  virtual void
+  loadFileDescriptorProtos(const Envoy::Protobuf::FileDescriptorSet& file_descriptor_set);
+  virtual ~DescriptorPoolBuilder() {}
+
+private:
+  /**
+   * A copy of the original proto_config.
+   */
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder proto_config_;
+
+  /**
+   * A pointer to our AsyncReflectionFetcher if we are using reflection. Set to nullptr if we are
+   * not using reflection.
+   */
+  AsyncReflectionFetcherSharedPtr async_reflection_fetcher_;
+
+  /**
+   * A function to call when the requested descriptor pool is available.
+   * This is only necessary for when using reflection, although we use it
+   * everywhere for consistency.
+   */
+  std::function<void(std::unique_ptr<Protobuf::DescriptorPool>&&)> descriptor_pool_available_;
+
+  /**
+   * API used for reading from the filesystem when loading protos from the filesystem.
+   */
+  Api::Api* api_;
+};
+
+using DescriptorPoolBuilderSharedPtr = std::shared_ptr<DescriptorPoolBuilder>;
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/test/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -21,7 +21,60 @@ envoy_extension_cc_test(
     extension_names = ["envoy.filters.http.grpc_json_transcoder"],
     deps = [
         "//source/extensions/filters/http/grpc_json_transcoder:json_transcoder_filter_lib",
+        "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/http:http_mocks",
+        "//test/proto:bookstore_proto_cc_proto",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "descriptor_pool_builder_test",
+    srcs = ["descriptor_pool_builder_test.cc"],
+    data = [
+        "//test/proto:bookstore.proto",
+        "//test/proto:bookstore_proto_descriptor",
+    ],
+    extension_names = ["envoy.filters.http.grpc_json_transcoder"],
+    deps = [
+        "//source/extensions/filters/http/grpc_json_transcoder:json_transcoder_filter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/proto:bookstore_proto_cc_proto",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "async_reflection_fetcher_test",
+    srcs = ["async_reflection_fetcher_test.cc"],
+    data = [
+        "//test/proto:bookstore.proto",
+        "//test/proto:bookstore_proto_descriptor",
+    ],
+    extension_names = ["envoy.filters.http.grpc_json_transcoder"],
+    deps = [
+        "//source/extensions/filters/http/grpc_json_transcoder:json_transcoder_filter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/proto:bookstore_proto_cc_proto",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "async_reflection_fetcher_callbacks_test",
+    srcs = ["async_reflection_fetcher_callbacks_test.cc"],
+    extension_names = ["envoy.filters.http.grpc_json_transcoder"],
+    deps = [
+        "//source/extensions/filters/http/grpc_json_transcoder:json_transcoder_filter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "//test/proto:bookstore_proto_cc_proto",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_callbacks_test.cc
@@ -1,0 +1,86 @@
+#include <fstream>
+#include <functional>
+#include <memory>
+
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/grpc/codec.h"
+#include "source/common/grpc/common.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h"
+
+#include "test/mocks/grpc/mocks.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/server/factory_context.h"
+#include "test/proto/bookstore.pb.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::ByMove;
+using testing::Invoke;
+using testing::MockFunction;
+using testing::NiceMock;
+using testing::Return;
+
+using Envoy::Protobuf::FileDescriptorProto;
+using Envoy::Protobuf::FileDescriptorSet;
+using Envoy::Protobuf::util::MessageDifferencer;
+using Envoy::ProtobufUtil::StatusCode;
+using Envoy::Server::Configuration::MockFactoryContext;
+using google::api::HttpRule;
+using google::grpc::transcoding::Transcoder;
+using TranscoderPtr = std::unique_ptr<Transcoder>;
+
+using grpc::reflection::v1alpha::ServerReflectionResponse;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+namespace {
+
+class AsyncReflectionFetcherCallbacksTest : public testing::Test {
+public:
+  AsyncReflectionFetcherCallbacksTest() {}
+};
+
+/**
+ * Verify that we registered with the init manager when requestFileDescriptors
+ * is invoked.
+ */
+TEST_F(AsyncReflectionFetcherCallbacksTest, OnReceiveMessage) {
+  MockFunction<void(AsyncReflectionFetcherCallbacks*,
+                    std::unique_ptr<grpc::reflection::v1alpha::ServerReflectionResponse> &&)>
+      mock_on_success_callback;
+  AsyncReflectionFetcherCallbacks async_reflection_fetcher_callbacks(
+      mock_on_success_callback.AsStdFunction());
+  std::unique_ptr<ServerReflectionResponse> message = std::make_unique<ServerReflectionResponse>();
+
+  EXPECT_CALL(mock_on_success_callback, Call(_, _));
+  async_reflection_fetcher_callbacks.onReceiveMessage(std::move(message));
+}
+
+TEST_F(AsyncReflectionFetcherCallbacksTest, OnRemoteClose) {
+  MockFunction<void(AsyncReflectionFetcherCallbacks*,
+                    std::unique_ptr<grpc::reflection::v1alpha::ServerReflectionResponse> &&)>
+      mock_on_success_callback;
+  AsyncReflectionFetcherCallbacks async_reflection_fetcher_callbacks(
+      mock_on_success_callback.AsStdFunction());
+
+  EXPECT_CALL(mock_on_success_callback, Call(_, _)).Times(0);
+  async_reflection_fetcher_callbacks.onRemoteClose(Envoy::Grpc::Status::Unknown,
+                                                   "An unknown error occurred");
+}
+
+} // namespace
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/async_reflection_fetcher_test.cc
@@ -1,0 +1,142 @@
+#include <fstream>
+#include <functional>
+#include <memory>
+
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/grpc/codec.h"
+#include "source/common/grpc/common.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h"
+
+#include "test/mocks/grpc/mocks.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/server/factory_context.h"
+#include "test/proto/bookstore.pb.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::ByMove;
+using testing::Invoke;
+using testing::MockFunction;
+using testing::NiceMock;
+using testing::Return;
+
+using Envoy::Protobuf::FileDescriptorProto;
+using Envoy::Protobuf::FileDescriptorSet;
+using Envoy::Protobuf::util::MessageDifferencer;
+using Envoy::ProtobufUtil::StatusCode;
+using Envoy::Server::Configuration::MockFactoryContext;
+using google::api::HttpRule;
+using google::grpc::transcoding::Transcoder;
+using TranscoderPtr = std::unique_ptr<Transcoder>;
+
+using grpc::reflection::v1alpha::ServerReflectionResponse;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+namespace {
+
+class MockAsyncReflectionFetcherCallbacks : public AsyncReflectionFetcherCallbacks {
+public:
+  MockAsyncReflectionFetcherCallbacks()
+      : AsyncReflectionFetcherCallbacks(
+            [](AsyncReflectionFetcherCallbacks*, std::unique_ptr<ServerReflectionResponse>&&) {}) {}
+};
+
+class AsyncReflectionFetcherTest : public testing::Test {
+public:
+  AsyncReflectionFetcherTest()
+      : api_(Api::createApiForTest()),
+        mock_async_client_(std::make_shared<Envoy::Grpc::MockAsyncClient>()), mock_async_stream_() {
+  }
+
+protected:
+  Api::ApiPtr api_;
+  std::shared_ptr<Envoy::Grpc::MockAsyncClient> mock_async_client_;
+  Envoy::Grpc::MockAsyncStream mock_async_stream_;
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
+};
+
+/**
+ * Verify that we registered with the init manager when requestFileDescriptors
+ * is invoked.
+ */
+TEST_F(AsyncReflectionFetcherTest, RegisterInitManager) {
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder_ReflectionConfig
+      reflection_cluster_config;
+  Envoy::Protobuf::RepeatedPtrField<std::string> services;
+  std::vector<Grpc::RawAsyncClientSharedPtr> async_clients;
+  AsyncReflectionFetcher async_reflection_fetcher(reflection_cluster_config, services,
+                                                  async_clients, context_.initManager());
+
+  MockFunction<void(Envoy::Protobuf::FileDescriptorSet)> mock_file_descriptors_available;
+  EXPECT_CALL(mock_file_descriptors_available, Call(_)).Times(0);
+  EXPECT_CALL(context_.init_manager_, add(_));
+  async_reflection_fetcher.requestFileDescriptors(mock_file_descriptors_available.AsStdFunction());
+}
+
+/**
+ * Verify that callbacks are added by startReflectionRpcs.
+ */
+TEST_F(AsyncReflectionFetcherTest, StartReflectionRpcs) {
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder_ReflectionConfig
+      reflection_cluster_config;
+  Envoy::Protobuf::RepeatedPtrField<std::string> services;
+  services.Add("helloworld");
+  std::vector<Grpc::RawAsyncClientSharedPtr> async_clients;
+  async_clients.push_back(mock_async_client_);
+  AsyncReflectionFetcher async_reflection_fetcher(reflection_cluster_config, services,
+                                                  async_clients, context_.initManager());
+  EXPECT_CALL(*mock_async_client_, startRaw(_, _, _, _)).WillOnce(Return(&mock_async_stream_));
+  EXPECT_CALL(mock_async_stream_, sendMessageRaw_(_, true));
+  EXPECT_TRUE(async_reflection_fetcher.getRemainingCallBacksForTest().size() == 0);
+  async_reflection_fetcher.startReflectionRpcs();
+  EXPECT_TRUE(async_reflection_fetcher.getRemainingCallBacksForTest().size() == 1);
+  async_clients.clear();
+}
+
+/**
+ * Verify that successful Rpc responses are handled correctly.
+ */
+TEST_F(AsyncReflectionFetcherTest, OnRpcCompleted) {
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder_ReflectionConfig
+      reflection_cluster_config;
+  Envoy::Protobuf::RepeatedPtrField<std::string> services;
+  std::vector<Grpc::RawAsyncClientSharedPtr> async_clients;
+  async_clients.push_back(mock_async_client_);
+  AsyncReflectionFetcher async_reflection_fetcher(reflection_cluster_config, services,
+                                                  async_clients, context_.initManager());
+
+  absl::flat_hash_set<AsyncReflectionFetcherCallbacks*>& callbacks =
+      async_reflection_fetcher.getRemainingCallBacksForTest();
+  MockAsyncReflectionFetcherCallbacks async_reflection_fetcher_callbacks;
+  callbacks.insert(&async_reflection_fetcher_callbacks);
+
+  MockFunction<void(Envoy::Protobuf::FileDescriptorSet)> mock_file_descriptors_available;
+  EXPECT_CALL(mock_file_descriptors_available, Call(_));
+  // This test is not primarily testing this function, but the call is
+  // necessary because  onRpcCompleted calls the function passed
+  // into requestFileDescriptors.
+  async_reflection_fetcher.requestFileDescriptors(mock_file_descriptors_available.AsStdFunction());
+
+  ServerReflectionResponsePtr message = std::make_unique<ServerReflectionResponse>();
+  EXPECT_FALSE(callbacks.empty());
+  async_reflection_fetcher.onRpcCompleted(&async_reflection_fetcher_callbacks, std::move(message));
+  EXPECT_TRUE(callbacks.empty());
+}
+
+} // namespace
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/descriptor_pool_builder_test.cc
@@ -1,0 +1,151 @@
+#include <fstream>
+#include <functional>
+#include <memory>
+
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/grpc/codec.h"
+#include "source/common/grpc/common.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/proto/bookstore.pb.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::MockFunction;
+using testing::NiceMock;
+using testing::Return;
+
+using Envoy::Protobuf::FileDescriptorProto;
+using Envoy::Protobuf::FileDescriptorSet;
+using Envoy::Protobuf::util::MessageDifferencer;
+using Envoy::ProtobufUtil::StatusCode;
+using google::api::HttpRule;
+using google::grpc::transcoding::Transcoder;
+using TranscoderPtr = std::unique_ptr<Transcoder>;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+namespace {
+
+class DescriptorPoolBuilderTest : public testing::Test {
+public:
+  DescriptorPoolBuilderTest() : api_(Api::createApiForTest()) {}
+
+protected:
+  std::string makeProtoDescriptor(std::function<void(FileDescriptorSet&)> process) {
+    FileDescriptorSet descriptor_set;
+    descriptor_set.ParseFromString(api_->fileSystem().fileReadToEnd(
+        TestEnvironment::runfilesPath("test/proto/bookstore.descriptor")));
+
+    process(descriptor_set);
+
+    TestEnvironment::createPath(TestEnvironment::temporaryPath("envoy_test"));
+    std::string path = TestEnvironment::temporaryPath("envoy_test/proto.descriptor");
+    std::ofstream file(path, std::ios::binary);
+    descriptor_set.SerializeToOstream(&file);
+
+    return path;
+  }
+
+  const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder
+  getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
+                 bool match_incoming_request_route = false,
+                 const std::vector<std::string>& ignored_query_parameters = {}) {
+    const std::string json_string = "{\"proto_descriptor\": \"" + descriptor_path +
+                                    "\",\"services\": [\"" + service_name + "\"]}";
+    envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder proto_config;
+    TestUtility::loadFromJson(json_string, proto_config);
+    proto_config.set_match_incoming_request_route(match_incoming_request_route);
+    for (const auto& query_param : ignored_query_parameters) {
+      proto_config.add_ignored_query_parameters(query_param);
+    }
+
+    return proto_config;
+  }
+
+  void stripImports(FileDescriptorSet& descriptor_set, const std::string& file_name) {
+    FileDescriptorProto file_descriptor;
+    // filter down descriptor_set to only contain one proto specified as file_name but none of its
+    // dependencies
+    auto file_itr =
+        std::find_if(descriptor_set.file().begin(), descriptor_set.file().end(),
+                     [&file_name](const FileDescriptorProto& file) {
+                       // return whether file.name() ends with file_name
+                       return file.name().length() >= file_name.length() &&
+                              0 == file.name().compare(file.name().length() - file_name.length(),
+                                                       std::string::npos, file_name);
+                     });
+    RELEASE_ASSERT(file_itr != descriptor_set.file().end(), "");
+    file_descriptor = *file_itr;
+
+    descriptor_set.clear_file();
+    descriptor_set.add_file()->Swap(&file_descriptor);
+  }
+
+  Api::ApiPtr api_;
+};
+
+TEST_F(DescriptorPoolBuilderTest, ParseBinaryConfig) {
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder proto_config;
+  proto_config.set_proto_descriptor_bin(api_->fileSystem().fileReadToEnd(
+      TestEnvironment::runfilesPath("test/proto/bookstore.descriptor")));
+  proto_config.add_services("bookstore.Bookstore");
+  DescriptorPoolBuilder builder(proto_config, *api_);
+  MockFunction<void(std::unique_ptr<Protobuf::DescriptorPool> &&)> mock_descriptor_pool_available;
+  EXPECT_CALL(mock_descriptor_pool_available, Call(_));
+  EXPECT_NO_THROW(builder.requestDescriptorPool(mock_descriptor_pool_available.AsStdFunction()));
+}
+
+TEST_F(DescriptorPoolBuilderTest, IncompleteProto) {
+  auto proto_config = getProtoConfig(makeProtoDescriptor([&](FileDescriptorSet& pb) {
+                                       stripImports(pb, "test/proto/bookstore.proto");
+                                     }),
+                                     "bookstore.Bookstore");
+  DescriptorPoolBuilder builder(proto_config, *api_);
+  MockFunction<void(std::unique_ptr<Protobuf::DescriptorPool> &&)> mock_descriptor_pool_available;
+  EXPECT_CALL(mock_descriptor_pool_available, Call(_)).Times(0);
+  EXPECT_LOG_CONTAINS(
+      "error", "transcoding_filter: Missing dependencies when building proto descriptor pool",
+      builder.requestDescriptorPool(mock_descriptor_pool_available.AsStdFunction()));
+}
+
+TEST_F(DescriptorPoolBuilderTest, NonProto) {
+  auto proto_config = getProtoConfig(TestEnvironment::runfilesPath("test/proto/bookstore.proto"),
+                                     "grpc.service.UnknownService");
+  DescriptorPoolBuilder builder(proto_config, *api_);
+  MockFunction<void(std::unique_ptr<Protobuf::DescriptorPool> &&)> mock_descriptor_pool_available;
+  EXPECT_CALL(mock_descriptor_pool_available, Call(_)).Times(0);
+  EXPECT_THROW_WITH_MESSAGE(
+      builder.requestDescriptorPool(mock_descriptor_pool_available.AsStdFunction()), EnvoyException,
+      "transcoding_filter: Unable to parse proto descriptor");
+}
+
+TEST_F(DescriptorPoolBuilderTest, NonBinaryProto) {
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder proto_config;
+  proto_config.set_proto_descriptor_bin("This is invalid proto");
+  proto_config.add_services("bookstore.Bookstore");
+  MockFunction<void(std::unique_ptr<Protobuf::DescriptorPool> &&)> mock_descriptor_pool_available;
+  DescriptorPoolBuilder builder(proto_config, *api_);
+  EXPECT_THROW_WITH_MESSAGE(
+      builder.requestDescriptorPool(mock_descriptor_pool_available.AsStdFunction()), EnvoyException,
+      "transcoding_filter: Unable to parse proto descriptor");
+}
+
+} // namespace
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -36,6 +36,7 @@ abc
 abcd
 abd
 ar
+arbitrarily
 btree
 CAS
 CB
@@ -631,6 +632,7 @@ decrypt
 dedup
 dedupe
 deduplicate
+deduplicated
 deduplicates
 deduplication
 deflater
@@ -935,6 +937,7 @@ nonblocking
 noncopyable
 nonresponsive
 noop
+noops
 nop
 npos
 nthreads
@@ -1054,6 +1057,8 @@ pubkey
 pwd
 py
 qdtext
+qiwzhang
+qiwzhang's
 qps
 quantile
 quantiles
@@ -1093,6 +1098,7 @@ refcount
 referencee
 referer
 refetch
+reflection
 refvec
 regex
 regexes


### PR DESCRIPTION
Previously, the grpc_json_transcoder filter required a statically
generated set of protobuf descriptors to perform translation.

This commit adds the ability to fetch protobuf descriptors via grpc
reflection.

Note that, per discussion on #1182, this change entails a fairly major
restructuring of the filter's code.

In addition to unit tests, this PR was tested manually using `greeter_server` from grpc examples in the grpc repository.

Signed-off-by: Henry Qin <root@hq6.me>
