### PR TITLE
No longer override socketType() in ConnectionSocketImpl

### DIFF
--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -192,9 +192,6 @@ public:
     connection_info_provider_->setLocalAddress(local_address);
   }
 
-  // Network::Socket
-  Socket::Type socketType() const override { return Socket::Type::Stream; }
-
   // Network::ConnectionSocket
   void setDetectedTransportProtocol(absl::string_view protocol) override {
     transport_protocol_ = std::string(protocol);


### PR DESCRIPTION
No longer override socketType() in ConnectionSocketImpl

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: