### PR TITLE
http: improving shadowing with upstream filters

### DIFF
--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -93,6 +93,7 @@ class AsyncStreamImpl : public AsyncClient::Stream,
 public:
   AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
                   const AsyncClient::StreamOptions& options);
+  ~AsyncStreamImpl() override { router_.onDestroy(); }
 
   // Http::AsyncClient::Stream
   void sendHeaders(RequestHeaderMap& headers, bool end_stream) override;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -590,6 +590,8 @@ private:
   MetadataMatchCriteriaConstPtr metadata_match_;
   std::function<void(Http::ResponseHeaderMap&)> modify_headers_;
   std::vector<std::reference_wrapper<const ShadowPolicy>> active_shadow_policies_{};
+  std::unique_ptr<Http::RequestHeaderMap> shadow_headers_;
+  std::unique_ptr<Http::RequestTrailerMap> shadow_trailers_;
   // The stream lifetime configured by request header.
   absl::optional<std::chrono::milliseconds> dynamic_max_stream_duration_;
   // list of cookies to add to upstream headers

--- a/test/integration/filters/add_body_filter.cc
+++ b/test/integration/filters/add_body_filter.cc
@@ -54,12 +54,9 @@ public:
   }
 
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override {
-    // Ensure that decodeData is only called for HTTP/3 (where protocol is set at the
-    // connection level). In HTTP/3 the FIN arrives separately so we will get
-    // decodeData() with an empty body.
+    // decodeData is called for HTTP/3 where the FIN arrives separately from headers.
     if (config_->where_to_add_body_ == test::integration::filters::AddBodyFilterConfig::DEFAULT) {
-      if (end_stream && decoder_callbacks_->connection()->streamInfo().protocol() &&
-          data.length() == 0u) {
+      if (end_stream && data.length() == 0u) {
         data.add("body");
       }
     } else if (config_->where_to_add_body_ ==
@@ -83,12 +80,9 @@ public:
   }
 
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override {
-    // Ensure that encodeData is only called for HTTP/3 (where protocol is set at the
-    // connection level). In HTTP/3 the FIN arrives separately so we will get
-    // encodeData() with an empty body.
+    // encodeData is called for HTTP/3 where the FIN arrives separately from headers.
     if (config_->where_to_add_body_ == test::integration::filters::AddBodyFilterConfig::DEFAULT) {
-      if (end_stream && decoder_callbacks_->connection()->streamInfo().protocol() &&
-          data.length() == 0) {
+      if (end_stream && data.length() == 0) {
         data.add("body");
       }
     } else if (config_->where_to_add_body_ ==

--- a/test/integration/shadow_policy_integration_test.cc
+++ b/test/integration/shadow_policy_integration_test.cc
@@ -12,11 +12,24 @@ public:
   }
 
   void intitialConfigSetup(const std::string& cluster_name, const std::string& cluster_header) {
-    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* cluster = bootstrap.mutable_static_resources()->add_clusters();
       cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
       cluster->set_name(std::string(Envoy::RepickClusterFilter::ClusterName));
       ConfigHelper::setHttp2(*cluster);
+      if (cluster_with_local_reply_filter_.has_value()) {
+        auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(
+            *cluster_with_local_reply_filter_);
+
+        auto protocol_options = MessageUtil::anyConvert<ConfigHelper::HttpProtocolOptions>(
+            (*cluster->mutable_typed_extension_protocol_options())
+                ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]);
+        protocol_options.add_http_filters()->set_name("on-local-reply-filter");
+        protocol_options.add_http_filters()->set_name("envoy.filters.http.upstream_codec");
+        (*cluster->mutable_typed_extension_protocol_options())
+            ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                .PackFrom(protocol_options);
+      }
     });
 
     // Set the mirror policy with cluster header or cluster name.
@@ -53,6 +66,8 @@ public:
 
     cleanupUpstreamAndDownstream();
   }
+
+  absl::optional<int> cluster_with_local_reply_filter_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ShadowPolicyIntegrationTest,
@@ -68,6 +83,36 @@ TEST_P(ShadowPolicyIntegrationTest, RequestMirrorPolicyWithCluster) {
 
   EXPECT_EQ(test_server_->counter("cluster.cluster_1.upstream_cx_total")->value(), 1);
   EXPECT_EQ(test_server_->counter("cluster.cluster_0.upstream_cx_total")->value(), 1);
+}
+
+// Test request mirroring / shadowing with the original cluster having a local reply filter.
+TEST_P(ShadowPolicyIntegrationTest, OriginalClusterWithLocalReply) {
+  intitialConfigSetup("cluster_1", "");
+  cluster_with_local_reply_filter_ = 0;
+  setUpstreamProtocol(Http::CodecClient::Type::HTTP2);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("400", response->headers().getStatusValue());
+
+  EXPECT_EQ(test_server_->counter("cluster.cluster_1.upstream_cx_total")->value(), 0);
+  EXPECT_EQ(test_server_->counter("cluster.cluster_0.upstream_cx_total")->value(), 1);
+}
+
+// Test request mirroring / shadowing with the mirror cluster having a local reply filter.
+TEST_P(ShadowPolicyIntegrationTest, DISABLED_MirrorClusterWithLocalReply) {
+  // TODO(alyssawilk) fix.
+  intitialConfigSetup("cluster_1", "");
+  cluster_with_local_reply_filter_ = 1;
+  setUpstreamProtocol(Http::CodecClient::Type::HTTP2);
+  initialize();
+
+  sendRequestAndValidateResponse();
+
+  EXPECT_EQ(test_server_->counter("cluster.cluster_1.upstream_cx_total")->value(), 1);
+  EXPECT_EQ(test_server_->counter("cluster.cluster_0.upstream_cx_total")->value(), 0);
 }
 
 // Test request mirroring / shadowing with the cluster header.


### PR DESCRIPTION
Fixing a bug where the router was not properly shut down for shadowing with upstream filters.
Fixing a second bug where headers were latched too late, and request headers were not isolated from shadow headers

Testing: new integration tests
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/10455