### PR TITLE
router: use re2 for header formatter utilities.

### DIFF
--- a/source/common/json/json_internal.cc
+++ b/source/common/json/json_internal.cc
@@ -675,7 +675,7 @@ bool ObjectHandler::handleValueEvent(FieldSharedPtr ptr) {
 
 ObjectSharedPtr Factory::loadFromString(const std::string& json) {
   ObjectHandler handler;
-  auto json_container = JsonContainer(json.data(), &handler);
+  auto json_container = JsonContainer(json.c_str(), &handler);
 
   nlohmann::json::sax_parse(json_container, &handler);
 

--- a/source/common/router/header_parser_utils.cc
+++ b/source/common/router/header_parser_utils.cc
@@ -5,8 +5,14 @@
 #include "source/common/json/json_loader.h"
 #include "source/common/router/header_parser.h"
 
+#include "re2/re2.h"
+
 namespace Envoy {
 namespace Router {
+static const re2::RE2& getMetadataTranslatorPattern() {
+  CONSTRUCT_ON_FIRST_USE(re2::RE2,
+                         R"EOF(%(UPSTREAM|DYNAMIC)_METADATA\(\s*(\[(?:.|\r?\n)+?\]\s*)\)%)EOF");
+}
 
 // Related to issue 20389. Header formatters are parsed and processed by formatters defined in
 // source/common/formatter/substitution_formatter.cc. For backwards compatibility UPSTREAM_METADATA
@@ -16,16 +22,14 @@ namespace Router {
 // format.
 // TODO(cpakulski): Eventually JSON format should be deprecated in favor of colon format.
 std::string HeaderParser::translateMetadataFormat(const std::string& header_value) {
-  const std::regex command_w_args_regex(
-      R"EOF(%(UPSTREAM|DYNAMIC)_METADATA\(\s*(\[(?:.|\r?\n)+?\]\s*)\)%)EOF");
-  std::smatch m;
+  const re2::RE2& re = getMetadataTranslatorPattern();
+  ASSERT(re.ok());
   std::string new_header_value = header_value;
-  while (std::regex_search(new_header_value, m, command_w_args_regex)) {
-    ASSERT(m.size() == 3);
-    std::vector<std::string> params;
+  std::string json_array, metadata_type;
+  while (re.PartialMatch(new_header_value, re, &metadata_type, &json_array)) {
     std::string new_format;
     TRY_ASSERT_MAIN_THREAD {
-      Json::ObjectSharedPtr parsed_params = Json::Factory::loadFromString(m.str(2));
+      Json::ObjectSharedPtr parsed_params = Json::Factory::loadFromString(json_array);
 
       // The given json string may be an invalid object or with an empty object array.
       if (parsed_params == nullptr || parsed_params->asObjectArray().empty()) {
@@ -37,15 +41,14 @@ std::string HeaderParser::translateMetadataFormat(const std::string& header_valu
         new_format += ":" + parsed_params->asObjectArray()[i]->asString();
       }
 
-      new_format = "%" + m.str(1) + "_METADATA(" + new_format + ")%";
+      new_format = "%" + metadata_type + "_METADATA(" + new_format + ")%";
 
       ENVOY_LOG_MISC(
           warn,
           "Header formatter: JSON format of {} parameters has been obsoleted. Use colon format: {}",
-          m.str(1) + "_METADATA", new_format.c_str());
+          metadata_type + "_METADATA", new_format.c_str());
 
-      auto index = new_header_value.find(m.str(0));
-      new_header_value.replace(index, m.str(0).length(), new_format);
+      re2::RE2::Replace(&new_header_value, re, new_format);
     }
     END_TRY
     catch (Json::Exception& e) {
@@ -56,6 +59,10 @@ std::string HeaderParser::translateMetadataFormat(const std::string& header_valu
   return new_header_value;
 }
 
+static const re2::RE2& getPerRequestTranslatorPattern() {
+  CONSTRUCT_ON_FIRST_USE(re2::RE2, R"EOF(%PER_REQUEST_STATE\((.+?)\)%)EOF");
+}
+
 // Related to issue 20389.
 // Header's formatter PER_REQUEST_STATE(key) is equivalent to substitution
 // formatter FILTER_STATE(key:PLAIN). translatePerRequestState method
@@ -63,17 +70,16 @@ std::string HeaderParser::translateMetadataFormat(const std::string& header_valu
 // TODO(cpakulski): eventually PER_REQUEST_STATE formatter should be deprecated in
 // favor of FILTER_STATE.
 std::string HeaderParser::translatePerRequestState(const std::string& header_value) {
-  const std::regex command_w_args_regex(R"EOF(%PER_REQUEST_STATE\((.+?)\)%)EOF");
-  std::smatch m;
+  const re2::RE2& re = getPerRequestTranslatorPattern();
+  ASSERT(re.ok());
   std::string new_header_value = header_value;
-  while (std::regex_search(new_header_value, m, command_w_args_regex)) {
-    ASSERT(m.size() == 2);
-    std::string new_format = "%FILTER_STATE(" + m.str(1) + ":PLAIN)%";
+  std::string required_state;
+  while (re.PartialMatch(new_header_value, re, &required_state)) {
+    std::string new_format = "%FILTER_STATE(" + required_state + ":PLAIN)%";
 
     ENVOY_LOG_MISC(warn, "PER_REQUEST_STATE header formatter has been obsoleted. Use {}",
                    new_format.c_str());
-    auto index = new_header_value.find(m.str(0));
-    new_header_value.replace(index, m.str(0).length(), new_format);
+    re2::RE2::Replace(&new_header_value, re, new_format);
   }
   return new_header_value;
 }

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -1269,9 +1269,15 @@ TEST(HeaderParser, TestMetadataTranslator) {
       {"%UPSTREAM_METADATA([\"a\", \"b\",\"c\"])% %UPSTREAM_METADATA([\"d\", \"e\"])%",
        "%UPSTREAM_METADATA(a:b:c)% %UPSTREAM_METADATA(d:e)%"},
       {"%DYNAMIC_METADATA([\"a\", \"b\",\"c\"])%", "%DYNAMIC_METADATA(a:b:c)%"},
-      {"%UPSTREAM_METADATA([\"a\", \"b\",\"c\"])% %DYNAMIC_METADATA([\"d\", \"e\"])%",
-       "%UPSTREAM_METADATA(a:b:c)% %DYNAMIC_METADATA(d:e)%"},
-      {"nothing to translate", "nothing to translate"}};
+      {"%UPSTREAM_METADATA([\"a\", \"b\",\"c\"])% LEAVE_IT %DYNAMIC_METADATA([\"d\", \"e\"])%",
+       "%UPSTREAM_METADATA(a:b:c)% LEAVE_IT %DYNAMIC_METADATA(d:e)%"},
+      // The following test cases contain parts which should not be translated.
+      {"nothing to translate", "nothing to translate"},
+      {"%UPSTREAM_METADATA([\"a\", \"b\")%", "%UPSTREAM_METADATA([\"a\", \"b\")%"},
+      {"%UPSTREAM_METADATA([\"a\", \"b\"]])%", "%UPSTREAM_METADATA([\"a\", \"b\"]])%"},
+      {"%UPSTREAM_METADATA([\"a\", \"b\",\"c\"])% %DYNAMIC_METADATA([\"d\", \"e\")%",
+       "%UPSTREAM_METADATA(a:b:c)% %DYNAMIC_METADATA([\"d\", \"e\")%"},
+      {"UPSTREAM_METADATA([\"a\", \"b\"])%", "UPSTREAM_METADATA([\"a\", \"b\"])%"}};
 
   for (const auto& test_case : test_cases) {
     EXPECT_EQ(test_case.expected_output_, HeaderParser::translateMetadataFormat(test_case.input_));

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -185,7 +185,6 @@ paths:
     - source/common/common/regex.cc
     - source/common/common/utility.cc
     - source/common/formatter/substitution_formatter.cc
-    - source/common/router/header_parser_utils.cc
     - source/common/stats/tag_extractor_impl.h
     - source/common/stats/tag_extractor_impl.cc
     - source/common/version/version.cc


### PR DESCRIPTION
Commit Message:
use re2 for header formatter utilities.
Additional Description:
This PR addresses @jmarantz comment [about performance](https://github.com/envoyproxy/envoy/pull/21932#discussion_r988278306)
Risk Level: Low
Testing: Added few unit test cases, but functionality should be identical as before
Docs Changes: No
Release Notes: No
Platform Specific Features: No
