### PR TITLE
Prepends 'envoy_' to the names of QUICHE flags within QUICHE platform.

### DIFF
--- a/source/common/quic/platform/quiche_flags_impl.cc
+++ b/source/common/quic/platform/quiche_flags_impl.cc
@@ -61,7 +61,7 @@ template <> constexpr int32_t maybeOverride<int32_t>(absl::string_view name, int
 } // namespace
 
 // Flag definitions
-#define QUIC_FLAG(flag, value) ABSL_FLAG(bool, flag, maybeOverride(#flag, value), "");
+#define QUIC_FLAG(flag, value) ABSL_FLAG(bool, envoy_##flag, maybeOverride(#flag, value), "");
 #include "quiche/quic/core/quic_flags_list.h"
 QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_false, false)  // NOLINT
 QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_true, true)    // NOLINT
@@ -74,7 +74,7 @@ QUIC_FLAG(quic_restart_flag_http2_testonly_default_true, true)      // NOLINT
 #undef QUIC_FLAG
 
 #define DEFINE_PROTOCOL_FLAG_IMPL(type, flag, value, help)                                         \
-  ABSL_FLAG(type, flag, maybeOverride(#flag, value), help);
+  ABSL_FLAG(type, envoy_##flag, maybeOverride(#flag, value), help);
 
 #define DEFINE_PROTOCOL_FLAG_SINGLE_VALUE(type, flag, value, doc)                                  \
   DEFINE_PROTOCOL_FLAG_IMPL(type, flag, value, doc)
@@ -108,8 +108,8 @@ namespace {
 absl::flat_hash_map<absl::string_view, ReloadableFlag*> makeReloadableFlagMap() {
   absl::flat_hash_map<absl::string_view, ReloadableFlag*> flags;
 
-  ASSERT(absl::GetFlag(FLAGS_quic_restart_flag_quic_testonly_default_true) == true);
-#define QUIC_FLAG(flag, ...) flags.emplace("FLAGS_" #flag, &FLAGS_##flag);
+  ASSERT(absl::GetFlag(FLAGS_envoy_quic_restart_flag_quic_testonly_default_true) == true);
+#define QUIC_FLAG(flag, ...) flags.emplace("FLAGS_envoy_" #flag, &FLAGS_envoy_##flag);
 #include "quiche/quic/core/quic_flags_list.h"
   QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_false, false)
   QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_true, true)

--- a/source/common/quic/platform/quiche_flags_impl.h
+++ b/source/common/quic/platform/quiche_flags_impl.h
@@ -71,7 +71,8 @@ namespace quiche {
 
 #define SetQuicheFlagImpl(flag, value) absl::SetFlag(&FLAGS_envoy_##flag, value)
 
-#define GetQuicheReloadableFlagImpl(module, flag) absl::GetFlag(FLAGS_envoy_quic_reloadable_flag_##flag)
+#define GetQuicheReloadableFlagImpl(module, flag)                                                  \
+  absl::GetFlag(FLAGS_envoy_quic_reloadable_flag_##flag)
 
 #define SetQuicheReloadableFlagImpl(module, flag, value)                                           \
   absl::SetFlag(&FLAGS_envoy_quic_reloadable_flag_##flag, value)

--- a/source/common/quic/platform/quiche_flags_impl.h
+++ b/source/common/quic/platform/quiche_flags_impl.h
@@ -21,7 +21,7 @@
 namespace quiche {
 
 const std::string EnvoyQuicheReloadableFlagPrefix =
-    "envoy.reloadable_features.FLAGS_quic_reloadable_flag_";
+    "envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_";
 const std::string EnvoyFeaturePrefix = "envoy.reloadable_features.";
 
 using ReloadableFlag = absl::Flag<bool>;
@@ -45,7 +45,7 @@ private:
 } // namespace quiche
 
 // Flag declarations
-#define QUIC_FLAG(flag, ...) ABSL_DECLARE_FLAG(bool, flag);
+#define QUIC_FLAG(flag, ...) ABSL_DECLARE_FLAG(bool, envoy_##flag);
 #include "quiche/quic/core/quic_flags_list.h"
 QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_false, false)  // NOLINT
 QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_true, true)    // NOLINT
@@ -57,28 +57,28 @@ QUIC_FLAG(quic_restart_flag_http2_testonly_default_false, false)    // NOLINT
 QUIC_FLAG(quic_restart_flag_http2_testonly_default_true, true)      // NOLINT
 #undef QUIC_FLAG
 
-#define QUIC_PROTOCOL_FLAG(type, flag, ...) ABSL_DECLARE_FLAG(type, flag);
+#define QUIC_PROTOCOL_FLAG(type, flag, ...) ABSL_DECLARE_FLAG(type, envoy_##flag);
 #include "quiche/quic/core/quic_protocol_flags_list.h"
 #undef QUIC_PROTOCOL_FLAG
 
-#define QUICHE_PROTOCOL_FLAG(type, flag, ...) ABSL_DECLARE_FLAG(type, flag);
+#define QUICHE_PROTOCOL_FLAG(type, flag, ...) ABSL_DECLARE_FLAG(type, envoy_##flag);
 #include "quiche/common/quiche_protocol_flags_list.h"
 #undef QUICHE_PROTOCOL_FLAG
 
 namespace quiche {
 
-#define GetQuicheFlagImpl(flag) absl::GetFlag(FLAGS_##flag)
+#define GetQuicheFlagImpl(flag) absl::GetFlag(FLAGS_envoy_##flag)
 
-#define SetQuicheFlagImpl(flag, value) absl::SetFlag(&FLAGS_##flag, value)
+#define SetQuicheFlagImpl(flag, value) absl::SetFlag(&FLAGS_envoy_##flag, value)
 
-#define GetQuicheReloadableFlagImpl(module, flag) absl::GetFlag(FLAGS_quic_reloadable_flag_##flag)
+#define GetQuicheReloadableFlagImpl(module, flag) absl::GetFlag(FLAGS_envoy_quic_reloadable_flag_##flag)
 
 #define SetQuicheReloadableFlagImpl(module, flag, value)                                           \
-  absl::SetFlag(&FLAGS_quic_reloadable_flag_##flag, value)
+  absl::SetFlag(&FLAGS_envoy_quic_reloadable_flag_##flag, value)
 
-#define GetQuicheRestartFlagImpl(module, flag) absl::GetFlag(FLAGS_quic_restart_flag_##flag)
+#define GetQuicheRestartFlagImpl(module, flag) absl::GetFlag(FLAGS_envoy_quic_restart_flag_##flag)
 
 #define SetQuicheRestartFlagImpl(module, flag, value)                                              \
-  absl::SetFlag(&FLAGS_quic_restart_flag_##flag, value)
+  absl::SetFlag(&FLAGS_envoy_quic_restart_flag_##flag, value)
 
 } // namespace quiche

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -157,7 +157,7 @@ bool hasRuntimePrefix(absl::string_view feature) {
   // Track Envoy reloadable and restart features, excluding synthetic QUIC flags
   // which are not tracked in the list below.
   return (absl::StartsWith(feature, "envoy.reloadable_features.") &&
-          !absl::StartsWith(feature, "envoy.reloadable_features.FLAGS_quic")) ||
+          !absl::StartsWith(feature, "envoy.reloadable_features.FLAGS_envoy_quic")) ||
          absl::StartsWith(feature, "envoy.restart_features.");
 }
 

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -454,20 +454,20 @@ TEST_F(QuicPlatformTest, UpdateReloadableFlags) {
 
   // Flip both flags to a non-default value.
   flag_registry.updateReloadableFlags(
-      {{"FLAGS_quic_reloadable_flag_quic_testonly_default_false", true},
-       {"FLAGS_quic_reloadable_flag_quic_testonly_default_true", false}});
+      {{"FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_false", true},
+       {"FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true", false}});
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
 
   // Flip one flag back to a default value.
   flag_registry.updateReloadableFlags(
-      {{"FLAGS_quic_reloadable_flag_quic_testonly_default_false", false}});
+      {{"FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_false", false}});
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
 
   // Flip the other back to a default value.
   flag_registry.updateReloadableFlags(
-      {{"FLAGS_quic_reloadable_flag_quic_testonly_default_true", true}});
+      {{"FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true", true}});
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
 }

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -549,9 +549,9 @@ TEST_F(StaticLoaderImplTest, All) {
 TEST_F(StaticLoaderImplTest, QuicheReloadableFlags) {
   // Test that Quiche flags can be overwritten via Envoy runtime config.
   base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
-    envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_testonly_default_false: true
-    envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_testonly_default_true: false
-    envoy.reloadable_features.FLAGS_quic_reloadable_flag_spdy_testonly_default_false: false
+    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_false: true
+    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: false
+    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_spdy_testonly_default_false: false
   )EOF");
   SetQuicReloadableFlag(spdy_testonly_default_false, true);
   EXPECT_TRUE(GetQuicReloadableFlag(spdy_testonly_default_false));
@@ -562,7 +562,7 @@ TEST_F(StaticLoaderImplTest, QuicheReloadableFlags) {
 
   // Test that Quiche flags can be overwritten again.
   base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
-    envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_testonly_default_true: true
+    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: true
   )EOF");
   setup();
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -509,7 +509,7 @@ TEST_P(QuicHttpIntegrationTest, Draft29NotSupportedByDefault) {
 TEST_P(QuicHttpIntegrationTest, RuntimeEnableDraft29) {
   supported_versions_ = {quic::ParsedQuicVersion::Draft29()};
   config_helper_.addRuntimeOverride(
-      "envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_disable_version_draft_29",
+      "envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_disable_version_draft_29",
       "false");
   initialize();
 


### PR DESCRIPTION
Signed-off-by: Biren Roy <birenroy@google.com>

Since Envoy is only one embedder of the QUICHE library, this will help reduce conflicts if a project has multiple dependencies on QUICHE.

Commit Message: Prepends 'envoy' to the names of QUICHE flags within QUICHE platform.
Additional Description:
Risk Level: low
Testing: ran all tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
