### PR TITLE
router: set stream_info_'s request headers of upstream request

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -667,6 +667,8 @@ void UpstreamRequest::onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
     parent_.callbacks()->activeSpan().injectContext(*parent_.downstreamHeaders(), host);
   }
 
+  stream_info_.setRequestHeaders(*parent_.downstreamHeaders());
+
   for (auto* callback : upstream_callbacks_) {
     callback->onUpstreamConnectionEstablished();
     return;


### PR DESCRIPTION
Commit Message: router: set stream_info_'s request headers of upstream request
Additional Description:
Now custom_tags are applied also for upstream spans due to https://github.com/envoyproxy/envoy/pull/22987/files#diff-36ebe2d9da39e88ceeccb197a9ff0b8a1dc97a5f72c8597c40d27f61a9ead00f.
But requestHeaders of stream_info is not set for UpstreamRequest and custom_tags won't work. So this PR set it to make it work.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: