### PR TITLE
generic proxy: make sure the execute order of encoder filters is the reverse of decoder filters'

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -23,6 +23,9 @@ bug_fixes:
 - area: oauth2
   change: |
     fixed a bug when passthrough header was matched, envoy would always remove the authorization header. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.oauth_header_passthrough_fix`` to false.
+- area: generic_proxy
+  change: |
+    fixed a bug that encoder filters and decoder filters of generic proxy will be executed in the same order. The encoder filters' execuate order should be the reverse of decoder filters' in the generic proxy.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -193,6 +193,8 @@ public:
     encoder_filters_.emplace_back(std::move(filter));
   }
 
+  void initializeFilterChain(FilterChainFactory& factory);
+
   Envoy::Event::Dispatcher& dispatcher();
   const CodecFactory& downstreamCodec();
   void resetStream();

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -601,13 +601,13 @@ TEST_F(FilterTest, ActiveStreamAddFiltersOrder) {
   EXPECT_EQ(3, active_stream->decoderFiltersForTest().size());
   EXPECT_EQ(3, active_stream->encoderFiltersForTest().size());
 
-  EXPECT_EQ(filter_0.get(), active_stream->decoderFiltersForTest()[0].get());
-  EXPECT_EQ(filter_1.get(), active_stream->decoderFiltersForTest()[1].get());
-  EXPECT_EQ(filter_2.get(), active_stream->decoderFiltersForTest()[2].get());
+  EXPECT_EQ(filter_0.get(), active_stream->decoderFiltersForTest()[0]->filter_.get());
+  EXPECT_EQ(filter_1.get(), active_stream->decoderFiltersForTest()[1]->filter_.get());
+  EXPECT_EQ(filter_2.get(), active_stream->decoderFiltersForTest()[2]->filter_.get());
 
-  EXPECT_EQ(filter_2.get(), active_stream->encoderFiltersForTest()[0].get());
-  EXPECT_EQ(filter_1.get(), active_stream->encoderFiltersForTest()[1].get());
-  EXPECT_EQ(filter_0.get(), active_stream->encoderFiltersForTest()[2].get());
+  EXPECT_EQ(filter_2.get(), active_stream->encoderFiltersForTest()[0]->filter_.get());
+  EXPECT_EQ(filter_1.get(), active_stream->encoderFiltersForTest()[1]->filter_.get());
+  EXPECT_EQ(filter_0.get(), active_stream->encoderFiltersForTest()[2]->filter_.get());
 }
 
 TEST_F(FilterTest, ActiveStreamFiltersContinueDecoding) {

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -580,6 +580,36 @@ TEST_F(FilterTest, ActiveStreamAddFilters) {
   EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
 }
 
+TEST_F(FilterTest, ActiveStreamAddFiltersOrder) {
+  auto filter_0 = std::make_shared<NiceMock<MockStreamFilter>>();
+  auto filter_1 = std::make_shared<NiceMock<MockStreamFilter>>();
+  auto filter_2 = std::make_shared<NiceMock<MockStreamFilter>>();
+
+  mock_stream_filters_ = {{"fake_test_filter_name_0", filter_0},
+                          {"fake_test_filter_name_1", filter_1},
+                          {"fake_test_filter_name_2", filter_2}};
+
+  initializeFilter();
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+
+  filter_->newDownstreamRequest(std::move(request));
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  EXPECT_EQ(3, active_stream->decoderFiltersForTest().size());
+  EXPECT_EQ(3, active_stream->encoderFiltersForTest().size());
+
+  EXPECT_EQ(filter_0.get(), active_stream->decoderFiltersForTest()[0].get());
+  EXPECT_EQ(filter_1.get(), active_stream->decoderFiltersForTest()[1].get());
+  EXPECT_EQ(filter_2.get(), active_stream->decoderFiltersForTest()[2].get());
+
+  EXPECT_EQ(filter_2.get(), active_stream->encoderFiltersForTest()[0].get());
+  EXPECT_EQ(filter_1.get(), active_stream->encoderFiltersForTest()[1].get());
+  EXPECT_EQ(filter_0.get(), active_stream->encoderFiltersForTest()[2].get());
+}
+
 TEST_F(FilterTest, ActiveStreamFiltersContinueDecoding) {
   auto mock_stream_filter_0 = std::make_shared<NiceMock<MockStreamFilter>>();
   auto mock_stream_filter_1 = std::make_shared<NiceMock<MockStreamFilter>>();


### PR DESCRIPTION
Commit Message: generic proxy: make sure the execute order of encoder filters is the reverse of decoder filters'
Additional Description:

Minor fix to the execute order of generic l7 filters.

Risk Level: Low. WIP extension.
Testing: unit test added.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.