### PR TITLE
cors filter: use typed_per_filter_config to configure cors filter 

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -142,8 +142,16 @@ message VirtualHost {
     items {string {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}}
   }];
 
-  // Indicates that the virtual host has a CORS policy.
-  CorsPolicy cors = 8;
+  // Indicates that the virtual host has a CORS policy. This field is ignored if related cors policy is
+  // found in the
+  // :ref:`VirtualHost.typed_per_filter_config<envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>`.
+  //
+  // .. attention::
+  //
+  //   This option has been deprecated. Please use
+  //   :ref:`VirtualHost.typed_per_filter_config<envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>`
+  //   to configure the CORS HTTP filter.
+  CorsPolicy cors = 8 [deprecated = true];
 
   // The per_filter_config field can be used to provide virtual host-specific configurations for filters.
   // The key should match the :ref:`filter config name
@@ -1252,8 +1260,17 @@ message RouteAction {
   // ignoring the rest of the hash policy list.
   repeated HashPolicy hash_policy = 15;
 
-  // Indicates that the route has a CORS policy.
-  CorsPolicy cors = 17;
+  // Indicates that the route has a CORS policy. This field is ignored if related cors policy is
+  // found in the :ref:`Route.typed_per_filter_config<envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>` or
+  // :ref:`WeightedCluster.ClusterWeight.typed_per_filter_config<envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.typed_per_filter_config>`.
+  //
+  // .. attention::
+  //
+  //   This option has been deprecated. Please use
+  //   :ref:`Route.typed_per_filter_config<envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>` or
+  //   :ref:`WeightedCluster.ClusterWeight.typed_per_filter_config<envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.typed_per_filter_config>`
+  //   to configure the CORS HTTP filter.
+  CorsPolicy cors = 17 [deprecated = true];
 
   // Deprecated by :ref:`grpc_timeout_header_max <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the

--- a/api/envoy/extensions/filters/http/cors/v3/BUILD
+++ b/api/envoy/extensions/filters/http/cors/v3/BUILD
@@ -5,5 +5,9 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@com_github_cncf_udpa//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/config/core/v3:pkg",
+        "//envoy/type/matcher/v3:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
+    ],
 )

--- a/api/envoy/extensions/filters/http/cors/v3/cors.proto
+++ b/api/envoy/extensions/filters/http/cors/v3/cors.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.cors.v3;
 
+import "envoy/config/core/v3/base.proto";
+import "envoy/type/matcher/v3/string.proto";
+
+import "google/protobuf/wrappers.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 
@@ -19,4 +24,52 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Cors {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.cors.v2.Cors";
+}
+
+// [#next-free-field: 10]
+message CorsPolicy {
+  // Specifies string patterns that match allowed origins. An origin is allowed if any of the
+  // string matchers match.
+  repeated type.matcher.v3.StringMatcher allow_origin_string_match = 1;
+
+  // Specifies the content for the ``access-control-allow-methods`` header.
+  string allow_methods = 2;
+
+  // Specifies the content for the ``access-control-allow-headers`` header.
+  string allow_headers = 3;
+
+  // Specifies the content for the ``access-control-expose-headers`` header.
+  string expose_headers = 4;
+
+  // Specifies the content for the ``access-control-max-age`` header.
+  string max_age = 5;
+
+  // Specifies whether the resource allows credentials.
+  google.protobuf.BoolValue allow_credentials = 6;
+
+  // Specifies the % of requests for which the CORS filter is enabled.
+  //
+  // If neither ``filter_enabled``, nor ``shadow_enabled`` are specified, the CORS
+  // filter will be enabled for 100% of the requests.
+  //
+  // If :ref:`runtime_key <envoy_v3_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is
+  // specified, Envoy will lookup the runtime key to get the percentage of requests to filter.
+  config.core.v3.RuntimeFractionalPercent filter_enabled = 7;
+
+  // Specifies the % of requests for which the CORS policies will be evaluated and tracked, but not
+  // enforced.
+  //
+  // This field is intended to be used when ``filter_enabled`` is off. That field have to explicitly disable
+  // the filter in order for this setting to take effect.
+  //
+  // If :ref:`runtime_key <envoy_v3_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to get the percentage of requests for which it will evaluate
+  // and track the request's ``Origin`` to determine if it's valid but will not enforce any policies.
+  config.core.v3.RuntimeFractionalPercent shadow_enabled = 8;
+
+  // Specify whether allow requests whose target server's IP address is more private than that from
+  // which the request initiator was fetched.
+  //
+  // More details refer to https://developer.chrome.com/blog/private-network-access-preflight.
+  google.protobuf.BoolValue allow_private_network_access = 9;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -264,3 +264,11 @@ deprecated:
     deprecated :ref:`total weight <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>` for weighted
     clusters. The sum of the :ref:`clusters' weights <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.weight>`
     will be used as the total weight.
+- area: cors
+  change: |
+    deprecated :ref:`cors field of virtual host <envoy_v3_api_field_config.route.v3.VirtualHost.cors>` and
+    :ref:`cors field of route action <envoy_v3_api_field_config.route.v3.RouteAction.cors>`. Please used
+    :ref:`VirtualHost.typed_per_filter_config<envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>`,
+    :ref:`Route.typed_per_filter_config<envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>` or
+    :ref:`WeightedCluster.ClusterWeight.typed_per_filter_config<envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.typed_per_filter_config>`
+    to configure the CORS HTTP filter by the type :ref:`CorsPolicy in filter <envoy_v3_api_msg_extensions.filters.http.cors.v3.CorsPolicy>`.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -118,12 +118,21 @@ public:
 };
 
 /**
+ * All route specific config returned by the method at
+ *   NamedHttpFilterConfigFactory::createRouteSpecificFilterConfig
+ * should be derived from this class.
+ */
+class RouteSpecificFilterConfig {
+public:
+  virtual ~RouteSpecificFilterConfig() = default;
+};
+using RouteSpecificFilterConfigConstSharedPtr = std::shared_ptr<const RouteSpecificFilterConfig>;
+
+/**
  * CorsPolicy for Route and VirtualHost.
  */
-class CorsPolicy {
+class CorsPolicy : public RouteSpecificFilterConfig {
 public:
-  virtual ~CorsPolicy() = default;
-
   /**
    * @return std::vector<StringMatcherPtr>& access-control-allow-origin matchers.
    */
@@ -601,17 +610,6 @@ public:
 
 class RateLimitPolicy;
 class Config;
-
-/**
- * All route specific config returned by the method at
- *   NamedHttpFilterConfigFactory::createRouteSpecificFilterConfig
- * should be derived from this class.
- */
-class RouteSpecificFilterConfig {
-public:
-  virtual ~RouteSpecificFilterConfig() = default;
-};
-using RouteSpecificFilterConfigConstSharedPtr = std::shared_ptr<const RouteSpecificFilterConfig>;
 
 /**
  * Virtual host definition.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -377,25 +377,6 @@ absl::flat_hash_set<Http::Code> InternalRedirectPolicyImpl::buildRedirectRespons
   return ret;
 }
 
-CorsPolicyImpl::CorsPolicyImpl(const envoy::config::route::v3::CorsPolicy& config,
-                               Runtime::Loader& loader)
-    : config_(config), loader_(loader), allow_methods_(config.allow_methods()),
-      allow_headers_(config.allow_headers()), expose_headers_(config.expose_headers()),
-      max_age_(config.max_age()) {
-  for (const auto& string_match : config.allow_origin_string_match()) {
-    allow_origins_.push_back(
-        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
-            string_match));
-  }
-  if (config.has_allow_credentials()) {
-    allow_credentials_ = PROTOBUF_GET_WRAPPED_REQUIRED(config, allow_credentials);
-  }
-  if (config.has_allow_private_network_access()) {
-    allow_private_network_access_ =
-        PROTOBUF_GET_WRAPPED_REQUIRED(config, allow_private_network_access);
-  }
-}
-
 void validateMirrorClusterSpecifier(
     const envoy::config::route::v3::RouteAction::RequestMirrorPolicy& config) {
   if (!config.cluster().empty() && !config.cluster_header().empty()) {

--- a/source/extensions/filters/http/cors/BUILD
+++ b/source/extensions/filters/http/cors/BUILD
@@ -16,6 +16,9 @@ envoy_cc_library(
     name = "cors_filter_lib",
     srcs = ["cors_filter.cc"],
     hdrs = ["cors_filter.h"],
+    external_deps = [
+        "abseil_inlined_vector",
+    ],
     deps = [
         "//envoy/http:codes_interface",
         "//envoy/http:filter_interface",
@@ -34,6 +37,7 @@ envoy_cc_extension(
     deps = [
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
+        "//source/common/router:config_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "//source/extensions/filters/http/cors:cors_filter_lib",
         "@envoy_api//envoy/extensions/filters/http/cors/v3:pkg_cc_proto",

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -4,10 +4,20 @@
 
 #include "source/extensions/filters/http/cors/cors_filter.h"
 
+#include "source/common/router/config_impl.h"
+#include "envoy/router/router.h"
+#include "envoy/config/route/v3/route_components.pb.h"
+#include "envoy/config/route/v3/route_components.pb.validate.h"
+
+#include "source/common/protobuf/utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Cors {
+
+using CorsPolicyImpl =
+    Router::CorsPolicyImplBase<envoy::extensions::filters::http::cors::v3::CorsPolicy>;
 
 Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cors::v3::Cors&, const std::string& stats_prefix,
@@ -17,6 +27,13 @@ Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoTyped(
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CorsFilter>(config));
   };
+}
+
+Router::RouteSpecificFilterConfigConstSharedPtr
+CorsFilterFactory::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,
+    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+  return std::make_shared<CorsPolicyImpl>(policy, context.runtime());
 }
 
 /**

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -14,13 +14,19 @@ namespace Cors {
  * Config registration for the cors filter. @see NamedHttpFilterConfigFactory.
  */
 class CorsFilterFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::cors::v3::Cors> {
+    : public Common::FactoryBase<envoy::extensions::filters::http::cors::v3::Cors,
+                                 envoy::extensions::filters::http::cors::v3::CorsPolicy> {
 public:
   CorsFilterFactory() : FactoryBase("envoy.filters.http.cors") {}
 
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::cors::v3::CorsPolicy& policy,
+      Server::Configuration::ServerFactoryContext& context,
+      ProtobufMessage::ValidationVisitor& validator) override;
 };
 
 } // namespace Cors

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -8,6 +8,7 @@
 #include "source/common/common/enum_to_int.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
+#include <algorithm>
 
 namespace Envoy {
 namespace Extensions {
@@ -48,8 +49,32 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Respons
 CorsFilterConfig::CorsFilterConfig(const std::string& stats_prefix, Stats::Scope& scope)
     : stats_(generateStats(stats_prefix + "cors.", scope)) {}
 
-CorsFilter::CorsFilter(CorsFilterConfigSharedPtr config)
-    : policies_({{nullptr, nullptr}}), config_(std::move(config)) {}
+CorsFilter::CorsFilter(CorsFilterConfigSharedPtr config) : config_(std::move(config)) {}
+
+void CorsFilter::initilaizeCorsPolicy() {
+  decoder_callbacks_->traversePerFilterConfig([this](const Router::RouteSpecificFilterConfig& cfg) {
+    const auto* typed_cfg = dynamic_cast<const Router::CorsPolicy*>(&cfg);
+    if (typed_cfg != nullptr) {
+      policies_.push_back(typed_cfg);
+    }
+  });
+
+  // The 'traversePerFilterConfig' will handle cors policy of virtual host first. So, we need
+  // reverse the 'policies_' to make sure the cors policy of route entry to be first item in the
+  // 'policies_'.
+  if (policies_.size() >= 2) {
+    std::reverse(policies_.begin(), policies_.end());
+  }
+
+  // If no cors policy is configured in the per filter config, then the cors policy fields in the
+  // route configuration will be ignored.
+  if (policies_.empty()) {
+    policies_ = {
+        decoder_callbacks_->route()->routeEntry()->corsPolicy(),
+        decoder_callbacks_->route()->routeEntry()->virtualHost().corsPolicy(),
+    };
+  }
+}
 
 // This handles the CORS preflight request as described in
 // https://www.w3.org/TR/cors/#resource-preflight-requests
@@ -59,10 +84,7 @@ Http::FilterHeadersStatus CorsFilter::decodeHeaders(Http::RequestHeaderMap& head
     return Http::FilterHeadersStatus::Continue;
   }
 
-  policies_ = {{
-      decoder_callbacks_->route()->routeEntry()->corsPolicy(),
-      decoder_callbacks_->route()->routeEntry()->virtualHost().corsPolicy(),
-  }};
+  initilaizeCorsPolicy();
 
   if (!enabled() && !shadowEnabled()) {
     return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/http/cors/cors_filter.h
+++ b/source/extensions/filters/http/cors/cors_filter.h
@@ -6,6 +6,8 @@
 
 #include "source/common/buffer/buffer_impl.h"
 
+#include "absl/container/inlined_vector.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -46,6 +48,8 @@ class CorsFilter : public Http::StreamFilter {
 public:
   CorsFilter(CorsFilterConfigSharedPtr config);
 
+  void initilaizeCorsPolicy();
+
   // Http::StreamFilterBase
   void onDestroy() override {}
 
@@ -79,6 +83,10 @@ public:
     encoder_callbacks_ = &callbacks;
   };
 
+  const absl::InlinedVector<const Envoy::Router::CorsPolicy*, 2>& policiesForTest() const {
+    return policies_;
+  }
+
 private:
   friend class CorsFilterTest;
 
@@ -95,7 +103,7 @@ private:
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
-  std::array<const Envoy::Router::CorsPolicy*, 2> policies_;
+  absl::InlinedVector<const Envoy::Router::CorsPolicy*, 2> policies_;
   bool is_cors_request_{};
   const Http::HeaderEntry* origin_{};
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6671,7 +6671,7 @@ virtual_hosts:
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 
-TEST_F(RoutePropertyTest, TestVHostCorsConfig) {
+TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TestVHostCorsConfig)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
   - name: "default"
@@ -6733,7 +6733,7 @@ virtual_hosts:
   EXPECT_EQ(cors_policy->allowPrivateNetworkAccess(), true);
 }
 
-TEST_F(RoutePropertyTest, TestRouteCorsConfig) {
+TEST_F(RoutePropertyTest, DEPRECATED_FEATURE_TEST(TestRouteCorsConfig)) {
   const std::string yaml = R"EOF(
 virtual_hosts:
   - name: "default"

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -52,11 +52,12 @@ public:
     cors_policy_->allow_private_network_access_ = true;
     cors_policy_->max_age_ = "0";
 
-    ON_CALL(decoder_callbacks_.route_->route_entry_, corsPolicy())
-        .WillByDefault(Return(cors_policy_.get()));
-
-    ON_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_, corsPolicy())
-        .WillByDefault(Return(cors_policy_.get()));
+    ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+        .WillByDefault(
+            Invoke([this](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
+              cb(*cors_policy_); // Cors policy of virtual host.
+              cb(*cors_policy_); // Cors policy of route entry.
+            }));
 
     filter_.setDecoderFilterCallbacks(decoder_callbacks_);
     filter_.setEncoderFilterCallbacks(encoder_callbacks_);
@@ -77,6 +78,96 @@ public:
   std::unique_ptr<Router::TestCorsPolicy> cors_policy_;
   Router::MockDirectResponseEntry direct_response_entry_;
 };
+
+TEST_F(CorsFilterTest, initializePoliciesTest) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "get"}};
+  // Cors plocies in the 'typed_per_filter_config'.
+  {
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+    EXPECT_EQ(false, IsCorsRequest());
+    EXPECT_EQ(2, filter_.policiesForTest().size());
+    EXPECT_EQ(cors_policy_.get(), filter_.policiesForTest().at(0));
+    EXPECT_EQ(cors_policy_.get(), filter_.policiesForTest().at(1));
+  }
+
+  // Only 'typed_per_filter_config' of virtual host has cors policy.
+  {
+    filter_ = CorsFilter(config_);
+    filter_.setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_.setEncoderFilterCallbacks(encoder_callbacks_);
+
+    ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+        .WillByDefault(
+            Invoke([this](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
+              cb(*cors_policy_); // Cors policy of virtual host.
+            }));
+
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+    EXPECT_EQ(false, IsCorsRequest());
+    EXPECT_EQ(1, filter_.policiesForTest().size());
+    EXPECT_EQ(cors_policy_.get(), filter_.policiesForTest().at(0));
+  }
+
+  // No cors policy in the 'typed_per_filter_config'.
+  {
+    filter_ = CorsFilter(config_);
+    filter_.setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_.setEncoderFilterCallbacks(encoder_callbacks_);
+
+    EXPECT_CALL(decoder_callbacks_.route_->route_entry_, corsPolicy()).WillOnce(Return(nullptr));
+    EXPECT_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_, corsPolicy())
+        .WillOnce(Return(nullptr));
+
+    ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+        .WillByDefault(
+            Invoke([](std::function<void(const Router::RouteSpecificFilterConfig&)>) {}));
+
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+    EXPECT_EQ(false, IsCorsRequest());
+    EXPECT_EQ(2, filter_.policiesForTest().size());
+    EXPECT_EQ(nullptr, filter_.policiesForTest().at(0));
+    EXPECT_EQ(nullptr, filter_.policiesForTest().at(1));
+  }
+  {
+    filter_ = CorsFilter(config_);
+    filter_.setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_.setEncoderFilterCallbacks(encoder_callbacks_);
+
+    EXPECT_CALL(decoder_callbacks_.route_->route_entry_, corsPolicy())
+        .WillOnce(Return(cors_policy_.get()));
+    EXPECT_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_, corsPolicy())
+        .WillOnce(Return(nullptr));
+
+    ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+        .WillByDefault(
+            Invoke([](std::function<void(const Router::RouteSpecificFilterConfig&)>) {}));
+
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, true));
+    EXPECT_EQ(false, IsCorsRequest());
+    EXPECT_EQ(2, filter_.policiesForTest().size());
+    EXPECT_EQ(cors_policy_.get(), filter_.policiesForTest().at(0));
+    EXPECT_EQ(nullptr, filter_.policiesForTest().at(1));
+  }
+  {
+    filter_ = CorsFilter(config_);
+    filter_.setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_.setEncoderFilterCallbacks(encoder_callbacks_);
+
+    EXPECT_CALL(decoder_callbacks_.route_->route_entry_, corsPolicy()).WillOnce(Return(nullptr));
+    EXPECT_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_, corsPolicy())
+        .WillOnce(Return(cors_policy_.get()));
+
+    ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+        .WillByDefault(
+            Invoke([](std::function<void(const Router::RouteSpecificFilterConfig&)>) {}));
+
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+    EXPECT_EQ(false, IsCorsRequest());
+    EXPECT_EQ(2, filter_.policiesForTest().size());
+    EXPECT_EQ(nullptr, filter_.policiesForTest().at(0));
+    EXPECT_EQ(cors_policy_.get(), filter_.policiesForTest().at(1));
+  }
+}
 
 TEST_F(CorsFilterTest, RequestWithoutOrigin) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "get"}};
@@ -573,8 +664,11 @@ TEST_F(CorsFilterTest, NoCorsEntry) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":method", "OPTIONS"}, {"origin", "localhost"}, {"access-control-request-method", "GET"}};
 
+  // No cors policy in the 'typed_per_filter_config'.
+  ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+      .WillByDefault(Invoke([](std::function<void(const Router::RouteSpecificFilterConfig&)>) {}));
+  // No cors policy in route entry or virtual host.
   ON_CALL(decoder_callbacks_.route_->route_entry_, corsPolicy()).WillByDefault(Return(nullptr));
-
   ON_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_, corsPolicy())
       .WillByDefault(Return(nullptr));
 
@@ -598,7 +692,11 @@ TEST_F(CorsFilterTest, NoRouteCorsEntry) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":method", "OPTIONS"}, {"origin", "localhost"}, {"access-control-request-method", "GET"}};
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_, corsPolicy()).WillByDefault(Return(nullptr));
+  ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+      .WillByDefault(
+          Invoke([this](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
+            cb(*cors_policy_); // Cors policy of route entry.
+          }));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "200"},
@@ -628,8 +726,11 @@ TEST_F(CorsFilterTest, NoVHostCorsEntry) {
 
   cors_policy_->allow_methods_ = "";
 
-  ON_CALL(decoder_callbacks_.route_->route_entry_.virtual_host_, corsPolicy())
-      .WillByDefault(Return(nullptr));
+  ON_CALL(decoder_callbacks_, traversePerFilterConfig(_))
+      .WillByDefault(
+          Invoke([this](std::function<void(const Router::RouteSpecificFilterConfig&)> cb) {
+            cb(*cors_policy_); // Cors policy of route entry.
+          }));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "200"},


### PR DESCRIPTION

Commit Message: cors filter: use typed_per_filter_config to configure cors filter 
Additional Description:

See #8097.

Risk Level: Mid
Testing: unit test, integration test.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
