### PR TITLE
Fix undefined behavior

### DIFF
--- a/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
@@ -158,7 +158,7 @@ TEST_F(TsiHandshakerTest, DeleteOnDone) {
   handshaker->deferredDelete();
 
   // Make sure the handshaker is not in dispatcher_ queue, since the next call is not done.
-  EXPECT_NE(dispatcher_.to_delete_.back().get(), handshaker.get());
+  EXPECT_TRUE(dispatcher_.to_delete_.empty());
 
   // After deferredDelete, the callback should be never invoked, in real use it might be already
   // a dangling pointer.


### PR DESCRIPTION
std::list's back() is UB when called on an empty list.

Signed-off-by: yurykats <yurykats@yahoo.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
