### PR TITLE
Explicitly disable libpsl for curl

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -264,6 +264,7 @@ envoy_cmake(
         "BUILD_SHARED_LIBS": "off",
         "CURL_HIDDEN_SYMBOLS": "off",
         "CURL_USE_LIBSSH2": "off",
+        "CURL_USE_LIBPSL": "off",
         "CURL_BROTLI": "off",
         "CURL_USE_GSSAPI": "off",
         "HTTP_ONLY": "on",


### PR DESCRIPTION
Risk: Low
Testing: test/dependencies/curl_test.cc tests that libpsl is disabled

On my workstation (running Arch Linux) I had a linker error:
```
ld.lld: error: undefined symbol: psl_is_cookie_domain_acceptable
>>> referenced by cookie.c
>>>               cookie.c.o:(Curl_cookie_add) in archive bazel-out/k8-opt/bin/external/envoy/bazel/foreign_cc/curl/lib/libcurl.a
...
```

In test/dependencies/curl_test.cc I see that it is expected that curl does not use libpsl.
Apparently did curl somehow compile with libpsl support but failed to link against it since it is not included in Envoy. Explicitly disabling libpsl fixed my problem.

Signed-off-by: Jonatan Vela <jonatan.vela@ergon.ch>