### PR TITLE
redis: fix flake in QUIT test

### DIFF
--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -709,7 +709,12 @@ TEST_P(RedisProxyWithCommandStatsIntegrationTest, MGETRequestAndResponse) {
 
 TEST_P(RedisProxyIntegrationTest, QUITRequestAndResponse) {
   initialize();
-  simpleProxyResponse(makeBulkStringArray({"quit"}), "+OK\r\n");
+  IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
+  ASSERT_TRUE(redis_client->write(makeBulkStringArray({"quit"}), false, false));
+  redis_client->waitForData("+OK\r\n");
+  redis_client->waitForDisconnect();
+  EXPECT_EQ(redis_client->data(), "+OK\r\n");
+  redis_client->close();
 }
 
 // This test sends an invalid Redis command from a fake


### PR DESCRIPTION
The `QUITRequestAndResponse` test could sometimes be seen to fail like this:
```
[ RUN      ] IpVersions/RedisProxyIntegrationTest.QUITRequestAndResponse/IPv6
test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc:606: Failure
Value of: redis_client->write(request)
  Actual: false (Failed to complete write or unexpected disconnect. disconnected_: true bytes_drained: 14 bytes_expected: 14)
Expected: true
Stack trace:
  0x28ab1de: Envoy::(anonymous namespace)::RedisProxyIntegrationTest::proxyResponseStep()
  0x28ab05d: Envoy::(anonymous namespace)::RedisProxyIntegrationTest::simpleProxyResponse()
  0x28aad6a: Envoy::(anonymous namespace)::RedisProxyIntegrationTest_QUITRequestAndResponse_Test::TestBody()
  0x695f34b: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
  0x694f4aa: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x693b283: testing::Test::Run()
  0x693bc24: testing::TestInfo::Run()
```
Such a failure is not unexpected since the `QUIT` command closes the connection. The solution is to modify the test to expect a disconnect.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
