### PR TITLE
Add cache_file_fixed_block as first piece of filesystem_cache

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -190,8 +190,9 @@ extensions/filters/http/oauth2 @derekargueta @snowp
 # Config Validators
 /*/extensions/config/validators/minimum_clusters @adisuissa @htuch
 # File system based extensions
-/*/extensions/common/async_files @mattklein123 @ravenblack
-/*/extensions/filters/http/file_system_buffer @mattklein123 @ravenblack
+/*/extensions/common/async_files @mattklein123 @ravenblackx
+/*/extensions/filters/http/file_system_buffer @mattklein123 @ravenblackx
+/*/extensions/http/cache/file_system_http_cache @mattklein123 @ravenblackx
 # Google Cloud Platform Authentication Filter
 /*/extensions/filters/http/gcp_authn @tyxia @yanavlasov
 # DNS resolution

--- a/source/extensions/http/cache/file_system_http_cache/BUILD
+++ b/source/extensions/http/cache/file_system_http_cache/BUILD
@@ -1,0 +1,20 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "cache_file_fixed_block",
+    srcs = ["cache_file_fixed_block.cc"],
+    hdrs = ["cache_file_fixed_block.h"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/common:safe_memcpy_lib",
+        "@com_google_absl//absl/strings",
+    ],
+)

--- a/source/extensions/http/cache/file_system_http_cache/BUILD
+++ b/source/extensions/http/cache/file_system_http_cache/BUILD
@@ -13,9 +13,7 @@ envoy_cc_library(
     srcs = ["cache_file_fixed_block.cc"],
     hdrs = ["cache_file_fixed_block.h"],
     deps = [
-        "//source/common/common:assert_lib",
-        "//source/common/common:byte_order_lib",
-        "//source/common/common:safe_memcpy_lib",
+        "//envoy/buffer:buffer_interface",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/source/extensions/http/cache/file_system_http_cache/BUILD
+++ b/source/extensions/http/cache/file_system_http_cache/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["cache_file_fixed_block.h"],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/common:byte_order_lib",
         "//source/common/common:safe_memcpy_lib",
         "@com_google_absl//absl/strings",
     ],

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -25,7 +25,7 @@ constexpr std::array<char, 4> ExpectedCacheVersionId = {'0', '0', '0', '0'};
 
 CacheFileFixedBlock::CacheFileFixedBlock()
     : file_id_(ExpectedFileId), cache_version_id_(ExpectedCacheVersionId), header_size_(0),
-      body_size_(0), trailer_size_(0) {}
+      trailer_size_(0), body_size_(0) {}
 
 void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   // The string view should be the size of the buffer, and
@@ -38,8 +38,8 @@ void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   std::copy(s.begin(), s.begin() + 4, file_id_.begin());
   std::copy(s.begin() + 4, s.begin() + 8, cache_version_id_.begin());
   header_size_ = absl::big_endian::Load32(&s[8]);
-  body_size_ = absl::big_endian::Load64(&s[12]);
-  trailer_size_ = absl::big_endian::Load32(&s[20]);
+  trailer_size_ = absl::big_endian::Load32(&s[12]);
+  body_size_ = absl::big_endian::Load64(&s[16]);
 }
 
 void CacheFileFixedBlock::serializeToBuffer(Buffer::Instance& buffer) {
@@ -53,8 +53,8 @@ void CacheFileFixedBlock::serializeToBuffer(Buffer::Instance& buffer) {
   std::copy(file_id_.begin(), file_id_.end(), &b[0]);
   std::copy(cache_version_id_.begin(), cache_version_id_.end(), &b[4]);
   absl::big_endian::Store32(&b[8], header_size_);
-  absl::big_endian::Store64(&b[12], body_size_);
-  absl::big_endian::Store32(&b[20], trailer_size_);
+  absl::big_endian::Store32(&b[12], trailer_size_);
+  absl::big_endian::Store64(&b[16], body_size_);
   // Append that buffer into the target buffer object.
   buffer.add(absl::string_view{b, size()});
 }

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -13,13 +13,13 @@ namespace {
 // The expected first four bytes of the header - if fileId() doesn't match ExpectedFileId
 // then the file is not a cache file and should be removed from the cache.
 // Beginning of file should be "CACH".
-std::array<char, 4> ExpectedFileId = {'C', 'A', 'C', 'H'};
+constexpr std::array<char, 4> ExpectedFileId = {'C', 'A', 'C', 'H'};
 
 // The expected next four bytes of the header - if cacheVersionId() doesn't match
 // ExpectedCacheVersionId then the file is from an incompatible cache version and should
 // be removed from the cache.
 // Next 4 bytes of file should be "0000".
-std::array<char, 4> ExpectedCacheVersionId = {'0', '0', '0', '0'};
+constexpr std::array<char, 4> ExpectedCacheVersionId = {'0', '0', '0', '0'};
 
 // Deserialize 4 bytes into a uint32_t.
 uint32_t deserializeUint32(const char* p) {
@@ -63,8 +63,8 @@ CacheFileFixedBlock::CacheFileFixedBlock() {
 void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   ASSERT(s.size() == size() && size() == 24);
   // Serialize the values from the string_view s into the member values.
-  std::copy_n(s.begin(), 4, file_id_.begin());
-  std::copy_n(s.begin() + 4, 4, cache_version_id_.begin());
+  std::copy(s.begin(), s.begin() + 4, file_id_.begin());
+  std::copy(s.begin() + 4, s.begin() + 8, cache_version_id_.begin());
   header_size_ = deserializeUint32(&s[8]);
   body_size_ = deserializeUint64(&s[12]);
   trailer_size_ = deserializeUint32(&s[20]);
@@ -74,8 +74,8 @@ void CacheFileFixedBlock::serializeToBuffer(Buffer::Instance& buffer) {
   char b[size()];
   ASSERT(size() == 24);
   // Serialize the values from the member values into the stack buffer b.
-  std::copy_n(file_id_.begin(), 4, &b[0]);
-  std::copy_n(cache_version_id_.begin(), 4, &b[4]);
+  std::copy(file_id_.begin(), file_id_.end(), &b[0]);
+  std::copy(cache_version_id_.begin(), cache_version_id_.end(), &b[4]);
   serializeUint32(header_size_, &b[8]);
   serializeUint64(body_size_, &b[12]);
   serializeUint32(trailer_size_, &b[20]);

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -21,35 +21,6 @@ constexpr std::array<char, 4> ExpectedFileId = {'C', 'A', 'C', 'H'};
 // Next 4 bytes of file should be "0000".
 constexpr std::array<char, 4> ExpectedCacheVersionId = {'0', '0', '0', '0'};
 
-// Deserialize 4 bytes into a uint32_t.
-uint32_t deserializeUint32(const char* p) {
-  // chars must be cast to uint8_t first so that e.g. -1 becomes 0xff, before casting to uint32_t
-  // - otherwise -1 becomes 0xffffffff.
-  return static_cast<uint32_t>(static_cast<uint8_t>(p[0])) << 24 |
-         static_cast<uint32_t>(static_cast<uint8_t>(p[1])) << 16 |
-         static_cast<uint32_t>(static_cast<uint8_t>(p[2])) << 8 |
-         static_cast<uint32_t>(static_cast<uint8_t>(p[3]));
-}
-
-// Deserialize 8 bytes into a uint64_t.
-uint64_t deserializeUint64(const char* p) {
-  return static_cast<uint64_t>(deserializeUint32(p)) | deserializeUint32(p + 4);
-}
-
-// Serialize a uint32 into 4 bytes at pointer p.
-void serializeUint32(uint32_t value, char* p) {
-  p[0] = value >> 24;
-  p[1] = value >> 16 & 0xff;
-  p[2] = value >> 8 & 0xff;
-  p[3] = value & 0xff;
-}
-
-// Serialize a uint64 into 8 bytes at pointer p.
-void serializeUint64(uint64_t value, char* p) {
-  serializeUint32(value >> 32, p);
-  serializeUint32(value & 0xffffffff, p + 4);
-}
-
 } // namespace
 
 CacheFileFixedBlock::CacheFileFixedBlock() {
@@ -61,24 +32,33 @@ CacheFileFixedBlock::CacheFileFixedBlock() {
 }
 
 void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
+  // The string view should be the size of the buffer, and
+  // Since we're explicitly reading byte offsets here, the size should match
+  // what we read.
+  // (This will remind us to change this function if we change the size
+  // and vice-versa!)
   ASSERT(s.size() == size() && size() == 24);
   // Serialize the values from the string_view s into the member values.
   std::copy(s.begin(), s.begin() + 4, file_id_.begin());
   std::copy(s.begin() + 4, s.begin() + 8, cache_version_id_.begin());
-  header_size_ = deserializeUint32(&s[8]);
-  body_size_ = deserializeUint64(&s[12]);
-  trailer_size_ = deserializeUint32(&s[20]);
+  header_size_ = absl::big_endian::Load32(&s[8]);
+  body_size_ = absl::big_endian::Load64(&s[12]);
+  trailer_size_ = absl::big_endian::Load32(&s[20]);
 }
 
 void CacheFileFixedBlock::serializeToBuffer(Buffer::Instance& buffer) {
   char b[size()];
+  // Since we're explicitly writing byte offsets here, the size should match
+  // what we write.
+  // (This will remind us to change this function if we change the size
+  // and vice-versa!)
   ASSERT(size() == 24);
   // Serialize the values from the member values into the stack buffer b.
   std::copy(file_id_.begin(), file_id_.end(), &b[0]);
   std::copy(cache_version_id_.begin(), cache_version_id_.end(), &b[4]);
-  serializeUint32(header_size_, &b[8]);
-  serializeUint64(body_size_, &b[12]);
-  serializeUint32(trailer_size_, &b[20]);
+  absl::big_endian::Store32(&b[8], header_size_);
+  absl::big_endian::Store64(&b[12], body_size_);
+  absl::big_endian::Store32(&b[20], trailer_size_);
   // Append that buffer into the target buffer object.
   buffer.add(absl::string_view{b, size()});
 }

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -1,0 +1,82 @@
+#include "source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/common/safe_memcpy.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Cache {
+namespace FileSystemHttpCache {
+
+namespace {
+uint64_t ntohl64(uint64_t n) {
+#if defined(ABSL_IS_LITTLE_ENDIAN)
+  // in-place byte order swap for a uint64.
+  // Optimization in clang or gcc can recognize this as a single `bswap` instruction.
+  n = ((n & 0xFF00000000000000u) >> 56u) | ((n & 0x00FF000000000000u) >> 40u) |
+      ((n & 0x0000FF0000000000u) >> 24u) | ((n & 0x000000FF00000000u) >> 8u) |
+      ((n & 0x00000000FF000000u) << 8u) | ((n & 0x0000000000FF0000u) << 24u) |
+      ((n & 0x000000000000FF00u) << 40u) | ((n & 0x00000000000000FFu) << 56u);
+#endif
+  return n;
+}
+uint64_t htonl64(uint64_t n) { return ntohl64(n); }
+
+uint32_t ntohl32(uint32_t n) {
+#if defined(ABSL_IS_LITTLE_ENDIAN)
+  // in-place byte order swap for a uint32.
+  // Optimization in clang or gcc can recognize this as a single `bswap` instruction.
+  n = ((n & 0xFF000000u) >> 24u) | ((n & 0x00FF0000u) >> 8u) | ((n & 0x0000FF00u) << 8u) |
+      ((n & 0x000000FFu) << 24u);
+#endif
+  return n;
+}
+uint64_t htonl32(uint32_t n) { return ntohl32(n); }
+
+// The expected first four bytes of the header - if fileId() doesn't match expectedFileId
+// then the file is not a cache file and should be removed from the cache.
+// Beginning of file should be "CACH".
+constexpr uint32_t expectedFileId = (static_cast<uint32_t>('C') << 24) +
+                                    (static_cast<uint32_t>('A') << 16) +
+                                    (static_cast<uint32_t>('C') << 8) + static_cast<uint32_t>('H');
+
+// The expected next four bytes of the header - if cacheVersionId() doesn't match
+// expectedCacheVersionId then the file is from an incompatible cache version and should
+// be removed from the cache.
+// Next 4 bytes of file should be "0000".
+// Increment this to invalidate old cache files if the format changes.
+// Formatted string-style rather than as an actual int to make it easily human-readable.
+constexpr uint32_t expectedCacheVersionId =
+    (static_cast<uint32_t>('0') << 24) + (static_cast<uint32_t>('0') << 16) +
+    (static_cast<uint32_t>('0') << 8) + static_cast<uint32_t>('0');
+
+} // namespace
+
+CacheFileFixedBlock::CacheFileFixedBlock() {
+  setFileId(expectedFileId);
+  setCacheVersionId(expectedCacheVersionId);
+  setHeadersSize(0);
+  setTrailersSize(0);
+  setBodySize(0);
+}
+
+void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
+  ASSERT(s.size() == size());
+  safeMemcpyUnsafeSrc(&contents_, s.begin());
+}
+
+uint32_t CacheFileFixedBlock::getUint32(const uint32_t& t) const { return ntohl32(t); }
+uint64_t CacheFileFixedBlock::getUint64(const uint64_t& t) const { return ntohl64(t); }
+void CacheFileFixedBlock::setUint32(uint32_t& t, uint32_t v) { t = htonl32(v); }
+void CacheFileFixedBlock::setUint64(uint64_t& t, uint64_t v) { t = htonl64(v); }
+
+bool CacheFileFixedBlock::isValid() const {
+  return fileId() == expectedFileId && cacheVersionId() == expectedCacheVersionId;
+}
+
+} // namespace FileSystemHttpCache
+} // namespace Cache
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -10,28 +10,28 @@ namespace Cache {
 namespace FileSystemHttpCache {
 
 namespace {
-// The expected first four bytes of the header - if fileId() doesn't match expectedFileId
+// The expected first four bytes of the header - if fileId() doesn't match ExpectedFileId
 // then the file is not a cache file and should be removed from the cache.
 // Beginning of file should be "CACH".
-constexpr uint32_t expectedFileId = (static_cast<uint32_t>('C') << 24) |
+constexpr uint32_t ExpectedFileId = (static_cast<uint32_t>('C') << 24) |
                                     (static_cast<uint32_t>('A') << 16) |
                                     (static_cast<uint32_t>('C') << 8) | static_cast<uint32_t>('H');
 
 // The expected next four bytes of the header - if cacheVersionId() doesn't match
-// expectedCacheVersionId then the file is from an incompatible cache version and should
+// ExpectedCacheVersionId then the file is from an incompatible cache version and should
 // be removed from the cache.
 // Next 4 bytes of file should be "0000".
 // Increment this to invalidate old cache files if the format changes.
 // Formatted string-style rather than as an actual int to make it easily human-readable.
-constexpr uint32_t expectedCacheVersionId =
+constexpr uint32_t ExpectedCacheVersionId =
     (static_cast<uint32_t>('0') << 24) | (static_cast<uint32_t>('0') << 16) |
     (static_cast<uint32_t>('0') << 8) | static_cast<uint32_t>('0');
 
 } // namespace
 
 CacheFileFixedBlock::CacheFileFixedBlock() {
-  setFileId(expectedFileId);
-  setCacheVersionId(expectedCacheVersionId);
+  setFileId(ExpectedFileId);
+  setCacheVersionId(ExpectedCacheVersionId);
   setHeadersSize(0);
   setTrailersSize(0);
   setBodySize(0);
@@ -43,7 +43,7 @@ void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
 }
 
 bool CacheFileFixedBlock::isValid() const {
-  return fileId() == expectedFileId && cacheVersionId() == expectedCacheVersionId;
+  return fileId() == ExpectedFileId && cacheVersionId() == ExpectedCacheVersionId;
 }
 
 } // namespace FileSystemHttpCache

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -10,36 +10,12 @@ namespace Cache {
 namespace FileSystemHttpCache {
 
 namespace {
-uint64_t ntohl64(uint64_t n) {
-#if defined(ABSL_IS_LITTLE_ENDIAN)
-  // in-place byte order swap for a uint64.
-  // Optimization in clang or gcc can recognize this as a single `bswap` instruction.
-  n = ((n & 0xFF00000000000000u) >> 56u) | ((n & 0x00FF000000000000u) >> 40u) |
-      ((n & 0x0000FF0000000000u) >> 24u) | ((n & 0x000000FF00000000u) >> 8u) |
-      ((n & 0x00000000FF000000u) << 8u) | ((n & 0x0000000000FF0000u) << 24u) |
-      ((n & 0x000000000000FF00u) << 40u) | ((n & 0x00000000000000FFu) << 56u);
-#endif
-  return n;
-}
-uint64_t htonl64(uint64_t n) { return ntohl64(n); }
-
-uint32_t ntohl32(uint32_t n) {
-#if defined(ABSL_IS_LITTLE_ENDIAN)
-  // in-place byte order swap for a uint32.
-  // Optimization in clang or gcc can recognize this as a single `bswap` instruction.
-  n = ((n & 0xFF000000u) >> 24u) | ((n & 0x00FF0000u) >> 8u) | ((n & 0x0000FF00u) << 8u) |
-      ((n & 0x000000FFu) << 24u);
-#endif
-  return n;
-}
-uint64_t htonl32(uint32_t n) { return ntohl32(n); }
-
 // The expected first four bytes of the header - if fileId() doesn't match expectedFileId
 // then the file is not a cache file and should be removed from the cache.
 // Beginning of file should be "CACH".
-constexpr uint32_t expectedFileId = (static_cast<uint32_t>('C') << 24) +
-                                    (static_cast<uint32_t>('A') << 16) +
-                                    (static_cast<uint32_t>('C') << 8) + static_cast<uint32_t>('H');
+constexpr uint32_t expectedFileId = (static_cast<uint32_t>('C') << 24) |
+                                    (static_cast<uint32_t>('A') << 16) |
+                                    (static_cast<uint32_t>('C') << 8) | static_cast<uint32_t>('H');
 
 // The expected next four bytes of the header - if cacheVersionId() doesn't match
 // expectedCacheVersionId then the file is from an incompatible cache version and should
@@ -48,8 +24,8 @@ constexpr uint32_t expectedFileId = (static_cast<uint32_t>('C') << 24) +
 // Increment this to invalidate old cache files if the format changes.
 // Formatted string-style rather than as an actual int to make it easily human-readable.
 constexpr uint32_t expectedCacheVersionId =
-    (static_cast<uint32_t>('0') << 24) + (static_cast<uint32_t>('0') << 16) +
-    (static_cast<uint32_t>('0') << 8) + static_cast<uint32_t>('0');
+    (static_cast<uint32_t>('0') << 24) | (static_cast<uint32_t>('0') << 16) |
+    (static_cast<uint32_t>('0') << 8) | static_cast<uint32_t>('0');
 
 } // namespace
 
@@ -65,11 +41,6 @@ void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   ASSERT(s.size() == size());
   safeMemcpyUnsafeSrc(&contents_, s.begin());
 }
-
-uint32_t CacheFileFixedBlock::getUint32(const uint32_t& t) const { return ntohl32(t); }
-uint64_t CacheFileFixedBlock::getUint64(const uint64_t& t) const { return ntohl64(t); }
-void CacheFileFixedBlock::setUint32(uint32_t& t, uint32_t v) { t = htonl32(v); }
-void CacheFileFixedBlock::setUint64(uint64_t& t, uint64_t v) { t = htonl64(v); }
 
 bool CacheFileFixedBlock::isValid() const {
   return fileId() == expectedFileId && cacheVersionId() == expectedCacheVersionId;

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -25,7 +25,7 @@ constexpr std::array<char, 4> ExpectedCacheVersionId = {'0', '0', '0', '0'};
 
 CacheFileFixedBlock::CacheFileFixedBlock()
     : file_id_(ExpectedFileId), cache_version_id_(ExpectedCacheVersionId), header_size_(0),
-      trailer_size_(0), body_size_(0) {}
+      body_size_(0), trailer_size_(0) {}
 
 void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   // The string view should be the size of the buffer, and

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -23,13 +23,9 @@ constexpr std::array<char, 4> ExpectedCacheVersionId = {'0', '0', '0', '0'};
 
 } // namespace
 
-CacheFileFixedBlock::CacheFileFixedBlock() {
-  setFileId(ExpectedFileId);
-  setCacheVersionId(ExpectedCacheVersionId);
-  setHeadersSize(0);
-  setTrailersSize(0);
-  setBodySize(0);
-}
+CacheFileFixedBlock::CacheFileFixedBlock()
+    : file_id_(ExpectedFileId), cache_version_id_(ExpectedCacheVersionId), header_size_(0),
+      trailer_size_(0), body_size_(0) {}
 
 void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   // The string view should be the size of the buffer, and

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.cc
@@ -62,7 +62,7 @@ CacheFileFixedBlock::CacheFileFixedBlock() {
 
 void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
   ASSERT(s.size() == size() && size() == 24);
-  // Bytewise serialize the values from the string_view s into the member values.
+  // Serialize the values from the string_view s into the member values.
   std::copy_n(s.begin(), 4, file_id_.begin());
   std::copy_n(s.begin() + 4, 4, cache_version_id_.begin());
   header_size_ = deserializeUint32(&s[8]);
@@ -73,7 +73,7 @@ void CacheFileFixedBlock::populateFromStringView(absl::string_view s) {
 void CacheFileFixedBlock::serializeToBuffer(Buffer::Instance& buffer) {
   char b[size()];
   ASSERT(size() == 24);
-  // Bytewise serialize the values from the member values into the stack buffer b.
+  // Serialize the values from the member values into the stack buffer b.
   std::copy_n(file_id_.begin(), 4, &b[0]);
   std::copy_n(cache_version_id_.begin(), 4, &b[4]);
   serializeUint32(header_size_, &b[8]);

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -15,84 +15,152 @@ namespace HttpFilters {
 namespace Cache {
 namespace FileSystemHttpCache {
 
-// This represents a minimal header block on the cache entry file; it uses a struct that
-// is required to be packed, and explicit network byte order, to ensure consistency.
+/**
+ * CacheFileFixedBlock represents a minimal header block on the cache entry file; it
+ * uses a struct that is required to be packed, and explicit byte order, to ensure
+ * consistency.
+ *
+ * This data is serialized as a flat object rather than protobuf serialization because it
+ * needs to be readable from the start of the file, but writeable after the rest of the
+ * file has been completely written (as the body size and trailer size aren't necessarily
+ * known until the entire content has been streamed). Serialized proto messages can
+ * change size when values change, which makes them unsuited for this purpose.
+ *
+ * The CacheFileFixedBlock object contains an already-serialized representation of the
+ * header block, so its contents can be simply copied into or from a buffer object.
+ */
 class CacheFileFixedBlock {
 public:
+  /**
+   * the constructor initializes with the current compile-time constant values
+   * for fileId and cacheVersionId, and zero for all other member values.
+   */
   CacheFileFixedBlock();
 
-  // Deserializes the string representation of a CacheFileFixedBlock into this instance.
+  /**
+   * deserializes the string representation of a CacheFileFixedBlock into this instance.
+   * Since the CacheFileFixedBlock is already a serialized representation, this is
+   * essentially a memcpy operation.
+   * @param str The string_view from which to populate the block.
+   */
   void populateFromStringView(absl::string_view s);
 
-  // Returns the size in bytes of a CacheFileFixedBlock.
+  /**
+   * the size in bytes of a CacheFileFixedBlock. This is compile-time constant.
+   * @return the size in bytes.
+   */
   static size_t size() { return sizeof(contents_); }
 
-  // fileId is a fixed value used to identify that this is a cache file.
-  uint32_t fileId() const { return fromEndianness<ByteOrder::BigEndian>(contents_.file_id_); }
+  /**
+   * fileId is a compile-time fixed value used to identify that this is a cache file.
+   * @return the file ID.
+   */
+  uint32_t fileId() const { return fromEndianness<ByteOrder::LittleEndian>(contents_.file_id_); }
 
-  // cacheVersionId is a value that should be consistent between versions of the file
-  // cache implementation. Changing version in code will invalidate all cache
-  // entries where the version ID does not match.
+  /**
+   * cacheVersionId is a compile-time fixed value that should be consistent between
+   * versions of the file cache implementation. Changing version in code will
+   * invalidate all cache entries where the version ID does not match.
+   * @return the cache version ID.
+   */
   uint32_t cacheVersionId() const {
-    return fromEndianness<ByteOrder::BigEndian>(contents_.cache_version_id_);
+    return fromEndianness<ByteOrder::LittleEndian>(contents_.cache_version_id_);
   }
 
-  // Size of the serialized proto message capturing headers and metadata.
-  size_t headerSize() const { return fromEndianness<ByteOrder::BigEndian>(contents_.header_size_); }
+  /**
+   * the size of the serialized proto message capturing headers and metadata.
+   * @return the size in bytes.
+   */
+  size_t headerSize() const {
+    return fromEndianness<ByteOrder::LittleEndian>(contents_.header_size_);
+  }
 
-  // Size of the serialized proto message capturing trailers.
+  /**
+   * the size of the serialized proto message capturing trailers.
+   * @return the size in bytes.
+   */
   size_t trailerSize() const {
-    return fromEndianness<ByteOrder::BigEndian>(contents_.trailer_size_);
+    return fromEndianness<ByteOrder::LittleEndian>(contents_.trailer_size_);
   }
 
-  // Size of the http body of the cache entry.
-  size_t bodySize() const { return fromEndianness<ByteOrder::BigEndian>(contents_.body_size_); }
+  /**
+   * the size of the http body of the cache entry.
+   * @return the size in bytes.
+   */
+  size_t bodySize() const { return fromEndianness<ByteOrder::LittleEndian>(contents_.body_size_); }
 
-  // Sets the size of the serialized headers, key and metadata.
+  /**
+   * sets the size of the serialized http headers, plus key and metadata, in the header block.
+   * @param sz The size of the serialized headers, key and metadata.
+   */
   void setHeadersSize(size_t sz) {
-    contents_.header_size_ = toEndianness<ByteOrder::BigEndian>(static_cast<uint32_t>(sz));
+    contents_.header_size_ = toEndianness<ByteOrder::LittleEndian>(static_cast<uint32_t>(sz));
   }
 
-  // Sets the size of the serialized trailers.
+  /**
+   * sets the size of the serialized trailers in the header block.
+   * @param sz The size of the serialized trailers.
+   */
   void setTrailersSize(size_t sz) {
-    contents_.trailer_size_ = toEndianness<ByteOrder::BigEndian>(static_cast<uint32_t>(sz));
+    contents_.trailer_size_ = toEndianness<ByteOrder::LittleEndian>(static_cast<uint32_t>(sz));
   }
 
-  // Sets the size of the serialized body.
+  /**
+   * sets the size of the serialized body in the header block.
+   * @param sz The size of the body data.
+   */
   void setBodySize(size_t sz) {
-    contents_.body_size_ = toEndianness<ByteOrder::BigEndian>(static_cast<uint64_t>(sz));
+    contents_.body_size_ = toEndianness<ByteOrder::LittleEndian>(static_cast<uint64_t>(sz));
   }
 
-  // Returns the offset from the start of the file to the start of the
-  // serialized headers proto.
-  static size_t offsetToHeaders() { return size(); }
+  /**
+   * the offset from the start of the file to the start of the serialized headers proto.
+   * @return the offset in bytes.
+   */
+  static off_t offsetToHeaders() { return size(); }
 
-  // Returns the offset from the start of the file to the start of the body data.
-  size_t offsetToBody() const { return offsetToHeaders() + headerSize(); }
+  /**
+   * the offset from the start of the file to the start of the body data.
+   * @return the offset in bytes.
+   */
+  off_t offsetToBody() const { return offsetToHeaders() + headerSize(); }
 
-  // Returns the offset from the start of the file to the start of the
-  // serialized trailers proto.
-  size_t offsetToTrailers() const { return offsetToBody() + bodySize(); }
+  /**
+   * the offset from the start of the file to the start of the serialized trailers proto.
+   * @return the offset in bytes.
+   */
+  off_t offsetToTrailers() const { return offsetToBody() + bodySize(); }
 
-  // Returns a string_view of the serialized fixed header chunk.
+  /**
+   * the serialized fixed header chunk.
+   * @return a string view over the entire structure of the header chunk.
+   */
   absl::string_view stringView() const { return {contents_.as_str_, size()}; }
 
-  // Returns true if the fileId and cacheVersionId match the compile-time constants from
-  // cache_file_fixed_block.cc
+  /**
+   * is this a valid cache file header block for the current code version?
+   * @return True if the block's cache version id and file id match the current version.
+   */
   bool isValid() const;
 
 private:
-  // sets the fileId, a fixed value used to identify that this is a cache file.
-  // This is private so only the unit test can call it, as the file ID should be
-  // a compile-time constant in ordinary use.
-  void setFileId(uint32_t id) { contents_.file_id_ = toEndianness<ByteOrder::BigEndian>(id); }
+  /**
+   * sets the fileId, a fixed value used to identify that this is a cache file.
+   * This is private so only the unit test can call it, as the file ID should be
+   * a compile-time constant in ordinary use.
+   * @param id The file ID to set.
+   */
+  void setFileId(uint32_t id) { contents_.file_id_ = toEndianness<ByteOrder::LittleEndian>(id); }
 
-  // sets the cacheVersionId, a value that should be consistent between versions
-  // of the file cache implementation.
-  // This is private so only the unit test can call it, as the version ID should be
-  // a compile-time constant in ordinary use.
+  /**
+   * sets the cacheVersionId, a value that should be consistent between versions
+   * of the file cache implementation.
+   * This is private so only the unit test can call it, as the version ID should be
+   * a compile-time constant in ordinary use.
+   * @param id The cache version ID to set.
+   */
   void setCacheVersionId(uint32_t id) {
-    contents_.cache_version_id_ = toEndianness<ByteOrder::BigEndian>(id);
+    contents_.cache_version_id_ = toEndianness<ByteOrder::LittleEndian>(id);
   }
 
   union {

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -54,7 +54,7 @@ public:
    * bodySize serializes to an 8-byte uint.
    * @return the size in bytes.
    */
-  static constexpr size_t size() { return sizeof(uint32_t) * 4 + sizeof(uint64_t); }
+  static constexpr uint32_t size() { return sizeof(uint32_t) * 4 + sizeof(uint64_t); }
 
   /**
    * fileId is a compile-time fixed value used to identify that this is a cache file.
@@ -74,55 +74,55 @@ public:
    * the size of the serialized proto message capturing headers and metadata.
    * @return the size in bytes.
    */
-  size_t headerSize() const { return header_size_; }
-
-  /**
-   * the size of the serialized proto message capturing trailers.
-   * @return the size in bytes.
-   */
-  size_t trailerSize() const { return trailer_size_; }
+  uint32_t headerSize() const { return header_size_; }
 
   /**
    * the size of the http body of the cache entry.
    * @return the size in bytes.
    */
-  size_t bodySize() const { return body_size_; }
+  uint64_t bodySize() const { return body_size_; }
+
+  /**
+   * the size of the serialized proto message capturing trailers.
+   * @return the size in bytes.
+   */
+  uint32_t trailerSize() const { return trailer_size_; }
 
   /**
    * sets the size of the serialized http headers, plus key and metadata, in the header block.
    * @param sz The size of the serialized headers, key and metadata.
    */
-  void setHeadersSize(size_t sz) { header_size_ = sz; }
+  void setHeadersSize(uint32_t sz) { header_size_ = sz; }
 
   /**
    * sets the size of the serialized trailers in the header block.
    * @param sz The size of the serialized trailers.
    */
-  void setTrailersSize(size_t sz) { trailer_size_ = sz; }
+  void setTrailersSize(uint32_t sz) { trailer_size_ = sz; }
 
   /**
    * sets the size of the serialized body in the header block.
    * @param sz The size of the body data.
    */
-  void setBodySize(size_t sz) { body_size_ = sz; }
+  void setBodySize(uint64_t sz) { body_size_ = sz; }
 
   /**
    * the offset from the start of the file to the start of the serialized headers proto.
    * @return the offset in bytes.
    */
-  static off_t offsetToHeaders() { return size(); }
+  static uint32_t offsetToHeaders() { return size(); }
 
   /**
    * the offset from the start of the file to the start of the body data.
    * @return the offset in bytes.
    */
-  off_t offsetToBody() const { return offsetToHeaders() + headerSize(); }
+  uint32_t offsetToBody() const { return offsetToHeaders() + headerSize(); }
 
   /**
    * the offset from the start of the file to the start of the serialized trailers proto.
    * @return the offset in bytes.
    */
-  off_t offsetToTrailers() const { return offsetToBody() + bodySize(); }
+  uint64_t offsetToTrailers() const { return offsetToBody() + bodySize(); }
 
   /**
    * is this a valid cache file header block for the current code version?
@@ -133,9 +133,9 @@ public:
 private:
   std::array<char, 4> file_id_;
   std::array<char, 4> cache_version_id_;
-  size_t header_size_;
-  size_t trailer_size_;
-  size_t body_size_;
+  uint32_t header_size_;
+  uint64_t body_size_;
+  uint32_t trailer_size_;
 };
 
 } // namespace FileSystemHttpCache

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -58,7 +58,7 @@ public:
    * fileId is a compile-time fixed value used to identify that this is a cache file.
    * @return the file ID.
    */
-  uint32_t fileId() const { return file_id_; }
+  std::array<char, 4> fileId() const { return file_id_; }
 
   /**
    * cacheVersionId is a compile-time fixed value that should be consistent between
@@ -66,7 +66,7 @@ public:
    * invalidate all cache entries where the version ID does not match.
    * @return the cache version ID.
    */
-  uint32_t cacheVersionId() const { return cache_version_id_; }
+  std::array<char, 4> cacheVersionId() const { return cache_version_id_; }
 
   /**
    * the size of the serialized proto message capturing headers and metadata.
@@ -135,7 +135,7 @@ private:
    * a compile-time constant in ordinary use.
    * @param id The file ID to set.
    */
-  void setFileId(uint32_t id) { file_id_ = id; }
+  void setFileId(std::array<char, 4> id) { file_id_ = id; }
 
   /**
    * sets the cacheVersionId, a value that should be consistent between versions
@@ -144,10 +144,10 @@ private:
    * a compile-time constant in ordinary use.
    * @param id The cache version ID to set.
    */
-  void setCacheVersionId(uint32_t id) { cache_version_id_ = id; }
+  void setCacheVersionId(std::array<char, 4> id) { cache_version_id_ = id; }
 
-  uint32_t file_id_;
-  uint32_t cache_version_id_;
+  std::array<char, 4> file_id_;
+  std::array<char, 4> cache_version_id_;
   size_t header_size_;
   size_t trailer_size_;
   size_t body_size_;

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -21,7 +21,7 @@ namespace FileSystemHttpCache {
  * consistency.
  *
  * This data is serialized as a flat object rather than protobuf serialization because it
- * needs to be readable from the start of the file, but writeable after the rest of the
+ * needs to be at the start of the file for efficient read, but write after the rest of the
  * file has been completely written (as the body size and trailer size aren't necessarily
  * known until the entire content has been streamed). Serialized proto messages can
  * change size when values change, which makes them unsuited for this purpose.

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -48,7 +48,7 @@ public:
 
   /**
    * the size in bytes of a serialized CacheFileFixedBlock. This is compile-time constant.
-   * fileId, cacheVersionId, headerSize and trailerSize serialize to 4-byte uints.
+   * fileId, cacheVersionId, headerSize and trailerSize serialize to 4 bytes each.
    * bodySize serializes to an 8-byte uint.
    * @return the size in bytes.
    */

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <sys/types.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Cache {
+namespace FileSystemHttpCache {
+
+// This represents a minimal header block on the cache entry file; it uses a struct that
+// is required to be packed, and explicit network byte order, to ensure compatibility.
+class CacheFileFixedBlock {
+public:
+  CacheFileFixedBlock();
+  void populateFromStringView(absl::string_view s);
+  static size_t size() { return sizeof(contents_); }
+  // fileId is a fixed value used to identify that this is a cache file.
+  uint32_t fileId() const { return getUint32(contents_.file_id_); }
+  // cacheVersionId is a value that should be consistent between versions of the file
+  // cache implementation. Changing version in code will invalidate all cache
+  // entries where the version ID does not match.
+  uint32_t cacheVersionId() const { return getUint32(contents_.cache_version_id_); }
+  // Size of the serialized proto message capturing headers and metadata.
+  size_t headerSize() const { return getUint32(contents_.header_size_); }
+  // Size of the serialized proto message capturing trailers.
+  size_t trailerSize() const { return getUint32(contents_.trailer_size_); }
+  // Size of the http body of the cache entry.
+  size_t bodySize() const { return getUint64(contents_.body_size_); }
+  void setFileId(uint32_t id) { setUint32(contents_.file_id_, id); }
+  void setCacheVersionId(uint32_t id) { setUint32(contents_.cache_version_id_, id); }
+  void setHeadersSize(size_t sz) { setUint32(contents_.header_size_, sz); }
+  void setTrailersSize(size_t sz) { setUint32(contents_.trailer_size_, sz); }
+  void setBodySize(size_t sz) { setUint64(contents_.body_size_, sz); }
+  static size_t offsetToHeaders() { return size(); }
+  size_t offsetToBody() const { return offsetToHeaders() + headerSize(); }
+  size_t offsetToTrailers() const { return offsetToBody() + bodySize(); }
+  absl::string_view stringView() const { return {contents_.as_str_, size()}; }
+  // Returns true if the fileId and cacheVersionId match the compile-time constants from
+  // cache_file_fixed_block.cc
+  bool isValid() const;
+
+private:
+  union {
+    struct {
+      uint32_t file_id_;
+      uint32_t cache_version_id_;
+      uint32_t header_size_;
+      uint32_t trailer_size_;
+      uint64_t body_size_;
+    };
+    char as_str_[1];
+  } contents_;
+  static_assert(sizeof(contents_) ==
+                    sizeof(contents_.file_id_) + sizeof(contents_.cache_version_id_) +
+                        sizeof(contents_.header_size_) + sizeof(contents_.trailer_size_) +
+                        sizeof(contents_.body_size_),
+                "contents_ must be fully packed for consistency");
+  uint32_t getUint32(const uint32_t& t) const;
+  uint64_t getUint64(const uint64_t& t) const;
+  void setUint32(uint32_t& t, uint32_t v);
+  void setUint64(uint64_t& t, uint64_t v);
+};
+
+} // namespace FileSystemHttpCache
+} // namespace Cache
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "source/common/common/byte_order.h"
+
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -14,38 +16,85 @@ namespace Cache {
 namespace FileSystemHttpCache {
 
 // This represents a minimal header block on the cache entry file; it uses a struct that
-// is required to be packed, and explicit network byte order, to ensure compatibility.
+// is required to be packed, and explicit network byte order, to ensure consistency.
 class CacheFileFixedBlock {
 public:
   CacheFileFixedBlock();
+
+  // Deserializes the string representation of a CacheFileFixedBlock into this instance.
   void populateFromStringView(absl::string_view s);
+
+  // Returns the size in bytes of a CacheFileFixedBlock.
   static size_t size() { return sizeof(contents_); }
+
   // fileId is a fixed value used to identify that this is a cache file.
-  uint32_t fileId() const { return getUint32(contents_.file_id_); }
+  uint32_t fileId() const { return fromEndianness<ByteOrder::BigEndian>(contents_.file_id_); }
+
   // cacheVersionId is a value that should be consistent between versions of the file
   // cache implementation. Changing version in code will invalidate all cache
   // entries where the version ID does not match.
-  uint32_t cacheVersionId() const { return getUint32(contents_.cache_version_id_); }
+  uint32_t cacheVersionId() const {
+    return fromEndianness<ByteOrder::BigEndian>(contents_.cache_version_id_);
+  }
+
   // Size of the serialized proto message capturing headers and metadata.
-  size_t headerSize() const { return getUint32(contents_.header_size_); }
+  size_t headerSize() const { return fromEndianness<ByteOrder::BigEndian>(contents_.header_size_); }
+
   // Size of the serialized proto message capturing trailers.
-  size_t trailerSize() const { return getUint32(contents_.trailer_size_); }
+  size_t trailerSize() const {
+    return fromEndianness<ByteOrder::BigEndian>(contents_.trailer_size_);
+  }
+
   // Size of the http body of the cache entry.
-  size_t bodySize() const { return getUint64(contents_.body_size_); }
-  void setFileId(uint32_t id) { setUint32(contents_.file_id_, id); }
-  void setCacheVersionId(uint32_t id) { setUint32(contents_.cache_version_id_, id); }
-  void setHeadersSize(size_t sz) { setUint32(contents_.header_size_, sz); }
-  void setTrailersSize(size_t sz) { setUint32(contents_.trailer_size_, sz); }
-  void setBodySize(size_t sz) { setUint64(contents_.body_size_, sz); }
+  size_t bodySize() const { return fromEndianness<ByteOrder::BigEndian>(contents_.body_size_); }
+
+  // Sets the size of the serialized headers, key and metadata.
+  void setHeadersSize(size_t sz) {
+    contents_.header_size_ = toEndianness<ByteOrder::BigEndian>(static_cast<uint32_t>(sz));
+  }
+
+  // Sets the size of the serialized trailers.
+  void setTrailersSize(size_t sz) {
+    contents_.trailer_size_ = toEndianness<ByteOrder::BigEndian>(static_cast<uint32_t>(sz));
+  }
+
+  // Sets the size of the serialized body.
+  void setBodySize(size_t sz) {
+    contents_.body_size_ = toEndianness<ByteOrder::BigEndian>(static_cast<uint64_t>(sz));
+  }
+
+  // Returns the offset from the start of the file to the start of the
+  // serialized headers proto.
   static size_t offsetToHeaders() { return size(); }
+
+  // Returns the offset from the start of the file to the start of the body data.
   size_t offsetToBody() const { return offsetToHeaders() + headerSize(); }
+
+  // Returns the offset from the start of the file to the start of the
+  // serialized trailers proto.
   size_t offsetToTrailers() const { return offsetToBody() + bodySize(); }
+
+  // Returns a string_view of the serialized fixed header chunk.
   absl::string_view stringView() const { return {contents_.as_str_, size()}; }
+
   // Returns true if the fileId and cacheVersionId match the compile-time constants from
   // cache_file_fixed_block.cc
   bool isValid() const;
 
 private:
+  // sets the fileId, a fixed value used to identify that this is a cache file.
+  // This is private so only the unit test can call it, as the file ID should be
+  // a compile-time constant in ordinary use.
+  void setFileId(uint32_t id) { contents_.file_id_ = toEndianness<ByteOrder::BigEndian>(id); }
+
+  // sets the cacheVersionId, a value that should be consistent between versions
+  // of the file cache implementation.
+  // This is private so only the unit test can call it, as the version ID should be
+  // a compile-time constant in ordinary use.
+  void setCacheVersionId(uint32_t id) {
+    contents_.cache_version_id_ = toEndianness<ByteOrder::BigEndian>(id);
+  }
+
   union {
     struct {
       uint32_t file_id_;
@@ -61,10 +110,8 @@ private:
                         sizeof(contents_.header_size_) + sizeof(contents_.trailer_size_) +
                         sizeof(contents_.body_size_),
                 "contents_ must be fully packed for consistency");
-  uint32_t getUint32(const uint32_t& t) const;
-  uint64_t getUint64(const uint64_t& t) const;
-  void setUint32(uint32_t& t, uint32_t v);
-  void setUint64(uint64_t& t, uint64_t v);
+
+  friend class CacheFileFixedBlockTest;
 };
 
 } // namespace FileSystemHttpCache

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -95,16 +95,16 @@ public:
   void setHeadersSize(uint32_t sz) { header_size_ = sz; }
 
   /**
-   * sets the size of the serialized trailers in the header block.
-   * @param sz The size of the serialized trailers.
-   */
-  void setTrailersSize(uint32_t sz) { trailer_size_ = sz; }
-
-  /**
    * sets the size of the serialized body in the header block.
    * @param sz The size of the body data.
    */
   void setBodySize(uint64_t sz) { body_size_ = sz; }
+
+  /**
+   * sets the size of the serialized trailers in the header block.
+   * @param sz The size of the serialized trailers.
+   */
+  void setTrailersSize(uint32_t sz) { trailer_size_ = sz; }
 
   /**
    * the offset from the start of the file to the start of the serialized headers proto.
@@ -134,8 +134,8 @@ private:
   std::array<char, 4> file_id_;
   std::array<char, 4> cache_version_id_;
   uint32_t header_size_;
-  uint64_t body_size_;
   uint32_t trailer_size_;
+  uint64_t body_size_;
 };
 
 } // namespace FileSystemHttpCache

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -18,7 +18,9 @@ namespace FileSystemHttpCache {
 /**
  * CacheFileFixedBlock represents a minimal header block on the cache entry file; it
  * uses a struct that is required to be packed, and explicit byte order, to ensure
- * consistency.
+ * consistency. (It is not *expected* that a cache file will be handled by different
+ * machines, but it costs little to accommodate it, and can simplify issue
+ * investigation if the file format doesn't vary.)
  *
  * This data is serialized as a flat object rather than protobuf serialization because it
  * needs to be at the start of the file for efficient read, but write after the rest of the

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -135,7 +135,7 @@ public:
    * the serialized fixed header chunk.
    * @return a string view over the entire structure of the header chunk.
    */
-  absl::string_view stringView() const { return {contents_.as_str_, size()}; }
+  absl::string_view stringView() const { return {contents_.raw_, size()}; }
 
   /**
    * is this a valid cache file header block for the current code version?
@@ -171,7 +171,7 @@ private:
       uint32_t trailer_size_;
       uint64_t body_size_;
     };
-    char as_str_[1];
+    char raw_[sizeof(uint32_t) * 4 + sizeof(uint64_t)];
   } contents_;
   static_assert(sizeof(contents_) ==
                     sizeof(contents_.file_id_) + sizeof(contents_.cache_version_id_) +

--- a/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h
@@ -131,30 +131,11 @@ public:
   bool isValid() const;
 
 private:
-  /**
-   * sets the fileId, a fixed value used to identify that this is a cache file.
-   * This is private so only the unit test can call it, as the file ID should be
-   * a compile-time constant in ordinary use.
-   * @param id The file ID to set.
-   */
-  void setFileId(std::array<char, 4> id) { file_id_ = id; }
-
-  /**
-   * sets the cacheVersionId, a value that should be consistent between versions
-   * of the file cache implementation.
-   * This is private so only the unit test can call it, as the version ID should be
-   * a compile-time constant in ordinary use.
-   * @param id The cache version ID to set.
-   */
-  void setCacheVersionId(std::array<char, 4> id) { cache_version_id_ = id; }
-
   std::array<char, 4> file_id_;
   std::array<char, 4> cache_version_id_;
   size_t header_size_;
   size_t trailer_size_;
   size_t body_size_;
-
-  friend class CacheFileFixedBlockTest;
 };
 
 } // namespace FileSystemHttpCache

--- a/test/extensions/http/cache/file_system_http_cache/BUILD
+++ b/test/extensions/http/cache/file_system_http_cache/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "cache_file_fixed_block_test",
+    srcs = ["cache_file_fixed_block_test.cc"],
+    deps = [
+        "//source/extensions/http/cache/file_system_http_cache:cache_file_fixed_block",
+    ],
+)

--- a/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
@@ -1,0 +1,88 @@
+#include "source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Cache {
+namespace FileSystemHttpCache {
+namespace {
+
+TEST(CacheFileFixedBlock, InitializesToValid) {
+  CacheFileFixedBlock default_block;
+  EXPECT_TRUE(default_block.isValid());
+}
+
+TEST(CacheFileFixedBlock, GettersRecoverValuesThatWereSet) {
+  CacheFileFixedBlock block;
+  block.setFileId(98765);
+  block.setCacheVersionId(56789);
+  block.setBodySize(999999);
+  block.setHeadersSize(1234);
+  block.setTrailersSize(4321);
+  EXPECT_EQ(block.fileId(), 98765);
+  EXPECT_EQ(block.cacheVersionId(), 56789);
+  EXPECT_EQ(block.bodySize(), 999999);
+  EXPECT_EQ(block.headerSize(), 1234);
+  EXPECT_EQ(block.trailerSize(), 4321);
+}
+
+TEST(CacheFileFixedBlock, IsValidReturnsFalseOnBadFileId) {
+  CacheFileFixedBlock block;
+  block.setFileId(98765);
+  EXPECT_FALSE(block.isValid());
+}
+
+TEST(CacheFileFixedBlock, IsValidReturnsFalseOnBadCacheVersionId) {
+  CacheFileFixedBlock block;
+  block.setCacheVersionId(98765);
+  EXPECT_FALSE(block.isValid());
+}
+
+TEST(CacheFileFixedBlock, IsValidReturnsTrueOnBlockWithNonDefaultValues) {
+  CacheFileFixedBlock block;
+  block.setHeadersSize(1234);
+  block.setBodySize(999999);
+  block.setTrailersSize(4321);
+  EXPECT_TRUE(block.isValid());
+}
+
+TEST(CacheFileFixedBlock, ReturnsCorrectOffsets) {
+  CacheFileFixedBlock block;
+  block.setHeadersSize(100);
+  block.setBodySize(1000);
+  block.setTrailersSize(10);
+  EXPECT_EQ(block.offsetToHeaders(), CacheFileFixedBlock::size());
+  EXPECT_EQ(block.offsetToBody(), CacheFileFixedBlock::size() + 100);
+  EXPECT_EQ(block.offsetToTrailers(), CacheFileFixedBlock::size() + 1100);
+}
+
+TEST(CacheFileFixedBlock, CopiesCorrectlyViaStringView) {
+  CacheFileFixedBlock block;
+  block.setHeadersSize(100);
+  block.setBodySize(1000);
+  block.setTrailersSize(10);
+  CacheFileFixedBlock block2;
+  block2.populateFromStringView(block.stringView());
+  EXPECT_EQ(block2.offsetToHeaders(), CacheFileFixedBlock::size());
+  EXPECT_EQ(block2.offsetToBody(), CacheFileFixedBlock::size() + 100);
+  EXPECT_EQ(block2.offsetToTrailers(), CacheFileFixedBlock::size() + 1100);
+  EXPECT_TRUE(block2.isValid());
+}
+
+TEST(CacheFileFixedBlock, NumbersAreInNetworkByteOrder) {
+  CacheFileFixedBlock block;
+  block.setHeadersSize(0xfaaf);
+  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[8]), 0);
+  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[9]), 0);
+  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[10]), 0xfa);
+  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[11]), 0xaf);
+}
+
+} // namespace
+} // namespace FileSystemHttpCache
+} // namespace Cache
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
@@ -7,17 +7,25 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 namespace FileSystemHttpCache {
+
+class CacheFileFixedBlockTest : public ::testing::Test {
+public:
+  // Wrappers for private test-only functions.
+  void setFileId(CacheFileFixedBlock& block, uint32_t id) { block.setFileId(id); }
+  void setCacheVersionId(CacheFileFixedBlock& block, uint32_t id) { block.setCacheVersionId(id); }
+};
+
 namespace {
 
-TEST(CacheFileFixedBlock, InitializesToValid) {
+TEST_F(CacheFileFixedBlockTest, InitializesToValid) {
   CacheFileFixedBlock default_block;
   EXPECT_TRUE(default_block.isValid());
 }
 
-TEST(CacheFileFixedBlock, GettersRecoverValuesThatWereSet) {
+TEST_F(CacheFileFixedBlockTest, GettersRecoverValuesThatWereSet) {
   CacheFileFixedBlock block;
-  block.setFileId(98765);
-  block.setCacheVersionId(56789);
+  setFileId(block, 98765);
+  setCacheVersionId(block, 56789);
   block.setBodySize(999999);
   block.setHeadersSize(1234);
   block.setTrailersSize(4321);
@@ -28,19 +36,19 @@ TEST(CacheFileFixedBlock, GettersRecoverValuesThatWereSet) {
   EXPECT_EQ(block.trailerSize(), 4321);
 }
 
-TEST(CacheFileFixedBlock, IsValidReturnsFalseOnBadFileId) {
+TEST_F(CacheFileFixedBlockTest, IsValidReturnsFalseOnBadFileId) {
   CacheFileFixedBlock block;
-  block.setFileId(98765);
+  setFileId(block, 98765);
   EXPECT_FALSE(block.isValid());
 }
 
-TEST(CacheFileFixedBlock, IsValidReturnsFalseOnBadCacheVersionId) {
+TEST_F(CacheFileFixedBlockTest, IsValidReturnsFalseOnBadCacheVersionId) {
   CacheFileFixedBlock block;
-  block.setCacheVersionId(98765);
+  setCacheVersionId(block, 98765);
   EXPECT_FALSE(block.isValid());
 }
 
-TEST(CacheFileFixedBlock, IsValidReturnsTrueOnBlockWithNonDefaultValues) {
+TEST_F(CacheFileFixedBlockTest, IsValidReturnsTrueOnBlockWithNonDefaultValues) {
   CacheFileFixedBlock block;
   block.setHeadersSize(1234);
   block.setBodySize(999999);
@@ -48,7 +56,7 @@ TEST(CacheFileFixedBlock, IsValidReturnsTrueOnBlockWithNonDefaultValues) {
   EXPECT_TRUE(block.isValid());
 }
 
-TEST(CacheFileFixedBlock, ReturnsCorrectOffsets) {
+TEST_F(CacheFileFixedBlockTest, ReturnsCorrectOffsets) {
   CacheFileFixedBlock block;
   block.setHeadersSize(100);
   block.setBodySize(1000);
@@ -58,7 +66,7 @@ TEST(CacheFileFixedBlock, ReturnsCorrectOffsets) {
   EXPECT_EQ(block.offsetToTrailers(), CacheFileFixedBlock::size() + 1100);
 }
 
-TEST(CacheFileFixedBlock, CopiesCorrectlyViaStringView) {
+TEST_F(CacheFileFixedBlockTest, CopiesCorrectlyViaStringView) {
   CacheFileFixedBlock block;
   block.setHeadersSize(100);
   block.setBodySize(1000);
@@ -71,7 +79,7 @@ TEST(CacheFileFixedBlock, CopiesCorrectlyViaStringView) {
   EXPECT_TRUE(block2.isValid());
 }
 
-TEST(CacheFileFixedBlock, NumbersAreInNetworkByteOrder) {
+TEST_F(CacheFileFixedBlockTest, NumbersAreInNetworkByteOrder) {
   CacheFileFixedBlock block;
   block.setHeadersSize(0xfaaf);
   EXPECT_EQ(static_cast<unsigned char>(block.stringView()[8]), 0);

--- a/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
@@ -12,8 +12,10 @@ namespace FileSystemHttpCache {
 class CacheFileFixedBlockTest : public ::testing::Test {
 public:
   // Wrappers for private test-only functions.
-  void setFileId(CacheFileFixedBlock& block, uint32_t id) { block.setFileId(id); }
-  void setCacheVersionId(CacheFileFixedBlock& block, uint32_t id) { block.setCacheVersionId(id); }
+  void setFileId(CacheFileFixedBlock& block, std::array<char, 4> id) { block.setFileId(id); }
+  void setCacheVersionId(CacheFileFixedBlock& block, std::array<char, 4> id) {
+    block.setCacheVersionId(id);
+  }
 };
 
 namespace {
@@ -25,13 +27,15 @@ TEST_F(CacheFileFixedBlockTest, InitializesToValid) {
 
 TEST_F(CacheFileFixedBlockTest, GettersRecoverValuesThatWereSet) {
   CacheFileFixedBlock block;
-  setFileId(block, 98765);
-  setCacheVersionId(block, 56789);
+  std::array<char, 4> test_file_id{'F', 'I', 'L', 'E'};
+  std::array<char, 4> test_cache_version_id{'V', 'E', 'R', 'S'};
+  setFileId(block, test_file_id);
+  setCacheVersionId(block, test_cache_version_id);
   block.setBodySize(999999);
   block.setHeadersSize(1234);
   block.setTrailersSize(4321);
-  EXPECT_EQ(block.fileId(), 98765);
-  EXPECT_EQ(block.cacheVersionId(), 56789);
+  EXPECT_EQ(block.fileId(), test_file_id);
+  EXPECT_EQ(block.cacheVersionId(), test_cache_version_id);
   EXPECT_EQ(block.bodySize(), 999999);
   EXPECT_EQ(block.headerSize(), 1234);
   EXPECT_EQ(block.trailerSize(), 4321);
@@ -40,14 +44,14 @@ TEST_F(CacheFileFixedBlockTest, GettersRecoverValuesThatWereSet) {
 TEST_F(CacheFileFixedBlockTest, IsValidReturnsFalseOnBadFileId) {
   CacheFileFixedBlock block;
   // Any file id other than the current compile time constant should be invalid.
-  setFileId(block, 98765);
+  setFileId(block, {'B', 'A', 'D', 'F'});
   EXPECT_FALSE(block.isValid());
 }
 
 TEST_F(CacheFileFixedBlockTest, IsValidReturnsFalseOnBadCacheVersionId) {
   CacheFileFixedBlock block;
   // Any cache version id other than the current compile time constant should be invalid.
-  setCacheVersionId(block, 98765);
+  setCacheVersionId(block, {'B', 'A', 'D', 'C'});
   EXPECT_FALSE(block.isValid());
 }
 

--- a/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
@@ -38,17 +38,19 @@ TEST_F(CacheFileFixedBlockTest, GettersRecoverValuesThatWereSet) {
 
 TEST_F(CacheFileFixedBlockTest, IsValidReturnsFalseOnBadFileId) {
   CacheFileFixedBlock block;
+  // Any file id other than the current compile time constant should be invalid.
   setFileId(block, 98765);
   EXPECT_FALSE(block.isValid());
 }
 
 TEST_F(CacheFileFixedBlockTest, IsValidReturnsFalseOnBadCacheVersionId) {
   CacheFileFixedBlock block;
+  // Any cache version id other than the current compile time constant should be invalid.
   setCacheVersionId(block, 98765);
   EXPECT_FALSE(block.isValid());
 }
 
-TEST_F(CacheFileFixedBlockTest, IsValidReturnsTrueOnBlockWithNonDefaultValues) {
+TEST_F(CacheFileFixedBlockTest, IsValidReturnsTrueOnBlockWithNonDefaultSizes) {
   CacheFileFixedBlock block;
   block.setHeadersSize(1234);
   block.setBodySize(999999);
@@ -79,13 +81,15 @@ TEST_F(CacheFileFixedBlockTest, CopiesCorrectlyViaStringView) {
   EXPECT_TRUE(block2.isValid());
 }
 
-TEST_F(CacheFileFixedBlockTest, NumbersAreInNetworkByteOrder) {
+TEST_F(CacheFileFixedBlockTest, NumbersAreInLittleEndianByteOrder) {
   CacheFileFixedBlock block;
-  block.setHeadersSize(0xfaaf);
-  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[8]), 0);
-  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[9]), 0);
-  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[10]), 0xfa);
-  EXPECT_EQ(static_cast<unsigned char>(block.stringView()[11]), 0xaf);
+  block.setHeadersSize(0x7654);
+  absl::string_view str = block.stringView();
+  ASSERT_GT(str.size(), 12);
+  EXPECT_EQ(str[8], 0x54);
+  EXPECT_EQ(str[9], 0x76);
+  EXPECT_EQ(str[10], 0x00);
+  EXPECT_EQ(str[11], 0x00);
 }
 
 } // namespace

--- a/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
@@ -1,6 +1,5 @@
-#include "source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h"
-
 #include "source/common/buffer/buffer_impl.h"
+#include "source/extensions/http/cache/file_system_http_cache/cache_file_fixed_block.h"
 
 #include "gtest/gtest.h"
 

--- a/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/cache_file_fixed_block_test.cc
@@ -64,8 +64,11 @@ TEST_F(CacheFileFixedBlockTest, ReturnsCorrectOffsets) {
 
 TEST_F(CacheFileFixedBlockTest, SerializesAndDeserializesCorrectly) {
   CacheFileFixedBlock block;
+  // A body size that doesn't fit in a uint32, to ensure large numbers also serialize.
+  constexpr uint64_t billion = 1000 * 1000 * 1000;
+  constexpr uint64_t large_body_size = 10 * billion;
   block.setHeadersSize(100);
-  block.setBodySize(10000000000);
+  block.setBodySize(large_body_size);
   block.setTrailersSize(10);
   CacheFileFixedBlock block2;
   Buffer::OwnedImpl buf;
@@ -74,9 +77,9 @@ TEST_F(CacheFileFixedBlockTest, SerializesAndDeserializesCorrectly) {
   EXPECT_TRUE(block2.isValid());
   EXPECT_EQ(block2.offsetToHeaders(), CacheFileFixedBlock::size());
   EXPECT_EQ(block2.offsetToBody(), CacheFileFixedBlock::size() + 100);
-  EXPECT_EQ(block2.offsetToTrailers(), CacheFileFixedBlock::size() + 10000000000 + 100);
+  EXPECT_EQ(block2.offsetToTrailers(), CacheFileFixedBlock::size() + large_body_size + 100);
   EXPECT_EQ(block2.headerSize(), 100);
-  EXPECT_EQ(block2.bodySize(), 10000000000);
+  EXPECT_EQ(block2.bodySize(), large_body_size);
   EXPECT_EQ(block2.trailerSize(), 10);
 }
 

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -648,6 +648,7 @@ deserialize
 deserialized
 deserializer
 deserializers
+deserializes
 deserializing
 dest
 destructor


### PR DESCRIPTION
Commit Message: cache_file_fixed_block: part one of filesystem_cache
Additional Description: #23175 is the target end state of this.
Risk Level: None, it is dead-code until the API part is added.
Testing: Unit tested.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
