### PR TITLE
stats: fix tag extraction for `worker_id` to avoid double counting

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -41,7 +41,7 @@ minor_behavior_changes:
     changed the filter callback interfaces to make sure that downstream-only functionality is explicit.
 - area: stats
   change: |
-    Default tag extraction rules were changed for `worker_id` extraction. Previously, `worker_` was removed from the original name during the extraction. This
+    Default tag extraction rules were changed for ``worker_id`` extraction. Previously, ``worker_`` was removed from the original name during the extraction. This
     led to the same base stat name for both the per-worker and overall stat. For instance, in prometheus stats, the following stats were produced: ::
 
       envoy_listener_downstream_cx_total{envoy_listener_address="vip"} 2

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -44,16 +44,16 @@ minor_behavior_changes:
     Default tag extraction rules were changed for ``worker_id`` extraction. Previously, ``worker_`` was removed from the original name during the extraction. This
     led to the same base stat name for both the per-worker and overall stat. For instance, in prometheus stats, the following stats were produced: ::
 
-      envoy_listener_downstream_cx_total{} 2
-      envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1
-      envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1
+      envoy_listener_downstream_cx_total{} 2.
+      envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1.
+      envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1.
 
     This resulted in ``sum(envoy_listener_downstream_cx_total)`` producing 4, even though there are only 2 connections.
     The new behavior results in stats such as this: ::
 
-      envoy_listener_downstream_cx_total{} 2
-      envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1
-      envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1
+      envoy_listener_downstream_cx_total{} 2.
+      envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1.
+      envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -39,6 +39,21 @@ minor_behavior_changes:
 - area: http
   change: |
     changed the filter callback interfaces to make sure that downstream-only functionality is explicit.
+- area: stats
+  change: |
+    Default tag extraction rules were changed for `worker_id` extraction. Previously, `worker_` was removed from the original name during the extraction. This
+    led to the same base stat name for both the per-worker and overall stat. For instance, in prometheus stats, the following stats were produced: ::
+
+      envoy_listener_downstream_cx_total{envoy_listener_address="vip"} 2
+      envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1
+      envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1
+
+    This resulted in ``sum(envoy_listener_downstream_cx_total)`` producing 4, even though there are only 2 connections.
+    The new behavior results in stats such as this: ::
+
+      envoy_listener_downstream_cx_total{envoy_listener_address="vip"} 2
+      envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1
+      envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -44,14 +44,14 @@ minor_behavior_changes:
     Default tag extraction rules were changed for ``worker_id`` extraction. Previously, ``worker_`` was removed from the original name during the extraction. This
     led to the same base stat name for both the per-worker and overall stat. For instance, in prometheus stats, the following stats were produced: ::
 
-      envoy_listener_downstream_cx_total{envoy_listener_address="vip"} 2
+      envoy_listener_downstream_cx_total{} 2
       envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1
       envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1
 
     This resulted in ``sum(envoy_listener_downstream_cx_total)`` producing 4, even though there are only 2 connections.
     The new behavior results in stats such as this: ::
 
-      envoy_listener_downstream_cx_total{envoy_listener_address="vip"} 2
+      envoy_listener_downstream_cx_total{} 2
       envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1
       envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1
 

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -140,7 +140,7 @@ TagNameValues::TagNameValues() {
   // server.(worker_<id>.)*
   addRe2(
       WORKER_ID,
-      R"(^(?:listener\.(?:<ADDRESS>|<TAG_VALUE>)\.|server\.|listener_manager\.)(worker_(\d+)\.))",
+      R"(^(?:listener\.(?:<ADDRESS>|<TAG_VALUE>)\.|server\.|listener_manager\.)worker_((\d+)\.))",
       "");
 
   // listener.(<address|stat_prefix>.)*, but specifically excluding "admin"

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -392,19 +392,20 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   worker_id.value_ = "123";
 
   regex_tester.testRegex("listener_manager.worker_123.dispatcher.loop_duration_us",
-                         "listener_manager.dispatcher.loop_duration_us", {worker_id});
+                         "listener_manager.worker_dispatcher.loop_duration_us", {worker_id});
 
   // Listener worker id
   listener_address.value_ = "127.0.0.1_3012";
   regex_tester.testRegex("listener.127.0.0.1_3012.worker_123.downstream_cx_active",
-                         "listener.downstream_cx_active", {listener_address, worker_id});
+                         "listener.worker_downstream_cx_active", {listener_address, worker_id});
 
   listener_address.value_ = "myprefix";
   regex_tester.testRegex("listener.myprefix.worker_123.downstream_cx_active",
-                         "listener.downstream_cx_active", {listener_address, worker_id});
+                         "listener.worker_downstream_cx_active", {listener_address, worker_id});
 
   // Server worker id
-  regex_tester.testRegex("server.worker_123.watchdog_miss", "server.watchdog_miss", {worker_id});
+  regex_tester.testRegex("server.worker_123.watchdog_miss", "server.worker_watchdog_miss",
+                         {worker_id});
 
   // Thrift Proxy Prefix
   Tag thrift_prefix;

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -486,7 +486,7 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
       {listenerStatPrefix("ssl.ocsp_staple_failed"), "listener.ssl.ocsp_staple_failed"},
       {listenerStatPrefix("http.config_test.downstream_rq_2xx"), "listener.http.downstream_rq_xx"},
       {listenerStatPrefix("http.config_test.downstream_rq_5xx"), "listener.http.downstream_rq_xx"},
-      {listenerStatPrefix("worker_0.downstream_cx_total"), "listener.downstream_cx_total"},
+      {listenerStatPrefix("worker_0.downstream_cx_total"), "listener.worker_downstream_cx_total"},
       {listenerStatPrefix("ssl.fail_verify_san"), "listener.ssl.fail_verify_san"},
       {listenerStatPrefix("downstream_cx_transport_socket_connect_timeout"),
        "listener.downstream_cx_transport_socket_connect_timeout"},
@@ -677,7 +677,7 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
       {"http.config_test.downstream_rq_failed_path_normalization",
        "http.downstream_rq_failed_path_normalization"},
       {"cluster.cluster_0.original_dst_host_invalid", "cluster.original_dst_host_invalid"},
-      {"server.worker_0.watchdog_miss", "server.watchdog_miss"},
+      {"server.worker_0.watchdog_miss", "server.worker_watchdog_miss"},
       {"http.config_test.downstream_rq_rx_reset", "http.downstream_rq_rx_reset"},
       {"cluster.cluster_0.upstream_cx_destroy_local_with_active_rq",
        "cluster.upstream_cx_destroy_local_with_active_rq"},
@@ -760,7 +760,7 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
        "listener.admin.downstream_cx_overload_reject"},
       {"http.config_test.tracing.random_sampling", "http.tracing.random_sampling"},
       {"cluster.cluster_0.upstream_cx_pool_overflow", "cluster.upstream_cx_pool_overflow"},
-      {"server.worker_0.watchdog_mega_miss", "server.watchdog_mega_miss"},
+      {"server.worker_0.watchdog_mega_miss", "server.worker_watchdog_mega_miss"},
       {"cluster.cluster_0.upstream_cx_tx_bytes_total", "cluster.upstream_cx_tx_bytes_total"},
       {"http.admin.rs_too_large", "http.rs_too_large"},
       {"listener.admin.downstream_cx_transport_socket_connect_timeout",
@@ -830,7 +830,7 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
       {"listener.admin.downstream_cx_destroy", "listener.admin.downstream_cx_destroy"}};
 
   tag_extracted_gauge_map = {
-      {listenerStatPrefix("worker_0.downstream_cx_active"), "listener.downstream_cx_active"},
+      {listenerStatPrefix("worker_0.downstream_cx_active"), "listener.worker_downstream_cx_active"},
       {listenerStatPrefix("downstream_cx_active"), "listener.downstream_cx_active"},
       {listenerStatPrefix("downstream_pre_cx_active"), "listener.downstream_pre_cx_active"},
       {"listener.admin.downstream_cx_active", "listener.admin.downstream_cx_active"},


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
stats: fix tag extraction for `worker_id` to avoid double counting

Default tag extraction rules were changed for `worker_id` extraction. Previously, `worker_` was removed from the original name during the extraction. This led to the same base stat name for both the per-worker and overall stat. For instance, in prometheus stats, the following stats were produced:

      envoy_listener_downstream_cx_total{} 2
      envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1
      envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1

This resulted in ``sum(envoy_listener_downstream_cx_total)`` producing 4, even though there are only 2 connections.
The new behavior results in stats such as this:

      envoy_listener_downstream_cx_total{} 2
      envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1
      envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1

Additional Description:
Risk Level: Low
Testing: adjusted
Docs Changes:
Release Notes: added (and verified generated formatting is correct)
Platform Specific Features:
[Optional Runtime guard:]
Fixes #22705
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
