### PR TITLE
yamllint: disable line length check

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,9 +5,7 @@ rules:
   indentation:
     spaces: consistent
     indent-sequences: false
-  line-length:
-    max: 200
-    level: warning
+  line-length: disable
   truthy:
     allowed-values:
     - "yes"


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

Now `yamlint` check would raise 400+ warnings, all about too large line length.

But in Envoy, all those lines are necessary, check the line length does not get any benefit.

Risk Level: Low
Release Notes: N/A