### PR TITLE
[cache] Make an aborted insert operation call the callback with false

### DIFF
--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -47,12 +47,12 @@ public:
   CacheInfo cacheInfo() const override;
 
   Entry lookup(const LookupRequest& request);
-  void insert(const Key& key, Http::ResponseHeaderMapPtr&& response_headers,
+  bool insert(const Key& key, Http::ResponseHeaderMapPtr&& response_headers,
               ResponseMetadata&& metadata, std::string&& body,
               Http::ResponseTrailerMapPtr&& trailers);
 
   // Inserts a response that has been varied on certain headers.
-  void varyInsert(const Key& request_key, Http::ResponseHeaderMapPtr&& response_headers,
+  bool varyInsert(const Key& request_key, Http::ResponseHeaderMapPtr&& response_headers,
                   ResponseMetadata&& metadata, std::string&& body,
                   const Http::RequestHeaderMap& request_headers,
                   const VaryAllowList& vary_allow_list, Http::ResponseTrailerMapPtr&& trailers);

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
@@ -20,6 +20,7 @@
 using ::envoy::extensions::filters::http::cache::v3::CacheConfig;
 using ::testing::_;
 using ::testing::AnyNumber;
+using ::testing::Not;
 
 namespace Envoy {
 namespace Extensions {
@@ -486,7 +487,7 @@ TEST_P(HttpCacheImplementationTest, VaryOnDisallowedKey) {
   LookupContextPtr first_value_vary = lookup(request_path);
   EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
   const std::string body("one");
-  ASSERT_THAT(insert(move(first_value_vary), response_headers, body), IsOk());
+  ASSERT_THAT(insert(move(first_value_vary), response_headers, body), Not(IsOk()));
   first_value_vary = lookup(request_path);
   EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
 }


### PR DESCRIPTION
Commit Message: [cache] Make an aborted insert operation call the callback with false
Additional Description: The callback's parameter is currently only used in testing (though it could potentially be used to abandon an insert operation early); the previous implementation asserted that the insert callback was called with true, before checking that the insert did not in fact complete, which doesn't really make a lot of sense. The reasonable fixes were either to have the test ignore the callback's value and have it only check that the insert didn't actually happen, or validate that the return value correctly reflects an uncompleted insert operation, which involved also making simple_http_cache fulfill that expectation.
Risk Level: Very low (mostly test-only change to WIP extension)
Testing: Mostly a change to only test-facing behavior.
Docs Changes: n/a
Release Notes: May require a corresponding change to any existing external cache implementations in order for them to pass the generic cache test suite.
Platform Specific Features: n/a
