### PR TITLE
bazel: Add temporary patch for googletest

### DIFF
--- a/bazel/googletest.patch
+++ b/bazel/googletest.patch
@@ -1,0 +1,13 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 8099642a85..3598661079 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -40,7 +40,7 @@ exports_files(["LICENSE"])
+
+ config_setting(
+     name = "windows",
+-    constraint_values = ["@bazel_tools//platforms:windows"],
++    constraint_values = ["@platforms//os:windows"],
+ )
+
+ config_setting(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -641,7 +641,11 @@ def _com_github_ncopa_suexec():
     )
 
 def _com_google_googletest():
-    external_http_archive("com_google_googletest")
+    external_http_archive(
+        "com_google_googletest",
+        patches = ["@envoy//bazel:googletest.patch"],
+        patch_args = ["-p1"],
+    )
     native.bind(
         name = "googletest",
         actual = "@com_google_googletest//:gtest",


### PR DESCRIPTION
This has landed upstream, but updating googletest proved harder than expected. This fixes https://github.com/envoyproxy/envoy/issues/22758 in the meantime.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>