### PR TITLE
change regex UI prompt to say 'Google re2' rather than ecmascript in the description

### DIFF
--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -196,7 +196,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
                         "Render text_readouts as new gaugues with value 0 (increases Prometheus "
                         "data size)"},
                        {ParamDescriptor::Type::String, "filter",
-                        "Regular expression (ecmascript) for filtering stats"}}),
+                        "Regular expression (google re2) for filtering stats"}}),
           makeHandler("/stats/recentlookups", "Show recent stat-name lookups",
                       MAKE_ADMIN_HANDLER(stats_handler_.handlerStatsRecentLookups), false, false),
           makeHandler("/stats/recentlookups/clear", "clear list of stat-name lookups and counter",

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -196,7 +196,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
                         "Render text_readouts as new gaugues with value 0 (increases Prometheus "
                         "data size)"},
                        {ParamDescriptor::Type::String, "filter",
-                        "Regular expression (google re2) for filtering stats"}}),
+                        "Regular expression (Google re2) for filtering stats"}}),
           makeHandler("/stats/recentlookups", "Show recent stat-name lookups",
                       MAKE_ADMIN_HANDLER(stats_handler_.handlerStatsRecentLookups), false, false),
           makeHandler("/stats/recentlookups/clear", "clear list of stat-name lookups and counter",

--- a/source/server/admin/stats_handler.cc
+++ b/source/server/admin/stats_handler.cc
@@ -173,7 +173,7 @@ Admin::UrlHandler StatsHandler::statsHandler() {
       {{Admin::ParamDescriptor::Type::Boolean, "usedonly",
         "Only include stats that have been written by system since restart"},
        {Admin::ParamDescriptor::Type::String, "filter",
-        "Regular expression (ecmascript) for filtering stats"},
+        "Regular expression (Google re2) for filtering stats"},
        {Admin::ParamDescriptor::Type::Enum, "format", "Format to use", {"html", "text", "json"}},
        {Admin::ParamDescriptor::Type::Enum,
         "type",

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -170,14 +170,14 @@ TEST_P(AdminInstanceTest, Help) {
   /server_info: print server version/status information
   /stats: print server stats
       usedonly: Only include stats that have been written by system since restart
-      filter: Regular expression (ecmascript) for filtering stats
+      filter: Regular expression (Google re2) for filtering stats
       format: Format to use; One of (html, text, json)
       type: Stat types to include.; One of (All, Counters, Histograms, Gauges, TextReadouts)
       histogram_buckets: Histogram bucket display mode; One of (cumulative, disjoint, none)
   /stats/prometheus: print server stats in prometheus format
       usedonly: Only include stats that have been written by system since restart
       text_readouts: Render text_readouts as new gaugues with value 0 (increases Prometheus data size)
-      filter: Regular expression (ecmascript) for filtering stats
+      filter: Regular expression (Google re2) for filtering stats
   /stats/recentlookups: Show recent stat-name lookups
   /stats/recentlookups/clear (POST): clear list of stat-name lookups and counter
   /stats/recentlookups/disable (POST): disable recording of reset stat-name lookup names


### PR DESCRIPTION
Commit Message: In https://github.com/envoyproxy/envoy/pull/21058 the default regex engine used for admin `/stats?filter=` was changed from std::regex (ecmascript) to Google re2. However the prompt in the admin HTML launch page was not flipped accordingly. This PR fixes that..
Additional Description:
Risk Level: low
Testing: just CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

