### PR TITLE
Make URL query in unit test standard compliant

### DIFF
--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -280,18 +280,9 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, QueryParamsDecodedName) {
       },
       R"({"id":"20","theme":"Children"})");
 
-  // json_name = "search[decoded]", "search[decoded]" should work
-  testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
-      Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                     {":path", "/shelf?shelf.search[decoded]=Google"},
-                                     {":authority", "host"},
-                                     {"content-type", "application/json"}},
-      "", {R"(shelf { search_decoded: "Google" })"}, {R"(id: 20 theme: "Children" )"}, Status(),
-      Http::TestResponseHeaderMapImpl{
-          {":status", "200"},
-          {"content-type", "application/json"},
-      },
-      R"({"id":"20","theme":"Children"})");
+  // The [] characters are not valid in URL query per
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-3.4 As a result the case json_name =
+  // "search[decoded]", "search[decoded]" is not tested
 
   // json_name = "search%5Bencoded%5D", "search[encode]" should fail.
   // It is tested in test case "DecodedQueryParameterWithEncodedJsonName"


### PR DESCRIPTION
Commit Message:
`[]` characters are not allowed in URL query per https://datatracker.ietf.org/doc/html/rfc3986#section-3.4

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>

