### PR TITLE
dlb: add retry logic

### DIFF
--- a/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
+++ b/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
@@ -33,5 +33,5 @@ message Dlb {
 
   // Control how many times Envoy makes an attempt to send event to DLB hardware.
   // No retry as default.
-  uint32 retry_times = 2;
+  uint32 most_send_retries = 2;
 }

--- a/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
+++ b/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
@@ -31,7 +31,7 @@ message Dlb {
   // If not specified, use the first available device as default.
   uint32 id = 1;
 
-  // Control how many times Envoy makes an attempt to send event to DLB hardware.
+  // Maximum number of retries when sending to DLB device fails.
   // No retry as default.
-  uint32 most_send_retries = 2;
+  uint32 max_retries = 2;
 }

--- a/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
+++ b/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
@@ -30,4 +30,8 @@ message Dlb {
   // The ID of the Dlb hardware, start from 0.
   // If not specified, use the first available device as default.
   uint32 id = 1;
+
+  // Control how many times Envoy makes an attempt to send event to DLB hardware.
+  // No retry as default.
+  uint32 retry_times = 2;
 }

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -46,11 +46,11 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
     ENVOY_LOG(warn, "dlb device {} is not found, use dlb device {} instead", config_id, device_id);
   }
 
-  retry_times = dlb_config.retry_times();
-
 #ifdef DLB_DISABLED
   throw EnvoyException("X86_64 architecture is required for Dlb.");
 #else
+
+  retry_times = dlb_config.retry_times();
 
   dlb_resources_t rsrcs;
   if (dlb_open(device_id, &dlb) == -1) {

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -50,7 +50,7 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
   throw EnvoyException("X86_64 architecture is required for Dlb.");
 #else
 
-  retry_times = dlb_config.retry_times();
+  most_send_retries = dlb_config.most_send_retries();
 
   dlb_resources_t rsrcs;
   if (dlb_open(device_id, &dlb) == -1) {
@@ -250,7 +250,7 @@ void DlbBalancedConnectionHandlerImpl::post(Network::ConnectionSocketPtr&& socke
   int ret = dlb_send(DlbConnectionBalanceFactorySingleton::get().tx_ports[index_], 1, &events[0]);
   if (ret != 1) {
     uint i = 0;
-    while (i < DlbConnectionBalanceFactorySingleton::get().retry_times) {
+    while (i < DlbConnectionBalanceFactorySingleton::get().most_send_retries) {
       ENVOY_LOG(debug, "{} dlb_send fail, start retry, errono: {}", name_, errno);
       ret = dlb_send(DlbConnectionBalanceFactorySingleton::get().tx_ports[index_], 1, &events[0]);
       if (ret == 1) {
@@ -262,7 +262,7 @@ void DlbBalancedConnectionHandlerImpl::post(Network::ConnectionSocketPtr&& socke
 
     if (ret != 1) {
       ENVOY_LOG(error, "{} dlb_send fail with {} times retry, errono: {}, message: {}", name_,
-                DlbConnectionBalanceFactorySingleton::get().retry_times, errno,
+                DlbConnectionBalanceFactorySingleton::get().most_send_retries, errno,
                 errorDetails(errno));
     }
   } else {

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -50,7 +50,7 @@ DlbConnectionBalanceFactory::createConnectionBalancerFromProto(
   throw EnvoyException("X86_64 architecture is required for Dlb.");
 #else
 
-  most_send_retries = dlb_config.most_send_retries();
+  max_retries = dlb_config.max_retries();
 
   dlb_resources_t rsrcs;
   if (dlb_open(device_id, &dlb) == -1) {
@@ -250,7 +250,7 @@ void DlbBalancedConnectionHandlerImpl::post(Network::ConnectionSocketPtr&& socke
   int ret = dlb_send(DlbConnectionBalanceFactorySingleton::get().tx_ports[index_], 1, &events[0]);
   if (ret != 1) {
     uint i = 0;
-    while (i < DlbConnectionBalanceFactorySingleton::get().most_send_retries) {
+    while (i < DlbConnectionBalanceFactorySingleton::get().max_retries) {
       ENVOY_LOG(debug, "{} dlb_send fail, start retry, errono: {}", name_, errno);
       ret = dlb_send(DlbConnectionBalanceFactorySingleton::get().tx_ports[index_], 1, &events[0]);
       if (ret == 1) {
@@ -262,7 +262,7 @@ void DlbBalancedConnectionHandlerImpl::post(Network::ConnectionSocketPtr&& socke
 
     if (ret != 1) {
       ENVOY_LOG(error, "{} dlb_send fail with {} times retry, errono: {}, message: {}", name_,
-                DlbConnectionBalanceFactorySingleton::get().most_send_retries, errno,
+                DlbConnectionBalanceFactorySingleton::get().max_retries, errno,
                 errorDetails(errno));
     }
   } else {

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -101,6 +101,7 @@ public:
 
   // Share those cross worker threads.
   std::vector<dlb_port_hdl_t> tx_ports, rx_ports;
+  uint retry_times;
 #endif
   std::vector<int> efds;
   std::vector<std::shared_ptr<DlbBalancedConnectionHandlerImpl>> dlb_handlers;

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -101,7 +101,7 @@ public:
 
   // Share those cross worker threads.
   std::vector<dlb_port_hdl_t> tx_ports, rx_ports;
-  uint most_send_retries;
+  uint max_retries;
 #endif
   std::vector<int> efds;
   std::vector<std::shared_ptr<DlbBalancedConnectionHandlerImpl>> dlb_handlers;

--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.h
@@ -101,7 +101,7 @@ public:
 
   // Share those cross worker threads.
   std::vector<dlb_port_hdl_t> tx_ports, rx_ports;
-  uint retry_times;
+  uint most_send_retries;
 #endif
   std::vector<int> efds;
   std::vector<std::shared_ptr<DlbBalancedConnectionHandlerImpl>> dlb_handlers;

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -41,7 +41,7 @@ TEST_F(DlbConnectionBalanceFactoryTest, MakeDefaultConfig) {
   makeDlbConnectionBalanceConfig(typed_config, dlb);
   verifyDlbConnectionBalanceConfigAndUnpack(typed_config, dlb);
   EXPECT_EQ(0, dlb.id());
-  EXPECT_EQ(0, dlb.most_send_retries());
+  EXPECT_EQ(0, dlb.max_retries());
 }
 
 TEST_F(DlbConnectionBalanceFactoryTest, MakeCustomConfig) {

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -41,7 +41,7 @@ TEST_F(DlbConnectionBalanceFactoryTest, MakeDefaultConfig) {
   makeDlbConnectionBalanceConfig(typed_config, dlb);
   verifyDlbConnectionBalanceConfigAndUnpack(typed_config, dlb);
   EXPECT_EQ(0, dlb.id());
-  EXPECT_EQ(0, dlb.retry_times());
+  EXPECT_EQ(0, dlb.most_send_retries());
 }
 
 TEST_F(DlbConnectionBalanceFactoryTest, MakeCustomConfig) {
@@ -49,12 +49,12 @@ TEST_F(DlbConnectionBalanceFactoryTest, MakeCustomConfig) {
 
   envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb dlb;
   dlb.set_id(10);
-  dlb.set_retry_times(12);
+  dlb.set_most_send_retries(12);
 
   makeDlbConnectionBalanceConfig(typed_config, dlb);
   verifyDlbConnectionBalanceConfigAndUnpack(typed_config, dlb);
   EXPECT_EQ(10, dlb.id());
-  EXPECT_EQ(12, dlb.retry_times());
+  EXPECT_EQ(12, dlb.most_send_retries());
 }
 
 TEST_F(DlbConnectionBalanceFactoryTest, EmptyProto) {

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -49,12 +49,12 @@ TEST_F(DlbConnectionBalanceFactoryTest, MakeCustomConfig) {
 
   envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb dlb;
   dlb.set_id(10);
-  dlb.set_most_send_retries(12);
+  dlb.set_max_retries(12);
 
   makeDlbConnectionBalanceConfig(typed_config, dlb);
   verifyDlbConnectionBalanceConfigAndUnpack(typed_config, dlb);
   EXPECT_EQ(10, dlb.id());
-  EXPECT_EQ(12, dlb.most_send_retries());
+  EXPECT_EQ(12, dlb.max_retries());
 }
 
 TEST_F(DlbConnectionBalanceFactoryTest, EmptyProto) {

--- a/contrib/network/connection_balance/dlb/test/config_test.cc
+++ b/contrib/network/connection_balance/dlb/test/config_test.cc
@@ -41,6 +41,7 @@ TEST_F(DlbConnectionBalanceFactoryTest, MakeDefaultConfig) {
   makeDlbConnectionBalanceConfig(typed_config, dlb);
   verifyDlbConnectionBalanceConfigAndUnpack(typed_config, dlb);
   EXPECT_EQ(0, dlb.id());
+  EXPECT_EQ(0, dlb.retry_times());
 }
 
 TEST_F(DlbConnectionBalanceFactoryTest, MakeCustomConfig) {
@@ -48,10 +49,12 @@ TEST_F(DlbConnectionBalanceFactoryTest, MakeCustomConfig) {
 
   envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb dlb;
   dlb.set_id(10);
+  dlb.set_retry_times(12);
 
   makeDlbConnectionBalanceConfig(typed_config, dlb);
   verifyDlbConnectionBalanceConfigAndUnpack(typed_config, dlb);
   EXPECT_EQ(10, dlb.id());
+  EXPECT_EQ(12, dlb.retry_times());
 }
 
 TEST_F(DlbConnectionBalanceFactoryTest, EmptyProto) {


### PR DESCRIPTION
When big traffic come, dlb_send() may fail due to temporarily unavailable resource.

Add retry logic to ensure every connection is sent successfully by dlb.

Signed-off-by: Loong <loong.dai@intel.com>

Risk Level: Low
Testing: Add
Release Notes: N/A
