### PR TITLE
[backport/1.24] improve the run_envoy_docker.sh compatibility on mac. (#23832)

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -41,7 +41,7 @@ else
   BUILD_DIR_MOUNT_DEST=/build
   SOURCE_DIR="${PWD}"
   SOURCE_DIR_MOUNT_DEST=/source
-  DOCKER_GID="$(stat -c '%g' /var/run/docker.sock)"
+  DOCKER_GID="$(stat -c %g /var/run/docker.sock 2>/dev/null || stat -f %g /var/run/docker.sock)"
   START_COMMAND=("/bin/bash" "-lc" "groupadd --gid ${DOCKER_GID} -f envoygroup \
     && useradd -o --uid $(id -u) --gid ${DOCKER_GID} --no-create-home --home-dir /build envoybuild \
     && usermod -a -G pcap envoybuild \


### PR DESCRIPTION
Since the stat on mac missing the -c option, i.e.
stat: illegal option -- c
usage: stat [-FLnq] [-f format | -l | -r | -s | -x] [-t timefmt] [file ...]

Signed-off-by: doujiang24 <doujiang24@gmail.com>
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
