### PR TITLE
local ratelimit: make sure the timer of local limit could be destoryed safely

### DIFF
--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
@@ -23,9 +23,9 @@ const std::string& PerConnectionRateLimiter::key() {
 
 FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& config,
-    const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher, Stats::Scope& scope,
+    const LocalInfo::LocalInfo& local_info, Event::Dispatcher& main_dispatcher, Stats::Scope& scope,
     Runtime::Loader& runtime, const bool per_route)
-    : status_(toErrorCode(config.status().code())),
+    : main_dispatcher_(main_dispatcher), status_(toErrorCode(config.status().code())),
       stats_(generateStats(config.stat_prefix(), scope)),
       fill_interval_(std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(config.token_bucket(), fill_interval, 0))),
@@ -33,8 +33,8 @@ FilterConfig::FilterConfig(
       tokens_per_fill_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.token_bucket(), tokens_per_fill, 1)),
       descriptors_(config.descriptors()),
       rate_limit_per_connection_(config.local_rate_limit_per_downstream_connection()),
-      rate_limiter_(Filters::Common::LocalRateLimit::LocalRateLimiterImpl(
-          fill_interval_, max_tokens_, tokens_per_fill_, dispatcher, descriptors_)),
+      rate_limiter_(new Filters::Common::LocalRateLimit::LocalRateLimiterImpl(
+          fill_interval_, max_tokens_, tokens_per_fill_, main_dispatcher, descriptors_)),
       local_info_(local_info), runtime_(runtime),
       filter_enabled_(
           config.has_filter_enabled()
@@ -67,22 +67,22 @@ FilterConfig::FilterConfig(
 
 bool FilterConfig::requestAllowed(
     absl::Span<const RateLimit::LocalDescriptor> request_descriptors) const {
-  return rate_limiter_.requestAllowed(request_descriptors);
+  return rate_limiter_->requestAllowed(request_descriptors);
 }
 
 uint32_t
 FilterConfig::maxTokens(absl::Span<const RateLimit::LocalDescriptor> request_descriptors) const {
-  return rate_limiter_.maxTokens(request_descriptors);
+  return rate_limiter_->maxTokens(request_descriptors);
 }
 
 uint32_t FilterConfig::remainingTokens(
     absl::Span<const RateLimit::LocalDescriptor> request_descriptors) const {
-  return rate_limiter_.remainingTokens(request_descriptors);
+  return rate_limiter_->remainingTokens(request_descriptors);
 }
 
 int64_t FilterConfig::remainingFillInterval(
     absl::Span<const RateLimit::LocalDescriptor> request_descriptors) const {
-  return rate_limiter_.remainingFillInterval(request_descriptors);
+  return rate_limiter_->remainingFillInterval(request_descriptors);
 }
 
 LocalRateLimitStats FilterConfig::generateStats(const std::string& prefix, Stats::Scope& scope) {

--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
@@ -23,9 +23,9 @@ const std::string& PerConnectionRateLimiter::key() {
 
 FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& config,
-    const LocalInfo::LocalInfo& local_info, Event::Dispatcher& main_dispatcher, Stats::Scope& scope,
+    const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher, Stats::Scope& scope,
     Runtime::Loader& runtime, const bool per_route)
-    : main_dispatcher_(main_dispatcher), status_(toErrorCode(config.status().code())),
+    : dispatcher_(dispatcher), status_(toErrorCode(config.status().code())),
       stats_(generateStats(config.stat_prefix(), scope)),
       fill_interval_(std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(config.token_bucket(), fill_interval, 0))),
@@ -34,7 +34,7 @@ FilterConfig::FilterConfig(
       descriptors_(config.descriptors()),
       rate_limit_per_connection_(config.local_rate_limit_per_downstream_connection()),
       rate_limiter_(new Filters::Common::LocalRateLimit::LocalRateLimiterImpl(
-          fill_interval_, max_tokens_, tokens_per_fill_, main_dispatcher, descriptors_)),
+          fill_interval_, max_tokens_, tokens_per_fill_, dispatcher, descriptors_)),
       local_info_(local_info), runtime_(runtime),
       filter_enabled_(
           config.has_filter_enabled()

--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.h
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.h
@@ -74,10 +74,10 @@ public:
                Stats::Scope& scope, Runtime::Loader& runtime, bool per_route = false);
   ~FilterConfig() override {
     if (!main_dispatcher_.isThreadSafe()) {
-      main_dispatcher_.post(
-          [limiter_wrapper = std::make_shared<
-               std::unique_ptr<Filters::Common::LocalRateLimit::LocalRateLimiterImpl>>(
-               std::move(rate_limiter_))]() { limiter_wrapper->reset(); });
+      auto shared_ptr_wrapper =
+          std::make_shared<std::unique_ptr<Filters::Common::LocalRateLimit::LocalRateLimiterImpl>>(
+              std::move(rate_limiter_));
+      main_dispatcher_.post([shared_ptr_wrapper]() { shared_ptr_wrapper->reset(); });
     }
   }
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }

--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.h
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.h
@@ -70,15 +70,15 @@ private:
 class FilterConfig : public Router::RouteSpecificFilterConfig {
 public:
   FilterConfig(const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& config,
-               const LocalInfo::LocalInfo& local_info, Event::Dispatcher& main_dispatcher,
+               const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispatcher,
                Stats::Scope& scope, Runtime::Loader& runtime, bool per_route = false);
   ~FilterConfig() override {
-    if (!main_dispatcher_.isThreadSafe()) {
-      auto shared_ptr_wrapper =
-          std::make_shared<std::unique_ptr<Filters::Common::LocalRateLimit::LocalRateLimiterImpl>>(
-              std::move(rate_limiter_));
-      main_dispatcher_.post([shared_ptr_wrapper]() { shared_ptr_wrapper->reset(); });
-    }
+    // Ensure that the LocalRateLimiterImpl instance will be destroyed on the thread where its inner
+    // timer is created and running.
+    auto shared_ptr_wrapper =
+        std::make_shared<std::unique_ptr<Filters::Common::LocalRateLimit::LocalRateLimiterImpl>>(
+            std::move(rate_limiter_));
+    dispatcher_.post([shared_ptr_wrapper]() { shared_ptr_wrapper->reset(); });
   }
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }
   Runtime::Loader& runtime() { return runtime_; }
@@ -122,7 +122,7 @@ private:
     return Http::Code::TooManyRequests;
   }
 
-  Event::Dispatcher& main_dispatcher_;
+  Event::Dispatcher& dispatcher_;
   const Http::Code status_;
   mutable LocalRateLimitStats stats_;
   const std::chrono::milliseconds fill_interval_;

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -269,7 +269,7 @@ TEST_P(LocalRateLimitFilterIntegrationTest, PermitRequestAcrossDifferentConnecti
   EXPECT_EQ(0, response->body().size());
 }
 
-TEST_P(LocalRateLimitFilterIntegrationTest, BasicTestOfLuaPerRoute) {
+TEST_P(LocalRateLimitFilterIntegrationTest, BasicTestPerRouteAndRds) {
   initializeFilterWithRds(fmt::format(filter_config_, true), "basic_routes", initial_route_config_);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -13,6 +13,72 @@ protected:
     initialize();
   }
 
+  void initializeFilterWithRds(const std::string& filter_config,
+                               const std::string& route_config_name,
+                               const std::string& initial_route_config) {
+    // Set this flag to true to create fake upstream for xds_cluster.
+    create_xds_upstream_ = true;
+    // Create static clusters.
+    createClusters();
+
+    config_helper_.prependFilter(filter_config);
+
+    // Set RDS config source.
+    config_helper_.addConfigModifier(
+        [route_config_name](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
+          hcm.mutable_rds()->set_route_config_name(route_config_name);
+          hcm.mutable_rds()->mutable_config_source()->set_resource_api_version(
+              envoy::config::core::v3::ApiVersion::V3);
+          envoy::config::core::v3::ApiConfigSource* rds_api_config_source =
+              hcm.mutable_rds()->mutable_config_source()->mutable_api_config_source();
+          rds_api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+          rds_api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
+          envoy::config::core::v3::GrpcService* grpc_service =
+              rds_api_config_source->add_grpc_services();
+          grpc_service->mutable_envoy_grpc()->set_cluster_name("xds_cluster");
+        });
+
+    on_server_init_function_ = [&]() {
+      AssertionResult result =
+          fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, xds_connection_);
+      RELEASE_ASSERT(result, result.message());
+      result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+      RELEASE_ASSERT(result, result.message());
+      xds_stream_->startGrpcStream();
+
+      EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "",
+                                              {route_config_name}, true));
+      sendSotwDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+          Config::TypeUrl::get().RouteConfiguration,
+          {TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(
+              initial_route_config)},
+          "1");
+    };
+    initialize();
+    registerTestServerPorts({"http"});
+  }
+
+  void createClusters() {
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* xds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      xds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      xds_cluster->set_name("xds_cluster");
+      ConfigHelper::setHttp2(*xds_cluster);
+    });
+  }
+
+  void cleanUpXdsConnection() {
+    if (xds_connection_ != nullptr) {
+      AssertionResult result = xds_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = xds_connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      xds_connection_ = nullptr;
+    }
+  }
+
   const std::string filter_config_ =
       R"EOF(
 name: envoy.filters.http.local_ratelimit
@@ -39,6 +105,77 @@ typed_config:
         key: x-local-rate-limit
         value: 'true'
   local_rate_limit_per_downstream_connection: {}
+)EOF";
+
+  const std::string initial_route_config_ = R"EOF(
+name: basic_routes
+virtual_hosts:
+- name: rds_vhost_1
+  domains: ["*"]
+  routes:
+  - match:
+      prefix: "/"
+    route:
+      cluster: cluster_0
+    typed_per_filter_config:
+      envoy.filters.http.local_ratelimit:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+        stat_prefix: http_local_rate_limiter
+        token_bucket:
+          max_tokens: 1
+          tokens_per_fill: 1
+          fill_interval: 1000s
+        filter_enabled:
+          runtime_key: local_rate_limit_enabled
+          default_value:
+            numerator: 100
+            denominator: HUNDRED
+        filter_enforced:
+          runtime_key: local_rate_limit_enforced
+          default_value:
+            numerator: 100
+            denominator: HUNDRED
+        response_headers_to_add:
+          - append_action: OVERWRITE_IF_EXISTS_OR_ADD
+            header:
+              key: x-local-rate-limit
+              value: 'true'
+        local_rate_limit_per_downstream_connection: true
+)EOF";
+
+  const std::string update_route_config_ = R"EOF(
+name: basic_routes
+virtual_hosts:
+- name: rds_vhost_1
+  domains: ["*"]
+  routes:
+  - match:
+      prefix: "/"
+    route:
+      cluster: cluster_0
+    typed_per_filter_config:
+      envoy.filters.http.local_ratelimit:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+        stat_prefix: http_local_rate_limiter
+        token_bucket:
+          max_tokens: 1
+          tokens_per_fill: 1
+          fill_interval: 1000s
+        filter_enabled:
+          runtime_key: local_rate_limit_enabled
+          default_value:
+            numerator: 100
+            denominator: HUNDRED
+        filter_enforced:
+          runtime_key: local_rate_limit_enforced
+          default_value:
+            numerator: 100
+            denominator: HUNDRED
+        response_headers_to_add:
+          - header:
+              key: x-local-rate-limit
+              value: 'true'
+        local_rate_limit_per_downstream_connection: true
 )EOF";
 };
 
@@ -130,6 +267,50 @@ TEST_P(LocalRateLimitFilterIntegrationTest, PermitRequestAcrossDifferentConnecti
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
   EXPECT_EQ(0, response->body().size());
+}
+
+TEST_P(LocalRateLimitFilterIntegrationTest, BasicTestOfLuaPerRoute) {
+  initializeFilterWithRds(fmt::format(filter_config_, true), "basic_routes", initial_route_config_);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeRequestWithBody(default_request_headers_, 0);
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, 1);
+
+  // Update route config by RDS when request is sending. Test whether RDS can work normally.
+  sendSotwDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TypeUrl::get().RouteConfiguration,
+      {TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(update_route_config_)},
+      "2");
+  test_server_->waitForCounterGe("http.config_test.rds.basic_routes.update_success", 2);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ(0, response->body().size());
+
+  cleanupUpstreamAndDownstream();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  response = codec_client_->makeRequestWithBody(default_request_headers_, 0);
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, 1);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ(0, response->body().size());
+
+  cleanupUpstreamAndDownstream();
+
+  cleanUpXdsConnection();
 }
 
 } // namespace


### PR DESCRIPTION

Commit Message: local ratelimit: make sure the timer of local limit could be destoryed safely
Additional Description:

Timer is used by the `LocalRatelimitImpl`, so we should ensure the `LocalRatelimitImpl` always be destroyed in the thread where its inner timer is created and running.
However, the `LocalRatelimitImpl` in the `FilterConfig` of local rate limit filter may be created in the main thread and destroyed in the worker theads when the route configuration is updated by the RDS.

Risk Level: Low.
Testing: integration test.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.