### PR TITLE
Improve logs for resuming xds

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -201,11 +201,12 @@ ScopedResume GrpcMuxImpl::pause(const std::vector<std::string> type_urls) {
   return std::make_unique<Cleanup>([this, type_urls]() {
     for (const auto& type_url : type_urls) {
       ApiState& api_state = apiStateFor(type_url);
-      ENVOY_LOG(debug, "Resuming discovery requests for {} (previous count {})", type_url,
-                api_state.pauses_);
+      ENVOY_LOG(debug, "Decreasing pause count on discovery requests for {} (previous count {})",
+                type_url, api_state.pauses_);
       ASSERT(api_state.paused());
 
       if (--api_state.pauses_ == 0 && api_state.pending_ && api_state.subscribed_) {
+        ENVOY_LOG(debug, "Resuming discovery requests for {}", type_url);
         queueDiscoveryRequest(type_url);
         api_state.pending_ = false;
       }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Improve logging while resuming xds to indicate clearly when it is actually resuming the xds 
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
