### PR TITLE
Allow disabling the guard dog

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -302,6 +302,27 @@ config_setting(
 )
 
 bool_flag(
+    name = "guarddog",
+    build_setting_default = True,
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "disable_guarddog_setting",
+    flag_values = {
+        ":guarddog": "False",
+    },
+    visibility = ["//visibility:private"],
+)
+
+selects.config_setting_group(
+    name = "disable_guarddog",
+    match_any = [
+        ":disable_guarddog_setting",
+    ],
+)
+
+bool_flag(
     name = "http3",
     build_setting_default = True,
     visibility = ["//visibility:private"],

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -21,6 +21,7 @@ load(
     _envoy_select_admin_html = "envoy_select_admin_html",
     _envoy_select_admin_no_html = "envoy_select_admin_no_html",
     _envoy_select_boringssl = "envoy_select_boringssl",
+    _envoy_select_enable_guarddog = "envoy_select_enable_guarddog",
     _envoy_select_enable_http3 = "envoy_select_enable_http3",
     _envoy_select_google_grpc = "envoy_select_google_grpc",
     _envoy_select_hot_restart = "envoy_select_hot_restart",
@@ -212,6 +213,7 @@ envoy_select_admin_html = _envoy_select_admin_html
 envoy_select_admin_no_html = _envoy_select_admin_no_html
 envoy_select_boringssl = _envoy_select_boringssl
 envoy_select_google_grpc = _envoy_select_google_grpc
+envoy_select_enable_guarddog = _envoy_select_enable_guarddog
 envoy_select_enable_http3 = _envoy_select_enable_http3
 envoy_select_hot_restart = _envoy_select_hot_restart
 envoy_select_wasm_cpp_tests = _envoy_select_wasm_cpp_tests

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -1,6 +1,6 @@
 # DO NOT LOAD THIS FILE. Targets from this file should be considered private
 # and not used outside of the @envoy//bazel package.
-load(":envoy_select.bzl", "envoy_select_admin_html", "envoy_select_enable_http3", "envoy_select_google_grpc", "envoy_select_hot_restart")
+load(":envoy_select.bzl", "envoy_select_admin_html", "envoy_select_enable_guarddog", "envoy_select_enable_http3", "envoy_select_google_grpc", "envoy_select_hot_restart")
 
 # Compute the final copts based on various options.
 def envoy_copts(repository, test = False):
@@ -124,6 +124,7 @@ def envoy_copts(repository, test = False):
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
            envoy_select_admin_html(["-DENVOY_ADMIN_HTML"], repository) + \
            envoy_select_enable_http3(["-DENVOY_ENABLE_QUIC"], repository) + \
+           envoy_select_enable_guarddog(["-DENVOY_ENABLE_GUARDDOG"], repository) + \
            _envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
            _envoy_select_perfetto(["-DENVOY_PERFETTO"]) + \
            envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -45,6 +45,13 @@ def envoy_select_enable_http3(xs, repository = ""):
         "//conditions:default": xs,
     })
 
+# Selects the given values if the guard dog is enabled in the current build.
+def envoy_select_enable_guarddog(xs, repository = ""):
+    return select({
+        repository + "//bazel:disable_guarddog": [],
+        "//conditions:default": xs,
+    })
+
 # Selects the given values if hot restart is enabled in the current build.
 def envoy_select_hot_restart(xs, repository = ""):
     return select({

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_enable_guarddog",
     "envoy_select_enable_http3",
     "envoy_select_hot_restart",
 )
@@ -577,7 +578,6 @@ envoy_cc_library(
         ":active_raw_udp_listener_config",
         ":configuration_lib",
         ":connection_handler_lib",
-        ":guarddog_lib",
         ":listener_hooks_lib",
         ":listener_manager_lib",
         ":ssl_context_manager_lib",
@@ -633,7 +633,7 @@ envoy_cc_library(
         "//source/server/admin:admin_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
-    ],
+    ] + envoy_select_enable_guarddog([":guarddog_lib"]),
 )
 
 envoy_cc_library(

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -55,11 +55,12 @@
 #include "source/server/admin/utils.h"
 #include "source/server/configuration_impl.h"
 #include "source/server/connection_handler_impl.h"
+#include "source/server/listener_hooks.h"
+#include "source/server/ssl_context_manager.h"
+
 #ifdef ENVOY_ENABLE_GUARDDOG
 #include "source/server/guarddog_impl.h"
 #endif
-#include "source/server/listener_hooks.h"
-#include "source/server/ssl_context_manager.h"
 
 namespace Envoy {
 namespace Server {


### PR DESCRIPTION
Commit Message: Allow disabling the guard dog
Additional Description: Which Envoy Mobile should never enable, because terminating the Envoy process would mean terminating the host iOS or Android app. See https://github.com/envoyproxy/envoy-mobile/issues/2581 for more details.
Risk Level: Low, compile-time flag, no-op by default.
Testing: Building Envoy Mobile locally.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: Will be disabled when building Envoy Mobile.
Fixes: https://github.com/envoyproxy/envoy-mobile/issues/2581

Signed-off-by: JP Simard <jp@jpsim.com>