### PR TITLE
[WIP] listener: enable to add/remove addresses without draining the whole listener.

### DIFF
--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -76,8 +76,10 @@ public:
    * Stop listeners using the listener tag as a key. This will not close any connections and is used
    * for draining.
    * @param listener_tag supplies the tag passed to addListener().
+   * @param addresses will be stopped. If not specified, the whole listener will be stopped.
    */
-  virtual void stopListeners(uint64_t listener_tag) PURE;
+  virtual void stopListeners(uint64_t listener_tag,
+                             OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses = absl::nullopt) PURE;
 
   /**
    * Stop all listeners. This will not close any connections and is used for draining.

--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -58,8 +58,11 @@ public:
    * Remove listeners using the listener tag as a key. All connections owned by the removed
    * listeners will be closed.
    * @param listener_tag supplies the tag passed to addListener().
+   * @param addresses specified listeners will be removed.
    */
-  virtual void removeListeners(uint64_t listener_tag) PURE;
+  virtual void removeListeners(uint64_t listener_tag,
+                               OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                                   addresses = absl::nullopt) PURE;
 
   /**
    * Remove the filter chains and the connections in the listener. All connections owned
@@ -79,7 +82,8 @@ public:
    * @param addresses will be stopped. If not specified, the whole listener will be stopped.
    */
   virtual void stopListeners(uint64_t listener_tag,
-                             OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses = absl::nullopt) PURE;
+                             OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                                 addresses = absl::nullopt) PURE;
 
   /**
    * Stop all listeners. This will not close any connections and is used for draining.

--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -47,9 +47,12 @@ public:
    * @param overridden_listener tag of the existing listener. nullopt if no previous listener.
    * @param config listener configuration options.
    * @param runtime the runtime for the server.
+   * @param new_addresses will be added.
    */
   virtual void addListener(absl::optional<uint64_t> overridden_listener, ListenerConfig& config,
-                           Runtime::Loader& runtime) PURE;
+                           Runtime::Loader& runtime,
+                           OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                               new_addresses = absl::nullopt) PURE;
 
   /**
    * Remove listeners using the listener tag as a key. All connections owned by the removed

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -60,6 +60,13 @@ public:
   virtual const Address::InstanceConstSharedPtr& localAddress() const PURE;
 
   /**
+   * @return the original listening address specified in the config. For example, the listening
+   * address could be a zero port address. Then the `localAddress()` will return the address which
+   * include the kernel allocated port.
+   */
+  virtual const Address::InstanceConstSharedPtr& listeningAddress() const PURE;
+
+  /**
    * Clone this socket factory so it can be used by a new listener (e.g., if the address is shared).
    */
   virtual ListenSocketFactoryPtr clone() const PURE;

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -32,10 +32,13 @@ public:
    * @param completion supplies the completion to call when the listener has been added (or not) on
    *                   the worker.
    * @param runtime, supplies the runtime for the server
+   * @param addresses will be added.
    */
-  virtual void addListener(absl::optional<uint64_t> overridden_listener,
-                           Network::ListenerConfig& listener, AddListenerCompletion completion,
-                           Runtime::Loader& runtime) PURE;
+  virtual void
+  addListener(absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& listener,
+              AddListenerCompletion completion, Runtime::Loader& runtime,
+              OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses =
+                  absl::nullopt) PURE;
 
   /**
    * @return uint64_t the number of connections across all listeners that the worker owns.

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -355,6 +355,9 @@ private:
     const Network::Address::InstanceConstSharedPtr& localAddress() const override {
       return socket_->connectionInfoProvider().localAddress();
     }
+    const Network::Address::InstanceConstSharedPtr& listeningAddress() const override {
+      return socket_->connectionInfoProvider().localAddress();
+    }
     Network::SocketSharedPtr getListenSocket(uint32_t) override {
       // This is only supposed to be called once.
       RELEASE_ASSERT(!socket_create_, "AdminListener's socket shouldn't be shared.");

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -31,6 +31,7 @@ void ConnectionHandlerImpl::addListener(
     absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& config,
     Runtime::Loader& runtime,
     OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> new_addresses) {
+  ASSERT(!overridden_listener.has_value() ? !new_addresses.has_value() : true);
   if (overridden_listener.has_value()) {
     ActiveListenerDetailsOptRef listener_detail =
         findActiveListenerByTag(overridden_listener.value());

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -81,13 +81,13 @@ void ConnectionHandlerImpl::addListener(
           local_registry->createActiveInternalListener(*this, config, dispatcher());
       // TODO(soulxu): support multiple internal addresses in listener in the future.
       ASSERT(config.listenSocketFactories().size() == 1);
-      details->addActiveListener(config, socket_factory->localAddress(), listener_reject_fraction_,
+      details->addActiveListener(config, socket_factory->localAddress(), socket_factory->listeningAddress(), listener_reject_fraction_,
                                  disable_listeners_, std::move(internal_listener));
     } else if (socket_factory->socketType() == Network::Socket::Type::Stream) {
       auto address = socket_factory->localAddress();
       // worker_index_ doesn't have a value on the main thread for the admin server.
       details->addActiveListener(
-          config, address, listener_reject_fraction_, disable_listeners_,
+          config, address, socket_factory->listeningAddress(), listener_reject_fraction_, disable_listeners_,
           std::make_unique<ActiveTcpListener>(
               *this, config, runtime,
               socket_factory->getListenSocket(worker_index_.has_value() ? *worker_index_ : 0),
@@ -97,7 +97,7 @@ void ConnectionHandlerImpl::addListener(
       ASSERT(worker_index_.has_value());
       auto address = socket_factory->localAddress();
       details->addActiveListener(
-          config, address, listener_reject_fraction_, disable_listeners_,
+          config, address, socket_factory->listeningAddress(), listener_reject_fraction_, disable_listeners_,
           config.udpListenerConfig()->listenerFactory().createActiveUdpListener(
               runtime, *worker_index_, *this, socket_factory->getListenSocket(*worker_index_),
               dispatcher_, config));

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -80,6 +80,7 @@ private:
     // Strong pointer to the listener, whether TCP, UDP, QUIC, etc.
     Network::ConnectionHandler::ActiveListenerPtr listener_;
     Network::Address::InstanceConstSharedPtr address_;
+    Network::Address::InstanceConstSharedPtr listen_address_;
     uint64_t listener_tag_;
 
     absl::variant<absl::monostate, std::reference_wrapper<ActiveTcpListener>,
@@ -114,12 +115,14 @@ private:
     template <class ActiveListener>
     void addActiveListener(Network::ListenerConfig& config,
                            const Network::Address::InstanceConstSharedPtr& address,
+                           const Network::Address::InstanceConstSharedPtr& listen_address,
                            UnitFloat& listener_reject_fraction, bool disable_listeners,
                            ActiveListener&& listener) {
       auto per_address_details = std::make_shared<PerAddressActiveListenerDetails>();
       per_address_details->typed_listener_ = *listener;
       per_address_details->listener_ = std::move(listener);
       per_address_details->address_ = address;
+      per_address_details->listen_address_ = listen_address;
       if (disable_listeners) {
         per_address_details->listener_->pauseListening();
       }

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -97,16 +97,15 @@ private:
   struct ActiveListenerDetails {
     std::vector<std::shared_ptr<PerAddressActiveListenerDetails>> per_address_details_list_;
 
-    using ListenerMethodFn = std::function<void(Network::ConnectionHandler::ActiveListener&)>;
+    using ListenerMethodFn = std::function<void(const PerAddressActiveListenerDetails&)>;
 
     /**
      * A helper to execute specific method on each PerAddressActiveListenerDetails item.
      */
     void invokeListenerMethod(ListenerMethodFn fn) {
-      std::for_each(per_address_details_list_.begin(), per_address_details_list_.end(),
-                    [&fn](std::shared_ptr<PerAddressActiveListenerDetails>& details) {
-                      fn(*details->listener_);
-                    });
+      std::for_each(
+          per_address_details_list_.begin(), per_address_details_list_.end(),
+          [&fn](std::shared_ptr<PerAddressActiveListenerDetails>& details) { fn(*details); });
     }
 
     /**

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -51,7 +51,8 @@ public:
   void removeFilterChains(uint64_t listener_tag,
                           const std::list<const Network::FilterChain*>& filter_chains,
                           std::function<void()> completion) override;
-  void stopListeners(uint64_t listener_tag) override;
+  void stopListeners(uint64_t listener_tag,
+                     OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses = absl::nullopt) override;
   void stopListeners() override;
   void disableListeners() override;
   void enableListeners() override;

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -44,7 +44,9 @@ public:
   void incNumConnections() override;
   void decNumConnections() override;
   void addListener(absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& config,
-                   Runtime::Loader& runtime) override;
+                   Runtime::Loader& runtime,
+                   OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                       new_addresses = absl::nullopt) override;
   void removeListeners(uint64_t listener_tag) override;
   void removeFilterChains(uint64_t listener_tag,
                           const std::list<const Network::FilterChain*>& filter_chains,

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -47,12 +47,15 @@ public:
                    Runtime::Loader& runtime,
                    OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
                        new_addresses = absl::nullopt) override;
-  void removeListeners(uint64_t listener_tag) override;
+  void removeListeners(uint64_t listener_tag,
+                       OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                           addresses = absl::nullopt) override;
   void removeFilterChains(uint64_t listener_tag,
                           const std::list<const Network::FilterChain*>& filter_chains,
                           std::function<void()> completion) override;
   void stopListeners(uint64_t listener_tag,
-                     OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses = absl::nullopt) override;
+                     OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses =
+                         absl::nullopt) override;
   void stopListeners() override;
   void disableListeners() override;
   void enableListeners() override;
@@ -131,6 +134,16 @@ private:
       }
       per_address_details->listener_tag_ = config.listenerTag();
       per_address_details_list_.emplace_back(per_address_details);
+    }
+
+    void removeActiveListener(const Network::Address::InstanceConstSharedPtr& listen_address) {
+      auto per_address_details_iter =
+          find_if(per_address_details_list_.begin(), per_address_details_list_.end(),
+                  [&listen_address](std::shared_ptr<PerAddressActiveListenerDetails>& details) {
+                    return *(details->listen_address_) == *listen_address;
+                  });
+      ASSERT(per_address_details_iter != per_address_details_list_.end());
+      per_address_details_list_.erase(per_address_details_iter);
     }
   };
 

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -348,8 +348,10 @@ public:
 
   // Check whether a new listener can share sockets with this listener.
   bool hasCompatibleAddress(const ListenerImpl& other) const;
-  // Check whether a new listener has duplicated listening address this listener.
-  bool hasDuplicatedAddress(const ListenerImpl& other) const;
+  // Check whether a new listener has duplicated listening address with this listener.
+  bool hasDuplicatedAddress(const ListenerImpl& other,
+                            OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                                addresses = absl::nullopt) const;
 
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *filter_chain_manager_; }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -238,7 +238,9 @@ private:
 
   bool doFinalPreWorkerListenerInit(ListenerImpl& listener);
   void addListenerToWorker(Worker& worker, absl::optional<uint64_t> overridden_listener,
-                           ListenerImpl& listener, ListenerCompletionCallback completion_callback);
+                           ListenerImpl& listener, ListenerCompletionCallback completion_callback,
+                           OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                               addresses = absl::nullopt);
 
   ProtobufTypes::MessagePtr dumpListenerConfigs(const Matchers::StringMatcher& name_matcher);
   static ListenerManagerStats generateStats(Stats::Scope& scope);

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -188,6 +188,7 @@ public:
 
   void onListenerWarmed(ListenerImpl& listener);
   void inPlaceFilterChainUpdate(ListenerImpl& listener);
+  void inAddressesOnlyUpdate(ListenerImpl& listener);
 
   // Server::ListenerManager
   bool addOrUpdateListener(const envoy::config::listener::v3::Listener& config,

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -242,8 +242,10 @@ private:
 
   ProtobufTypes::MessagePtr dumpListenerConfigs(const Matchers::StringMatcher& name_matcher);
   static ListenerManagerStats generateStats(Stats::Scope& scope);
-  static bool hasListenerWithDuplicatedAddress(const ListenerList& list,
-                                               const ListenerImpl& listener);
+  static bool hasListenerWithDuplicatedAddress(
+      const ListenerList& list, const ListenerImpl& listener,
+      OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses =
+          absl::nullopt);
   void updateWarmingActiveGauges() {
     // Using set() avoids a multiple modifiers problem during the multiple processes phase of hot
     // restart.
@@ -299,8 +301,13 @@ private:
    */
   ListenerList::iterator getListenerByName(ListenerList& listeners, const std::string& name);
 
-  void setNewOrDrainingSocketFactory(const std::string& name, ListenerImpl& listener);
-  void createListenSocketFactory(ListenerImpl& listener);
+  void setNewOrDrainingSocketFactory(
+      const std::string& name, ListenerImpl& listener,
+      OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses =
+          absl::nullopt);
+  void createListenSocketFactory(ListenerImpl& listener,
+                                 OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>
+                                     addresses = absl::nullopt);
 
   void maybeCloseSocketsForListener(ListenerImpl& listener);
 

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -42,11 +42,12 @@ WorkerImpl::WorkerImpl(ThreadLocal::Instance& tls, ListenerHooks& hooks,
       [this](OverloadActionState state) { resetStreamsUsingExcessiveMemory(state); });
 }
 
-void WorkerImpl::addListener(absl::optional<uint64_t> overridden_listener,
-                             Network::ListenerConfig& listener, AddListenerCompletion completion,
-                             Runtime::Loader& runtime) {
+void WorkerImpl::addListener(
+    absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& listener,
+    AddListenerCompletion completion, Runtime::Loader& runtime,
+    OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses) {
   dispatcher_->post([this, overridden_listener, &listener, &runtime, completion]() -> void {
-    handler_->addListener(overridden_listener, listener, runtime);
+    handler_->addListener(overridden_listener, listener, runtime, addresses);
     hooks_.onWorkerListenerAdded();
     completion();
   });

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -53,7 +53,9 @@ public:
 
   // Server::Worker
   void addListener(absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& listener,
-                   AddListenerCompletion completion, Runtime::Loader& loader) override;
+                   AddListenerCompletion completion, Runtime::Loader& loader,
+                   OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses =
+                       absl::nullopt) override;
   uint64_t numConnections() const override;
 
   void removeListener(Network::ListenerConfig& listener, std::function<void()> completion) override;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -757,6 +757,9 @@ private:
     const Network::Address::InstanceConstSharedPtr& localAddress() const override {
       return socket_->connectionInfoProvider().localAddress();
     }
+    const Network::Address::InstanceConstSharedPtr& listeningAddress() const override {
+      return socket_->connectionInfoProvider().localAddress();
+    }
     Network::SocketSharedPtr getListenSocket(uint32_t) override { return socket_; }
     Network::ListenSocketFactoryPtr clone() const override { return nullptr; }
     void closeAllSockets() override {}

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -490,7 +490,7 @@ public:
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));
-  MOCK_METHOD(void, stopListeners, (uint64_t listener_tag));
+  MOCK_METHOD(void, stopListeners, (uint64_t listener_tag, OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses));
   MOCK_METHOD(void, stopListeners, ());
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -486,11 +486,15 @@ public:
               (absl::optional<uint64_t> overridden_listener, ListenerConfig& config,
                Runtime::Loader& runtime,
                OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>));
-  MOCK_METHOD(void, removeListeners, (uint64_t listener_tag));
+  MOCK_METHOD(void, removeListeners,
+              (uint64_t listener_tag,
+               OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses));
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));
-  MOCK_METHOD(void, stopListeners, (uint64_t listener_tag, OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses));
+  MOCK_METHOD(void, stopListeners,
+              (uint64_t listener_tag,
+               OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses));
   MOCK_METHOD(void, stopListeners, ());
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -393,6 +393,7 @@ public:
 
   MOCK_METHOD(Network::Socket::Type, socketType, (), (const));
   MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, localAddress, (), (const));
+  MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, listeningAddress, (), (const));
   MOCK_METHOD(Network::SocketSharedPtr, getListenSocket, (uint32_t));
   MOCK_METHOD(bool, reusePort, (), (const));
   MOCK_METHOD(Network::ListenSocketFactoryPtr, clone, (), (const));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -484,7 +484,8 @@ public:
   MOCK_METHOD(void, decNumConnections, ());
   MOCK_METHOD(void, addListener,
               (absl::optional<uint64_t> overridden_listener, ListenerConfig& config,
-               Runtime::Loader& runtime));
+               Runtime::Loader& runtime,
+               OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>));
   MOCK_METHOD(void, removeListeners, (uint64_t listener_tag));
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,

--- a/test/mocks/server/worker.cc
+++ b/test/mocks/server/worker.cc
@@ -12,15 +12,16 @@ using ::testing::_;
 using ::testing::Invoke;
 
 MockWorker::MockWorker() {
-  ON_CALL(*this, addListener(_, _, _, _))
-      .WillByDefault(Invoke([this](absl::optional<uint64_t> overridden_listener,
-                                   Network::ListenerConfig& config,
-                                   AddListenerCompletion completion, Runtime::Loader&) -> void {
-        UNREFERENCED_PARAMETER(overridden_listener);
-        config.listenSocketFactories()[0]->getListenSocket(0);
-        EXPECT_EQ(nullptr, add_listener_completion_);
-        add_listener_completion_ = completion;
-      }));
+  ON_CALL(*this, addListener(_, _, _, _, _))
+      .WillByDefault(Invoke(
+          [this](absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& config,
+                 AddListenerCompletion completion, Runtime::Loader&,
+                 OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>) -> void {
+            UNREFERENCED_PARAMETER(overridden_listener);
+            config.listenSocketFactories()[0]->getListenSocket(0);
+            EXPECT_EQ(nullptr, add_listener_completion_);
+            add_listener_completion_ = completion;
+          }));
 
   ON_CALL(*this, removeListener(_, _))
       .WillByDefault(

--- a/test/mocks/server/worker.h
+++ b/test/mocks/server/worker.h
@@ -33,7 +33,8 @@ public:
   // Server::Worker
   MOCK_METHOD(void, addListener,
               (absl::optional<uint64_t> overridden_listener, Network::ListenerConfig& listener,
-               AddListenerCompletion completion, Runtime::Loader&));
+               AddListenerCompletion completion, Runtime::Loader&,
+               OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>> addresses));
   MOCK_METHOD(uint64_t, numConnections, (), (const));
   MOCK_METHOD(void, removeListener,
               (Network::ListenerConfig & listener, std::function<void()> completion));

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -306,9 +306,13 @@ public:
     if (address == nullptr) {
       EXPECT_CALL(listeners_.back()->socketFactory(), localAddress())
           .WillRepeatedly(ReturnRef(local_address_));
+      EXPECT_CALL(listeners_.back()->socketFactory(), listeningAddress())
+          .WillRepeatedly(ReturnRef(local_address_));
       listeners_.back()->sockets_[0]->connection_info_provider_->setLocalAddress(local_address_);
     } else {
       EXPECT_CALL(listeners_.back()->socketFactory(), localAddress())
+          .WillRepeatedly(ReturnRefOfCopy(address));
+      EXPECT_CALL(listeners_.back()->socketFactory(), listeningAddress())
           .WillRepeatedly(ReturnRefOfCopy(address));
       listeners_.back()->sockets_[0]->connection_info_provider_->setLocalAddress(address);
     }
@@ -377,6 +381,8 @@ public:
     for (std::vector<Network::Listener*>::size_type i = 0; i < mock_listeners.size(); i++) {
       EXPECT_CALL(listeners_.back()->socketFactory(i), socketType()).WillOnce(Return(socket_type));
       EXPECT_CALL(listeners_.back()->socketFactory(i), localAddress())
+          .WillRepeatedly(ReturnRef(addresses[i]));
+      EXPECT_CALL(listeners_.back()->socketFactory(i), listeningAddress())
           .WillRepeatedly(ReturnRef(addresses[i]));
       EXPECT_CALL(listeners_.back()->socketFactory(i), getListenSocket(_))
           .WillOnce(Return(listeners_.back()->sockets_[i]));

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -374,8 +374,8 @@ public:
     TestMultiAddressesListener* test_listener_raw_ptr = test_listener.get();
     listeners_.emplace_back(std::move(test_listener));
 
-    EXPECT_CALL(listeners_.back()->socketFactory(0), socketType()).WillOnce(Return(socket_type));
     for (std::vector<Network::Listener*>::size_type i = 0; i < mock_listeners.size(); i++) {
+      EXPECT_CALL(listeners_.back()->socketFactory(i), socketType()).WillOnce(Return(socket_type));
       EXPECT_CALL(listeners_.back()->socketFactory(i), localAddress())
           .WillRepeatedly(ReturnRef(addresses[i]));
       EXPECT_CALL(listeners_.back()->socketFactory(i), getListenSocket(_))

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -129,7 +129,7 @@ public:
   void expectAddListener(const envoy::config::listener::v3::Listener& listener_proto,
                          ListenerHandle*) {
     EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    EXPECT_CALL(*worker_, addListener(_, _, _, _));
+    EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
     addOrUpdateListener(listener_proto);
     worker_->callAddCompletion();
     EXPECT_EQ(1UL, manager_->listeners().size());
@@ -150,7 +150,7 @@ public:
       new_socket = listener_factory_.socket_.get();
       EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, bind_type, _, 0));
     }
-    EXPECT_CALL(*worker_, addListener(_, _, _, _));
+    EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
     EXPECT_CALL(*worker_, stopListener(_, _));
     EXPECT_CALL(*old_listener_handle->drain_manager_, startDrainSequence(_));
 
@@ -498,7 +498,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, UdpAddress) {
   EXPECT_TRUE(Protobuf::TextFormat::ParseFromString(proto_text, &listener_proto));
 
   EXPECT_CALL(server_.api_.random_, uuid());
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(listener_factory_,
               createListenSocket(_, Network::Socket::Type::Datagram, _,
                                  ListenerComponentFactory::BindType::ReusePort, _, 0))
@@ -1144,7 +1144,7 @@ dynamic_listeners:
         nanos: 2000000
 )EOF");
 
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, start(_, _));
   manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
   worker_->callAddCompletion();
@@ -1256,7 +1256,7 @@ dynamic_listeners:
         nanos: 4000000
 )EOF");
 
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_baz_different_address->target_.ready();
   worker_->callAddCompletion();
 
@@ -1534,9 +1534,11 @@ filter_chains: {}
 
   // Start workers and capture ListenerImpl.
   Network::ListenerConfig* listener_config = nullptr;
-  EXPECT_CALL(*worker_, addListener(_, _, _, _))
-      .WillOnce(Invoke([&listener_config](auto, Network::ListenerConfig& config, auto,
-                                          Runtime::Loader&) -> void { listener_config = &config; }))
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _))
+      .WillOnce(Invoke(
+          [&listener_config](auto, Network::ListenerConfig& config, auto, Runtime::Loader&,
+                             OptRef<const std::vector<Network::Address::InstanceConstSharedPtr>>)
+              -> void { listener_config = &config; }))
       .RetiresOnSaturation();
 
   EXPECT_CALL(*worker_, start(_, _));
@@ -1560,7 +1562,7 @@ filter_chains:
 
   ListenerHandle* listener_foo_update1 = expectListenerOverridden(false);
   EXPECT_CALL(*listener_factory_.socket_, duplicate());
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   auto* timer = new Event::MockTimer(dynamic_cast<Event::MockDispatcher*>(&server_.dispatcher()));
   EXPECT_CALL(*timer, enableTimer(_, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_update1_yaml)));
@@ -1697,7 +1699,7 @@ dynamic_listeners:
                    .value());
 
   // Start workers.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, start(_, _));
   manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
   // Validate that workers_started stat is still zero before workers set the status via
@@ -1723,7 +1725,7 @@ dynamic_listeners:
   // removal.
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
   EXPECT_CALL(*duplicated_socket, duplicate());
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, stopListener(_, _));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "version3", true));
@@ -1793,7 +1795,7 @@ filter_chains: {}
 
   ListenerHandle* listener_bar = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml), "version4", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -1901,7 +1903,7 @@ filter_chains:
   checkStats(__LINE__, 3, 3, 0, 1, 2, 0, 0);
 
   // Finish initialization for baz which should make it active.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_baz_update1->target_.ready();
   EXPECT_EQ(3UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -1934,7 +1936,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2000,7 +2002,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2068,7 +2070,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2132,7 +2134,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -2155,7 +2157,7 @@ filter_chains:
   // Add foo again.
   ListenerHandle* listener_foo2 = expectListenerCreate(false, true);
   EXPECT_CALL(*listener_factory_.socket_, duplicate());
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 2, 0, 1, 0, 1, 1, 0);
@@ -2193,7 +2195,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -2216,7 +2218,7 @@ filter_chains:
   // Add foo again.
   ListenerHandle* listener_foo2 = expectListenerCreate(false, true);
   EXPECT_CALL(*listener_factory_.socket_, duplicate()).Times(2);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 2, 0, 1, 0, 1, 1, 0);
@@ -2253,7 +2255,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -2271,7 +2273,7 @@ filter_chains:
   // Add foo again. We should use the socket from draining.
   ListenerHandle* listener_foo2 = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 2, 0, 1, 0, 1, 1, 0);
@@ -2307,7 +2309,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -2324,7 +2326,7 @@ filter_chains:
 
   ListenerHandle* listener_foo2 = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 2, 0, 1, 0, 1, 1, 0);
@@ -2411,7 +2413,7 @@ filter_chains:
             return real_listener_factory.createListenSocket(
                 address, socket_type, options, bind_type, creation_options, worker_index);
           }));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
 
   worker_->callAddCompletion();
@@ -2673,7 +2675,7 @@ filter_chains:
 
   ListenerHandle* listener_foo = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
@@ -2744,7 +2746,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 2, 0, 1, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2811,7 +2813,7 @@ filter_chains:
   auto foo_inbound_proto = parseListenerFromV3Yaml(listener_foo_yaml);
   EXPECT_TRUE(addOrUpdateListener(foo_inbound_proto));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2833,7 +2835,7 @@ filter_chains:
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
   EXPECT_CALL(listener_foo_outbound->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_outbound_yaml)));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo_outbound->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(2UL, manager_->listeners().size());
@@ -2858,7 +2860,7 @@ filter_chains:
 
   ListenerHandle* listener_bar_outbound = expectListenerCreate(false, true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_outbound_yaml)));
   EXPECT_EQ(3UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -2912,7 +2914,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -2961,7 +2963,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -3071,7 +3073,7 @@ filter_chains:
       "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
   // Move foo to active and then try to add again. This should still fail.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
 
@@ -6255,7 +6257,7 @@ per_connection_buffer_limit_bytes: 10
                    .value());
 
   // Start workers.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, start(_, _));
   manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
   // Validate that workers_started stat is still zero before workers set the status via
@@ -6280,7 +6282,7 @@ per_connection_buffer_limit_bytes: 10
   // Update foo. Should go into warming, have an immediate warming callback, and start immediate
   // removal.
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*worker_, stopListener(_, _));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "version3", true));
@@ -6338,7 +6340,7 @@ per_connection_buffer_limit_bytes: 10
     )EOF";
 
   ListenerHandle* listener_bar = expectListenerCreate(false, true);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml), "version4", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -6431,7 +6433,7 @@ per_connection_buffer_limit_bytes: 10
   checkStats(__LINE__, 3, 3, 0, 1, 2, 0, 0);
 
   // Finish initialization for baz which should make it active.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_baz_update1->target_.ready();
   EXPECT_EQ(3UL, manager_->listeners().size());
   worker_->callAddCompletion();
@@ -6467,7 +6469,7 @@ filter_chains:
   EXPECT_EQ(0, server_.stats_store_.counter("listener_manager.listener_in_place_updated").value());
 
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6529,7 +6531,7 @@ filter_chains:
   EXPECT_EQ(0, server_.stats_store_.counter("listener_manager.listener_in_place_updated").value());
 
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6598,7 +6600,7 @@ filter_chains:
   EXPECT_EQ(0, server_.stats_store_.counter("listener_manager.listener_in_place_updated").value());
 
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6627,7 +6629,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // Listener warmed up.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(*listener_foo, onDestroy());
   listener_foo_update1->target_.ready();
   worker_->callAddCompletion();
@@ -6659,7 +6661,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6689,7 +6691,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
@@ -6745,7 +6747,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6773,7 +6775,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
@@ -6815,7 +6817,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6843,7 +6845,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
@@ -6914,7 +6916,7 @@ filter_chains:
   EXPECT_CALL(listener_foo->target_, initialize());
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   listener_foo->target_.ready();
   worker_->callAddCompletion();
   EXPECT_EQ(1UL, manager_->listeners().size());
@@ -6947,7 +6949,7 @@ filter_chains:
   checkStats(__LINE__, 1, 1, 0, 1, 1, 0, 0);
 
   // The warmed up starts the drain timer.
-  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
   EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));


### PR DESCRIPTION
Commit Message: listener: enable to add/remove addresses without draining the whole listener.
Additional Description:
Risk Level: high
Testing: TODO
Docs Changes: TODO
Release Notes: TODO
Platform Specific Features: n/a
Fixes #23431
