### PR TITLE
remove default wasm runtime in the config examples

### DIFF
--- a/docs/root/configuration/listeners/network_filters/wasm_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/wasm_filter.rst
@@ -27,7 +27,6 @@ Example filter configuration:
       config:
         name: "my_plugin"
         vm_config:
-          runtime: "envoy.wasm.runtime.v8"
           code:
             local:
               filename: "/etc/envoy_filter_http_wasm_example.wasm"

--- a/docs/root/configuration/other_features/wasm_service.rst
+++ b/docs/root/configuration/other_features/wasm_service.rst
@@ -24,7 +24,6 @@ Example plugin configuration:
               "my_config_value": "my_value"
             }
         vm_config:
-          runtime: "envoy.wasm.runtime.v8"
           code:
             local:
               filename: "/etc/envoy_filter_http_wasm_example.wasm"

--- a/examples/wasm-cc/envoy.yaml
+++ b/examples/wasm-cc/envoy.yaml
@@ -37,7 +37,6 @@ static_resources:
                   value: |
                     {}
                 vm_config:
-                  runtime: "envoy.wasm.runtime.v8"
                   vm_id: "my_vm_id"
                   code:
                     local:


### PR DESCRIPTION
`vm_config.runtime` is currently optional. This PR updates the config examples to remove the wasm runtime defaults.


Signed-off-by: Jiayu Wu <jiayu1.wu@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #21749
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
