### PR TITLE
tracing: fixing a regression in router initiated spans

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1631,6 +1631,9 @@ void ConnectionManagerImpl::ActiveStream::onBelowWriteBufferLowWatermark() {
 }
 
 Tracing::OperationName ConnectionManagerImpl::ActiveStream::operationName() const {
+  if (!connection_manager_.config_.tracingConfig()) {
+    return Tracing::OperationName::Egress;
+  }
   return connection_manager_.config_.tracingConfig()->operation_name_;
 }
 
@@ -1639,10 +1642,14 @@ const Tracing::CustomTagMap* ConnectionManagerImpl::ActiveStream::customTags() c
 }
 
 bool ConnectionManagerImpl::ActiveStream::verbose() const {
-  return connection_manager_.config_.tracingConfig()->verbose_;
+  return connection_manager_.config_.tracingConfig() &&
+         connection_manager_.config_.tracingConfig()->verbose_;
 }
 
 uint32_t ConnectionManagerImpl::ActiveStream::maxPathTagLength() const {
+  if (!connection_manager_.config_.tracingConfig()) {
+    return Tracing::DefaultMaxPathTagLength;
+  }
   return connection_manager_.config_.tracingConfig()->max_path_tag_length_;
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -283,6 +283,7 @@ private:
     void onRequestDataTooLarge() override;
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
     void onLocalReply(Code code) override;
+    // TODO(alyssawilk) this should be an optional reference.
     Tracing::Config& tracingConfig() override;
     const ScopeTrackedObject& scope() override;
     OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return *this; }

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -286,6 +286,20 @@ TEST_P(ProtocolIntegrationTest, AddBodyToRequestAndWaitForIt) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+TEST_P(ProtocolIntegrationTest, RouterOnlyTracing) {
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        envoy::extensions::filters::http::router::v3::Router router_config;
+        router_config.set_start_child_span(true);
+        hcm.mutable_http_filters(0)->mutable_typed_config()->PackFrom(router_config);
+      });
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+}
+
 TEST_P(ProtocolIntegrationTest, AddBodyToResponseAndWaitForIt) {
   config_helper_.prependFilter(R"EOF(
   name: add-body-filter


### PR DESCRIPTION
Fixes an issue where route spans were not performed correctly when HCM config was absent. Now if HCM is not configured, the egress config defaults will again be used.

Risk Level: low
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Fixes commit #22987
