### PR TITLE
test: wait for end stream in HTTP timeout integration tests

### DIFF
--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -38,7 +38,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
   timeSystem().advanceTimeWait(std::chrono::milliseconds(501));
 
   // Ensure we got a timeout downstream and canceled the upstream request.
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
   codec_client_->close();
@@ -81,7 +81,7 @@ TEST_P(HttpTimeoutIntegrationTest, UseTimeoutSetByEgressEnvoy) {
   timeSystem().advanceTimeWait(std::chrono::milliseconds(301));
 
   // Ensure we got a timeout downstream and canceled the upstream request.
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
   codec_client_->close();
@@ -122,7 +122,7 @@ TEST_P(HttpTimeoutIntegrationTest, DeriveTimeoutInIngressEnvoy) {
   timeSystem().advanceTimeWait(std::chrono::milliseconds(501));
 
   // Ensure we got a timeout downstream and canceled the upstream request.
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
   codec_client_->close();
@@ -164,7 +164,7 @@ TEST_P(HttpTimeoutIntegrationTest, IgnoreTimeoutSetByEgressEnvoy) {
   timeSystem().advanceTimeWait(std::chrono::milliseconds(501));
 
   // Ensure we got a timeout downstream and canceled the upstream request.
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
   codec_client_->close();
@@ -261,7 +261,7 @@ TEST_P(HttpTimeoutIntegrationTest, PerTryTimeout) {
 
   // Trigger global timeout.
   timeSystem().advanceTimeWait(std::chrono::milliseconds(100));
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
 
   codec_client_->close();
 
@@ -313,7 +313,7 @@ TEST_P(HttpTimeoutIntegrationTest, PerTryTimeoutWithoutGlobalTimeout) {
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   upstream_request_->encodeHeaders(response_headers, true);
 
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
   codec_client_->close();
 
   EXPECT_TRUE(upstream_request_->complete());
@@ -368,7 +368,7 @@ TEST_P(HttpTimeoutIntegrationTest, HedgedPerTryTimeout) {
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   upstream_request_->encodeHeaders(response_headers, true);
 
-  response->waitForHeaders();
+  ASSERT_TRUE(response->waitForEndStream());
 
   // The second request should be reset since we used the response from the first request.
   ASSERT_TRUE(upstream_request2->waitForReset(std::chrono::seconds(15)));


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: test: wait for end stream in HTTP timeout integration tests
Additional Description:

Currently, these integration tests only wait for headers and close the codec client, which will cause the response stay incomplete and lead to expect failure in an extremely slow network. The patch makes these tests wait for end stream before closing codec client.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
