### PR TITLE
Persist key-value-store TTLs to disk in flush()

### DIFF
--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -1,5 +1,4 @@
 #include "source/common/common/key_value_store_base.h"
-#include "source/common/common/key_value_store_base.h"
 
 #include <algorithm>
 #include <chrono>

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -1,7 +1,5 @@
 #include "source/common/common/key_value_store_base.h"
 
-#include <bits/chrono.h>
-
 #include <algorithm>
 #include <chrono>
 

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -79,14 +79,15 @@ bool KeyValueStoreBase::parseContents(absl::string_view contents) {
         ttl.emplace(std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::time_point<std::chrono::system_clock>(std::chrono::seconds(ttl_int)) -
             time_source_.systemTime()));
+        if (ttl <= std::chrono::seconds(0)) {
+          continue;
+        }
       } else {
         ENVOY_LOG(warn, "TTL was read from disk but failed to convert to integer");
         return false;
       }
     }
-    if (!ttl.has_value() || ttl > std::chrono::seconds(0)) {
-      addOrUpdate(key.value(), value.value(), ttl);
-    }
+    addOrUpdate(key.value(), value.value(), ttl);
   }
   return true;
 }

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -1,7 +1,8 @@
 #include "source/common/common/key_value_store_base.h"
 
-#include <algorithm>
 #include <bits/chrono.h>
+
+#include <algorithm>
 #include <chrono>
 
 #include "absl/cleanup/cleanup.h"
@@ -73,7 +74,8 @@ bool KeyValueStoreBase::parseContents(absl::string_view contents) {
       auto token = getToken(contents, error);
       if (token.has_value()) {
         if (absl::SimpleAtoi(token.value(), &ttlInt)) {
-          ttl.emplace(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::seconds(ttlInt) - std::chrono::system_clock::now().time_since_epoch()));
+          ttl.emplace(std::chrono::duration_cast<std::chrono::seconds>(
+              std::chrono::seconds(ttlInt) - std::chrono::system_clock::now().time_since_epoch()));
         }
       }
     }

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -1,4 +1,4 @@
-#include "key_value_store_base.h"
+#include "source/common/common/key_value_store_base.h"
 #include "source/common/common/key_value_store_base.h"
 
 #include <algorithm>
@@ -33,8 +33,8 @@ absl::optional<absl::string_view> getToken(absl::string_view& contents, std::str
 }
 
 bool checkForTtl(absl::string_view& contents) {
-  if (contents.size() > TTL_KEY.length() && contents.substr(0, TTL_KEY.length()) == TTL_KEY) {
-    contents.remove_prefix(TTL_KEY.length());
+  if (contents.size() > KV_STORE_TTL_KEY.length() && contents.substr(0, KV_STORE_TTL_KEY.length()) == KV_STORE_TTL_KEY) {
+    contents.remove_prefix(KV_STORE_TTL_KEY.length());
     return true;
   }
   return false;
@@ -84,7 +84,7 @@ bool KeyValueStoreBase::parseContents(absl::string_view contents) {
         }
       }
     }
-    if (!(ttl.has_value() && ttl <= std::chrono::seconds(0))) {
+    if (!ttl.has_value() || ttl > std::chrono::seconds(0)) {
       addOrUpdate(key.value(), value.value(), ttl);
     }
   }

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -80,9 +80,8 @@ bool KeyValueStoreBase::parseContents(absl::string_view contents) {
       } else {
         if (!token.has_value()) {
           ENVOY_LOG(warn, error);
-        }
-        else {
-          ENVOY_LOG(warn, "TTL was read from disk, but aoti() failed")
+        } else {
+          ENVOY_LOG(warn, "TTL was read from disk, but aoti() failed");
         }
       }
     }

--- a/source/common/common/key_value_store_base.cc
+++ b/source/common/common/key_value_store_base.cc
@@ -32,7 +32,8 @@ absl::optional<absl::string_view> getToken(absl::string_view& contents, std::str
 }
 
 bool checkForTtl(absl::string_view& contents) {
-  if (contents.size() > KV_STORE_TTL_KEY.length() && contents.substr(0, KV_STORE_TTL_KEY.length()) == KV_STORE_TTL_KEY) {
+  if (contents.size() > KV_STORE_TTL_KEY.length() &&
+      contents.substr(0, KV_STORE_TTL_KEY.length()) == KV_STORE_TTL_KEY) {
     contents.remove_prefix(KV_STORE_TTL_KEY.length());
     return true;
   }

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -12,6 +12,7 @@
 #include "quiche/common/quiche_linked_hash_map.h"
 
 namespace Envoy {
+inline constexpr absl::string_view KV_STORE_TTL_KEY = "TTL";
 
 // This is the base implementation of the KeyValueStore. It handles the various
 // functions other than flush(), which will be implemented by subclasses.
@@ -50,5 +51,4 @@ protected:
   TimeSource& time_source_;
 };
 
-inline constexpr absl::string_view TTL_KEY = "TTL";
 } // namespace Envoy

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -41,6 +41,7 @@ protected:
   const uint32_t max_entries_;
   const Event::TimerPtr flush_timer_;
   Config::TtlManager ttl_manager_;
+  // Pair.first is the value and pair.second is an optional TTL
   quiche::QuicheLinkedHashMap<std::string,
                               std::pair<std::string, absl::optional<std::chrono::seconds>>>
       store_;
@@ -49,4 +50,5 @@ protected:
   TimeSource& time_source_;
 };
 
+inline constexpr absl::string_view TTL_KEY = "TTL";
 } // namespace Envoy

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -41,7 +41,9 @@ protected:
   const uint32_t max_entries_;
   const Event::TimerPtr flush_timer_;
   Config::TtlManager ttl_manager_;
-  quiche::QuicheLinkedHashMap<std::string, std::pair<std::string, absl::optional<std::chrono::seconds>>> store_;
+  quiche::QuicheLinkedHashMap<std::string,
+                              std::pair<std::string, absl::optional<std::chrono::seconds>>>
+      store_;
   // Used for validation only.
   mutable bool under_iterate_{};
   TimeSource& time_source_;

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -41,8 +41,7 @@ protected:
   const uint32_t max_entries_;
   const Event::TimerPtr flush_timer_;
   Config::TtlManager ttl_manager_;
-  quiche::QuicheLinkedHashMap<std::string, std::string> store_;
-  quiche::QuicheLinkedHashMap<std::string, std::chrono::seconds> ttl_store_;
+  quiche::QuicheLinkedHashMap<std::string, std::pair<std::string, absl::optional<std::chrono::seconds>>> store_;
   // Used for validation only.
   mutable bool under_iterate_{};
   TimeSource& time_source_;

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -45,6 +45,7 @@ protected:
   quiche::QuicheLinkedHashMap<std::string, std::chrono::seconds> ttl_store_;
   // Used for validation only.
   mutable bool under_iterate_{};
+  TimeSource& time_source_;
 };
 
 } // namespace Envoy

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -42,6 +42,7 @@ protected:
   const Event::TimerPtr flush_timer_;
   Config::TtlManager ttl_manager_;
   quiche::QuicheLinkedHashMap<std::string, std::string> store_;
+  quiche::QuicheLinkedHashMap<std::string, std::chrono::seconds> ttl_store_;
   // Used for validation only.
   mutable bool under_iterate_{};
 };

--- a/source/extensions/key_value/file_based/config.cc
+++ b/source/extensions/key_value/file_based/config.cc
@@ -34,11 +34,10 @@ void FileBasedKeyValueStore::flush() {
   for (const auto& it : store_) {
     file->write(absl::StrCat(it.first.length(), "\n"));
     file->write(it.first);
-    file->write(absl::StrCat(it.second.length(), "\n"));
-    file->write(it.second);
-    auto ttl_it = ttl_store_.find(it.first);
-    if (ttl_it != ttl_store_.end()) {
-      std::string ttl = std::to_string(ttl_it->second.count());
+    file->write(absl::StrCat(it.second.first.length(), "\n"));
+    file->write(it.second.first);
+    if (it.second.second.has_value()) {
+      std::string ttl = std::to_string(it.second.second.value().count());
       file->write("TTL");
       file->write(absl::StrCat(ttl.length(), "\n"));
       file->write(ttl);

--- a/source/extensions/key_value/file_based/config.cc
+++ b/source/extensions/key_value/file_based/config.cc
@@ -38,7 +38,7 @@ void FileBasedKeyValueStore::flush() {
     file->write(it.second.first);
     if (it.second.second.has_value()) {
       std::string ttl = std::to_string(it.second.second.value().count());
-      file->write(TTL_KEY);
+      file->write(KV_STORE_TTL_KEY);
       file->write(absl::StrCat(ttl.length(), "\n"));
       file->write(ttl);
     }

--- a/source/extensions/key_value/file_based/config.cc
+++ b/source/extensions/key_value/file_based/config.cc
@@ -38,7 +38,7 @@ void FileBasedKeyValueStore::flush() {
     file->write(it.second.first);
     if (it.second.second.has_value()) {
       std::string ttl = std::to_string(it.second.second.value().count());
-      file->write("TTL");
+      file->write(TTL_KEY);
       file->write(absl::StrCat(ttl.length(), "\n"));
       file->write(ttl);
     }

--- a/source/extensions/key_value/file_based/config.cc
+++ b/source/extensions/key_value/file_based/config.cc
@@ -36,6 +36,13 @@ void FileBasedKeyValueStore::flush() {
     file->write(it.first);
     file->write(absl::StrCat(it.second.length(), "\n"));
     file->write(it.second);
+    auto ttl_it = ttl_store_.find(it.first);
+    if (ttl_it != ttl_store_.end()) {
+      std::string ttl = std::to_string(ttl_it->second.count());
+      file->write("TTL");
+      file->write(absl::StrCat(ttl.length(), "\n"));
+      file->write(ttl);
+    }
   }
   file->close();
 }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -982,6 +982,8 @@ void ConfigHelper::setPorts(const std::vector<uint32_t>& ports, bool override_po
   auto* static_resources = bootstrap_.mutable_static_resources();
   for (int i = 0; i < bootstrap_.mutable_static_resources()->clusters_size(); ++i) {
     auto* cluster = static_resources->mutable_clusters(i);
+    std::cout << "CLUSTER HERE \n";
+    std::cout << MessageUtil::getYamlStringFromMessage(*cluster);
     if (cluster->type() == envoy::config::cluster::v3::Cluster::EDS) {
       eds_hosts = true;
     } else if (cluster->type() == envoy::config::cluster::v3::Cluster::ORIGINAL_DST) {
@@ -994,9 +996,12 @@ void ConfigHelper::setPorts(const std::vector<uint32_t>& ports, bool override_po
         auto locality_lb = cluster->mutable_load_assignment()->mutable_endpoints(j);
         for (int k = 0; k < locality_lb->lb_endpoints_size(); ++k) {
           auto lb_endpoint = locality_lb->mutable_lb_endpoints(k);
+          std::cout << "WE ARE IN THERE";
           if (lb_endpoint->endpoint().address().has_socket_address()) {
+            std::cout << "1";
             if (lb_endpoint->endpoint().address().socket_address().port_value() == 0 ||
                 override_port_zero) {
+              std::cout << "2";
               RELEASE_ASSERT(ports.size() > port_idx, "");
               lb_endpoint->mutable_endpoint()
                   ->mutable_address()

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -982,8 +982,6 @@ void ConfigHelper::setPorts(const std::vector<uint32_t>& ports, bool override_po
   auto* static_resources = bootstrap_.mutable_static_resources();
   for (int i = 0; i < bootstrap_.mutable_static_resources()->clusters_size(); ++i) {
     auto* cluster = static_resources->mutable_clusters(i);
-    std::cout << "CLUSTER HERE \n";
-    std::cout << MessageUtil::getYamlStringFromMessage(*cluster);
     if (cluster->type() == envoy::config::cluster::v3::Cluster::EDS) {
       eds_hosts = true;
     } else if (cluster->type() == envoy::config::cluster::v3::Cluster::ORIGINAL_DST) {
@@ -996,12 +994,9 @@ void ConfigHelper::setPorts(const std::vector<uint32_t>& ports, bool override_po
         auto locality_lb = cluster->mutable_load_assignment()->mutable_endpoints(j);
         for (int k = 0; k < locality_lb->lb_endpoints_size(); ++k) {
           auto lb_endpoint = locality_lb->mutable_lb_endpoints(k);
-          std::cout << "WE ARE IN THERE";
           if (lb_endpoint->endpoint().address().has_socket_address()) {
-            std::cout << "1";
             if (lb_endpoint->endpoint().address().socket_address().port_value() == 0 ||
                 override_port_zero) {
-              std::cout << "2";
               RELEASE_ASSERT(ports.size() > port_idx, "");
               lb_endpoint->mutable_endpoint()
                   ->mutable_address()

--- a/test/extensions/key_value/file_based/key_value_store_test.cc
+++ b/test/extensions/key_value/file_based/key_value_store_test.cc
@@ -150,10 +150,11 @@ TEST_F(KeyValueStoreTest, Persist) {
 }
 
 TEST_F(KeyValueStoreTest, PersistWithTTL) {
+  test_time_.setSystemTime(std::chrono::milliseconds(0));
   store_->addOrUpdate("foo", "bar", std::chrono::seconds(2));
   store_->addOrUpdate("ee", "ba", std::chrono::seconds(1));
   flush_timer_->invokeCallback(); // flush manually
-  test_time_.setMonotonicTime(std::chrono::milliseconds(1000));
+  test_time_.setSystemTime(std::chrono::milliseconds(1000));
   // Keys should expire based on the absolute time.
   // 'ee' should expire on load because it's been 1 second.
   createStore();

--- a/test/extensions/key_value/file_based/key_value_store_test.cc
+++ b/test/extensions/key_value/file_based/key_value_store_test.cc
@@ -149,6 +149,21 @@ TEST_F(KeyValueStoreTest, Persist) {
   EXPECT_FALSE(store_->get("bar").has_value());
 }
 
+TEST_F(KeyValueStoreTest, PersistWithTTL) {
+  store_->addOrUpdate("foo", "bar", std::chrono::seconds(2));
+  store_->addOrUpdate("ee", "ba", std::chrono::seconds(1));
+  flush_timer_->invokeCallback(); // flush manually
+  test_time_.setSystemTime(std::chrono::milliseconds(1000));
+  // Keys should expire based on the absolute time.
+  // ee should expire on load because it's been 1 second.
+  createStore();
+  EXPECT_EQ("bar", store_->get("foo").value());
+  EXPECT_EQ(absl::nullopt, store_->get("ee"));
+  test_time_.setSystemTime(std::chrono::milliseconds(2000));
+  ttl_timer_->invokeCallback();
+  EXPECT_EQ(absl::nullopt, store_->get("foo"));
+}
+
 TEST_F(KeyValueStoreTest, Iterate) {
   store_->addOrUpdate("foo", "bar", absl::nullopt);
   store_->addOrUpdate("baz", "eep", absl::nullopt);

--- a/test/extensions/key_value/file_based/key_value_store_test.cc
+++ b/test/extensions/key_value/file_based/key_value_store_test.cc
@@ -153,13 +153,13 @@ TEST_F(KeyValueStoreTest, PersistWithTTL) {
   store_->addOrUpdate("foo", "bar", std::chrono::seconds(2));
   store_->addOrUpdate("ee", "ba", std::chrono::seconds(1));
   flush_timer_->invokeCallback(); // flush manually
-  test_time_.setSystemTime(std::chrono::milliseconds(1000));
+  test_time_.setMonotonicTime(std::chrono::milliseconds(1000));
   // Keys should expire based on the absolute time.
   // ee should expire on load because it's been 1 second.
   createStore();
   EXPECT_EQ("bar", store_->get("foo").value());
   EXPECT_EQ(absl::nullopt, store_->get("ee"));
-  test_time_.setSystemTime(std::chrono::milliseconds(2000));
+  test_time_.setMonotonicTime(std::chrono::milliseconds(2000));
   ttl_timer_->invokeCallback();
   EXPECT_EQ(absl::nullopt, store_->get("foo"));
 }

--- a/test/extensions/key_value/file_based/key_value_store_test.cc
+++ b/test/extensions/key_value/file_based/key_value_store_test.cc
@@ -155,7 +155,7 @@ TEST_F(KeyValueStoreTest, PersistWithTTL) {
   flush_timer_->invokeCallback(); // flush manually
   test_time_.setMonotonicTime(std::chrono::milliseconds(1000));
   // Keys should expire based on the absolute time.
-  // ee should expire on load because it's been 1 second.
+  // 'ee' should expire on load because it's been 1 second.
   createStore();
   EXPECT_EQ("bar", store_->get("foo").value());
   EXPECT_EQ(absl::nullopt, store_->get("ee"));


### PR DESCRIPTION
Turns out the TTL functionality I added needs the ability to persist to disk.  Do this by piggybacking on the existing persistence code; writing an optional absolute TTL to disk and then converting it back to relative form for the `ttl_manager` to use.