### PR TITLE
bazel: remove //tools/... from default compdb

### DIFF
--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -118,12 +118,9 @@ if __name__ == "__main__":
     parser.add_argument('--exclude_contrib', action='store_true')
     parser.add_argument('--bazel', default='bazel')
     parser.add_argument(
-        'bazel_targets',
-        nargs='*',
-        default=[
+        'bazel_targets', nargs='*', default=[
             "//source/...",
             "//test/...",
-            "//tools/...",
             "//contrib/...",
         ])
     args = parser.parse_args()


### PR DESCRIPTION
For the compilation commands json file we only care about C/C++ targets of which there are nearly 0 of in tools/, this avoids hitting any jq rules, which fail to resolve on arm64 linux.

Fixes https://github.com/envoyproxy/envoy/issues/23649

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>