### PR TITLE
Envoy ASSERT() due to regex rewrite path string contains \r

### DIFF
--- a/api/envoy/type/matcher/v3/regex.proto
+++ b/api/envoy/type/matcher/v3/regex.proto
@@ -95,5 +95,6 @@ message RegexMatchAndSubstitute {
   // backslash followed by the capture group number to denote a numbered
   // capture group. E.g., ``\1`` refers to capture group 1, and ``\2`` refers
   // to capture group 2.
-  string substitution = 2;
+  string substitution = 2
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 }

--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-4718246398132224.fuzz
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-4718246398132224.fuzz
@@ -1,0 +1,23 @@
+config {
+  virtual_hosts {
+    name: "*"
+    domains: "*"
+    matcher {
+      on_no_match {
+        action {
+          name: "*"
+          typed_config {
+            type_url: "m/envoy.config.route.v3.Route"
+            value: "\n\002\022\000\022\'\n\001*\202\002!\n\004\022\002%*\022\031ty/envoy.$nigfig.rououte"
+          }
+        }
+      }
+    }
+  }
+}
+headers {
+  headers {
+    key: "x-forwarded-proto"
+    value: "D"
+  }
+}


### PR DESCRIPTION
It is observed that Envoy crash in ASSERT() due to regex rewrite path string contains invalid character '\r'.

We should prohibit null characters \0, \r, \n in the regex rewrite substitution string.   This is well guarded in most other cases like RouteAction:prefix_rewrite, but is missing in RouteAction:regex_rewrite:substitution.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
