### PR TITLE
Make shadow state visible from StreamInfo.

### DIFF
--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -219,6 +219,11 @@ public:
       return *this;
     }
 
+    StreamOptions& setIsShadow(bool s) {
+      is_shadow = s;
+      return *this;
+    }
+
     // For gmock test
     bool operator==(const StreamOptions& src) const {
       return timeout == src.timeout && buffer_body_for_retry == src.buffer_body_for_retry &&
@@ -247,6 +252,8 @@ public:
     envoy::config::core::v3::Metadata metadata;
 
     absl::optional<envoy::config::route::v3::RetryPolicy> retry_policy;
+
+    bool is_shadow{false};
   };
 
   /**
@@ -284,6 +291,10 @@ public:
     }
     RequestOptions& setRetryPolicy(const envoy::config::route::v3::RetryPolicy& p) {
       StreamOptions::setRetryPolicy(p);
+      return *this;
+    }
+    RequestOptions& setIsShadow(bool s) {
+      StreamOptions::setIsShadow(s);
       return *this;
     }
     RequestOptions& setParentSpan(Tracing::Span& parent_span) {

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -743,6 +743,8 @@ public:
    */
   virtual void setDownstreamBytesMeter(const BytesMeterSharedPtr& downstream_bytes_meter) PURE;
 
+  virtual bool isShadow() const PURE;
+
   static void syncUpstreamAndDownstreamBytesMeter(StreamInfo& downstream_info,
                                                   StreamInfo& upstream_info) {
     downstream_info.setUpstreamBytesMeter(upstream_info.getUpstreamBytesMeter());

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -88,6 +88,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       send_xff_(options.send_xff) {
 
   stream_info_.dynamicMetadata().MergeFrom(options.metadata);
+  stream_info_.setIsShadow(options.is_shadow);
 
   if (options.buffer_body_for_retry) {
     buffered_body_ = std::make_unique<Buffer::OwnedImpl>();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -898,7 +898,8 @@ void Filter::maybeDoShadowing() {
                        .setTimeout(timeout_.global_timeout_)
                        .setParentSpan(callbacks_->activeSpan())
                        .setChildSpanName("mirror")
-                       .setSampled(shadow_policy.traceSampled());
+                       .setSampled(shadow_policy.traceSampled())
+                       .setIsShadow(true);
     config_.shadowWriter().shadow(std::string(cluster_name.value()), std::move(request), options);
   }
 }

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -29,8 +29,13 @@ void ShadowWriterImpl::shadow(const std::string& cluster, Http::RequestMessagePt
   request->headers().setHost(parts.size() == 2
                                  ? absl::StrJoin(parts, "-shadow:")
                                  : absl::StrCat(request->headers().getHostValue(), "-shadow"));
+  const auto& shadow_options = options.is_shadow ? options : [options] {
+    Http::AsyncClient::RequestOptions actual_options(options);
+    actual_options.setIsShadow(true);
+    return actual_options;
+  }();
   // This is basically fire and forget. We don't handle cancelling.
-  thread_local_cluster->httpAsyncClient().send(std::move(request), *this, options);
+  thread_local_cluster->httpAsyncClient().send(std::move(request), *this, shadow_options);
 }
 
 } // namespace Router

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -334,6 +334,9 @@ struct StreamInfoImpl : public StreamInfo {
     start_time_monotonic_ = info.startTimeMonotonic();
   }
 
+  void setIsShadow(bool is_shadow) { is_shadow_ = is_shadow; }
+  bool isShadow() const override { return is_shadow_; }
+
   TimeSource& time_source_;
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;
@@ -386,6 +389,7 @@ private:
   // Default construct the object because upstream stream is not constructed in some cases.
   BytesMeterSharedPtr upstream_bytes_meter_{std::make_shared<BytesMeter>()};
   BytesMeterSharedPtr downstream_bytes_meter_;
+  bool is_shadow_{false};
 };
 
 } // namespace StreamInfo

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -135,6 +135,7 @@ public:
   MOCK_METHOD(void, setUpstreamBytesMeter, (const BytesMeterSharedPtr&));
   MOCK_METHOD(void, setDownstreamBytesMeter, (const BytesMeterSharedPtr&));
   MOCK_METHOD(void, dumpState, (std::ostream & os, int indent_level), (const));
+  MOCK_METHOD(bool, isShadow, (), (const, override));
   Envoy::Event::SimulatedTimeSystem ts_;
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;


### PR DESCRIPTION
Signed-off-by: Paul Gallagher <pgal@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Make shadow state visible from Stream Info.
Additional Description: This will give upstream http filters visibility into whether they are on a shadow stream or not.
Risk Level: Low
Testing: Unit
Docs Changes: None
