### PR TITLE
[RDS] Add Top RouteConfiguration level per-filter-config

### DIFF
--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -6,6 +6,7 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/route/v3/route_components.proto";
 
+import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
@@ -140,6 +141,21 @@ message RouteConfiguration {
   // Envoy by default takes ":path" as "<path>;<params>".
   // For users who want to only match path on the "<path>" portion, this option should be true.
   bool ignore_path_parameters_in_path_matching = 15;
+
+  // The per_filter_config field can be used to provide RouteConfiguration level per filter config.
+  // The key should match the :ref:`filter config name
+  // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
+  // The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
+  // be used for the backwards compatibility. If there is no entry referred by the filter config name, the
+  // entry referred by the canonical filter name will be provided to the filters as fallback.
+  //
+  // Use of this field is filter specific;
+  // see the :ref:`HTTP filter documentation <config_http_filters>` for if and how it is utilized.
+  // [#comment: An entry's value may be wrapped in a
+  // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
+  // message to specify additional options.]
+  map<string, google.protobuf.Any> typed_per_filter_config = 16;
+
 }
 
 message Vhds {

--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
 // * HTTP :ref:`router filter <config_http_filters_router>`
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.RouteConfiguration";
 
@@ -142,7 +142,7 @@ message RouteConfiguration {
   // For users who want to only match path on the "<path>" portion, this option should be true.
   bool ignore_path_parameters_in_path_matching = 15;
 
-  // The per_filter_config field can be used to provide RouteConfiguration level per filter config.
+  // The typed_per_filter_config field can be used to provide RouteConfiguration level per filter config.
   // The key should match the :ref:`filter config name
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
   // The canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) can also
@@ -155,7 +155,6 @@ message RouteConfiguration {
   // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
   // message to specify additional options.]
   map<string, google.protobuf.Any> typed_per_filter_config = 16;
-
 }
 
 message Vhds {

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -389,7 +389,7 @@ public:
   virtual const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const PURE;
 
   /**
-   * Fold all the available per route filter configs, invoking the callback with each config (if
+   * Find all the available per route filter configs, invoking the callback with each config (if
    * it is present). Iteration of the configs is in order of specificity. That means that the
    * callback will be called first for a config on a Virtual host, then a route, and finally a route
    * entry (weighted cluster). If a config is not present, the callback will not be invoked.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -659,6 +659,24 @@ public:
    *         rather than no limit applies.
    */
   virtual uint32_t retryShadowBufferLimit() const PURE;
+
+  /**
+   * This is a helper to get the route's per-filter config if it exists, up along the config
+   * hierarchy (Route --> VirtualHost --> RouteConfiguration). Or nullptr if none of them exist.
+   */
+  virtual const RouteSpecificFilterConfig*
+  mostSpecificPerFilterConfig(const std::string& name) const PURE;
+
+  /**
+   * Fold all the available per route filter configs, invoking the callback with
+   * each config (if it is present). Iteration of the configs is in order of
+   * specificity. That means that the callback will be called first for a config on
+   * a route configuration, virtual host, route, and finally a route entry (weighted cluster). If
+   * a config is not present, the callback will not be invoked.
+   */
+  virtual void traversePerFilterConfig(
+      const std::string& filter_name,
+      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const PURE;
 };
 
 /**
@@ -1176,8 +1194,8 @@ public:
   virtual const RouteTracing* tracingConfig() const PURE;
 
   /**
-   * This is a helper to get the route's per-filter config if it exists, otherwise the virtual
-   * host's. Or nullptr if none of them exist.
+   * This is a helper to get the route's per-filter config if it exists, up along the config
+   * hierarchy(Route --> VirtualHost --> RouteConfiguration). Or nullptr if none of them exist.
    */
   virtual const RouteSpecificFilterConfig*
   mostSpecificPerFilterConfig(const std::string& name) const PURE;

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -668,7 +668,7 @@ public:
   mostSpecificPerFilterConfig(const std::string& name) const PURE;
 
   /**
-   * Fold all the available per route filter configs, invoking the callback with
+   * Find all the available per route filter configs, invoking the callback with
    * each config (if it is present). Iteration of the configs is in order of
    * specificity. That means that the callback will be called first for a config on
    * a route configuration, virtual host, route, and finally a route entry (weighted cluster). If
@@ -1201,7 +1201,7 @@ public:
   mostSpecificPerFilterConfig(const std::string& name) const PURE;
 
   /**
-   * Fold all the available per route filter configs, invoking the callback with each config (if
+   * Find all the available per route filter configs, invoking the callback with each config (if
    * it is present). Iteration of the configs is in order of specificity. That means that the
    * callback will be called first for a config on a Virtual host, then a route, and finally a route
    * entry (weighted cluster). If a config is not present, the callback will not be invoked.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -167,6 +167,13 @@ private:
     uint32_t retryShadowBufferLimit() const override {
       return std::numeric_limits<uint32_t>::max();
     }
+    const Router::RouteSpecificFilterConfig*
+    mostSpecificPerFilterConfig(const std::string&) const override {
+      return nullptr;
+    }
+    void traversePerFilterConfig(
+        const std::string&,
+        std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullConfig route_configuration_;
   };

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1409,10 +1409,7 @@ void RouteEntryImplBase::validateClusters(
 void RouteEntryImplBase::traversePerFilterConfig(
     const std::string& filter_name,
     std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const {
-  auto maybe_vhost_config = vhost_.perFilterConfig(filter_name);
-  if (maybe_vhost_config != nullptr) {
-    cb(*maybe_vhost_config);
-  }
+  vhost_.traversePerFilterConfig(filter_name, cb);
 
   auto maybe_route_config = per_filter_configs_.get(filter_name);
   if (maybe_route_config != nullptr) {
@@ -1775,8 +1772,24 @@ VirtualHostImpl::VirtualClusterEntry::VirtualClusterEntry(
 
 const Config& VirtualHostImpl::routeConfig() const { return global_route_config_; }
 
-const RouteSpecificFilterConfig* VirtualHostImpl::perFilterConfig(const std::string& name) const {
-  return per_filter_configs_.get(name);
+const RouteSpecificFilterConfig*
+VirtualHostImpl::mostSpecificPerFilterConfig(const std::string& name) const {
+  auto* per_filter_config = per_filter_configs_.get(name);
+  return per_filter_config != nullptr ? per_filter_config
+                                      : global_route_config_.perFilterConfig(name);
+}
+void VirtualHostImpl::traversePerFilterConfig(
+    const std::string& filter_name,
+    std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const {
+  // Parent first.
+  if (auto* maybe_rc_config = global_route_config_.perFilterConfig(filter_name);
+      maybe_rc_config != nullptr) {
+    cb(*maybe_rc_config);
+  }
+  if (auto* maybe_vhost_config = per_filter_configs_.get(filter_name);
+      maybe_vhost_config != nullptr) {
+    cb(*maybe_vhost_config);
+  }
 }
 
 const VirtualHostImpl* RouteMatcher::findWildcardVirtualHost(
@@ -2022,7 +2035,9 @@ ConfigImpl::ConfigImpl(const envoy::config::route::v3::RouteConfiguration& confi
       max_direct_response_body_size_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_direct_response_body_size_bytes,
                                           DEFAULT_MAX_DIRECT_RESPONSE_BODY_SIZE_BYTES)),
-      ignore_path_parameters_in_path_matching_(config.ignore_path_parameters_in_path_matching()) {
+      ignore_path_parameters_in_path_matching_(config.ignore_path_parameters_in_path_matching()),
+      per_filter_configs_(config.typed_per_filter_config(), optional_http_filters, factory_context,
+                          validator) {
   if (!config.request_mirror_policies().empty()) {
     shadow_policies_.reserve(config.request_mirror_policies().size());
     for (const auto& mirror_policy_config : config.request_mirror_policies()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -219,7 +219,7 @@ public:
   Stats::StatName statName() const override { return stat_name_storage_.statName(); }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
   const Config& routeConfig() const override;
-  const RouteSpecificFilterConfig* perFilterConfig(const std::string&) const;
+  const RouteSpecificFilterConfig* mostSpecificPerFilterConfig(const std::string&) const override;
   bool includeAttemptCountInRequest() const override { return include_attempt_count_in_request_; }
   bool includeAttemptCountInResponse() const override { return include_attempt_count_in_response_; }
   const std::vector<ShadowPolicyPtr>& shadowPolicies() const { return shadow_policies_; }
@@ -230,6 +230,10 @@ public:
     return hedge_policy_;
   }
   uint32_t retryShadowBufferLimit() const override { return retry_shadow_buffer_limit_; }
+
+  void traversePerFilterConfig(
+      const std::string& filter_name,
+      std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const override;
 
 private:
   enum class SslRequirements { None, ExternalOnly, All };
@@ -631,7 +635,7 @@ public:
   const RouteSpecificFilterConfig*
   mostSpecificPerFilterConfig(const std::string& name) const override {
     auto* config = per_filter_configs_.get(name);
-    return config ? config : vhost_.perFilterConfig(name);
+    return config ? config : vhost_.mostSpecificPerFilterConfig(name);
   }
   void traversePerFilterConfig(
       const std::string& filter_name,
@@ -1304,6 +1308,10 @@ public:
     return route_matcher_->findVirtualHost(headers) != nullptr;
   }
 
+  const RouteSpecificFilterConfig* perFilterConfig(const std::string& name) const {
+    return per_filter_configs_.get(name);
+  }
+
   // Router::Config
   RouteConstSharedPtr route(const Http::RequestHeaderMap& headers,
                             const StreamInfo::StreamInfo& stream_info,
@@ -1352,6 +1360,7 @@ private:
   // Cluster specifier plugins/providers.
   absl::flat_hash_map<std::string, ClusterSpecifierPluginSharedPtr> cluster_specifier_plugins_;
   const bool ignore_path_parameters_in_path_matching_;
+  PerFilterConfigs per_filter_configs_;
 };
 
 /**

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -9840,6 +9840,11 @@ virtual_hosts:
 
 TEST_F(PerFilterConfigsTest, RouteLocalTypedConfig) {
   const std::string yaml = R"EOF(
+typed_per_filter_config:
+  test.filter:
+    "@type": type.googleapis.com/google.protobuf.Timestamp
+    value:
+      seconds: 9090
 virtual_hosts:
   - name: bar
     domains: ["*"]
@@ -9859,12 +9864,17 @@ virtual_hosts:
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
-  absl::InlinedVector<uint32_t, 3> expected_traveled_config({456, 123});
+  absl::InlinedVector<uint32_t, 3> expected_traveled_config({9090, 456, 123});
   checkEach(yaml, 123, expected_traveled_config, "test.filter");
 }
 
 TEST_F(PerFilterConfigsTest, RouteLocalTypedConfigWithDirectResponse) {
   const std::string yaml = R"EOF(
+typed_per_filter_config:
+  test.filter:
+    "@type": type.googleapis.com/google.protobuf.Timestamp
+    value:
+      seconds: 9090
 virtual_hosts:
   - name: bar
     domains: ["*"]
@@ -9885,12 +9895,17 @@ virtual_hosts:
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
-  absl::InlinedVector<uint32_t, 3> expected_traveled_config({456, 123});
+  absl::InlinedVector<uint32_t, 3> expected_traveled_config({9090, 456, 123});
   checkEach(yaml, 123, expected_traveled_config, "test.filter");
 }
 
 TEST_F(PerFilterConfigsTest, WeightedClusterTypedConfig) {
   const std::string yaml = R"EOF(
+typed_per_filter_config:
+  test.filter:
+    "@type": type.googleapis.com/google.protobuf.Timestamp
+    value:
+      seconds: 9090
 virtual_hosts:
   - name: bar
     domains: ["*"]
@@ -9914,12 +9929,40 @@ virtual_hosts:
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
-  absl::InlinedVector<uint32_t, 3> expected_traveled_config({1011, 789});
+  absl::InlinedVector<uint32_t, 3> expected_traveled_config({9090, 1011, 789});
   checkEach(yaml, 789, expected_traveled_config, "test.filter");
 }
 
+TEST_F(PerFilterConfigsTest, RouteConfigurationTypedConfig) {
+  const std::string yaml = R"EOF(
+typed_per_filter_config:
+  test.filter:
+    "@type": type.googleapis.com/google.protobuf.Timestamp
+    value:
+      seconds: 9090
+virtual_hosts:
+  - name: bar
+    domains: ["*"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            clusters:
+              - name: baz
+                weight: 100
+)EOF";
+
+  factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
+  absl::InlinedVector<uint32_t, 3> expected_traveled_config({9090});
+  checkEach(yaml, 9090, expected_traveled_config, "test.filter");
+}
 TEST_F(PerFilterConfigsTest, WeightedClusterFallthroughTypedConfig) {
   const std::string yaml = R"EOF(
+typed_per_filter_config:
+  test.filter:
+    "@type": type.googleapis.com/google.protobuf.Timestamp
+    value:
+      seconds: 9090
 virtual_hosts:
   - name: bar
     domains: ["*"]
@@ -9943,7 +9986,7 @@ virtual_hosts:
 )EOF";
 
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
-  absl::InlinedVector<uint32_t, 3> expected_traveled_config({1415, 1213});
+  absl::InlinedVector<uint32_t, 3> expected_traveled_config({9090, 1415, 1213});
   checkEach(yaml, 1213, expected_traveled_config, "test.filter");
 }
 

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -294,12 +294,16 @@ public:
   MOCK_METHOD(const RateLimitPolicy&, rateLimitPolicy, (), (const));
   MOCK_METHOD(const CorsPolicy*, corsPolicy, (), (const));
   MOCK_METHOD(const Config&, routeConfig, (), (const));
-  MOCK_METHOD(const RouteSpecificFilterConfig*, perFilterConfig, (const std::string&), (const));
+  MOCK_METHOD(const RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (const std::string&),
+              (const));
   MOCK_METHOD(bool, includeAttemptCountInRequest, (), (const));
   MOCK_METHOD(bool, includeAttemptCountInResponse, (), (const));
   MOCK_METHOD(Upstream::RetryPrioritySharedPtr, retryPriority, ());
   MOCK_METHOD(Upstream::RetryHostPredicateSharedPtr, retryHostPredicate, ());
   MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
+  MOCK_METHOD(void, traversePerFilterConfig,
+              (const std::string&, std::function<void(const Router::RouteSpecificFilterConfig&)>),
+              (const));
 
   Stats::StatName statName() const override {
     stat_name_ = std::make_unique<Stats::StatNameManagedStorage>(name(), *symbol_table_);


### PR DESCRIPTION
Commit Message: Add Top RouteConfiguration level per-filter-config
Additional Description:
Risk Level: low 
Testing: unit test
Docs Changes: 
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #17662

[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
