### PR TITLE
Docs: Fix broken link in HTTP3 arch overview

### DIFF
--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -35,7 +35,7 @@ log a warning on start-up if BPF is unsupported on the platform, or is attempted
 
 It is recommanded to monitor some UDP listener and QUIC connection stats:
 * :repo:`UDP listener downstream_rx_datagram_dropped </docs/root/configuration/listeners/stats.rst#udp-statistics>`: non-zero means kernel's UDP listen socket's receive buffer isn't large enough. In Linux, it can be configured via listener :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>` by setting prebinding socket option SO_RCVBUF at SOL_SOCKET level.
-* :repo:`QUIC connection error codes and stream reset error codes </docs/root/configuration/http/http_conn_man/stats.rst#http3-per-listener-statistics>`: please refer to `quic_error_codes.h <https://github.com/google/quiche/blob/main/quic/core/quic_error_codes.h>`_ for the meaning of each error codes.
+* :repo:`QUIC connection error codes and stream reset error codes </docs/root/configuration/http/http_conn_man/stats.rst#http3-per-listener-statistics>`: please refer to `quic_error_codes.h <https://github.com/google/quiche/blob/main/quiche/quic/core/quic_error_codes.h>`_ for the meaning of each error code.
 
 HTTP3 upstream
 --------------


### PR DESCRIPTION
Signed-off-by: Adam Anderson <6754028+AdamEAnderson@users.noreply.github.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix broken link in HTTP3 arch overview
Additional Description: QUIC error code reference link broken by remote repo renames, fixed
Risk Level: Minimal
Testing: Click the link, it works
Docs Changes: That's all this is
Release Notes: Fix broken link in HTTP3 arch overview
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
