### PR TITLE
api: add socket_options for multiple addresses

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -119,6 +119,16 @@ message TcpKeepalive {
 message ExtraSourceAddress {
   // The additional address to bind.
   SocketAddress address = 1 [(validate.rules).message = {required: true}];
+
+  // [#not-implemented-hide:]
+  oneof socket_options_specifier {
+    // [#not-implemented-hide:]
+    // Additional socket options that may not be present in Envoy source code or
+    // precompiled binaries. If no socket options specified, the BindConfig's
+    // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
+    // will apply to this address.
+    repeated core.SocketOption socket_options = 2;
+  }
 }
 
 // [#next-free-field: 6]

--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -122,16 +122,13 @@ message ExtraSourceAddress {
 
   // [#not-implemented-hide:]
   // Additional socket options that may not be present in Envoy source code or
-  // precompiled binaries. If no socket options specified, the BindConfig's
+  // precompiled binaries. If specified, this will override the
   // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
-  // will apply to this address.
-  repeated SocketOption socket_options = 2;
-
-  // [#not-implemented-hide:]
-  // Indicate no any socket options apply to this address even the BindConfig's
-  // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
-  // has specified.
-  bool no_socket_options = 3;
+  // in the BindConfig. If specified with no
+  // :ref:`socket_options <envoy_v3_api_field_config.core.v3.SocketOptionsOverride.socket_options>`
+  // or an empty list of :ref:`socket_options <envoy_v3_api_field_config.core.v3.SocketOptionsOverride.socket_options>`,
+  // it means no socket option will apply.
+  SocketOptionsOverride socket_options = 2;
 }
 
 // [#next-free-field: 6]

--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -125,7 +125,13 @@ message ExtraSourceAddress {
   // precompiled binaries. If no socket options specified, the BindConfig's
   // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
   // will apply to this address.
-  repeated core.SocketOption socket_options = 2;
+  repeated SocketOption socket_options = 2;
+
+  // [#not-implemented-hide:]
+  // Indicate no any socket options apply to this address even the BindConfig's
+  // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
+  // has specified.
+  bool no_socket_options = 3;
 }
 
 // [#next-free-field: 6]

--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -121,14 +121,11 @@ message ExtraSourceAddress {
   SocketAddress address = 1 [(validate.rules).message = {required: true}];
 
   // [#not-implemented-hide:]
-  oneof socket_options_specifier {
-    // [#not-implemented-hide:]
-    // Additional socket options that may not be present in Envoy source code or
-    // precompiled binaries. If no socket options specified, the BindConfig's
-    // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
-    // will apply to this address.
-    repeated core.SocketOption socket_options = 2;
-  }
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries. If no socket options specified, the BindConfig's
+  // :ref:`socket_options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
+  // will apply to this address.
+  repeated core.SocketOption socket_options = 2;
 }
 
 // [#next-free-field: 6]

--- a/api/envoy/config/core/v3/socket_option.proto
+++ b/api/envoy/config/core/v3/socket_option.proto
@@ -75,3 +75,8 @@ message SocketOption {
   // STATE_PREBIND is currently the only valid value.
   SocketState state = 6 [(validate.rules).enum = {defined_only: true}];
 }
+
+// [#not-implemented-hide:]
+message SocketOptionsOverride {
+  repeated SocketOption socket_options = 1;
+}

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -36,6 +36,16 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // The additional address the listener is listening on.
 message AdditionalAddress {
   core.v3.Address address = 1;
+
+  // [#not-implemented-hide:]
+  oneof socket_options_specifier {
+    // [#not-implemented-hide:]
+    // Additional socket options that may not be present in Envoy source code or
+    // precompiled binaries. If not specified, the listener's
+    // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
+    // will apply to this address.
+    repeated core.SocketOption socket_options = 2;
+  }
 }
 
 // Listener list collections. Entries are ``Listener`` resources or references.

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -42,7 +42,13 @@ message AdditionalAddress {
   // precompiled binaries. If not specified, the listener's
   // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
   // will apply to this address.
-  repeated core.SocketOption socket_options = 2;
+  repeated core.v3.SocketOption socket_options = 2;
+
+  // [#not-implemented-hide:]
+  // Indicate no any socket options apply to this address even the listener's
+  // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
+  // has specified.
+  bool no_socket_options = 3;
 }
 
 // Listener list collections. Entries are ``Listener`` resources or references.

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -39,16 +39,13 @@ message AdditionalAddress {
 
   // [#not-implemented-hide:]
   // Additional socket options that may not be present in Envoy source code or
-  // precompiled binaries. If not specified, the listener's
+  // precompiled binaries. If specified, this will override the
   // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
-  // will apply to this address.
-  repeated core.v3.SocketOption socket_options = 2;
-
-  // [#not-implemented-hide:]
-  // Indicate no any socket options apply to this address even the listener's
-  // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
-  // has specified.
-  bool no_socket_options = 3;
+  // in the listener. If specified with no
+  // :ref:`socket_options <envoy_v3_api_field_config.core.v3.SocketOptionsOverride.socket_options>`
+  // or an empty list of :ref:`socket_options <envoy_v3_api_field_config.core.v3.SocketOptionsOverride.socket_options>`,
+  // it means no socket option will apply.
+  core.v3.SocketOptionsOverride socket_options = 2;
 }
 
 // Listener list collections. Entries are ``Listener`` resources or references.

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -38,14 +38,11 @@ message AdditionalAddress {
   core.v3.Address address = 1;
 
   // [#not-implemented-hide:]
-  oneof socket_options_specifier {
-    // [#not-implemented-hide:]
-    // Additional socket options that may not be present in Envoy source code or
-    // precompiled binaries. If not specified, the listener's
-    // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
-    // will apply to this address.
-    repeated core.SocketOption socket_options = 2;
-  }
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries. If not specified, the listener's
+  // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
+  // will apply to this address.
+  repeated core.SocketOption socket_options = 2;
 }
 
 // Listener list collections. Entries are ``Listener`` resources or references.


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: api: add socket_options for multiple addresses
Additional Description:
Since the ipv4 and ipv6 have different socket option flags, when using multiple addresses, the user has to specify different socket options for the ipv4 address and the ipv6 address.

For the listener, the additional address can be the Ipv6 address, then it should be able to set an Ipv6 flag corresponding to the ipv4 one. Add socket_option field for each additional address.

For the upstream, the endpoint can be ipv4 or ipv6, currently, the user can specify the ipv4 and ipv6 local bind address in the bind config, but there is only a global socket_options that apply to both the ipv4 and ipv6 addresses. Add socket_options for each extra source address. https://envoyproxy.slack.com/archives/C78HA81DH/p1664228598624269

Risk Level: low
Testing: n/a
Docs Changes: API doc
Release Notes: n/a
Platform Specific Features: n/a
