### PR TITLE
tools, github: Add current SOURCE_VERSION writer

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -32,6 +32,18 @@ independently sourced, the following steps should be followed:
 1. Configure, build and/or install the [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/start/building#requirements).
 1. `bazel build -c opt envoy` from the repository root.
 
+### Building from a release tarball
+
+To build Envoy from a release tarball, you can download a release tarball from Assets section in each release in project [Releases page](https://github.com/envoyproxy/envoy/releases).
+Given all required [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/start/building#requirements) are installed, the following steps should be followed:
+
+1. Download and extract source code of a release tarball from the Releases page. For example: https://github.com/envoyproxy/envoy/releases/tag/v1.24.0.
+1. `python3 tools/github/tools/github/write_current_source_version.py` from the repository root.
+1. `bazel build -c opt envoy` from the repository root.
+
+> Note: If the the `write_current_source_version.py` script is missing from the extracted source code directory, you can download it from [here](https://raw.githubusercontent.com/envoyproxy/envoy/tree/main/tools/github/write_current_source_version.py).
+> This script is used to generate SOURCE_VERSION that is required by [`bazel/get_workspace_status`](./get_workspace_status) to "stamp" the binary in a non-git directory.
+
 ## Quick start Bazel build for developers
 
 This section describes how to and what dependencies to install to get started building Envoy with Bazel.

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -1,5 +1,3 @@
-# Copyright 2020 Envoyproxy Authors
-
 # Produces SOURCE_VERSION file with content from current version commit hash. As a reminder,
 # SOURCE_VERSION is required when building Envoy from an extracted release tarball (non-git).
 # See: bazel/get_workspace_status for more information.

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -1,0 +1,55 @@
+# Copyright 2020 Envoyproxy Authors
+
+# Produces SOURCE_VERSION file with content from current version commit hash. As a reminder,
+# SOURCE_VERSION is required when building Envoy from an extracted release tarball (non-git).
+# See: bazel/get_workspace_status for more information.
+#
+# The SOURCE_VERSION is produced by reading the VERSION.txt file then fetch the corresponding commit
+# hass from GitHub. Note: This script can only be executed from project root directory of an
+# extracted "release" tarball.
+
+import os
+import sys
+import json
+
+from urllib import request
+from pathlib import Path
+
+if __name__ == "__main__":
+    # Simple check if a .git directory exists. We should only rely on information from "git".
+    if Path(".git").exists():
+        print(
+            "Failed to create SOURCE_VERSION. "
+            "Run this script from an extracted release tarball directory."
+        )
+        sys.exit(1)
+
+    # Check if we have VERSION.txt available
+    current_version_file = Path("VERSION.txt")
+    if not current_version_file.exists():
+        print(
+            "Failed to read VERSION.txt. "
+            "Run this script from project root of an extracted release tarball directory."
+        )
+        sys.exit(1)
+
+    current_version = current_version_file.read_text().rstrip()
+
+    # Exit when we are in a "main" copy.
+    if current_version.endswith("-dev"):
+        print(
+            "Failed to create SOURCE_VERSION. "
+            "The current VERSION.txt contains version with '-dev' suffix. "
+            "Run this script from an extracted release tarball directory."
+        )
+        sys.exit(1)
+
+    # Fetch the current version commit information from GitHub.
+    with request.urlopen(
+        "https://api.github.com/repos/envoyproxy/envoy/commits/v" + current_version
+    ) as response:
+        commit_info = json.loads(response.read())
+        source_version_file = Path("SOURCE_VERSION")
+        with source_version_file.open("w", encoding="utf-8") as source_version:
+            # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
+            source_version.write(commit_info["sha"])

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -13,41 +13,40 @@ import json
 from urllib import request
 from pathlib import Path
 
-if __name__ == "__main__":
-    # Simple check if a .git directory exists. When we are in a Git repo, we should rely on git.
-    if Path(".git").exists():
-        print(
-            "Failed to create SOURCE_VERSION. "
-            "Run this script from an extracted release tarball directory."
-        )
-        sys.exit(1)
+# Simple check if a .git directory exists. When we are in a Git repo, we should rely on git.
+if Path(".git").exists():
+    print(
+        "Failed to create SOURCE_VERSION. "
+        "Run this script from an extracted release tarball directory."
+    )
+    sys.exit(1)
 
-    # Check if we have VERSION.txt available
-    current_version_file = Path("VERSION.txt")
-    if not current_version_file.exists():
-        print(
-            "Failed to read VERSION.txt. "
-            "Run this script from project root of an extracted release tarball directory."
-        )
-        sys.exit(1)
+# Check if we have VERSION.txt available
+current_version_file = Path("VERSION.txt")
+if not current_version_file.exists():
+    print(
+        "Failed to read VERSION.txt. "
+        "Run this script from project root of an extracted release tarball directory."
+    )
+    sys.exit(1)
 
-    current_version = current_version_file.read_text().rstrip()
+current_version = current_version_file.read_text().rstrip()
 
-    # Exit when we are in a "main" copy.
-    if current_version.endswith("-dev"):
-        print(
-            "Failed to create SOURCE_VERSION. "
-            "The current VERSION.txt contains version with '-dev' suffix. "
-            "Run this script from an extracted release tarball directory."
-        )
-        sys.exit(1)
+# Exit when we are in a "main" copy.
+if current_version.endswith("-dev"):
+    print(
+        "Failed to create SOURCE_VERSION. "
+        "The current VERSION.txt contains version with '-dev' suffix. "
+        "Run this script from an extracted release tarball directory."
+    )
+    sys.exit(1)
 
-    # Fetch the current version commit information from GitHub.
-    with request.urlopen(
-        "https://api.github.com/repos/envoyproxy/envoy/commits/v" + current_version
-    ) as response:
-        commit_info = json.loads(response.read())
-        source_version_file = Path("SOURCE_VERSION")
-        with source_version_file.open("w", encoding="utf-8") as source_version:
-            # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
-            source_version.write(commit_info["sha"])
+# Fetch the current version commit information from GitHub.
+with request.urlopen(
+    "https://api.github.com/repos/envoyproxy/envoy/commits/v" + current_version
+) as response:
+    commit_info = json.loads(response.read())
+    source_version_file = Path("SOURCE_VERSION")
+    with source_version_file.open("w", encoding="utf-8") as source_version:
+        # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
+        source_version.write(commit_info["sha"])

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -44,6 +44,5 @@ if __name__ == '__main__':
                                 + current_version) as response:
         commit_info = json.loads(response.read())
         source_version_file = pathlib.Path("SOURCE_VERSION")
-        with source_version_file.open("w", encoding="utf-8") as source_version:
-            # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
-            source_version.write(commit_info["sha"])
+        # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
+        source_version_file.write_text(commit_info["sha"])

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -6,7 +6,6 @@
 # hass from GitHub. Note: This script can only be executed from project root directory of an
 # extracted "release" tarball.
 
-import os
 import sys
 import json
 
@@ -17,8 +16,7 @@ from pathlib import Path
 if Path(".git").exists():
     print(
         "Failed to create SOURCE_VERSION. "
-        "Run this script from an extracted release tarball directory."
-    )
+        "Run this script from an extracted release tarball directory.")
     sys.exit(1)
 
 # Check if we have VERSION.txt available
@@ -26,8 +24,7 @@ current_version_file = Path("VERSION.txt")
 if not current_version_file.exists():
     print(
         "Failed to read VERSION.txt. "
-        "Run this script from project root of an extracted release tarball directory."
-    )
+        "Run this script from project root of an extracted release tarball directory.")
     sys.exit(1)
 
 current_version = current_version_file.read_text().rstrip()
@@ -37,14 +34,12 @@ if current_version.endswith("-dev"):
     print(
         "Failed to create SOURCE_VERSION. "
         "The current VERSION.txt contains version with '-dev' suffix. "
-        "Run this script from an extracted release tarball directory."
-    )
+        "Run this script from an extracted release tarball directory.")
     sys.exit(1)
 
 # Fetch the current version commit information from GitHub.
-with request.urlopen(
-    "https://api.github.com/repos/envoyproxy/envoy/commits/v" + current_version
-) as response:
+with request.urlopen("https://api.github.com/repos/envoyproxy/envoy/commits/v"
+                     + current_version) as response:
     commit_info = json.loads(response.read())
     source_version_file = Path("SOURCE_VERSION")
     with source_version_file.open("w", encoding="utf-8") as source_version:

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
 
     # Fetch the current version commit information from GitHub.
     with urllib.request.urlopen("https://api.github.com/repos/envoyproxy/envoy/commits/v"
-                        + current_version) as response:
+                                + current_version) as response:
         commit_info = json.loads(response.read())
         source_version_file = pathlib.Path("SOURCE_VERSION")
         with source_version_file.open("w", encoding="utf-8") as source_version:

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -1,10 +1,12 @@
-# Produces SOURCE_VERSION file with content from current version commit hash. As a reminder,
-# SOURCE_VERSION is required when building Envoy from an extracted release tarball (non-git).
-# See: bazel/get_workspace_status for more information.
+# This script produces SOURCE_VERSION file with content from current version commit hash. As a
+# reminder,SOURCE_VERSION is required when building Envoy from an extracted release tarball
+# (non-git). See: bazel/get_workspace_status for more information.
 #
-# The SOURCE_VERSION is produced by reading the VERSION.txt file then fetch the corresponding commit
-# hass from GitHub. Note: This script can only be executed from project root directory of an
-# extracted "release" tarball.
+# The SOURCE_VERSION file is produced by reading current version tag from VERSION.txt file then
+# fetch the corresponding commit hash from GitHub.
+#
+# Note: This script can only be executed from project root directory of an extracted "release"
+# tarball.
 
 import sys
 import json

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -14,7 +14,7 @@ from urllib import request
 from pathlib import Path
 
 if __name__ == "__main__":
-    # Simple check if a .git directory exists. We should only rely on information from "git".
+    # Simple check if a .git directory exists. When we are in a Git repo, we should rely on git.
     if Path(".git").exists():
         print(
             "Failed to create SOURCE_VERSION. "


### PR DESCRIPTION
Commit Message: This adds a script to produce the `SOURCE_VERSION` file which is useful to build envoy in a non-git (from an extracted release tarball) directory. See: `bazel/get_workspace_status` for more information.

Relevant: https://github.com/envoyproxy/envoy/issues/2181.

Additional Description: This is useful to have a way to produce `SOURCE_VERSION`, for example, to solve: https://github.com/Homebrew/homebrew-core/blob/923bb7a622b86876a662d1ed4a7ac51ccb2befcf/Formula/envoy.rb#L4. So downstream builder can consume release tarballs to build envoy without adding custom scripts to create `SOURCE_VERSION`.
Risk Level: Low, since this is an optional tool.
Testing: Run the script in git and non-git environments.
Docs Changes: Added.
Release Notes: N/A
Platform-Specific Features: N/A
