### PR TITLE
docs: Fix link to AttributeContext.HttpRequest.body

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -173,8 +173,8 @@ message BufferSettings {
 
   // If true, the body sent to the external authorization service is set with raw bytes, it sets
   // the :ref:`raw_body<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.raw_body>`
-  // field of HTTP request attribute context. Otherwise, :ref:`
-  // body<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
+  // field of HTTP request attribute context. Otherwise, :ref:`body
+  // <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
   // with UTF-8 string request body.
   bool pack_as_bytes = 3;
 }


### PR DESCRIPTION
Fix how the link to `envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body` is rendered.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>

Commit Message: Fix how the link to `envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body` is rendered.
Additional Description:

Before:

<img width="909" alt="image" src="https://user-images.githubusercontent.com/73152/190840959-eda0c0c4-f9c2-497d-ba87-53bb08a7a4a5.png">

After:

<img width="890" alt="image" src="https://user-images.githubusercontent.com/73152/190840980-921aa5c3-ee43-4906-8905-6d62912073f0.png">

Risk Level: N/A
Testing: N/A
Docs Changes: This is a small docs change
Release Notes: N/A
Platform Specific Features: N/A
