### PR TITLE
Use a named struct instead of a pair in key_value_store_base.h

### DIFF
--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -41,7 +41,8 @@ public:
 protected:
   // Values in a KeyValueStore have an optional TTL.
   struct ValueWithTtl {
-    ValueWithTtl(std::string value, absl::optional<std::chrono::seconds> ttl) : value_(value), ttl_(ttl) {}
+    ValueWithTtl(std::string value, absl::optional<std::chrono::seconds> ttl)
+        : value_(value), ttl_(ttl) {}
     std::string value_;
     absl::optional<std::chrono::seconds> ttl_;
   };

--- a/source/common/common/key_value_store_base.h
+++ b/source/common/common/key_value_store_base.h
@@ -39,13 +39,22 @@ public:
   void iterate(ConstIterateCb cb) const override;
 
 protected:
+  // Values in a KeyValueStore have an optional TTL.
+  struct ValueWithTtl {
+    ValueWithTtl(std::string value, absl::optional<std::chrono::seconds> ttl) : value_(value), ttl_(ttl) {}
+    std::string value_;
+    absl::optional<std::chrono::seconds> ttl_;
+  };
+
+  using KeyValueMap = quiche::QuicheLinkedHashMap<std::string, ValueWithTtl>;
+
+  const KeyValueMap& store() { return store_; }
+
+private:
   const uint32_t max_entries_;
   const Event::TimerPtr flush_timer_;
   Config::TtlManager ttl_manager_;
-  // Pair.first is the value and pair.second is an optional TTL
-  quiche::QuicheLinkedHashMap<std::string,
-                              std::pair<std::string, absl::optional<std::chrono::seconds>>>
-      store_;
+  KeyValueMap store_;
   // Used for validation only.
   mutable bool under_iterate_{};
   TimeSource& time_source_;

--- a/source/extensions/key_value/file_based/config.cc
+++ b/source/extensions/key_value/file_based/config.cc
@@ -31,13 +31,13 @@ void FileBasedKeyValueStore::flush() {
     ENVOY_LOG(error, "Failed to flush cache to file {}", filename_);
     return;
   }
-  for (const auto& it : store_) {
-    file->write(absl::StrCat(it.first.length(), "\n"));
-    file->write(it.first);
-    file->write(absl::StrCat(it.second.first.length(), "\n"));
-    file->write(it.second.first);
-    if (it.second.second.has_value()) {
-      std::string ttl = std::to_string(it.second.second.value().count());
+  for (const auto& [key, value_with_ttl] : store()) {
+    file->write(absl::StrCat(key.length(), "\n"));
+    file->write(key);
+    file->write(absl::StrCat(value_with_ttl.value_.length(), "\n"));
+    file->write(value_with_ttl.value_);
+    if (value_with_ttl.ttl_.has_value()) {
+      std::string ttl = std::to_string(value_with_ttl.ttl_.value().count());
       file->write(KV_STORE_TTL_KEY);
       file->write(absl::StrCat(ttl.length(), "\n"));
       file->write(ttl);


### PR DESCRIPTION
std::pair tends to result in fairly unreadable code so use a named struct instead.

Also make members private instead of public as per the style guide.

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A