### PR TITLE
Update doc string for `server_names`

### DIFF
--- a/api/envoy/config/listener/v3/listener_components.proto
+++ b/api/envoy/config/listener/v3/listener_components.proto
@@ -154,7 +154,7 @@ message FilterChainMatch {
   // The server name will be matched against all wildcard domains, i.e. ``www.example.com``
   // will be first matched against ``www.example.com``, then ``*.example.com``, then ``*.com``.
   //
-  // Note that partial wildcards are not supported, and values like ``*w.example.com`` are invalid.
+  // Note that partial wildcards are not supported, and values like ``*w.example.com`` and `*` are invalid.
   //
   // .. attention::
   //

--- a/api/envoy/config/listener/v3/listener_components.proto
+++ b/api/envoy/config/listener/v3/listener_components.proto
@@ -154,7 +154,8 @@ message FilterChainMatch {
   // The server name will be matched against all wildcard domains, i.e. ``www.example.com``
   // will be first matched against ``www.example.com``, then ``*.example.com``, then ``*.com``.
   //
-  // Note that partial wildcards are not supported, and values like ``*w.example.com`` and `*` are invalid.
+  // Note that partial wildcards are not supported, and values like ``*w.example.com`` are invalid.
+  // The value ``*`` is also not supported, and ``server_names`` should be omitted instead.
   //
   // .. attention::
   //


### PR DESCRIPTION
* Currently envoy expects that if `server_names` contains a  wildcard `*`, it must start with `*.`. So just including `*` in the `server_names` is rejected by Envoy. A simple workaround is to not fill up the `server_names` field with `*` and leave it empty to achieve the same result

* Updated the doc string to mention that the user cannot specify just `*` in the `server_names` field

* Relates to https://github.com/envoyproxy/gateway/issues/601#issuecomment-1283113482

Signed-off-by: Arko Dasgupta <arko@tetrate.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
