### PR TITLE
tls: remove stale comment

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -109,10 +109,6 @@ int DefaultCertValidator::initializeSslContexts(std::vector<SSL_CTX*> contexts,
       verify_mode = SSL_VERIFY_PEER;
       verify_trusted_ca_ = true;
 
-      // NOTE: We're using SSL_CTX_set_cert_verify_callback() instead of X509_verify_cert()
-      // directly. However, our new callback is still calling X509_verify_cert() under
-      // the hood. Therefore, to ignore cert expiration, we need to set the callback
-      // for X509_verify_cert to ignore that error.
       if (config_->allowExpiredCertificate()) {
         CertValidatorUtil::setIgnoreCertificateExpiration(store);
       }


### PR DESCRIPTION
Commit Message:
Both things the comment says are inaccurate: After #23320, this mechanism no longer uses the X509_STORE callback, but a flag. After #21417, Envoy is also not (always) using
SSL_CTX_set_cert_verify_callback, but a different one.

Just remove the comment altogether, as it doesn't seem to provide any value. All it's saying is that, because Envoy still uses `store` at the end of the day, configuring things on `store` does stuff. But the whole function configures things on `store`, so it's not specific to that block anyway.

Signed-off-by: David Benjamin <davidben@google.com>

Additional Description:
Risk Level: none (comment-only change)
Testing: CI (comment-only change)
Docs Changes: n/a (comment-only change)
Release Notes: n/a (comment-only change)
Platform Specific Features: n/a (comment-only change)
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
