### PR TITLE
subscription stats: Add a new metric to track the time since the last successful xds update.

### DIFF
--- a/docs/root/configuration/overview/mgmt_server.rst
+++ b/docs/root/configuration/overview/mgmt_server.rst
@@ -60,6 +60,7 @@ The following statistics are generated for all subscriptions.
  update_failure, Counter, Total API fetches that failed because of network errors
  update_rejected, Counter, Total API fetches that failed because of schema/validation errors
  update_time, Gauge, Timestamp of the last successful API fetch attempt as milliseconds since the epoch. Refreshed even after a trivial configuration reload that contained no configuration changes.
+ time_since_last_update, Gauge, Approximate milliseconds since the last successful API fetch attempt. Even a trivial configuration reload that contains no changes resets this stat to zero.
  version, Gauge, Hash of the contents from the last successful API fetch
  version_text, TextReadout, The version text from the last successful API fetch
  control_plane.connected_state, Gauge, A boolean (1 for connected and 0 for disconnected) that indicates the current connection state with management server

--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -239,6 +239,7 @@ using SubscriptionPtr = std::unique_ptr<Subscription>;
   COUNTER(update_success)                                                                          \
   GAUGE(update_time, NeverImport)                                                                  \
   GAUGE(version, NeverImport)                                                                      \
+  GAUGE(time_since_last_update, NeverImport)                                                       \
   HISTOGRAM(update_duration, Milliseconds)                                                         \
   TEXT_READOUT(version_text)
 
@@ -249,6 +250,8 @@ struct SubscriptionStats {
   ALL_SUBSCRIPTION_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT,
                          GENERATE_TEXT_READOUT_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
+
+constexpr uint32_t PERIODIC_STATS_TIMER_REFRESH_MS = 10 * 1000;
 
 } // namespace Config
 } // namespace Envoy

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/api/api.h"
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
@@ -29,6 +31,7 @@ public:
                              OpaqueResourceDecoderSharedPtr resource_decoder,
                              SubscriptionStats stats,
                              ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api);
+  ~FilesystemSubscriptionImpl() override;
 
   // Config::Subscription
   // We report all discovered resources in the watched file, so the resource names arguments are
@@ -53,6 +56,9 @@ protected:
   SubscriptionStats stats_;
   Api::Api& api_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
+  Event::Dispatcher& dispatcher_;
+  Event::TimerPtr periodic_stats_timer_;
+  uint64_t last_update_time_;
 };
 
 // Currently a FilesystemSubscriptionImpl subclass, but this will need to change when we support

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 
 #include "envoy/config/grpc_mux.h"
@@ -44,6 +45,8 @@ public:
 
   ScopedResume pause();
 
+  ~GrpcSubscriptionImpl() override;
+
 private:
   void disableInitFetchTimeoutTimer();
 
@@ -60,6 +63,8 @@ private:
   Event::TimerPtr init_fetch_timeout_timer_;
   const bool is_aggregated_;
   const SubscriptionOptions options_;
+  Event::TimerPtr periodic_stats_timer_;
+  uint64_t last_update_time_;
 
   struct ResourceNameFormatter {
     void operator()(std::string* out, const Config::DecodedResourceRef& resource) {

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -31,6 +31,7 @@ public:
                        OpaqueResourceDecoderSharedPtr resource_decoder, SubscriptionStats stats,
                        std::chrono::milliseconds init_fetch_timeout,
                        ProtobufMessage::ValidationVisitor& validation_visitor);
+  ~HttpSubscriptionImpl() override;
 
   // Config::Subscription
   void start(const absl::flat_hash_set<std::string>& resource_names) override;
@@ -60,6 +61,8 @@ private:
   std::chrono::milliseconds init_fetch_timeout_;
   Event::TimerPtr init_fetch_timeout_timer_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
+  Event::TimerPtr periodic_stats_timer_;
+  uint64_t last_update_time_;
 };
 
 } // namespace Config

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "test/common/config/grpc_subscription_test_harness.h"
 
 #include "gtest/gtest.h"
@@ -20,8 +22,8 @@ INSTANTIATE_TEST_SUITE_P(GrpcSubscriptionImplTest, GrpcSubscriptionImplTest,
 // Validate that stream creation results in a timer based retry and can recover.
 TEST_P(GrpcSubscriptionImplTest, StreamCreationFailure) {
   InSequence s;
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(nullptr));
-
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
@@ -29,7 +31,7 @@ TEST_P(GrpcSubscriptionImplTest, StreamCreationFailure) {
   EXPECT_CALL(random_, random());
   EXPECT_CALL(*timer_, enableTimer(_, _));
   subscription_->start({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, "", 0));
   // Ensure this doesn't cause an issue by sending a request, since we don't
   // have a gRPC stream.
   subscription_->updateResourceInterest({"cluster2"});
@@ -39,73 +41,83 @@ TEST_P(GrpcSubscriptionImplTest, StreamCreationFailure) {
 
   expectSendMessage({"cluster2"}, "", true);
   timer_->invokeCallback();
-  EXPECT_TRUE(statsAre(3, 0, 0, 1, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(3, 0, 0, 1, 0, 0, 0, "", 0));
   verifyControlPlaneStats(1);
+  expectDisablePeriodicStatsTimer();
 }
 
 // Validate that the client can recover from a remote stream closure via retry.
 TEST_P(GrpcSubscriptionImplTest, RemoteStreamClose) {
+  InSequence s;
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
       .Times(0);
-  EXPECT_CALL(*timer_, enableTimer(_, _));
   EXPECT_CALL(random_, random());
+  EXPECT_CALL(*timer_, enableTimer(_, _));
   onRemoteClose();
-  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, "", 0));
   verifyControlPlaneStats(0);
 
   // Retry and succeed.
   EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({"cluster0", "cluster1"}, "", true);
   timer_->invokeCallback();
-  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, "", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 // Validate that When the management server gets multiple requests for the same version, it can
 // ignore later ones. This allows the nonce to be used.
 TEST_P(GrpcSubscriptionImplTest, RepeatedNonce) {
   InSequence s;
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   // First with the initial, empty version update to "0".
   updateResourceInterest({"cluster2"});
-  EXPECT_TRUE(statsAre(2, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 0, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", false);
-  EXPECT_TRUE(statsAre(3, 0, 1, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(3, 0, 1, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", true);
-  EXPECT_TRUE(statsAre(4, 1, 1, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(4, 1, 1, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
   // Now with version "0" update to "1".
   updateResourceInterest({"cluster3"});
-  EXPECT_TRUE(statsAre(5, 1, 1, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(5, 1, 1, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
   deliverConfigUpdate({"cluster3"}, "42", false);
-  EXPECT_TRUE(statsAre(6, 1, 2, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(6, 1, 2, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
   deliverConfigUpdate({"cluster3"}, "42", true);
-  EXPECT_TRUE(statsAre(7, 2, 2, 0, 0, TEST_TIME_MILLIS, 7919287270473417401, "42"));
+  EXPECT_TRUE(statsAre(7, 2, 2, 0, 0, TEST_TIME_MILLIS, 7919287270473417401, "42", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 TEST_P(GrpcSubscriptionImplTest, UpdateTimeNotChangedOnUpdateReject) {
   InSequence s;
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", false);
-  EXPECT_TRUE(statsAre(2, 0, 1, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 1, 0, 0, 0, 0, "", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 TEST_P(GrpcSubscriptionImplTest, UpdateTimeChangedOnUpdateSuccess) {
   InSequence s;
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", true);
-  EXPECT_TRUE(statsAre(2, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(2, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
 
   // Advance the simulated time and verify that a trivial update (no change) also changes the update
   // time.
   simTime().setSystemTime(SystemTime(std::chrono::milliseconds(TEST_TIME_MILLIS + 1)));
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", true);
-  EXPECT_TRUE(statsAre(2, 2, 0, 0, 0, TEST_TIME_MILLIS + 1, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(2, 2, 0, 0, 0, TEST_TIME_MILLIS + 1, 7148434200721666028, "0", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 } // namespace

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -12,6 +12,7 @@ class HttpSubscriptionImplTest : public testing::Test, public HttpSubscriptionTe
 
 // Validate that we start the retry timer when there is no cluster.
 TEST_F(HttpSubscriptionImplTest, NoCluster) {
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   ON_CALL(cm_, getThreadLocalCluster("eds_cluster")).WillByDefault(Return(nullptr));
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
@@ -21,10 +22,12 @@ TEST_F(HttpSubscriptionImplTest, NoCluster) {
   version_ = "";
   cluster_names_ = {"cluster0", "cluster1"};
   subscription_->start({"cluster0", "cluster1"});
+  expectDisablePeriodicStatsTimer();
 }
 
 // Validate that the client can recover from a remote fetch failure.
 TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
   EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
   EXPECT_CALL(*timer_, enableTimer(_, _));
@@ -32,15 +35,17 @@ TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::ConnectionFailure, _))
       .Times(0);
   http_callbacks_->onFailure(http_request_, Http::AsyncClient::FailureReason::Reset);
-  EXPECT_TRUE(statsAre(1, 0, 0, 1, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 1, 0, 0, 0, "", 0));
   timerTick();
-  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 0, 1, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster1"}, "42", true);
-  EXPECT_TRUE(statsAre(3, 1, 0, 1, 0, TEST_TIME_MILLIS, 7919287270473417401, "42"));
+  EXPECT_TRUE(statsAre(3, 1, 0, 1, 0, TEST_TIME_MILLIS, 7919287270473417401, "42", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 // Validate that the client can recover from bad JSON responses.
 TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
   Http::ResponseHeaderMapPtr response_headers{
       new Http::TestResponseHeaderMapImpl{{":status", "200"}}};
@@ -51,48 +56,54 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   EXPECT_CALL(callbacks_,
               onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, _));
   http_callbacks_->onSuccess(http_request_, std::move(message));
-  EXPECT_TRUE(statsAre(1, 0, 1, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 1, 0, 0, 0, 0, "", 0));
   request_in_progress_ = false;
   timerTick();
-  EXPECT_TRUE(statsAre(2, 0, 1, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 1, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  EXPECT_TRUE(statsAre(3, 1, 1, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(3, 1, 1, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 TEST_F(HttpSubscriptionImplTest, ConfigNotModified) {
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   timerTick();
-  EXPECT_TRUE(statsAre(2, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 0, 0, 0, 0, 0, "", 0));
 
   // accept and modify.
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true, true, "200");
-  EXPECT_TRUE(statsAre(3, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(3, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
 
   // accept and does not modify.
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true, false, "304");
-  EXPECT_TRUE(statsAre(4, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(4, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 TEST_F(HttpSubscriptionImplTest, UpdateTimeNotChangedOnUpdateReject) {
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
-  EXPECT_TRUE(statsAre(2, 0, 1, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(2, 0, 1, 0, 0, 0, 0, "", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 TEST_F(HttpSubscriptionImplTest, UpdateTimeChangedOnUpdateSuccess) {
+  expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds(PERIODIC_STATS_TIMER_REFRESH_MS));
   startSubscription({"cluster0", "cluster1"});
-  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, ""));
+  EXPECT_TRUE(statsAre(1, 0, 0, 0, 0, 0, 0, "", 0));
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  EXPECT_TRUE(statsAre(2, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(2, 1, 0, 0, 0, TEST_TIME_MILLIS, 7148434200721666028, "0", 0));
 
   // Advance the simulated time and verify that a trivial update (no change) also changes the update
   // time.
   simTime().setSystemTime(SystemTime(std::chrono::milliseconds(TEST_TIME_MILLIS + 1)));
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  EXPECT_TRUE(statsAre(3, 2, 0, 0, 0, TEST_TIME_MILLIS + 1, 7148434200721666028, "0"));
+  EXPECT_TRUE(statsAre(3, 2, 0, 0, 0, TEST_TIME_MILLIS + 1, 7148434200721666028, "0", 0));
+  expectDisablePeriodicStatsTimer();
 }
 
 } // namespace

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -189,6 +189,20 @@ public:
     timer_cb_();
   }
 
+  void expectCreateEnablePeriodicStatsTimer(std::chrono::milliseconds period) override {
+    periodic_stats_timer_ = new Event::MockTimer(&dispatcher_);
+    expectEnablePeriodicStatsTimer(period);
+  }
+
+  void expectEnablePeriodicStatsTimer(std::chrono::milliseconds period) override {
+    EXPECT_CALL(*periodic_stats_timer_, enableTimer(period, _));
+  }
+  void expectDisablePeriodicStatsTimer() override {
+    EXPECT_CALL(*periodic_stats_timer_, disableTimer());
+  }
+
+  void callPeriodicStatsTimerCb() override { periodic_stats_timer_->invokeCallback(); }
+
   bool request_in_progress_{};
   std::string version_;
   std::set<std::string> cluster_names_;
@@ -207,6 +221,7 @@ public:
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   Event::MockTimer* init_timeout_timer_;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
+  Event::MockTimer* periodic_stats_timer_;
 };
 
 } // namespace Config

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -219,6 +219,7 @@ TEST_F(SubscriptionFactoryTest, FilesystemSubscription) {
   std::string test_path = TestEnvironment::temporaryDirectory();
   config.set_path(test_path);
   auto* watcher = new Filesystem::MockWatcher();
+  EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(dispatcher_, createFilesystemWatcher_()).WillOnce(Return(watcher));
   EXPECT_CALL(*watcher, addWatch(test_path, _, _));
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_, _));
@@ -236,6 +237,7 @@ TEST_F(SubscriptionFactoryTest, FilesystemSubscriptionNonExistentFile) {
 TEST_F(SubscriptionFactoryTest, FilesystemCollectionSubscription) {
   std::string test_path = TestEnvironment::temporaryDirectory();
   auto* watcher = new Filesystem::MockWatcher();
+  EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(dispatcher_, createFilesystemWatcher_()).WillOnce(Return(watcher));
   EXPECT_CALL(*watcher, addWatch(test_path, _, _));
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_, _));
@@ -262,7 +264,7 @@ TEST_F(SubscriptionFactoryTest, HttpSubscriptionCustomRequestTimeout) {
   Upstream::ClusterManager::ClusterSet primary_clusters;
   primary_clusters.insert("static_cluster");
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
-  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(3);
   cm_.initializeThreadLocalClusters({"static_cluster"});
   EXPECT_CALL(cm_, getThreadLocalCluster("static_cluster"));
   EXPECT_CALL(cm_.thread_local_cluster_, httpAsyncClient());
@@ -282,7 +284,7 @@ TEST_F(SubscriptionFactoryTest, HttpSubscription) {
   Upstream::ClusterManager::ClusterSet primary_clusters;
   primary_clusters.insert("static_cluster");
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
-  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(3);
   cm_.initializeThreadLocalClusters({"static_cluster"});
   EXPECT_CALL(cm_, getThreadLocalCluster("static_cluster"));
   EXPECT_CALL(cm_.thread_local_cluster_, httpAsyncClient());
@@ -335,7 +337,7 @@ TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux, GrpcSubscription) {
         return async_client_factory;
       }));
   EXPECT_CALL(random_, random());
-  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(3);
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(4);
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_, _)).Times(0);
   subscriptionFromConfigSource(config)->start({"static_cluster"});
@@ -393,7 +395,7 @@ TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux, GrpcCollectionAggregatedSubscr
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
   GrpcMuxSharedPtr ads_mux = std::make_shared<NiceMock<MockGrpcMux>>();
   EXPECT_CALL(cm_, adsMux()).WillOnce(Return(ads_mux));
-  EXPECT_CALL(dispatcher_, createTimer_(_));
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_, _)).Times(0);
   collectionSubscriptionFromUrl("xdstp://foo/envoy.config.endpoint.v3.ClusterLoadAssignment/bar",
@@ -411,7 +413,7 @@ TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux, GrpcCollectionDeltaSubscriptio
   primary_clusters.insert("static_cluster");
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
-  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(3);
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(4);
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_, _)).Times(0);
   collectionSubscriptionFromUrl("xdstp://foo/envoy.config.endpoint.v3.ClusterLoadAssignment/bar",

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -76,7 +76,7 @@ public:
 
   void expectConnectionCreation(size_t id) {
     EXPECT_CALL(*connection_provider_, createNextConnection(_))
-        .WillOnce(testing::Invoke([ this, id ](uint64_t conn_id) -> auto{
+        .WillOnce(testing::Invoke([ this, id ](uint64_t conn_id) -> auto {
           EXPECT_EQ(connection_provider_->nextConnection(), id);
           return connection_provider_->getNextConnection(conn_id);
         }));


### PR DESCRIPTION
This change addresses the following issue:
https://github.com/envoyproxy/envoy/issues/22661

Signed-off-by: Can Cecen <ccecen@netflix.com>

Commit Message: Add a new metric to track the time since the last successful xds update.
Additional Description: More context here https://github.com/envoyproxy/envoy/issues/22661
Adding a time_since_last_update metric is makes it easier to alarm on, and can make the metric easier to reason about.
Risk Level: Low
Testing: Unit tests and manual testing.
Docs Changes: Updated metrics list.
Release Notes: n/a
Platform Specific Features: n/a