### PR TITLE
dlb: optimize auto detect logic

### DIFF
--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -36,10 +36,13 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
   }
 
   const uint& config_id = dlb_config.id();
-  const uint& device_id = detectDlbDevice(config_id, "/dev");
-  if (device_id < 0) {
+  const auto& result = detectDlbDevice(config_id, "/dev");
+  if (!result.has_value()) {
     ExceptionUtil::throwEnvoyException("no available dlb hardware");
-  } else if (device_id != config_id) {
+  }
+
+  const uint& device_id = result.value();
+  if (device_id != config_id) {
     ENVOY_LOG(warn, "dlb device {} is not found, use dlb device {} instead", config_id, device_id);
   }
 

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -7,8 +7,6 @@
 #include <cstdlib>
 #include <memory>
 
-#include "source/common/api/os_sys_calls_impl.h"
-
 #ifndef DLB_DISABLED
 #include "dlb.h"
 #endif
@@ -40,27 +38,12 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
 #ifdef DLB_DISABLED
   throw EnvoyException("X86_64 architecture is required for Dlb.");
 #else
-  int device_id = dlb_config.id();
-  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
-  struct stat buffer;
-
-  std::string device_name = fmt::format("/dev/dlb{}", device_id);
-  if (os_sys_calls.stat(device_name.c_str(), &buffer).return_value_ != 0) {
-    int i = 0;
-    // auto detect available dlb devices, now the max number of dlb device id is 63.
-    const int max_id = 64;
-    for (; i < max_id; i++) {
-      device_name = fmt::format("/dev/dlb{}", i);
-      if (os_sys_calls.stat(device_name.c_str(), &buffer).return_value_ == 0) {
-        device_id = i;
-        ENVOY_LOG(warn, "dlb device {} is not found, use dlb device {} instead", dlb_config.id(),
-                  device_id);
-        break;
-      }
-    }
-    if (i == 64) {
-      ExceptionUtil::throwEnvoyException("no available dlb hardware");
-    }
+  const int& config_id = dlb_config.id();
+  const int& device_id = detectDlbDevice(config_id, "/dev");
+  if (device_id == -1) {
+    ExceptionUtil::throwEnvoyException("no available dlb hardware");
+  } else if (device_id != config_id) {
+    ENVOY_LOG(warn, "dlb device {} is not found, use dlb device {} instead", config_id, device_id);
   }
 
   dlb_resources_t rsrcs;

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -35,9 +35,6 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
         "please decrease the number of threads by `--concurrency`");
   }
 
-#ifdef DLB_DISABLED
-  throw EnvoyException("X86_64 architecture is required for Dlb.");
-#else
   const int& config_id = dlb_config.id();
   const int& device_id = detectDlbDevice(config_id, "/dev");
   if (device_id == -1) {
@@ -45,6 +42,10 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
   } else if (device_id != config_id) {
     ENVOY_LOG(warn, "dlb device {} is not found, use dlb device {} instead", config_id, device_id);
   }
+
+#ifdef DLB_DISABLED
+  throw EnvoyException("X86_64 architecture is required for Dlb.");
+#else
 
   dlb_resources_t rsrcs;
   if (dlb_open(device_id, &dlb) == -1) {

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -35,9 +35,9 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
         "please decrease the number of threads by `--concurrency`");
   }
 
-  const int& config_id = dlb_config.id();
-  const int& device_id = detectDlbDevice(config_id, "/dev");
-  if (device_id == -1) {
+  const uint& config_id = dlb_config.id();
+  const uint& device_id = detectDlbDevice(config_id, "/dev");
+  if (device_id < 0) {
     ExceptionUtil::throwEnvoyException("no available dlb hardware");
   } else if (device_id != config_id) {
     ENVOY_LOG(warn, "dlb device {} is not found, use dlb device {} instead", config_id, device_id);

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -54,8 +54,8 @@ private:
 // The dir should always be "/dev" in production.
 // For test it is a temporary directory.
 // Return Dlb device id, -1 means error.
-static int detectDlbDevice(const uint config_id, const std::string& dir) {
-  int device_id = config_id;
+static absl::optional<uint> detectDlbDevice(const uint config_id, const std::string& dir) {
+  uint device_id = config_id;
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   struct stat buffer;
 
@@ -72,10 +72,10 @@ static int detectDlbDevice(const uint config_id, const std::string& dir) {
       }
     }
     if (i == 64) {
-      return -1;
+      return absl::nullopt;
     }
   }
-  return device_id;
+  return absl::optional<uint>{device_id};
 }
 
 class DlbConnectionBalanceFactory : public Envoy::Network::ConnectionBalanceFactory,

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <ostream>
 #include <string>
 
 #include "envoy/event/dispatcher.h"
@@ -61,14 +60,12 @@ static int detectDlbDevice(const int& config_id, const std::string& dir) {
   struct stat buffer;
 
   std::string device_path = fmt::format("{}/dlb{}", dir, device_id);
-  std::cout << "xxxx" << device_path << std::endl;
   if (os_sys_calls.stat(device_path.c_str(), &buffer).return_value_ != 0) {
     int i = 0;
     // auto detect available dlb devices, now the max number of dlb device id is 63.
     const int max_id = 64;
     for (; i < max_id; i++) {
       device_path = fmt::format("{}/dlb{}", dir, i);
-      std::cout << "xxxx" << device_path << std::endl;
       if (os_sys_calls.stat(device_path.c_str(), &buffer).return_value_ == 0) {
         device_id = i;
         break;

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -54,7 +54,7 @@ private:
 // The dir should always be "/dev" in production.
 // For test it is a temporary directory.
 // Return Dlb device id, -1 means error.
-static int detectDlbDevice(const int& config_id, const std::string& dir) {
+static int detectDlbDevice(const uint config_id, const std::string& dir) {
   int device_id = config_id;
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   struct stat buffer;

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -53,7 +53,7 @@ private:
 
 // The dir should always be "/dev" in production.
 // For test it is a temporary directory.
-// Return Dlb device id, -1 means error.
+// Return Dlb device id, absl::nullopt means error.
 static absl::optional<uint> detectDlbDevice(const uint config_id, const std::string& dir) {
   uint device_id = config_id;
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -127,7 +127,6 @@ public:
 #endif
 };
 
-REGISTER_FACTORY(DlbConnectionBalanceFactory, Envoy::Network::ConnectionBalanceFactory);
 using DlbConnectionBalanceFactorySingleton = InjectableSingleton<DlbConnectionBalanceFactory>;
 
 /**

--- a/contrib/network/connection_balance/dlb/test/BUILD
+++ b/contrib/network/connection_balance/dlb/test/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
         "//contrib/network/connection_balance/dlb/source:connection_balancer",
         "//source/common/protobuf:utility_lib",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:environment_lib",
         "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/contrib/network/connection_balance/dlb/test/BUILD
+++ b/contrib/network/connection_balance/dlb/test/BUILD
@@ -12,9 +12,10 @@ envoy_cc_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     deps = [
+        "//contrib/network/connection_balance/dlb/source:connection_balancer",
         "//source/common/protobuf:utility_lib",
+        "//test/mocks/server:factory_context_mocks",
         "//test/test_common:status_utility_lib",
-        "@envoy_api//contrib/envoy/extensions/network/connection_balance/dlb/v3alpha:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -69,7 +69,9 @@ TEST_F(DlbConnectionBalanceFactoryTest, MockDetectDlbDevice) {
   TestEnvironment::createPath(dlb_path);
   const std::ofstream file(dlb_path + "/" + "dlb6");
 
-  EXPECT_EQ(6, detectDlbDevice(dlb.id(), dlb_path));
+  const auto& result = detectDlbDevice(dlb.id(), dlb_path);
+  EXPECT_EQ(true, result.has_value());
+  EXPECT_EQ(6, result.value());
   TestEnvironment::removePath(dlb_path);
 }
 

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -61,6 +61,18 @@ TEST_F(DlbConnectionBalanceFactoryTest, EmptyProto) {
                 factory.createEmptyConfigProto().get()));
 }
 
+TEST_F(DlbConnectionBalanceFactoryTest, MockDetectDlbDevice) {
+  envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb dlb;
+  dlb.set_id(1);
+
+  const std::string& dlb_path = TestEnvironment::temporaryDirectory();
+  TestEnvironment::createPath(dlb_path);
+  const std::ofstream file(dlb_path + "/" + "dlb6");
+
+  EXPECT_EQ(6, detectDlbDevice(dlb.id(), dlb_path));
+  TestEnvironment::removePath(dlb_path);
+}
+
 #ifndef DLB_DISABLED
 
 using testing::HasSubstr;
@@ -90,19 +102,6 @@ TEST_F(DlbConnectionBalanceFactoryTest, TooManyThreads) {
       factory.createConnectionBalancerFromProto(typed_config, context), EnvoyException,
       HasSubstr("Dlb connection balanncer only supports up to 32 worker threads"));
 }
-
-TEST_F(DlbConnectionBalanceFactoryTest, MockDetectDlbDevice) {
-  envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb dlb;
-  dlb.set_id(1);
-
-  const std::string& dlb_path = TestEnvironment::temporaryDirectory();
-  TestEnvironment::createPath(dlb_path);
-  const std::ofstream file(dlb_path + "/" + "dlb6");
-
-  EXPECT_EQ(6, detectDlbDevice(dlb.id(), dlb_path));
-  TestEnvironment::removePath(dlb_path);
-}
-
 #endif
 
 } // namespace Dlb

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -3,6 +3,7 @@
 #include "source/common/protobuf/utility.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/status_utility.h"
 
 #include "contrib/network/connection_balance/dlb/source/connection_balancer_impl.h"
@@ -89,6 +90,19 @@ TEST_F(DlbConnectionBalanceFactoryTest, TooManyThreads) {
       factory.createConnectionBalancerFromProto(typed_config, context), EnvoyException,
       HasSubstr("Dlb connection balanncer only supports up to 32 worker threads"));
 }
+
+TEST_F(DlbConnectionBalanceFactoryTest, MockDetectDlbDevice) {
+  envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb dlb;
+  dlb.set_id(1);
+
+  const std::string& dlb_path = TestEnvironment::temporaryDirectory();
+  TestEnvironment::createPath(dlb_path);
+  const std::ofstream file(dlb_path + "/" + "dlb6");
+
+  EXPECT_EQ(6, detectDlbDevice(dlb.id(), dlb_path));
+  TestEnvironment::removePath(dlb_path);
+}
+
 #endif
 
 } // namespace Dlb


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

The default of type uint32 in protobuf is 0, so the `else` field can not run into.

Fix the above issue and add tests to cover some cases.

DLB mock functions are in development, so only test the config logic for now.

Commit Message: 
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
