### PR TITLE
gcp_authn: Modify the token time constraint check

### DIFF
--- a/source/extensions/filters/http/gcp_authn/token_cache.h
+++ b/source/extensions/filters/http/gcp_authn/token_cache.h
@@ -32,6 +32,8 @@ public:
   void insert(const std::string& key, std::unique_ptr<TokenType>&& token);
   TokenType* validateTokenAndReturn(const std::string& key, TokenType* const found_token);
 
+  uint64_t capacity() { return lru_cache_.maxSize(); }
+
   ~TokenCacheImpl() {
     // Remove all entries from the cache.
     lru_cache_.clear();

--- a/source/extensions/filters/http/gcp_authn/token_cache.h
+++ b/source/extensions/filters/http/gcp_authn/token_cache.h
@@ -91,6 +91,7 @@ TokenType* TokenCacheImpl<TokenType>::validateTokenAndReturn(const std::string& 
     // Note: verifyTimeConstraint() interface is correct for the token consumer. However, as the
     // token producer here, we should instead include the clock skew as the part of the `now` time
     // up front to account for the clock skew on the consumer side where the token will be consumed.
+    // TODO(tyxia) Add test for token verification. It currently relies on the tests in jwt library.
     if (found_token->verifyTimeConstraint(
             DateUtil::nowToSeconds(time_source_) + ::google::jwt_verify::kClockSkewInSecond,
             /*clock_skew=*/0) == ::google::jwt_verify::Status::JwtExpired) {

--- a/source/extensions/filters/http/gcp_authn/token_cache.h
+++ b/source/extensions/filters/http/gcp_authn/token_cache.h
@@ -86,10 +86,11 @@ TokenType* TokenCacheImpl<TokenType>::validateTokenAndReturn(const std::string& 
                                                              TokenType* const found_token) {
   if constexpr (std::is_same<TokenType, JwtToken>::value) {
     ASSERT(found_token != nullptr);
-    // Verify the validness of the token by checking its expiration time field.
-    // Note: verifyTimeConstraint() interface is correct to be used by token consumer. However, for
-    // the token producer here, we should instead include the clock skew as the part of the current
-    // time up front to account for the clock skew on the consumer side,
+    // Verify the validness of the token by checking its expiration time field. Default clock skew
+    // is one minute and it could be configurable via config if it is needed in the future.
+    // Note: verifyTimeConstraint() interface is correct fo the token consumer. However, as the
+    // token producer here, we should instead include the clock skew as the part of the `now` time
+    // up front to account for the clock skew on the consumer side where the token will be consumed.
     if (found_token->verifyTimeConstraint(
             DateUtil::nowToSeconds(time_source_) + ::google::jwt_verify::kClockSkewInSecond,
             /*clock_skew=*/0) == ::google::jwt_verify::Status::JwtExpired) {

--- a/source/extensions/filters/http/gcp_authn/token_cache.h
+++ b/source/extensions/filters/http/gcp_authn/token_cache.h
@@ -88,7 +88,7 @@ TokenType* TokenCacheImpl<TokenType>::validateTokenAndReturn(const std::string& 
     ASSERT(found_token != nullptr);
     // Verify the validness of the token by checking its expiration time field. Default clock skew
     // is one minute and it could be configurable via config if it is needed in the future.
-    // Note: verifyTimeConstraint() interface is correct fo the token consumer. However, as the
+    // Note: verifyTimeConstraint() interface is correct for the token consumer. However, as the
     // token producer here, we should instead include the clock skew as the part of the `now` time
     // up front to account for the clock skew on the consumer side where the token will be consumed.
     if (found_token->verifyTimeConstraint(

--- a/test/extensions/filters/http/gcp_authn/BUILD
+++ b/test/extensions/filters/http/gcp_authn/BUILD
@@ -70,3 +70,18 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/filters/http/gcp_authn/v3:pkg_cc_proto",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "token_cache_test",
+    srcs = ["token_cache_test.cc"],
+    extension_names = ["envoy.filters.http.gcp_authn"],
+    deps = [
+        "//source/extensions/filters/http/gcp_authn",
+        "//source/extensions/filters/http/gcp_authn:config",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/gcp_authn/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/filters/http/gcp_authn/token_cache_test.cc
+++ b/test/extensions/filters/http/gcp_authn/token_cache_test.cc
@@ -1,0 +1,124 @@
+#include <cstdint>
+#include <memory>
+
+#include "envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.pb.h"
+
+#include "source/common/protobuf/utility.h"
+#include "source/extensions/filters/http/gcp_authn/token_cache.h"
+
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GcpAuthn {
+namespace {
+
+using Server::Configuration::MockFactoryContext;
+using ::testing::NiceMock;
+
+// Good token
+// {"iss":"https://example.com","sub":"test@example.com", "aud":"example_service",
+// "exp":2001001001 - Sun May 29 2033 13:36:41 GMT-0400}
+constexpr absl::string_view GoodTokenStr =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUu"
+    "Y29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImV4cCI6MjAwMTAwMTAwMSwiY"
+    "XVkIjoiZXhhbXBsZV9zZXJ2aWNlIn0.cuui_Syud76B0tqvjESE8IZbX7vzG6xA-M"
+    "Daof1qEFNIoCFT_YQPkseLSUSR2Od3TJcNKk-dKjvUEL1JW3kGnyC1dBx4f3-Xxro"
+    "yL23UbR2eS8TuxO9ZcNCGkjfvH5O4mDb6cVkFHRDEolGhA7XwNiuVgkGJ5Wkrvshi"
+    "h6nqKXcPNaRx9lOaRWg2PkE6ySNoyju7rNfunXYtVxPuUIkl0KMq3WXWRb_cb8a_Z"
+    "EprqSZUzi_ZzzYzqBNVhIJujcNWij7JRra2sXXiSAfKjtxHQoxrX8n4V1ySWJ3_1T"
+    "H_cJcdfS_RKP7YgXRWC0L16PNF5K7iqRqmjKALNe83ZFnFIw";
+
+// Expired token
+// {"iss":"https://example.com","sub":"test@example.com","aud":"example_service",
+// "exp":1205005587 - Sat Mar 08 2008 14:46:27 GMT-0500}
+constexpr absl::string_view ExpiredToken =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUu"
+    "Y29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImV4cCI6MTIwNTAwNTU4NywiY"
+    "XVkIjoiZXhhbXBsZV9zZXJ2aWNlIn0.izDa6aHNgbsbeRzucE0baXIP7SXOrgopYQ"
+    "ALLFAsKq_N0GvOyqpAZA9nwCAhqCkeKWcL-9gbQe3XJa0KN3FPa2NbW4ChenIjmf2"
+    "QYXOuOQaDu9QRTdHEY2Y4mRy6DiTZAsBHWGA71_cLX-rzTSO_8aC8eIqdHo898oJw"
+    "3E8ISKdryYjayb9X3wtF6KLgNomoD9_nqtOkliuLElD8grO0qHKI1xQurGZNaoeyi"
+    "V1AdwgX_5n3SmQTacVN0WcSgk6YJRZG6VE8PjxZP9bEameBmbSB0810giKRpdTU1-"
+    "RJtjq6aCSTD4CYXtW38T5uko4V-S4zifK3BXeituUTebkgoA";
+
+const char DefaultConfig[] = R"EOF(
+    http_uri:
+      uri: "gcp_authn:9000"
+      cluster: gcp_authn
+      timeout:
+        seconds: 5
+    cache_config:
+      cache_size: 100
+  )EOF";
+
+class TokenCacheTest : public testing::Test {
+public:
+  TokenCacheTest() {
+    envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig config;
+    // Initialize the token cache with filter configuration.
+    TestUtility::loadFromYaml(DefaultConfig, config);
+    token_cache_ = std::make_unique<TokenCacheImpl<JwtToken>>(config.cache_config(), time_system_);
+
+    jwt_ = std::make_unique<::google::jwt_verify::Jwt>();
+  }
+
+  NiceMock<MockFactoryContext> context_;
+  std::unique_ptr<TokenCacheImpl<JwtToken>> token_cache_;
+  Event::SimulatedTimeSystem time_system_;
+  std::unique_ptr<::google::jwt_verify::Jwt> jwt_ = nullptr;
+};
+
+TEST_F(TokenCacheTest, ValidToken) {
+  EXPECT_EQ(token_cache_->capacity(), 100);
+  std::string good_token = std::string(GoodTokenStr);
+  ::google::jwt_verify::Status status = jwt_->parseFromString(good_token);
+  EXPECT_TRUE(status == ::google::jwt_verify::Status::Ok);
+  auto* old_jwt = jwt_.get();
+  token_cache_->insert(good_token, std::move(jwt_));
+  auto* found_jwt = token_cache_->lookUp(good_token);
+  EXPECT_TRUE(found_jwt != nullptr);
+  EXPECT_EQ(found_jwt, old_jwt);
+}
+
+TEST_F(TokenCacheTest, ExpiredToken) {
+  std::string expired_token = std::string(ExpiredToken);
+  ::google::jwt_verify::Status status = jwt_->parseFromString(expired_token);
+  EXPECT_TRUE(status == ::google::jwt_verify::Status::Ok);
+  token_cache_->insert(expired_token, std::move(jwt_));
+  auto* found_jwt = token_cache_->lookUp(expired_token);
+  EXPECT_TRUE(found_jwt == nullptr);
+}
+
+// Test the token with the clock skew.
+TEST_F(TokenCacheTest, TokenWithClockSkew) {
+  // Set the time to `Sun May 29 2033 13:35:42 GMT-0400` while the expiration time in the token
+  // is `Sun May 29 2033 13:36:41 GMT-0400`. i.e., set to the time to 1 second later than exp
+  // time.
+  const time_t exp_time = 2001000942;
+  time_system_.setSystemTime(std::chrono::system_clock::from_time_t(exp_time));
+  std::string token = std::string(GoodTokenStr);
+  ::google::jwt_verify::Status status = jwt_->parseFromString(token);
+  EXPECT_TRUE(status == ::google::jwt_verify::Status::Ok);
+  token_cache_->insert(token, std::move(jwt_));
+  auto* found_jwt = token_cache_->lookUp(token);
+  EXPECT_TRUE(found_jwt == nullptr);
+
+  std::unique_ptr<::google::jwt_verify::Jwt> jwt = std::make_unique<::google::jwt_verify::Jwt>();
+  // Set the time to `exp_time - 1s`.
+  time_system_.setSystemTime(std::chrono::system_clock::from_time_t(exp_time - 1));
+  auto* old_jwt = jwt.get();
+  token_cache_->insert(token, std::move(jwt));
+  found_jwt = token_cache_->lookUp(token);
+  EXPECT_TRUE(found_jwt != nullptr);
+  EXPECT_EQ(found_jwt, old_jwt);
+}
+
+} // namespace
+} // namespace GcpAuthn
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -1051,7 +1051,7 @@ yarl==1.8.1 \
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.4.0 \
-    --hash=sha256:a8f6e213b4b0661f590ccf40de95d28a177cd747d098624ad3f69c40287297e9 \
-    --hash=sha256:c2d2709550f15aab6c9110196ea312f468f41cd546bceb24127a1be6fdcaeeb1
+setuptools==65.4.1 \
+    --hash=sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012 \
+    --hash=sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e
     # via -r requirements.in


### PR DESCRIPTION
`VerifyTimeConstraint()` interface is correct for the token consumer. However, as the token producer here, we should instead include the clock skew as the part of the `now` time up front to account for the clock skew on the consumer side where the token will be consumed. Also, in this way, we can avoid changing the third-party library interface `VerifyTimeConstraint()` (which might requires longer turnaround time)

Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

