### PR TITLE
[backport/v1.23]: ci: use host docker gid for envoybuild + deps: Update ragel

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -112,9 +112,6 @@ configure_make(
 )
 
 configure_make(
-<<<<<<< HEAD
-    name = "ragel",
-=======
     name = "colm",
     autogen = True,
     configure_in_place = True,
@@ -146,7 +143,6 @@ configure_make(
         "--enable-static",
         "--with-colm=$EXT_BUILD_DEPS/colm",
     ],
->>>>>>> 835dc5021a (deps: update Ragel (#22635))
     # Workaround for the issue with statically linked libstdc++
     # using -l:libstdc++.a.
     env = {

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -112,7 +112,41 @@ configure_make(
 )
 
 configure_make(
+<<<<<<< HEAD
     name = "ragel",
+=======
+    name = "colm",
+    autogen = True,
+    configure_in_place = True,
+    configure_options = [
+        "AUTOMAKE=automake",
+        "ACLOCAL=aclocal",
+        "--disable-shared",
+        "--enable-static",
+    ],
+    # Workaround for the issue with statically linked libstdc++
+    # using -l:libstdc++.a.
+    env = {
+        "CXXFLAGS": "-lstdc++ -Wno-unused-command-line-argument",
+    },
+    lib_source = "@net_colm_open_source_colm//:all",
+    out_binaries = ["colm"],
+    tags = ["skip_on_windows"],
+)
+
+configure_make(
+    name = "ragel",
+    autogen = True,
+    configure_in_place = True,
+    configure_options = [
+        "AUTOMAKE=automake",
+        "ACLOCAL=aclocal",
+        "--disable-manual",
+        "--disable-shared",
+        "--enable-static",
+        "--with-colm=$EXT_BUILD_DEPS/colm",
+    ],
+>>>>>>> 835dc5021a (deps: update Ragel (#22635))
     # Workaround for the issue with statically linked libstdc++
     # using -l:libstdc++.a.
     env = {
@@ -121,6 +155,7 @@ configure_make(
     lib_source = "@net_colm_open_source_ragel//:all",
     out_binaries = ["ragel"],
     tags = ["skip_on_windows"],
+    deps = [":colm"],
 )
 
 # ICU used by the language detection filter (i18n).

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -207,6 +207,7 @@ def envoy_dependencies(skip_targets = []):
     _com_lightstep_tracer_cpp()
     _io_hyperscan()
     _io_opentracing_cpp()
+    _net_colm_open_source_colm()
     _net_colm_open_source_ragel()
     _net_zlib()
     _intel_dlb()
@@ -413,6 +414,16 @@ def _com_github_libevent_libevent():
     native.bind(
         name = "event",
         actual = "@envoy//bazel/foreign_cc:event",
+    )
+
+def _net_colm_open_source_colm():
+    external_http_archive(
+        name = "net_colm_open_source_colm",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.bind(
+        name = "colm",
+        actual = "@envoy//bazel/foreign_cc:colm",
     )
 
 def _net_colm_open_source_ragel():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -507,17 +507,47 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2020-07-28",
         cpe = "cpe:2.3:a:libevent_project:libevent:*",
     ),
+    net_colm_open_source_colm = dict(
+        project_name = "Colm",
+        project_desc = "The Colm Programming Language",
+        project_url = "https://www.colm.net/open-source/colm/",
+        # The latest release version v0.14.7 prevents building statically (see
+        # https://github.com/adrian-thurston/colm/issues/146). The latest SHA includes the fix (see
+        # https://github.com/adrian-thurston/colm/commit/fc61ecb3a22b89864916ec538eaf04840e7dd6b5).
+        # TODO(zhxie): Update to the next release version when it is released.
+        version = "2d8ba76ddaf6634f285d0a81ee42d5ee77d084cf",
+        sha256 = "0399e9bef7603a8f3d94acd0b0af6b5944cc3103e586734719379d3ec09620c0",
+        strip_prefix = "colm-{version}",
+        urls = ["https://github.com/adrian-thurston/colm/archive/{version}.tar.gz"],
+        use_category = ["dataplane_ext"],
+        extensions = [
+            "envoy.matching.input_matchers.hyperscan",
+            "envoy.regex_engines.hyperscan",
+        ],
+        release_date = "2021-12-28",
+        cpe = "N/A",
+    ),
     net_colm_open_source_ragel = dict(
         project_name = "Ragel",
         project_desc = "Ragel State Machine Compiler",
         project_url = "https://www.colm.net/open-source/ragel/",
-        version = "6.10",
-        sha256 = "5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f",
+        # We used the stable release Ragel 6.10 previously and it is under GPLv2 license (see
+        # http://www.colm.net/open-source/ragel). Envoy uses its binary only as a tool for
+        # compiling contrib extension Hyperscan. For copyright consideration, we update Ragel to
+        # its development release which is under MIT license.
+        # The latest release version v7.0.4 is not compatible with its dependency Colm we use. The
+        # latest SHA includes fix for compatibility.
+        # TODO(zhxie): Update to the next release version when it is released.
+        version = "d4577c924451b331c73c8ed0af04f6efd35ac0b4",
+        sha256 = "fa3474d50da9c870b79b51ad43f8d11cdf05268f5ec05a602ecd5b1b5f5febb0",
         strip_prefix = "ragel-{version}",
-        urls = ["https://www.colm.net/files/ragel/ragel-{version}.tar.gz"],
+        urls = ["https://github.com/adrian-thurston/ragel/archive/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
-        extensions = ["envoy.matching.input_matchers.hyperscan"],
-        release_date = "2017-03-24",
+        extensions = [
+            "envoy.matching.input_matchers.hyperscan",
+            "envoy.regex_engines.hyperscan",
+        ],
+        release_date = "2021-12-28",
         cpe = "N/A",
     ),
     # This should be removed, see https://github.com/envoyproxy/envoy/issues/13261.

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -41,8 +41,9 @@ else
   BUILD_DIR_MOUNT_DEST=/build
   SOURCE_DIR="${PWD}"
   SOURCE_DIR_MOUNT_DEST=/source
-  START_COMMAND=("/bin/bash" "-lc" "groupadd --gid $(id -g) -f envoygroup \
-    && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /build envoybuild \
+  DOCKER_GID="$(stat -c '%g' /var/run/docker.sock)"
+  START_COMMAND=("/bin/bash" "-lc" "groupadd --gid ${DOCKER_GID} -f envoygroup \
+    && useradd -o --uid $(id -u) --gid ${DOCKER_GID} --no-create-home --home-dir /build envoybuild \
     && usermod -a -G pcap envoybuild \
     && chown envoybuild:envoygroup /build \
     && sudo -EHs -u envoybuild bash -c 'cd /source && $*'")


### PR DESCRIPTION
Cherry-picked from: 
- https://github.com/envoyproxy/envoy/commit/7ac5336bc807f32e84f04cd20d2c95d95e923aa7
- 835dc50

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>
Signed-off-by: Dhi Aurrahman <dio@rockybars.com>


