### PR TITLE
tracing: update the tracingConfig() to return opt ref

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -360,7 +360,7 @@ public:
   /**
    * @return tracing configuration.
    */
-  virtual const Tracing::Config& tracingConfig() PURE;
+  virtual OptRef<const Tracing::Config> tracingConfig() const PURE;
 
   /**
    * @return the ScopeTrackedObject for this stream.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -363,7 +363,9 @@ private:
   // TODO(kbaichoo): Plumb account from owning request filter.
   Buffer::BufferMemoryAccountSharedPtr account() const override { return nullptr; }
   Tracing::Span& activeSpan() override { return active_span_; }
-  const Tracing::Config& tracingConfig() override { return tracing_config_; }
+  OptRef<const Tracing::Config> tracingConfig() const override {
+    return makeOptRef<const Tracing::Config>(tracing_config_);
+  }
   void continueDecoding() override {}
   RequestTrailerMap& addDecodedTrailers() override { PANIC("not implemented"); }
   void addDecodedData(Buffer::Instance&, bool) override {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -202,12 +202,16 @@ private:
       return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, details);
     }
 
+  private:
+    // Keep these methods private to ensure that these methods are only called by the reference
+    // returned by the public tracingConfig() method.
     // Tracing::TracingConfig
     Tracing::OperationName operationName() const override;
     const Tracing::CustomTagMap* customTags() const override;
     bool verbose() const override;
     uint32_t maxPathTagLength() const override;
 
+  public:
     // ScopeTrackedObject
     void dumpState(std::ostream& os, int indent_level = 0) const override {
       const char* spaces = spacesForLevel(indent_level);
@@ -283,8 +287,7 @@ private:
     void onRequestDataTooLarge() override;
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
     void onLocalReply(Code code) override;
-    // TODO(alyssawilk) this should be an optional reference.
-    Tracing::Config& tracingConfig() override;
+    OptRef<const Tracing::Config> tracingConfig() const override;
     const ScopeTrackedObject& scope() override;
     OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return *this; }
 
@@ -363,6 +366,7 @@ private:
     bool validateHeaders();
 
     ConnectionManagerImpl& connection_manager_;
+    const TracingConnectionManagerConfig* connection_manager_tracing_config_{};
     // TODO(snowp): It might make sense to move this to the FilterManager to avoid storing it in
     // both locations, then refer to the FM when doing stream logs.
     const uint64_t stream_id_;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -253,7 +253,7 @@ void ActiveStreamFilterBase::restoreContextOnContinue(
   parent_.contextOnContinue(tracked_object_stack);
 }
 
-const Tracing::Config& ActiveStreamFilterBase::tracingConfig() {
+OptRef<const Tracing::Config> ActiveStreamFilterBase::tracingConfig() const {
   return parent_.filter_manager_callbacks_.tracingConfig();
 }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -92,7 +92,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   uint64_t streamId() const override;
   StreamInfo::StreamInfo& streamInfo() override;
   Tracing::Span& activeSpan() override;
-  const Tracing::Config& tracingConfig() override;
+  OptRef<const Tracing::Config> tracingConfig() const override;
   const ScopeTrackedObject& scope() override;
   void restoreContextOnContinue(ScopeTrackedObjectStack& tracked_object_stack) override;
   void resetIdleTimer() override;
@@ -504,7 +504,7 @@ public:
   /**
    * Returns the tracing configuration to use for this stream.
    */
-  virtual const Tracing::Config& tracingConfig() PURE;
+  virtual OptRef<const Tracing::Config> tracingConfig() const PURE;
 
   /**
    * Returns the tracked scope to use for this stream.

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -94,13 +94,15 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
           Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_upstream_filters")),
       stream_options_({can_send_early_data, can_use_http3}) {
   if (parent_.config().start_child_span_) {
-    span_ = parent_.callbacks()->activeSpan().spawnChild(
-        parent_.callbacks()->tracingConfig(),
-        absl::StrCat("router ", parent.cluster()->observabilityName(), " egress"),
-        parent.timeSource().systemTime());
-    if (parent.attemptCount() != 1) {
-      // This is a retry request, add this metadata to span.
-      span_->setTag(Tracing::Tags::get().RetryCount, std::to_string(parent.attemptCount() - 1));
+    if (auto tracing_config = parent_.callbacks()->tracingConfig(); tracing_config.has_value()) {
+      span_ = parent_.callbacks()->activeSpan().spawnChild(
+          tracing_config.value().get(),
+          absl::StrCat("router ", parent.cluster()->observabilityName(), " egress"),
+          parent.timeSource().systemTime());
+      if (parent.attemptCount() != 1) {
+        // This is a retry request, add this metadata to span.
+        span_->setTag(Tracing::Tags::get().RetryCount, std::to_string(parent.attemptCount() - 1));
+      }
     }
   }
   stream_info_.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
@@ -142,8 +144,10 @@ void UpstreamRequest::cleanUp() {
   }
 
   if (span_ != nullptr) {
+    auto tracing_config = parent_.callbacks()->tracingConfig();
+    ASSERT(tracing_config.has_value());
     Tracing::HttpTracerUtility::finalizeUpstreamSpan(*span_, stream_info_,
-                                                     parent_.callbacks()->tracingConfig());
+                                                     tracing_config.value().get());
   }
 
   if (per_try_timeout_ != nullptr) {
@@ -840,7 +844,7 @@ const ScopeTrackedObject& UpstreamRequestFilterManagerCallbacks::scope() {
   return upstream_request_.parent_.callbacks()->scope();
 }
 
-const Tracing::Config& UpstreamRequestFilterManagerCallbacks::tracingConfig() {
+OptRef<const Tracing::Config> UpstreamRequestFilterManagerCallbacks::tracingConfig() const {
   return upstream_request_.parent_.callbacks()->tracingConfig();
 }
 

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -322,7 +322,7 @@ public:
   }
 
   // These functions are delegated to the downstream HCM/FM
-  const Tracing::Config& tracingConfig() override;
+  OptRef<const Tracing::Config> tracingConfig() const override;
   const ScopeTrackedObject& scope() override;
   Tracing::Span& activeSpan() override;
   void resetStream(Http::StreamResetReason reset_reason,

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -140,8 +140,8 @@ TEST_F(UpstreamRequestTest, AcceptRouterHeaders) {
   EXPECT_FALSE(filter->callbacks_->informationalHeaders().has_value());
   EXPECT_FALSE(filter->callbacks_->responseHeaders().has_value());
   EXPECT_FALSE(filter->callbacks_->http1StreamEncoderOptions().has_value());
-  EXPECT_EQ(&filter->callbacks_->tracingConfig(),
-            &router_filter_interface_.callbacks_.tracingConfig());
+  EXPECT_EQ(&filter->callbacks_->tracingConfig().value().get(),
+            &router_filter_interface_.callbacks_.tracingConfig().value().get());
   EXPECT_EQ(filter->callbacks_->clusterInfo(), router_filter_interface_.callbacks_.clusterInfo());
   EXPECT_EQ(&filter->callbacks_->activeSpan(), &router_filter_interface_.callbacks_.activeSpan());
   EXPECT_EQ(&filter->callbacks_->streamInfo(), &router_filter_interface_.callbacks_.streamInfo());

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -85,7 +85,8 @@ MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
       }));
 
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
-  ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
+  ON_CALL(*this, tracingConfig())
+      .WillByDefault(Return(makeOptRef<const Tracing::Config>(tracing_config_)));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
   ON_CALL(*this, sendLocalReply(_, _, _, _, _))
       .WillByDefault(Invoke([this](Code code, absl::string_view body,
@@ -143,7 +144,8 @@ MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {
   initializeMockStreamFilterCallbacks(*this);
   ON_CALL(*this, encodingBuffer()).WillByDefault(Invoke(&buffer_, &Buffer::InstancePtr::get));
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
-  ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
+  ON_CALL(*this, tracingConfig())
+      .WillByDefault(Return(makeOptRef<const Tracing::Config>(tracing_config_)));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
 
   ON_CALL(*this, mostSpecificPerFilterConfig())

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -108,7 +108,7 @@ public:
   MOCK_METHOD(OptRef<DownstreamStreamFilterCallbacks>, downstreamCallbacks, ());
   MOCK_METHOD(OptRef<UpstreamStreamFilterCallbacks>, upstreamCallbacks, ());
   MOCK_METHOD(void, onLocalReply, (Code code));
-  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(OptRef<const Tracing::Config>, tracingConfig, (), (const));
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, restoreContextOnContinue, (ScopeTrackedObjectStack&));
 
@@ -248,7 +248,7 @@ public:
   MOCK_METHOD(uint64_t, streamId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
   MOCK_METHOD(Tracing::Span&, activeSpan, ());
-  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(OptRef<const Tracing::Config>, tracingConfig, (), (const));
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, restoreContextOnContinue, (ScopeTrackedObjectStack&));
   MOCK_METHOD(void, onDecoderFilterAboveWriteBufferHighWatermark, ());
@@ -344,7 +344,7 @@ public:
   MOCK_METHOD(uint64_t, streamId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
   MOCK_METHOD(Tracing::Span&, activeSpan, ());
-  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(OptRef<const Tracing::Config>, tracingConfig, (), (const));
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, onEncoderFilterAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onEncoderFilterBelowWriteBufferLowWatermark, ());


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>

Commit Message:
Additional Description:

The #22987 triggered a bug, that envoy may access dangling reference when router set_start_child_span is set to true and there's no HCM trace config.
And @alyssawilk fixed it in the #23490.

But after talking with @alyssawilk offline, we both agree to optimize the current API to make it more clear to aoivd similar problem.

Risk Level: mid. core code update.
Testing: n/a. 
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.