### PR TITLE
build: fix char signed vs unsigned warning

### DIFF
--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -64,7 +64,7 @@ public:
         position += 2;
         break;
       default:
-        if (character >= 0x00 && character <= 0x1f) {
+        if (character == 0x00 || (character > 0x00 && character <= 0x1f)) {
           // Print character as unicode hex.
           sprintf(&result[position + 1], "u%04x", static_cast<int>(character));
           position += 6;
@@ -107,7 +107,7 @@ public:
       }
 
       default: {
-        if (character >= 0x00 && character <= 0x1f) {
+        if (character == 0x00 || (character > 0x00 && character <= 0x1f)) {
           // From character (1 byte) to unicode hex (6 bytes).
           result += 5;
         }


### PR DESCRIPTION
char defaults to signed on most x86 platforms, but unsigned on arm64. When targeting linux arm64 this produced a warning because character was always >= 0. This change circumvents this warning without changing behavior even though it seems pretty unreasonable to have a character less than 0 in this use case. Theoretically we could disable a warning flag instead but that differs between clang and gcc.

Fixes https://github.com/envoyproxy/envoy/issues/23569

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>