### PR TITLE
Upgrade Http1ServerConnectionImplTest.Utf8Path/BalsaParser.

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -3282,11 +3282,6 @@ TEST_P(Http1ServerConnectionImplTest, PipedRequestWithMutipleEvent) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Utf8Path) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   initialize();
 
   MockRequestDecoder decoder;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -3286,27 +3286,33 @@ TEST_P(Http1ServerConnectionImplTest, Utf8Path) {
 
   MockRequestDecoder decoder;
   Buffer::OwnedImpl buffer("GET /δ¶/δt/pope?q=1#narf HXXP/1.1\r\n\r\n");
+  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
+
 #ifdef ENVOY_ENABLE_UHV
-  // permissive
-  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
-
-  TestRequestHeaderMapImpl expected_headers{
-      {":path", "/δ¶/δt/pope?q=1#narf"},
-      {":method", "GET"},
-  };
-  EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
-
-  auto status = codec_->dispatch(buffer);
-  EXPECT_TRUE(status.ok());
-  EXPECT_EQ(0U, buffer.length());
+  bool strict = false;
 #else
-  // strict
-  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
-
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
-  auto status = codec_->dispatch(buffer);
-  EXPECT_TRUE(isCodecProtocolError(status));
+  bool strict = true;
 #endif
+
+  if (parser_impl_ == ParserImpl::BalsaParser) {
+    strict = true;
+  }
+
+  if (strict) {
+    EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+    auto status = codec_->dispatch(buffer);
+    EXPECT_TRUE(isCodecProtocolError(status));
+  } else {
+    TestRequestHeaderMapImpl expected_headers{
+        {":path", "/δ¶/δt/pope?q=1#narf"},
+        {":method", "GET"},
+    };
+    EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
+
+    auto status = codec_->dispatch(buffer);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(0U, buffer.length());
+  }
 }
 
 // Tests that incomplete response headers of 80 kB header value fails.


### PR DESCRIPTION
Update Http1ServerConnectionImplTest.Utf8Path to reflect that BalsaParser always signals error on UTF8 path.

Signed-off-by: Bence Béky <bnc@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
