### PR TITLE
Make TCP_KEEPALIVE socket options only apply to TCP sockets

### DIFF
--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -23,7 +23,8 @@ SocketImpl::SocketImpl(IoHandlePtr&& io_handle,
                        const Address::InstanceConstSharedPtr& remote_address)
     : io_handle_(std::move(io_handle)),
       connection_info_provider_(
-          std::make_shared<ConnectionInfoSetterImpl>(local_address, remote_address)) {
+          std::make_shared<ConnectionInfoSetterImpl>(local_address, remote_address)),
+      sock_type_(Network::Socket::Type::Stream) {
 
   if (connection_info_provider_->localAddress() != nullptr) {
     addr_type_ = connection_info_provider_->localAddress()->type();

--- a/source/common/network/socket_option_factory.cc
+++ b/source/common/network/socket_option_factory.cc
@@ -13,23 +13,24 @@ namespace Network {
 std::unique_ptr<Socket::Options>
 SocketOptionFactory::buildTcpKeepaliveOptions(Network::TcpKeepaliveConfig keepalive_config) {
   std::unique_ptr<Socket::Options> options = std::make_unique<Socket::Options>();
+  absl::optional<Network::Socket::Type> tcp_only = {Network::Socket::Type::Stream};
   options->push_back(std::make_shared<Network::SocketOptionImpl>(
-      envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_SO_KEEPALIVE, 1));
+      envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_SO_KEEPALIVE, 1, tcp_only));
 
   if (keepalive_config.keepalive_probes_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(
         envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_TCP_KEEPCNT,
-        keepalive_config.keepalive_probes_.value()));
+        keepalive_config.keepalive_probes_.value(), tcp_only));
   }
   if (keepalive_config.keepalive_interval_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(
         envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_TCP_KEEPINTVL,
-        keepalive_config.keepalive_interval_.value()));
+        keepalive_config.keepalive_interval_.value(), tcp_only));
   }
   if (keepalive_config.keepalive_time_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(
         envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_TCP_KEEPIDLE,
-        keepalive_config.keepalive_time_.value()));
+        keepalive_config.keepalive_time_.value(), tcp_only));
   }
   return options;
 }

--- a/source/common/network/socket_option_factory.cc
+++ b/source/common/network/socket_option_factory.cc
@@ -15,7 +15,8 @@ SocketOptionFactory::buildTcpKeepaliveOptions(Network::TcpKeepaliveConfig keepal
   std::unique_ptr<Socket::Options> options = std::make_unique<Socket::Options>();
   absl::optional<Network::Socket::Type> tcp_only = {Network::Socket::Type::Stream};
   options->push_back(std::make_shared<Network::SocketOptionImpl>(
-      envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_SO_KEEPALIVE, 1, tcp_only));
+      envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_SO_KEEPALIVE, 1,
+      tcp_only));
 
   if (keepalive_config.keepalive_probes_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(

--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -21,6 +21,11 @@ bool SocketOptionImpl::setOption(Socket& socket,
       return false;
     }
 
+    if (socket_type_.has_value() && *socket_type_ != socket.socketType()) {
+      ENVOY_LOG(info, "Skipping inapplicable socket option {}", optname_.name());
+      return true;
+    }
+
     const Api::SysCallIntResult result =
         SocketOptionImpl::setSocketOption(socket, optname_, value_.data(), value_.size());
     if (result.return_value_ != 0) {

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -137,12 +137,14 @@ public:
                    int value, // Yup, int. See setsockopt(2).
                    absl::optional<Network::Socket::Type> socket_type = absl::nullopt)
       : SocketOptionImpl(in_state, optname,
-                         absl::string_view(reinterpret_cast<char*>(&value), sizeof(value)), socket_type) {}
+                         absl::string_view(reinterpret_cast<char*>(&value), sizeof(value)),
+                         socket_type) {}
 
   SocketOptionImpl(envoy::config::core::v3::SocketOption::SocketState in_state,
                    Network::SocketOptionName optname, absl::string_view value,
                    absl::optional<Network::Socket::Type> socket_type = absl::nullopt)
-      : in_state_(in_state), optname_(optname), value_(value.begin(), value.end()), socket_type_(socket_type) {
+      : in_state_(in_state), optname_(optname), value_(value.begin(), value.end()),
+        socket_type_(socket_type) {
     ASSERT(reinterpret_cast<uintptr_t>(value_.data()) % alignof(void*) == 0);
   }
 

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -134,13 +134,15 @@ class SocketOptionImpl : public Socket::Option, Logger::Loggable<Logger::Id::con
 public:
   SocketOptionImpl(envoy::config::core::v3::SocketOption::SocketState in_state,
                    Network::SocketOptionName optname,
-                   int value) // Yup, int. See setsockopt(2).
+                   int value, // Yup, int. See setsockopt(2).
+                   absl::optional<Network::Socket::Type> socket_type = absl::nullopt)
       : SocketOptionImpl(in_state, optname,
-                         absl::string_view(reinterpret_cast<char*>(&value), sizeof(value))) {}
+                         absl::string_view(reinterpret_cast<char*>(&value), sizeof(value)), socket_type) {}
 
   SocketOptionImpl(envoy::config::core::v3::SocketOption::SocketState in_state,
-                   Network::SocketOptionName optname, absl::string_view value)
-      : in_state_(in_state), optname_(optname), value_(value.begin(), value.end()) {
+                   Network::SocketOptionName optname, absl::string_view value,
+                   absl::optional<Network::Socket::Type> socket_type = absl::nullopt)
+      : in_state_(in_state), optname_(optname), value_(value.begin(), value.end()), socket_type_(socket_type) {
     ASSERT(reinterpret_cast<uintptr_t>(value_.data()) % alignof(void*) == 0);
   }
 
@@ -172,6 +174,9 @@ private:
   // This has to be a std::vector<uint8_t> but not std::string because std::string might inline
   // the buffer so its data() is not aligned in to alignof(void*).
   const std::vector<uint8_t> value_;
+  // If present, specifies the socket type that this option applies to. Attempting to set this
+  // option on a socket of a different type will be a no-op.
+  absl::optional<Network::Socket::Type> socket_type_;
 };
 
 } // namespace Network

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -84,6 +84,19 @@ TEST_P(MultiplexedUpstreamIntegrationTest, GrpcRetry) { testGrpcRetry(); }
 
 TEST_P(MultiplexedUpstreamIntegrationTest, Trailers) { testTrailers(1024, 2048, true, true); }
 
+TEST_P(MultiplexedUpstreamIntegrationTest, RouterRequestAndResponseWithTcpKeepalive) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto keepalive = bootstrap.mutable_static_resources()
+        ->mutable_clusters(0)
+        ->mutable_upstream_connection_options()
+        ->mutable_tcp_keepalive();
+    keepalive->mutable_keepalive_probes()->set_value(4);
+    keepalive->mutable_keepalive_time()->set_value(7);
+    keepalive->mutable_keepalive_interval()->set_value(1);
+  });
+  testRouterRequestAndResponseWithBody(1024, 512, false);
+}
+
 TEST_P(MultiplexedUpstreamIntegrationTest, TestSchemeAndXFP) {
   autonomous_upstream_ = true;
   initialize();

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -87,9 +87,9 @@ TEST_P(MultiplexedUpstreamIntegrationTest, Trailers) { testTrailers(1024, 2048, 
 TEST_P(MultiplexedUpstreamIntegrationTest, RouterRequestAndResponseWithTcpKeepalive) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto keepalive = bootstrap.mutable_static_resources()
-        ->mutable_clusters(0)
-        ->mutable_upstream_connection_options()
-        ->mutable_tcp_keepalive();
+                         ->mutable_clusters(0)
+                         ->mutable_upstream_connection_options()
+                         ->mutable_tcp_keepalive();
     keepalive->mutable_keepalive_probes()->set_value(4);
     keepalive->mutable_keepalive_time()->set_value(7);
     keepalive->mutable_keepalive_interval()->set_value(1);


### PR DESCRIPTION
Make TCP_KEEPALIVE socket options only apply to TCP sockets

Fixes #22663
Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: New integration tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A