### PR TITLE
route: Use `prefix_rewrite_` directly

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -669,7 +669,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
         "Specify only one of prefix_rewrite, regex_rewrite or path_rewrite_policy");
   }
 
-  if (!route.route().prefix_rewrite().empty() && path_matcher_ != nullptr) {
+  if (!prefix_rewrite_.empty() && path_matcher_ != nullptr) {
     throw EnvoyException("Cannot use prefix_rewrite with matcher extension");
   }
 


### PR DESCRIPTION
Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: use prefix_rewrite_ that has already been initialized directly. This avoids unnecessary function calls to route() and prefix_rewrite(). Follow-up PR for #23160
