### PR TITLE
header: implement and doc %TLS_JA3_FINGERPRINT%

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -74,6 +74,9 @@ new_features:
   change: |
     added :ref:`dubbo codec support <envoy_v3_api_msg_extensions.filters.network.generic_proxy.codecs.dubbo.v3.DubboCodecConfig>` to the
     :ref:`generic_proxy filter <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
+- area: http
+  change: |
+    Added support for generating headers containing the TLS inspector's JA3 hash.
 - area: upstream
   change: |
     added a new field :ref:`socket_options <envoy_v3_api_field_config.core.v3.ExtraSourceAddress.socket_options>` to the ExtraSourceAddress, allowing specifying discrete socket options for each source address.

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -902,6 +902,13 @@ The following command operators are supported:
   UDP
     Not implemented ("-").
 
+%TLS_JA3_FINGERPRINT%
+  HTTP/TCP/THRIFT
+    The JA3 fingerprint computed from the downstream client's TLS ClientHello. Computation of the
+    fingerprint must be enabled in the :ref:`TLS inspector listener filter. <config_listener_filters_tls_inspector>`
+  UDP
+    Not implemented ("-").
+
 %DOWNSTREAM_PEER_FINGERPRINT_256%
   HTTP/TCP/THRIFT
     The hex-encoded SHA256 fingerprint of the client certificate used to establish the downstream TLS connection.

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -328,6 +328,8 @@ StreamInfoHeaderFormatter::StreamInfoHeaderFormatter(absl::string_view field_nam
   } else if (field_name == "DOWNSTREAM_TLS_VERSION") {
     field_extractor_ = sslConnectionInfoStringHeaderExtractor(
         [](const Ssl::ConnectionInfo& connection_info) { return connection_info.tlsVersion(); });
+  } else if (field_name == "TLS_JA3_FINGERPRINT") {
+    field_extractor_ = parseSubstitutionFormatField(field_name, formatter_map_);
   } else if (field_name == "DOWNSTREAM_PEER_FINGERPRINT_256") {
     field_extractor_ =
         sslConnectionInfoStringHeaderExtractor([](const Ssl::ConnectionInfo& connection_info) {

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -451,6 +451,17 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsVersionNoTls) {
   testFormatting(stream_info, "DOWNSTREAM_TLS_VERSION", EMPTY_STRING);
 }
 
+TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithTlsJa3Hash) {
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  stream_info.downstream_connection_info_provider_->setJA3Hash("ABADCAFE");
+  testFormatting(stream_info, "TLS_JA3_FINGERPRINT", "ABADCAFE");
+}
+
+TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithTlsJa3HashNoHash) {
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  testFormatting(stream_info, "TLS_JA3_FINGERPRINT", EMPTY_STRING);
+}
+
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha256Fingerprint) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();


### PR DESCRIPTION
Additional Description:
Support %TLS_JA3_FINGERPRINT% in the header formatter and document its existence with a reference to the TLS inspector listener filter.

Risk Level: low
Testing: added unit tests
Docs Changes: added
Release Notes: added
Platform Specific Features: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
