### PR TITLE
test: Add option to use node metadata in Bootstrap config

### DIFF
--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -389,7 +389,7 @@ void BaseIntegrationTest::createGeneratedApiTestServer(
       bootstrap_path, version_, on_server_ready_function_, on_server_init_function_,
       deterministic_value_, timeSystem(), *api_, defer_listener_finalization_, process_object_,
       validator_config, concurrency_, drain_time_, drain_strategy_, proxy_buffer_factory_,
-      use_real_stats_);
+      use_real_stats_, use_bootstrap_node_metadata_);
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0 &&
       !defer_listener_finalization_) {
 

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -506,6 +506,12 @@ protected:
   // If true, skip checking stats for missing tag-extraction rules.
   bool skip_tag_extraction_rule_check_{};
 
+  // By default, node metadata (node name, cluster name, locality) for the test server gets set to
+  // hard-coded values in the OptionsImpl ("node_name", "cluster_name", etc.). Set to true if your
+  // test specifies the node metadata in the Bootstrap configuration and that's what you want to use
+  // for node info in Envoy.
+  bool use_bootstrap_node_metadata_{false};
+
 private:
   // Configuration for the fake upstream.
   FakeUpstreamConfig upstream_config_{time_system_};

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -30,8 +30,13 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
                                   Network::Address::IpVersion ip_version,
                                   FieldValidationConfig validation_config, uint32_t concurrency,
                                   std::chrono::seconds drain_time,
-                                  Server::DrainStrategy drain_strategy) {
-  OptionsImpl test_options("cluster_name", "node_name", "zone_name", spdlog::level::info);
+                                  Server::DrainStrategy drain_strategy,
+                                  bool use_bootstrap_node_metadata) {
+  // Empty string values mean the Bootstrap node metadata won't be overridden.
+  const std::string service_cluster = use_bootstrap_node_metadata ? "" : "cluster_name";
+  const std::string service_node = use_bootstrap_node_metadata ? "" : "node_name";
+  const std::string service_zone = use_bootstrap_node_metadata ? "" : "zone_name";
+  OptionsImpl test_options(service_cluster, service_node, service_zone, spdlog::level::info);
 
   test_options.setConfigPath(config_path);
   test_options.setConfigYaml(config_yaml);
@@ -58,7 +63,8 @@ IntegrationTestServerPtr IntegrationTestServer::create(
     Event::TestTimeSystem& time_system, Api::Api& api, bool defer_listener_finalization,
     ProcessObjectOptRef process_object, Server::FieldValidationConfig validation_config,
     uint32_t concurrency, std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
-    Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_real_stats) {
+    Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_real_stats,
+    bool use_bootstrap_node_metadata) {
   IntegrationTestServerPtr server{
       std::make_unique<IntegrationTestServerImpl>(time_system, api, config_path, use_real_stats)};
   if (server_ready_function != nullptr) {
@@ -66,7 +72,7 @@ IntegrationTestServerPtr IntegrationTestServer::create(
   }
   server->start(version, on_server_init_function, deterministic_value, defer_listener_finalization,
                 process_object, validation_config, concurrency, drain_time, drain_strategy,
-                watermark_factory);
+                watermark_factory, use_bootstrap_node_metadata);
   return server;
 }
 
@@ -99,15 +105,15 @@ void IntegrationTestServer::start(
     absl::optional<uint64_t> deterministic_value, bool defer_listener_finalization,
     ProcessObjectOptRef process_object, Server::FieldValidationConfig validator_config,
     uint32_t concurrency, std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
-    Buffer::WatermarkFactorySharedPtr watermark_factory) {
+    Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_bootstrap_node_metadata) {
   ENVOY_LOG(info, "starting integration test server");
   ASSERT(!thread_);
-  thread_ = api_.threadFactory().createThread([version, deterministic_value, process_object,
-                                               validator_config, concurrency, drain_time,
-                                               drain_strategy, watermark_factory, this]() -> void {
-    threadRoutine(version, deterministic_value, process_object, validator_config, concurrency,
-                  drain_time, drain_strategy, watermark_factory);
-  });
+  thread_ = api_.threadFactory().createThread(
+      [version, deterministic_value, process_object, validator_config, concurrency, drain_time,
+       drain_strategy, watermark_factory, use_bootstrap_node_metadata, this]() -> void {
+        threadRoutine(version, deterministic_value, process_object, validator_config, concurrency,
+                      drain_time, drain_strategy, watermark_factory, use_bootstrap_node_metadata);
+      });
 
   // If any steps need to be done prior to workers starting, do them now. E.g., xDS pre-init.
   // Note that there is no synchronization guaranteeing this happens either
@@ -179,15 +185,14 @@ void IntegrationTestServer::serverReady() {
   server_set_.setReady();
 }
 
-void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version,
-                                          absl::optional<uint64_t> deterministic_value,
-                                          ProcessObjectOptRef process_object,
-                                          Server::FieldValidationConfig validation_config,
-                                          uint32_t concurrency, std::chrono::seconds drain_time,
-                                          Server::DrainStrategy drain_strategy,
-                                          Buffer::WatermarkFactorySharedPtr watermark_factory) {
+void IntegrationTestServer::threadRoutine(
+    const Network::Address::IpVersion version, absl::optional<uint64_t> deterministic_value,
+    ProcessObjectOptRef process_object, Server::FieldValidationConfig validation_config,
+    uint32_t concurrency, std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
+    Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_bootstrap_node_metadata) {
   OptionsImpl options(Server::createTestOptionsImpl(config_path_, "", version, validation_config,
-                                                    concurrency, drain_time, drain_strategy));
+                                                    concurrency, drain_time, drain_strategy,
+                                                    use_bootstrap_node_metadata));
   Thread::MutexBasicLockable lock;
 
   Random::RandomGeneratorPtr random_generator;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -46,7 +46,8 @@ createTestOptionsImpl(const std::string& config_path, const std::string& config_
                       FieldValidationConfig validation_config = FieldValidationConfig(),
                       uint32_t concurrency = 1,
                       std::chrono::seconds drain_time = std::chrono::seconds(1),
-                      Server::DrainStrategy drain_strategy = Server::DrainStrategy::Gradual);
+                      Server::DrainStrategy drain_strategy = Server::DrainStrategy::Gradual,
+                      bool use_bootstrap_node_metadata = false);
 
 class TestComponentFactory : public ComponentFactory {
 public:
@@ -437,16 +438,18 @@ class IntegrationTestServer : public Logger::Loggable<Logger::Id::testing>,
                               public IntegrationTestServerStats,
                               public Server::ComponentFactory {
 public:
-  static IntegrationTestServerPtr create(
-      const std::string& config_path, const Network::Address::IpVersion version,
-      std::function<void(IntegrationTestServer&)> on_server_ready_function,
-      std::function<void()> on_server_init_function, absl::optional<uint64_t> deterministic_value,
-      Event::TestTimeSystem& time_system, Api::Api& api, bool defer_listener_finalization = false,
-      ProcessObjectOptRef process_object = absl::nullopt,
-      Server::FieldValidationConfig validation_config = Server::FieldValidationConfig(),
-      uint32_t concurrency = 1, std::chrono::seconds drain_time = std::chrono::seconds(1),
-      Server::DrainStrategy drain_strategy = Server::DrainStrategy::Gradual,
-      Buffer::WatermarkFactorySharedPtr watermark_factory = nullptr, bool use_real_stats = false);
+  static IntegrationTestServerPtr
+  create(const std::string& config_path, const Network::Address::IpVersion version,
+         std::function<void(IntegrationTestServer&)> on_server_ready_function,
+         std::function<void()> on_server_init_function,
+         absl::optional<uint64_t> deterministic_value, Event::TestTimeSystem& time_system,
+         Api::Api& api, bool defer_listener_finalization = false,
+         ProcessObjectOptRef process_object = absl::nullopt,
+         Server::FieldValidationConfig validation_config = Server::FieldValidationConfig(),
+         uint32_t concurrency = 1, std::chrono::seconds drain_time = std::chrono::seconds(1),
+         Server::DrainStrategy drain_strategy = Server::DrainStrategy::Gradual,
+         Buffer::WatermarkFactorySharedPtr watermark_factory = nullptr, bool use_real_stats = false,
+         bool use_bootstrap_node_metadata = false);
   // Note that the derived class is responsible for tearing down the server in its
   // destructor.
   ~IntegrationTestServer() override;
@@ -475,7 +478,7 @@ public:
              ProcessObjectOptRef process_object, Server::FieldValidationConfig validation_config,
              uint32_t concurrency, std::chrono::seconds drain_time,
              Server::DrainStrategy drain_strategy,
-             Buffer::WatermarkFactorySharedPtr watermark_factory);
+             Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_bootstrap_node_metadata);
 
   void waitForCounterEq(const std::string& name, uint64_t value,
                         std::chrono::milliseconds timeout = TestUtility::DefaultTimeout,
@@ -593,7 +596,8 @@ private:
                      ProcessObjectOptRef process_object,
                      Server::FieldValidationConfig validation_config, uint32_t concurrency,
                      std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
-                     Buffer::WatermarkFactorySharedPtr watermark_factory);
+                     Buffer::WatermarkFactorySharedPtr watermark_factory,
+                     bool use_bootstrap_node_metadata);
 
   Event::TestTimeSystem& time_system_;
   Api::Api& api_;


### PR DESCRIPTION
Prior to this commit, the test integration server was created with an OptionsImpl that contains hard-coded default cluster, node, and zone values. Since the non-empty values in Options overwrites the node metadata in Bootstrap, this meant that the integration test server always used the same hard-coded metadata without being able to override it.

This commit introduces a new knob to BaseIntegrationTest: `use_bootstrap_node_metadata_`. If set to true, the node metadata from the Bootstrap config's `node` field will be used by Envoy instead of the OptionsImpl overrides. This enables Envoy tests to use node metadata specified in the Bootstrap config, which is necessary for some integration tests being written for Envoy Mobile.

Signed-off-by: Ali Beyad <abeyad@google.com>