### PR TITLE
Stricter boundary checks for Duration when it is converted to std::chrono::milliseconds

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -919,22 +919,34 @@ ProtobufWkt::Value ValueUtil::listValue(const std::vector<ProtobufWkt::Value>& v
 
 namespace {
 
-void validateDuration(const ProtobufWkt::Duration& duration) {
+void validateDuration(const ProtobufWkt::Duration& duration, int64_t max_seconds_value) {
   if (duration.seconds() < 0 || duration.nanos() < 0) {
     throw DurationUtil::OutOfRangeException(
         fmt::format("Expected positive duration: {}", duration.DebugString()));
   }
-  if (duration.nanos() > 999999999 ||
-      duration.seconds() > Protobuf::util::TimeUtil::kDurationMaxSeconds) {
+  if (duration.nanos() > 999999999 || duration.seconds() > max_seconds_value) {
     throw DurationUtil::OutOfRangeException(
         fmt::format("Duration out-of-range: {}", duration.DebugString()));
   }
 }
 
+void validateDuration(const ProtobufWkt::Duration& duration) {
+  validateDuration(duration, Protobuf::util::TimeUtil::kDurationMaxSeconds);
+}
+
+void validateDurationAsMilliseconds(const ProtobufWkt::Duration& duration) {
+  // Apply stricter max boundary to the `seconds` value to avoid overflow.
+  // Note that protobuf internally converts to nanoseconds.
+  // The kMaxInt64Nanoseconds = 9223372036, which is about 300 years.
+  constexpr int64_t kMaxInt64Nanoseconds =
+      std::numeric_limits<int64_t>::max() / (1000 * 1000 * 1000);
+  validateDuration(duration, kMaxInt64Nanoseconds);
+}
+
 } // namespace
 
 uint64_t DurationUtil::durationToMilliseconds(const ProtobufWkt::Duration& duration) {
-  validateDuration(duration);
+  validateDurationAsMilliseconds(duration);
   return Protobuf::util::TimeUtil::DurationToMilliseconds(duration);
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1672,6 +1672,13 @@ TEST(DurationUtilTest, OutOfRange) {
     duration.set_seconds(Protobuf::util::TimeUtil::kDurationMaxSeconds + 1);
     EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
   }
+  {
+    ProtobufWkt::Duration duration;
+    constexpr int64_t kMaxInt64Nanoseconds =
+        std::numeric_limits<int64_t>::max() / (1000 * 1000 * 1000);
+    duration.set_seconds(kMaxInt64Nanoseconds + 1);
+    EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
+  }
 }
 
 // Verify WIP accounting of the file based annotations. This test uses the strict validator to test


### PR DESCRIPTION
Commit Message:
Internally protobuf first converts seconds to nanoseconds before converting to milliseconds. This can overflow if the default bound checks are applied to the `seconds` value.

This can potentially be a breaking change for configuration that erroneously supplied values higher than 9223372036, since Envoy will now be rejecting such config. Before it was accepting it and using the "wrapped around" value.

This case is also verified by the test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5988544525893632 corpus, however the asan sanitizer needs to be of a newer version to catch the error.

Risk Level: Low. Small possibility of a breaking change.
Testing: Unit Test 
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
