### PR TITLE
bazel: fix -no_deduplicate for test targets

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -70,7 +70,7 @@ def _envoy_test_linkopts():
         # TODO(mattklein123): It's not great that we universally link against the following libs.
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
-    }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"])
+    }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"]) + envoy_dbg_linkopts()
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
 def envoy_cc_fuzz_test(
@@ -106,7 +106,7 @@ def envoy_cc_fuzz_test(
     native.cc_test(
         name = name,
         copts = envoy_copts("@envoy", test = True),
-        linkopts = _envoy_test_linkopts() + envoy_dbg_linkopts() + select({
+        linkopts = _envoy_test_linkopts() + select({
             "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
             "//conditions:default": [],
         }),


### PR DESCRIPTION
I accidentally only added this flag to fuzz tests, this moves it to the private `_envoy_test_linkopts` function which is used by all test targets in this file.

2a3643ec5d90b6302b13196e21ce0df14fb99c92

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>