### PR TITLE
Fix oauth2 intergration test flake

### DIFF
--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -401,6 +401,13 @@ TEST_P(OauthIntegrationTest, LoadListenerAfterServerIsInitialized) {
   test_server_->waitForGaugeEq("listener_manager.total_listeners_warming", 0);
 
   doAuthenticationFlow("token_secret", "hmac_secret");
+  if (lds_connection_ != nullptr) {
+    AssertionResult result = lds_connection_->close();
+    RELEASE_ASSERT(result, result.message());
+    result = lds_connection_->waitForDisconnect();
+    RELEASE_ASSERT(result, result.message());
+    lds_connection_.reset();
+  }
 }
 class OauthIntegrationTestWithBasicAuth : public OauthIntegrationTest {
   void setOauthConfig() override {


### PR DESCRIPTION
Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

fixes: https://github.com/envoyproxy/envoy/issues/23618
Commit Message: Fix oauth2 intergration test flake
Additional Description:

tried with `--gtest_repeat=500 --gtest_break_on_failure`, no failure

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
