### PR TITLE
test: fixing access log function

### DIFF
--- a/test/extensions/internal_redirect/redirect_extension_integration_test.cc
+++ b/test/extensions/internal_redirect/redirect_extension_integration_test.cc
@@ -123,14 +123,14 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedByPreviousRout
   redirect_response_.setLocation("http://handle.internal.redirect.max.three.hop/random/path");
   first_request->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   auto second_request = waitForNextStream();
   // Redirect back to the original route.
   redirect_response_.setLocation("http://handle.internal.redirect.no.repeated.target/another/path");
   second_request->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   auto third_request = waitForNextStream();
   // Redirect to the same route as the first redirect. This should fail.
@@ -140,7 +140,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedByPreviousRout
   ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_THAT(waitForAccessLog(access_log_name_, 2),
-              HasSubstr("302 via_upstream test-header-value\n"));
+              HasSubstr("302 via_upstream test-header-value"));
   EXPECT_EQ("302", response->headers().getStatusValue());
   EXPECT_EQ("http://handle.internal.redirect.max.three.hop/yet/another/path",
             response->headers().getLocationValue());
@@ -190,7 +190,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedByAllowListedR
   redirect_response_.setLocation("http://handle.internal.redirect.max.three.hop/random/path");
   first_request->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   auto second_request = waitForNextStream();
   // Redirect back to the original route.
@@ -198,7 +198,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedByAllowListedR
       "http://handle.internal.redirect.only.allow.listed.target/another/path");
   second_request->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   auto third_request = waitForNextStream();
   // Redirect to the non-allow-listed route. This should fail.
@@ -217,7 +217,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedByAllowListedR
       test_server_->counter("http.config_test.passthrough_internal_redirect_predicate")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_THAT(waitForAccessLog(access_log_name_, 2),
-              HasSubstr("302 via_upstream test-header-value\n"));
+              HasSubstr("302 via_upstream test-header-value"));
   EXPECT_EQ("test-header-value",
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }
@@ -260,7 +260,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedBySafeCrossSch
   redirect_response_.setLocation("http://handle.internal.redirect.max.three.hop/random/path");
   first_request->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   auto second_request = waitForNextStream();
   // Redirect back to the original route.
@@ -268,7 +268,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedBySafeCrossSch
       "http://handle.internal.redirect.only.allow.safe.cross.scheme.redirect/another/path");
   second_request->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   auto third_request = waitForNextStream();
   // Redirect to https target. This should fail.
@@ -287,7 +287,7 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedBySafeCrossSch
       test_server_->counter("http.config_test.passthrough_internal_redirect_predicate")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_THAT(waitForAccessLog(access_log_name_, 2),
-              HasSubstr("302 via_upstream test-header-value\n"));
+              HasSubstr("302 via_upstream test-header-value"));
   EXPECT_EQ("test-header-value",
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -239,7 +239,7 @@ TEST_P(FilterIntegrationTest, MissingHeadersLocalReplyWithBody) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready"));
 }
 
 TEST_P(FilterIntegrationTest, MissingHeadersLocalReplyWithBodyBytesCount) {

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -1076,7 +1076,7 @@ TEST_P(MultiplexedIntegrationTest, DEPRECATED_FEATURE_TEST(GrpcRequestTimeoutMix
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("via_upstream\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("via_upstream"));
 }
 
 TEST_P(MultiplexedIntegrationTest, GrpcRequestTimeout) {

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -608,7 +608,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReply) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready"));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyDownstreamBytesCount) {
@@ -675,7 +675,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyWithBody) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid_header_filter_ready"));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, MissingHeadersLocalReplyWithBodyBytesCount) {

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -111,8 +111,7 @@ TEST_P(RedirectIntegrationTest, RedirectNotConfigured) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("302", response->headers().getStatusValue());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
-  EXPECT_THAT(waitForAccessLog(access_log_name_),
-              HasSubstr("302 via_upstream test-header-value\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("302 via_upstream test-header-value"));
   EXPECT_EQ("test-header-value",
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }
@@ -148,8 +147,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectPassedThrough) {
       0,
       test_server_->counter("cluster.cluster_0.upstream_internal_redirect_failed_total")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
-  EXPECT_THAT(waitForAccessLog(access_log_name_),
-              HasSubstr("302 via_upstream test-header-value\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("302 via_upstream test-header-value"));
   EXPECT_EQ("test-header-value",
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }
@@ -175,7 +173,7 @@ TEST_P(RedirectIntegrationTest, BasicInternalRedirect) {
 
   upstream_request_->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   waitForNextUpstreamRequest();
   ASSERT(upstream_request_->headers().EnvoyOriginalUrl() != nullptr);
@@ -196,7 +194,7 @@ TEST_P(RedirectIntegrationTest, BasicInternalRedirect) {
   EXPECT_EQ(0, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
   // No test header
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -"));
 }
 
 TEST_P(RedirectIntegrationTest, BasicInternalRedirectDownstreamBytesCount) {
@@ -333,7 +331,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectWithRequestBody) {
   // Respond with a redirect.
   upstream_request_->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   // Second request to redirected upstream.
   waitForNextUpstreamRequest();
@@ -357,7 +355,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectWithRequestBody) {
   EXPECT_EQ(0, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
   // No test header
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -"));
 }
 
 TEST_P(RedirectIntegrationTest, InternalRedirectHandlesHttp303) {
@@ -392,7 +390,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectHandlesHttp303) {
   redirect_response_.setStatus(303);
   upstream_request_->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("303 internal_redirect test-header-value\n"));
+              HasSubstr("303 internal_redirect test-header-value"));
 
   // Second request to redirected upstream.
   waitForNextUpstreamRequest();
@@ -418,7 +416,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectHandlesHttp303) {
   EXPECT_EQ(0, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
   // No test header
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -"));
 }
 
 TEST_P(RedirectIntegrationTest, InternalRedirectHttp303PreservesHeadMethod) {
@@ -450,7 +448,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectHttp303PreservesHeadMethod) {
   redirect_response_.setStatus(303);
   upstream_request_->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("303 internal_redirect test-header-value\n"));
+              HasSubstr("303 internal_redirect test-header-value"));
 
   // Second request to redirected upstream.
   waitForNextUpstreamRequest();
@@ -475,7 +473,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectHttp303PreservesHeadMethod) {
   EXPECT_EQ(0, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
   // No test header
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -"));
 }
 
 TEST_P(RedirectIntegrationTest, InternalRedirectCancelledDueToBufferOverflow) {
@@ -586,10 +584,10 @@ TEST_P(RedirectIntegrationTest, InternalRedirectWithThreeHopLimit) {
     upstream_requests.back()->encodeHeaders(redirect_response_, true);
     if (i != 3) {
       EXPECT_THAT(waitForAccessLog(access_log_name_, i),
-                  HasSubstr("302 internal_redirect test-header-value\n"));
+                  HasSubstr("302 internal_redirect test-header-value"));
     } else {
       EXPECT_THAT(waitForAccessLog(access_log_name_, i),
-                  HasSubstr("302 via_upstream test-header-value\n"));
+                  HasSubstr("302 via_upstream test-header-value"));
     }
   }
 
@@ -627,7 +625,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectToDestinationWithResponseBody) {
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(redirect_response_, true);
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
 
   waitForNextUpstreamRequest();
   ASSERT(upstream_request_->headers().EnvoyOriginalUrl() != nullptr);
@@ -651,7 +649,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectToDestinationWithResponseBody) {
   EXPECT_EQ(0, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
   // No test header
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("200 via_upstream -"));
 }
 
 TEST_P(RedirectIntegrationTest, InvalidRedirect) {
@@ -670,8 +668,7 @@ TEST_P(RedirectIntegrationTest, InvalidRedirect) {
       1,
       test_server_->counter("cluster.cluster_0.upstream_internal_redirect_failed_total")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
-  EXPECT_THAT(waitForAccessLog(access_log_name_),
-              HasSubstr("302 via_upstream test-header-value\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("302 via_upstream test-header-value"));
   EXPECT_EQ("test-header-value",
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }
@@ -704,9 +701,9 @@ TEST_P(RedirectIntegrationTest, InternalRedirectHandledByDirectResponse) {
   EXPECT_EQ(0, test_server_->counter("http.config_test.downstream_rq_3xx")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
   EXPECT_THAT(waitForAccessLog(access_log_name_, 0, true),
-              HasSubstr("302 internal_redirect test-header-value\n"));
+              HasSubstr("302 internal_redirect test-header-value"));
   // No test header
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("204 direct_response -\n"));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("204 direct_response -"));
 }
 
 INSTANTIATE_TEST_SUITE_P(Protocols, RedirectIntegrationTest,

--- a/test/integration/upstream_filter_state_integration_test.cc
+++ b/test/integration/upstream_filter_state_integration_test.cc
@@ -145,7 +145,7 @@ TEST_P(UpstreamAccessLogTest, UpstreamFilterState) {
         envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
         access_log_config.set_path(log_file);
         access_log_config.mutable_log_format()->mutable_text_format_source()->set_inline_string(
-            "%UPSTREAM_FILTER_STATE(test_key)%");
+            "%UPSTREAM_FILTER_STATE(test_key)%\n");
         upstream_log_config->mutable_typed_config()->PackFrom(access_log_config);
         typed_config->PackFrom(router_config);
       });


### PR DESCRIPTION
the test access log function doesn't truncate logs.  Fixing this.
And also removing the trailing \n (which requires test fix ups and I can revert this part if it feels too toily)
