### PR TITLE
http conn man: fix memory leak with watermark buffer

### DIFF
--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -354,6 +354,11 @@ public:
   virtual void setFlushTimeout(std::chrono::milliseconds timeout) PURE;
 
   /**
+   * @return the account, if any, used by this stream.
+   */
+  virtual Buffer::BufferMemoryAccountSharedPtr account() const PURE;
+
+  /**
    * Sets the account for this stream, propagating it to all of its buffers.
    * @param the account to assign this stream.
    */

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1766,6 +1766,11 @@ void ConnectionManagerImpl::ActiveStream::recreateStream(
   // Make sure to not check for deferred close as we'll be immediately creating a new stream.
   connection_manager_.doEndStream(*this, /*check_for_deferred_close*/ false);
 
+  auto oldAccount = response_encoder->getStream().account();
+  if (oldAccount != nullptr) {
+    oldAccount->clearDownstream();
+  }
+
   RequestDecoder& new_stream = connection_manager_.newStream(*response_encoder, true);
   // We don't need to copy over the old parent FilterState from the old StreamInfo if it did not
   // store any objects with a LifeSpan at or above DownstreamRequest. This is to avoid unnecessary

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -69,6 +69,8 @@ public:
     // require a flush timeout not already covered by other timeouts.
   }
 
+  Buffer::BufferMemoryAccountSharedPtr account() const override { return buffer_memory_account_; }
+
   void setAccount(Buffer::BufferMemoryAccountSharedPtr account) override {
     // TODO(kbaichoo): implement account tracking for H1. Particularly, binding
     // the account to the buffers used. The current wiring is minimal, and used

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -270,6 +270,7 @@ protected:
       return parent_.connection_.connectionInfoProvider();
     }
     absl::string_view responseDetails() override { return details_; }
+    Buffer::BufferMemoryAccountSharedPtr account() const override { return buffer_memory_account_; }
     void setAccount(Buffer::BufferMemoryAccountSharedPtr account) override;
 
     // ScopeTrackedObject

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -82,6 +82,8 @@ public:
     return connection()->connectionInfoProvider();
   }
 
+  Buffer::BufferMemoryAccountSharedPtr account() const override { return buffer_memory_account_; }
+
   void setAccount(Buffer::BufferMemoryAccountSharedPtr account) override {
     buffer_memory_account_ = account;
   }

--- a/test/integration/buffer_accounting_integration_test.cc
+++ b/test/integration/buffer_accounting_integration_test.cc
@@ -270,15 +270,55 @@ TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirect) {
   ASSERT_TRUE(response->complete());
 
   if (streamBufferAccounting()) {
-    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(2)) << printAccounts();
-  } else {
-    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(0));
-  }
-
-  if (streamBufferAccounting()) {
-    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 2);
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 1) << printAccounts();
+    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(1)) << printAccounts();
   } else {
     EXPECT_EQ(buffer_factory_->numAccountsCreated(), 0);
+    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(0));
+  }
+}
+
+TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirectWithRequestBody) {
+  Http::TestResponseHeaderMapImpl redirect_response_{
+      {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
+
+  auto handle = config_helper_.createVirtualHost("handle.internal.redirect");
+  handle.mutable_routes(0)->set_name("redirect");
+  handle.mutable_routes(0)->mutable_route()->mutable_internal_redirect_policy();
+  config_helper_.addVirtualHost(handle);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  default_request_headers_.setHost("handle.internal.redirect");
+  default_request_headers_.setMethod("POST");
+
+  const std::string& request_body = "foobarbizbaz";
+  buffer_factory_->setExpectedAccountBalance(request_body.size(), 1);
+
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeRequestWithBody(default_request_headers_, request_body);
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(redirect_response_, true);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+
+  if (streamBufferAccounting()) {
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 1) << printAccounts();
+    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(1)) << printAccounts();
+    EXPECT_TRUE(
+        buffer_factory_->waitForExpectedAccountBalanceWithTimeout(TestUtility::DefaultTimeout))
+        << "buffer total: " << buffer_factory_->totalBufferSize()
+        << " buffer max: " << buffer_factory_->maxBufferSize() << printAccounts();
+  } else {
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 0);
+    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(0));
   }
 }
 

--- a/test/integration/buffer_accounting_integration_test.cc
+++ b/test/integration/buffer_accounting_integration_test.cc
@@ -237,6 +237,51 @@ TEST_P(Http2BufferWatermarksTest, ShouldCreateFourBuffersPerAccount) {
   EXPECT_TRUE(buffer_factory_->waitUntilExpectedNumberOfAccountsAndBoundBuffers(0, 0));
 }
 
+TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirect) {
+  Http::TestResponseHeaderMapImpl redirect_response_{
+      {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
+
+  auto handle = config_helper_.createVirtualHost("handle.internal.redirect");
+  handle.mutable_routes(0)->set_name("redirect");
+  handle.mutable_routes(0)->mutable_route()->mutable_internal_redirect_policy();
+  config_helper_.addVirtualHost(handle);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  default_request_headers_.setHost("handle.internal.redirect");
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  waitForNextUpstreamRequest();
+
+  if (streamBufferAccounting()) {
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 1);
+  } else {
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 0);
+  }
+
+  upstream_request_->encodeHeaders(redirect_response_, true);
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+
+  if (streamBufferAccounting()) {
+    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(2)) << printAccounts();
+  } else {
+    EXPECT_TRUE(buffer_factory_->waitForExpectedAccountUnregistered(0));
+  }
+
+  if (streamBufferAccounting()) {
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 2);
+  } else {
+    EXPECT_EQ(buffer_factory_->numAccountsCreated(), 0);
+  }
+}
+
 TEST_P(Http2BufferWatermarksTest, ShouldTrackAllocatedBytesToUpstream) {
   const int num_requests = 5;
   const uint32_t request_body_size = 4096;

--- a/test/integration/buffer_accounting_integration_test.cc
+++ b/test/integration/buffer_accounting_integration_test.cc
@@ -238,7 +238,7 @@ TEST_P(Http2BufferWatermarksTest, ShouldCreateFourBuffersPerAccount) {
 }
 
 TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirect) {
-  Http::TestResponseHeaderMapImpl redirect_response_{
+  const Http::TestResponseHeaderMapImpl redirect_response{
       {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
 
   auto handle = config_helper_.createVirtualHost("handle.internal.redirect");
@@ -261,7 +261,7 @@ TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirect) {
     EXPECT_EQ(buffer_factory_->numAccountsCreated(), 0);
   }
 
-  upstream_request_->encodeHeaders(redirect_response_, true);
+  upstream_request_->encodeHeaders(redirect_response, true);
   waitForNextUpstreamRequest();
 
   upstream_request_->encodeHeaders(default_response_headers_, true);
@@ -279,7 +279,7 @@ TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirect) {
 }
 
 TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirectWithRequestBody) {
-  Http::TestResponseHeaderMapImpl redirect_response_{
+  const Http::TestResponseHeaderMapImpl redirect_response{
       {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
 
   auto handle = config_helper_.createVirtualHost("handle.internal.redirect");
@@ -293,14 +293,14 @@ TEST_P(Http2BufferWatermarksTest, AccountsAndInternalRedirectWithRequestBody) {
   default_request_headers_.setHost("handle.internal.redirect");
   default_request_headers_.setMethod("POST");
 
-  const std::string& request_body = "foobarbizbaz";
+  const std::string request_body = "foobarbizbaz";
   buffer_factory_->setExpectedAccountBalance(request_body.size(), 1);
 
   IntegrationStreamDecoderPtr response =
       codec_client_->makeRequestWithBody(default_request_headers_, request_body);
 
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(redirect_response_, true);
+  upstream_request_->encodeHeaders(redirect_response, true);
 
   waitForNextUpstreamRequest();
 

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -23,6 +23,7 @@ public:
   MOCK_METHOD(uint32_t, bufferLimit, (), (const));
   MOCK_METHOD(const Network::ConnectionInfoProvider&, connectionInfoProvider, ());
   MOCK_METHOD(void, setFlushTimeout, (std::chrono::milliseconds timeout));
+  MOCK_METHOD(Buffer::BufferMemoryAccountSharedPtr, account, (), (const));
   MOCK_METHOD(void, setAccount, (Buffer::BufferMemoryAccountSharedPtr));
 
   // Use the same underlying structure as StreamCallbackHelper to insure iteration stability


### PR DESCRIPTION
Fix memory leak with stream recreated when watermark buffer tracking enabled.

Do not create a new memory account for the recreated stream in ConnectionManagerImpl::ActiveStream::recreateStream.
Re-use an account from the old stream.

Risk Level: low
Testing: integration
