### PR TITLE
tls: fix error-reporting in doSynchronousVerifyCertChain

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -109,6 +109,9 @@ bug_fixes:
 - area: upstream
   change: |
     fixed a bug where custom transport socket hashes might not be respected by wrapper passthrough sockets. This change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.fix_hash_key`` to false.
+- area: tls
+  change: |
+    fixed a bug where, when runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` is set to false, the wrong TLS alerts would sometimes be sent in response to certificate validation failures.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -209,10 +209,12 @@ int DefaultCertValidator::doSynchronousVerifyCertChain(
       return allow_untrusted_certificate_ ? 1 : ret;
     }
   }
-  return verifyCertAndUpdateStatus(ssl_extended_info, &leaf_cert, transport_socket_options, nullptr,
-                                   nullptr)
-             ? 1
-             : 0;
+  if (!verifyCertAndUpdateStatus(ssl_extended_info, &leaf_cert, transport_socket_options, nullptr,
+                                 nullptr)) {
+    X509_STORE_CTX_set_error(store_ctx, X509_V_ERR_APPLICATION_VERIFICATION);
+    return 0;
+  }
+  return 1;
 }
 
 bool DefaultCertValidator::verifyCertAndUpdateStatus(

--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -180,7 +180,8 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithNoValidationContex
                                                  nullptr),
             Envoy::Ssl::ClientValidationStatus::NotValidated);
   bssl::UniquePtr<X509> cert(X509_new());
-  EXPECT_EQ(default_validator->doSynchronousVerifyCertChain(/*store_ctx=*/nullptr,
+  bssl::UniquePtr<X509_STORE_CTX> store_ctx(X509_STORE_CTX_new());
+  EXPECT_EQ(default_validator->doSynchronousVerifyCertChain(/*store_ctx=*/store_ctx.get(),
                                                             /*ssl_extended_info=*/nullptr,
                                                             /*leaf_cert=*/*cert,
                                                             /*transport_socket_options=*/nullptr),

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -1729,7 +1729,7 @@ TEST_P(SslSocketTest, FailedClientCertAllowExpiredBadHashVerification) {
           .setExpectedTransportFailureReasonContains(
               Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_async_cert_validation")
                   ? "TLSV1.*_BAD_CERTIFICATE_HASH_VALUE"
-                  : "SSLV3_ALERT_CERTIFICATE_EXPIRED"));
+                  : "SSLV3_ALERT_HANDSHAKE_FAILURE"));
 }
 
 // Allow expired certificates, but use the wrong CA so it should fail still.
@@ -2286,7 +2286,7 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationWrongClientCertific
           .setExpectedTransportFailureReasonContains(
               Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_async_cert_validation")
                   ? "TLSV1.*_BAD_CERTIFICATE_HASH_VALUE"
-                  : "SSLV3_ALERT_CERTIFICATE_UNKNOWN"));
+                  : "SSLV3_ALERT_HANDSHAKE_FAILURE"));
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
@@ -2324,7 +2324,7 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationNoCAWrongClientCert
           .setExpectedTransportFailureReasonContains(
               Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_async_cert_validation")
                   ? "TLSV1.*_BAD_CERTIFICATE_HASH_VALUE"
-                  : "SSLV3_ALERT_CERTIFICATE_UNKNOWN"));
+                  : "SSLV3_ALERT_HANDSHAKE_FAILURE"));
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
@@ -2534,7 +2534,7 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationWrongClientC
           .setExpectedTransportFailureReasonContains(
               Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_async_cert_validation")
                   ? "TLSV1.*_BAD_CERTIFICATE_HASH_VALUE"
-                  : "SSLV3_ALERT_CERTIFICATE_UNKNOWN"));
+                  : "SSLV3_ALERT_HANDSHAKE_FAILURE"));
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
@@ -2573,7 +2573,7 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationNoCAWrongCli
           .setExpectedTransportFailureReasonContains(
               Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_async_cert_validation")
                   ? "TLSV1.*_BAD_CERTIFICATE_HASH_VALUE"
-                  : "SSLV3_ALERT_CERTIFICATE_UNKNOWN"));
+                  : "SSLV3_ALERT_HANDSHAKE_FAILURE"));
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);


### PR DESCRIPTION
This PR is a preparatory fix for PR #23320.

The intent was to upload a pair of dependent PRs. I've made them into separate PRs because it looked like you all prefer one commit per PR (since PR descriptions ask for a commit message), and it seemed worth keeping the changes ultimately separate. Let me know if this isn't the preferred workflow.

---

Commit Message:

This fixes a bug in the pre-tls_async_cert_validation codepath. The tls_async_cert_validation codepath is unaffected.

Per both OpenSSL and BoringSSL documentation, if you use SSL_CTX_set_cert_verify_callback, the library expects to find the error code in X509_STORE_CTX. This error determines the TLS alert. X509_verify_cert does this for you, but Envoy's callback was not doing this when doSynchronousVerifyCertChain runs the extra checks in verifyCertAndUpdateStatus. This change fixes this and sets the generic X509_V_ERR_APPLICATION_VERIFICATION.

Before this commit, the error would usually be X509_V_OK, but sometimes it would be something else. Envoy implements the
allow_expired_certificate using the X509_STORE_CTX verify callback, via ignoreCertificateExpirationCallback. This callback, when it suppresses an error, will sometimes leave stray errors in X509_STORE_CTX. These are usually benign, *but* if Envoy then does extra checks, which fail, and then report some *other* failure, it will inadvertantly return the stray error to BoringSSL!

That is why FailedClientCertAllowExpiredBadHashVerification expected a SSLV3_ALERT_CERTIFICATE_EXPIRED alert. The alert makes no sense because the connection sets allow_expired_certificate! Rather, the test actually caught an Envoy bug, but https://github.com/envoyproxy/envoy/pull/6018 mistakenly codified it as expected behavior, rather than correctly diagnosing it as a bug. This commit fixes that bug.

Unfortunately, OpenSSL/BoringSSL map X509_V_ERR_APPLICATION_VERIFICATION to handshake_failure rather than certificate_unknown, so this does change the alert returned by the pre-tls_async_cert_validation codepath in other cases. (certificate_unknown came from X509_V_OK hitting the default in a switch-case.) Arguably certificate_unknown is a better alert than handshake_failure, so I'm slightly inclined to fix BoringSSL to map that differently. But since Envoy needs to support an old BoringSSL, I've just updated the expectations for now. Either way, tls_async_cert_validation gives full control over the alert and will make this moot.

Signed-off-by: David Benjamin <davidben@google.com>

Additional Description:
Risk Level: Low
Testing: `bazelist test //test/extensions/transport_sockets/tls`
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
