### PR TITLE
docs: correct spelling of multi

### DIFF
--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -194,7 +194,7 @@ For details on each command's usage see the official
   LREM, List
   LSET, List
   LTRIM, List
-  MUTLI, Transaction
+  MULTI, Transaction
   RPOP, List
   RPUSH, List
   RPUSHX, List


### PR DESCRIPTION
Signed-off-by: Brian P O'Rourke <brian@orourke.io>

Commit Message: Correct command name in Redis docs
Additional Description: s/MUTLI/MULTI/
Risk Level: Low
Testing: Docs only
Docs Changes: Docs only
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
