### PR TITLE
tools, github: Silently exit when writing sha in git

### DIFF
--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -8,41 +8,55 @@
 # Note: This script can only be executed from project root directory of an extracted "release"
 # tarball.
 
+import argparse
 import json
 import pathlib
 import sys
 import urllib.request
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Write current source version')
+    parser.add_argument(
+        '--skip_error_in_git',
+        dest='skip_error_in_git',
+        help='Skip returning error on exit when the current directory is a git repository.',
+        action='store_true')
+    args = parser.parse_args()
+
     # Simple check if a .git directory exists. When we are in a Git repo, we should rely on git.
-    if pathlib.Path(".git").exists():
+    if pathlib.Path('.git').exists():
         print(
-            "Failed to create SOURCE_VERSION. "
-            "Run this script from an extracted release tarball directory.")
+            'Failed to create SOURCE_VERSION. '
+            'Run this script from an extracted release tarball directory.')
+        if args.skip_error_in_git:
+            # We can optionally "silent" the error and the workspace status check will be done using
+            # git instead.
+            print('Workspace status check will be done using git.')
+            sys.exit(0)
         sys.exit(1)
 
     # Check if we have VERSION.txt available
-    current_version_file = pathlib.Path("VERSION.txt")
+    current_version_file = pathlib.Path('VERSION.txt')
     if not current_version_file.exists():
         print(
-            "Failed to read VERSION.txt. "
-            "Run this script from project root of an extracted release tarball directory.")
+            'Failed to read VERSION.txt. '
+            'Run this script from project root of an extracted release tarball directory.')
         sys.exit(1)
 
     current_version = current_version_file.read_text().rstrip()
 
     # Exit when we are in a "main" copy.
-    if current_version.endswith("-dev"):
+    if current_version.endswith('-dev'):
         print(
-            "Failed to create SOURCE_VERSION. "
-            "The current VERSION.txt contains version with '-dev' suffix. "
-            "Run this script from an extracted release tarball directory.")
+            'Failed to create SOURCE_VERSION. '
+            'The current VERSION.txt contains version with "-dev" suffix. '
+            'Run this script from an extracted release tarball directory.')
         sys.exit(1)
 
     # Fetch the current version commit information from GitHub.
-    with urllib.request.urlopen("https://api.github.com/repos/envoyproxy/envoy/commits/v"
+    with urllib.request.urlopen('https://api.github.com/repos/envoyproxy/envoy/commits/v'
                                 + current_version) as response:
         commit_info = json.loads(response.read())
-        source_version_file = pathlib.Path("SOURCE_VERSION")
+        source_version_file = pathlib.Path('SOURCE_VERSION')
         # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
-        source_version_file.write_text(commit_info["sha"])
+        source_version_file.write_text(commit_info['sha'])


### PR DESCRIPTION
Commit Message: This patch allows to silently exit when writing the current version SHA when in a git repository. User can supply `--skip_error_in_git`.
Additional Description: This is to support running this script when in a git repository for automation, for example in homebrew's `brew --HEAD` scenario. This script can be still executed (either in a git repo or an extracted tarball) without sophisticated checks and carry-on using git to do the workspace status check. 
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform-Specific Features: N/A
