### PR TITLE
xds: Add xDS delegate feature support to the unified mux

### DIFF
--- a/contrib/config/test/kv_store_xds_delegate_integration_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_integration_test.cc
@@ -56,16 +56,19 @@ std::string invalidProtoKvStoreDelegateConfig() {
     )EOF";
 }
 
-class KeyValueStoreXdsDelegateIntegrationTest : public HttpIntegrationTest,
-                                                public Grpc::GrpcClientIntegrationParamTest {
+class KeyValueStoreXdsDelegateIntegrationTest
+    : public HttpIntegrationTest,
+      public Grpc::UnifiedOrLegacyMuxIntegrationParamTest {
 public:
   KeyValueStoreXdsDelegateIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion(),
                             ConfigHelper::baseConfigNoListeners()) {
     use_lds_ = false;
-    // TODO(abeyad): add UnifiedSotw tests too when implementation is ready.
-    sotw_or_delta_ = Grpc::SotwOrDelta::Sotw;
     skip_tag_extraction_rule_check_ = true;
+
+    if (isUnified()) {
+      config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux", "true");
+    }
 
     // Make the default cluster HTTP2.
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -276,7 +279,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, KeyValueStoreXdsDelegateIntegrationTest,
-                         GRPC_CLIENT_INTEGRATION_PARAMS);
+                         UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS);
 
 TEST_P(KeyValueStoreXdsDelegateIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [this]() {
@@ -354,10 +357,10 @@ TEST_P(KeyValueStoreXdsDelegateIntegrationTest, BasicSuccess) {
   test_server_->waitForCounterGe("runtime.load_success", 2);
 
   // Verify that the latest resource values are used by Envoy.
-  EXPECT_EQ(2, test_server_->counter("xds.kv_store.load_success")->value());
-  EXPECT_EQ(0, test_server_->counter("xds.kv_store.resources_not_found")->value());
-  EXPECT_EQ(0, test_server_->counter("xds.kv_store.resource_missing")->value());
-  EXPECT_EQ(0, test_server_->counter("xds.kv_store.parse_failed")->value());
+  EXPECT_GE(test_server_->counter("xds.kv_store.load_success")->value(), 2);
+  EXPECT_EQ(test_server_->counter("xds.kv_store.resources_not_found")->value(), 0);
+  EXPECT_EQ(test_server_->counter("xds.kv_store.resource_missing")->value(), 0);
+  EXPECT_EQ(test_server_->counter("xds.kv_store.parse_failed")->value(), 0);
   checkSecretExists(std::string(CLIENT_CERT_NAME), /*version_info=*/"1");
   EXPECT_EQ("whatevs", getRuntimeKey("foo"));
   EXPECT_EQ("yar", getRuntimeKey("bar"));
@@ -450,15 +453,17 @@ public:
 
 class InvalidProtoKeyValueStoreXdsDelegateIntegrationTest
     : public HttpIntegrationTest,
-      public Grpc::GrpcClientIntegrationParamTest {
+      public Grpc::UnifiedOrLegacyMuxIntegrationParamTest {
 public:
   InvalidProtoKeyValueStoreXdsDelegateIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion(),
                             ConfigHelper::baseConfigNoListeners()) {
     use_lds_ = false;
-    // TODO(abeyad): add UnifiedSotw tests too when implementation is ready.
-    sotw_or_delta_ = Grpc::SotwOrDelta::Sotw;
     skip_tag_extraction_rule_check_ = true;
+
+    if (isUnified()) {
+      config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux", "true");
+    }
 
     // One static CDS cluster and CDS config.
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -506,7 +511,7 @@ public:
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, InvalidProtoKeyValueStoreXdsDelegateIntegrationTest,
-                         GRPC_CLIENT_INTEGRATION_PARAMS);
+                         UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS);
 
 TEST_P(InvalidProtoKeyValueStoreXdsDelegateIntegrationTest, InvalidProto) {
   InvalidProtoKeyValueStoreFactory factory;

--- a/contrib/config/test/kv_store_xds_delegate_integration_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_integration_test.cc
@@ -357,10 +357,10 @@ TEST_P(KeyValueStoreXdsDelegateIntegrationTest, BasicSuccess) {
   test_server_->waitForCounterGe("runtime.load_success", 2);
 
   // Verify that the latest resource values are used by Envoy.
-  EXPECT_GE(test_server_->counter("xds.kv_store.load_success")->value(), 2);
-  EXPECT_EQ(test_server_->counter("xds.kv_store.resources_not_found")->value(), 0);
-  EXPECT_EQ(test_server_->counter("xds.kv_store.resource_missing")->value(), 0);
-  EXPECT_EQ(test_server_->counter("xds.kv_store.parse_failed")->value(), 0);
+  EXPECT_EQ(2, test_server_->counter("xds.kv_store.load_success")->value());
+  EXPECT_EQ(0, test_server_->counter("xds.kv_store.resources_not_found")->value());
+  EXPECT_EQ(0, test_server_->counter("xds.kv_store.resource_missing")->value());
+  EXPECT_EQ(0, test_server_->counter("xds.kv_store.parse_failed")->value());
   checkSecretExists(std::string(CLIENT_CERT_NAME), /*version_info=*/"1");
   EXPECT_EQ("whatevs", getRuntimeKey("foo"));
   EXPECT_EQ("yar", getRuntimeKey("bar"));

--- a/envoy/config/xds_resources_delegate.h
+++ b/envoy/config/xds_resources_delegate.h
@@ -57,6 +57,7 @@ public:
    * @param resource_names The names of the requested resources.
    * @return A set of xDS resources for the given source.
    */
+  // TODO(abeyad): change resource_names to a set.
   virtual std::vector<envoy::service::discovery::v3::Resource>
   getResources(const XdsSourceId& source_id,
                const std::vector<std::string>& resource_names) const PURE;

--- a/source/common/config/decoded_resource_impl.h
+++ b/source/common/config/decoded_resource_impl.h
@@ -43,6 +43,12 @@ public:
         version, absl::nullopt));
   }
 
+  static DecodedResourceImplPtr
+  fromResource(OpaqueResourceDecoder& resource_decoder,
+               const envoy::service::discovery::v3::Resource& resource) {
+    return std::make_unique<DecodedResourceImpl>(resource_decoder, resource);
+  }
+
   DecodedResourceImpl(OpaqueResourceDecoder& resource_decoder,
                       const envoy::service::discovery::v3::Resource& resource)
       : DecodedResourceImpl(resource_decoder, resource.name(), resource.aliases(),

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -394,9 +394,9 @@ void GrpcMuxImpl::onEstablishmentFailure() {
           /*type_url=*/api_state.first,
           std::vector<std::string>{api_state.second->request_.resource_names().begin(),
                                    api_state.second->request_.resource_names().end()});
+      previously_fetched_data_ = true;
     }
   }
-  previously_fetched_data_ = true;
 }
 
 void GrpcMuxImpl::queueDiscoveryRequest(absl::string_view queue_item) {

--- a/source/common/config/xds_mux/BUILD
+++ b/source/common/config/xds_mux/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
         "//source/common/config:api_version_lib",
         "//source/common/config:decoded_resource_lib",
         "//source/common/config:utility_lib",
+        "//source/common/config:xds_source_id_lib",
         "//source/common/grpc:common_lib",
         "//source/common/protobuf",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
@@ -42,6 +43,7 @@ envoy_cc_library(
     hdrs = ["subscription_state.h"],
     deps = [
         "//envoy/config:subscription_interface",
+        "//envoy/config:xds_resources_delegate_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/local_info:local_info_interface",
         "//source/common/common:minimal_logger_lib",

--- a/source/common/config/xds_mux/delta_subscription_state.h
+++ b/source/common/config/xds_mux/delta_subscription_state.h
@@ -114,7 +114,9 @@ public:
   ~DeltaSubscriptionStateFactory() override = default;
   std::unique_ptr<DeltaSubscriptionState>
   makeSubscriptionState(const std::string& type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        OpaqueResourceDecoderSharedPtr) override {
+                        OpaqueResourceDecoderSharedPtr,
+                        XdsResourcesDelegateOptRef /*xds_resources_delegate*/,
+                        const std::string& /*target_xds_authority*/) override {
     return std::make_unique<DeltaSubscriptionState>(type_url, callbacks, dispatcher_);
   }
 

--- a/source/common/config/xds_mux/grpc_mux_impl.cc
+++ b/source/common/config/xds_mux/grpc_mux_impl.cc
@@ -41,7 +41,8 @@ GrpcMuxImpl<S, F, RQ, RS>::GrpcMuxImpl(
     const LocalInfo::LocalInfo& local_info, Grpc::RawAsyncClientPtr&& async_client,
     Event::Dispatcher& dispatcher, const Protobuf::MethodDescriptor& service_method,
     Random::RandomGenerator& random, Stats::Scope& scope,
-    const RateLimitSettings& rate_limit_settings, CustomConfigValidatorsPtr&& config_validators)
+    const RateLimitSettings& rate_limit_settings, CustomConfigValidatorsPtr&& config_validators,
+    XdsResourcesDelegateOptRef xds_resources_delegate, const std::string& target_xds_authority)
     : grpc_stream_(this, std::move(async_client), service_method, random, dispatcher, scope,
                    rate_limit_settings),
       subscription_state_factory_(std::move(subscription_state_factory)),
@@ -50,7 +51,8 @@ GrpcMuxImpl<S, F, RQ, RS>::GrpcMuxImpl(
           [this](absl::string_view resource_type_url) {
             onDynamicContextUpdate(resource_type_url);
           })),
-      config_validators_(std::move(config_validators)) {
+      config_validators_(std::move(config_validators)),
+      xds_resources_delegate_(xds_resources_delegate), target_xds_authority_(target_xds_authority) {
   Config::Utility::checkLocalInfo("ads", local_info);
   AllMuxes::get().insert(this);
 }
@@ -88,7 +90,8 @@ Config::GrpcMuxWatchPtr GrpcMuxImpl<S, F, RQ, RS>::addWatch(
                                                           *config_validators_.get()))
             .first;
     subscriptions_.emplace(type_url, subscription_state_factory_->makeSubscriptionState(
-                                         type_url, *watch_maps_[type_url], resource_decoder));
+                                         type_url, *watch_maps_[type_url], resource_decoder,
+                                         xds_resources_delegate_, target_xds_authority_));
     subscription_ordering_.emplace_back(type_url);
   }
 
@@ -382,10 +385,13 @@ GrpcMuxSotw::GrpcMuxSotw(Grpc::RawAsyncClientPtr&& async_client, Event::Dispatch
                          Random::RandomGenerator& random, Stats::Scope& scope,
                          const RateLimitSettings& rate_limit_settings,
                          const LocalInfo::LocalInfo& local_info, bool skip_subsequent_node,
-                         CustomConfigValidatorsPtr&& config_validators)
+                         CustomConfigValidatorsPtr&& config_validators,
+                         XdsResourcesDelegateOptRef xds_resources_delegate,
+                         const std::string& target_xds_authority)
     : GrpcMuxImpl(std::make_unique<SotwSubscriptionStateFactory>(dispatcher), skip_subsequent_node,
                   local_info, std::move(async_client), dispatcher, service_method, random, scope,
-                  rate_limit_settings, std::move(config_validators)) {}
+                  rate_limit_settings, std::move(config_validators), xds_resources_delegate,
+                  target_xds_authority) {}
 
 Config::GrpcMuxWatchPtr NullGrpcMuxImpl::addWatch(const std::string&,
                                                   const absl::flat_hash_set<std::string>&,

--- a/source/common/config/xds_mux/grpc_mux_impl.h
+++ b/source/common/config/xds_mux/grpc_mux_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/common/token_bucket.h"
 #include "envoy/config/grpc_mux.h"
 #include "envoy/config/subscription.h"
+#include "envoy/config/xds_resources_delegate.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/grpc/status.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
@@ -62,7 +63,9 @@ public:
               Event::Dispatcher& dispatcher, const Protobuf::MethodDescriptor& service_method,
               Random::RandomGenerator& random, Stats::Scope& scope,
               const RateLimitSettings& rate_limit_settings,
-              CustomConfigValidatorsPtr&& config_validators);
+              CustomConfigValidatorsPtr&& config_validators,
+              XdsResourcesDelegateOptRef xds_resources_delegate = absl::nullopt,
+              const std::string& target_xds_authority = "");
 
   ~GrpcMuxImpl() override;
 
@@ -203,6 +206,8 @@ private:
   const LocalInfo::LocalInfo& local_info_;
   Common::CallbackHandlePtr dynamic_update_callback_handle_;
   CustomConfigValidatorsPtr config_validators_;
+  XdsResourcesDelegateOptRef xds_resources_delegate_;
+  const std::string target_xds_authority_;
 
   // True iff Envoy is shutting down; no messages should be sent on the `grpc_stream_` when this is
   // true because it may contain dangling pointers.
@@ -232,7 +237,9 @@ public:
               const Protobuf::MethodDescriptor& service_method, Random::RandomGenerator& random,
               Stats::Scope& scope, const RateLimitSettings& rate_limit_settings,
               const LocalInfo::LocalInfo& local_info, bool skip_subsequent_node,
-              CustomConfigValidatorsPtr&& config_validators);
+              CustomConfigValidatorsPtr&& config_validators,
+              XdsResourcesDelegateOptRef xds_resources_delegate = absl::nullopt,
+              const std::string& target_xds_authority = "");
 
   // GrpcStreamCallbacks
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {

--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -127,6 +127,7 @@ void SotwSubscriptionState::handleEstablishmentFailure() {
     }
 
     callbacks().onConfigUpdate(decoded_resources, version_info);
+    previously_fetched_data_ = true;
   }
   END_TRY
   catch (const EnvoyException& e) {

--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -130,7 +130,7 @@ void SotwSubscriptionState::handleEstablishmentFailure() {
 
     callbacks().onConfigUpdate(decoded_resources, version_info);
     previously_fetched_data_ = true;
-    if (unaccounted.empty()) {
+    if (unaccounted.empty() && !version_info.empty()) {
       // All the requested resources were found and validated from the xDS delegate, so set the last
       // known good version.
       last_good_version_info_ = version_info;

--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -102,7 +102,6 @@ void SotwSubscriptionState::handleEstablishmentFailure() {
   const XdsConfigSourceId source_id{target_xds_authority_, type_url_};
   TRY_ASSERT_MAIN_THREAD {
     const std::vector<std::string> resource_names{names_tracked_.begin(), names_tracked_.end()};
-    std::cout << "=> AAB resources_names.size=" << resource_names.size() << std::endl;
     std::vector<envoy::service::discovery::v3::Resource> resources =
         xds_resources_delegate_->getResources(source_id, resource_names);
 
@@ -116,7 +115,6 @@ void SotwSubscriptionState::handleEstablishmentFailure() {
       unaccounted.erase(Envoy::Config::Wildcard);
     }
 
-    std::cout << "=> AAB resources.size=" << resources.size() << std::endl;
     for (const auto& resource : resources) {
       if (version_info.empty()) {
         version_info = resource.version();

--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -81,6 +81,7 @@ void SotwSubscriptionState::handleGoodResponse(
   if (xds_resources_delegate_.has_value()) {
     XdsConfigSourceId source_id{target_xds_authority_, message.type_url()};
     std::vector<DecodedResourceRef> resource_refs;
+    resource_refs.reserve(non_heartbeat_resources.size());
     for (const DecodedResourcePtr& r : non_heartbeat_resources) {
       resource_refs.emplace_back(*r);
     }

--- a/source/common/config/xds_mux/sotw_subscription_state.h
+++ b/source/common/config/xds_mux/sotw_subscription_state.h
@@ -22,7 +22,9 @@ public:
   // Note that, outside of tests, we expect callbacks to always be a WatchMap.
   SotwSubscriptionState(std::string type_url, UntypedConfigUpdateCallbacks& callbacks,
                         Event::Dispatcher& dispatcher,
-                        OpaqueResourceDecoderSharedPtr resource_decoder);
+                        OpaqueResourceDecoderSharedPtr resource_decoder,
+                        XdsResourcesDelegateOptRef xds_resources_delegate,
+                        const std::string& target_xds_authority);
   ~SotwSubscriptionState() override;
 
   // Update which resources we're interested in subscribing to.
@@ -35,6 +37,8 @@ public:
   void markStreamFresh() override;
 
   void ttlExpiryCallback(const std::vector<std::string>& expired) override;
+
+  void handleEstablishmentFailure() override;
 
   SotwSubscriptionState(const SotwSubscriptionState&) = delete;
   SotwSubscriptionState& operator=(const SotwSubscriptionState&) = delete;
@@ -69,9 +73,12 @@ public:
   ~SotwSubscriptionStateFactory() override = default;
   std::unique_ptr<SotwSubscriptionState>
   makeSubscriptionState(const std::string& type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        OpaqueResourceDecoderSharedPtr resource_decoder) override {
+                        OpaqueResourceDecoderSharedPtr resource_decoder,
+                        XdsResourcesDelegateOptRef xds_resources_delegate,
+                        const std::string& target_xds_authority) override {
     return std::make_unique<SotwSubscriptionState>(type_url, callbacks, dispatcher_,
-                                                   resource_decoder);
+                                                   resource_decoder, xds_resources_delegate,
+                                                   target_xds_authority);
   }
 
 private:

--- a/source/common/config/xds_mux/subscription_state.h
+++ b/source/common/config/xds_mux/subscription_state.h
@@ -5,6 +5,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/config/subscription.h"
+#include "envoy/config/xds_resources_delegate.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 
@@ -32,10 +33,14 @@ class BaseSubscriptionState : public SubscriptionState,
 public:
   // Note that, outside of tests, we expect callbacks to always be a WatchMap.
   BaseSubscriptionState(std::string type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        Event::Dispatcher& dispatcher)
+                        Event::Dispatcher& dispatcher,
+                        XdsResourcesDelegateOptRef xds_resources_delegate = absl::nullopt,
+                        const std::string& target_xds_authority = "")
       : ttl_([this](const std::vector<std::string>& expired) { ttlExpiryCallback(expired); },
              dispatcher, dispatcher.timeSource()),
-        type_url_(std::move(type_url)), callbacks_(callbacks), dispatcher_(dispatcher) {}
+        type_url_(std::move(type_url)), callbacks_(callbacks), dispatcher_(dispatcher),
+        xds_resources_delegate_(xds_resources_delegate),
+        target_xds_authority_(target_xds_authority) {}
 
   virtual ~BaseSubscriptionState() = default;
 
@@ -65,10 +70,11 @@ public:
     catch (const EnvoyException& e) {
       handleBadResponse(e, ack);
     }
+    previously_fetched_data_ = true;
     return ack;
   }
 
-  void handleEstablishmentFailure() {
+  virtual void handleEstablishmentFailure() {
     ENVOY_LOG(debug, "SubscriptionState establishment failed for {}", typeUrl());
     callbacks().onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure,
                                      nullptr);
@@ -115,6 +121,9 @@ protected:
   Event::Dispatcher& dispatcher_;
   bool dynamic_context_changed_{};
   std::string control_plane_identifier_{};
+  XdsResourcesDelegateOptRef xds_resources_delegate_;
+  const std::string target_xds_authority_;
+  bool previously_fetched_data_{};
 };
 
 template <class T> class SubscriptionStateFactory {
@@ -123,7 +132,9 @@ public:
   // Note that, outside of tests, we expect callbacks to always be a WatchMap.
   virtual std::unique_ptr<T>
   makeSubscriptionState(const std::string& type_url, UntypedConfigUpdateCallbacks& callbacks,
-                        OpaqueResourceDecoderSharedPtr resource_decoder) PURE;
+                        OpaqueResourceDecoderSharedPtr resource_decoder,
+                        XdsResourcesDelegateOptRef xds_resources_delegate = absl::nullopt,
+                        const std::string& target_xds_authority = "") PURE;
 };
 
 } // namespace XdsMux

--- a/test/common/config/sotw_subscription_state_test.cc
+++ b/test/common/config/sotw_subscription_state_test.cc
@@ -56,7 +56,7 @@ public:
       cla.set_cluster_name(resource_name);
       if (resource_name == std::string(BAD_CLA_RESOURCE_NAME)) {
         // If the bad resource is requested, set an invalid enum value (1000) for the Policy's
-        // Denominator drop percentage.
+        // drop percentage denominator.
         cla.mutable_policy()->add_drop_overloads()->mutable_drop_percentage()->set_denominator(
             static_cast<envoy::type::v3::FractionalPercent_DenominatorType>(1000));
       }

--- a/test/common/config/sotw_subscription_state_test.cc
+++ b/test/common/config/sotw_subscription_state_test.cc
@@ -33,7 +33,8 @@ protected:
     ttl_timer_ = new Event::MockTimer(&dispatcher_);
     state_ = std::make_unique<XdsMux::SotwSubscriptionState>(
         Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>(), callbacks_,
-        dispatcher_, resource_decoder_);
+        dispatcher_, resource_decoder_, /*xds_resources_delegate=*/absl::nullopt,
+        /*target_xds_authority=*/"");
     state_->updateSubscriptionInterest({"name1", "name2", "name3"}, {});
     auto cur_request = getNextDiscoveryRequestAckless();
     EXPECT_THAT(cur_request->resource_names(), UnorderedElementsAre("name1", "name2", "name3"));

--- a/test/common/config/sotw_subscription_state_test.cc
+++ b/test/common/config/sotw_subscription_state_test.cc
@@ -70,7 +70,7 @@ public:
     return resources;
   }
 
-  std::vector<std::string>& failed_resource_names() { return failed_resource_names_; }
+  std::vector<std::string>& failedResourceNames() { return failed_resource_names_; }
 
   void setThrowsException() { throws_ex_ = true; }
 
@@ -338,7 +338,7 @@ TEST_F(SotwSubscriptionStateTest, HandleEstablishmentFailureWithInvalidResource)
                              std::string(RESOURCE_VERSION)));
   EXPECT_CALL(*ttl_timer_, disableTimer());
   state_->handleEstablishmentFailure();
-  EXPECT_THAT(xds_resources_delegate_->failed_resource_names(),
+  EXPECT_THAT(xds_resources_delegate_->failedResourceNames(),
               AllOf(SizeIs(1), Contains(bad_resource_name)));
 }
 

--- a/test/integration/xds_delegate_extension_integration_test.cc
+++ b/test/integration/xds_delegate_extension_integration_test.cc
@@ -92,7 +92,7 @@ public:
   }
 };
 
-class XdsDelegateExtensionIntegrationTest : public Grpc::GrpcClientIntegrationParamTest,
+class XdsDelegateExtensionIntegrationTest : public Grpc::UnifiedOrLegacyMuxIntegrationParamTest,
                                             public HttpIntegrationTest {
 public:
   XdsDelegateExtensionIntegrationTest()
@@ -101,6 +101,10 @@ public:
     // TODO(abeyad): Add test for Unified SotW when the UnifiedMux support is implemented.
     use_lds_ = false;
     create_xds_upstream_ = true;
+
+    if (isUnified()) {
+      config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux", "true");
+    }
 
     // Make the default cluster HTTP2.
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -194,7 +198,7 @@ public:
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, XdsDelegateExtensionIntegrationTest,
-                         GRPC_CLIENT_INTEGRATION_PARAMS);
+                         UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Verifies that, if an XdsResourcesDelegate is configured, then it is invoked whenever there is a
 // set of updated resources in the DiscoveryResponse from an xDS server.


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/22473 and https://github.com/envoyproxy/envoy/pull/22921 added support for the xDS resources delegate in the gRPC Sotw mux. This PR adds support for the xDS resources delegate feature to the unified gRPC Sotw implementation, which is intended to be the default implementation in the future.

Signed-off-by: Ali Beyad <abeyad@google.com>
