### PR TITLE
ssl: extend SSL manager lifetime beyond the dispatcher

### DIFF
--- a/source/server/server.h
+++ b/source/server/server.h
@@ -353,6 +353,9 @@ private:
   Random::RandomGeneratorPtr random_generator_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   Api::ApiPtr api_;
+  // ssl_context_manager_ must come before dispatcher_, since ClusterInfo
+  // references SslSocketFactory and is deleted on the main thread via the dispatcher.
+  std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   Event::DispatcherPtr dispatcher_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::unique_ptr<AdminImpl> admin_;
@@ -360,7 +363,6 @@ private:
   Network::ConnectionHandlerPtr handler_;
   std::unique_ptr<Runtime::ScopedLoaderSingleton> runtime_singleton_;
   std::unique_ptr<Runtime::Loader> runtime_;
-  std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   ProdListenerComponentFactory listener_component_factory_;
   ProdWorkerFactory worker_factory_;
   std::unique_ptr<ListenerManager> listener_manager_;


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Ensure that SSL context manager outlives the dispatcher during shutdown. ClusterInfo deletion is posted on the dispatcher and it references SSL socket factory shared pointers, which remove themselves from the SSL context manager on destruction.
Risk Level: low, SSL manager is a fairly dumb container of objects
Testing: TODO
Docs Changes: none
Release Notes: none
Fixes: https://github.com/envoyproxy/envoy/issues/21447