### PR TITLE
 access_log/opentelemetry: stop emitting deprecated fields

### DIFF
--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -49,7 +49,7 @@ void GrpcAccessLoggerImpl::initMessageRoot(
         config,
     const LocalInfo::LocalInfo& local_info) {
   auto* resource_logs = message_.add_resource_logs();
-  root_ = resource_logs->add_instrumentation_library_logs();
+  root_ = resource_logs->add_scope_logs();
   auto* resource = resource_logs->mutable_resource();
   *resource->add_attributes() = getStringKeyValue("log_name", config.common_config().log_name());
   *resource->add_attributes() = getStringKeyValue("zone_name", local_info.zoneName());

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
@@ -25,8 +25,7 @@ namespace OpenTelemetry {
 // Note: OpenTelemetry protos are extra flexible and used also in the OT collector for batching and
 // so forth. As a result, some fields are repeated, but for our use case we assume the following
 // structure:
-// ExportLogsServiceRequest -> (single) ResourceLogs -> (single) InstrumentationLibraryLogs ->
-// (repeated) LogRecord.
+// ExportLogsServiceRequest -> (single) ResourceLogs -> (single) ScopeLogs -> (repeated) LogRecord.
 class GrpcAccessLoggerImpl
     : public Common::GrpcAccessLogger<
           opentelemetry::proto::logs::v1::LogRecord,
@@ -55,7 +54,7 @@ private:
   void initMessage() override;
   void clearMessage() override;
 
-  opentelemetry::proto::logs::v1::InstrumentationLibraryLogs* root_;
+  opentelemetry::proto::logs::v1::ScopeLogs* root_;
 };
 
 class GrpcAccessLoggerCacheImpl

--- a/test/extensions/access_loggers/open_telemetry/access_log_integration_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_integration_test.cc
@@ -33,7 +33,7 @@ constexpr char EXPECTED_REQUEST_MESSAGE[] = R"EOF(
           - key: "node_name"
             value:
               string_value: "node_name"
-      instrumentation_library_logs:
+      scope_logs:
         - log_records:
             body:
               string_value: "GET HTTP/1.1 404"
@@ -118,7 +118,7 @@ public:
     TestUtility::loadFromYaml(expected_request_msg_yaml, expected_request_msg);
     // Clear start time which is not deterministic.
     request_msg.mutable_resource_logs(0)
-        ->mutable_instrumentation_library_logs(0)
+        ->mutable_scope_logs(0)
         ->mutable_log_records(0)
         ->clear_time_unix_nano();
 

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -116,7 +116,7 @@ TEST_F(GrpcAccessLoggerImplTest, Log) {
         - key: "node_name"
           value:
             string_value: "node_name"
-    instrumentation_library_logs:
+    scope_logs:
       - log_records:
           - severity_text: "test-severity-text"
   )EOF");
@@ -179,7 +179,7 @@ TEST_F(GrpcAccessLoggerCacheImplTest, LoggerCreation) {
         - key: "node_name"
           value:
             string_value: "node_name"
-    instrumentation_library_logs:
+    scope_logs:
       - log_records:
           - severity_text: "test-severity-text"
   )EOF");
@@ -239,7 +239,7 @@ values:
         - key: k8s.pod.createtimestamp
           value:
             int_value: 1655429509
-    instrumentation_library_logs:
+    scope_logs:
       - log_records:
           - severity_text: "test-severity-text"
   )EOF");


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

OpenTelemetry introduced a rename of `instrumentation_library_logs` field to
`scope_logs`, while keeping the protobuf field number (2). The
`intrumentation_library_logs` field was readded though with different number
(1000) for compatibility reasons. As an effect, Envoy code using
`instrumentation_library_logs` continued to compile, but with change in wire
format (emitting field with number 1000 instead of 2). This commit fixes that
by using `scope_logs` field (with number 2).

Additional Description:
See #23234

Note: this PR is submitted to a release branch, as main is already fixed by #22694.

Risk Level:
not sure

Testing:
Unit tests adjusted.

Docs Changes:
n/a

Release Notes:
fixed OpenTelemetry access logger wire format, bringing it back to the same behaviour as with Envoy 1.22. This makes OpenTelemetry access logger compatible with opentelemetry collector >= 0.58 and < 0.49.0.

Platform Specific Features:
n/a

Fixes #23234
