### PR TITLE
jwt_authn: upgrade its security status to stable

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -355,7 +355,7 @@ envoy.filters.http.jwt_authn:
   categories:
   - envoy.filters.http
   security_posture: robust_to_untrusted_downstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
   - envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

jwt_authn http filter have been used by many products.  But its security status is still alpha.

Did not find the process of upgrading its status. 

Risk Level: None
Testing:  None
Docs Changes: None
Release Notes: None
