### PR TITLE
Fix premature termination of transaction client

### DIFF
--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -189,7 +189,7 @@ void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePt
   }
 
   // Check if there is an active transaction that needs to be closed.
-  if (transaction_.should_close_) {
+  if (transaction_.should_close_ && pending_requests_.empty()) {
     transaction_.close();
   }
 }

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -189,7 +189,7 @@ void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePt
   }
 
   // Check if there is an active transaction that needs to be closed.
-  if (transaction_.should_close_ /*&& pending_requests_.empty()*/) {
+  if (transaction_.should_close_ && pending_requests_.empty()) {
     transaction_.close();
   }
 }

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -189,7 +189,7 @@ void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePt
   }
 
   // Check if there is an active transaction that needs to be closed.
-  if (transaction_.should_close_ && pending_requests_.empty()) {
+  if (transaction_.should_close_ /*&& pending_requests_.empty()*/) {
     transaction_.close();
   }
 }

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -1325,7 +1325,7 @@ TEST_P(RedisProxyWithCommandStatsIntegrationTest, PipelinedTransactionTest) {
   std::string transaction_commands =
       makeBulkStringArray({"MULTI"}) + makeBulkStringArray({"set", "foo", "bar"}) +
       makeBulkStringArray({"get", "foo"}) + makeBulkStringArray({"exec"});
-  const std::string& response = "";
+  const std::string& response = "+OK\r\n+QUEUED\r\n+QUEUED\r\n*2\r\n+OK\r\n$3\r\nbar\r\n";
   IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
   ASSERT_TRUE(redis_client->write(transaction_commands));
 

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -1317,6 +1317,28 @@ TEST_P(RedisProxyWithCommandStatsIntegrationTest, SendMultiBeforeCommandInTransa
   redis_client->close();
 }
 
+// This test verifies that a transaction can be pipelined.
+TEST_P(RedisProxyWithCommandStatsIntegrationTest, PipelinedTransactionTest) {
+  initialize();
+
+  std::array<FakeRawConnectionPtr, 1> fake_upstream_connection;
+  std::string transaction_commands = makeBulkStringArray({"MULTI"}) +
+                                     makeBulkStringArray({"set", "foo", "bar"}) +
+                                     makeBulkStringArray({"get", "foo"}) +
+                                     makeBulkStringArray({"exec"});
+  const std::string& response = "";
+  IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
+  ASSERT_TRUE(redis_client->write(transaction_commands));
+
+  expectUpstreamRequestResponse(fake_upstreams_[0], transaction_commands, response, fake_upstream_connection[0]);
+
+  redis_client->waitForData(response);
+  EXPECT_EQ(response, redis_client->data());
+
+  EXPECT_TRUE(fake_upstream_connection[0]->close());
+  redis_client->close();
+}
+
 // TODO: Add full transaction test.
 
 } // namespace

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -1322,15 +1322,15 @@ TEST_P(RedisProxyWithCommandStatsIntegrationTest, PipelinedTransactionTest) {
   initialize();
 
   std::array<FakeRawConnectionPtr, 1> fake_upstream_connection;
-  std::string transaction_commands = makeBulkStringArray({"MULTI"}) +
-                                     makeBulkStringArray({"set", "foo", "bar"}) +
-                                     makeBulkStringArray({"get", "foo"}) +
-                                     makeBulkStringArray({"exec"});
+  std::string transaction_commands =
+      makeBulkStringArray({"MULTI"}) + makeBulkStringArray({"set", "foo", "bar"}) +
+      makeBulkStringArray({"get", "foo"}) + makeBulkStringArray({"exec"});
   const std::string& response = "";
   IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
   ASSERT_TRUE(redis_client->write(transaction_commands));
 
-  expectUpstreamRequestResponse(fake_upstreams_[0], transaction_commands, response, fake_upstream_connection[0]);
+  expectUpstreamRequestResponse(fake_upstreams_[0], transaction_commands, response,
+                                fake_upstream_connection[0]);
 
   redis_client->waitForData(response);
   EXPECT_EQ(response, redis_client->data());


### PR DESCRIPTION
Signed-off-by: asheryer <asheryer@amazon.com>

This commit fixes the issue https://github.com/envoyproxy/envoy/issues/23651
found by @untitaker

When pipelining a transaction the transaction connection terminates early which causes a segmentation fault.
I fixed this by checking that there are no more pending requests before closing the transaction.
I've tested this with several different scenarios and it works well.

Transactions can be pipelined now through envoy:
```
$printf '*1\r\n$5\r\nMULTI\r\n*3\r\n$3\r\nset\r\n$4\r\nfoo1\r\n$4\r\nbar1\r\n*2\r\n$3\r\nGET\r\n$4\r\nfoo1\r\n*1\r\n$4\r\nEXEC\r\n' | nc -w1 localhost 1998
+OK
+QUEUED
+QUEUED
*2
+OK
$4
bar1
```

Commit Message: Fix premature termination of transaction client
Additional Description: When transactions are pipelined the transaction client terminates early and this causes a segmentation fault.
Risk Level: Low
Testing: Local redis cluster
Docs Changes: Not needed
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #23651
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
