### PR TITLE
deps: update googleurl

### DIFF
--- a/bazel/external/googleurl.patch
+++ b/bazel/external/googleurl.patch
@@ -2,13 +2,13 @@
 # project using clang-cl. Tracked in https://github.com/envoyproxy/envoy/issues/11974.
 
 diff --git a/base/compiler_specific.h b/base/compiler_specific.h
-index 6651220..a469c19 100644
+index 0174b6d..fb5b80d 100644
 --- a/base/compiler_specific.h
 +++ b/base/compiler_specific.h
 @@ -7,10 +7,6 @@
- 
+
  #include "build/build_config.h"
- 
+
 -#if defined(COMPILER_MSVC) && !defined(__clang__)
 -#error "Only clang-cl is supported on Windows, see https://crbug.com/988071"
 -#endif
@@ -16,114 +16,87 @@ index 6651220..a469c19 100644
  // This is a wrapper around `__has_cpp_attribute`, which can be used to test for
  // the presence of an attribute. In case the compiler does not support this
  // macro it will simply evaluate to 0.
-@@ -75,8 +71,12 @@
- // prevent code folding, see NO_CODE_FOLDING() in base/debug/alias.h.
- // Use like:
- //   void NOT_TAIL_CALLED FooBar();
--#if defined(__clang__) && __has_attribute(not_tail_called)
-+#if defined(__clang__)
-+#if defined(__has_attribute)
-+#if __has_attribute(not_tail_called)
- #define NOT_TAIL_CALLED __attribute__((not_tail_called))
-+#endif
-+#endif
- #else
- #define NOT_TAIL_CALLED
- #endif
-@@ -273,7 +273,9 @@
- #endif
- #endif
- 
--#if defined(__clang__) && __has_attribute(uninitialized)
-+#if defined(__clang__)
-+#if defined(__has_attribute)
-+#if __has_attribute(uninitialized)
- // Attribute "uninitialized" disables -ftrivial-auto-var-init=pattern for
- // the specified variable.
- // Library-wide alternative is
-@@ -304,6 +306,8 @@
- // E.g. platform, bot, benchmark or test name in patch description or next to
- // the attribute.
- #define STACK_UNINITIALIZED __attribute__((uninitialized))
-+#endif
-+#endif
- #else
- #define STACK_UNINITIALIZED
- #endif
-@@ -365,8 +369,12 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
- #endif  // defined(__clang_analyzer__)
- 
- // Use nomerge attribute to disable optimization of merging multiple same calls.
--#if defined(__clang__) && __has_attribute(nomerge)
-+#if defined(__clang__)
-+#if defined(__has_attribute)
-+#if __has_attribute(nomerge)
- #define NOMERGE [[clang::nomerge]]
-+#endif
-+#endif
- #else
- #define NOMERGE
- #endif
-@@ -392,8 +400,12 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
- // See also:
- //   https://clang.llvm.org/docs/AttributeReference.html#trivial-abi
- //   https://libcxx.llvm.org/docs/DesignDocs/UniquePtrTrivialAbi.html
--#if defined(__clang__) && __has_attribute(trivial_abi)
-+#if defined(__clang__)
-+#if defined(__has_attribute)
-+#if __has_attribute(trivial_abi)
- #define TRIVIAL_ABI [[clang::trivial_abi]]
-+#endif
-+#endif
- #else
- #define TRIVIAL_ABI
- #endif
-@@ -401,8 +413,12 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
- // Marks a member function as reinitializing a moved-from variable.
- // See also
- // https://clang.llvm.org/extra/clang-tidy/checks/bugprone-use-after-move.html#reinitialization
--#if defined(__clang__) && __has_attribute(reinitializes)
-+#if defined(__clang__)
-+#if defined(__has_attribute)
-+#if __has_attribute(reinitializes)
- #define REINITIALIZES_AFTER_MOVE [[clang::reinitializes]]
-+#endif
-+#endif
- #else
- #define REINITIALIZES_AFTER_MOVE
- #endif
-
-# TODO(keith): Remove once bazel supports newer NDK versions https://github.com/bazelbuild/bazel/issues/12889
-
-diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
-index b5fe925..31aa81e 100644
---- a/base/containers/checked_iterators.h
-+++ b/base/containers/checked_iterators.h
-@@ -237,9 +237,11 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
- // [3] https://wg21.link/pointer.traits.optmem
- namespace std {
- 
-+#ifdef SUPPORTS_CPP_17_CONTIGUOUS_ITERATOR
- template <typename T>
- struct __is_cpp17_contiguous_iterator<::gurl_base::CheckedContiguousIterator<T>>
-     : true_type {};
-+#endif
- 
- template <typename T>
- struct pointer_traits<::gurl_base::CheckedContiguousIterator<T>> {
-
-# TODO(keith): Remove once https://quiche-review.googlesource.com/c/googleurl/+/10980 lands
-
-diff --git a/base/compiler_specific.h b/base/compiler_specific.h
-index 3a85453..a329de2 100644
---- a/base/compiler_specific.h
-+++ b/base/compiler_specific.h
-@@ -382,7 +382,7 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
+@@ -398,7 +394,7 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
  #define CONSTINIT
  #endif
- 
+
 -#if defined(__clang__)
 +#if defined(__clang__) && HAS_CPP_ATTRIBUTE(gsl::Pointer)
  #define GSL_OWNER [[gsl::Owner]]
  #define GSL_POINTER [[gsl::Pointer]]
  #else
+diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
+index dc8d2ba..9306697 100644
+--- a/base/containers/checked_iterators.h
++++ b/base/containers/checked_iterators.h
+@@ -237,9 +237,11 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ // [3] https://wg21.link/pointer.traits.optmem
+ namespace std {
+
++#ifdef SUPPORTS_CPP_17_CONTIGUOUS_ITERATOR
+ template <typename T>
+ struct __is_cpp17_contiguous_iterator<::gurl_base::CheckedContiguousIterator<T>>
+     : true_type {};
++#endif
+
+ template <typename T>
+ struct pointer_traits<::gurl_base::CheckedContiguousIterator<T>> {
+
+# TODO(keith): Remove unused parameter workarounds when https://quiche-review.googlesource.com/c/googleurl/+/11180 lands
+
+diff --git a/base/numerics/clamped_math_impl.h b/base/numerics/clamped_math_impl.h
+index 10023f0..783f5da 100644
+--- a/base/numerics/clamped_math_impl.h
++++ b/base/numerics/clamped_math_impl.h
+@@ -36,6 +36,7 @@ template <typename T,
+           typename std::enable_if<std::is_integral<T>::value &&
+                                   !std::is_signed<T>::value>::type* = nullptr>
+ constexpr T SaturatedNegWrapper(T value) {
++  (void)value; // unused
+   return T(0);
+ }
+
+diff --git a/base/numerics/safe_conversions.h b/base/numerics/safe_conversions.h
+index 4a9494e..ba44fa0 100644
+--- a/base/numerics/safe_conversions.h
++++ b/base/numerics/safe_conversions.h
+@@ -45,6 +45,7 @@ template <typename Dst, typename Src, typename Enable = void>
+ struct IsValueInRangeFastOp {
+   static constexpr bool is_supported = false;
+   static constexpr bool Do(Src value) {
++    (void)value; // unused
+     // Force a compile failure if instantiated.
+     return CheckOnFailure::template HandleFailure<bool>();
+   }
+@@ -164,6 +165,7 @@ template <typename Dst, typename Src, typename Enable = void>
+ struct SaturateFastOp {
+   static constexpr bool is_supported = false;
+   static constexpr Dst Do(Src value) {
++    (void)value; // unused
+     // Force a compile failure if instantiated.
+     return CheckOnFailure::template HandleFailure<Dst>();
+   }
+diff --git a/build_config/build_config.bzl b/build_config/build_config.bzl
+index 5960d2a..08295ff 100644
+--- a/build_config/build_config.bzl
++++ b/build_config/build_config.bzl
+@@ -7,6 +7,7 @@ _default_copts = select({
+     "//conditions:default": [
+         "-std=c++17",
+         "-fno-strict-aliasing",
++        "-Wno-unused-parameter",
+     ],
+ })
+
+diff --git a/url/url_canon_internal.h b/url/url_canon_internal.h
+index 58ae144..467da0b 100644
+--- a/url/url_canon_internal.h
++++ b/url/url_canon_internal.h
+@@ -305,6 +305,7 @@ inline bool AppendUTF8EscapedChar(const char* str,
+ // through it will point to the next character to be considered. On failure,
+ // |*begin| will be unchanged.
+ inline bool Is8BitChar(char c) {
++  (void)c; // unused
+   return true;  // this case is specialized to avoid a warning
+ }
+ inline bool Is8BitChar(char16_t c) {

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1094,10 +1094,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Chrome URL parsing library",
         project_desc = "Chrome URL parsing library",
         project_url = "https://quiche.googlesource.com/googleurl",
-        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/9cdb1f4d1a365ebdbcbf179dadf7f8aa5ee802e7.tar.gz.
-        version = "9cdb1f4d1a365ebdbcbf179dadf7f8aa5ee802e7",
-        sha256 = "a1bc96169d34dcc1406ffb750deef3bc8718bd1f9069a2878838e1bd905de989",
-        urls = ["https://storage.googleapis.com/quiche-envoy-integration/googleurl_{version}.tar.gz"],
+        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/fd287250b7f0d876478d88dd7641ba8a2e130bd2.tar.gz
+        version = "fd287250b7f0d876478d88dd7641ba8a2e130bd2",
+        sha256 = "053e6d8c80c7c4159012254de72ec17cc67a9945e709fbe9ac4925afcdb40884",
+        urls = ["https://storage.googleapis.com/quiche-envoy-integration/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
         extensions = [],
         release_date = "2022-04-04",


### PR DESCRIPTION
This slightly improves our patch because upstream started validating `__has_attribute` exists itself now.

There is a little bit of new patching due to https://quiche-review.googlesource.com/c/googleurl/+/11180

Fixes https://github.com/envoyproxy/envoy/issues/23340

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>