### PR TITLE
generic proxy: provides per filter config API to L7 filters to get route level config by the filter config name

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/action/v3/action.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/action/v3/action.proto
@@ -39,7 +39,8 @@ message RouteAction {
   // Route metadata.
   config.core.v3.Metadata metadata = 3;
 
-  // Route level config for L7 generic filters. The key should always be the generic
-  // filter name.
+  // Route level config for L7 generic filters. The key should be the related :ref:`extension name
+  // <envoy_v3_api_field_config.core.v3.TypedExtensionConfig.name>` in the :ref:`generic filters
+  // <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.filters>`.
   map<string, google.protobuf.Any> per_filter_config = 4;
 }

--- a/contrib/generic_proxy/filters/network/source/interface/filter.h
+++ b/contrib/generic_proxy/filters/network/source/interface/filter.h
@@ -151,10 +151,10 @@ public:
 };
 
 /**
- * A FilterChainFactory is used by a connection manager to create a connection level filter chain
- * when a new connection is created. Typically it would be implemented by a configuration engine
+ * A FilterChainFactory is used by a connection manager to create a stream level filter chain
+ * when a new stream is created. Typically it would be implemented by a configuration engine
  * that would install a set of filters that are able to process an application scenario on top of a
- * stream of Dubbo requests.
+ * stream of generic requests.
  */
 class FilterChainFactory {
 public:

--- a/contrib/generic_proxy/filters/network/source/interface/filter.h
+++ b/contrib/generic_proxy/filters/network/source/interface/filter.h
@@ -43,9 +43,15 @@ public:
    * @return const RouteEntry* cached route entry for current request.
    */
   virtual const RouteEntry* routeEntry() const PURE;
+
+  /**
+   * @return const RouteSpecificFilterConfig* route level per filter config. The filter config
+   * name will be used to get the config.
+   */
+  virtual const RouteSpecificFilterConfig* perFilterConfig() const PURE;
 };
 
-class DecoderFilterCallback : public StreamFilterCallbacks {
+class DecoderFilterCallback : public virtual StreamFilterCallbacks {
 public:
   virtual void sendLocalReply(Status status, ResponseUpdateFunction&& cb = nullptr) PURE;
 
@@ -56,7 +62,7 @@ public:
   virtual void completeDirectly() PURE;
 };
 
-class EncoderFilterCallback : public StreamFilterCallbacks {
+class EncoderFilterCallback : public virtual StreamFilterCallbacks {
 public:
   virtual void continueEncoding() PURE;
 };
@@ -66,8 +72,6 @@ enum class FilterStatus { Continue, StopIteration };
 class DecoderFilter {
 public:
   virtual ~DecoderFilter() = default;
-
-  virtual bool isDualFilter() const { return false; }
 
   virtual void onDestroy() PURE;
 
@@ -79,18 +83,13 @@ class EncoderFilter {
 public:
   virtual ~EncoderFilter() = default;
 
-  virtual bool isDualFilter() const { return false; }
-
   virtual void onDestroy() PURE;
 
   virtual void setEncoderFilterCallbacks(EncoderFilterCallback& callbacks) PURE;
   virtual FilterStatus onStreamEncoded(Response& response) PURE;
 };
 
-class StreamFilter : public DecoderFilter, public EncoderFilter {
-public:
-  bool isDualFilter() const final { return true; }
-};
+class StreamFilter : public DecoderFilter, public EncoderFilter {};
 
 using DecoderFilterSharedPtr = std::shared_ptr<DecoderFilter>;
 using EncoderFilterSharedPtr = std::shared_ptr<EncoderFilter>;
@@ -122,9 +121,39 @@ public:
 using FilterFactoryCb = std::function<void(FilterChainFactoryCallbacks& callbacks)>;
 
 /**
- * A FilterChainFactory is used by a connection manager to create a Kafka level filter chain when
- * a new connection is created. Typically it would be implemented by a configuration engine that
- * would install a set of filters that are able to process an application scenario on top of a
+ * Simple struct of additional contextual information of filter, e.g. filter config name
+ * from configuration.
+ */
+struct FilterContext {
+  // The name of the filter configuration that used to create related filter factory function.
+  // This could be any legitimate non-empty string.
+  // This config name will have longger lifetime than any related filter instance. So string
+  // view could be used here safely.
+  absl::string_view config_name;
+};
+
+/**
+ * The filter chain manager is provided by the connection manager to the filter chain factory.
+ * The filter chain factory will post the filter factory context and filter factory to the
+ * filter chain manager to create filter and construct HTTP stream filter chain.
+ */
+class FilterChainManager {
+public:
+  virtual ~FilterChainManager() = default;
+
+  /**
+   * Post filter factory context and filter factory to the filter chain manager. The filter
+   * chain manager will create filter instance based on the context and factory internally.
+   * @param context supplies additional contextual information of filter factory.
+   * @param factory factory function used to create filter instances.
+   */
+  virtual void applyFilterFactoryCb(FilterContext context, FilterFactoryCb& factory) PURE;
+};
+
+/**
+ * A FilterChainFactory is used by a connection manager to create a connection level filter chain
+ * when a new connection is created. Typically it would be implemented by a configuration engine
+ * that would install a set of filters that are able to process an application scenario on top of a
  * stream of Dubbo requests.
  */
 class FilterChainFactory {
@@ -132,11 +161,11 @@ public:
   virtual ~FilterChainFactory() = default;
 
   /**
-   * Called when a new Kafka stream is created on the connection.
-   * @param callbacks supplies the "sink" that is used for actually creating the filter chain. @see
-   *                  FilterChainFactoryCallbacks.
+   * Called when a new HTTP stream is created on the connection.
+   * @param manager supplies the "sink" that is used for actually creating the filter chain. @see
+   *                FilterChainManager.
    */
-  virtual void createFilterChain(FilterChainFactoryCallbacks& callbacks) PURE;
+  virtual void createFilterChain(FilterChainManager& manager) PURE;
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/test/mocks/filter.cc
+++ b/contrib/generic_proxy/filters/network/test/mocks/filter.cc
@@ -21,6 +21,14 @@ MockStreamFilterConfig::MockStreamFilterConfig() {
   ON_CALL(*this, configTypes()).WillByDefault(Return(std::set<std::string>{}));
 }
 
+MockFilterChainManager::MockFilterChainManager() {
+  ON_CALL(*this, applyFilterFactoryCb(_, _))
+      .WillByDefault(Invoke([this](FilterContext context, FilterFactoryCb& factory) {
+        contexts_.push_back(context);
+        factory(callbacks_);
+      }));
+}
+
 MockDecoderFilter::MockDecoderFilter() {
   ON_CALL(*this, onStreamDecoded(_)).WillByDefault(Return(FilterStatus::Continue));
 }

--- a/contrib/generic_proxy/filters/network/test/mocks/filter.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/filter.h
@@ -68,12 +68,23 @@ public:
   MOCK_METHOD(void, addFilter, (StreamFilterSharedPtr filter));
 };
 
+class MockFilterChainManager : public FilterChainManager {
+public:
+  MockFilterChainManager();
+
+  MOCK_METHOD(void, applyFilterFactoryCb, (FilterContext context, FilterFactoryCb& factory));
+
+  testing::NiceMock<MockFilterChainFactoryCallbacks> callbacks_;
+  std::vector<FilterContext> contexts_;
+};
+
 template <class Base> class MockStreamFilterCallbacks : public Base {
 public:
   MOCK_METHOD(Envoy::Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(const CodecFactory&, downstreamCodec, ());
   MOCK_METHOD(void, resetStream, ());
   MOCK_METHOD(const RouteEntry*, routeEntry, (), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (), (const));
 };
 
 class MockDecoderFilterCallback : public MockStreamFilterCallbacks<DecoderFilterCallback> {

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -173,26 +173,23 @@ TEST(BasicFilterConfigTest, CreatingFilterFactories) {
 class FilterConfigTest : public testing::Test {
 public:
   void initializeFilterConfig() {
-    std::vector<FilterFactoryCb> factories;
+    std::vector<NamedFilterFactoryCb> factories;
 
     for (const auto& filter : mock_stream_filters_) {
-      factories.push_back([f = filter](FilterChainFactoryCallbacks& cb) {
-        ASSERT(f->isDualFilter());
-        cb.addFilter(f);
-      });
+      factories.push_back({filter.first, [f = filter.second](FilterChainFactoryCallbacks& cb) {
+                             cb.addFilter(f);
+                           }});
     }
 
     for (const auto& filter : mock_decoder_filters_) {
-      factories.push_back([f = filter](FilterChainFactoryCallbacks& cb) {
-        ASSERT(!f->isDualFilter());
-        cb.addDecoderFilter(f);
-      });
+      factories.push_back({filter.first, [f = filter.second](FilterChainFactoryCallbacks& cb) {
+                             cb.addDecoderFilter(f);
+                           }});
     }
     for (const auto& filter : mock_encoder_filters_) {
-      factories.push_back([f = filter](FilterChainFactoryCallbacks& cb) {
-        ASSERT(!f->isDualFilter());
-        cb.addEncoderFilter(f);
-      });
+      factories.push_back({filter.first, [f = filter.second](FilterChainFactoryCallbacks& cb) {
+                             cb.addEncoderFilter(f);
+                           }});
     }
 
     auto codec_factory = std::make_unique<NiceMock<MockCodecFactory>>();
@@ -214,9 +211,13 @@ public:
   NiceMock<MockCodecFactory>* codec_factory_;
   NiceMock<MockRouteMatcher>* route_matcher_;
 
-  std::vector<std::shared_ptr<NiceMock<MockStreamFilter>>> mock_stream_filters_;
-  std::vector<std::shared_ptr<NiceMock<MockDecoderFilter>>> mock_decoder_filters_;
-  std::vector<std::shared_ptr<NiceMock<MockEncoderFilter>>> mock_encoder_filters_;
+  using MockStreamFilterSharedPtr = std::shared_ptr<NiceMock<MockStreamFilter>>;
+  using MockDecoderFilterSharedPtr = std::shared_ptr<NiceMock<MockDecoderFilter>>;
+  using MockEncoderFilterSharedPtr = std::shared_ptr<NiceMock<MockEncoderFilter>>;
+
+  std::vector<std::pair<std::string, MockStreamFilterSharedPtr>> mock_stream_filters_;
+  std::vector<std::pair<std::string, MockDecoderFilterSharedPtr>> mock_decoder_filters_;
+  std::vector<std::pair<std::string, MockEncoderFilterSharedPtr>> mock_encoder_filters_;
 
   std::shared_ptr<NiceMock<MockRouteEntry>> mock_route_entry_;
 };
@@ -239,15 +240,19 @@ TEST_F(FilterConfigTest, RouteEntry) {
  */
 TEST_F(FilterConfigTest, CreateFilterChain) {
   auto mock_stream_filter = std::make_shared<NiceMock<MockStreamFilter>>();
-  mock_stream_filters_ = {mock_stream_filter, mock_stream_filter, mock_stream_filter};
+  mock_stream_filters_ = {{"mock_0", mock_stream_filter},
+                          {"mock_1", mock_stream_filter},
+                          {"mock_2", mock_stream_filter}};
 
   initializeFilterConfig();
 
-  NiceMock<MockFilterChainFactoryCallbacks> cb;
+  NiceMock<MockFilterChainManager> cb;
 
-  EXPECT_CALL(cb, addFilter(_)).Times(3).WillRepeatedly(Invoke([&](StreamFilterSharedPtr filter) {
-    EXPECT_EQ(filter.get(), mock_stream_filter.get());
-  }));
+  EXPECT_CALL(cb.callbacks_, addFilter(_))
+      .Times(3)
+      .WillRepeatedly(Invoke([&](StreamFilterSharedPtr filter) {
+        EXPECT_EQ(filter.get(), mock_stream_filter.get());
+      }));
 
   filter_config_->createFilterChain(cb);
 }
@@ -328,7 +333,9 @@ TEST_F(FilterTest, OnDecodingFailureWithoutActiveStreams) {
 
 TEST_F(FilterTest, OnDecodingSuccessWithNormalRequest) {
   auto mock_stream_filter = std::make_shared<NiceMock<MockStreamFilter>>();
-  mock_stream_filters_ = {mock_stream_filter, mock_stream_filter, mock_stream_filter};
+  mock_stream_filters_ = {{"mock_0", mock_stream_filter},
+                          {"mock_1", mock_stream_filter},
+                          {"mock_2", mock_stream_filter}};
 
   initializeFilter();
 
@@ -416,6 +423,44 @@ TEST_F(FilterTest, NewStreamAndResetStream) {
   EXPECT_EQ(0, filter_->activeStreamsForTest().size());
 }
 
+TEST_F(FilterTest, SimpleBufferWaterMarkTest) {
+  initializeFilter();
+  filter_->onAboveWriteBufferHighWatermark();
+  filter_->onBelowWriteBufferLowWatermark();
+}
+
+TEST_F(FilterTest, NewStreamAndResetStreamFromFilter) {
+  mock_stream_filters_.push_back({"mock_0", std::make_shared<NiceMock<MockStreamFilter>>()});
+
+  initializeFilter();
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+
+  filter_->newDownstreamRequest(std::move(request));
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  active_stream->decoderFiltersForTest()[0]->resetStream();
+
+  EXPECT_EQ(0, filter_->activeStreamsForTest().size());
+}
+
+TEST_F(FilterTest, NewStreamAndDispatcher) {
+  mock_stream_filters_.push_back({"mock_0", std::make_shared<NiceMock<MockStreamFilter>>()});
+
+  initializeFilter();
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+
+  filter_->newDownstreamRequest(std::move(request));
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  EXPECT_EQ(&active_stream->decoderFiltersForTest()[0]->dispatcher(), &active_stream->dispatcher());
+}
+
 TEST_F(FilterTest, OnDecodingFailureWithActiveStreams) {
   initializeFilter();
 
@@ -446,9 +491,53 @@ TEST_F(FilterTest, ActiveStreamRouteEntry) {
   EXPECT_EQ(1, filter_->activeStreamsForTest().size());
 
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
-
-  active_stream->continueDecoding();
   EXPECT_EQ(active_stream->routeEntry(), route_matcher_->route_entry_.get());
+}
+
+TEST_F(FilterTest, ActiveStreamPerFilterConfig) {
+  mock_stream_filters_.push_back(
+      {"fake_test_filter_name_0", std::make_shared<NiceMock<MockStreamFilter>>()});
+
+  initializeFilter();
+
+  EXPECT_CALL(*route_matcher_, routeEntry(_)).WillOnce(Return(mock_route_entry_));
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+  filter_->newDownstreamRequest(std::move(request));
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  EXPECT_EQ(1, active_stream->decoderFiltersForTest().size());
+  EXPECT_EQ(1, active_stream->encoderFiltersForTest().size());
+  EXPECT_EQ(1, active_stream->nextDecoderFilterIndexForTest());
+  EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
+
+  EXPECT_CALL(*mock_route_entry_, perFilterConfig("fake_test_filter_name_0"))
+      .WillOnce(Return(nullptr));
+  EXPECT_EQ(nullptr, active_stream->decoderFiltersForTest()[0]->perFilterConfig());
+}
+
+TEST_F(FilterTest, ActiveStreamPerFilterConfigNoRouteEntry) {
+  mock_stream_filters_.push_back(
+      {"fake_test_filter_name_0", std::make_shared<NiceMock<MockStreamFilter>>()});
+
+  initializeFilter();
+
+  EXPECT_CALL(*route_matcher_, routeEntry(_)).WillOnce(Return(nullptr));
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+  filter_->newDownstreamRequest(std::move(request));
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  EXPECT_EQ(1, active_stream->decoderFiltersForTest().size());
+  EXPECT_EQ(1, active_stream->encoderFiltersForTest().size());
+  EXPECT_EQ(1, active_stream->nextDecoderFilterIndexForTest());
+  EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
+
+  EXPECT_EQ(nullptr, active_stream->decoderFiltersForTest()[0]->perFilterConfig());
 }
 
 TEST_F(FilterTest, ActiveStreamAddFilters) {
@@ -467,18 +556,23 @@ TEST_F(FilterTest, ActiveStreamAddFilters) {
   EXPECT_EQ(0, active_stream->nextDecoderFilterIndexForTest());
   EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
 
+  ActiveStream::FilterChainFactoryCallbacksHelper helper(*active_stream, {"fake_test"});
+
   auto new_filter_0 = std::make_shared<NiceMock<MockStreamFilter>>();
   auto new_filter_1 = std::make_shared<NiceMock<MockStreamFilter>>();
   auto new_filter_3 = std::make_shared<NiceMock<MockStreamFilter>>();
 
-  active_stream->addDecoderFilter(new_filter_0);
-  active_stream->addEncoderFilter(new_filter_0);
+  helper.addDecoderFilter(new_filter_0);
+  helper.addEncoderFilter(new_filter_0);
 
-  active_stream->addDecoderFilter(new_filter_1);
-  active_stream->addFilter(new_filter_3);
+  helper.addDecoderFilter(new_filter_1);
+  helper.addFilter(new_filter_3);
 
   EXPECT_EQ(3, active_stream->decoderFiltersForTest().size());
   EXPECT_EQ(2, active_stream->encoderFiltersForTest().size());
+
+  EXPECT_EQ("fake_test", active_stream->decoderFiltersForTest()[0]->context_.config_name);
+  EXPECT_EQ("fake_test", active_stream->encoderFiltersForTest()[0]->context_.config_name);
 
   active_stream->continueDecoding();
 
@@ -491,10 +585,14 @@ TEST_F(FilterTest, ActiveStreamFiltersContinueDecoding) {
   auto mock_stream_filter_1 = std::make_shared<NiceMock<MockStreamFilter>>();
   auto mock_stream_filter_2 = std::make_shared<NiceMock<MockStreamFilter>>();
 
-  mock_stream_filters_ = {mock_stream_filter_0, mock_stream_filter_1, mock_stream_filter_2};
+  mock_stream_filters_ = {{"mock_0", mock_stream_filter_0},
+                          {"mock_1", mock_stream_filter_1},
+                          {"mock_2", mock_stream_filter_2}};
 
   auto mock_encoder_filter = std::make_shared<NiceMock<MockEncoderFilter>>();
-  mock_encoder_filters_ = {mock_encoder_filter, mock_encoder_filter, mock_encoder_filter};
+  mock_encoder_filters_ = {{"mock_encoder_0", mock_encoder_filter},
+                           {"mock_encoder_1", mock_encoder_filter},
+                           {"mock_encoder_2", mock_encoder_filter}};
 
   ON_CALL(*mock_stream_filter_1, onStreamDecoded(_))
       .WillByDefault(Return(FilterStatus::StopIteration));
@@ -515,7 +613,7 @@ TEST_F(FilterTest, ActiveStreamFiltersContinueDecoding) {
   EXPECT_EQ(2, active_stream->nextDecoderFilterIndexForTest());
   EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
 
-  active_stream->continueDecoding();
+  active_stream->decoderFiltersForTest()[1]->continueDecoding();
 
   EXPECT_EQ(3, active_stream->nextDecoderFilterIndexForTest());
   EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
@@ -526,10 +624,14 @@ TEST_F(FilterTest, ActiveStreamFiltersContinueEncoding) {
   auto mock_stream_filter_1 = std::make_shared<NiceMock<MockStreamFilter>>();
   auto mock_stream_filter_2 = std::make_shared<NiceMock<MockStreamFilter>>();
 
-  mock_stream_filters_ = {mock_stream_filter_0, mock_stream_filter_1, mock_stream_filter_2};
+  mock_stream_filters_ = {{"mock_0", mock_stream_filter_0},
+                          {"mock_1", mock_stream_filter_1},
+                          {"mock_2", mock_stream_filter_2}};
 
   auto mock_decoder_filter = std::make_shared<NiceMock<MockDecoderFilter>>();
-  mock_decoder_filters_ = {mock_decoder_filter, mock_decoder_filter, mock_decoder_filter};
+  mock_decoder_filters_ = {{"mock_decoder_0", mock_decoder_filter},
+                           {"mock_decoder_1", mock_decoder_filter},
+                           {"mock_decoder_2", mock_decoder_filter}};
 
   ON_CALL(*mock_stream_filter_1, onStreamEncoded(_))
       .WillByDefault(Return(FilterStatus::StopIteration));
@@ -566,7 +668,7 @@ TEST_F(FilterTest, ActiveStreamFiltersContinueEncoding) {
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  active_stream->continueEncoding();
+  active_stream->encoderFiltersForTest()[1]->continueEncoding();
 }
 
 TEST_F(FilterTest, ActiveStreamSendLocalReply) {
@@ -610,6 +712,23 @@ TEST_F(FilterTest, ActiveStreamCompleteDirectly) {
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
 
   active_stream->completeDirectly();
+
+  EXPECT_EQ(0, filter_->activeStreamsForTest().size());
+}
+
+TEST_F(FilterTest, ActiveStreamCompleteDirectlyFromFilter) {
+  mock_stream_filters_.push_back({"mock_0", std::make_shared<NiceMock<MockStreamFilter>>()});
+
+  initializeFilter();
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+
+  filter_->newDownstreamRequest(std::move(request));
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  active_stream->decoderFiltersForTest()[0]->completeDirectly();
 
   EXPECT_EQ(0, filter_->activeStreamsForTest().size());
 }


### PR DESCRIPTION


Commit Message: generic proxy: make the l7 filter could be configured repeatedly
Additional Description:

Add a new `perFilterConfig` API to the `StreamFilterCallbacks` of generic proxy. This API will get route level filter config from the route entry by the filter config name.

It's similar to #21525.

**I think there is no third-party L7 filter for generic proxy for now. So, this change won't break anything.**


Risk Level: Low.
Testing: Unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.