### PR TITLE
grpc_json_transcoder: bug fix to allow async continuation of trailers

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -647,7 +647,7 @@ Http::FilterDataStatus JsonTranscoderFilter::encodeData(Buffer::Instance& data, 
   }
 
   response_in_.move(data);
-  if (encoderBufferLimitReached(response_in_.bytesStored())) {
+  if (encoderBufferLimitReached(response_in_.bytesStored() + response_out_.length())) {
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
@@ -655,16 +655,23 @@ Http::FilterDataStatus JsonTranscoderFilter::encodeData(Buffer::Instance& data, 
     response_in_.finish();
   }
 
-  readToBuffer(*transcoder_->ResponseOutput(), data);
+  readToBuffer(*transcoder_->ResponseOutput(), response_out_);
   if (checkAndRejectIfResponseTranscoderFailed()) {
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
   if (!method_->descriptor_->server_streaming() && !end_stream) {
-    // Buffer until the response is complete.
-    return Http::FilterDataStatus::StopIterationAndBuffer;
+    ENVOY_STREAM_LOG(debug,
+                     "internally buffering unary response waiting for end_stream during "
+                     "encodeData, transcoded data size={}",
+                     *encoder_callbacks_, response_out_.length());
+    return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
+  data.move(response_out_);
+  ENVOY_STREAM_LOG(debug,
+                   "continuing response during encodeData, transcoded data size={}, end_stream={}",
+                   *encoder_callbacks_, data.length(), end_stream);
   return Http::FilterDataStatus::Continue;
 }
 
@@ -689,13 +696,15 @@ void JsonTranscoderFilter::doTrailers(Http::ResponseHeaderOrTrailerMap& headers_
   }
 
   if (!method_->response_type_is_http_body_) {
-    Buffer::OwnedImpl data;
-    readToBuffer(*transcoder_->ResponseOutput(), data);
+    readToBuffer(*transcoder_->ResponseOutput(), response_out_);
     if (checkAndRejectIfResponseTranscoderFailed()) {
       return;
     }
-    if (data.length()) {
-      encoder_callbacks_->addEncodedData(data, true);
+    if (response_out_.length() > 0) {
+      ENVOY_STREAM_LOG(debug,
+                       "adding remaining data during encodeTrailers, transcoded data size={}",
+                       *encoder_callbacks_, response_out_.length());
+      encoder_callbacks_->addEncodedData(response_out_, true);
     }
   }
 

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -216,6 +216,9 @@ private:
   bool error_{false};
   bool has_body_{false};
   bool http_body_response_headers_set_{false};
+
+  // Don't buffer unary response data in the `FilterManager` buffer.
+  Buffer::OwnedImpl response_out_;
 };
 
 } // namespace GrpcJsonTranscoder

--- a/test/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/test/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -81,3 +81,21 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "transcoder_async_inject_body_test",
+    srcs = ["transcoder_async_inject_body_test.cc"],
+    data = [
+        "//test/proto:bookstore.proto",
+        "//test/proto:bookstore_proto_descriptor",
+    ],
+    extension_names = ["envoy.filters.http.grpc_json_transcoder"],
+    deps = [
+        "//source/common/http:utility_lib",
+        "//source/common/protobuf",
+        "//source/extensions/filters/http/grpc_json_transcoder:config",
+        "//test/integration:http_protocol_integration_lib",
+        "//test/integration/filters:async_inject_body_at_end_stream_filter_lib",
+        "//test/proto:bookstore_proto_cc_proto",
+    ],
+)

--- a/test/extensions/filters/http/grpc_json_transcoder/transcoder_async_inject_body_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/transcoder_async_inject_body_test.cc
@@ -1,0 +1,206 @@
+#include "source/common/protobuf/protobuf.h"
+
+#include "test/integration/http_protocol_integration.h"
+#include "test/proto/bookstore.pb.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/str_format.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+namespace {
+
+using Envoy::Protobuf::TextFormat;
+
+constexpr absl::string_view kTranscoderConfig =
+    R"(
+          name: grpc_json_transcoder
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
+            proto_descriptor : "%s"
+            services : "bookstore.Bookstore"
+          )";
+
+class TranscoderAsyncBodyInjectionIntegrationTest : public HttpProtocolIntegrationTest {
+public:
+  void SetUp() override {
+    HttpProtocolIntegrationTest::SetUp();
+
+    config_helper_.prependFilter(R"EOF(
+    name: async-inject-body-at-end-stream-filter
+    )EOF");
+    config_helper_.prependFilter(absl::StrFormat(
+        kTranscoderConfig, TestEnvironment::runfilesPath("test/proto/bookstore.descriptor")));
+    config_helper_.prependFilter(R"EOF(
+    name: async-inject-body-at-end-stream-filter
+    )EOF");
+
+    initialize();
+  }
+
+  template <class ResponseType>
+  void encodeGrpcResponseMessages(const std::vector<std::string>& response_messages_txtpb) {
+    for (const auto& response_message_txtpb : response_messages_txtpb) {
+      ResponseType response_message;
+      EXPECT_TRUE(TextFormat::ParseFromString(response_message_txtpb, &response_message));
+      auto buffer = Grpc::Common::serializeToGrpcFrame(response_message);
+      upstream_request_->encodeData(*buffer, false);
+    }
+  }
+};
+
+// Send request/response with NO trailers. Transcoding filter will
+// pass through the request because strict validation options are not enabled.
+TEST_P(TranscoderAsyncBodyInjectionIntegrationTest, HttpPassThroughNoTrailers) {
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send request with no trailers.
+  auto response = codec_client_->makeRequestWithBody(default_request_headers_, "request_body");
+  waitForNextUpstreamRequest();
+
+  // Make sure that the body was properly propagated (with no modification).
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(upstream_request_->receivedData());
+  EXPECT_EQ(upstream_request_->body().toString(), "request_body");
+
+  // Send response with no trailers.
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeData("response_body", true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Make sure that the body was properly propagated (with no modification).
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ(response->body(), "response_body");
+}
+
+// Send simple HTTP request/response with trailers. Transcoding filter will
+// pass through the request because strict validation options are not enabled.
+TEST_P(TranscoderAsyncBodyInjectionIntegrationTest, HttpPassThroughWithTrailers) {
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send request with trailers.
+  auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+  codec_client_->sendData(*request_encoder_, "request_body", false);
+  Http::TestRequestTrailerMapImpl request_trailers{{"trailer-key", "request"}};
+  codec_client_->sendTrailers(*request_encoder_, request_trailers);
+  waitForNextUpstreamRequest();
+
+  // Make sure that the body and trailers were properly propagated (with no modification).
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(upstream_request_->receivedData());
+  EXPECT_EQ(upstream_request_->body().toString(), "request_body");
+  ASSERT_TRUE(upstream_request_->trailers());
+  EXPECT_EQ(upstream_request_->trailers()->size(), 1);
+
+  // Send response with trailers.
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeData("response_body", false);
+  Http::TestResponseTrailerMapImpl response_trailers{{"trailer-key", "response"}};
+  upstream_request_->encodeTrailers(response_trailers);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Make sure that the body and trailers were properly propagated (with no modification).
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ(response->body(), "response_body");
+  ASSERT_TRUE(response->trailers());
+  EXPECT_EQ(response->trailers()->size(), 1);
+}
+
+// Send HTTP request and unary gRPC response WITH trailers.
+//
+// Tests filter chain with multiple filters, including one that buffers on the
+// response path (gRPC transcoder buffers entire body for unary response).
+//
+// Previously, this test would result in response (encoder) path failing with
+// `upstream_reset_before_response_started{connection_termination}` because the
+// transcoder kept buffered data in the `FilterManager` shared buffer. This
+// conflicted with `async-inject-body-at-end-stream-filter` doing async
+// continuation of trailers.
+TEST_P(TranscoderAsyncBodyInjectionIntegrationTest, UnaryGrpcTranscoding) {
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send HTTP/JSON request (no trailers).
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/shelf"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"content-type", "application/json"}};
+  auto response = codec_client_->makeRequestWithBody(request_headers, R"({"theme": "Children"})");
+  waitForNextUpstreamRequest();
+
+  // Make sure gRPC request was received.
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(upstream_request_->receivedData());
+  EXPECT_GT(upstream_request_->body().length(), 0);
+
+  // Send gRPC response with trailers.
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"content-type", "application/grpc"}};
+  upstream_request_->encodeHeaders(response_headers, false);
+  encodeGrpcResponseMessages<bookstore::Shelf>({R"(id: 20 theme: "Children")"});
+  Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
+  upstream_request_->encodeTrailers(response_trailers);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Make sure downstream received HTTP/JSON request.
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ(response->body(), R"({"id":"20","theme":"Children"})");
+}
+
+// Send HTTP request and streaming gRPC response WITH trailers.
+TEST_P(TranscoderAsyncBodyInjectionIntegrationTest, StreamingGrpcTranscoding) {
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send HTTP/JSON request (no trailers).
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/shelves/1/books"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"content-type", "application/json"}};
+  auto response = codec_client_->makeRequestWithBody(request_headers, "");
+  waitForNextUpstreamRequest();
+
+  // Make sure gRPC request was received.
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(upstream_request_->receivedData());
+  EXPECT_GT(upstream_request_->body().length(), 0);
+
+  // Send gRPC response with trailers.
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"content-type", "application/grpc"}};
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  // Two messages.
+  encodeGrpcResponseMessages<bookstore::Book>({
+      R"(id: 1 author: "Neal Stephenson" title: "Readme")",
+      R"(id: 2 author: "George R.R. Martin" title: "A Game of Thrones")",
+  });
+
+  Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
+  upstream_request_->encodeTrailers(response_trailers);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Make sure downstream received HTTP/JSON request.
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ(response->body(),
+            R"([{"id":"1","author":"Neal Stephenson","title":"Readme"})"
+            R"(,{"id":"2","author":"George R.R. Martin","title":"A Game of Thrones"}])");
+}
+
+// We only test with HTTP/2 because these test cases involve trailers.
+INSTANTIATE_TEST_SUITE_P(TestTranscoderChain, TranscoderAsyncBodyInjectionIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
+                             /*downstream_protocols=*/{Http::CodecType::HTTP2},
+                             /*upstream_protocols=*/{Http::CodecType::HTTP2})),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+} // namespace
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -194,6 +194,23 @@ envoy_cc_test_library(
         "//envoy/http:filter_interface",
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
+        "//source/common/http:utility_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "async_inject_body_at_end_stream_filter_lib",
+    srcs = [
+        "async_inject_body_at_end_stream_filter.cc",
+    ],
+    deps = [
+        ":common_lib",
+        "//envoy/http:filter_interface",
+        "//envoy/registry",
+        "//envoy/server:filter_config_interface",
+        "//source/common/http:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//test/extensions/filters/http/common:empty_http_filter_config_lib",
     ],

--- a/test/integration/filters/async_inject_body_at_end_stream_filter.cc
+++ b/test/integration/filters/async_inject_body_at_end_stream_filter.cc
@@ -1,0 +1,99 @@
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/http/utility.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "test/integration/filters/common.h"
+
+namespace Envoy {
+
+// A test filter that:
+// - Allows headers through (but NOT headers-only requests/responses).
+// - Internally buffers all body data.
+// - When end stream occurs (either with/without trailers), injects data to the
+//   next filter asynchronously.
+// - Continues filter iteration if trailers were present.
+class AsyncInjectBodyAtEndStreamFilter : public Http::PassThroughFilter {
+public:
+  constexpr static char name[] = "async-inject-body-at-end-stream-filter";
+
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool end_stream) override {
+    ASSERT(!end_stream);
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
+                                          bool end_stream) override {
+    ASSERT(Http::Utility::getResponseStatus(headers) == 200);
+    ASSERT(!end_stream);
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override {
+    request_buffer_.move(data);
+    if (end_stream) {
+      doRequestInjection(/*has_trailers=*/false);
+    }
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
+  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override {
+    response_buffer_.move(data);
+    if (end_stream) {
+      doResponseInjection(/*has_trailers=*/false);
+    }
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
+    doRequestInjection(/*has_trailers=*/true);
+    return Http::FilterTrailersStatus::StopIteration;
+  }
+
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap&) override {
+    doResponseInjection(/*has_trailers=*/true);
+    return Http::FilterTrailersStatus::StopIteration;
+  }
+
+private:
+  void doRequestInjection(bool has_trailers) {
+    decoder_callbacks_->dispatcher().post([this, has_trailers]() -> void {
+      // Emulate multiple injections to next filter.
+      Envoy::Buffer::OwnedImpl split_request;
+      split_request.move(request_buffer_, 1);
+      decoder_callbacks_->injectDecodedDataToFilterChain(split_request, /*end_stream=*/false);
+      decoder_callbacks_->injectDecodedDataToFilterChain(request_buffer_,
+                                                         /*end_stream=*/!has_trailers);
+      if (has_trailers) {
+        decoder_callbacks_->continueDecoding();
+      }
+    });
+  }
+
+  void doResponseInjection(bool has_trailers) {
+    encoder_callbacks_->dispatcher().post([this, has_trailers]() -> void {
+      // Emulate multiple injections to next filter.
+      Envoy::Buffer::OwnedImpl split_response;
+      split_response.move(response_buffer_, 1);
+      encoder_callbacks_->injectEncodedDataToFilterChain(split_response, /*end_stream=*/false);
+      encoder_callbacks_->injectEncodedDataToFilterChain(response_buffer_,
+                                                         /*end_stream=*/!has_trailers);
+      if (has_trailers) {
+        encoder_callbacks_->continueEncoding();
+      }
+    });
+  }
+
+  Envoy::Buffer::OwnedImpl request_buffer_;
+  Envoy::Buffer::OwnedImpl response_buffer_;
+};
+
+static Registry::RegisterFactory<SimpleFilterConfig<AsyncInjectBodyAtEndStreamFilter>,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: 
grpc_json_transcoder: bug fix to allow async continuation of trailers

Additional Description:

We discovered a bug in the encoder path when gRPC JSON transcoder filter is chained with any other filter that does async continuation of trailers. See https://github.com/envoyproxy/envoy/issues/22064 for details.

Root cause: gRPC transcoder uses the `FilterManager` buffer to wait for a full response in the unary gRPC response path. But unfortunately Envoy does not correctly track which filter the buffered data belongs to (@KBaichoo can explain this). This results in the internal buffer being posted to `encodeData` for the wrong filter (i.e. filters before the transcoder in the encode path).

Fix: Modify the transcoder to not use `FilterManager` buffer. It now:
- Uses its own internal buffer
- Returns `StopIterationNoBuffer`
- Adds data from internal buffers during `encodeTrailers`.

Risk Level: Low

Testing: New integration test, updated unit tests.

Docs Changes: None. This is a bug that only occurs when used with other custom extensions.

Release Notes: None. This is a bug that only occurs when used with other custom extensions.

Platform Specific Features: None

Fixes https://github.com/envoyproxy/envoy/issues/22064