### PR TITLE
http: fixing a bug where internal redirects aren't served on drained connections

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -45,6 +45,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: http
+  change: |
+    fixed a bug with internal redirects not being performed for drained connections.
 - area: listener
   change: |
     fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a memory leak.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -182,9 +182,6 @@ ConnectionManagerImpl::~ConnectionManagerImpl() {
 }
 
 void ConnectionManagerImpl::checkForDeferredClose(bool skip_delay_close) {
-  if (under_recreate_stream_) {
-//    return;
-  }
   Network::ConnectionCloseType close = Network::ConnectionCloseType::FlushWriteAndDelay;
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.skip_delay_close") &&
       skip_delay_close) {
@@ -196,7 +193,7 @@ void ConnectionManagerImpl::checkForDeferredClose(bool skip_delay_close) {
   }
 }
 
-void ConnectionManagerImpl::doEndStream(ActiveStream& stream) {
+void ConnectionManagerImpl::doEndStream(ActiveStream& stream, bool check_for_deferred_close) {
   // The order of what happens in this routine is important and a little complicated. We first see
   // if the stream needs to be reset. If it needs to be, this will end up invoking reset callbacks
   // and then moving the stream to the deferred destruction list. If the stream has not been reset,
@@ -254,12 +251,14 @@ void ConnectionManagerImpl::doEndStream(ActiveStream& stream) {
   bool connection_close = stream.state_.saw_connection_close_;
   bool request_complete = stream.filter_manager_.remoteDecodeComplete();
 
-  // Don't do delay close for responses which are framed by connection close:
-  // HTTP/1.0 and below, upgrades, and CONNECT responses.
-  checkForDeferredClose(
-      (connection_close && (request_complete || http_10_sans_cl)) ||
-      (stream.state_.is_tunneling_ &&
-       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.no_delay_close_for_upgrades")));
+  if (check_for_deferred_close) {
+    // Don't do delay close for responses which are framed by connection close:
+    // HTTP/1.0 and below, upgrades, and CONNECT responses.
+    checkForDeferredClose(
+        (connection_close && (request_complete || http_10_sans_cl)) ||
+        (stream.state_.is_tunneling_ &&
+         Runtime::runtimeFeatureEnabled("envoy.reloadable_features.no_delay_close_for_upgrades")));
+  }
 }
 
 void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
@@ -1748,7 +1747,6 @@ void ConnectionManagerImpl::ActiveStream::onRequestDataTooLarge() {
 
 void ConnectionManagerImpl::ActiveStream::recreateStream(
     StreamInfo::FilterStateSharedPtr filter_state) {
-  connection_manager_.under_recreate_stream_ = true;
   // n.b. we do not currently change the codecs to point at the new stream
   // decoder because the decoder callbacks are complete. It would be good to
   // null out that pointer but should not be necessary.
@@ -1765,7 +1763,8 @@ void ConnectionManagerImpl::ActiveStream::recreateStream(
   response_encoder->getStream().removeCallbacks(*this);
   // This functionally deletes the stream (via deferred delete) so do not
   // reference anything beyond this point.
-  connection_manager_.doEndStream(*this);
+  // Make sure to not check for deferred close as we'll be immediately creating a new stream.
+  connection_manager_.doEndStream(*this, /*check_for_deferred_close*/ false);
 
   RequestDecoder& new_stream = connection_manager_.newStream(*response_encoder, true);
   // We don't need to copy over the old parent FilterState from the old StreamInfo if it did not
@@ -1793,7 +1792,6 @@ void ConnectionManagerImpl::ActiveStream::recreateStream(
     // case of upstream sending an early response mid-request.
     new_stream.decodeData(*request_data, true);
   }
-  connection_manager_.under_recreate_stream_ = false;
 }
 
 Http1StreamEncoderOptionsOptRef ConnectionManagerImpl::ActiveStream::http1StreamEncoderOptions() {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -69,6 +69,7 @@ public:
                         Upstream::ClusterManager& cluster_manager,
                         Server::OverloadManager& overload_manager, TimeSource& time_system);
   ~ConnectionManagerImpl() override;
+  bool under_recreate_stream_ = false;
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
   static ConnectionManagerTracingStats generateTracingStats(const std::string& prefix,

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -69,7 +69,6 @@ public:
                         Upstream::ClusterManager& cluster_manager,
                         Server::OverloadManager& overload_manager, TimeSource& time_system);
   ~ConnectionManagerImpl() override;
-  bool under_recreate_stream_ = false;
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
   static ConnectionManagerTracingStats generateTracingStats(const std::string& prefix,
@@ -424,8 +423,10 @@ private:
 
   /**
    * Process a stream that is ending due to upstream response or reset.
+   * If check_for_deferred_close is true, the ConnectionManager will check to
+   * see if the connection was drained and should be closed if no streams remain.
    */
-  void doEndStream(ActiveStream& stream);
+  void doEndStream(ActiveStream& stream, bool check_for_deferred_close = true);
 
   void resetAllStreams(absl::optional<StreamInfo::ResponseFlag> response_flag,
                        absl::string_view details);

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -157,20 +157,17 @@ TEST_P(RedirectIntegrationTest, InternalRedirectPassedThrough) {
 TEST_P(RedirectIntegrationTest, BasicInternalRedirect) {
   useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE% %RESPONSE_CODE_DETAILS% %RESP(test-header)%");
   // Validate that header sanitization is only called once.
-  config_helper_.addConfigModifier(
-      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-             hcm) {
-          hcm.mutable_delayed_close_timeout()->set_seconds(0);
-        hcm.set_via("via_value");
-      });
+  config_helper_.addConfigModifier([](envoy::extensions::filters::network::http_connection_manager::
+                                          v3::HttpConnectionManager& hcm) {
+    hcm.mutable_delayed_close_timeout()->set_seconds(0);
+    hcm.set_via("via_value");
+    hcm.mutable_common_http_protocol_options()->mutable_max_requests_per_connection()->set_value(1);
+  });
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   default_request_headers_.setHost("handle.internal.redirect");
-  if (downstreamProtocol() == Http::CodecType::HTTP1) {
-    default_request_headers_.setConnection("close");
-  }
   IntegrationStreamDecoderPtr response =
       codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 


### PR DESCRIPTION
Previously, if performing an internal redirect on a drained connection, the HCM would checkForDrainedConnections and for HTTP/1.1 downstream, seeing no streams between the close and the recreate, would close the connection before serving the redirect.

Risk Level: low
Testing: new integration test
Docs Changes: n/a
Release Notes: inline