### PR TITLE
Thrift: Defer route cache after apply applyDecoderFilters

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -111,6 +111,9 @@ bug_fixes:
 - area: logger
   change: |
     added the %j and %_ format support for fine-grain loggers to make it consistant with default loggers.
+- area: thrift
+  change: |
+    fixed the routing decision when thrift filters change the value of the cluster header.
 - area: router
   change: |
     fixed edge-case interaction between weighted clusters, cluster headers and (request|response)_headers_to_(add|remove).

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -841,6 +841,7 @@ FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr
 
   // Filters could change cluster_header's value, which affect the routing decision.
   // Therefore, we need to apply filter chain before the routing decision is made and cached.
+  // TODO(kuochunghsu): implement FilterCallbacks::clearRouteCache
   auto result = applyDecoderFilters(DecoderEvent::MessageBegin, metadata);
 
   const auto& route_ptr = route();

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -839,6 +839,10 @@ FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr
     ASSERT(upgrade_handler_ != nullptr);
   }
 
+  // Filters could change cluster_header's value, which affect the routing decision.
+  // Therefore, we need to apply filter chain before the routing decision is made ad cached.
+  auto result = applyDecoderFilters(DecoderEvent::MessageBegin, metadata);
+
   const auto& route_ptr = route();
 
   ProtobufWkt::Struct stats_obj;
@@ -863,7 +867,7 @@ FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr
       metadata_->sequenceId(), metadata->hasMethodName() ? metadata->methodName() : "-",
       metadata->hasFrameSize() ? metadata->frameSize() : -1, metadata->requestHeaders());
 
-  return applyDecoderFilters(DecoderEvent::MessageBegin, metadata);
+  return result;
 }
 
 FilterStatus ConnectionManager::ActiveRpc::messageEnd() {

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -840,7 +840,7 @@ FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr
   }
 
   // Filters could change cluster_header's value, which affect the routing decision.
-  // Therefore, we need to apply filter chain before the routing decision is made ad cached.
+  // Therefore, we need to apply filter chain before the routing decision is made and cached.
   auto result = applyDecoderFilters(DecoderEvent::MessageBegin, metadata);
 
   const auto& route_ptr = route();


### PR DESCRIPTION
Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>

Commit Message:

Filters could change cluster_header's value, which affect the routing decision.
Therefore, we need to apply filter chain before the routing decision is made and cached.

Risk Level: low
Testing: unit
