### PR TITLE
[backport/1.24] ci: Pin images in github actions (#23860)

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
 
-    # CodeQL runs on ubuntu-latest and windows-latest
-    runs-on: ubuntu-latest
+    # CodeQL runs on ubuntu-20.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
 
-    # CodeQL runs on ubuntu-latest and windows-latest
-    runs-on: ubuntu-latest
+    # CodeQL runs on ubuntu-20.04
+    runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'
 
     steps:

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -13,7 +13,7 @@ jobs:
       statuses: read # for pr_notifier.py
       pull-requests: read # for pr_notifier.py
     name: PR Notifier
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
     name: Prune Stale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'
 
     steps:


### PR DESCRIPTION
Prevent bitrot on release branches

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
