### PR TITLE
Fix msan failure in the GrpcJsonTranscoderFilterTest.ResponseBodyExceedsBufferLimit

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -834,11 +834,10 @@ bool JsonTranscoderFilter::readToBuffer(Protobuf::io::ZeroCopyInputStream& strea
   const void* out;
   int size;
   while (stream.Next(&out, &size)) {
-    data.add(out, size);
-
     if (size == 0) {
       return true;
     }
+    data.add(out, size);
   }
   return false;
 }


### PR DESCRIPTION
Commit Message:
msan triggers use of uninitialized value in the GrpcJsonTranscoderFilterTest.ResponseBodyExceedsBufferLimit test when a new slice with size == 0 is added to the buffer. Trigger point is just passing uninitialized value to the add() call. With size == 0 the add() call is a no-op.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>

