### PR TITLE
http2: Use uncheckedGetStream.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1419,7 +1419,7 @@ Status ConnectionImpl::onStreamClose(StreamImpl* stream, uint32_t error_code) {
 }
 
 Status ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
-  return onStreamClose(getStream(stream_id), error_code);
+  return onStreamClose(getStreamUnchecked(stream_id), error_code);
 }
 
 int ConnectionImpl::onMetadataReceived(int32_t stream_id, const uint8_t* data, size_t len) {


### PR DESCRIPTION
Commit Message: http2: Use uncheckedGetStream.
Additional Description:
Use uncheckedGetStream() in a location where a null-stream is pretty fine due to null checks further on.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
