### PR TITLE
Minor cleanup for TLS inspector filter.

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/filters/listener/tls_inspector/tls_inspector.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -76,7 +77,7 @@ Config::Config(
 
 bssl::UniquePtr<SSL> Config::newSsl() { return bssl::UniquePtr<SSL>{SSL_new(ssl_ctx_.get())}; }
 
-Filter::Filter(const ConfigSharedPtr config) : config_(config), ssl_(config_->newSsl()) {
+Filter::Filter(const ConfigSharedPtr& config) : config_(config), ssl_(config_->newSsl()) {
   SSL_set_app_data(ssl_.get(), this);
   SSL_set_accept_state(ssl_.get());
 }
@@ -196,12 +197,7 @@ static constexpr std::array<uint16_t, 16> GREASE = {
 };
 
 bool isNotGrease(uint16_t id) {
-  for (size_t grease_id : GREASE) {
-    if (id == grease_id) {
-      return false;
-    }
-  }
-  return true;
+  return std::find(GREASE.begin(), GREASE.end(), id) == GREASE.end();
 }
 
 void writeCipherSuites(const SSL_CLIENT_HELLO* ssl_client_hello, std::string& fingerprint) {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -64,7 +64,7 @@ public:
 private:
   TlsInspectorStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
-  bool enable_ja3_fingerprinting_;
+  const bool enable_ja3_fingerprinting_;
   const uint32_t max_client_hello_size_;
 };
 
@@ -75,7 +75,7 @@ using ConfigSharedPtr = std::shared_ptr<Config>;
  */
 class Filter : public Network::ListenerFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  Filter(const ConfigSharedPtr config);
+  Filter(const ConfigSharedPtr& config);
 
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -166,7 +166,7 @@ TEST_P(TlsInspectorIntegrationTest, ContinueOnListenerTimeout) {
   // will continue wait. Then the listener filter timeout timer will be triggered.
   Buffer::OwnedImpl buffer("fake data");
   client_->write(buffer, false);
-  // the timeout is set as one seconds, sleep 5 to trigger the timeout.
+  // the timeout is set as one seconds, advance 2 seconds to trigger the timeout.
   timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(2000));
   client_->close(Network::ConnectionCloseType::NoFlush);
   EXPECT_THAT(waitForAccessLog(listener_access_log_name_), testing::Eq("-"));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -166,7 +166,7 @@ TEST_P(TlsInspectorIntegrationTest, ContinueOnListenerTimeout) {
   // will continue wait. Then the listener filter timeout timer will be triggered.
   Buffer::OwnedImpl buffer("fake data");
   client_->write(buffer, false);
-  // the timeout is set as one seconds, advance 2 seconds to trigger the timeout.
+  // The timeout is set as one seconds, advance 2 seconds to trigger the timeout.
   timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(2000));
   client_->close(Network::ConnectionCloseType::NoFlush);
   EXPECT_THAT(waitForAccessLog(listener_access_log_name_), testing::Eq("-"));


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:Cleanup for TLS inspector. 
Additional Description:
1) Avoid making share ptr copy
2) Use std algo vs loop
3) Make member const since it's only read after init


Risk Level:low
Testing: ran test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
