### PR TITLE
udp_proxy: support proxy access logging

### DIFF
--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -26,7 +26,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.udp_listener.udp_proxy]
 
 // Configuration for the UDP proxy filter.
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message UdpProxyConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.udp.udp_proxy.v2alpha.UdpProxyConfig";
@@ -106,5 +106,7 @@ message UdpProxyConfig {
   bool use_per_packet_load_balancing = 7;
 
   // Configuration for access logs emitted by the UDP proxy. Note that certain UDP specific data is emitted as :ref:`Dynamic Metadata <config_access_log_format_dynamic_metadata>`.
-  repeated config.accesslog.v3.AccessLog access_log = 8;
+  repeated config.accesslog.v3.AccessLog sess_access_log = 8;
+
+  repeated config.accesslog.v3.AccessLog proxy_access_log = 9;
 }

--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -105,8 +105,9 @@ message UdpProxyConfig {
   // to upstream host selected on first chunk receival for that "session" (identified by source IP/port and local IP/port).
   bool use_per_packet_load_balancing = 7;
 
-  // Configuration for access logs emitted by the UDP proxy. Note that certain UDP specific data is emitted as :ref:`Dynamic Metadata <config_access_log_format_dynamic_metadata>`.
+  // Configuration for session access logs emitted by the UDP proxy. Note that certain UDP specific data is emitted as :ref:`Dynamic Metadata <config_access_log_format_dynamic_metadata>`.
   repeated config.accesslog.v3.AccessLog sess_access_log = 8;
 
+  // Configuration for proxy access logs emitted by the UDP proxy. Note that certain UDP specific data is emitted as :ref:`Dynamic Metadata <config_access_log_format_dynamic_metadata>`.
   repeated config.accesslog.v3.AccessLog proxy_access_log = 10;
 }

--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -108,5 +108,5 @@ message UdpProxyConfig {
   // Configuration for access logs emitted by the UDP proxy. Note that certain UDP specific data is emitted as :ref:`Dynamic Metadata <config_access_log_format_dynamic_metadata>`.
   repeated config.accesslog.v3.AccessLog sess_access_log = 8;
 
-  repeated config.accesslog.v3.AccessLog proxy_access_log = 9;
+  repeated config.accesslog.v3.AccessLog proxy_access_log = 10;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -238,6 +238,9 @@ new_features:
 - area: grpc_json_transcoder
   change: |
     added support for parsing enum value case insensitively enabled by the config :ref:`case_insensitive_enum_parsing <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.case_insensitive_enum_parsing>`.
+- area: udp_proxy
+  change: |
+    added support for :ref:`proxy_access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.
 
 deprecated:
 - area: http

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -650,28 +650,50 @@ The following command operators are supported:
 
   UDP
     For :ref:`UDP Proxy <config_udp_listener_filters_udp_proxy>`,
-    NAMESPACE should be always set to "udp.proxy", optional KEYs are as follows:
+    if NAMESPACE is set to "udp.proxy.session", optional KEYs are as follows:
 
     * ``cluster_name``: Name of the cluster.
     * ``bytes_sent``: Total number of downstream bytes sent to the upstream in the session.
     * ``bytes_received``: Total number of downstream bytes received from the upstream in the session.
     * ``errors_sent``: Number of errors that have occurred when sending datagrams to the upstream in the session.
-    * ``errors_received``: Number of errors that have occurred when receiving datagrams from the upstream in UDP proxy.
-      Since the receiving errors are counted in at the listener level (vs. the session), this counter is global to all sessions and may not be directly attributable to the session being logged.
     * ``datagrams_sent``: Number of datagrams sent to the upstream successfully in the session.
     * ``datagrams_received``: Number of datagrams received from the upstream successfully in the session.
 
-    Recommended access log format for UDP proxy:
+    Recommended session access log format for UDP proxy:
 
     .. code-block:: none
 
       [%START_TIME%] %DYNAMIC_METADATA(udp.proxy:cluster_name)%
-      %DYNAMIC_METADATA(udp.proxy:bytes_sent)%
-      %DYNAMIC_METADATA(udp.proxy:bytes_received)%
-      %DYNAMIC_METADATA(udp.proxy:errors_sent)%
-      %DYNAMIC_METADATA(udp.proxy:errors_received)%
-      %DYNAMIC_METADATA(udp.proxy:datagrams_sent)%
-      %DYNAMIC_METADATA(udp.proxy:datagrams_received)%\n
+      %DYNAMIC_METADATA(udp.proxy.session:bytes_sent)%
+      %DYNAMIC_METADATA(udp.proxy.session:bytes_received)%
+      %DYNAMIC_METADATA(udp.proxy.session:errors_sent)%
+      %DYNAMIC_METADATA(udp.proxy.session:datagrams_sent)%
+      %DYNAMIC_METADATA(udp.proxy.session:datagrams_received)%\n
+
+    if NAMESPACE is set to "udp.proxy.proxy", optional KEYs are as follows:
+
+    * ``bytes_sent``: Total number of downstream bytes sent to the upstream in UDP proxy.
+    * ``bytes_received``: Total number of downstream bytes received from the upstream in UDP proxy.
+    * ``errors_sent``: Number of errors that have occurred when sending datagrams to the upstream in UDP proxy.
+    * ``errors_received``: Number of errors that have occurred when receiving datagrams from the upstream in UDP proxy.
+    * ``datagrams_sent``: Number of datagrams sent to the upstream successfully in UDP proxy.
+    * ``datagrams_received``: Number of datagrams received from the upstream successfully in UDP proxy.
+    * ``no_route``: Number of times that no upstream cluster found in UDP proxy.
+    * ``sess_total``: Total number of sessions in UDP proxy.
+    * ``idle_timeout``: Number of times that sessions idle timeout occurred in UDP proxy.
+
+    Recommended proxy access log format for UDP proxy:
+
+    .. code-block:: none
+
+      [%START_TIME%]
+      %DYNAMIC_METADATA(udp.proxy.proxy:bytes_sent)%
+      %DYNAMIC_METADATA(udp.proxy.proxy:bytes_received)%
+      %DYNAMIC_METADATA(udp.proxy.proxy:errors_sent)%
+      %DYNAMIC_METADATA(udp.proxy.proxy:errors_received)%
+      %DYNAMIC_METADATA(udp.proxy.proxy:datagrams_sent)%
+      %DYNAMIC_METADATA(udp.proxy.proxy:datagrams_received)%
+      %DYNAMIC_METADATA(udp.proxy.proxy:sess_total)%\n
 
   THRIFT
     For :ref:`Thrift Proxy <config_network_filters_thrift_proxy>`,

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -22,12 +22,11 @@ UdpProxyFilter::UdpProxyFilter(Network::UdpReadFilterCallbacks& callbacks,
   }
 
   if (!config_->proxyAccessLogs().empty()) {
-    udp_proxy_stats_.emplace(
-        StreamInfo::StreamInfoImpl(config_->timeSource(), nullptr));
+    udp_proxy_stats_.emplace(StreamInfo::StreamInfoImpl(config_->timeSource(), nullptr));
   }
 }
 
-UdpProxyFilter::~UdpProxyFilter(){
+UdpProxyFilter::~UdpProxyFilter() {
   if (!config_->proxyAccessLogs().empty()) {
     fillProxyStreamInfo();
     for (const auto& access_log : config_->proxyAccessLogs()) {
@@ -35,6 +34,7 @@ UdpProxyFilter::~UdpProxyFilter(){
     }
   }
 }
+
 void UdpProxyFilter::onClusterAddOrUpdate(Upstream::ThreadLocalCluster& cluster) {
   auto cluster_name = cluster.info()->name();
   ENVOY_LOG(debug, "udp proxy: attaching to cluster {}", cluster_name);
@@ -322,12 +322,23 @@ void UdpProxyFilter::ActiveSession::fillSessionStreamInfo() {
 void UdpProxyFilter::fillProxyStreamInfo() {
   ProtobufWkt::Struct stats_obj;
   auto& fields_map = *stats_obj.mutable_fields();
+  fields_map["bytes_sent"] =
+      ValueUtil::numberValue(config_->stats().downstream_sess_tx_bytes_.value());
+  fields_map["bytes_received"] =
+      ValueUtil::numberValue(config_->stats().downstream_sess_rx_bytes_.value());
+  fields_map["errors_sent"] =
+      ValueUtil::numberValue(config_->stats().downstream_sess_tx_errors_.value());
+  fields_map["errors_received"] =
+      ValueUtil::numberValue(config_->stats().downstream_sess_rx_errors_.value());
+  fields_map["datagrams_sent"] =
+      ValueUtil::numberValue(config_->stats().downstream_sess_tx_datagrams_.value());
+  fields_map["datagrams_received"] =
+      ValueUtil::numberValue(config_->stats().downstream_sess_rx_datagrams_.value());
   fields_map["no_route"] =
       ValueUtil::numberValue(config_->stats().downstream_sess_no_route_.value());
   fields_map["sess_total"] =
-    ValueUtil::numberValue(config_->stats().downstream_sess_total_.value());
-  fields_map["idle_timeout"] =
-    ValueUtil::numberValue(config_->stats().idle_timeout_.value());
+      ValueUtil::numberValue(config_->stats().downstream_sess_total_.value());
+  fields_map["idle_timeout"] = ValueUtil::numberValue(config_->stats().idle_timeout_.value());
 
   udp_proxy_stats_.value().setDynamicMetadata("udp.proxy.proxy", stats_obj);
 }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -309,8 +309,6 @@ void UdpProxyFilter::ActiveSession::fillSessionStreamInfo() {
   fields_map["bytes_sent"] = ValueUtil::numberValue(session_stats_.downstream_sess_tx_bytes_);
   fields_map["bytes_received"] = ValueUtil::numberValue(session_stats_.downstream_sess_rx_bytes_);
   fields_map["errors_sent"] = ValueUtil::numberValue(session_stats_.downstream_sess_tx_errors_);
-  fields_map["errors_received"] =
-      ValueUtil::numberValue(cluster_.filter_.config_->stats().downstream_sess_rx_errors_.value());
   fields_map["datagrams_sent"] =
       ValueUtil::numberValue(session_stats_.downstream_sess_tx_datagrams_);
   fields_map["datagrams_received"] =

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -121,8 +121,12 @@ public:
   const Network::ResolvedUdpSocketConfig& upstreamSocketConfig() const {
     return upstream_socket_config_;
   }
-  const std::vector<AccessLog::InstanceSharedPtr>& sessionAccessLogs() const { return sess_access_logs_; }
-  const std::vector<AccessLog::InstanceSharedPtr>& proxyAccessLogs() const { return proxy_access_logs_; }
+  const std::vector<AccessLog::InstanceSharedPtr>& sessionAccessLogs() const {
+    return sess_access_logs_;
+  }
+  const std::vector<AccessLog::InstanceSharedPtr>& proxyAccessLogs() const {
+    return proxy_access_logs_;
+  }
 
 private:
   static UdpProxyDownstreamStats generateStats(const std::string& stat_prefix,

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -172,6 +172,7 @@ class UdpProxyFilter : public Network::UdpListenerReadFilter,
 public:
   UdpProxyFilter(Network::UdpReadFilterCallbacks& callbacks,
                  const UdpProxyFilterConfigSharedPtr& config);
+  ~UdpProxyFilter() override;
 
   // Network::UdpListenerReadFilter
   Network::FilterStatus onData(Network::UdpRecvData& data) override;
@@ -200,7 +201,7 @@ private:
   private:
     void onIdleTimer();
     void onReadReady();
-    void fillStreamInfo();
+    void fillSessionStreamInfo();
 
     // Network::UdpPacketProcessor
     void processPacket(Network::Address::InstanceConstSharedPtr local_address,
@@ -383,15 +384,7 @@ private:
                                                  nullptr, Network::SocketCreationOptions{});
   }
 
-  /**
-  * Struct definition for proxy access logging.
-  */
-  struct UdpProxyStats {
-    uint64_t downstream_proxy_no_route_;
-    uint64_t downstream_proxy_total_;
-    uint64_t downstream_proxy_idle_timeout_;
-    uint64_t downstream_sess_rx_errors_;
-  };
+  void fillProxyStreamInfo();
 
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(Upstream::ThreadLocalCluster& cluster) final;
@@ -401,6 +394,8 @@ private:
   const Upstream::ClusterUpdateCallbacksHandlePtr cluster_update_callbacks_;
   // Map for looking up cluster info with its name.
   absl::flat_hash_map<std::string, ClusterInfoPtr> cluster_infos_;
+
+  absl::optional<StreamInfo::StreamInfoImpl> udp_proxy_stats_;
 };
 
 } // namespace UdpProxy

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -536,11 +536,11 @@ TEST_F(UdpProxyFilterTest, SendReceiveErrorHandling) {
       "%DYNAMIC_METADATA(udp.proxy.session:bytes_sent)% "
       "%DYNAMIC_METADATA(udp.proxy.session:bytes_received)% "
       "%DYNAMIC_METADATA(udp.proxy.session:errors_sent)% "
-      "%DYNAMIC_METADATA(udp.proxy.session:errors_received)% "
       "%DYNAMIC_METADATA(udp.proxy.session:datagrams_sent)% "
       "%DYNAMIC_METADATA(udp.proxy.session:datagrams_received)%";
 
-  const std::string proxy_access_log_format = "%DYNAMIC_METADATA(udp.proxy.proxy:no_route)% "
+  const std::string proxy_access_log_format = "%DYNAMIC_METADATA(udp.proxy.proxy:errors_received)% "
+                                              "%DYNAMIC_METADATA(udp.proxy.proxy:no_route)% "
                                               "%DYNAMIC_METADATA(udp.proxy.proxy:sess_total)% "
                                               "%DYNAMIC_METADATA(udp.proxy.proxy:idle_timeout)%";
 
@@ -595,8 +595,8 @@ matcher:
 
   filter_.reset();
   EXPECT_EQ(output_.size(), 2);
-  EXPECT_EQ(output_.front(), "0 1 0");
-  EXPECT_EQ(output_.back(), "fake_cluster 0 10 1 1 0 2");
+  EXPECT_EQ(output_.front(), "1 0 1 0");
+  EXPECT_EQ(output_.back(), "fake_cluster 0 10 1 0 2");
 }
 
 // No upstream host handling.

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -167,7 +167,8 @@ public:
         peer_address_(std::move(peer_address)) {
     // Disable strict mock warnings.
     ON_CALL(*factory_context_.access_log_manager_.file_, write(_))
-        .WillByDefault(SaveArg<0>(&access_log_data_));
+        .WillByDefault(
+            Invoke([&](absl::string_view data) { output_.push_back(std::string(data)); }));
     ON_CALL(os_sys_calls_, supportsIpTransparent()).WillByDefault(Return(true));
     EXPECT_CALL(os_sys_calls_, supportsUdpGro()).Times(AtLeast(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(callbacks_, udpListener()).Times(AtLeast(0));
@@ -275,16 +276,31 @@ use_original_src_ip: true
 
   // Return the config from yaml, plus one file access log with the specified format
   envoy::extensions::filters::udp::udp_proxy::v3::UdpProxyConfig
-  accessLogConfig(const std::string& yaml, const std::string& access_log_format) {
+  accessLogConfig(const std::string& yaml, const std::string& sess_access_log_format,
+                  const std::string& proxy_access_log_format) {
     auto config = readConfig(yaml);
 
-    envoy::config::accesslog::v3::AccessLog* access_log = config.mutable_access_log()->Add();
-    access_log->set_name("envoy.access_loggers.file");
-    envoy::extensions::access_loggers::file::v3::FileAccessLog file_access_log;
-    file_access_log.set_path("unused");
-    file_access_log.mutable_log_format()->mutable_text_format_source()->set_inline_string(
-        access_log_format);
-    access_log->mutable_typed_config()->PackFrom(file_access_log);
+    if (!sess_access_log_format.empty()) {
+      envoy::config::accesslog::v3::AccessLog* sess_access_log =
+          config.mutable_sess_access_log()->Add();
+      sess_access_log->set_name("envoy.access_loggers.file");
+      envoy::extensions::access_loggers::file::v3::FileAccessLog sess_file_access_log;
+      sess_file_access_log.set_path("unused");
+      sess_file_access_log.mutable_log_format()->mutable_text_format_source()->set_inline_string(
+          sess_access_log_format);
+      sess_access_log->mutable_typed_config()->PackFrom(sess_file_access_log);
+    }
+
+    if (!proxy_access_log_format.empty()) {
+      envoy::config::accesslog::v3::AccessLog* proxy_access_log =
+          config.mutable_proxy_access_log()->Add();
+      proxy_access_log->set_name("envoy.access_loggers.file");
+      envoy::extensions::access_loggers::file::v3::FileAccessLog proxy_file_access_log;
+      proxy_file_access_log.set_path("unused");
+      proxy_file_access_log.mutable_log_format()->mutable_text_format_source()->set_inline_string(
+          proxy_access_log_format);
+      proxy_access_log->mutable_typed_config()->PackFrom(proxy_file_access_log);
+    }
     return config;
   }
 
@@ -314,6 +330,7 @@ use_original_src_ip: true
   std::unique_ptr<TestUdpProxyFilter> filter_;
   std::vector<TestSession> test_sessions_;
   StringViewSaver access_log_data_;
+  std::vector<std::string> output_;
   bool expect_gro_{};
   const Network::Address::InstanceConstSharedPtr upstream_address_;
   const Network::Address::InstanceConstSharedPtr peer_address_;
@@ -368,10 +385,20 @@ public:
 TEST_F(UdpProxyFilterTest, BasicFlow) {
   InSequence s;
 
-  const std::string access_log_format = "%DYNAMIC_METADATA(udp.proxy:bytes_received)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:datagrams_received)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:bytes_sent)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:datagrams_sent)%";
+  const std::string sess_access_log_format =
+      "%DYNAMIC_METADATA(udp.proxy.session:bytes_received)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:datagrams_received)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:bytes_sent)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:datagrams_sent)%";
+
+  const std::string proxy_access_log_format =
+      "%DYNAMIC_METADATA(udp.proxy.proxy:bytes_received)% "
+      "%DYNAMIC_METADATA(udp.proxy.proxy:datagrams_received)% "
+      "%DYNAMIC_METADATA(udp.proxy.proxy:bytes_sent)% "
+      "%DYNAMIC_METADATA(udp.proxy.proxy:datagrams_sent)% "
+      "%DYNAMIC_METADATA(udp.proxy.proxy:no_route)% "
+      "%DYNAMIC_METADATA(udp.proxy.proxy:sess_total)% "
+      "%DYNAMIC_METADATA(udp.proxy.proxy:idle_timeout)%";
 
   setup(accessLogConfig(R"EOF(
 stat_prefix: foo
@@ -385,7 +412,7 @@ matcher:
 upstream_socket_config:
   prefer_gro: false
   )EOF",
-                        access_log_format),
+                        sess_access_log_format, proxy_access_log_format),
         true, false);
 
   expectSessionCreate(upstream_address_);
@@ -410,7 +437,9 @@ upstream_socket_config:
   checkTransferStats(17 /*rx_bytes*/, 3 /*rx_datagrams*/, 17 /*tx_bytes*/, 3 /*tx_datagrams*/);
 
   filter_.reset();
-  EXPECT_EQ(access_log_data_.value(), "17 3 17 3");
+  EXPECT_EQ(output_.size(), 2);
+  EXPECT_EQ(output_.front(), "17 3 17 3 0 1 0");
+  EXPECT_EQ(output_.back(), "17 3 17 3");
 }
 
 // Route with source IP.
@@ -460,7 +489,12 @@ matcher:
 TEST_F(UdpProxyFilterTest, IdleTimeout) {
   InSequence s;
 
-  setup(readConfig(R"EOF(
+  const std::string sess_access_log_format = "";
+
+  const std::string proxy_access_log_format = "%DYNAMIC_METADATA(udp.proxy.proxy:sess_total)% "
+                                              "%DYNAMIC_METADATA(udp.proxy.proxy:idle_timeout)%";
+
+  setup(accessLogConfig(R"EOF(
 stat_prefix: foo
 matcher:
   on_no_match:
@@ -469,7 +503,8 @@ matcher:
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
         cluster: fake_cluster
-  )EOF"));
+  )EOF",
+                        sess_access_log_format, proxy_access_log_format));
 
   expectSessionCreate(upstream_address_);
   test_sessions_[0].expectWriteToUpstream("hello");
@@ -486,19 +521,28 @@ matcher:
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
   EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
   EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+
+  filter_.reset();
+  EXPECT_EQ(output_.size(), 1);
+  EXPECT_EQ(output_.front(), "2 1");
 }
 
 // Verify downstream send and receive error handling.
 TEST_F(UdpProxyFilterTest, SendReceiveErrorHandling) {
   InSequence s;
 
-  const std::string access_log_format = "%DYNAMIC_METADATA(udp.proxy:cluster_name)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:bytes_sent)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:bytes_received)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:errors_sent)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:errors_received)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:datagrams_sent)% "
-                                        "%DYNAMIC_METADATA(udp.proxy:datagrams_received)%";
+  const std::string sess_access_log_format =
+      "%DYNAMIC_METADATA(udp.proxy.session:cluster_name)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:bytes_sent)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:bytes_received)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:errors_sent)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:errors_received)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:datagrams_sent)% "
+      "%DYNAMIC_METADATA(udp.proxy.session:datagrams_received)%";
+
+  const std::string proxy_access_log_format = "%DYNAMIC_METADATA(udp.proxy.proxy:no_route)% "
+                                              "%DYNAMIC_METADATA(udp.proxy.proxy:sess_total)% "
+                                              "%DYNAMIC_METADATA(udp.proxy.proxy:idle_timeout)%";
 
   setup(accessLogConfig(R"EOF(
 stat_prefix: foo
@@ -510,7 +554,7 @@ matcher:
         '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
         cluster: fake_cluster
   )EOF",
-                        access_log_format));
+                        sess_access_log_format, proxy_access_log_format));
 
   filter_->onReceiveError(Api::IoError::IoErrorCode::UnknownError);
   EXPECT_EQ(1, config_->stats().downstream_sess_rx_errors_.value());
@@ -550,7 +594,9 @@ matcher:
              ->value());
 
   filter_.reset();
-  EXPECT_EQ(access_log_data_.value(), "fake_cluster 0 10 1 1 0 2");
+  EXPECT_EQ(output_.size(), 2);
+  EXPECT_EQ(output_.front(), "0 1 0");
+  EXPECT_EQ(output_.back(), "fake_cluster 0 10 1 1 0 2");
 }
 
 // No upstream host handling.
@@ -579,7 +625,11 @@ matcher:
 TEST_F(UdpProxyFilterTest, NoUpstreamClusterAtCreation) {
   InSequence s;
 
-  setup(readConfig(R"EOF(
+  const std::string sess_access_log_format = "";
+
+  const std::string proxy_access_log_format = "%DYNAMIC_METADATA(udp.proxy.proxy:no_route)%";
+
+  setup(accessLogConfig(R"EOF(
 stat_prefix: foo
 matcher:
   on_no_match:
@@ -588,11 +638,16 @@ matcher:
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
         cluster: fake_cluster
-  )EOF"),
+  )EOF",
+                        sess_access_log_format, proxy_access_log_format),
         false);
 
   recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
   EXPECT_EQ(1, config_->stats().downstream_sess_no_route_.value());
+
+  filter_.reset();
+  EXPECT_EQ(output_.size(), 1);
+  EXPECT_EQ(output_.front(), "1");
 }
 
 // Dynamic cluster addition and removal handling.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
Signed-off-by: giantcroc [changran.wang@intel.com](mailto:changran.wang@intel.com)

Commit Message: 
Some stats like `no_route` and `idle_timeout` can't be printed by session access log,
so we need proxy-level access logging to log global stats.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #23241
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
