### PR TITLE
upstream: Add support for sharing alt-svc entries between hosts.

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -171,6 +171,9 @@ message AlternateProtocolsCacheOptions {
 
   // Allows pre-populating the cache with entries, as described above.
   repeated AlternateProtocolsCacheEntry prepopulated_entries = 4;
+
+  // Optional list of hostnames suffixes for which Alt-Svc entries can be shared.
+  repeated string canonical_suffixes = 5;
 }
 
 // [#next-free-field: 7]

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -127,6 +127,7 @@ message UpstreamHttpProtocolOptions {
 // make an HTTP connection to an origin server. See https://tools.ietf.org/html/rfc7838 for
 // HTTP Alternative Services and https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-04
 // for the "HTTPS" DNS resource record.
+// [#next-free-field: 6]
 message AlternateProtocolsCacheOptions {
   // Allows pre-populating the cache with HTTP/3 alternate protocols entries with a 7 day lifetime.
   // This will cause Envoy to attempt HTTP/3 to those upstreams, even if the upstreams have not

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -174,10 +174,14 @@ message AlternateProtocolsCacheOptions {
   repeated AlternateProtocolsCacheEntry prepopulated_entries = 4;
 
   // Optional list of hostnames suffixes for which Alt-Svc entries can be shared. For example, if
-  // this list contained the value `.c.example.com`, then an Alt-Svc entry for `foo.c.example.com`
-  // could be shared with 'bar.c.example.com' but would not be shared with 'baz.example.com'. On
-  // the other hand, if the list contained the value '.youtube.com' then all three hosts could share
-  // Alt-Svc entries.
+  // this list contained the value ``.c.example.com``, then an Alt-Svc entry for ``foo.c.example.com``
+  // could be shared with ``bar.c.example.com`` but would not be shared with ``baz.example.com``. On
+  // the other hand, if the list contained the value ``.example.com`` then all three hosts could share
+  // Alt-Svc entries. Each entry must start with ``.``.  If a hostname matches multiple suffixes, the
+  // first listed suffix will be used.
+  //
+  // Since lookup in this list is O(n), it is recommended that the number of suffixes be limited.
+  // [#not-implemented-hide:]
   repeated string canonical_suffixes = 5;
 }
 

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -173,7 +173,11 @@ message AlternateProtocolsCacheOptions {
   // Allows pre-populating the cache with entries, as described above.
   repeated AlternateProtocolsCacheEntry prepopulated_entries = 4;
 
-  // Optional list of hostnames suffixes for which Alt-Svc entries can be shared.
+  // Optional list of hostnames suffixes for which Alt-Svc entries can be shared. For example, if
+  // this list contained the value `.c.example.com`, then an Alt-Svc entry for `foo.c.example.com`
+  // could be shared with 'bar.c.example.com' but would not be shared with 'baz.example.com'. On
+  // the other hand, if the list contained the value '.youtube.com' then all three hosts could share
+  // Alt-Svc entries.
   repeated string canonical_suffixes = 5;
 }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -196,9 +196,6 @@ new_features:
 - area: access_log
   change: |
     added support for number values in substitution format string in json_format.
-- area: upstream
-  change: |
-    added support for sharing alt-svc entries between hosts which share a suffix.
 - area: http
   change: |
     added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check for HTTP health check.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -196,6 +196,9 @@ new_features:
 - area: access_log
   change: |
     added support for number values in substitution format string in json_format.
+- area: upstream
+  change: |
+    added support for sharing alt-svc entries between hosts which share a suffix.
 - area: http
   change: |
     added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check for HTTP health check.

--- a/envoy/http/http_server_properties_cache.h
+++ b/envoy/http/http_server_properties_cache.h
@@ -32,8 +32,11 @@ public:
    */
   struct Origin {
   public:
+    Origin() = default;
+    Origin(const Origin& other) = default;
     Origin(absl::string_view scheme, absl::string_view hostname, uint32_t port)
         : scheme_(scheme), hostname_(hostname), port_(port) {}
+    Origin& operator=(const Origin&) = default;
 
     bool operator==(const Origin& other) const {
       return std::tie(scheme_, hostname_, port_) ==

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -306,7 +306,8 @@ absl::string_view HttpServerPropertiesCacheImpl::getCanonicalSuffix(absl::string
   return "";
 }
 
-absl::optional<HttpServerPropertiesCache::Origin> HttpServerPropertiesCacheImpl::getCanonicalOrigin(absl::string_view hostname) {
+absl::optional<HttpServerPropertiesCache::Origin>
+HttpServerPropertiesCacheImpl::getCanonicalOrigin(absl::string_view hostname) {
   absl::string_view suffix = getCanonicalSuffix(hostname);
   if (suffix.empty()) {
     return {};

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -30,6 +30,7 @@ class HttpServerPropertiesCacheImpl : public HttpServerPropertiesCache,
                                       Logger::Loggable<Logger::Id::alternate_protocols_cache> {
 public:
   HttpServerPropertiesCacheImpl(Event::Dispatcher& dispatcher,
+                                std::vector<std::string>&& canonical_suffixes,
                                 std::unique_ptr<KeyValueStore>&& store, size_t max_entries);
   ~HttpServerPropertiesCacheImpl() override;
 
@@ -90,9 +91,6 @@ public:
   size_t size() const override;
   HttpServerPropertiesCache::Http3StatusTracker&
   getOrCreateHttp3StatusTracker(const Origin& origin) override;
-
-  // Adds `suffix` to the list of canonical suffixes.
-  void addCanonicalSuffix(std::string suffix);
 
 private:
   // Time source used to check expiration of entries.

--- a/source/common/http/http_server_properties_cache_impl.h
+++ b/source/common/http/http_server_properties_cache_impl.h
@@ -91,6 +91,9 @@ public:
   HttpServerPropertiesCache::Http3StatusTracker&
   getOrCreateHttp3StatusTracker(const Origin& origin) override;
 
+  // Adds `suffix` to the list of canonical suffixes.
+  void addCanonicalSuffix(std::string suffix);
+
 private:
   // Time source used to check expiration of entries.
   Event::Dispatcher& dispatcher_;
@@ -132,8 +135,26 @@ private:
 
   ProtocolsMap::iterator addOriginData(const Origin& origin, OriginData&& origin_data);
 
+  // Returns the canonical suffix, if any, associated with `hostname`.
+  absl::string_view getCanonicalSuffix(absl::string_view hostname);
+
+  // Returns the canonical origin, if any, associated with `hostname`.
+  absl::optional<Origin> getCanonicalOrigin(absl::string_view hostname);
+
+  // If `origin` matches a canonical suffix then updates canonical_alt_svc_map_ accordingly.
+  void maybeSetCanonicalOrigin(const Origin& origin);
+
   // The key value store, if flushing to persistent storage.
   std::unique_ptr<KeyValueStore> key_value_store_;
+
+  // Contains a map of servers which could share the same alternate protocol.
+  // Map from a Canonical suffix to an actual origin, which has a plausible alternate
+  // protocol mapping.
+  std::map<std::string, Origin> canonical_alt_svc_map_;
+
+  // Contains list of suffixes (for example ".c.youtube.com",
+  // ".googlevideo.com", ".googleusercontent.com") of canonical hostnames.
+  std::vector<std::string> canonical_suffixes_;
 
   const size_t max_entries_;
 };

--- a/source/common/http/http_server_properties_cache_manager_impl.cc
+++ b/source/common/http/http_server_properties_cache_manager_impl.cc
@@ -51,8 +51,8 @@ HttpServerPropertiesCacheSharedPtr HttpServerPropertiesCacheManagerImpl::getCach
         factory.createStore(kv_config, data_.validation_visitor_, dispatcher, data_.file_system_);
   }
 
-  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(
-      dispatcher, std::move(store), options.max_entries().value());
+  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher, std::move(store),
+                                                                   options.max_entries().value());
 
   for (const std::string& suffix : options.canonical_suffixes()) {
     new_cache->addCanonicalSuffix(suffix);

--- a/source/common/http/http_server_properties_cache_manager_impl.cc
+++ b/source/common/http/http_server_properties_cache_manager_impl.cc
@@ -51,9 +51,12 @@ HttpServerPropertiesCacheSharedPtr HttpServerPropertiesCacheManagerImpl::getCach
         factory.createStore(kv_config, data_.validation_visitor_, dispatcher, data_.file_system_);
   }
 
-  HttpServerPropertiesCacheSharedPtr new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(
+  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(
       dispatcher, std::move(store), options.max_entries().value());
 
+  for (const std::string& suffix : options.canonical_suffixes()) {
+    new_cache->addCanonicalSuffix(suffix);
+  }
   for (const envoy::config::core::v3::AlternateProtocolsCacheOptions::AlternateProtocolsCacheEntry&
            entry : options.prepopulated_entries()) {
     const HttpServerPropertiesCacheImpl::Origin origin = {"https", entry.hostname(), entry.port()};

--- a/source/common/http/http_server_properties_cache_manager_impl.cc
+++ b/source/common/http/http_server_properties_cache_manager_impl.cc
@@ -51,16 +51,20 @@ HttpServerPropertiesCacheSharedPtr HttpServerPropertiesCacheManagerImpl::getCach
         factory.createStore(kv_config, data_.validation_visitor_, dispatcher, data_.file_system_);
   }
 
-  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher, std::move(store),
-                                                                   options.max_entries().value());
-
+  std::vector<std::string> canonical_suffixes;
   for (const std::string& suffix : options.canonical_suffixes()) {
     if (!absl::StartsWith(suffix, ".")) {
       IS_ENVOY_BUG(absl::StrCat("Suffix does not start with a leading '.': ", suffix));
       continue;
     }
-    new_cache->addCanonicalSuffix(suffix);
+    canonical_suffixes.push_back(suffix);
   }
+
+  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher, std::move(canonical_suffixes),
+                                                                   std::move(store),
+                                                                   options.max_entries().value());
+
+
   for (const envoy::config::core::v3::AlternateProtocolsCacheOptions::AlternateProtocolsCacheEntry&
            entry : options.prepopulated_entries()) {
     const HttpServerPropertiesCacheImpl::Origin origin = {"https", entry.hostname(), entry.port()};

--- a/source/common/http/http_server_properties_cache_manager_impl.cc
+++ b/source/common/http/http_server_properties_cache_manager_impl.cc
@@ -60,10 +60,8 @@ HttpServerPropertiesCacheSharedPtr HttpServerPropertiesCacheManagerImpl::getCach
     canonical_suffixes.push_back(suffix);
   }
 
-  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher, std::move(canonical_suffixes),
-                                                                   std::move(store),
-                                                                   options.max_entries().value());
-
+  auto new_cache = std::make_shared<HttpServerPropertiesCacheImpl>(
+      dispatcher, std::move(canonical_suffixes), std::move(store), options.max_entries().value());
 
   for (const envoy::config::core::v3::AlternateProtocolsCacheOptions::AlternateProtocolsCacheEntry&
            entry : options.prepopulated_entries()) {

--- a/source/common/http/http_server_properties_cache_manager_impl.cc
+++ b/source/common/http/http_server_properties_cache_manager_impl.cc
@@ -55,6 +55,10 @@ HttpServerPropertiesCacheSharedPtr HttpServerPropertiesCacheManagerImpl::getCach
                                                                    options.max_entries().value());
 
   for (const std::string& suffix : options.canonical_suffixes()) {
+    if (!absl::StartsWith(suffix, ".")) {
+      IS_ENVOY_BUG(absl::StrCat("Suffix does not start with a leading '.': ", suffix));
+      continue;
+    }
     new_cache->addCanonicalSuffix(suffix);
   }
   for (const envoy::config::core::v3::AlternateProtocolsCacheOptions::AlternateProtocolsCacheEntry&

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -125,8 +125,8 @@ public:
       : transport_socket_options_(
             std::make_shared<Network::TransportSocketOptionsImpl>("hostname")),
         options_({Http::Protocol::Http11, Http::Protocol::Http2, Http::Protocol::Http3}),
-        alternate_protocols_(
-            std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher_, nullptr, 10)),
+        alternate_protocols_(std::make_shared<HttpServerPropertiesCacheImpl>(
+            dispatcher_, std::vector<std::string>(), nullptr, 10)),
         quic_stat_names_(store_.symbolTable()) {}
 
   void initialize() {
@@ -154,7 +154,8 @@ public:
     if (!use_alternate_protocols) {
       return nullptr;
     }
-    return std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher_, nullptr, 10);
+    return std::make_shared<HttpServerPropertiesCacheImpl>(dispatcher_, std::vector<std::string>(),
+                                                           nullptr, 10);
   }
 
   void addHttp3AlternateProtocol(absl::optional<std::chrono::microseconds> rtt = {}) {

--- a/test/common/http/http_server_properties_cache_impl_test.cc
+++ b/test/common/http/http_server_properties_cache_impl_test.cc
@@ -37,12 +37,13 @@ public:
 
   void initialize() {
     protocols_ = std::make_unique<HttpServerPropertiesCacheImpl>(
-        dispatcher_, std::unique_ptr<KeyValueStore>(store_), max_entries_);
+        dispatcher_, std::move(suffixes_), std::unique_ptr<KeyValueStore>(store_), max_entries_);
   }
 
   size_t max_entries_ = 10;
 
   NiceMock<Event::MockDispatcher> dispatcher_;
+  std::vector<std::string> suffixes_;
   MockKeyValueStore* store_;
   std::unique_ptr<HttpServerPropertiesCacheImpl> protocols_;
 
@@ -375,18 +376,52 @@ TEST_F(HttpServerPropertiesCacheImplTest, GetOrCreateHttp3StatusTracker) {
 TEST_F(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
   std::string suffix = ".example.com";
   std::string host1 = "first.example.com";
-  std::string host2 = "second.example.com";
+  std::string host2 = "www.second.example.com";
   const HttpServerPropertiesCacheImpl::Origin origin1 = {https_, host1, port1_};
   const HttpServerPropertiesCacheImpl::Origin origin2 = {https_, host2, port2_};
 
+  suffixes_.push_back(suffix);
   initialize();
-  protocols_->addCanonicalSuffix(suffix);
   protocols_->setAlternatives(origin1, protocols1_);
 
   OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
       protocols_->findAlternatives(origin2);
   ASSERT_TRUE(protocols.has_value());
   EXPECT_EQ(protocols1_, protocols.ref());
+}
+
+TEST_F(HttpServerPropertiesCacheImplTest, CanonicalSuffixNoMatch) {
+  std::string suffix = ".example.com";
+  std::string host1 = "www.example.com";
+  std::string host2 = "www.other.com";
+  const HttpServerPropertiesCacheImpl::Origin origin1 = {https_, host1, port1_};
+  const HttpServerPropertiesCacheImpl::Origin origin2 = {https_, host2, port2_};
+
+  suffixes_.push_back(suffix);
+  initialize();
+  protocols_->setAlternatives(origin1, protocols1_);
+
+  OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
+      protocols_->findAlternatives(origin2);
+  ASSERT_FALSE(protocols.has_value());
+}
+
+TEST_F(HttpServerPropertiesCacheImplTest, ExplicitAlternativeTakesPriorityOverCanonicalSuffix) {
+  std::string suffix = ".example.com";
+  std::string host1 = "first.example.com";
+  std::string host2 = "second.example.com";
+  const HttpServerPropertiesCacheImpl::Origin origin1 = {https_, host1, port1_};
+  const HttpServerPropertiesCacheImpl::Origin origin2 = {https_, host2, port2_};
+
+  suffixes_.push_back(suffix);
+  initialize();
+  protocols_->setAlternatives(origin1, protocols1_);
+  protocols_->setAlternatives(origin2, protocols2_);
+
+  OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
+      protocols_->findAlternatives(origin2);
+  ASSERT_TRUE(protocols.has_value());
+  EXPECT_EQ(protocols2_, protocols.ref());
 }
 
 } // namespace

--- a/test/common/http/http_server_properties_cache_impl_test.cc
+++ b/test/common/http/http_server_properties_cache_impl_test.cc
@@ -372,6 +372,23 @@ TEST_F(HttpServerPropertiesCacheImplTest, GetOrCreateHttp3StatusTracker) {
   EXPECT_FALSE(protocols_->getOrCreateHttp3StatusTracker(origin1_).isHttp3Broken());
 }
 
+TEST_F(HttpServerPropertiesCacheImplTest, CanonicalSuffix) {
+  std::string suffix = ".example.com";
+  std::string host1 = "first.example.com";
+  std::string host2 = "second.example.com";
+  const HttpServerPropertiesCacheImpl::Origin origin1 = {https_, host1, port1_};
+  const HttpServerPropertiesCacheImpl::Origin origin2 = {https_, host2, port2_};
+
+  initialize();
+  protocols_->addCanonicalSuffix(suffix);
+  protocols_->setAlternatives(origin1, protocols1_);
+
+  OptRef<const std::vector<HttpServerPropertiesCacheImpl::AlternateProtocol>> protocols =
+      protocols_->findAlternatives(origin2);
+  ASSERT_TRUE(protocols.has_value());
+  EXPECT_EQ(protocols1_, protocols.ref());
+}
+
 } // namespace
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/http_server_properties_cache_manager_test.cc
+++ b/test/common/http/http_server_properties_cache_manager_test.cc
@@ -74,6 +74,22 @@ TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithEntry) {
   EXPECT_TRUE(cache->findAlternatives(origin).has_value());
 }
 
+TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithCanonicalEntry) {
+  auto* suffixes = options1_.add_canonical_suffixes();
+  *suffixes = "example.com";
+  auto* entry = options1_.add_prepopulated_entries();
+  entry->set_hostname("first.example.com");
+  entry->set_port(1);
+
+  initialize();
+  HttpServerPropertiesCacheSharedPtr cache = manager_->getCache(options1_, dispatcher_);
+  EXPECT_NE(nullptr, cache);
+  EXPECT_EQ(cache, manager_->getCache(options1_, dispatcher_));
+
+  const HttpServerPropertiesCacheImpl::Origin origin = {"https", "second.example.com", entry->port()};
+  EXPECT_TRUE(cache->findAlternatives(origin).has_value());
+}
+
 TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithFlushingAndConcurrency) {
   EXPECT_CALL(context_.options_, concurrency()).WillOnce(Return(5));
   options1_.mutable_key_value_store_config();

--- a/test/common/http/http_server_properties_cache_manager_test.cc
+++ b/test/common/http/http_server_properties_cache_manager_test.cc
@@ -86,7 +86,8 @@ TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithCanonicalEntry) {
   EXPECT_NE(nullptr, cache);
   EXPECT_EQ(cache, manager_->getCache(options1_, dispatcher_));
 
-  const HttpServerPropertiesCacheImpl::Origin origin = {"https", "second.example.com", entry->port()};
+  const HttpServerPropertiesCacheImpl::Origin origin = {"https", "second.example.com",
+                                                        entry->port()};
   EXPECT_TRUE(cache->findAlternatives(origin).has_value());
 }
 

--- a/test/common/http/http_server_properties_cache_manager_test.cc
+++ b/test/common/http/http_server_properties_cache_manager_test.cc
@@ -74,9 +74,18 @@ TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithEntry) {
   EXPECT_TRUE(cache->findAlternatives(origin).has_value());
 }
 
-TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithCanonicalEntry) {
+TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithInvalidCanonicalEntry) {
   auto* suffixes = options1_.add_canonical_suffixes();
   *suffixes = "example.com";
+
+  initialize();
+  EXPECT_ENVOY_BUG(manager_->getCache(options1_, dispatcher_),
+                   "Suffix does not start with a leading '.': example.com");
+}
+
+TEST_F(HttpServerPropertiesCacheManagerTest, GetCacheWithCanonicalEntry) {
+  auto* suffixes = options1_.add_canonical_suffixes();
+  *suffixes = ".example.com";
   auto* entry = options1_.add_prepopulated_entries();
   entry->set_hostname("first.example.com");
   entry->set_port(1);


### PR DESCRIPTION
Add a "canonical suffix" list to the Alt-Svc cache so that Alt-Svc entries can be shared across origins which share the same hostname suffix.

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: New unit tests
Docs Changes: Update proto docs
Release Notes: Updated