### PR TITLE
xds: change XdsResourcesDelegate::getResources to take a set

### DIFF
--- a/contrib/config/source/kv_store_xds_delegate.cc
+++ b/contrib/config/source/kv_store_xds_delegate.cc
@@ -38,11 +38,11 @@ KeyValueStoreXdsDelegate::KeyValueStoreXdsDelegate(KeyValueStorePtr&& xds_config
     : xds_config_store_(std::move(xds_config_store)),
       scope_(root_scope.createScope("xds.kv_store.")), stats_(generateStats(*scope_)) {}
 
-std::vector<envoy::service::discovery::v3::Resource>
-KeyValueStoreXdsDelegate::getResources(const XdsSourceId& source_id,
-                                       const std::vector<std::string>& resource_names) const {
+std::vector<envoy::service::discovery::v3::Resource> KeyValueStoreXdsDelegate::getResources(
+    const XdsSourceId& source_id, const absl::flat_hash_set<std::string>& resource_names) const {
   std::vector<envoy::service::discovery::v3::Resource> resources;
-  if (resource_names.empty() || (resource_names.size() == 1 && resource_names[0] == "*")) {
+  if (resource_names.empty() ||
+      (resource_names.size() == 1 && resource_names.contains(Envoy::Config::Wildcard))) {
     // Empty names or one entry with "*" means wildcard.
     resources = getAllResources(source_id);
   } else {

--- a/contrib/config/source/kv_store_xds_delegate.h
+++ b/contrib/config/source/kv_store_xds_delegate.h
@@ -5,6 +5,8 @@
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Config {
@@ -44,7 +46,7 @@ public:
 
   std::vector<envoy::service::discovery::v3::Resource>
   getResources(const Envoy::Config::XdsSourceId& source_id,
-               const std::vector<std::string>& resource_names) const override;
+               const absl::flat_hash_set<std::string>& resource_names) const override;
 
   void onConfigUpdated(const Envoy::Config::XdsSourceId& source_id,
                        const std::vector<Envoy::Config::DecodedResourceRef>& resources) override;

--- a/contrib/config/test/kv_store_xds_delegate_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_test.cc
@@ -70,7 +70,7 @@ protected:
 
   template <typename Resource>
   void checkSavedResources(const XdsSourceId& source_id,
-                           const std::vector<std::string>& resource_names,
+                           const absl::flat_hash_set<std::string>& resource_names,
                            const std::vector<DecodedResourceRef>& expected_resources) {
     // Retrieve the xDS resources.
     const auto retrieved_resources = xds_delegate_->getResources(source_id, resource_names);

--- a/envoy/config/xds_resources_delegate.h
+++ b/envoy/config/xds_resources_delegate.h
@@ -9,6 +9,7 @@
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -46,8 +47,8 @@ public:
   /**
    * Returns a list of xDS resources for the given source and names. The implementation is not
    * required to return all (or any) of the requested resources, but the resources it does return
-   * are required to be in the set of requested resources. An empty resource list will return all
-   * known resources from the given xDS source (i.e. the "wildcard").
+   * are required to be in the set of requested resources. An empty resource name set will return
+   * all known resources from the given xDS source (i.e. the "wildcard").
    *
    * This function is intended to only be called on xDS fetch startup, and allows the
    * implementation to return a set of resources to be loaded and used by the Envoy instance
@@ -55,12 +56,11 @@ public:
    *
    * @param source_id The xDS source for the requested resources.
    * @param resource_names The names of the requested resources.
-   * @return A set of xDS resources for the given source.
+   * @return A list of xDS resources for the given source.
    */
-  // TODO(abeyad): change resource_names to a set.
   virtual std::vector<envoy::service::discovery::v3::Resource>
   getResources(const XdsSourceId& source_id,
-               const std::vector<std::string>& resource_names) const PURE;
+               const absl::flat_hash_set<std::string>& resource_names) const PURE;
 
   /**
    * Invoked when SotW xDS configuration updates have been received from an xDS authority, have been

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -108,7 +108,7 @@ void GrpcMuxImpl::sendDiscoveryRequest(absl::string_view type_url) {
 }
 
 void GrpcMuxImpl::loadConfigFromDelegate(const std::string& type_url,
-                                         const std::vector<std::string>& resource_names) {
+                                         const absl::flat_hash_set<std::string>& resource_names) {
   if (!xds_resources_delegate_.has_value()) {
     return;
   }
@@ -393,8 +393,8 @@ void GrpcMuxImpl::onEstablishmentFailure() {
       // connectivity is established with the xDS server.
       loadConfigFromDelegate(
           /*type_url=*/api_state.first,
-          std::vector<std::string>{api_state.second->request_.resource_names().begin(),
-                                   api_state.second->request_.resource_names().end()});
+          absl::flat_hash_set<std::string>{api_state.second->request_.resource_names().begin(),
+                                           api_state.second->request_.resource_names().end()});
       previously_fetched_data_ = true;
     }
   }

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -170,7 +170,7 @@ private:
   void onDynamicContextUpdate(absl::string_view resource_type_url);
   // Must be invoked from the main or test thread.
   void loadConfigFromDelegate(const std::string& type_url,
-                              const std::vector<std::string>& resource_names);
+                              const absl::flat_hash_set<std::string>& resource_names);
   // Must be invoked from the main or test thread.
   void processDiscoveryResources(const std::vector<DecodedResourcePtr>& resources,
                                  ApiState& api_state, const std::string& type_url,

--- a/source/common/config/xds_mux/sotw_subscription_state.cc
+++ b/source/common/config/xds_mux/sotw_subscription_state.cc
@@ -101,14 +101,13 @@ void SotwSubscriptionState::handleEstablishmentFailure() {
 
   const XdsConfigSourceId source_id{target_xds_authority_, type_url_};
   TRY_ASSERT_MAIN_THREAD {
-    const std::vector<std::string> resource_names{names_tracked_.begin(), names_tracked_.end()};
     std::vector<envoy::service::discovery::v3::Resource> resources =
-        xds_resources_delegate_->getResources(source_id, resource_names);
+        xds_resources_delegate_->getResources(source_id, names_tracked_);
 
     std::vector<DecodedResourcePtr> decoded_resources;
     const auto scoped_update = ttl_.scopedTtlUpdate();
     std::string version_info;
-    int unaccounted = names_tracked_.size();
+    size_t unaccounted = names_tracked_.size();
     if (names_tracked_.size() == 1 && names_tracked_.contains(Envoy::Config::Wildcard)) {
       // For wildcard requests, there are no expectations for the number of resources returned.
       unaccounted = 0;

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -99,6 +99,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "sotw_subscription_state_test",
     srcs = ["sotw_subscription_state_test.cc"],
+    external_deps = ["abseil_flat_hash_set"],
     deps = [
         "//source/common/config:resource_name_lib",
         "//source/common/config/xds_mux:sotw_subscription_state_lib",

--- a/test/common/config/sotw_subscription_state_test.cc
+++ b/test/common/config/sotw_subscription_state_test.cc
@@ -11,6 +11,7 @@
 #include "test/mocks/local_info/mocks.h"
 #include "test/test_common/simulated_time_system.h"
 
+#include "absl/container/flat_hash_set.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -44,17 +45,18 @@ public:
 
   std::vector<envoy::service::discovery::v3::Resource>
   getResources(const Config::XdsSourceId& /*source_id*/,
-               const std::vector<std::string>& resource_names) const override {
+               const absl::flat_hash_set<std::string>& resource_names) const override {
     if (throws_ex_) {
       throw EnvoyException("intended exception thrown");
     }
 
     // If we get a wildcard request, generate CLA resources for the default {"name1", "name2",
     // "name3"}.
-    std::vector<std::string> resources_to_generate{resource_names.begin(), resource_names.end()};
+    absl::flat_hash_set<std::string> resources_to_generate{resource_names.begin(),
+                                                           resource_names.end()};
     if (resources_to_generate.empty() ||
         (resources_to_generate.size() == 1 &&
-         resources_to_generate[0] == std::string(Envoy::Config::Wildcard))) {
+         resources_to_generate.contains(Envoy::Config::Wildcard))) {
       resources_to_generate = {"name1", "name2", "name3"};
     }
 

--- a/test/integration/xds_delegate_extension_integration_test.cc
+++ b/test/integration/xds_delegate_extension_integration_test.cc
@@ -46,7 +46,7 @@ public:
 
   std::vector<envoy::service::discovery::v3::Resource>
   getResources(const Config::XdsSourceId& source_id,
-               const std::vector<std::string>& resource_names) const override {
+               const absl::flat_hash_set<std::string>& resource_names) const override {
     std::vector<envoy::service::discovery::v3::Resource> resources;
     for (const auto& resource_name : resource_names) {
       auto it = ResourcesMap.find(makeKey(source_id, resource_name));


### PR DESCRIPTION
The resource names requested in the `getResources` function should take a set of unique elements, so this commit changes the the `getResources` interface to take a `absl::flat_hash_set` for the resource names instead of a `std::vector`.

Risk Level: low (hidden, as-of-yet unused API)
Testing: existing unit & integration test coverage

Signed-off-by: Ali Beyad <abeyad@google.com>