### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -3,8 +3,15 @@ on:
   schedule:
   - cron: '0 5 * * 1,2,3,4,5'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   pr_notifier:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      statuses: read # for pr_notifier.py
+      pull-requests: read # for pr_notifier.py
     name: PR Notifier
     runs-on: ubuntu-latest
     if: github.repository == 'envoyproxy/envoy'


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.