### PR TITLE
dubbo codec: remove Http HeaderMap in the dubbo message

### DIFF
--- a/source/extensions/common/dubbo/BUILD
+++ b/source/extensions/common/dubbo/BUILD
@@ -42,7 +42,6 @@ envoy_cc_library(
     deps = [
         ":message_lib",
         "//source/common/buffer:buffer_lib",
-        "//source/common/http:header_map_lib",
     ],
 )
 
@@ -58,7 +57,6 @@ envoy_cc_library(
     deps = [
         ":hessian2_utils_lib",
         "//source/common/buffer:buffer_lib",
-        "//source/common/http:header_map_lib",
     ],
 )
 

--- a/source/extensions/common/dubbo/message_impl.cc
+++ b/source/extensions/common/dubbo/message_impl.cc
@@ -1,4 +1,5 @@
 #include "source/extensions/common/dubbo/message_impl.h"
+
 #include <memory>
 
 namespace Envoy {

--- a/source/extensions/common/dubbo/message_impl.cc
+++ b/source/extensions/common/dubbo/message_impl.cc
@@ -1,4 +1,5 @@
 #include "source/extensions/common/dubbo/message_impl.h"
+#include <memory>
 
 namespace Envoy {
 namespace Extensions {
@@ -16,8 +17,10 @@ void RpcRequestImpl::Attachment::insert(absl::string_view key, absl::string_view
 
   attachment_updated_ = true;
 
-  attachment_->toMutableUntypedMap().value().get()[std::make_unique<String>(key)] =
-      std::make_unique<String>(value);
+  Hessian2::ObjectPtr key_o = std::make_unique<String>(key);
+  Hessian2::ObjectPtr val_o = std::make_unique<String>(value);
+  attachment_->toMutableUntypedMap().value().get().insert_or_assign(std::move(key_o),
+                                                                    std::move(val_o));
 }
 
 void RpcRequestImpl::Attachment::remove(absl::string_view key) {

--- a/source/extensions/common/dubbo/message_impl.h
+++ b/source/extensions/common/dubbo/message_impl.h
@@ -51,12 +51,9 @@ public:
 
     const Map& attachment() const { return *attachment_; }
 
-    void insert(const std::string& key, const std::string& value);
-    void remove(const std::string& key);
-    const std::string* lookup(const std::string& key) const;
-
-    // Http::HeaderMap wrapper to attachment.
-    const Http::HeaderMap& headers() const { return *headers_; }
+    void insert(absl::string_view key, absl::string_view value);
+    void remove(absl::string_view key);
+    absl::optional<absl::string_view> lookup(absl::string_view key) const;
 
     // Whether the attachment should be re-serialized.
     bool attachmentUpdated() const { return attachment_updated_; }
@@ -71,11 +68,6 @@ public:
     // The binary offset of attachment in the original message. Retaining this value can help
     // subsequent re-serialization of the attachment without re-serializing the parameters.
     size_t attachment_offset_{};
-
-    // To reuse the HeaderMatcher API and related tools provided by Envoy, we store the key/value
-    // pair of the string type in the attachment in the Http::HeaderMap. This introduces additional
-    // overhead and ignores the case of the key in the attachment. But for now, it's acceptable.
-    Http::HeaderMapPtr headers_;
   };
   using AttachmentPtr = std::unique_ptr<Attachment>;
 

--- a/source/extensions/common/dubbo/message_impl.h
+++ b/source/extensions/common/dubbo/message_impl.h
@@ -2,8 +2,6 @@
 
 #include <string>
 
-#include "envoy/http/header_map.h"
-
 #include "source/extensions/common/dubbo/hessian2_utils.h"
 #include "source/extensions/common/dubbo/message.h"
 

--- a/source/extensions/common/dubbo/metadata.h
+++ b/source/extensions/common/dubbo/metadata.h
@@ -4,8 +4,6 @@
 #include <string>
 
 #include "source/common/common/assert.h"
-#include "source/common/common/empty_string.h"
-#include "source/common/http/header_map_impl.h"
 #include "source/extensions/common/dubbo/message.h"
 
 #include "absl/types/optional.h"

--- a/test/extensions/common/dubbo/message_test.cc
+++ b/test/extensions/common/dubbo/message_test.cc
@@ -28,8 +28,6 @@ TEST(RpcRequestImplTest, RpcRequestAttachmentTest) {
   RpcRequestImpl::Attachment attachment(std::move(map), 23333);
 
   EXPECT_EQ(4, attachment.attachment().toUntypedMap().value().get().size());
-  // Only string type key/value pairs will be inserted to header map.
-  EXPECT_EQ(2, attachment.headers().size());
 
   // Test lookup.
   EXPECT_EQ(nullptr, attachment.lookup("map_key"));
@@ -43,17 +41,14 @@ TEST(RpcRequestImplTest, RpcRequestAttachmentTest) {
   EXPECT_EQ(nullptr, attachment.lookup("fake_key"));
 
   EXPECT_EQ(3, attachment.attachment().toUntypedMap().value().get().size());
-  EXPECT_EQ(1, attachment.headers().size());
 
   // Test remove. Delete a key/value pair whose value type is map.
   attachment.remove("map_key");
   EXPECT_EQ(2, attachment.attachment().toUntypedMap().value().get().size());
-  EXPECT_EQ(1, attachment.headers().size());
 
   // Test insert.
   attachment.insert("test", "test_value");
   EXPECT_EQ(3, attachment.attachment().toUntypedMap().value().get().size());
-  EXPECT_EQ(2, attachment.headers().size());
 
   EXPECT_EQ("test_value", *attachment.lookup("test"));
 

--- a/test/extensions/common/dubbo/message_test.cc
+++ b/test/extensions/common/dubbo/message_test.cc
@@ -30,7 +30,7 @@ TEST(RpcRequestImplTest, RpcRequestAttachmentTest) {
   EXPECT_EQ(4, attachment.attachment().toUntypedMap().value().get().size());
 
   // Test lookup.
-  EXPECT_EQ(nullptr, attachment.lookup("map_key"));
+  EXPECT_EQ(absl::nullopt, attachment.lookup("map_key"));
   EXPECT_EQ("fake_group", *attachment.lookup("group"));
 
   EXPECT_FALSE(attachment.attachmentUpdated());
@@ -38,7 +38,7 @@ TEST(RpcRequestImplTest, RpcRequestAttachmentTest) {
   // Test remove. Remove a normal string type key/value pair.
   EXPECT_EQ("fake_value", *attachment.lookup("fake_key"));
   attachment.remove("fake_key");
-  EXPECT_EQ(nullptr, attachment.lookup("fake_key"));
+  EXPECT_EQ(absl::nullopt, attachment.lookup("fake_key"));
 
   EXPECT_EQ(3, attachment.attachment().toUntypedMap().value().get().size());
 


### PR DESCRIPTION
Commit Message: dubbo codec: remove Http HeaderMap in the dubbo message
Additional Description:

In the original implementation of dubbo proxy, `Http::HeaderMap` is used to store a copy of dubbo attachments. By this way, we can reuse `HeaderMatcher`-related functions/classes. It's not necessary for now because the unified matcher API will be used.

And the key of `Http::HeaderMap` is case-insensitive and only string value could be stored in. So, we must use a `Hessian2::Object::UntypedMap` to store complete attachments. It would bring some additional overhead.

This PR removed `Http::HeaderMap` from our new dubbo codec.

Risk Level: Low
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.