### PR TITLE
ci: Add branch and remote to Bazel get_workspace_status

### DIFF
--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -45,8 +45,8 @@ git_branch=$(git rev-parse --abbrev-ref HEAD)
 echo "BUILD_SCM_BRANCH ${git_branch}"
 
 git_remote=$(git remote get-url origin)
-git_remote_code=$?
-if [[ git_remote_code == 0 ]]; then
+git_remote_exit_code=$?
+if [[ git_remote_exit_code == 0 ]]; then
     echo "BUILD_SCM_REMOTE ${git_remote}"
 fi
 

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -40,3 +40,13 @@ git diff-index --quiet HEAD -- || {
 }
 echo "BUILD_SCM_STATUS ${tree_status}"
 echo "STABLE_BUILD_SCM_STATUS ${tree_status}"
+
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+echo "BUILD_SCM_BRANCH ${git_branch}"
+
+git_remote=$(git remote get-url origin)
+if [[ $? == 0 ]]; then
+    echo "BUILD_SCM_REMOTE ${git_remote}"
+fi
+
+

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -45,8 +45,7 @@ git_branch=$(git rev-parse --abbrev-ref HEAD)
 echo "BUILD_SCM_BRANCH ${git_branch}"
 
 git_remote=$(git remote get-url origin)
-git_remote_exit_code=$?
-if [[ $git_remote_exit_code == 0 ]]; then
+if [[ -n "$git_remote" ]]; then
     echo "BUILD_SCM_REMOTE ${git_remote}"
 fi
 

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -45,7 +45,8 @@ git_branch=$(git rev-parse --abbrev-ref HEAD)
 echo "BUILD_SCM_BRANCH ${git_branch}"
 
 git_remote=$(git remote get-url origin)
-if [[ $? == 0 ]]; then
+git_remote_code=$?
+if [[ git_remote_code == 0 ]]; then
     echo "BUILD_SCM_REMOTE ${git_remote}"
 fi
 

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -46,7 +46,7 @@ echo "BUILD_SCM_BRANCH ${git_branch}"
 
 git_remote=$(git remote get-url origin)
 git_remote_exit_code=$?
-if [[ git_remote_exit_code == 0 ]]; then
+if [[ $git_remote_exit_code == 0 ]]; then
     echo "BUILD_SCM_REMOTE ${git_remote}"
 fi
 


### PR DESCRIPTION
Signed-off-by: Will Martin <will@engflow.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
This change adds the BUILD_SCM_REMOTE and BUILD_SCM_BRANCH variables to those reported by Bazel. This will allow downstream consumers of the BEP within the CI system to include information regarding the repository and branch that a build was triggered from.

Additional Description: 
Specifically, this adds repository and branch to the [EngFlow UI][1] for envoy-mobile but may be used by any BEP consumer.

Risk Level: Low
Testing: Manual
Docs Changes: None
Release Notes: None
Platform Specific Features: N/A


[1]: https://envoy.cluster.engflow.com/
