### PR TITLE
thrift_proxy: decode passthrough data by protocol parsing only for payload_to_metadata filter

### DIFF
--- a/docs/root/configuration/other_protocols/thrift_filters/payload_to_metadata_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/payload_to_metadata_filter.rst
@@ -62,7 +62,7 @@ This filter is designed to support payload passthrough. Performing payload to me
 can do deserialization once, and pass the metadata to other filters. This means that load balancing
 decisions, consumed from log and routing could all use payload information with a single parse.
 Also notably performing the parsing in payload passthrough buffer will mean deserialization once
-and not re-serializing, which is the most performant outcome. Currently there is an redundant buffer
+and not re-serializing, which is the most performant outcome. Currently there is a redundant buffer
 copy until we have `BufferView <https://github.com/envoyproxy/envoy/issues/23901>`_.
 
 If any of the filter chain doesn't support payload passthrough, a customized non-passthrough

--- a/docs/root/configuration/other_protocols/thrift_filters/payload_to_metadata_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/payload_to_metadata_filter.rst
@@ -62,7 +62,8 @@ This filter is designed to support payload passthrough. Performing payload to me
 can do deserialization once, and pass the metadata to other filters. This means that load balancing
 decisions, consumed from log and routing could all use payload information with a single parse.
 Also notably performing the parsing in payload passthrough buffer will mean deserialization once
-and not re-serializing, which is the most performant outcome.
+and not re-serializing, which is the most performant outcome. Currently there is an redundant buffer
+copy until we have `BufferView <https://github.com/envoyproxy/envoy/issues/23901>`_.
 
 If any of the filter chain doesn't support payload passthrough, a customized non-passthrough
 filter to setup metadata is encouraged from point of performance view.

--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -412,6 +412,15 @@ ProtocolState DecoderStateMachine::run(Buffer::Instance& buffer) {
   return state_;
 }
 
+void DecoderStateMachine::runPassthroughData(Buffer::Instance& buffer) {
+  handler_.messageBegin(metadata_);
+  setCurrentState(ProtocolState::StructBegin);
+  stack_.clear();
+  stack_.emplace_back(Frame(ProtocolState::MessageEnd));
+  ProtocolState done = run(buffer);
+  ASSERT(done == ProtocolState::Done);
+}
+
 Decoder::Decoder(Transport& transport, Protocol& protocol, DecoderCallbacks& callbacks)
     : transport_(transport), protocol_(protocol), callbacks_(callbacks) {}
 

--- a/source/extensions/filters/network/thrift_proxy/decoder.h
+++ b/source/extensions/filters/network/thrift_proxy/decoder.h
@@ -88,7 +88,14 @@ public:
   ProtocolState currentState() const { return state_; }
 
   /**
-   * Set the current state. Used for testing only.
+   * Consumes whole passthrough data without the body start.
+   * @param buffer a buffer containing whole passthrough data
+   * @throw Envoy Exception if thrown by the underlying Protocol
+   */
+  void runPassthroughData(Buffer::Instance& buffer);
+
+  /**
+   * Set the current state. Used for testing and decoder internal only.
    */
   void setCurrentState(ProtocolState state) { state_ = state; }
 

--- a/source/extensions/filters/network/thrift_proxy/decoder.h
+++ b/source/extensions/filters/network/thrift_proxy/decoder.h
@@ -88,7 +88,7 @@ public:
   ProtocolState currentState() const { return state_; }
 
   /**
-   * Consumes whole passthrough data without the body start.
+   * Consumes whole passthrough data without the message start portion.
    * @param buffer a buffer containing whole passthrough data
    * @throw Envoy Exception if thrown by the underlying Protocol
    */

--- a/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h
@@ -142,8 +142,6 @@ private:
   uint16_t steps_{0};
 };
 
-using TrieMatchHandlerPtr = std::unique_ptr<TrieMatchHandler>;
-
 const uint32_t MAX_PAYLOAD_VALUE_LEN = 8 * 1024;
 
 class PayloadToMetadataFilter : public MetadataHandler,
@@ -178,11 +176,8 @@ private:
 
   const ConfigSharedPtr config_;
   absl::flat_hash_set<uint16_t> matched_rule_ids_;
-  TrieMatchHandlerPtr handler_;
-  TransportPtr transport_;
-  ProtocolPtr protocol_;
-  DecoderPtr decoder_;
   StructMap structs_by_namespace_;
+  MessageMetadataSharedPtr metadata_;
 };
 
 } // namespace PayloadToMetadataFilter

--- a/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter_test.cc
@@ -1,6 +1,5 @@
 #include <string>
 
-#include "source/common/common/base64.h"
 #include "source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h"
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
@@ -42,7 +41,9 @@ MATCHER_P(MapEqNum, rhs, "") {
 
 using namespace Envoy::Extensions::NetworkFilters;
 
-class PayloadToMetadataTest : public testing::Test {
+class PayloadToMetadataTest : public testing::Test,
+                              public DecoderCallbacks,
+                              public PassThroughDecoderEventHandler {
 public:
   void initializeFilter(const std::string& yaml, bool expect_type_inquiry = true) {
     envoy::extensions::filters::network::thrift_proxy::filters::payload_to_metadata::v3::
@@ -52,12 +53,26 @@ public:
     filter_ = std::make_shared<PayloadToMetadataFilter>(filter_config);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     if (expect_type_inquiry) {
-      EXPECT_CALL(decoder_callbacks_, downstreamTransportType()).WillOnce(Return(transport_));
       EXPECT_CALL(decoder_callbacks_, downstreamProtocolType()).WillOnce(Return(protocol_));
     } else {
-      EXPECT_CALL(decoder_callbacks_, downstreamTransportType()).Times(0);
       EXPECT_CALL(decoder_callbacks_, downstreamProtocolType()).Times(0);
     }
+  }
+
+  // DecoderCallbacks
+  DecoderEventHandler& newDecoderEventHandler() override { return *this; }
+  bool passthroughEnabled() const override { return true; }
+  bool isRequest() const override { return false; }
+  bool headerKeysPreserveCase() const override { return false; }
+
+  // PassThroughDecoderEventHandler
+  FilterStatus passthroughData(Buffer::Instance& data) override {
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+    return ThriftProxy::FilterStatus::Continue;
+  }
+  FilterStatus messageBegin(MessageMetadataSharedPtr metadata) override {
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
+    return ThriftProxy::FilterStatus::Continue;
   }
 
   // Request payload
@@ -75,8 +90,12 @@ public:
   //     f10: set
   //   }
   // }
-  void writeMessage(MessageMetadata& metadata, Buffer::Instance& buffer,
-                    std::string string_value = "two") {
+  void writeMessage(std::string string_value = "two") {
+    Buffer::OwnedImpl buffer;
+    auto metadata_ptr =
+        std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
+    auto& metadata = *metadata_ptr;
+
     Buffer::OwnedImpl msg;
     ProtocolPtr proto = NamedProtocolConfigFactory::getFactory(protocol_).createProtocol();
     metadata.setProtocol(protocol_);
@@ -154,6 +173,14 @@ public:
 
     TransportPtr transport = NamedTransportConfigFactory::getFactory(transport_).createTransport();
     transport->encodeFrame(buffer, metadata, msg);
+
+    // Simulate the decoder events. Check PassThroughDecoderEventHandler.
+    ProtocolPtr decoder_proto = NamedProtocolConfigFactory::getFactory(protocol_).createProtocol();
+    TransportPtr decoder_transport =
+        NamedTransportConfigFactory::getFactory(transport_).createTransport();
+    DecoderPtr decoder = std::make_unique<Decoder>(*decoder_transport, *decoder_proto, *this);
+    bool underflow = false;
+    decoder->onData(buffer, underflow);
   }
 
   NiceMock<ThriftProxy::ThriftFilters::MockDecoderFilterCallbacks> decoder_callbacks_;
@@ -185,11 +212,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -218,11 +241,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -248,11 +267,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -281,11 +296,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -314,11 +325,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -347,11 +354,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -380,11 +383,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -413,11 +412,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -446,11 +441,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -476,11 +467,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -504,11 +491,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -531,11 +514,7 @@ request_rules:
               setDynamicMetadata("envoy.filters.thrift.payload_to_metadata", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -562,11 +541,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -597,11 +572,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -633,11 +604,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data, value);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -669,11 +636,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data, value);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -696,16 +659,13 @@ request_rules:
 )EOF";
 
   std::map<std::string, int> expected = {{"number", 1}};
+  const std::string value = "1";
 
   initializeFilter(request_config_yaml);
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEqNum(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data, "1");
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -726,15 +686,13 @@ request_rules:
       key: missing
       value: unknown
 )EOF";
+
+  const std::string value = "invalid";
   initializeFilter(request_config_yaml);
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data, "invalid");
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -753,16 +711,13 @@ request_rules:
 )EOF";
 
   std::map<std::string, int> expected = {{"number", 1}};
+  const std::string value = "1";
 
   initializeFilter(request_config_yaml);
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEqNum(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data, "1");
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -786,16 +741,13 @@ request_rules:
 )EOF";
 
   std::map<std::string, int> expected = {{"number", 911}};
+  const std::string value = "1";
 
   initializeFilter(request_config_yaml);
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEqNum(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data, "1");
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -821,11 +773,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -854,11 +802,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -890,11 +834,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -920,11 +860,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -953,11 +889,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -986,11 +918,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -1011,11 +939,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -1036,11 +960,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -1064,13 +984,10 @@ request_rules:
   initializeFilter(request_config_yaml);
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
-
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
   // empty payload on the field
-  writeMessage(*metadata, data, "");
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  const std::string value = "";
+
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -1095,13 +1012,10 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-
   auto length = MAX_PAYLOAD_VALUE_LEN + 1;
-  writeMessage(*metadata, data, std::string(length, 'x'));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  const std::string value = std::string(length, 'x');
+
+  writeMessage(std::move(value));;
   filter_->onDestroy();
 }
 
@@ -1151,11 +1065,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 
@@ -1212,11 +1122,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  Buffer::OwnedImpl data;
-  auto metadata = std::make_shared<Extensions::NetworkFilters::ThriftProxy::MessageMetadata>();
-  writeMessage(*metadata, data);
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(metadata));
-  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->passthroughData(data));
+  writeMessage();
   filter_->onDestroy();
 }
 

--- a/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter_test.cc
@@ -604,7 +604,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -636,7 +636,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -665,7 +665,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEqNum(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -692,7 +692,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -717,7 +717,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEqNum(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -747,7 +747,7 @@ request_rules:
   EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEqNum(expected)));
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -987,7 +987,7 @@ request_rules:
   // empty payload on the field
   const std::string value = "";
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 
@@ -1015,7 +1015,7 @@ request_rules:
   auto length = MAX_PAYLOAD_VALUE_LEN + 1;
   const std::string value = std::string(length, 'x');
 
-  writeMessage(std::move(value));;
+  writeMessage(std::move(value));
   filter_->onDestroy();
 }
 


### PR DESCRIPTION
…yload_to_metadata filter

Signed-off-by: kuochunghsu <kuochunghsu@pinterest.com>

Commit Message:
This PR fixes two issues:
(a) the decoder actually `drain` the buffer so the router couldn't get the data to send.
we copy to buffer to parse for now as we're waiting for https://github.com/envoyproxy/envoy/issues/23901

(b) passthrough data is not the whole thrift request, 
therefore we introduce `DecoderStateMachine::runPassthroughData` to decode the protocol part only.

Additional Description:
Risk Level: low
Testing: unit test
Docs Changes: filter rst