### PR TITLE
Expand comment on `ExternalProcessor.mutation_rules`

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -157,6 +157,11 @@ message ExternalProcessor {
   // with the header prefix set via
   // :ref:`header_prefix <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.header_prefix>`
   // (which is usually "x-envoy").
+  // Note that changing headers such as "host" or ":authority" may not in itself
+  // change Envoy's routing decision, as routes can be cached. To also force the
+  // route to be recomputed, set the
+  // :ref:`clear_route_cache <envoy_v3_api_field_service.ext_proc.v3.CommonResponse.clear_route_cache>`
+  // field to true in the same response.
   config.common.mutation_rules.v3.HeaderMutationRules mutation_rules = 9;
 }
 


### PR DESCRIPTION
This is a comments-changes-only PR.

The `ExternalProcessor` has a `mutation_rules` field, whose purpose is to let users modify otherwise-restricted headers, such as `"host"` and `":authority"`. Odds are that users who are modifying such headers are trying to influence the routing decisions that Envoy makes, such as was the case in https://github.com/envoyproxy/envoy/issues/23919.

However, setting only `"host"` or `":authority"` is not sufficient to change such routing decisions; users must also set a `clear_route_cache` field.

This PR aims to make it harder to overlook the `clear_route_cache` field, like I did in https://github.com/envoyproxy/envoy/issues/23919, by improving the comments on the `mutation_rules` field.