### PR TITLE
Revert "listener filter: hide envoy internals from ListenerFilterCallbacks interface (#22732)

### DIFF
--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -287,6 +287,20 @@ public:
   virtual ConnectionSocket& socket() PURE;
 
   /**
+   * @return the Dispatcher for issuing events.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
+   * If a filter stopped filter iteration by returning FilterStatus::StopIteration,
+   * the filter should call continueFilterChain(true) when complete to continue the filter chain,
+   * or continueFilterChain(false) if the filter execution failed and the connection must be
+   * closed.
+   * @param success boolean telling whether the filter execution was successful or not.
+   */
+  virtual void continueFilterChain(bool success) PURE;
+
+  /**
    * @param name the namespace used in the metadata in reverse DNS format, for example:
    * envoy.test.my_filter.
    * @param value the struct to set on the namespace. A merge will be performed with new values for
@@ -327,21 +341,15 @@ public:
 
   /**
    * Called when a new connection is accepted, but before a Connection is created.
-   * Filter chain iteration can be stopped if need more data from the connection
-   * by returning `FilterStatus::StopIteration`, or continue the filter chain iteration
-   * by returning `FilterStatus::ContinueIteration`. Reject the connection by closing
-   * the socket and returning `FilterStatus::StopIteration`.
+   * Filter chain iteration can be stopped if needed.
    * @param cb the callbacks the filter instance can use to communicate with the filter chain.
    * @return status used by the filter manager to manage further filter iteration.
    */
   virtual FilterStatus onAccept(ListenerFilterCallbacks& cb) PURE;
 
   /**
-   * Called when data is read from the connection. If the filter doesn't get
-   * enough data, filter chain iteration can be stopped if needed by returning
-   * `FilterStatus::StopIteration`. Or continue the filter chain iteration by returning
-   * `FilterStatus::ContinueIteration` if the filter get enough data. Reject the connection
-   * by closing the socket and returning `FilterStatus::StopIteration`.
+   * Called when data read from the connection. If the filter chain doesn't get
+   * enough data, the filter chain can be stopped, then waiting for more data.
    * @param buffer the buffer of data.
    * @return status used by the filter manager to manage further filter iteration.
    */

--- a/source/server/active_stream_listener_base.h
+++ b/source/server/active_stream_listener_base.h
@@ -85,28 +85,28 @@ public:
   void onSocketAccepted(std::unique_ptr<ActiveTcpSocket> active_socket) {
     // Create and run the filters
     if (config_->filterChainFactory().createListenerFilterChain(*active_socket)) {
-      active_socket->startFilterChain();
+      active_socket->continueFilterChain(true);
     } else {
       // If create listener filter chain failed, it means the listener is missing
       // config due to the ECDS. Then close the connection directly.
-      active_socket->socket().close();
-      ASSERT(active_socket->isEndFilterIteration());
+      active_socket->socket_->close();
+      ASSERT(active_socket->iter_ == active_socket->accept_filters_.end());
     }
 
     // Move active_socket to the sockets_ list if filter iteration needs to continue later.
     // Otherwise we let active_socket be destructed when it goes out of scope.
-    if (!active_socket->isEndFilterIteration()) {
+    if (active_socket->iter_ != active_socket->accept_filters_.end()) {
       active_socket->startTimer();
       LinkedList::moveIntoListBack(std::move(active_socket), sockets_);
     } else {
-      if (!active_socket->connected()) {
+      if (!active_socket->connected_) {
         // If active_socket is about to be destructed, emit logs if a connection is not created.
-        if (active_socket->streamInfo() != nullptr) {
-          emitLogs(*config_, *active_socket->streamInfo());
+        if (active_socket->stream_info_ != nullptr) {
+          emitLogs(*config_, *active_socket->stream_info_);
         } else {
           // If the active_socket is not connected, this socket is not promoted to active
           // connection. Thus the stream_info_ is owned by this active socket.
-          ENVOY_BUG(active_socket->streamInfo() != nullptr,
+          ENVOY_BUG(active_socket->stream_info_ != nullptr,
                     "the unconnected active socket must have stream info.");
         }
       }

--- a/source/server/active_tcp_socket.cc
+++ b/source/server/active_tcp_socket.cc
@@ -36,6 +36,8 @@ ActiveTcpSocket::~ActiveTcpSocket() {
   }
 }
 
+Event::Dispatcher& ActiveTcpSocket::dispatcher() { return listener_.dispatcher(); }
+
 void ActiveTcpSocket::onTimeout() {
   listener_.stats_.downstream_pre_cx_timeout_.inc();
   ASSERT(inserted());

--- a/test/server/active_tcp_listener_test.cc
+++ b/test/server/active_tcp_listener_test.cc
@@ -482,7 +482,7 @@ TEST_F(ActiveTcpListenerTest, PopulateSNIWhenActiveTcpSocketTimeout) {
   generic_active_listener_->sockets().front()->onTimeout();
 
   EXPECT_EQ(server_name,
-            tcp_socket->streamInfo()->downstreamAddressProvider().requestedServerName());
+            tcp_socket->stream_info_->downstreamAddressProvider().requestedServerName());
 }
 
 // Verify that the server connection with recovered address is rebalanced at redirected listener.

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -35,7 +35,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::ByMove;
 using testing::InSequence;
 using testing::Invoke;
 using testing::MockFunction;
@@ -2086,50 +2085,39 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   TestListener* test_listener =
       addListener(1, true, false, "test_listener", listener, &listener_callbacks);
   handler_->addListener(absl::nullopt, *test_listener, runtime_);
-  size_t max_size = 10;
-  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter(max_size);
+
+  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter(123);
   EXPECT_CALL(factory_, createListenerFilterChain(_))
       .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
         manager.addAcceptFilter(listener_filter_matcher_, Network::ListenerFilterPtr{test_filter});
         return true;
       }));
+  Network::ListenerFilterCallbacks* listener_filter_cb{};
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
+  std::string data = "test";
   EXPECT_CALL(*test_filter, onAccept(_))
-      .WillOnce(Invoke([](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
+      .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
+        listener_filter_cb = &cb;
         return Network::FilterStatus::StopIteration;
       }));
-  Network::MockIoHandle io_handle;
-  EXPECT_CALL(*accepted_socket, ioHandle()).WillOnce(ReturnRef(io_handle));
-  EXPECT_CALL(io_handle, isOpen()).WillOnce(Return(true));
-  EXPECT_CALL(*accepted_socket, ioHandle()).WillOnce(ReturnRef(io_handle));
-
-  Event::FileReadyCb file_event_callback;
-  EXPECT_CALL(io_handle,
-              createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
-                               Event::FileReadyType::Read | Event::FileReadyType::Closed))
-      .WillOnce(SaveArg<1>(&file_event_callback));
-  EXPECT_CALL(io_handle, activateFileEvents(_));
+  Network::IoSocketHandleImpl io_handle{42};
+  EXPECT_CALL(*accepted_socket, ioHandle()).WillOnce(ReturnRef(io_handle)).RetiresOnSaturation();
+  EXPECT_CALL(*accepted_socket, ioHandle()).WillOnce(ReturnRef(io_handle)).RetiresOnSaturation();
+  Event::FileEvent* file_event = new NiceMock<Event::MockFileEvent>();
+  EXPECT_CALL(dispatcher_, createFileEvent_(_, _, _, _)).WillOnce(Return(file_event));
 
   Event::MockTimer* timeout = new Event::MockTimer(&dispatcher_);
   EXPECT_CALL(*timeout, enableTimer(std::chrono::milliseconds(15000), _));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
 
-  EXPECT_CALL(io_handle, recv(_, _, _))
-      .WillOnce(Return(ByMove(
-          Api::IoCallUint64Result(max_size, Api::IoErrorPtr(nullptr, [](Api::IoError*) {})))));
-  EXPECT_CALL(*test_filter, onData(_))
-      .WillOnce(Invoke([](Network::ListenerFilterBuffer&) -> Network::FilterStatus {
-        return Network::FilterStatus::Continue;
-      }));
-  EXPECT_CALL(io_handle, resetFileEvents());
   EXPECT_CALL(*test_filter, destroy_());
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(*access_log_, log(_, _, _, _));
   EXPECT_CALL(*timeout, disableTimer());
+  listener_filter_cb->continueFilterChain(true);
 
-  file_event_callback(Event::FileReadyType::Read);
-
-  EXPECT_CALL(io_handle, createFileEvent_(_, _, _, _));
+  Event::FileEvent* file_event2 = new NiceMock<Event::MockFileEvent>();
+  EXPECT_CALL(dispatcher_, createFileEvent_(_, _, _, _)).WillOnce(Return(file_event2));
   EXPECT_CALL(*listener, onDestroy());
 
   // Verify the file event created by listener filter was reset. If not


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: Revert "listener filter: hide envoy internals from ListenerFilterCallbacks interface (#22732)
Additional Description:
https://envoyproxy.slack.com/archives/C78HA81DH/p1665661946626769 there is a case showing up, people still need a way to trigger the listener filter iteration in the listener filter.

This reverts commit 350c7f947149fcff41c4bdeac633aab80ae207fe.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

