### PR TITLE
Fix simple_http_cache updateHeaders for vary

### DIFF
--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -148,19 +148,25 @@ void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
   const auto& simple_lookup_context = static_cast<const SimpleLookupContext&>(lookup_context);
   const Key& key = simple_lookup_context.request().key();
   absl::WriterMutexLock lock(&mutex_);
-
   auto iter = map_.find(key);
   if (iter == map_.end() || !iter->second.response_headers_) {
     on_complete(false);
     return;
   }
-  auto& entry = iter->second;
-
-  // TODO(tangsaidi) handle Vary header updates properly
-  if (VaryHeaderUtils::hasVary(*(entry.response_headers_))) {
-    on_complete(false);
-    return;
+  if (VaryHeaderUtils::hasVary(*iter->second.response_headers_)) {
+    auto varied_key =
+        variedRequestKey(simple_lookup_context.request(), *iter->second.response_headers_);
+    if (!varied_key.has_value()) {
+      on_complete(false);
+      return;
+    }
+    iter = map_.find(varied_key.value());
+    if (iter == map_.end() || !iter->second.response_headers_) {
+      on_complete(false);
+      return;
+    }
   }
+  auto& entry = iter->second;
 
   // Assumptions:
   // 1. The internet is fast, i.e. we get the result as soon as the server sends it.
@@ -224,25 +230,35 @@ bool SimpleHttpCache::insert(const Key& key, Http::ResponseHeaderMapPtr&& respon
   return true;
 }
 
+absl::optional<Key>
+SimpleHttpCache::variedRequestKey(const LookupRequest& request,
+                                  const Http::ResponseHeaderMap& response_headers) const {
+  absl::btree_set<absl::string_view> vary_header_values =
+      VaryHeaderUtils::getVaryValues(response_headers);
+  ASSERT(!vary_header_values.empty());
+  const absl::optional<std::string> vary_identifier = VaryHeaderUtils::createVaryIdentifier(
+      request.varyAllowList(), vary_header_values, request.requestHeaders());
+  if (!vary_identifier.has_value()) {
+    // The vary allow list has changed and has made the vary header of this
+    // cached value not cacheable.
+    return absl::nullopt;
+  }
+  Key varied_request_key = request.key();
+  varied_request_key.add_custom_fields(vary_identifier.value());
+  return varied_request_key;
+}
+
 SimpleHttpCache::Entry
 SimpleHttpCache::varyLookup(const LookupRequest& request,
                             const Http::ResponseHeaderMapPtr& response_headers) {
   // This method should be called from lookup, which holds the mutex for reading.
   mutex_.AssertReaderHeld();
 
-  absl::btree_set<absl::string_view> vary_header_values =
-      VaryHeaderUtils::getVaryValues(*response_headers);
-  ASSERT(!vary_header_values.empty());
-
-  Key varied_request_key = request.key();
-  const absl::optional<std::string> vary_identifier = VaryHeaderUtils::createVaryIdentifier(
-      request.varyAllowList(), vary_header_values, request.requestHeaders());
-  if (!vary_identifier.has_value()) {
-    // The vary allow list has changed and has made the vary header of this
-    // cached value not cacheable.
+  auto maybe_key = variedRequestKey(request, *response_headers);
+  if (!maybe_key.has_value()) {
     return SimpleHttpCache::Entry{};
   }
-  varied_request_key.add_custom_fields(vary_identifier.value());
+  Key& varied_request_key = maybe_key.value();
 
   auto iter = map_.find(varied_request_key);
   if (iter == map_.end()) {

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -25,6 +25,12 @@ private:
     Http::ResponseTrailerMapPtr trailers_;
   };
 
+  // Returns a Key with the vary header added to custom_fields.
+  // It is an error to call this with headers that don't include vary.
+  // Returns nullopt if the vary headers are no longer valid.
+  absl::optional<Key> variedRequestKey(const LookupRequest& request,
+                                       const Http::ResponseHeaderMap& response_headers) const;
+
   // Looks for a response that has been varied. Only called from lookup.
   Entry varyLookup(const LookupRequest& request,
                    const Http::ResponseHeaderMapPtr& response_headers);

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -25,12 +25,6 @@ private:
     Http::ResponseTrailerMapPtr trailers_;
   };
 
-  // Returns a Key with the vary header added to custom_fields.
-  // It is an error to call this with headers that don't include vary.
-  // Returns nullopt if the vary headers are no longer valid.
-  absl::optional<Key> variedRequestKey(const LookupRequest& request,
-                                       const Http::ResponseHeaderMap& response_headers) const;
-
   // Looks for a response that has been varied. Only called from lookup.
   Entry varyLookup(const LookupRequest& request,
                    const Http::ResponseHeaderMapPtr& response_headers);

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
@@ -564,7 +564,7 @@ TEST_P(HttpCacheImplementationTest, UpdateHeadersForMissingKeyFails) {
   EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
 }
 
-TEST_P(HttpCacheImplementationTest, UpdateHeadersDisabledForVaryHeaders) {
+TEST_P(HttpCacheImplementationTest, UpdateHeadersForVaryHeaders) {
   if (!validationEnabled()) {
     // UpdateHeaders would not be called when validation is disabled.
     GTEST_SKIP();
@@ -590,10 +590,10 @@ TEST_P(HttpCacheImplementationTest, UpdateHeadersDisabledForVaryHeaders) {
                                                      {"cache-control", "public,max-age=3600"},
                                                      {"accept", "image/*"},
                                                      {"vary", "accept"}};
-  EXPECT_FALSE(updateHeaders(request_path_1, response_headers_2, {time_2}));
-  response_headers_1.setReferenceKey(Http::LowerCaseString("age"), "3600");
+  EXPECT_TRUE(updateHeaders(request_path_1, response_headers_2, {time_2}));
+  response_headers_2.setReferenceKey(Http::LowerCaseString("age"), "0");
   // the age is still 0 because an entry is considered fresh after validation
-  EXPECT_TRUE(expectLookupSuccessWithHeaders(lookup(request_path_1).get(), response_headers_1));
+  EXPECT_TRUE(expectLookupSuccessWithHeaders(lookup(request_path_1).get(), response_headers_2));
 }
 
 TEST_P(HttpCacheImplementationTest, UpdateHeadersSkipEtagHeader) {


### PR DESCRIPTION
Commit Message: Fix simple_http_cache updateHeaders for vary
Additional Description: There was a TODO for this, and a test that validates the behavior was incorrect in a way that matched the implementation, with comments falsely suggesting it was validating the correct behavior. This change makes the behavior correct and the validation correct, thereby enabling other correct cache implementations to pass the test suite.
Risk Level: Very low. Changes only to WIP filter, only fixing incorrect behavior.
Testing: Fixed existing test.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
