### PR TITLE
Fix uninitialized value in the retry policy mock

### DIFF
--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -141,7 +141,7 @@ public:
   std::chrono::milliseconds per_try_idle_timeout_{0};
   uint32_t num_retries_{};
   uint32_t retry_on_{};
-  uint32_t host_selection_max_attempts_;
+  uint32_t host_selection_max_attempts_{0};
   std::vector<uint32_t> retriable_status_codes_;
   std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
   std::vector<Http::HeaderMatcherSharedPtr> retriable_request_headers_;


### PR DESCRIPTION
Additional Description:
detected internally by an updated msan

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
