### PR TITLE
set fips mode explicitly to publish to stats sinks

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -505,7 +505,7 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
   if (VersionInfo::sslFipsCompliant()) {
     server_compilation_settings_stats_->fips_mode_.set(1);
   } else {
-    // Set this explicitly so that "used" flag is set.
+    // Set this explicitly so that "used" flag is set so that it can be pushed to stats sinks.
     server_compilation_settings_stats_->fips_mode_.set(0);
   }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -504,6 +504,9 @@ void InstanceImpl::initialize(Network::Address::InstanceConstSharedPtr local_add
   server_stats_->version_.set(version_int);
   if (VersionInfo::sslFipsCompliant()) {
     server_compilation_settings_stats_->fips_mode_.set(1);
+  } else {
+    // Set this explicitly so that "used" flag is set.
+    server_compilation_settings_stats_->fips_mode_.set(0);
   }
 
   // If user has set user_agent_name in the bootstrap config, use it.


### PR DESCRIPTION
Currently we set this flag only if it is fips build. So non FIPS versions, do not set this stat and hence not publishes to stats sinks like metrics sinks. Publishing it will help creating alerts more easily.

Commit Message: set fips mode explicitly to publish to stats sinks
Additional Description: N/A
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
