### PR TITLE
ci: accelerate local build

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -91,8 +91,8 @@ function cp_binary_for_image_build() {
   mkdir -p "${BASE_TARGET_DIR}"/"${TARGET_DIR}"_stripped
   strip "${FINAL_DELIVERY_DIR}"/envoy -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"_stripped/envoy
 
-  # Copy for azp which doesn't preserve permissions, creating a tar archive
-  tar czf "${ENVOY_BUILD_DIR}"/"${EXE_NAME}"_binary.tar.gz -C "${BASE_TARGET_DIR}" "${TARGET_DIR}" "${TARGET_DIR}"_stripped
+  # Copy for azp which doesn't preserve permissions, creating a tar archive only when release
+  [[ "${BINARY_TYPE}" == "release" ]] && tar czf "${ENVOY_BUILD_DIR}"/"${EXE_NAME}"_binary.tar.gz -C "${BASE_TARGET_DIR}" "${TARGET_DIR}" "${TARGET_DIR}"_stripped
 
   # Remove binaries to save space, only if BUILD_REASON exists (running in AZP)
   [[ -z "${BUILD_REASON}" ]] || \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -91,13 +91,15 @@ function cp_binary_for_image_build() {
   mkdir -p "${BASE_TARGET_DIR}"/"${TARGET_DIR}"_stripped
   strip "${FINAL_DELIVERY_DIR}"/envoy -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"_stripped/envoy
 
-  # Copy for azp which doesn't preserve permissions, creating a tar archive only when release
-  [[ "${BINARY_TYPE}" == "release" ]] && tar czf "${ENVOY_BUILD_DIR}"/"${EXE_NAME}"_binary.tar.gz -C "${BASE_TARGET_DIR}" "${TARGET_DIR}" "${TARGET_DIR}"_stripped
+  # only if BUILD_REASON exists (running in AZP)
+  if [[ "${BUILD_REASON}" ]]; then
+    # Copy for azp which doesn't preserve permissions
+    tar czf "${ENVOY_BUILD_DIR}"/"${EXE_NAME}"_binary.tar.gz -C "${BASE_TARGET_DIR}" "${TARGET_DIR}" "${TARGET_DIR}"_stripped
 
-  # Remove binaries to save space, only if BUILD_REASON exists (running in AZP)
-  [[ -z "${BUILD_REASON}" ]] || \
+    # Remove binaries to save space
     rm -rf "${BASE_TARGET_DIR:?}"/"${TARGET_DIR}" "${BASE_TARGET_DIR:?}"/"${TARGET_DIR}"_stripped "${FINAL_DELIVERY_DIR:?}"/envoy{,.dwp} \
       bazel-bin/"${ENVOY_BIN}"{,.dwp}
+  fi
 }
 
 function bazel_binary_build() {


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

Create a TAR waste lots of time, skip it if not release.

Before this:
```
Copying binary for image build...

real    0m32.585s
user    0m30.830s
sys     0m2.557s
```

After this:
```
Copying binary for image build...

real    0m1.912s
user    0m0.806s
sys     0m1.105s
```

Save 30s in total.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
