### PR TITLE
grpc_transcoder: fix a bug with http2 when request body is Http.Body

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,33 +11,6 @@ bug_fixes:
 - area: grpc_json_transcoder
   change: |
     fix a bug when using http2, request body has google.api.HttpBody and the size is < 16KB, it will cause EOF from the backend grpc server.
-- area: http
-  change: |
-    fixed a bug with internal redirects not being performed for drained connections.
-- area: jwt_authn
-  change: |
-    fixed a bug where a negative "exp", "iat", or "nbf" integer in JWT token readed as a large positive value.
-- area: listener
-  change: |
-    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a memory leak.
-- area: transport_socket
-  change: |
-    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.
-- area: logger
-  change: |
-    added the %j and %_ format support for fine-grain loggers to make it consistant with default loggers.
-- area: thrift
-  change: |
-    fixed the routing decision when thrift filters change the value of the cluster header.
-- area: router
-  change: |
-    fixed edge-case interaction between weighted clusters, cluster headers and (request|response)_headers_to_(add|remove).
-- area: upstream
-  change: |
-    fixed a bug where custom transport socket hashes might not be respected by wrapper passthrough sockets. This change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.fix_hash_key`` to false.
-- area: tls
-  change: |
-    fixed a bug where, when runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` is set to false, the wrong TLS alerts would sometimes be sent in response to certificate validation failures.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,36 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: grpc_json_transcoder
+  change: |
+    fix a bug when using http2, request body has google.api.HttpBody and the size is < 16KB, it will cause EOF from the backend grpc server.
+- area: http
+  change: |
+    fixed a bug with internal redirects not being performed for drained connections.
+- area: jwt_authn
+  change: |
+    fixed a bug where a negative "exp", "iat", or "nbf" integer in JWT token readed as a large positive value.
+- area: listener
+  change: |
+    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a memory leak.
+- area: transport_socket
+  change: |
+    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.
+- area: logger
+  change: |
+    added the %j and %_ format support for fine-grain loggers to make it consistant with default loggers.
+- area: thrift
+  change: |
+    fixed the routing decision when thrift filters change the value of the cluster header.
+- area: router
+  change: |
+    fixed edge-case interaction between weighted clusters, cluster headers and (request|response)_headers_to_(add|remove).
+- area: upstream
+  change: |
+    fixed a bug where custom transport socket hashes might not be respected by wrapper passthrough sockets. This change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.fix_hash_key`` to false.
+- area: tls
+  change: |
+    fixed a bug where, when runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` is set to false, the wrong TLS alerts would sometimes be sent in response to certificate validation failures.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -525,7 +525,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
   }
 
   if (end_stream && method_->request_type_is_http_body_) {
-    maybeSendHttpBodyRequestMessage();
+    maybeSendHttpBodyRequestMessage(nullptr);
   } else if (end_stream) {
     request_in_.finish();
 
@@ -560,7 +560,7 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
 
     // TODO(euroelessar): Upper bound message size for streaming case.
     if (end_stream || method_->descriptor_->client_streaming()) {
-      maybeSendHttpBodyRequestMessage();
+      maybeSendHttpBodyRequestMessage(&data);
     } else {
       // TODO(euroelessar): Avoid buffering if content length is already known.
       return Http::FilterDataStatus::StopIterationAndBuffer;
@@ -597,7 +597,7 @@ Http::FilterTrailersStatus JsonTranscoderFilter::decodeTrailers(Http::RequestTra
   }
 
   if (method_->request_type_is_http_body_) {
-    maybeSendHttpBodyRequestMessage();
+    maybeSendHttpBodyRequestMessage(nullptr);
   } else {
     request_in_.finish();
 
@@ -841,7 +841,7 @@ bool JsonTranscoderFilter::readToBuffer(Protobuf::io::ZeroCopyInputStream& strea
   return false;
 }
 
-void JsonTranscoderFilter::maybeSendHttpBodyRequestMessage() {
+void JsonTranscoderFilter::maybeSendHttpBodyRequestMessage(Buffer::Instance* data) {
   if (first_request_sent_ && request_data_.length() == 0) {
     return;
   }
@@ -855,7 +855,11 @@ void JsonTranscoderFilter::maybeSendHttpBodyRequestMessage() {
 
   Envoy::Grpc::Encoder().prependFrameHeader(Envoy::Grpc::GRPC_FH_DEFAULT, message_payload);
 
-  decoder_callbacks_->addDecodedData(message_payload, true);
+  if (data) {
+    data->move(message_payload);
+  } else {
+    decoder_callbacks_->addDecodedData(message_payload, true);
+  }
 
   first_request_sent_ = true;
 }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -181,7 +181,7 @@ private:
   bool checkAndRejectIfRequestTranscoderFailed(const std::string& details);
   bool checkAndRejectIfResponseTranscoderFailed();
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
-  void maybeSendHttpBodyRequestMessage();
+  void maybeSendHttpBodyRequestMessage(Buffer::Instance* data);
   /**
    * Builds response from HttpBody protobuf.
    * Returns true if at least one gRPC frame has processed.


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix: https://github.com/envoyproxy/envoy/issues/16629

When using http2, and request body has google.api.HttpBody, the size is < 16KB, it will cause EOF.

Risk Level: Low
Testing:  unit-tested
Docs Changes:
Release Notes: Yes
Platform Specific Features:
[