### PR TITLE
Listener Fuzzer: avoid dangling reference to dtor unique_ptr

### DIFF
--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -84,18 +84,18 @@ public:
     return filter_chain_.get();
   }
 
+  void fuzz(Network::ListenerFilterPtr filter,
+            const test::extensions::filters::listener::FilterFuzzWithDataTestCase& input);
+
+private:
   void write(const std::string& s) {
     Buffer::OwnedImpl buf(s);
     conn_->write(buf, false);
   }
 
-  void connect(Network::ListenerFilterPtr filter);
+  void connect();
   void disconnect();
 
-  void fuzz(Network::ListenerFilterPtr filter,
-            const test::extensions::filters::listener::FilterFuzzWithDataTestCase& input);
-
-private:
   testing::NiceMock<Runtime::MockLoader> runtime_;
   Stats::TestUtil::TestStore stats_store_;
   Api::ApiPtr api_;
@@ -105,6 +105,7 @@ private:
   std::vector<Network::ListenSocketFactoryPtr> socket_factories_;
   Network::NopConnectionBalancerImpl connection_balancer_;
   Network::ConnectionHandlerPtr connection_handler_;
+  Network::ListenerFilterPtr filter_{nullptr};
   Network::MockFilterChainFactory factory_;
   Network::ClientConnectionPtr conn_;
   NiceMock<Network::MockConnectionCallbacks> connection_callbacks_;


### PR DESCRIPTION
Let fuzzer own filter to avoid dangling reference if listener filter chain doesn't get created in connect. 

We'd need to upgrade googletest in order to support moveable actions hence why I can't just move the filter into the lambda, but we have some build breakages associated with googletest, a windows patch. 

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Listener Fuzzer: avoid dangling reference to dtor unique_ptr.
Additional Description:
Risk Level: low (fuzz)
Testing: ran fuzzer
Docs Changes: na
Release Notes: na
Platform Specific Features:
Fixes #23520

