### PR TITLE
[Not for upstream] Envoy support for k8s IAM Roles for Service Accounts (IRSA)

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -276,11 +276,9 @@ envoy_cmake(
         "ENABLE_ARES": "on",
         "CARES_LIBRARY": "$EXT_BUILD_DEPS/ares",
         "CARES_INCLUDE_DIR": "$EXT_BUILD_DEPS/ares/include",
-        # SSL (via Envoy's SSL dependency) is disabled, curl's CMake uses
-        # FindOpenSSL.cmake which fails at what looks like version parsing
-        # (the libraries are found ok).
+        # SSL.
         "CURL_CA_PATH": "none",
-        "CURL_USE_OPENSSL": "off",
+        "CURL_USE_OPENSSL": "on",
         "OPENSSL_ROOT_DIR": "$EXT_BUILD_DEPS",
         # Avoid libidn2
         "USE_LIBIDN2": "off",

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -594,3 +594,19 @@ envoy_cmake(
     }),
     working_directory = "build/cmake",
 )
+
+envoy_cmake(
+    name = "tinyxml2",
+    cache_entries = {
+        "BUILD_SHARED_LIBS": "off",
+        "BUILD_STATIC_LIBS": "on",
+        "BUILD_TESTS": "off",
+        "CMAKE_CXX_COMPILER_FORCED": "on",
+        "CMAKE_INSTALL_LIBDIR": "lib",
+    },
+    lib_source = "@com_github_leethomason_tinyxml2//:all",
+    out_static_libs = select({
+        "//bazel:windows_x86_64": ["tinyxml2.lib"],
+        "//conditions:default": ["libtinyxml2.a"],
+    }),
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -197,6 +197,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_tencent_rapidjson()
     _com_github_nlohmann_json()
     _com_github_ncopa_suexec()
+    _com_github_leethomason_tinyxml2()
     _com_google_absl()
     _com_google_googletest()
     _com_google_protobuf()
@@ -611,6 +612,16 @@ def _com_github_nlohmann_json():
     native.bind(
         name = "json",
         actual = "@com_github_nlohmann_json//:json",
+    )
+
+def _com_github_leethomason_tinyxml2():
+    external_http_archive(
+        name = "com_github_leethomason_tinyxml2",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.bind(
+        name = "tinyxml2",
+        actual = "@envoy//bazel/foreign_cc:tinyxml2",
     )
 
 def _com_github_nodejs_http_parser():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -825,6 +825,20 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "MIT",
         license_url = "https://github.com/ncopa/su-exec/blob/{version}/LICENSE",
     ),
+    com_github_leethomason_tinyxml2 = dict(
+        project_name = "TinyXML-2",
+        project_desc = "Simple, small, efficient, C++ XML parser that can be easily integrated into other programs.",
+        project_url = "https://github.com/leethomason/tinyxml2",
+        version = "9.0.0",
+        sha256 = "cc2f1417c308b1f6acc54f88eb70771a0bf65f76282ce5c40e54cfe52952702c",
+        strip_prefix = "tinyxml2-9.0.0",
+        urls = ["https://github.com/leethomason/tinyxml2/archive/9.0.0.tar.gz"],
+        use_category = ["dataplane_ext"],
+        # TODO: Verify & update the extensions
+        extensions = ["envoy.grpc_credentials.aws_iam"],
+        release_date = "2021-06-06",
+        cpe = "cpe:2.3:a:tinyxml2_project:tinyxml2:*",
+    ),
     com_google_googletest = dict(
         project_name = "Google Test",
         project_desc = "Google's C++ test framework",

--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -29,7 +29,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/crypto:utility_lib",
-        "//source/common/http:headers_lib",
+        "//source/common/http:message_lib",
         "//source/common/singleton:const_singleton",
     ],
 )
@@ -44,9 +44,13 @@ envoy_cc_library(
     name = "credentials_provider_impl_lib",
     srcs = ["credentials_provider_impl.cc"],
     hdrs = ["credentials_provider_impl.h"],
-    external_deps = ["abseil_time"],
+    external_deps = [
+        "abseil_time",
+        "tinyxml2",
+    ],
     deps = [
         ":credentials_provider_interface",
+        ":utility_lib",
         "//envoy/api:api_interface",
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",
@@ -65,6 +69,7 @@ envoy_cc_library(
         "//source/common/common:matchers_lib",
         "//source/common/common:utility_lib",
         "//source/common/http:headers_lib",
+        "//envoy/http:message_interface",
     ],
 )
 

--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -29,7 +29,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/crypto:utility_lib",
-        "//source/common/http:message_lib",
+        "//source/common/http:headers_lib",
         "//source/common/singleton:const_singleton",
     ],
 )
@@ -47,7 +47,6 @@ envoy_cc_library(
     external_deps = ["abseil_time"],
     deps = [
         ":credentials_provider_interface",
-        ":utility_lib",
         "//envoy/api:api_interface",
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",
@@ -62,7 +61,6 @@ envoy_cc_library(
     hdrs = ["utility.h"],
     external_deps = ["curl"],
     deps = [
-        "//envoy/http:message_interface",
         "//source/common/common:empty_string",
         "//source/common/common:matchers_lib",
         "//source/common/common:utility_lib",

--- a/source/extensions/common/aws/credentials_provider.h
+++ b/source/extensions/common/aws/credentials_provider.h
@@ -21,10 +21,9 @@ namespace Aws {
  */
 class Credentials {
 public:
-  explicit Credentials(absl::string_view access_key_id = absl::string_view(),
-                       absl::string_view secret_access_key = absl::string_view(),
-                       absl::string_view session_token = absl::string_view()) {
-    // TODO(suniltheta): Move credential expiration date in here
+  Credentials(absl::string_view access_key_id = absl::string_view(),
+              absl::string_view secret_access_key = absl::string_view(),
+              absl::string_view session_token = absl::string_view()) {
     if (!access_key_id.empty()) {
       access_key_id_ = std::string(access_key_id);
       if (!secret_access_key.empty()) {

--- a/source/extensions/common/aws/credentials_provider.h
+++ b/source/extensions/common/aws/credentials_provider.h
@@ -21,9 +21,10 @@ namespace Aws {
  */
 class Credentials {
 public:
-  Credentials(absl::string_view access_key_id = absl::string_view(),
-              absl::string_view secret_access_key = absl::string_view(),
-              absl::string_view session_token = absl::string_view()) {
+  explicit Credentials(absl::string_view access_key_id = absl::string_view(),
+                       absl::string_view secret_access_key = absl::string_view(),
+                       absl::string_view session_token = absl::string_view()) {
+    // TODO(lavignes): Move credential expiration date in here
     if (!access_key_id.empty()) {
       access_key_id_ = std::string(access_key_id);
       if (!secret_access_key.empty()) {

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -3,8 +3,13 @@
 #include "envoy/common/exception.h"
 
 #include "source/common/common/lock_guard.h"
+#include "source/common/http/message_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/json/json_loader.h"
+
+#include "source/extensions/common/aws/utility.h"
+
+#include "tinyxml2.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -17,11 +22,19 @@ constexpr char AWS_ACCESS_KEY_ID[] = "AWS_ACCESS_KEY_ID";
 constexpr char AWS_SECRET_ACCESS_KEY[] = "AWS_SECRET_ACCESS_KEY";
 constexpr char AWS_SESSION_TOKEN[] = "AWS_SESSION_TOKEN";
 
+constexpr char AWS_ROLE_ARN[] = "AWS_ROLE_ARN";
+constexpr char AWS_WEB_IDENTITY_TOKEN_FILE[] = "AWS_WEB_IDENTITY_TOKEN_FILE";
+constexpr char AWS_ROLE_SESSION_NAME[] = "AWS_ROLE_SESSION_NAME";
+
+constexpr char WEB_IDENTITY_RESULT_ELEMENT[] = "AssumeRoleWithWebIdentityResult";
+constexpr char CREDENTIALS[] = "Credentials";
 constexpr char ACCESS_KEY_ID[] = "AccessKeyId";
 constexpr char SECRET_ACCESS_KEY[] = "SecretAccessKey";
 constexpr char TOKEN[] = "Token";
+constexpr char SESSION_TOKEN[] = "SessionToken";
 constexpr char EXPIRATION[] = "Expiration";
 constexpr char EXPIRATION_FORMAT[] = "%E4Y%m%dT%H%M%S%z";
+constexpr char STS_EXPIRATION_FORMAT[] = "%E4Y-%m-%dT%H:%M:%S%z";
 constexpr char TRUE[] = "true";
 
 constexpr char AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
@@ -71,8 +84,12 @@ void InstanceProfileCredentialsProvider::refresh() {
   ENVOY_LOG(debug, "Getting AWS credentials from the instance metadata");
 
   // First discover the Role of this instance
-  const auto instance_role_string =
-      metadata_fetcher_(EC2_METADATA_HOST, SECURITY_CREDENTIALS_PATH, "");
+  Http::RequestMessageImpl message;
+  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
+  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
+  message.headers().setHost(EC2_METADATA_HOST);
+  message.headers().setPath(SECURITY_CREDENTIALS_PATH);
+  const auto instance_role_string = metadata_fetcher_(message);
   if (!instance_role_string) {
     ENVOY_LOG(error, "Could not retrieve credentials listing from the instance metadata");
     return;
@@ -94,7 +111,8 @@ void InstanceProfileCredentialsProvider::refresh() {
   ENVOY_LOG(debug, "AWS credentials path: {}", credential_path);
 
   // Then fetch and parse the credentials
-  const auto credential_document = metadata_fetcher_(EC2_METADATA_HOST, credential_path, "");
+  message.headers().setPath(credential_path);
+  const auto credential_document = metadata_fetcher_(message);
   if (!credential_document) {
     ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
     return;
@@ -133,9 +151,14 @@ void TaskRoleCredentialsProvider::refresh() {
   absl::string_view host;
   absl::string_view path;
   Http::Utility::extractHostPathFromUri(credential_uri_, host, path);
-  const auto credential_document =
-      metadata_fetcher_(std::string(host.data(), host.size()),
-                        std::string(path.data(), path.size()), authorization_token_);
+
+  Http::RequestMessageImpl message;
+  message.headers().setScheme(Http::Headers::get().SchemeValues.Http);
+  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
+  message.headers().setHost(host);
+  message.headers().setPath(path);
+  message.headers().setCopy(Http::CustomHeaders::get().Authorization, authorization_token_);
+  const auto credential_document = metadata_fetcher_(message);
   if (!credential_document) {
     ENVOY_LOG(error, "Could not load AWS credentials document from the task role");
     return;
@@ -171,6 +194,99 @@ void TaskRoleCredentialsProvider::refresh() {
   cached_credentials_ = Credentials(access_key_id, secret_access_key, session_token);
 }
 
+bool WebIdentityCredentialsProvider::needsRefresh() {
+  const auto now = api_.timeSource().systemTime();
+  return (now - last_updated_ > REFRESH_INTERVAL) ||
+         (expiration_time_ - now < REFRESH_GRACE_PERIOD);
+}
+
+void WebIdentityCredentialsProvider::refresh() {
+  ENVOY_LOG(debug, "Getting AWS web identity credentials from STS: {}", sts_endpoint_);
+
+  const auto web_token = api_.fileSystem().fileReadToEnd(token_file_path_);
+
+  Http::RequestMessageImpl message;
+  message.headers().setScheme(Http::Headers::get().SchemeValues.Https);
+  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
+  message.headers().setHost(sts_endpoint_);
+  message.headers().setPath(
+      fmt::format("/?Action=AssumeRoleWithWebIdentity"
+                  "&Version=2011-06-15"
+                  "&RoleSessionName={}"
+                  "&RoleArn={}"
+                  "&WebIdentityToken={}",
+                  Envoy::Http::Utility::PercentEncoding::encode(role_session_name_),
+                  Envoy::Http::Utility::PercentEncoding::encode(role_arn_),
+                  Envoy::Http::Utility::PercentEncoding::encode(web_token)));
+
+  const auto credential_document = metadata_fetcher_(message);
+  if (!credential_document) {
+    ENVOY_LOG(error, "Could not load AWS credentials document from STS");
+    return;
+  }
+
+  tinyxml2::XMLDocument document_xml;
+  if (document_xml.Parse(credential_document->c_str()) != tinyxml2::XML_SUCCESS) {
+    ENVOY_LOG(error, "Could not parse AWS credentials document from STS: {}",
+              document_xml.ErrorStr());
+    return;
+  }
+
+  const auto* root = document_xml.RootElement();
+  if (root == nullptr) {
+    ENVOY_LOG(error, "AWS STS credentials document is empty");
+    return;
+  }
+
+  const tinyxml2::XMLElement* result_element = root;
+  // The result may be wrapped in another container, so recurse one level just in case.
+  if (absl::string_view(root->Name()) != WEB_IDENTITY_RESULT_ELEMENT) {
+    result_element = root->FirstChildElement(WEB_IDENTITY_RESULT_ELEMENT);
+  }
+
+  if (result_element == nullptr) {
+    ENVOY_LOG(error, "AWS STS returned an unexpected result");
+    return;
+  }
+
+  const auto credentials = result_element->FirstChildElement(CREDENTIALS);
+  if (credentials == nullptr) {
+    ENVOY_LOG(error, "AWS STS credentials document does not contain any credentials");
+    return;
+  }
+
+  const auto access_key_id_element = credentials->FirstChildElement(ACCESS_KEY_ID);
+  const std::string access_key_id =
+      access_key_id_element == nullptr ? "" : access_key_id_element->GetText();
+
+  const auto secret_access_key_element = credentials->FirstChildElement(SECRET_ACCESS_KEY);
+  const std::string secret_access_key =
+      secret_access_key_element == nullptr ? "" : secret_access_key_element->GetText();
+
+  const auto session_token_element = credentials->FirstChildElement(SESSION_TOKEN);
+  const std::string session_token =
+      session_token_element == nullptr ? "" : session_token_element->GetText();
+
+  ENVOY_LOG(debug, "Received the following AWS credentials from STS: {}={}, {}={}, {}={}",
+            AWS_ACCESS_KEY_ID, access_key_id, AWS_SECRET_ACCESS_KEY,
+            secret_access_key.empty() ? "" : "*****", AWS_SESSION_TOKEN,
+            session_token.empty() ? "" : "*****");
+
+  const auto expiration_element = credentials->FirstChildElement(EXPIRATION);
+  const std::string expiration_str =
+      expiration_element == nullptr ? "" : expiration_element->GetText();
+  if (!expiration_str.empty()) {
+    absl::Time expiration_time;
+    if (absl::ParseTime(STS_EXPIRATION_FORMAT, expiration_str, &expiration_time, nullptr)) {
+      ENVOY_LOG(debug, "AWS STS credentials expiration time: {}", expiration_str);
+      expiration_time_ = absl::ToChronoTime(expiration_time);
+    }
+  }
+
+  last_updated_ = api_.timeSource().systemTime();
+  cached_credentials_ = Credentials(access_key_id, secret_access_key, session_token);
+}
+
 Credentials CredentialsProviderChain::getCredentials() {
   for (auto& provider : providers_) {
     const auto credentials = provider->getCredentials();
@@ -184,10 +300,34 @@ Credentials CredentialsProviderChain::getCredentials() {
 }
 
 DefaultCredentialsProviderChain::DefaultCredentialsProviderChain(
-    Api::Api& api, const MetadataCredentialsProviderBase::MetadataFetcher& metadata_fetcher,
+    Api::Api& api, absl::string_view region,
+    const MetadataCredentialsProviderBase::MetadataFetcher& metadata_fetcher,
     const CredentialsProviderChainFactories& factories) {
   ENVOY_LOG(debug, "Using environment credentials provider");
   add(factories.createEnvironmentCredentialsProvider());
+
+  const auto web_token_path = absl::NullSafeStringView(std::getenv(AWS_WEB_IDENTITY_TOKEN_FILE));
+  const auto role_arn = absl::NullSafeStringView(std::getenv(AWS_ROLE_ARN));
+  if (!web_token_path.empty() && !role_arn.empty()) {
+    const auto role_session_name = absl::NullSafeStringView(std::getenv(AWS_ROLE_SESSION_NAME));
+    std::string actual_session_name;
+    if (!role_session_name.empty()) {
+      actual_session_name = std::string(role_session_name);
+    } else {
+      // In practice, this value will be provided by the environment, so the placeholder value is
+      // not important. Some AWS SDKs use time in nanoseconds, so we'll just use that.
+      const auto now_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                 api.timeSource().systemTime().time_since_epoch())
+                                 .count();
+      actual_session_name = fmt::format("{}", now_nanos);
+    }
+    const auto sts_endpoint = Utility::getSTSEndpoint(region);
+    ENVOY_LOG(debug,
+              "Using web identity credentials provider with STS endpoint: {} and session name: {}",
+              sts_endpoint, actual_session_name);
+    add(factories.createWebIdentityCredentialsProvider(
+        api, metadata_fetcher, web_token_path, sts_endpoint, role_arn, actual_session_name));
+  }
 
   const auto relative_uri =
       absl::NullSafeStringView(std::getenv(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI));

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -3,10 +3,8 @@
 #include "envoy/common/exception.h"
 
 #include "source/common/common/lock_guard.h"
-#include "source/common/http/message_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/json/json_loader.h"
-#include "source/extensions/common/aws/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -73,29 +71,20 @@ void InstanceProfileCredentialsProvider::refresh() {
   ENVOY_LOG(debug, "Getting AWS credentials from the instance metadata");
 
   // First discover the Role of this instance
-  Http::RequestMessageImpl message;
-  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
-  message.headers().setHost(EC2_METADATA_HOST);
-  message.headers().setPath(SECURITY_CREDENTIALS_PATH);
-  const auto instance_role_string = metadata_fetcher_(message);
+  const auto instance_role_string =
+      metadata_fetcher_(EC2_METADATA_HOST, SECURITY_CREDENTIALS_PATH, "");
   if (!instance_role_string) {
     ENVOY_LOG(error, "Could not retrieve credentials listing from the instance metadata");
     return;
   }
-  fetchCredentialFromInstanceRole(instance_role_string.value());
-}
 
-void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
-    const std::string& instance_role) {
-  if (instance_role.empty()) {
-    return;
-  }
-  const auto instance_role_list = StringUtil::splitToken(StringUtil::trim(instance_role), "\n");
+  const auto instance_role_list =
+      StringUtil::splitToken(StringUtil::trim(instance_role_string.value()), "\n");
   if (instance_role_list.empty()) {
     ENVOY_LOG(error, "No AWS credentials were found in the instance metadata");
     return;
   }
-  ENVOY_LOG(debug, "AWS credentials list:\n{}", instance_role);
+  ENVOY_LOG(debug, "AWS credentials list:\n{}", instance_role_string.value());
 
   // Only one Role can be associated with an instance:
   // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
@@ -105,27 +94,15 @@ void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
   ENVOY_LOG(debug, "AWS credentials path: {}", credential_path);
 
   // Then fetch and parse the credentials
-  Http::RequestMessageImpl message;
-  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
-  message.headers().setHost(EC2_METADATA_HOST);
-  message.headers().setPath(credential_path);
-
-  const auto credential_document = metadata_fetcher_(message);
+  const auto credential_document = metadata_fetcher_(EC2_METADATA_HOST, credential_path, "");
   if (!credential_document) {
     ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
     return;
   }
-  extractCredentials(credential_document.value());
-}
 
-void InstanceProfileCredentialsProvider::extractCredentials(
-    const std::string& credential_document_value) {
-  if (credential_document_value.empty()) {
-    return;
-  }
   Json::ObjectSharedPtr document_json;
   try {
-    document_json = Json::Factory::loadFromString(credential_document_value);
+    document_json = Json::Factory::loadFromString(credential_document.value());
   } catch (EnvoyException& e) {
     ENVOY_LOG(error, "Could not parse AWS credentials document: {}", e.what());
     return;
@@ -156,27 +133,17 @@ void TaskRoleCredentialsProvider::refresh() {
   absl::string_view host;
   absl::string_view path;
   Http::Utility::extractHostPathFromUri(credential_uri_, host, path);
-
-  Http::RequestMessageImpl message;
-  message.headers().setMethod(Http::Headers::get().MethodValues.Get);
-  message.headers().setHost(host);
-  message.headers().setPath(path);
-  message.headers().setCopy(Http::CustomHeaders::get().Authorization, authorization_token_);
-  const auto credential_document = metadata_fetcher_(message);
+  const auto credential_document =
+      metadata_fetcher_(std::string(host.data(), host.size()),
+                        std::string(path.data(), path.size()), authorization_token_);
   if (!credential_document) {
     ENVOY_LOG(error, "Could not load AWS credentials document from the task role");
     return;
   }
-  extractCredentials(credential_document.value());
-}
 
-void TaskRoleCredentialsProvider::extractCredentials(const std::string& credential_document_value) {
-  if (credential_document_value.empty()) {
-    return;
-  }
   Json::ObjectSharedPtr document_json;
   try {
-    document_json = Json::Factory::loadFromString(credential_document_value);
+    document_json = Json::Factory::loadFromString(credential_document.value());
   } catch (EnvoyException& e) {
     ENVOY_LOG(error, "Could not parse AWS credentials document from the task role: {}", e.what());
     return;

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -4,7 +4,6 @@
 
 #include "envoy/api/api.h"
 #include "envoy/event/timer.h"
-#include "envoy/http/message.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
@@ -32,7 +31,8 @@ public:
 class MetadataCredentialsProviderBase : public CredentialsProvider,
                                         public Logger::Loggable<Logger::Id::aws> {
 public:
-  using MetadataFetcher = std::function<absl::optional<std::string>(Http::RequestMessage&)>;
+  using MetadataFetcher = std::function<absl::optional<std::string>(
+      const std::string& host, const std::string& path, const std::string& auth_token)>;
 
   MetadataCredentialsProviderBase(Api::Api& api, const MetadataFetcher& metadata_fetcher)
       : api_(api), metadata_fetcher_(metadata_fetcher) {}
@@ -68,8 +68,6 @@ public:
 private:
   bool needsRefresh() override;
   void refresh() override;
-  void extractCredentials(const std::string& credential_document_value);
-  void fetchCredentialFromInstanceRole(const std::string& instance_role);
 };
 
 /**
@@ -92,7 +90,6 @@ private:
 
   bool needsRefresh() override;
   void refresh() override;
-  void extractCredentials(const std::string& credential_document_value);
 };
 
 /**

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -48,7 +48,7 @@ using AwsSigV4HeaderExclusionVector = std::vector<envoy::type::matcher::v3::Stri
  * Implementation of the Signature V4 signing process.
  * See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
  */
-class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::http> {
+class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::aws> {
 public:
   SignerImpl(absl::string_view service_name, absl::string_view region,
              const CredentialsProviderSharedPtr& credentials_provider, TimeSource& time_source,

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -48,7 +48,7 @@ using AwsSigV4HeaderExclusionVector = std::vector<envoy::type::matcher::v3::Stri
  * Implementation of the Signature V4 signing process.
  * See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
  */
-class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::aws> {
+class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::http> {
 public:
   SignerImpl(absl::string_view service_name, absl::string_view region,
              const CredentialsProviderSharedPtr& credentials_provider, TimeSource& time_source,

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -223,7 +223,9 @@ static size_t curlCallback(char* ptr, size_t, size_t nmemb, void* data) {
   return nmemb;
 }
 
-absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message) {
+absl::optional<std::string> Utility::metadataFetcher(const std::string& host,
+                                                     const std::string& path,
+                                                     const std::string& auth_token) {
   static const size_t MAX_RETRIES = 4;
   static const std::chrono::milliseconds RETRY_DELAY{1000};
   static const std::chrono::seconds TIMEOUT{5};
@@ -233,10 +235,7 @@ absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message
     return absl::nullopt;
   };
 
-  const auto host = message.headers().getHostValue();
-  const auto path = message.headers().getPathValue();
-
-  const std::string url = fmt::format("http://{}{}", host, path);
+  const std::string url = fmt::format("http://{}/{}", host, path);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, TIMEOUT.count());
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
@@ -247,17 +246,9 @@ absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlCallback);
 
   struct curl_slist* headers = nullptr;
-  message.headers().iterate([&headers](const Http::HeaderEntry& entry) -> Http::HeaderMap::Iterate {
-    // Skip pseudo-headers
-    if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
-      return Http::HeaderMap::Iterate::Continue;
-    }
-    const std::string header =
-        fmt::format("{}: {}", entry.key().getStringView(), entry.value().getStringView());
-    headers = curl_slist_append(headers, header.c_str());
-    return Http::HeaderMap::Iterate::Continue;
-  });
-  if (headers != nullptr) {
+  if (!auth_token.empty()) {
+    const std::string auth = fmt::format("Authorization: {}", auth_token);
+    headers = curl_slist_append(headers, auth.c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
 

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -217,25 +217,31 @@ Utility::joinCanonicalHeaderNames(const std::map<std::string, std::string>& cano
   });
 }
 
+std::string Utility::getSTSEndpoint(absl::string_view region) {
+  if (region == "cn-northwest-1" || region == "cn-north-1") {
+    return fmt::format("sts.{}.amazonaws.com.cn", region);
+  }
+  return fmt::format("sts.{}.amazonaws.com", region);
+}
+
 static size_t curlCallback(char* ptr, size_t, size_t nmemb, void* data) {
   auto buf = static_cast<std::string*>(data);
   buf->append(ptr, nmemb);
   return nmemb;
 }
 
-absl::optional<std::string> Utility::metadataFetcher(const std::string& host,
-                                                     const std::string& path,
-                                                     const std::string& auth_token) {
+absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message) {
   static const size_t MAX_RETRIES = 4;
   static const std::chrono::milliseconds RETRY_DELAY{1000};
   static const std::chrono::seconds TIMEOUT{5};
 
   CURL* const curl = curl_easy_init();
-  if (!curl) {
-    return absl::nullopt;
-  };
+  RELEASE_ASSERT(curl != nullptr, "");
+  const auto host = message.headers().getHostValue();
+  const auto path = message.headers().getPathValue();
+  const auto scheme = message.headers().getSchemeValue();
 
-  const std::string url = fmt::format("http://{}/{}", host, path);
+  const std::string url = fmt::format("{}://{}{}", scheme, host, path);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, TIMEOUT.count());
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
@@ -246,9 +252,17 @@ absl::optional<std::string> Utility::metadataFetcher(const std::string& host,
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlCallback);
 
   struct curl_slist* headers = nullptr;
-  if (!auth_token.empty()) {
-    const std::string auth = fmt::format("Authorization: {}", auth_token);
-    headers = curl_slist_append(headers, auth.c_str());
+  message.headers().iterate([&headers](const Http::HeaderEntry& entry) -> Http::HeaderMap::Iterate {
+    // Skip pseudo-headers
+    if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
+      return Http::HeaderMap::Iterate::Continue;
+    }
+    const std::string header =
+        fmt::format("{}: {}", entry.key().getStringView(), entry.value().getStringView());
+    headers = curl_slist_append(headers, header.c_str());
+    return Http::HeaderMap::Iterate::Continue;
+  });
+  if (headers != nullptr) {
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }
 

--- a/source/extensions/common/aws/utility.h
+++ b/source/extensions/common/aws/utility.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "envoy/http/message.h"
-
 #include "source/common/common/matchers.h"
 #include "source/common/http/headers.h"
 
@@ -83,7 +81,9 @@ public:
   /**
    * Fetch AWS instance or task metadata.
    *
-   * @param message An HTTP request.
+   * @param host host or ip address of the metadata endpoint.
+   * @param path path of the metadata document.
+   * @auth_token authentication token to pass in the request, empty string indicates no auth.
    * @return Metadata document or nullopt in case if unable to fetch it.
    *
    * @note In case of an error, function will log ENVOY_LOG_MISC(debug) message.
@@ -91,7 +91,8 @@ public:
    * @note This is not main loop safe method as it is blocking. It is intended to be used from the
    * gRPC auth plugins that are able to schedule blocking plugins on a different thread.
    */
-  static absl::optional<std::string> fetchMetadata(Http::RequestMessage& message);
+  static absl::optional<std::string>
+  metadataFetcher(const std::string& host, const std::string& path, const std::string& auth_token);
 };
 
 } // namespace Aws

--- a/source/extensions/common/aws/utility.h
+++ b/source/extensions/common/aws/utility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/http/message.h"
 #include "source/common/common/matchers.h"
 #include "source/common/http/headers.h"
 
@@ -79,11 +80,17 @@ public:
   joinCanonicalHeaderNames(const std::map<std::string, std::string>& canonical_headers);
 
   /**
+   * Get the Security Token Service endpoint for a given region: sts.<region>.amazonaws.com
+   * See: https://docs.aws.amazon.com/general/latest/gr/rande.html#sts_region
+   * @param region An AWS region.
+   * @return an endpoint.
+   */
+  static std::string getSTSEndpoint(absl::string_view region);
+
+  /**
    * Fetch AWS instance or task metadata.
    *
-   * @param host host or ip address of the metadata endpoint.
-   * @param path path of the metadata document.
-   * @auth_token authentication token to pass in the request, empty string indicates no auth.
+   * @param message An HTTP request.
    * @return Metadata document or nullopt in case if unable to fetch it.
    *
    * @note In case of an error, function will log ENVOY_LOG_MISC(debug) message.
@@ -91,8 +98,7 @@ public:
    * @note This is not main loop safe method as it is blocking. It is intended to be used from the
    * gRPC auth plugins that are able to schedule blocking plugins on a different thread.
    */
-  static absl::optional<std::string>
-  metadataFetcher(const std::string& host, const std::string& path, const std::string& auth_token);
+  static absl::optional<std::string> fetchMetadata(Http::RequestMessage& message);
 };
 
 } // namespace Aws

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -37,16 +37,15 @@ Http::FilterFactoryCb AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
     const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
 
+  auto credentials_provider =
+      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
+          context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
+
   const auto arn = parseArn(proto_config.arn());
   if (!arn) {
     throw EnvoyException(fmt::format("aws_lambda_filter: Invalid ARN: {}", proto_config.arn()));
   }
   const std::string region = arn->region();
-
-  auto credentials_provider =
-      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-          context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
-
   auto signer = std::make_shared<Extensions::Common::Aws::SignerImpl>(
       service_name, region, std::move(credentials_provider),
       context.mainThreadDispatcher().timeSource(),

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -37,15 +37,16 @@ Http::FilterFactoryCb AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
     const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
 
-  auto credentials_provider =
-      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-          context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
-
   const auto arn = parseArn(proto_config.arn());
   if (!arn) {
     throw EnvoyException(fmt::format("aws_lambda_filter: Invalid ARN: {}", proto_config.arn()));
   }
   const std::string region = arn->region();
+
+  auto credentials_provider =
+      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
+          context.api(), region, Extensions::Common::Aws::Utility::fetchMetadata);
+
   auto signer = std::make_shared<Extensions::Common::Aws::SignerImpl>(
       service_name, region, std::move(credentials_provider),
       context.mainThreadDispatcher().timeSource(),

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-          context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
+          context.api(), config.region(), Extensions::Common::Aws::Utility::fetchMetadata);
   const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
       config.match_excluded_headers().begin(), config.match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
-          context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
+          context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
   const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
       config.match_excluded_headers().begin(), config.match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -44,10 +44,11 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
         const auto& config = Envoy::MessageUtil::downcastAndValidate<
             const envoy::config::grpc_credential::v3::AwsIamConfig&>(
             *config_message, ProtobufMessage::getNullValidationVisitor());
+        const auto region = getRegion(config);
         auto credentials_provider = std::make_shared<Common::Aws::DefaultCredentialsProviderChain>(
-            api, Common::Aws::Utility::metadataFetcher);
+            api, region, Common::Aws::Utility::fetchMetadata);
         auto signer = std::make_unique<Common::Aws::SignerImpl>(
-            config.service_name(), getRegion(config), credentials_provider, api.timeSource(),
+            config.service_name(), region, credentials_provider, api.timeSource(),
             // TODO: extend API to allow specifying header exclusion. ref:
             // https://github.com/envoyproxy/envoy/pull/18998
             Common::Aws::AwsSigV4HeaderExclusionVector{});

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -45,7 +45,7 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
             const envoy::config::grpc_credential::v3::AwsIamConfig&>(
             *config_message, ProtobufMessage::getNullValidationVisitor());
         auto credentials_provider = std::make_shared<Common::Aws::DefaultCredentialsProviderChain>(
-            api, Common::Aws::Utility::fetchMetadata);
+            api, Common::Aws::Utility::metadataFetcher);
         auto signer = std::make_unique<Common::Aws::SignerImpl>(
             config.service_name(), getRegion(config), credentials_provider, api.timeSource(),
             // TODO: extend API to allow specifying header exclusion. ref:

--- a/test/dependencies/curl_test.cc
+++ b/test/dependencies/curl_test.cc
@@ -13,7 +13,7 @@ TEST(CurlTest, BuiltWithExpectedFeatures) {
   // developer or os elections for DEBUG, CURL DEBUG and LARGE FILE
   EXPECT_NE(0, info->features & CURL_VERSION_IPV6);
   EXPECT_EQ(0, info->features & CURL_VERSION_KERBEROS4);
-  EXPECT_EQ(0, info->features & CURL_VERSION_SSL);
+  EXPECT_NE(0, info->features & CURL_VERSION_SSL);
   EXPECT_NE(0, info->features & CURL_VERSION_LIBZ);
   EXPECT_EQ(0, info->features & CURL_VERSION_NTLM);
   EXPECT_EQ(0, info->features & CURL_VERSION_GSSNEGOTIATE);
@@ -29,7 +29,7 @@ TEST(CurlTest, BuiltWithExpectedFeatures) {
   EXPECT_EQ(0, info->features & CURL_VERSION_KERBEROS5);
   EXPECT_NE(0, info->features & CURL_VERSION_UNIX_SOCKETS);
   EXPECT_EQ(0, info->features & CURL_VERSION_PSL);
-  EXPECT_EQ(0, info->features & CURL_VERSION_HTTPS_PROXY);
+  EXPECT_NE(0, info->features & CURL_VERSION_HTTPS_PROXY);
   EXPECT_EQ(0, info->features & CURL_VERSION_MULTI_SSL);
   EXPECT_EQ(0, info->features & CURL_VERSION_BROTLI);
   EXPECT_NE(0, info->features & CURL_VERSION_ALTSVC);

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -79,9 +79,12 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
+      {":path", "/"}, {":authority", authority}, {":scheme", "http"}, {":method", "GET"}}};
+  Http::RequestMessageImpl message(std::move(headers));
+  const auto response = Utility::fetchMetadata(message);
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE", *response);
@@ -91,9 +94,16 @@ TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
 }
 
 TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "", "AUTH_TOKEN");
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{
+      new Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                         {":authority", authority},
+                                         {":scheme", "http"},
+                                         {":method", "GET"},
+                                         {"authorization", "AUTH_TOKEN"}}};
+  Http::RequestMessageImpl message(std::move(headers));
+  const auto response = Utility::fetchMetadata(message);
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -103,9 +113,16 @@ TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
 }
 
 TEST_F(AwsMetadataIntegrationTestSuccess, Redirect) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
-  const auto response = Utility::metadataFetcher(endpoint, "redirect", "AUTH_TOKEN");
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{
+      new Http::TestRequestHeaderMapImpl{{":path", "/redirect"},
+                                         {":authority", authority},
+                                         {":scheme", "http"},
+                                         {":method", "GET"},
+                                         {"authorization", "AUTH_TOKEN"}}};
+  Http::RequestMessageImpl message(std::move(headers));
+  const auto response = Utility::fetchMetadata(message);
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -124,11 +141,18 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestFailure, Failure) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{
+      new Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                         {":authority", authority},
+                                         {":scheme", "http"},
+                                         {":method", "GET"},
+                                         {"authorization", "AUTH_TOKEN"}}};
 
+  Http::RequestMessageImpl message(std::move(headers));
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::fetchMetadata(message);
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
@@ -148,16 +172,19 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestTimeout, Timeout) {
-  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                    lookupPort("listener_0"));
+  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                     lookupPort("listener_0"));
+  auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
+      {":path", "/"}, {":authority", authority}, {":scheme", "http"}, {":method", "GET"}}};
+  Http::RequestMessageImpl message(std::move(headers));
 
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::metadataFetcher(endpoint, "", "");
+  const auto response = Utility::fetchMetadata(message);
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
 
-  // We do now check http.metadata_test.downstream_rq_completed value here because it's
+  // We do not check http.metadata_test.downstream_rq_completed value here because it's
   // behavior is different between Linux and Mac when Curl disconnects on timeout. On Mac it is
   // incremented, while on Linux it is not.
 

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -79,12 +79,9 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
-  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                     lookupPort("listener_0"));
-  auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
-      {":path", "/"}, {":authority", authority}, {":method", "GET"}}};
-  Http::RequestMessageImpl message(std::move(headers));
-  const auto response = Utility::fetchMetadata(message);
+  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                    lookupPort("listener_0"));
+  const auto response = Utility::metadataFetcher(endpoint, "", "");
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE", *response);
@@ -94,15 +91,9 @@ TEST_F(AwsMetadataIntegrationTestSuccess, Success) {
 }
 
 TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
-  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                     lookupPort("listener_0"));
-  auto headers = Http::RequestHeaderMapPtr{
-      new Http::TestRequestHeaderMapImpl{{":path", "/"},
-                                         {":authority", authority},
-                                         {":method", "GET"},
-                                         {"authorization", "AUTH_TOKEN"}}};
-  Http::RequestMessageImpl message(std::move(headers));
-  const auto response = Utility::fetchMetadata(message);
+  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                    lookupPort("listener_0"));
+  const auto response = Utility::metadataFetcher(endpoint, "", "AUTH_TOKEN");
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -112,15 +103,9 @@ TEST_F(AwsMetadataIntegrationTestSuccess, AuthToken) {
 }
 
 TEST_F(AwsMetadataIntegrationTestSuccess, Redirect) {
-  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                     lookupPort("listener_0"));
-  auto headers = Http::RequestHeaderMapPtr{
-      new Http::TestRequestHeaderMapImpl{{":path", "/redirect"},
-                                         {":authority", authority},
-                                         {":method", "GET"},
-                                         {"authorization", "AUTH_TOKEN"}}};
-  Http::RequestMessageImpl message(std::move(headers));
-  const auto response = Utility::fetchMetadata(message);
+  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                    lookupPort("listener_0"));
+  const auto response = Utility::metadataFetcher(endpoint, "redirect", "AUTH_TOKEN");
 
   ASSERT_TRUE(response.has_value());
   EXPECT_EQ("METADATA_VALUE_WITH_AUTH", *response);
@@ -139,17 +124,11 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestFailure, Failure) {
-  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                     lookupPort("listener_0"));
-  auto headers = Http::RequestHeaderMapPtr{
-      new Http::TestRequestHeaderMapImpl{{":path", "/"},
-                                         {":authority", authority},
-                                         {":method", "GET"},
-                                         {"authorization", "AUTH_TOKEN"}}};
+  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                    lookupPort("listener_0"));
 
-  Http::RequestMessageImpl message(std::move(headers));
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::fetchMetadata(message);
+  const auto response = Utility::metadataFetcher(endpoint, "", "");
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
@@ -169,19 +148,16 @@ public:
 };
 
 TEST_F(AwsMetadataIntegrationTestTimeout, Timeout) {
-  const auto authority = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
-                                     lookupPort("listener_0"));
-  auto headers = Http::RequestHeaderMapPtr{new Http::TestRequestHeaderMapImpl{
-      {":path", "/"}, {":authority", authority}, {":method", "GET"}}};
-  Http::RequestMessageImpl message(std::move(headers));
+  const auto endpoint = fmt::format("{}:{}", Network::Test::getLoopbackAddressUrlString(version_),
+                                    lookupPort("listener_0"));
 
   const auto start_time = timeSystem().monotonicTime();
-  const auto response = Utility::fetchMetadata(message);
+  const auto response = Utility::metadataFetcher(endpoint, "", "");
   const auto end_time = timeSystem().monotonicTime();
 
   EXPECT_FALSE(response.has_value());
 
-  // We do not check http.metadata_test.downstream_rq_completed value here because it's
+  // We do now check http.metadata_test.downstream_rq_completed value here because it's
   // behavior is different between Linux and Mac when Curl disconnects on timeout. On Mac it is
   // incremented, while on Linux it is not.
 

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -33,17 +33,12 @@ class MockMetadataFetcher {
 public:
   virtual ~MockMetadataFetcher() = default;
 
-  MOCK_METHOD(absl::optional<std::string>, fetch,
-              (const std::string&, const std::string&, const absl::optional<std::string>&),
-              (const));
+  MOCK_METHOD(absl::optional<std::string>, fetch, (Http::RequestMessage&), (const));
 };
 
 class DummyMetadataFetcher {
 public:
-  absl::optional<std::string> operator()(const std::string&, const std::string&,
-                                         const absl::optional<std::string>&) {
-    return absl::nullopt;
-  }
+  absl::optional<std::string> operator()(Http::RequestMessage&) { return absl::nullopt; }
 };
 
 } // namespace Aws

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -29,16 +29,21 @@ public:
   MOCK_METHOD(void, signUnsignedPayload, (Http::RequestHeaderMap&));
 };
 
-class MockFetchMetadata {
+class MockMetadataFetcher {
 public:
-  virtual ~MockFetchMetadata() = default;
+  virtual ~MockMetadataFetcher() = default;
 
-  MOCK_METHOD(absl::optional<std::string>, fetch, (Http::RequestMessage&), (const));
+  MOCK_METHOD(absl::optional<std::string>, fetch,
+              (const std::string&, const std::string&, const absl::optional<std::string>&),
+              (const));
 };
 
 class DummyMetadataFetcher {
 public:
-  absl::optional<std::string> operator()(Http::RequestMessage&) { return absl::nullopt; }
+  absl::optional<std::string> operator()(const std::string&, const std::string&,
+                                         const absl::optional<std::string>&) {
+    return absl::nullopt;
+  }
 };
 
 } // namespace Aws

--- a/test/extensions/common/aws/utility_test.cc
+++ b/test/extensions/common/aws/utility_test.cc
@@ -346,6 +346,19 @@ TEST(UtilityTest, JoinCanonicalHeaderNamesWithEmptyMap) {
   EXPECT_EQ("", names);
 }
 
+// The region is simply interpolated into sts.{}.amazonaws.com for most regions
+TEST(UtilityTest, GetNormalSTSEndpoints) {
+  EXPECT_EQ("sts.us-west-2.amazonaws.com", Utility::getSTSEndpoint("us-west-2"));
+  EXPECT_EQ("sts.us-east-1.amazonaws.com", Utility::getSTSEndpoint("us-east-1"));
+  EXPECT_EQ("sts.some-new-region.amazonaws.com", Utility::getSTSEndpoint("some-new-region"));
+}
+
+// Except the China regions: https://docs.aws.amazon.com/general/latest/gr/rande.html#sts_region
+TEST(UtilityTest, GetChinaSTSEndpoints) {
+  EXPECT_EQ("sts.cn-north-1.amazonaws.com.cn", Utility::getSTSEndpoint("cn-north-1"));
+  EXPECT_EQ("sts.cn-northwest-1.amazonaws.com.cn", Utility::getSTSEndpoint("cn-northwest-1"));
+}
+
 } // namespace
 } // namespace Aws
 } // namespace Common


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Envoy support for k8s IAM Roles for Service Accounts (IRSA)
Additional Description: This is not going to be upstreamed. We need to remove the libcurl usage by AWS extensions on Envoy before we can upstream this change to Envoy. https://github.com/aws/aws-app-mesh-roadmap/issues/182

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
