### PR TITLE
Fix bug in stream_info mock

### DIFF
--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -145,7 +145,9 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, hasAnyResponseFlag()).WillByDefault(Invoke([this]() {
     return response_flags_ != 0;
   }));
-  ON_CALL(*this, responseFlags()).WillByDefault(Return(response_flags_));
+  ON_CALL(*this, responseFlags()).WillByDefault(Invoke([this]() -> uint64_t {
+    return response_flags_;
+  }));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));


### PR DESCRIPTION
Signed-off-by: silverstar195 <seanmaloney@google.com>

Commit Message:
Fix bug in stream_info mock 

Additional Description:
``Return(value)`` in gmock copies ``value`` at setup time. Any updates to ``value`` during use of mock will not be reflected.

This caused ``responseFlags`` to always return the default value of ``0`` instead of any updates done by  ``setResponseFlag``

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
