### PR TITLE
Change ext_auth logger id

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -246,7 +246,7 @@ private:
  * HTTP ext_authz filter. Depending on the route configuration, this filter calls the global
  * ext_authz service before allowing further filter iteration.
  */
-class Filter : public Logger::Loggable<Logger::Id::filter>,
+class Filter : public Logger::Loggable<Logger::Id::ext_authz>,
                public Http::StreamFilter,
                public Filters::Common::ExtAuthz::RequestCallbacks {
 public:


### PR DESCRIPTION
Commit Message: Change ext_authz Filter logger id
Additional Description: -
Risk Level: low
Testing: Tested build locally and confirmed by running this command

```
./bazel-bin/source/exe/envoy-static -c /mnt/disks/envoy-project/examples/ext_authz.yaml --component-log-level ext_authz:trace
```
generated logs:
```
[2022-10-12 12:45:56.310][103024][trace][ext_authz] [source/extensions/filters/http/ext_authz/ext_authz.cc:73] [C0][S14765918889036524211] ext_authz filter calling authorization server
[2022-10-12 12:45:56.315][103024][trace][ext_authz] [source/extensions/filters/http/ext_authz/ext_authz.cc:417] [C0][S14765918889036524211] ext_authz filter rejected the request with an error. Response status code: 403
```

Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
