### PR TITLE
health_check: add the support to disable active hc for single endpoint

### DIFF
--- a/api/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/api/envoy/config/endpoint/v3/endpoint_components.proto
@@ -51,6 +51,10 @@ message Endpoint {
     //
     //   The form of the health check host address is expected to be a direct IP address.
     core.v3.Address address = 3;
+
+    // Optional flag to control if perform active health check for this endpoint.
+    // Active health check is enabled by default if there is a health checker.
+    bool disable_active_health_check = 4;
   }
 
   // The upstream host address.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -83,5 +83,8 @@ new_features:
 - area: udp_proxy
   change: |
     added support for :ref:`proxy_access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.
+- area: health_check
+  change: |
+    added an optional bool flag :ref:`disable_active_health_check <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.disable_active_health_check>` to disable the active health check for the endpoint.
 
 deprecated:

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -242,6 +242,16 @@ public:
    * connection pools no longer need this host.
    */
   virtual HostHandlePtr acquireHandle() const PURE;
+
+  /**
+   * @return true if active health check is disabled.
+   */
+  virtual bool disableActiveHealthCheck() const PURE;
+
+  /**
+   * Set true to disable active health check for the host.
+   */
+  virtual void setDisableActiveHealthCheck(bool disable_active_health_check) PURE;
 };
 
 using HostConstSharedPtr = std::shared_ptr<const Host>;

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -160,6 +160,9 @@ HealthCheckerImplBase::intervalWithJitter(uint64_t base_time_ms,
 
 void HealthCheckerImplBase::addHosts(const HostVector& hosts) {
   for (const HostSharedPtr& host : hosts) {
+    if (host->disableActiveHealthCheck()) {
+      continue;
+    }
     active_sessions_[host] = makeSession(host);
     host->setHealthChecker(
         HealthCheckHostMonitorPtr{new HealthCheckHostMonitorImpl(shared_from_this(), host)});
@@ -171,6 +174,9 @@ void HealthCheckerImplBase::onClusterMemberUpdate(const HostVector& hosts_added,
                                                   const HostVector& hosts_removed) {
   addHosts(hosts_added);
   for (const HostSharedPtr& host : hosts_removed) {
+    if (host->disableActiveHealthCheck()) {
+      continue;
+    }
     auto session_iter = active_sessions_.find(host);
     ASSERT(active_sessions_.end() != session_iter);
     // This deletion can happen inline in response to a host failure, so we deferred delete.

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -167,6 +167,12 @@ envoy::config::cluster::v3::Cluster HdsDelegate::createClusterConfig(
 
     // add all endpoints for this locality group to the config
     for (const auto& endpoint : locality_endpoints.endpoints()) {
+      if (endpoint.has_health_check_config() &&
+          endpoint.health_check_config().disable_active_health_check()) {
+        ENVOY_LOG(debug, "Skip adding the endpoint {} with optional disabled health check for HDS.",
+                  endpoint.DebugString());
+        continue;
+      }
       auto* new_endpoint = endpoints->add_lb_endpoints()->mutable_endpoint();
       new_endpoint->mutable_address()->MergeFrom(endpoint.address());
       new_endpoint->mutable_health_check_config()->MergeFrom(endpoint.health_check_config());

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1418,8 +1418,17 @@ void ClusterImplBase::onPreInitComplete() {
 void ClusterImplBase::onInitDone() {
   if (health_checker_ && pending_initialize_health_checks_ == 0) {
     for (auto& host_set : prioritySet().hostSetsPerPriority()) {
-      pending_initialize_health_checks_ += host_set->hosts().size();
+      uint64_t health_check_count = 0;
+      for (auto& host : host_set->hosts()) {
+        if (host->disableActiveHealthCheck()) {
+          continue;
+        }
+        ++health_check_count;
+      }
+      pending_initialize_health_checks_ += health_check_count;
     }
+    ENVOY_LOG(debug, "Clsuter onInitDone pending initialize health checks count {}",
+              pending_initialize_health_checks_);
 
     // TODO(mattklein123): Remove this callback when done.
     health_checker_->addHostCheckCompleteCb([this](HostSharedPtr, HealthTransition) -> void {
@@ -1505,6 +1514,7 @@ void ClusterImplBase::reloadHealthyHostsHelper(const HostSharedPtr&) {
     prioritySet().updateHosts(priority,
                               HostSetImpl::partitionHosts(hosts_copy, hosts_per_locality_copy),
                               host_set->localityWeights(), {}, {}, absl::nullopt);
+    ENVOY_LOG(debug, "Boteng prioritySet.updateHosts done.");
   }
 }
 
@@ -1770,8 +1780,9 @@ void PriorityStateManager::updateClusterPrioritySet(
   for (const HostSharedPtr& host : *hosts) {
     // Take into consideration when a non-EDS cluster has active health checking, i.e. to mark all
     // the hosts unhealthy (host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC)) and then fire
-    // update callbacks to start the health checking process.
-    if (health_checker_flag.has_value()) {
+    // update callbacks to start the health checking process. The endpoint with disabled active
+    // health check should not be set FAILED_ACTIVE_HC here.
+    if (health_checker_flag.has_value() && !host->disableActiveHealthCheck()) {
       host->healthFlagSet(health_checker_flag.value());
     }
     hosts_per_locality[host->locality()].push_back(host);
@@ -1852,6 +1863,9 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
   // Keep track of hosts for which locality is changed.
   absl::flat_hash_set<std::string> hosts_with_updated_locality_for_current_priority(
       current_priority_hosts.size());
+  // Keep track of hosts for which active health check flag is changed.
+  absl::flat_hash_set<std::string> hosts_with_active_health_check_flag_changed(
+      current_priority_hosts.size());
   HostVector final_hosts;
   for (const HostSharedPtr& host : new_hosts) {
     // To match a new host with an existing host means comparing their addresses.
@@ -1878,7 +1892,14 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
       hosts_with_updated_locality_for_current_priority.emplace(existing_host->first);
     }
 
-    const bool skip_inplace_host_update = health_check_address_changed || locality_changed;
+    const bool active_health_check_flag_changed =
+        (health_checker_ != nullptr && existing_host_found &&
+         existing_host->second->disableActiveHealthCheck() != host->disableActiveHealthCheck());
+    if (active_health_check_flag_changed) {
+      hosts_with_active_health_check_flag_changed.emplace(existing_host->first);
+    }
+    const bool skip_inplace_host_update =
+        health_check_address_changed || locality_changed || active_health_check_flag_changed;
 
     // When there is a match and we decided to do in-place update, we potentially update the
     // host's health check flag and metadata. Afterwards, the host is pushed back into the
@@ -1941,7 +1962,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
       }
 
       // If we are depending on a health checker, we initialize to unhealthy.
-      if (health_checker_ != nullptr) {
+      if (health_checker_ != nullptr && !host->disableActiveHealthCheck()) {
         host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
 
         // If we want to exclude hosts until they have been health checked, mark them with
@@ -1993,12 +2014,17 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
     erase_from = std::remove_if(
         current_priority_hosts.begin(), current_priority_hosts.end(),
         [&all_new_hosts, &new_hosts_for_current_priority,
-         &hosts_with_updated_locality_for_current_priority, &final_hosts,
+         &hosts_with_updated_locality_for_current_priority,
+         &hosts_with_active_health_check_flag_changed, &final_hosts,
          &max_host_weight](const HostSharedPtr& p) {
           // This host has already been added as a new host in the
           // new_hosts_for_current_priority. Return false here to make sure that host
           // reference with older locality gets cleaned up from the priority.
           if (hosts_with_updated_locality_for_current_priority.contains(p->address()->asString())) {
+            return false;
+          }
+
+          if (hosts_with_active_health_check_flag_changed.contains(p->address()->asString())) {
             return false;
           }
 
@@ -2013,8 +2039,11 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
             return false;
           }
 
-          if (!(p->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC) ||
-                p->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH))) {
+          // PENDING_DYNAMIC_REMOVAL doesn't apply for the host with disabled active
+          // health check, the host is removed immediately from this priority.
+          if ((!(p->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC) ||
+                 p->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH))) &&
+              !p->disableActiveHealthCheck()) {
             if (p->weight() > max_host_weight) {
               max_host_weight = p->weight();
             }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -266,11 +266,17 @@ public:
            TimeSource& time_source)
       : HostDescriptionImpl(cluster, hostname, address, metadata, locality, health_check_config,
                             priority, time_source),
+        disable_active_health_check_(health_check_config.disable_active_health_check()),
         health_status_(health_status) {
     // This EDS flags setting is still necessary for stats, configuration dump, canonical
     // coarseHealth() etc.
     setEdsHealthFlag(health_status);
     HostImpl::weight(initial_weight);
+  }
+
+  bool disableActiveHealthCheck() const override { return disable_active_health_check_; }
+  void setDisableActiveHealthCheck(bool disable_active_health_check) override {
+    disable_active_health_check_ = disable_active_health_check;
   }
 
   // Upstream::Host
@@ -359,6 +365,7 @@ private:
 
   std::atomic<uint32_t> health_flags_{};
   std::atomic<uint32_t> weight_;
+  bool disable_active_health_check_;
   // TODO(wbpcode): should we store the EDS health status to health_flags_ to get unified status or
   // flag access? May be we could refactor HealthFlag to contain all these statuses and flags in the
   // future.

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -699,6 +699,114 @@ TEST_F(EdsTest, MalformedIPForHealthChecks) {
                             EnvoyException, "malformed IP address: foo.bar.com");
 }
 
+TEST_F(EdsTest, DisableActiveHCEndpoints) {
+  envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
+  cluster_load_assignment.set_cluster_name("fare");
+
+  auto health_checker = std::make_shared<MockHealthChecker>();
+  EXPECT_CALL(*health_checker, start());
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(2);
+  cluster_->setHealthChecker(health_checker);
+  initialize();
+
+  auto add_endpoint = [&cluster_load_assignment](int port, bool disable_hc, bool healthy) {
+    auto* lb_endpoint = cluster_load_assignment.add_endpoints()->add_lb_endpoints();
+    auto* endpoint = lb_endpoint->mutable_endpoint();
+    auto* socket_address = endpoint->mutable_address()->mutable_socket_address();
+    socket_address->set_address("1.2.3.4");
+    socket_address->set_port_value(port);
+    endpoint->mutable_health_check_config()->set_disable_active_health_check(disable_hc);
+    if (disable_hc) {
+      if (healthy) {
+        lb_endpoint->set_health_status(envoy::config::core::v3::HEALTHY);
+      } else {
+        lb_endpoint->set_health_status(envoy::config::core::v3::TIMEOUT);
+      }
+    }
+  };
+
+  // First endpoint with disabled active HC.
+  add_endpoint(80, true, false);
+  // Second endpoint with enabled active HC.
+  add_endpoint(81, false, false);
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
+  {
+    auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(hosts.size(), 2);
+
+    // The endpoint with disabled active health check should not be set FAILED_ACTIVE_HC
+    // and PENDING_ACTIVE_HC at beginning.
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL));
+    EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH));
+    EXPECT_TRUE(hosts[1]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+
+    EXPECT_EQ(Host::Health::Unhealthy, hosts[0]->coarseHealth());
+    EXPECT_EQ(Host::Health::Unhealthy, hosts[1]->coarseHealth());
+
+    // Remove the pending HC & mark the second host as healthy.
+    // This is normally done by the health checker.
+    hosts[1]->healthFlagClear(Host::HealthFlag::PENDING_ACTIVE_HC);
+    hosts[1]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
+
+    // After the active health check status is changed, run the callbacks to reload hosts.
+    health_checker->runCallbacks(hosts[1], HealthTransition::Changed);
+
+    EXPECT_EQ(Host::Health::Healthy, hosts[1]->coarseHealth());
+    EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  }
+
+  // Now mark the port 80 endpoint as healthy through EDS, no change for the other one.
+  cluster_load_assignment.clear_endpoints();
+  add_endpoint(80, true, true);
+  add_endpoint(81, false, false);
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
+  HostSharedPtr removed_host;
+  {
+    auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(hosts.size(), 2);
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH));
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL));
+
+    removed_host = hosts[1];
+    EXPECT_FALSE(hosts[1]->healthFlagGet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL));
+    EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  }
+
+  // Disable active health check for both endpoints.
+  cluster_load_assignment.clear_endpoints();
+  add_endpoint(80, true, true);
+  add_endpoint(81, true, true);
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
+  {
+    // Both hosts should be present, and both should not be PENDING_DYNAMIC_REMOVAL.
+    auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(hosts.size(), 2);
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH));
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL));
+
+    // Verify that we have a new host. The host is removed even it is active
+    // healthy when the active hc flag is changed.
+    EXPECT_EQ(removed_host->address()->asString(), hosts[1]->address()->asString());
+    EXPECT_NE(removed_host, hosts[1]);
+    EXPECT_FALSE(hosts[1]->healthFlagGet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL));
+    EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  }
+
+  // Enable the active health check for the port 80 endpoint.
+  cluster_load_assignment.clear_endpoints();
+  add_endpoint(80, false, true);
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
+  {
+    auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(hosts.size(), 1);
+    EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  }
+}
+
 // Verify that a host is removed if it is removed from discovery, stabilized, and then later
 // fails active HC.
 TEST_F(EdsTest, EndpointRemovalAfterHcFail) {

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -153,7 +153,8 @@ protected:
   // Creates a HealthCheckSpecifier message that contains several clusters, endpoints, localities,
   // with only one health check type.
   std::unique_ptr<envoy::service::health::v3::HealthCheckSpecifier>
-  createComplexSpecifier(uint32_t n_clusters, uint32_t n_localities, uint32_t n_endpoints) {
+  createComplexSpecifier(uint32_t n_clusters, uint32_t n_localities, uint32_t n_endpoints,
+                         bool disable_hc = false) {
     // Final specifier to return.
     std::unique_ptr<envoy::service::health::v3::HealthCheckSpecifier> msg =
         std::make_unique<envoy::service::health::v3::HealthCheckSpecifier>();
@@ -188,11 +189,13 @@ protected:
 
         // add some endpoints to the locality group with iterative naming for verification.
         for (uint32_t endpoint_num = 0; endpoint_num < n_endpoints; endpoint_num++) {
-          auto* socket_address =
-              locality_endpoints->add_endpoints()->mutable_address()->mutable_socket_address();
+          auto* endpoint = locality_endpoints->add_endpoints();
+
+          auto* socket_address = endpoint->mutable_address()->mutable_socket_address();
           socket_address->set_address(
               absl::StrCat("127.", cluster_num, ".", loc_num, ".", endpoint_num));
           socket_address->set_port_value(1234);
+          endpoint->mutable_health_check_config()->set_disable_active_health_check(disable_hc);
         }
       }
     }
@@ -891,6 +894,42 @@ TEST_F(HdsTest, TestUpdateEndpoints) {
 
   // Check to see that HDS got three requests, and updated three times with it.
   checkHdsCounters(3, 0, 0, 3);
+}
+
+// Skip the endpoints with disabled active health check during message processing.
+TEST_F(HdsTest, TestUpdateEndpointsWithActiveHCflag) {
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(Return(&async_stream_));
+  EXPECT_CALL(async_stream_, sendMessageRaw_(_, _));
+  createHdsDelegate();
+
+  // Create Message, and later add/remove endpoints from the second cluster.
+  message.reset(createSimpleMessage());
+  message->MergeFrom(*createComplexSpecifier(1, 1, 2));
+
+  // Create a new active connection on request, setting its status to connected
+  // to mock a found endpoint.
+  expectCreateClientConnection();
+
+  EXPECT_CALL(*server_response_timer_, enableTimer(_, _)).Times(AtLeast(1));
+  EXPECT_CALL(async_stream_, sendMessageRaw_(_, false));
+  EXPECT_CALL(test_factory_, createClusterInfo(_)).WillRepeatedly(Return(cluster_info_));
+  EXPECT_CALL(server_context_.dispatcher_, deferredDelete_(_)).Times(AtLeast(1));
+  // Process message
+  hds_delegate_->onReceiveMessage(std::move(message));
+  hds_delegate_->sendResponse();
+
+  // Save list of hosts/endpoints for comparison later.
+  auto original_hosts = hds_delegate_->hdsClusters()[1]->hosts();
+  ASSERT_EQ(original_hosts.size(), 2);
+
+  // Ignoring the endpoints with disabled active health check.
+  message.reset(createSimpleMessage());
+  message->MergeFrom(*createComplexSpecifier(1, 1, 2, true));
+  hds_delegate_->onReceiveMessage(std::move(message));
+
+  // Get the new clusters list from HDS.
+  auto new_hosts = hds_delegate_->hdsClusters()[1]->hosts();
+  ASSERT_EQ(new_hosts.size(), 0);
 }
 
 // Test adding, reusing, and removing health checks.

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -163,6 +163,11 @@ public:
     return locality_zone_stat_name_->statName();
   }
 
+  bool disableActiveHealthCheck() const override { return disable_active_health_check_; }
+  void setDisableActiveHealthCheck(bool disable_active_health_check) override {
+    disable_active_health_check_ = disable_active_health_check;
+  }
+
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
   MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (),
               (const));
@@ -213,6 +218,7 @@ public:
   LoadMetricStatsImpl load_metric_stats_;
   mutable Stats::TestUtil::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;
+  bool disable_active_health_check_ = false;
 };
 
 } // namespace Upstream


### PR DESCRIPTION
Signed-off-by: Boteng Yao <boteng@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

This PR is going to add an optional flag in the Endpoint to disable or enable active health check for it. 
**Note**, it will impact all type of clusters if health checker is configured, e.g. EDS, strict_dns. 
However, we skip the endpoint at the message level for HDS.

Commit Message:
Additional Description:
Risk Level: M
Testing: unit and integration tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
