### PR TITLE
backport: tools, github: Add current SOURCE_VERSION writer

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -32,6 +32,18 @@ independently sourced, the following steps should be followed:
 1. Configure, build and/or install the [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/start/building#requirements).
 1. `bazel build -c opt envoy` from the repository root.
 
+### Building from a release tarball
+
+To build Envoy from a release tarball, you can download a release tarball from Assets section in each release in project [Releases page](https://github.com/envoyproxy/envoy/releases).
+Given all required [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/start/building#requirements) are installed, the following steps should be followed:
+
+1. Download and extract source code of a release tarball from the Releases page. For example: https://github.com/envoyproxy/envoy/releases/tag/v1.24.0.
+1. `python3 tools/github/tools/github/write_current_source_version.py` from the repository root.
+1. `bazel build -c opt envoy` from the repository root.
+
+> Note: If the the `write_current_source_version.py` script is missing from the extracted source code directory, you can download it from [here](https://raw.githubusercontent.com/envoyproxy/envoy/tree/main/tools/github/write_current_source_version.py).
+> This script is used to generate SOURCE_VERSION that is required by [`bazel/get_workspace_status`](./get_workspace_status) to "stamp" the binary in a non-git directory.
+
 ## Quick start Bazel build for developers
 
 This section describes how to and what dependencies to install to get started building Envoy with Bazel.

--- a/tools/github/write_current_source_version.py
+++ b/tools/github/write_current_source_version.py
@@ -1,0 +1,62 @@
+# This script produces SOURCE_VERSION file with content from current version commit hash. As a
+# reminder,SOURCE_VERSION is required when building Envoy from an extracted release tarball
+# (non-git). See: bazel/get_workspace_status for more information.
+#
+# The SOURCE_VERSION file is produced by reading current version tag from VERSION.txt file then
+# fetch the corresponding commit hash from GitHub.
+#
+# Note: This script can only be executed from project root directory of an extracted "release"
+# tarball.
+
+import argparse
+import json
+import pathlib
+import sys
+import urllib.request
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Write current source version")
+    parser.add_argument(
+        "--skip_error_in_git",
+        dest="skip_error_in_git",
+        help="Skip returning error on exit when the current directory is a git repository.",
+        action="store_true")
+    args = parser.parse_args()
+
+    # Simple check if a .git directory exists. When we are in a Git repo, we should rely on git.
+    if pathlib.Path(".git").exists():
+        print(
+            "Failed to create SOURCE_VERSION. "
+            "Run this script from an extracted release tarball directory.")
+        if args.skip_error_in_git:
+            # We can optionally "silent" the error and the workspace status check will be done using
+            # git instead.
+            print("Workspace status check will be done using git.")
+            sys.exit(0)
+        sys.exit(1)
+
+    # Check if we have VERSION.txt available
+    current_version_file = pathlib.Path("VERSION.txt")
+    if not current_version_file.exists():
+        print(
+            "Failed to read VERSION.txt. "
+            "Run this script from project root of an extracted release tarball directory.")
+        sys.exit(1)
+
+    current_version = current_version_file.read_text().rstrip()
+
+    # Exit when we are in a "main" copy.
+    if current_version.endswith("-dev"):
+        print(
+            "Failed to create SOURCE_VERSION. "
+            "The current VERSION.txt contains version with '-dev' suffix. "
+            "Run this script from an extracted release tarball directory.")
+        sys.exit(1)
+
+    # Fetch the current version commit information from GitHub.
+    with urllib.request.urlopen("https://api.github.com/repos/envoyproxy/envoy/commits/v"
+                                + current_version) as response:
+        commit_info = json.loads(response.read())
+        source_version_file = pathlib.Path("SOURCE_VERSION")
+        # Write the extracted current version commit hash "sha" to SOURCE_VERSION.
+        source_version_file.write_text(commit_info["sha"])


### PR DESCRIPTION
Commit Message: This adds a script to write the current SOURCE_VERSION.

Cherry-picked from:
 - 9dcd8063a93bb7aec2cc271eb3fc05dfa96b177e
 - 8e73e50126094174054c5dcfbef5bacae00af65f
 
Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
  
Additional Description: To provide the script inside the source code tarball for each release version. The next tag will have this, but even before I can use the merged patch to get it, without `curl`-ing directly from https://raw.githubusercontent.com.
Risk Level: N/A
Testing: Manual
Docs Changes: Updated. 
Release Notes: N/A
Platform-Specific Features: N/A