### PR TITLE
access_logs: Fix crash due to uninitialized bytes meter

### DIFF
--- a/source/server/active_stream_listener_base.cc
+++ b/source/server/active_stream_listener_base.cc
@@ -33,6 +33,7 @@ void ActiveStreamListenerBase::newConnection(Network::ConnectionSocketPtr&& sock
     ENVOY_LOG(debug, "closing connection from {}: no matching filter chain found",
               socket->connectionInfoProvider().remoteAddress()->asString());
     stats_.no_filter_chain_match_.inc();
+    stream_info->setDownstreamBytesMeter(std::make_shared<StreamInfo::BytesMeter>());
     stream_info->setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
     stream_info->setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().FilterChainNotFound);
     emitLogs(*config_, *stream_info);


### PR DESCRIPTION
Opening this to get others' thoughts.  Not sure if this is how it should be handled or if there should be safety checks in the callbacks themselves.

Signed-off-by: Brian Sonnenberg <bsonnenberg@google.com>

Commit Message:  call setDownstreamBytesMeter in the case that no filter chain matched to avoid crashing due to uninitialized bytes meter.
Additional Description:
Risk Level:  Low
Testing: Manual only
Docs Changes:
Release Notes: TBD
Platform Specific Features:
[Optional Fixes #Issue] [#22335](https://github.com/envoyproxy/envoy/issues/22335)
[Optional Fixes commit #PR or SHA]
