### PR TITLE
docs: fix listener filter order in best practice envoy config 

### DIFF
--- a/docs/root/configuration/best_practices/_include/edge.yaml
+++ b/docs/root/configuration/best_practices/_include/edge.yaml
@@ -31,13 +31,13 @@ static_resources:
         address: 0.0.0.0
         port_value: 443
     listener_filters:
-    - name: "envoy.filters.listener.tls_inspector"
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     # Uncomment if Envoy is behind a load balancer that exposes client IP address using the PROXY protocol.
     # - name: envoy.filters.listener.proxy_protocol
     #   typed_config:
     #     "@type": type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol
+    - name: "envoy.filters.listener.tls_inspector"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     per_connection_buffer_limit_bytes: 32768  # 32 KiB
     filter_chains:
     - filter_chain_match:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: 
doc fix about the listener filter order in best practice example

Additional Description:
Proxy protocol listener filter should be ahead of tls_inspector listener filter. See this issue for more context: https://github.com/envoyproxy/envoy/issues/23205 

Risk Level:
Low

Testing:
Manual testing with envoy 1.22.2

Docs Changes:
yes

Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
