### PR TITLE
bazel: workaround boringssl warning

### DIFF
--- a/bazel/boringssl_static.patch
+++ b/bazel/boringssl_static.patch
@@ -1,11 +1,12 @@
 diff --git a/BUILD b/BUILD
-index 1ec2bdf18..8834f80c2 100644
+index 1ec2bdf18..50fe0f050 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -96,12 +96,18 @@ linux_copts = posix_copts + [
+@@ -96,12 +96,19 @@ linux_copts = posix_copts + [
      # it should not be set on Apple platforms, where it instead disables APIs
      # we use. See compat(5) and sys/cdefs.h.
      "-D_XOPEN_SOURCE=700",
++    # https://bugs.chromium.org/p/boringssl/issues/detail?id=492
 +    "-Wno-array-bounds",
 +    "-Wno-stringop-overflow",
 +    "-Wno-unknown-warning-option",
@@ -22,7 +23,7 @@ index 1ec2bdf18..8834f80c2 100644
      "//conditions:default": [],
  })
  
-@@ -163,6 +169,7 @@ cc_library(
+@@ -163,6 +170,7 @@ cc_library(
          "@platforms//os:windows": ["-defaultlib:advapi32.lib"],
          "//conditions:default": ["-lpthread"],
      }),
@@ -30,7 +31,7 @@ index 1ec2bdf18..8834f80c2 100644
      visibility = ["//visibility:public"],
  )
  
-@@ -172,6 +179,7 @@ cc_library(
+@@ -172,6 +180,7 @@ cc_library(
      hdrs = ssl_headers,
      copts = boringssl_copts_cxx,
      includes = ["src/include"],

--- a/bazel/boringssl_static.patch
+++ b/bazel/boringssl_static.patch
@@ -6,7 +6,7 @@ index 1ec2bdf18..50fe0f050 100644
      # it should not be set on Apple platforms, where it instead disables APIs
      # we use. See compat(5) and sys/cdefs.h.
      "-D_XOPEN_SOURCE=700",
-+    # https://bugs.chromium.org/p/boringssl/issues/detail?id=492
++    # TODO(keith): Remove https://bugs.chromium.org/p/boringssl/issues/detail?id=492
 +    "-Wno-array-bounds",
 +    "-Wno-stringop-overflow",
 +    "-Wno-unknown-warning-option",

--- a/bazel/boringssl_static.patch
+++ b/bazel/boringssl_static.patch
@@ -1,8 +1,15 @@
 diff --git a/BUILD b/BUILD
-index cfa695a44..e748f9b46 100644
+index 1ec2bdf18..fdad13e66 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -101,7 +101,10 @@ linux_copts = posix_copts + [
+@@ -96,12 +96,17 @@ linux_copts = posix_copts + [
+     # it should not be set on Apple platforms, where it instead disables APIs
+     # we use. See compat(5) and sys/cdefs.h.
+     "-D_XOPEN_SOURCE=700",
++    "-Wno-array-bounds",
++    "-Wno-stringop-overflow",
+ ]
+ 
  boringssl_copts = select({
      "@platforms//os:linux": linux_copts,
      "@platforms//os:macos": posix_copts,
@@ -14,7 +21,15 @@ index cfa695a44..e748f9b46 100644
      "//conditions:default": [],
  })
  
-@@ -163,6 +166,7 @@ cc_library(
+@@ -114,6 +119,7 @@ crypto_sources_asm = select({
+     ":macos_x86_64": crypto_sources_apple_x86_64,
+     "//conditions:default": [],
+ })
++
+ boringssl_copts += select({
+     ":linux_aarch64": [],
+     ":linux_ppc64le": [],
+@@ -163,6 +169,7 @@ cc_library(
          "@platforms//os:windows": ["-defaultlib:advapi32.lib"],
          "//conditions:default": ["-lpthread"],
      }),
@@ -22,7 +37,7 @@ index cfa695a44..e748f9b46 100644
      visibility = ["//visibility:public"],
  )
  
-@@ -172,6 +176,7 @@ cc_library(
+@@ -172,6 +179,7 @@ cc_library(
      hdrs = ssl_headers,
      copts = boringssl_copts_cxx,
      includes = ["src/include"],

--- a/bazel/boringssl_static.patch
+++ b/bazel/boringssl_static.patch
@@ -1,13 +1,14 @@
 diff --git a/BUILD b/BUILD
-index 1ec2bdf18..fdad13e66 100644
+index 1ec2bdf18..8834f80c2 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -96,12 +96,17 @@ linux_copts = posix_copts + [
+@@ -96,12 +96,18 @@ linux_copts = posix_copts + [
      # it should not be set on Apple platforms, where it instead disables APIs
      # we use. See compat(5) and sys/cdefs.h.
      "-D_XOPEN_SOURCE=700",
 +    "-Wno-array-bounds",
 +    "-Wno-stringop-overflow",
++    "-Wno-unknown-warning-option",
  ]
  
  boringssl_copts = select({
@@ -21,14 +22,6 @@ index 1ec2bdf18..fdad13e66 100644
      "//conditions:default": [],
  })
  
-@@ -114,6 +119,7 @@ crypto_sources_asm = select({
-     ":macos_x86_64": crypto_sources_apple_x86_64,
-     "//conditions:default": [],
- })
-+
- boringssl_copts += select({
-     ":linux_aarch64": [],
-     ":linux_ppc64le": [],
 @@ -163,6 +169,7 @@ cc_library(
          "@platforms//os:windows": ["-defaultlib:advapi32.lib"],
          "//conditions:default": ["-lpthread"],


### PR DESCRIPTION
New warning with gcc 12, upstream issue: https://bugs.chromium.org/p/boringssl/issues/detail?id=492

Fixes https://github.com/envoyproxy/envoy/issues/23568

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>