### PR TITLE
Initialize max_pending_lookups_ without client_config

### DIFF
--- a/source/extensions/filters/udp/dns_filter/dns_filter.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.cc
@@ -169,6 +169,7 @@ DnsFilterEnvoyConfig::DnsFilterEnvoyConfig(
   } else {
     // In case client_config doesn't exist, create default DNS resolver factory and save it.
     dns_resolver_factory_ = &Network::createDefaultDnsResolverFactory(typed_dns_resolver_config_);
+    max_pending_lookups_ = 0;
   }
 }
 


### PR DESCRIPTION
max_pending_lookups_ is uninitialized by some branches, but it
unconditionally passed into DnsFilterResolver on the line 254.
It's UB in C++.

