### PR TITLE
Thrift: fix header_to_metadata proto annotation

### DIFF
--- a/api/envoy/extensions/filters/network/thrift_proxy/filters/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/filters/header_to_metadata/v3/header_to_metadata.proto
@@ -55,19 +55,15 @@ message HeaderToMetadata {
       // The value to pair with the given key.
       //
       // When used for on_present case, if value is non-empty it'll be used instead
-      // of the header value. If both are empty, no metadata is added.
+      // of the header value. If both are empty, the header value is used as-is.
       //
-      // When used for on_missing case, a non-empty value must be provided otherwise
-      // no metadata is added.
+      // When used for on_missing case, a non-empty value must be provided.
       string value = 3;
 
       // If present, the header's value will be matched and substituted with this.
-      // If there is no match or substitution, the header value
-      // is used as-is.
+      // If there is no match or substitution, the header value is used as-is.
       //
       // This is only used for on_present.
-      //
-      // Note: if the ``value`` field is non-empty this field should be empty.
       type.matcher.v3.RegexMatchAndSubstitute regex_value_rewrite = 4;
     }
 


### PR DESCRIPTION
Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>

Commit Message:
Fix thrift header_to_metadata proto annotation

Additional Description:

(a) As we can see in the following test, empty value will copy the header value to metadata.
https://github.com/envoyproxy/envoy/blob/6bba2d69a17e4cf374eb09f7f51fbf0f0ce4b7da/test/extensions/filters/network/thrift_proxy/filters/header_to_metadata/header_to_metadata_filter_test.cc#L68

(b) Fail to set value for on_missing will throw instead of not setting metadata
https://github.com/envoyproxy/envoy/blob/6bba2d69a17e4cf374eb09f7f51fbf0f0ce4b7da/source/extensions/filters/network/thrift_proxy/filters/header_to_metadata/header_to_metadata_filter.cc#L41

(c) `oneof` in proto guarantee no value is set when we have regex

