### PR TITLE
backport: c++: provide type to std::weak_ptr template 

### DIFF
--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -399,9 +399,10 @@ bool FileSystemBufferFilter::maybeStorage(BufferedStreamState& state,
       // We can't use getSafeDispatcher here because we need to close the file if the filter
       // was deleted before the callback, not just do nothing.
       cancel_in_flight_async_action_ = config_->asyncFileManager().createAnonymousFile(
-          config_->storageBufferPath(), [this, me = std::weak_ptr(shared_from_this()),
-                                         dispatcher = &request_callbacks_->dispatcher(),
-                                         &state](absl::StatusOr<AsyncFileHandle> file_handle) {
+          config_->storageBufferPath(),
+          [this, me = std::weak_ptr<FileSystemBufferFilter>(shared_from_this()),
+           dispatcher = &request_callbacks_->dispatcher(),
+           &state](absl::StatusOr<AsyncFileHandle> file_handle) {
             dispatcher->post([this, me = std::move(me), &state, file_handle]() {
               if (!me.lock()) {
                 // If we opened a file but the filter went away in the meantime, close the file


### PR DESCRIPTION
Commit Message: backport: c++: provide type to std::weak_ptr template 

Cherry-picked from [68aa00067bbeb7aaf13599f75e54e8837cfb13ef](https://github.com/envoyproxy/envoy/commit/68aa00067bbeb7aaf13599f75e54e8837cfb13ef). 

Signed-off-by: Christoph Pakulski <christoph@tetrate.io>

Additional Description:

This is asked by: https://github.com/Homebrew/homebrew-core/pull/110883#discussion_r974679771.

Risk Level: N/A
Testing: Provided
Docs Changes: N/A 
Release Notes: N/A
Platform Specific Features: N/A