### PR TITLE
Enable envoy.reloadable_features.http1_use_balsa_parser

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,6 +5,10 @@ behavior_changes:
 - area: build
   change: |
     moved the strict_dns, original_dst, and logical_dns clusters to extensions. If you use these clusters and override extensions_build_config.bzl you will now need to include it explicitly.
+    moved the original_dst cluster to extensions. If you use this cluster and override extensions_build_config.bzl you will now need to include it explicitly.
+- area: http
+  change: |
+    Flip default value of ``envoy.reloadable_features.http1_use_balsa_parser`` runtime flag from false to true.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -143,7 +143,12 @@ ParserStatus BalsaParser::getStatus() const { return status_; }
 uint16_t BalsaParser::statusCode() const { return headers_.parsed_response_code(); }
 
 bool BalsaParser::isHttp11() const {
-  return absl::EndsWith(headers_.first_line(), Http::Headers::get().ProtocolStrings.Http11String);
+  if (framer_.is_request()) {
+    return absl::EndsWith(headers_.first_line(), Http::Headers::get().ProtocolStrings.Http11String);
+  } else {
+    return absl::StartsWith(headers_.first_line(),
+                            Http::Headers::get().ProtocolStrings.Http11String);
+  }
 }
 
 absl::optional<uint64_t> BalsaParser::contentLength() const {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -45,6 +45,7 @@ RUNTIME_GUARD(envoy_reloadable_features_do_not_count_mapped_pages_as_free);
 RUNTIME_GUARD(envoy_reloadable_features_enable_compression_bomb_protection);
 RUNTIME_GUARD(envoy_reloadable_features_fix_hash_key);
 RUNTIME_GUARD(envoy_reloadable_features_get_route_config_factory_by_type);
+RUNTIME_GUARD(envoy_reloadable_features_http1_use_balsa_parser);
 RUNTIME_GUARD(envoy_reloadable_features_http2_delay_keepalive_timeout);
 RUNTIME_GUARD(envoy_reloadable_features_http3_sends_early_data);
 RUNTIME_GUARD(envoy_reloadable_features_http_reject_path_with_fragment);
@@ -84,8 +85,6 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_defer_processing_backedup_streams)
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_thrift_connection_draining);
 // TODO(birenroy) flip after a burn-in period
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
-// TODO(bencebeky): Finish BalsaParser implementation, then enable by default. See issue #21245.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_http1_use_balsa_parser);
 // Used to track if runtime is initialized.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 // TODO(mattklein123): Flip this to true and/or remove completely once verified by Envoy Mobile.

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -904,10 +904,6 @@ TEST_P(Http1ServerConnectionImplTest, Http10MultipleResponses) {
 
   // Now send an HTTP/1.1 request and make sure the protocol is tracked correctly.
   {
-    TestRequestHeaderMapImpl expected_headers{{":authority", "www.somewhere.com"},
-                                              {":scheme", "http"},
-                                              {":path", "/foobar"},
-                                              {":method", "GET"}};
     Buffer::OwnedImpl buffer("GET /foobar HTTP/1.1\r\nHost: www.somewhere.com\r\n\r\n");
 
     Http::ResponseEncoder* response_encoder = nullptr;
@@ -1141,6 +1137,7 @@ TEST_P(Http1ServerConnectionImplTest, SimpleGet) {
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0U, buffer.length());
+  EXPECT_EQ(Protocol::Http11, codec_->protocol());
 }
 
 // Test that if the stream is not created at the time an error is detected, it
@@ -1550,6 +1547,7 @@ TEST_P(Http1ServerConnectionImplTest, HeaderOnlyResponse) {
   TestResponseHeaderMapImpl headers{{":status", "200"}};
   response_encoder->encodeHeaders(headers, true);
   EXPECT_EQ("HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", output);
+  EXPECT_EQ(Protocol::Http11, codec_->protocol());
 }
 
 // As with Http1ClientConnectionImplTest.LargeHeaderRequestEncode but validate
@@ -3763,6 +3761,26 @@ TEST_P(Http1ServerConnectionImplTest, ParseUrl) {
     EXPECT_TRUE(isCodecProtocolError(status)) << invalid_first_line;
     EXPECT_EQ("http/1.1 protocol error: HPE_INVALID_URL", status.message());
     EXPECT_EQ("http1.codec_error", response_encoder->getStream().responseDetails());
+  }
+}
+
+// The client's HTTP parser does not have access to the request.
+// Test that it determines the HTTP version based on the response correctly.
+TEST_P(Http1ClientConnectionImplTest, ResponseHttpVersion) {
+  for (Protocol http_version : {Protocol::Http10, Protocol::Http11}) {
+    initialize();
+    NiceMock<MockResponseDecoder> response_decoder;
+    Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+    TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+    EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+    EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
+    Buffer::OwnedImpl response(http_version == Protocol::Http10
+                                   ? "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"
+                                   : "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+    auto status = codec_->dispatch(response);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(http_version, codec_->protocol());
   }
 }
 


### PR DESCRIPTION
DO NOT CHECK IN

Default-enable BalsaParser flag to see what presubmit test fails.

Includes #23915 (GitHub does not support dependent PRs).

Signed-off-by: Bence Béky [bnc@google.com](mailto:bnc@google.com)