### PR TITLE
dubbo: fix compilation error.

### DIFF
--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -16,6 +16,7 @@ namespace Dubbo {
 namespace {
 
 constexpr absl::string_view VERSION_KEY = "version";
+constexpr absl::string_view UNKNOWN_RESPONSE_STATUS = "UnknownResponseStatus";
 
 #define ENUM_TO_STRING_VIEW(X)                                                                     \
   case Common::Dubbo::ResponseStatus::X:                                                           \
@@ -35,8 +36,7 @@ absl::string_view responseStatusToStringView(Common::Dubbo::ResponseStatus statu
     ENUM_TO_STRING_VIEW(ClientError);
     ENUM_TO_STRING_VIEW(ServerThreadpoolExhaustedError);
   }
-  static constexpr char notFound[] = "Enum not found";
-  return notFound;
+  return UNKNOWN_RESPONSE_STATUS;
 }
 
 Common::Dubbo::ResponseStatus genericStatusToStatus(StatusCode code) {

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -34,9 +34,9 @@ absl::string_view responseStatusToStringView(Common::Dubbo::ResponseStatus statu
     ENUM_TO_STRING_VIEW(ServerError);
     ENUM_TO_STRING_VIEW(ClientError);
     ENUM_TO_STRING_VIEW(ServerThreadpoolExhaustedError);
-    default:
-      static constexpr char notFound[] = "Enum not found";                                              \
-      return notFound;
+  default:
+    static constexpr char notFound[] = "Enum not found";
+    return notFound;
   }
 }
 

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -34,10 +34,9 @@ absl::string_view responseStatusToStringView(Common::Dubbo::ResponseStatus statu
     ENUM_TO_STRING_VIEW(ServerError);
     ENUM_TO_STRING_VIEW(ClientError);
     ENUM_TO_STRING_VIEW(ServerThreadpoolExhaustedError);
-  default:
-    static constexpr char notFound[] = "Enum not found";
-    return notFound;
   }
+  static constexpr char notFound[] = "Enum not found";
+  return notFound;
 }
 
 Common::Dubbo::ResponseStatus genericStatusToStatus(StatusCode code) {
@@ -70,9 +69,8 @@ StatusCode statusToGenericStatus(Common::Dubbo::ResponseStatus status) {
     return StatusCode::kUnavailable;
   case Common::Dubbo::ResponseStatus::ServerThreadpoolExhaustedError:
     return StatusCode::kResourceExhausted;
-  default:
-    return StatusCode::kUnavailable;
   }
+  return StatusCode::kUnavailable;
 }
 
 } // namespace

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -34,6 +34,9 @@ absl::string_view responseStatusToStringView(Common::Dubbo::ResponseStatus statu
     ENUM_TO_STRING_VIEW(ServerError);
     ENUM_TO_STRING_VIEW(ClientError);
     ENUM_TO_STRING_VIEW(ServerThreadpoolExhaustedError);
+    default:
+      static constexpr char notFound[] = "Enum not found";                                              \
+      return notFound;
   }
 }
 
@@ -67,6 +70,8 @@ StatusCode statusToGenericStatus(Common::Dubbo::ResponseStatus status) {
     return StatusCode::kUnavailable;
   case Common::Dubbo::ResponseStatus::ServerThreadpoolExhaustedError:
     return StatusCode::kResourceExhausted;
+  default:
+    return StatusCode::kUnavailable;
   }
 }
 


### PR DESCRIPTION
Commit Message: dubbo: fix compilation error.

Additional Description:

There's a compilation error in dubbo (gcc version 11.3.1 20220421), because the switch/case statement isn't handling the default case:

    contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc: In function 'absl::string_view Envoy::Extensions::NetworkFilters::GenericProxy::Codec::Dubbo::{anonymous}::responseStatusToStringView(Envoy::Extensions::Common::Dubbo::ResponseStatus)':
    contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc:38:1: error: control reaches end of non-void function [-Werror=return-type]
       38 | }
          | ^
    contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc: In function 'Envoy::Extensions::NetworkFilters::GenericProxy::StatusCode Envoy::Extensions::NetworkFilters::GenericProxy::Codec::Dubbo::{anonymous}::statusToGenericStatus(Envoy::Extensions::Common::Dubbo::ResponseStatus)':
    contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc:71:1: error: control reaches end of non-void function [-Werror=return-type]
       71 | }
          | ^
    cc1plus: all warnings being treated as errors

@wbpcode WDYT?

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A