### PR TITLE
test, ext_authz: Remove unused method

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -453,13 +453,6 @@ public:
     addFakeUpstream(Http::CodecType::HTTP1);
   }
 
-  // By default, HTTP Service uses case sensitive string matcher.
-  void disableCaseSensitiveStringMatcher() {
-    config_helper_.addRuntimeOverride(
-        "envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher",
-        "false");
-  }
-
   void initiateClientConnection() {
     auto conn = makeClientConnection(lookupPort("http"));
     codec_client_ = makeHttpConnection(std::move(conn));


### PR DESCRIPTION
Commit Message: Remove unused method in test (ext_authz integration test), since `envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher` flag is removed.
Risk Level: N/A
Testing: Test only
Docs Changes: N/A
Release Notes: N/A
Platform-Specific Features: N/A

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>