### PR TITLE
docs: fix a typo in ext_authz docs

### DIFF
--- a/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -194,7 +194,7 @@ message AuthorizationResponse {
   // Note that coexistent headers will be overridden.
   type.matcher.ListStringMatcher allowed_upstream_headers = 1;
 
-  // When this :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>`. is set, authorization
+  // When this :ref:`list <envoy_api_msg_type.matcher.ListStringMatcher>` is set, authorization
   // response headers that have a correspondent match will be added to the client's response. Note
   // that when this list is *not* set, all the authorization response headers, except *Authority
   // (Host)* will be in the response to the client. When a header is included in this list, *Path*,

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -268,14 +268,14 @@ message AuthorizationResponse {
   // that coexistent headers will be appended.
   type.matcher.v3.ListStringMatcher allowed_upstream_headers_to_append = 3;
 
-  // When this :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. is set, authorization
+  // When this :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>` is set, authorization
   // response headers that have a correspondent match will be added to the client's response. Note
   // that when this list is *not* set, all the authorization response headers, except ``Authority
   // (Host)`` will be in the response to the client. When a header is included in this list, ``Path``,
   // ``Status``, ``Content-Length``, ``WWWAuthenticate`` and ``Location`` are automatically added.
   type.matcher.v3.ListStringMatcher allowed_client_headers = 2;
 
-  // When this :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. is set, authorization
+  // When this :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>` is set, authorization
   // response headers that have a correspondent match will be added to the client's response when
   // the authorization response itself is successful, i.e. not failed or denied. When this list is
   // *not* set, no additional headers will be added to the client's response on success.


### PR DESCRIPTION
Commit Message:  fix a typo in ext_authz docs
Additional Description: removes an extra dot from ext_authz field comments
Risk Level: low
Testing:
Docs Changes: yes
Release Notes:
Platform Specific Features: