### PR TITLE
router: fix `regex_rewrite` for redirects matched on prefix

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,9 @@ bug_fixes:
 - area: grpc_json_transcoder
   change: |
     fix a bug when using http2, request body has google.api.HttpBody and the size is < 16KB, it will cause EOF from the backend grpc server.
+- area: router
+  change: |
+    fixed a bug that incorrectly rewrote the path when using ``regex_rewrite`` for redirects matched on prefix.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -960,6 +960,13 @@ absl::optional<std::string> RouteEntryImplBase::currentUrlPathAfterRewriteWithMa
   // TODO(perf): can we avoid the string copy for the common case?
   std::string path(headers.getPathValue());
   if (!rewrite.empty()) {
+    if (regex_rewrite_redirect_ != nullptr) {
+      // As the rewrite constant may contain the result of a regex rewrite for a redirect, we must
+      // replace the full path if this is the case. This is because the matched path does not need
+      // to correspond to the full path, e.g. in the case of prefix matches.
+      auto just_path(Http::PathUtil::removeQueryAndFragment(path));
+      return path.replace(0, just_path.size(), rewrite);
+    }
     ASSERT(case_sensitive_ ? absl::StartsWith(path, matched_path)
                            : absl::StartsWithIgnoreCase(path, matched_path));
     return path.replace(0, matched_path.size(), rewrite);


### PR DESCRIPTION
Commit Message: router: fix `regex_rewrite` for redirects matched on prefix
Additional Description:
These changes fixes an issue when using `regex_rewrite` as a part of a redirect when the path that is matched does not equal the full path. The issue was that only the matched section of the original path (e.g. prefix) was replaced with the substitution of the regex rewrite, while the expected behaviour is that the full path should be replaced.

This solves this by adding a case for these scenarios, i.e. if we have a redirect and use `regex_rewrite`, replace the full path with the rewritten path.

Risk Level: medium (changes the behaviour of how `regex_rewrite` and redirects works together)
Testing: Implemented unit tests to ensure the expected behaviour.
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
Fixes #Issue: #23557

Signed-off-by: Axel Pettersson <axel@pettersson.cc>