### PR TITLE
filter manager: ability to convert upstream Starttls to secure mode

### DIFF
--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -161,6 +161,14 @@ public:
    * Set the currently selected upstream host for the connection.
    */
   virtual void upstreamHost(Upstream::HostDescriptionConstSharedPtr host) PURE;
+
+  /**
+   * Signal to the filter manager to enable secure transport mode in upstream connection.
+   * This is done when upstream connection's transport socket is of startTLS type. At the moment
+   * it is the only transport socket type which can be programmatically converted from non-secure
+   * mode to secure mode.
+   */
+  virtual bool startUpstreamSecureTransport() PURE;
 };
 
 /**
@@ -199,6 +207,13 @@ public:
    * @param callbacks supplies the callbacks.
    */
   virtual void initializeReadFilterCallbacks(ReadFilterCallbacks& callbacks) PURE;
+
+  /**
+   * Method is called by the filter manager to convert upstream's connection transport socket
+   * from non-secure mode to secure mode. Only terminal filters are aware of upstream connection and
+   * non-terminal filters should not implement startUpstreamSecureTransport.
+   */
+  virtual bool startUpstreamSecureTransport() { return false; }
 };
 
 using ReadFilterSharedPtr = std::shared_ptr<ReadFilter>;

--- a/envoy/tcp/upstream.h
+++ b/envoy/tcp/upstream.h
@@ -126,6 +126,11 @@ public:
    */
   virtual Tcp::ConnectionPool::ConnectionData*
   onDownstreamEvent(Network::ConnectionEvent event) PURE;
+
+  /* Called to convert underlying transport socket from non-secure mode
+   * to secure mode. Implemented only by start_tls transport socket.
+   */
+  virtual bool startUpstreamSecureTransport() PURE;
 };
 
 using GenericConnPoolPtr = std::unique_ptr<GenericConnPool>;

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -88,6 +88,19 @@ void FilterManagerImpl::onRead() {
   onContinueReading(nullptr, connection_);
 }
 
+bool FilterManagerImpl::startUpstreamSecureTransport() {
+  for (auto& filter : upstream_filters_) {
+    if (!(filter)->filter_) {
+      continue;
+    }
+    if (filter->filter_->startUpstreamSecureTransport()) {
+      // Success. The filter converted upstream's transport socket to secure mode.
+      return true;
+    }
+  }
+  return false;
+}
+
 FilterStatus FilterManagerImpl::onWrite() { return onWrite(nullptr, connection_); }
 
 FilterStatus FilterManagerImpl::onWrite(ActiveWriteFilter* filter,

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -90,10 +90,7 @@ void FilterManagerImpl::onRead() {
 
 bool FilterManagerImpl::startUpstreamSecureTransport() {
   for (auto& filter : upstream_filters_) {
-    if (!(filter)->filter_) {
-      continue;
-    }
-    if (filter->filter_->startUpstreamSecureTransport()) {
+    if (filter->filter_ != nullptr && filter->filter_->startUpstreamSecureTransport()) {
       // Success. The filter converted upstream's transport socket to secure mode.
       return true;
     }

--- a/source/common/network/filter_manager_impl.h
+++ b/source/common/network/filter_manager_impl.h
@@ -111,6 +111,7 @@ public:
   bool initializeReadFilters();
   void onRead();
   FilterStatus onWrite();
+  bool startUpstreamSecureTransport();
 
 private:
   struct ActiveReadFilter : public ReadFilterCallbacks, LinkedObject<ActiveReadFilter> {
@@ -130,6 +131,7 @@ private:
     void upstreamHost(Upstream::HostDescriptionConstSharedPtr host) override {
       parent_.host_description_ = host;
     }
+    bool startUpstreamSecureTransport() override { return parent_.startUpstreamSecureTransport(); }
 
     FilterManagerImpl& parent_;
     ReadFilterSharedPtr filter_;

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -599,6 +599,8 @@ Network::FilterStatus Filter::onNewConnection() {
   return establishUpstreamConnection();
 }
 
+bool Filter::startUpstreamSecureTransport() { return upstream_->startUpstreamSecureTransport(); }
+
 void Filter::onDownstreamEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::LocalClose ||
       event == Network::ConnectionEvent::RemoteClose) {

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -337,6 +337,7 @@ public:
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
   Network::FilterStatus onNewConnection() override;
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+  bool startUpstreamSecureTransport() override;
 
   // GenericConnectionPoolCallbacks
   void onGenericPoolReady(StreamInfo::StreamInfo* info, std::unique_ptr<GenericUpstream>&& upstream,

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -43,6 +43,10 @@ void TcpUpstream::addBytesSentCallback(Network::Connection::BytesSentCb cb) {
   upstream_conn_data_->connection().addBytesSentCallback(cb);
 }
 
+bool TcpUpstream::startUpstreamSecureTransport() {
+  return upstream_conn_data_->connection().startSecureTransport();
+}
+
 Tcp::ConnectionPool::ConnectionData*
 TcpUpstream::onDownstreamEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose) {

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -44,7 +44,9 @@ void TcpUpstream::addBytesSentCallback(Network::Connection::BytesSentCb cb) {
 }
 
 bool TcpUpstream::startUpstreamSecureTransport() {
-  return upstream_conn_data_->connection().startSecureTransport();
+  return (upstream_conn_data_ == nullptr)
+             ? false
+             : upstream_conn_data_->connection().startSecureTransport();
 }
 
 Tcp::ConnectionPool::ConnectionData*

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -113,6 +113,7 @@ public:
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void addBytesSentCallback(Network::Connection::BytesSentCb cb) override;
   Tcp::ConnectionPool::ConnectionData* onDownstreamEvent(Network::ConnectionEvent event) override;
+  bool startUpstreamSecureTransport() override;
 
 private:
   Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;
@@ -135,6 +136,9 @@ public:
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void addBytesSentCallback(Network::Connection::BytesSentCb cb) override;
   Tcp::ConnectionPool::ConnectionData* onDownstreamEvent(Network::ConnectionEvent event) override;
+  // HTTP upstream must not implement converting upstream transport
+  // socket from non-secure to secure mode.
+  bool startUpstreamSecureTransport() override { return false; }
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -67,6 +67,10 @@ protected:
     void injectReadDataToFilterChain(Buffer::Instance&, bool) override {
       IS_ENVOY_BUG("Unexpected call to injectReadDataToFilterChain");
     }
+    bool startUpstreamSecureTransport() override {
+      IS_ENVOY_BUG("Unexpected call to injectUpstreamConnectionEvent");
+      return false;
+    }
     Upstream::HostDescriptionConstSharedPtr upstreamHost() override { return nullptr; }
     void upstreamHost(Upstream::HostDescriptionConstSharedPtr) override {
       IS_ENVOY_BUG("Unexpected call to upstreamHost");

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -68,7 +68,7 @@ protected:
       IS_ENVOY_BUG("Unexpected call to injectReadDataToFilterChain");
     }
     bool startUpstreamSecureTransport() override {
-      IS_ENVOY_BUG("Unexpected call to injectUpstreamConnectionEvent");
+      IS_ENVOY_BUG("Unexpected call to startUpstreamSecureTransport");
       return false;
     }
     Upstream::HostDescriptionConstSharedPtr upstreamHost() override { return nullptr; }

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -414,6 +414,25 @@ TEST_F(NetworkFilterManagerTest, InjectWriteDataToFilterChain) {
   filter->write_callbacks_->injectWriteDataToFilterChain(injected_buffer, true);
 }
 
+TEST_F(NetworkFilterManagerTest, StartUpstreamSecureTransport) {
+  InSequence s;
+
+  MockReadFilter* read_filter_1(new MockReadFilter());
+  MockReadFilter* read_filter_2(new MockReadFilter());
+  MockFilter* filter(new MockFilter());
+
+  FilterManagerImpl manager(connection_, socket_);
+  manager.addReadFilter(ReadFilterSharedPtr{read_filter_1});
+  manager.addReadFilter(ReadFilterSharedPtr{read_filter_2});
+  manager.addFilter(FilterSharedPtr{filter});
+
+  // Verify that filter manager calls each filter's 'startUpstreamsecureTransport' method.
+  // when one filter calls startUpstreamSecureTransport.
+  EXPECT_CALL(*read_filter_1, startUpstreamSecureTransport);
+  EXPECT_CALL(*read_filter_2, startUpstreamSecureTransport);
+  filter->callbacks_->startUpstreamSecureTransport();
+}
+
 } // namespace
 } // namespace Network
 } // namespace Envoy

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1328,6 +1328,17 @@ TEST_F(TcpProxyTest, UpstreamConnectFailureStreamInfoAccessLog) {
   EXPECT_EQ(access_log_data_, "test_transport_failure");
 }
 
+// Test that call to tcp_proxy filter's startUpstreamSecureTransport results
+// in upstream's startUpstreamSecureTransport call.
+TEST_F(TcpProxyTest, UpstreamStartSecuteTransport) {
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
+
+  setup(1, config);
+  raiseEventUpstreamConnected(0);
+  EXPECT_CALL(*upstream_connections_.at(0), startSecureTransport);
+  filter_->startUpstreamSecureTransport();
+}
+
 } // namespace
 } // namespace TcpProxy
 } // namespace Envoy

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1330,7 +1330,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailureStreamInfoAccessLog) {
 
 // Test that call to tcp_proxy filter's startUpstreamSecureTransport results
 // in upstream's startUpstreamSecureTransport call.
-TEST_F(TcpProxyTest, UpstreamStartSecuteTransport) {
+TEST_F(TcpProxyTest, UpstreamStartSecureTransport) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
 
   setup(1, config);

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -103,6 +103,7 @@ public:
   MOCK_METHOD(void, injectReadDataToFilterChain, (Buffer::Instance & data, bool end_stream));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, upstreamHost, ());
   MOCK_METHOD(void, upstreamHost, (Upstream::HostDescriptionConstSharedPtr host));
+  MOCK_METHOD(bool, startUpstreamSecureTransport, ());
 
   testing::NiceMock<MockConnection> connection_;
   Upstream::HostDescriptionConstSharedPtr host_;
@@ -116,6 +117,7 @@ public:
   MOCK_METHOD(FilterStatus, onData, (Buffer::Instance & data, bool end_stream));
   MOCK_METHOD(FilterStatus, onNewConnection, ());
   MOCK_METHOD(void, initializeReadFilterCallbacks, (ReadFilterCallbacks & callbacks));
+  MOCK_METHOD(bool, startUpstreamSecureTransport, ());
 
   ReadFilterCallbacks* callbacks_{};
 };


### PR DESCRIPTION
Commit Message:
filter manager: ability to convert upstream Starttls to secure mode

Additional Description:
This PR provides a signalling path from a downstream read filter to a terminal filter in order to convert StartTLS upstream transport socket from non-secure mode to secure mode. StartTLS transport socket is basically a wrapper around raw (cleartext socket) and TLS socket. StartTLS transport socket always starts in cleartext and in order to convert it to secure mode, `startSecureTransport` method must be called. The main use of StartTLS transport socket is implementation of Opportunistic TLS protocol, where the first few messages are exchanged in cleartext and then TLS handshake is done on the same TCP session. The first few cleartext messages are protocol specific. Postgres messages are different than for example SMTP messages. Therefore a Read downstream filter is needed to parse those protocol specific messages and recognize the need to start TLS. The problem is that the Read filter (postgres, smtp, mysql) does not have an access to upstream connection, where the StartTLS transport socket is attached. The only filter which has a knowledge about both downstream and upstream connections it the terminal filter. Therefore the signal must be somehow conveyed from one of the downstream Read filters to the terminal filter. The result of the operation (whether upstream startTLS has been successfully converted to secure mode) should be returned to the Read filter.
That problem was discussed in one of the community meetings. @mattklein123 suggested to extend network FilterManager's callbacks and this PR uses that idea. The network filter manager iterates over all downstream filters and calls `startUpstreamSecureTransport` until one of them returns `true`. The only terminal filter which implements `startUpstreamSecureTransport` method is tcp_proxy. All other filters use `startUpstreamSecureTransport` defined in base class which is empty/no-op. @ggreenway raised a concern that tcp_proxy may be used for tunnelling. To address that issue only non-http upstream has `startUpstreamSecureTransport` implemented. The idea is described below.

![FM](https://user-images.githubusercontent.com/36484366/192332777-798e6277-ce04-4ee1-aa38-b20b0f73ffff.svg)

I used a modified postgres filter to exercise the new signalling path and it works properly.

Risk Level: Low. 
Testing: Added unit and integration testing.
Docs Changes: No.
Release Notes: No
Platform Specific Features: No.
Part of #19527