### PR TITLE
tools: Enable FQN in proto fields through an annotation

### DIFF
--- a/tools/api_proto_plugin/annotations.py
+++ b/tools/api_proto_plugin/annotations.py
@@ -31,6 +31,10 @@ NEXT_MAJOR_VERSION_ANNOTATION = 'next-major-version'
 # Comment. Just used for adding text that will not go into the docs at all.
 COMMENT_ANNOTATION = 'comment'
 
+# Annotation on leading comments that permits fields to be declared with the
+# fully-qualified-name (FQN) type.
+ALLOW_FULLY_QUALIFIED_NAME_ANNOTATION = 'allow-fully-qualified-name'
+
 VALID_ANNOTATIONS = set([
     DOC_TITLE_ANNOTATION,
     EXTENSION_ANNOTATION,
@@ -39,6 +43,7 @@ VALID_ANNOTATIONS = set([
     NEXT_FREE_FIELD_ANNOTATION,
     NEXT_MAJOR_VERSION_ANNOTATION,
     COMMENT_ANNOTATION,
+    ALLOW_FULLY_QUALIFIED_NAME_ANNOTATION,
 ])
 
 # These can propagate from file scope to message/enum scope (and be overridden).

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -342,6 +342,11 @@ def normalize_field_type_name(type_context, field_fqn):
         Normalized type name as a string.
     """
     if field_fqn.startswith('.'):
+        # If there's a [#allow-fully-qualified-name] annotation, return the FQN
+        # field types without attempting to normalize.
+        if annotations.ALLOW_FULLY_QUALIFIED_NAME_ANNOTATION in type_context.leading_comment.annotations:
+            return field_fqn
+
         # Let's say we have type context namespace a.b.c.d.e and the type we're
         # trying to normalize is a.b.d.e. We take (from the end) on package fragment
         # at a time, and apply the inner-most evaluation that protoc performs to see

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -343,7 +343,7 @@ def normalize_field_type_name(type_context, field_fqn):
     """
     if field_fqn.startswith('.'):
         # If there's a [#allow-fully-qualified-name] annotation, return the FQN
-        # field types without attempting to normalize.
+        # field type without attempting to normalize.
         if annotations.ALLOW_FULLY_QUALIFIED_NAME_ANNOTATION in type_context.leading_comment.annotations:
             return field_fqn
 

--- a/tools/testdata/protoxform/envoy/v2/fully_qualified_names.proto
+++ b/tools/testdata/protoxform/envoy/v2/fully_qualified_names.proto
@@ -28,4 +28,10 @@ message UsesFullyQualifiedTypeNames {
   .external.PackageLevelType external_package_level_type_fqn = 6;
 
   .RootLevelType external_root_level_type_fqn = 7;
+
+  // [#allow-fully-qualified-name:]
+  .envoy.api.v2.core.Locality another_envoy_type_keep_fqn = 8;
+
+  // [#allow-fully-qualified-name:]
+  repeated .envoy.api.v2.core.Locality repeated_another_envoy_type_keep_fqn = 9;
 }

--- a/tools/testdata/protoxform/envoy/v2/fully_qualified_names.proto.active_or_frozen.gold
+++ b/tools/testdata/protoxform/envoy/v2/fully_qualified_names.proto.active_or_frozen.gold
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.v2;
 
+import "envoy/api/v2/core/base.proto";
+
 import "google/protobuf/any.proto";
 
 import "tools/testdata/protoxform/external/package_type.proto";

--- a/tools/testdata/protoxform/envoy/v2/fully_qualified_names.proto.active_or_frozen.gold
+++ b/tools/testdata/protoxform/envoy/v2/fully_qualified_names.proto.active_or_frozen.gold
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.v2;
 
-import "envoy/api/v2/core/base.proto";
-
 import "google/protobuf/any.proto";
 
 import "tools/testdata/protoxform/external/package_type.proto";
@@ -20,7 +18,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.external.v3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Verifies normalization of fully-qualified type names.
-// [#next-free-field: 8]
+// [#next-free-field: 10]
 message UsesFullyQualifiedTypeNames {
   api.v2.core.Locality another_envoy_type = 1;
 
@@ -35,4 +33,10 @@ message UsesFullyQualifiedTypeNames {
   external.PackageLevelType external_package_level_type_fqn = 6;
 
   .RootLevelType external_root_level_type_fqn = 7;
+
+  // [#allow-fully-qualified-name:]
+  .envoy.api.v2.core.Locality another_envoy_type_keep_fqn = 8;
+
+  // [#allow-fully-qualified-name:]
+  repeated .envoy.api.v2.core.Locality repeated_another_envoy_type_keep_fqn = 9;
 }


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/issues/23135 discussed some situations where the proto_format.sh tool normalizes the fully-qualified-name (FQN) of a field, when such normalization actually results in a build error from the compiler.

This PR introduces a new annotation, allow-fully-qualified-name, that can be used to annotate the comments of a field for which the proto_format.sh tool should permit a FQN to be used and not try to normalize the field type.

Signed-off-by: Ali Beyad <abeyad@google.com>

Risk Level: Low
Testing: Unit test
