### PR TITLE
OAuth2 filter fix handling callback url with Non-ASCII characters

### DIFF
--- a/source/extensions/filters/http/oauth2/BUILD
+++ b/source/extensions/filters/http/oauth2/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/protobuf:message_validator_lib",
         "//source/extensions/filters/http/oauth2:oauth_callback_interface",
+        "@com_googlesource_googleurl//url",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )


### PR DESCRIPTION
Commit Message: Fix handling urls with Non-ASCII symbols on OAuth2 filter
Additional Description: http_parser library was replaced by GURL library in the OAuth2 filter for valudation url
Risk: Medium
Testing: I have tested manually. As for me for testing changes it's enough current oauth2_filter tests 
Release notes: Fixed processing callback url with Non-ASCII characters in the OAuth2 filter
Fix issue #23167

