### PR TITLE
bazel: workaround invalid nonnull warning in v8

### DIFF
--- a/bazel/v8.patch
+++ b/bazel/v8.patch
@@ -31,7 +31,7 @@ index 4e89f90e7e..3fcb38b3f3 100644
  
  # Default setting for v8_enable_pointer_compression.
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index e957c0fad3..5870a914aa 100644
+index e957c0fad3..a6de50e6ab 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
 @@ -116,6 +116,7 @@ def _default_args():
@@ -42,7 +42,15 @@ index e957c0fad3..5870a914aa 100644
                  "-std=c++17",
              ],
              "@v8//bazel/config:is_gcc": [
-@@ -151,6 +152,23 @@ def _default_args():
+@@ -131,6 +132,7 @@ def _default_args():
+                 "-Wno-redundant-move",
+                 "-Wno-return-type",
+                 "-Wno-stringop-overflow",
++                "-Wno-nonnull",
+                 # Use GNU dialect, because GCC doesn't allow using
+                 # ##__VA_ARGS__ when in standards-conforming mode.
+                 "-std=gnu++17",
+@@ -151,6 +153,23 @@ def _default_args():
                  "-fno-integrated-as",
              ],
              "//conditions:default": [],


### PR DESCRIPTION
Since gcc 12 it seems there are some false positives around this warning.

Upstream gcc reports:

- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107252
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100366
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106199

We can't use `--per_file_copt` in this case because we build this in the host configuration https://github.com/bazelbuild/bazel/issues/12406

Upstream v8 report: https://bugs.chromium.org/p/v8/issues/detail?id=13441

Fixes https://github.com/envoyproxy/envoy/issues/23692

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>