### PR TITLE
mobile: starting the repo merge with the assertion filter

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -58,3 +58,10 @@ package_group(
         "//examples/...",
     ],
 )
+
+package_group(
+    name = "mobile_library",
+    packages = [
+        "//mobile/...",
+    ],
+)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -283,6 +283,9 @@ extensions/filters/http/oauth2 @derekargueta @snowp
 /*/extensions/path/uri_template_lib @alyssawilk @yanjunxiang-google
 /*/extensions/path/uri_template_lib/proto @alyssawilk @yanjunxiang-google
 
+# mobile
+/mobile/ @jpsim @Augustyniak @RyanTheOptimist @alyssawilk @abeyad
+
 # Contrib
 /contrib/exe/ @mattklein123 @lizan
 /contrib/client_ssl_auth/ @UNOWNED @UNOWNED

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,7 +13,7 @@ routing PRs, questions, etc. to the right place.
   * xDS APIs, configuration and control plane.
 * Alyssa Wilk ([alyssawilk](https://github.com/alyssawilk)) (alyssar@google.com)
   * HTTP, flow control, cluster manager, load balancing, and core networking (listeners,
-    connections, etc.).
+    connections, etc.), Envoy Mobile.
 * Stephan Zuercher ([zuercher](https://github.com/zuercher)) (zuercher@gmail.com)
   * Load balancing, upstream clusters and cluster manager, logging, complex HTTP routing
     (metadata, etc.), and macOS build.
@@ -29,7 +29,7 @@ routing PRs, questions, etc. to the right place.
 * Ryan Northey ([phlax](https://github.com/phlax)) (ryan@synca.io)
   * Docs, tooling, CI, containers and sandbox examples
 * Ryan Hamilton ([RyanTheOptimist](https://github.com/ryantheoptimist)) (rch@google.com)
-  * HTTP/3, upstream connection management.
+  * HTTP/3, upstream connection management, Envoy Mobile.
 
 # Maintainers
 
@@ -50,6 +50,17 @@ routing PRs, questions, etc. to the right place.
 * Kuat Yessenov ([kyessenov](https://github.com/kyessenov)) (kuat@google.com)
   * Listeners, RBAC, CEL, matching, Istio.
 
+# Envoy mobile maintainers
+
+The following Envoy maintainers have final say over any changes only affecting /mobile
+
+* JP Simard ([jpsim](https://github.com/jpsim)) (jp@lyft.com)
+  * iOS (swift/objective-c) platform bindings.
+* Rafal Augustyniak ([Augustyniak](https://github.com/Augustyniak)) (raugustyniak@lyft.com)
+  * iOS (swift/objective-c) platform bindings.
+* Ali Beyad ([abeyad](https://github.com/abeyad)) (abeyad@google.com)
+  * xDS, C++ integration tests.
+
 # Senior extension maintainers
 
 The following extension maintainers have final say over the extensions mentioned below. Once they
@@ -60,10 +71,6 @@ without further review.
   * Wasm
 * Raúl Gutiérrez Segalés ([rgs1](https://github.com/rgs1)) (rgs@pinterest.com)
   * Thrift
-* Ryan Hamilton ([RyanTheOptimist](https://github.com/ryantheoptimist)) (rch@google.com)
-  * HTTP/3
-* Baiping Wang ([wbpcode](https://github.com/wbpcode)) (wbphub@live.com)
-  * Dubbo
 
 # Envoy security team
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -67,6 +67,9 @@ def envoy_extension_package(enabled_default = True, default_visibility = EXTENSI
         flag_values = {":enabled": "True"},
     )
 
+def envoy_mobile_package():
+    envoy_extension_package()
+
 def envoy_contrib_package():
     envoy_extension_package(default_visibility = CONTRIB_EXTENSION_PACKAGE_VISIBILITY)
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -74,5 +74,8 @@ new_features:
 - area: udp_proxy
   change: |
     added support for :ref:`proxy_access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.
+- area: mobile
+  change: |
+    started merging the Envoy mobile library into the main Envoy repo.
 
 deprecated:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -208,7 +208,7 @@ else
   elif [[ "${CI_TARGET}" == "bazel.msan" ]]; then
     COVERAGE_TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "-//test/extensions/...")
   fi
-  TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "@com_github_google_quiche//:ci_tests")
+  TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "@com_github_google_quiche//:ci_tests" "//mobile/test/...")
 fi
 
 if [[ "$CI_TARGET" == "bazel.release" ]]; then

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -76,8 +76,13 @@ function exclude_wasm_examples() {
   grep -v examples/wasm
 }
 
+# Exclude envoy mobile.
+function exclude_envoy_mobile() {
+  grep -v mobile/library | grep -v mobile/test
+}
+
 function filter_excludes() {
-  exclude_check_format_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party | exclude_wasm_emscripten | exclude_wasm_sdk | exclude_wasm_host | exclude_wasm_test_data | exclude_wasm_examples
+  exclude_envoy_mobile | exclude_check_format_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party | exclude_wasm_emscripten | exclude_wasm_sdk | exclude_wasm_host | exclude_wasm_test_data | exclude_wasm_examples
 }
 
 function run_clang_tidy() {

--- a/mobile/library/common/extensions/filters/http/assertion/BUILD
+++ b/mobile/library/common/extensions/filters/http/assertion/BUILD
@@ -1,0 +1,44 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_mobile_package",
+    "envoy_proto_library",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
+
+envoy_proto_library(
+    name = "filter",
+    srcs = ["filter.proto"],
+    deps = [
+        "@envoy_api//envoy/config/common/matcher/v3:pkg",
+    ],
+)
+
+envoy_cc_library(
+    name = "assertion_filter_lib",
+    srcs = ["filter.cc"],
+    hdrs = ["filter.h"],
+    repository = "@envoy",
+    deps = [
+        "filter_cc_proto",
+        "//envoy/http:codes_interface",
+        "//envoy/http:filter_interface",
+        "//source/common/http:header_map_lib",
+        "//source/extensions/common/matcher:matcher_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":assertion_filter_lib",
+        "//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)

--- a/mobile/library/common/extensions/filters/http/assertion/config.cc
+++ b/mobile/library/common/extensions/filters/http/assertion/config.cc
@@ -1,0 +1,29 @@
+#include "mobile/library/common/extensions/filters/http/assertion/config.h"
+
+#include "mobile/library/common/extensions/filters/http/assertion/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Assertion {
+
+Http::FilterFactoryCb AssertionFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoymobile::extensions::filters::http::assertion::Assertion& proto_config,
+    const std::string&, Server::Configuration::FactoryContext&) {
+
+  AssertionFilterConfigSharedPtr filter_config =
+      std::make_shared<AssertionFilterConfig>(proto_config);
+  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<AssertionFilter>(filter_config));
+  };
+}
+
+/**
+ * Static registration for the Assertion filter. @see NamedHttpFilterConfigFactory.
+ */
+REGISTER_FACTORY(AssertionFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+
+} // namespace Assertion
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/mobile/library/common/extensions/filters/http/assertion/config.h
+++ b/mobile/library/common/extensions/filters/http/assertion/config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+#include "source/extensions/filters/http/common/factory_base.h"
+
+#include "mobile/library/common/extensions/filters/http/assertion/filter.pb.h"
+#include "mobile/library/common/extensions/filters/http/assertion/filter.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Assertion {
+
+/**
+ * Config registration for the assertion filter. @see NamedHttpFilterConfigFactory.
+ */
+class AssertionFilterFactory
+    : public Common::FactoryBase<envoymobile::extensions::filters::http::assertion::Assertion> {
+public:
+  AssertionFilterFactory() : FactoryBase("assertion") {}
+
+private:
+  ::Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoymobile::extensions::filters::http::assertion::Assertion& config,
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+DECLARE_FACTORY(AssertionFilterFactory);
+
+} // namespace Assertion
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/mobile/library/common/extensions/filters/http/assertion/filter.cc
+++ b/mobile/library/common/extensions/filters/http/assertion/filter.cc
@@ -1,0 +1,224 @@
+#include "mobile/library/common/extensions/filters/http/assertion/filter.h"
+
+#include "envoy/http/codes.h"
+#include "envoy/server/filter_config.h"
+
+#include "source/common/http/header_map_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Assertion {
+
+AssertionFilterConfig::AssertionFilterConfig(
+    const envoymobile::extensions::filters::http::assertion::Assertion& proto_config) {
+  Common::Matcher::buildMatcher(proto_config.match_config(), matchers_);
+}
+
+Extensions::Common::Matcher::Matcher& AssertionFilterConfig::rootMatcher() const {
+  ASSERT(!matchers_.empty());
+  return *matchers_[0];
+}
+
+// Implementation of this filter is complicated by the fact that the streaming matchers have no
+// explicit mechanism to handle end_stream. This means that we must infer that matching has failed
+// if the stream ends with still-unsatisfied matches. We do this by potentially passing empty
+// body data and empty trailers to the matchers in the event the stream ends without including
+// these entities.
+AssertionFilter::AssertionFilter(AssertionFilterConfigSharedPtr config) : config_(config) {
+  statuses_ = Extensions::Common::Matcher::Matcher::MatchStatusVector(config_->matchersSize());
+  config_->rootMatcher().onNewStream(statuses_);
+}
+
+Http::FilterHeadersStatus AssertionFilter::decodeHeaders(Http::RequestHeaderMap& headers,
+                                                         bool end_stream) {
+  config_->rootMatcher().onHttpRequestHeaders(headers, statuses_);
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                       "Request Headers do not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  if (end_stream) {
+    // Check if there are unsatisfied assertions about stream trailers.
+    auto empty_trailers = Http::RequestTrailerMapImpl::create();
+    config_->rootMatcher().onHttpRequestTrailers(*empty_trailers, statuses_);
+    auto& final_match_status = config_->rootMatcher().matchStatus(statuses_);
+    if (!final_match_status.matches_ && !final_match_status.might_change_status_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                         "Request Trailers do not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+
+    // Because a stream only contains a single set of headers or trailers, if either fail to
+    // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+    // unsatisfied here, it must be because of body data.
+    if (!final_match_status.matches_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                         "Request Body does not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+  }
+
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterDataStatus AssertionFilter::decodeData(Buffer::Instance& data, bool end_stream) {
+  config_->rootMatcher().onRequestBody(data, statuses_);
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                       "Request Body does not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
+  if (end_stream) {
+    // Check if there are unsatisfied assertions about stream trailers.
+    auto empty_trailers = Http::RequestTrailerMapImpl::create();
+    config_->rootMatcher().onHttpRequestTrailers(*empty_trailers, statuses_);
+    auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+    if (!match_status.matches_ && !match_status.might_change_status_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                         "Request Trailers do not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+
+    // Because a stream only contains a single set of headers or trailers, if either fail to
+    // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+    // unsatisfied here, it must be because of body data.
+    if (!match_status.matches_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                         "Request Body does not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+  }
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterTrailersStatus AssertionFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
+  config_->rootMatcher().onHttpRequestTrailers(trailers, statuses_);
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                       "Request Trailers do not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterTrailersStatus::StopIteration;
+  }
+
+  // Because a stream only contains a single set of headers or trailers, if either fail to
+  // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+  // unsatisfied here, it must be because of body data.
+  if (!match_status.matches_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                       "Request Body does not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterTrailersStatus::StopIteration;
+  }
+  return Http::FilterTrailersStatus::Continue;
+}
+
+Http::FilterHeadersStatus AssertionFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
+                                                         bool end_stream) {
+  config_->rootMatcher().onHttpResponseHeaders(headers, statuses_);
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                       "Response Headers do not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  if (end_stream) {
+    // Check if there are unsatisfied assertions about stream trailers.
+    auto empty_trailers = Http::ResponseTrailerMapImpl::create();
+    config_->rootMatcher().onHttpResponseTrailers(*empty_trailers, statuses_);
+    auto& final_match_status = config_->rootMatcher().matchStatus(statuses_);
+    if (!final_match_status.matches_ && !final_match_status.might_change_status_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                         "Response Trailers do not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+
+    // Because a stream only contains a single set of headers or trailers, if either fail to
+    // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+    // unsatisfied here, it must be because of body data.
+    if (!final_match_status.matches_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                         "Response Body does not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+  }
+
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterDataStatus AssertionFilter::encodeData(Buffer::Instance& data, bool end_stream) {
+  config_->rootMatcher().onResponseBody(data, statuses_);
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                       "Response Body does not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
+  if (end_stream) {
+    // Check if there are unsatisfied assertions about stream trailers.
+    auto empty_trailers = Http::ResponseTrailerMapImpl::create();
+    config_->rootMatcher().onHttpResponseTrailers(*empty_trailers, statuses_);
+    auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+    if (!match_status.matches_ && !match_status.might_change_status_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                         "Response Trailers do not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+
+    // Because a stream only contains a single set of headers or trailers, if either fail to
+    // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+    // unsatisfied here, it must be because of body data.
+    if (!match_status.matches_) {
+      decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                         "Response Body does not match configured expectations",
+                                         nullptr, absl::nullopt, "");
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+  }
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterTrailersStatus AssertionFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
+  config_->rootMatcher().onHttpResponseTrailers(trailers, statuses_);
+  auto& match_status = config_->rootMatcher().matchStatus(statuses_);
+  if (!match_status.matches_ && !match_status.might_change_status_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                       "Response Trailers do not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterTrailersStatus::StopIteration;
+  }
+
+  // Because a stream only contains a single set of headers or trailers, if either fail to
+  // satisfy assertions, might_change_status_ will be false. Therefore if matches_ is still
+  // unsatisfied here, it must be because of body data.
+  if (!match_status.matches_) {
+    decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError,
+                                       "Response Body does not match configured expectations",
+                                       nullptr, absl::nullopt, "");
+    return Http::FilterTrailersStatus::StopIteration;
+  }
+  return Http::FilterTrailersStatus::Continue;
+}
+
+} // namespace Assertion
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/mobile/library/common/extensions/filters/http/assertion/filter.h
+++ b/mobile/library/common/extensions/filters/http/assertion/filter.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+
+#include "source/extensions/common/matcher/matcher.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "mobile/library/common/extensions/filters/http/assertion/filter.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Assertion {
+
+class AssertionFilterConfig {
+public:
+  AssertionFilterConfig(
+      const envoymobile::extensions::filters::http::assertion::Assertion& proto_config);
+
+  Extensions::Common::Matcher::Matcher& rootMatcher() const;
+  size_t matchersSize() const { return matchers_.size(); }
+
+private:
+  std::vector<Extensions::Common::Matcher::MatcherPtr> matchers_;
+};
+
+using AssertionFilterConfigSharedPtr = std::shared_ptr<AssertionFilterConfig>;
+
+/**
+ * Filter to assert expectations on HTTP requests.
+ */
+class AssertionFilter final : public Http::PassThroughFilter {
+public:
+  AssertionFilter(AssertionFilterConfigSharedPtr config);
+
+  // StreamDecoderFilter
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
+
+  // StreamEncoderFilter
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& trailers) override;
+
+private:
+  const AssertionFilterConfigSharedPtr config_;
+  Extensions::Common::Matcher::Matcher::MatchStatusVector statuses_;
+};
+
+} // namespace Assertion
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/mobile/library/common/extensions/filters/http/assertion/filter.proto
+++ b/mobile/library/common/extensions/filters/http/assertion/filter.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package envoymobile.extensions.filters.http.assertion;
+
+import "envoy/config/common/matcher/v3/matcher.proto";
+
+import "validate/validate.proto";
+
+message Assertion {
+  // The match configuration. If the configuration matches the request frames the filter will send
+  // a local reply with Http::Code::OK on the last frame of the request stream (continuing on
+  // intervening frames). Otherwise, it will send a local reply with Http::Code::BadRequest.
+  // TODO: update upstream MatchPredicate proto to require at least one matcher.
+  envoy.config.common.matcher.v3.MatchPredicate match_config = 1
+      [(validate.rules).message = {required: true}];
+}

--- a/mobile/test/common/extensions/filters/http/assertion/BUILD
+++ b/mobile/test/common/extensions/filters/http/assertion/BUILD
@@ -1,0 +1,21 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_mobile_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
+
+envoy_cc_test(
+    name = "assertion_filter_test",
+    srcs = ["assertion_filter_test.cc"],
+    deps = [
+        "//mobile/library/common/extensions/filters/http/assertion:config",
+        "//mobile/library/common/extensions/filters/http/assertion:filter_cc_proto",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/mobile/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
+++ b/mobile/test/common/extensions/filters/http/assertion/assertion_filter_test.cc
@@ -1,0 +1,562 @@
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/server/factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+#include "mobile/library/common/extensions/filters/http/assertion/config.h"
+#include "mobile/library/common/extensions/filters/http/assertion/filter.h"
+#include "mobile/library/common/extensions/filters/http/assertion/filter.pb.h"
+
+using testing::ByMove;
+using testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Assertion {
+namespace {
+
+class AssertionFilterTest : public testing::Test {
+public:
+  void setUpFilter(std::string&& yaml) {
+    envoymobile::extensions::filters::http::assertion::Assertion config;
+    TestUtility::loadFromYaml(yaml, config);
+    config_ = std::make_shared<AssertionFilterConfig>(config);
+    filter_ = std::make_unique<AssertionFilter>(config_);
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+  }
+
+  AssertionFilterConfigSharedPtr config_{};
+  std::unique_ptr<AssertionFilter> filter_{};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+};
+
+TEST_F(AssertionFilterTest, RequestHeadersMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_headers_match:
+    headers:
+      - name: ":authority"
+        exact_match: test.code
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(AssertionFilterTest, RequestHeadersMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_headers_match:
+    headers:
+      - name: ":authority"
+        exact_match: test.code
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+}
+
+TEST_F(AssertionFilterTest, RequestHeadersNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_headers_match:
+    headers:
+      - name: ":authority"
+        exact_match: test.code
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(AssertionFilterTest, RequestHeadersNoMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_headers_match:
+    headers:
+      - name: ":authority"
+        exact_match: test.code
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+TEST_F(AssertionFilterTest, RequestHeadersMatchWithEndstreamAndDataMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_headers_match:
+        headers:
+          - name: ":authority"
+            exact_match: test.code
+    - http_request_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(AssertionFilterTest, RequestHeadersMatchWithEndstreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_headers_match:
+        headers:
+          - name: ":authority"
+            exact_match: test.code
+    - http_request_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, false));
+}
+
+TEST_F(AssertionFilterTest, RequestDataNoMatchFastPath) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    bytes_limit: 1
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, false));
+}
+
+TEST_F(AssertionFilterTest, RequestDataNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataMatchWithEndStreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_generic_body_match:
+        patterns:
+          - string_match: match_me
+    - http_request_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, RequestDataNoMatchAfterTrailers) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_request_headers_match:
+        headers:
+          - name: ":authority"
+            exact_match: test.code
+    - http_request_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", "test.code"}};
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+  Http::TestRequestTrailerMapImpl request_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(*body, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
+}
+
+TEST_F(AssertionFilterTest, RequestTrailersMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF");
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
+}
+
+TEST_F(AssertionFilterTest, RequestTrailersNoMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_request_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF");
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"test-trailer", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "Request Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersNoMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_headers_match:
+    headers:
+      - name: ":status"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Headers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndstreamAndDataMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_headers_match:
+        headers:
+          - name: ":status"
+            exact_match: test.code
+    - http_response_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseHeadersMatchWithEndstreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_headers_match:
+        headers:
+          - name: ":status"
+            exact_match: test.code
+    - http_response_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*body, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataNoMatchFastPath) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    bytes_limit: 1
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(*body, false));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataNoMatchWithEndStream) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_generic_body_match:
+    patterns:
+      - string_match: match_me
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataMatchWithEndStreamAndTrailersMissing) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_generic_body_match:
+        patterns:
+          - string_match: match_me
+    - http_response_trailers_match:
+        headers:
+          - name: "test-trailer"
+            exact_match: test.code
+)EOF");
+
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("match_me")};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(*body, true));
+}
+
+TEST_F(AssertionFilterTest, ResponseDataNoMatchAfterTrailers) {
+  setUpFilter(R"EOF(
+match_config:
+  and_match:
+    rules:
+    - http_response_headers_match:
+        headers:
+          - name: ":status"
+            exact_match: test.code
+    - http_response_generic_body_match:
+        patterns:
+        - string_match: match_me
+)EOF");
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "test.code"}};
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("garbage")};
+  Http::TestResponseTrailerMapImpl response_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Body does not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*body, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->encodeTrailers(response_trailers));
+}
+
+TEST_F(AssertionFilterTest, ResponseTrailersMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseTrailerMapImpl response_trailers{{"test-trailer", "test.code"}};
+
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
+}
+
+TEST_F(AssertionFilterTest, ResponseTrailersNoMatch) {
+  setUpFilter(R"EOF(
+match_config:
+  http_response_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF");
+
+  Http::TestResponseTrailerMapImpl response_trailers{{"test-trailer", "no.match"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::InternalServerError,
+                             "Response Trailers do not match configured expectations", _, _, ""));
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->encodeTrailers(response_trailers));
+}
+
+TEST(AssertionFilterFactoryTest, DEPRECATED_FEATURE_TEST(Config)) {
+  AssertionFilterFactory factory;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
+  envoymobile::extensions::filters::http::assertion::Assertion proto_config =
+      *dynamic_cast<envoymobile::extensions::filters::http::assertion::Assertion*>(
+          factory.createEmptyConfigProto().get());
+
+  std::string config_str = R"EOF(
+match_config:
+  http_response_trailers_match:
+    headers:
+      - name: "test-trailer"
+        exact_match: test.code
+)EOF";
+
+  TestUtility::loadFromYamlAndValidate(config_str, proto_config);
+
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "test", context);
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamFilter(_));
+  cb(filter_callbacks);
+}
+
+} // namespace
+} // namespace Assertion
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -373,8 +373,8 @@ EXTENSIONS = {
 
 # These can be changed to ["//visibility:public"], for  downstream builds which
 # need to directly reference Envoy extensions.
-EXTENSION_CONFIG_VISIBILITY = ["//:extension_config", "//:contrib_library", "//:examples_library"]
-EXTENSION_PACKAGE_VISIBILITY = ["//:extension_library", "//:contrib_library", "//:examples_library"]
+EXTENSION_CONFIG_VISIBILITY = ["//:extension_config", "//:contrib_library", "//:examples_library", "//:mobile_library"]
+EXTENSION_PACKAGE_VISIBILITY = ["//:extension_library", "//:contrib_library", "//:examples_library", "//:mobile_library"]
 CONTRIB_EXTENSION_PACKAGE_VISIBILITY = ["//:contrib_library"]
 
 # Set this variable to true to disable alwayslink for envoy_cc_library.

--- a/tools/code_format/envoy_build_fixer.py
+++ b/tools/code_format/envoy_build_fixer.py
@@ -35,6 +35,7 @@ ENVOY_RULE_REGEX = re.compile(r'envoy[_\w]+\(')
 PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_package".*?\)\n)', re.DOTALL)
 EXTENSION_PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_extension_package".*?\)\n)', re.DOTALL)
 CONTRIB_PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_contrib_package".*?\)\n)', re.DOTALL)
+MOBILE_PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_mobile_package".*?\)\n)', re.DOTALL)
 
 # Match Buildozer 'print' output. Example of Buildozer print output:
 # cc_library json_transcoder_filter_lib [json_transcoder_filter.cc] (missing) (missing)
@@ -83,6 +84,10 @@ def fix_package_and_license(path, contents):
     if 'contrib/' in path:
         regex_to_use = CONTRIB_PACKAGE_LOAD_BLOCK_REGEX
         package_string = 'envoy_contrib_package'
+
+    if 'mobile/' in path:
+        regex_to_use = MOBILE_PACKAGE_LOAD_BLOCK_REGEX
+        package_string = 'envoy_mobile_package'
 
     # Ensure we have an envoy_package import load if this is a real Envoy package. We also allow
     # the prefix to be overridden if envoy is included in a larger workspace.


### PR DESCRIPTION
This PR sets up the directory structure, visibility rules, codeowners, adds E-M C++ tests to Envoy CI, and moves one extension over as a proof of concept.

Risk Level: low
Testing: ported test to Envoy CI.  did not turn up platform CI _yet_
Release Notes: inline
Part of https://github.com/envoyproxy/envoy/issues/23758
