### PR TITLE
Fix flakyness of signal tests

### DIFF
--- a/test/common/signal/BUILD
+++ b/test/common/signal/BUILD
@@ -11,9 +11,11 @@ envoy_package()
 envoy_cc_test(
     name = "signals_test",
     srcs = ["signals_test.cc"],
+    shard_count = 1,
     # Posix signal tests are irrelevant to Windows
     tags = [
         "backtrace",
+        "exclusive",
         "skip_on_windows",
     ],
     deps = [
@@ -27,6 +29,8 @@ envoy_cc_test(
 envoy_cc_test(
     name = "fatal_action_test",
     srcs = ["fatal_action_test.cc"],
+    shard_count = 1,
+    tags = ["exclusive"],
     deps = [
         "//source/common/signal:fatal_error_handler_lib",
         "//test/mocks/server:instance_mocks",


### PR DESCRIPTION
These tests are failing in my environment. Somehow they enter in a race condition. In fact this is even expected. See the comment here:

https://github.com/envoyproxy/envoy/blob/362e415045e1c8b7391fcb1a21f8c6003de3e8e0/source/common/signal/fatal_error_handler.cc#L27-L32

Applying the `exclusive` tags and setting the `shard_count` to 1 in bazel configuration, fixed the problem in my environment.

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>