### PR TITLE
doc: auto_host_rewrite works with STATIC clusters if hostname is provided

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -859,8 +859,9 @@ message RouteAction {
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
     // option is applicable only when the destination cluster for a route is of
-    // type *strict_dns* or *logical_dns*. Setting this to true with other cluster
-    // types has no effect.
+    // type ``STRICT_DNS``,  ``LOGICAL_DNS`` or ``STATIC``. For ``STATIC`` clusters, the
+    // hostname attribute of the endpoint must be configured. Setting this to true
+    // with other cluster types has no effect.
     google.protobuf.BoolValue auto_host_rewrite = 7;
 
     // Indicates that during forwarding, the host header will be swapped with the content of given


### PR DESCRIPTION
…ATIC clusters, provided that the hostname attribute of teh endpoint is configured.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Update documentation to indicate that auto_host_rewrite works with STATIC clusters, provided that the hostname attribute of the endpoint is configured.
Additional Description: Current documentation indicates that the auto_host_rewrite feature does not work with STATIC clusters. However, if the hostname attribute of the endpoints is configured, it works and sets the authority to the string configured at the hostname of the endpoint. 
Relates to issues https://github.com/envoyproxy/envoy/issues/23131
Risk Level: Low
Testing: Manual
Docs Changes: Update documentation to indicate that auto_host_rewrite works with STATIC clusters, provided that the hostname attribute of the endpoint is configured.
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
