### PR TITLE
jwt_authn: add a fuzz test for http filter jwt_authn

### DIFF
--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -196,6 +196,7 @@ MatcherConstPtr Matcher::create(const RequirementRule& rule) {
     return std::make_unique<PathSeparatedPrefixMatcherImpl>(rule);
   case RouteMatch::PathSpecifierCase::kPathMatchPolicy:
     // TODO(silverstar194): Implement matcher for template based match
+    throw EnvoyException("RouteMatch: path_match_policy is not supported");
     break;
   case RouteMatch::PathSpecifierCase::PATH_SPECIFIER_NOT_SET:
     break; // Fall through to PANIC.

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -1,8 +1,10 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_fuzz_test",
     "envoy_cc_library",
     "envoy_cc_mock",
     "envoy_package",
+    "envoy_proto_library",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -196,6 +198,33 @@ envoy_extension_cc_test(
         ":test_common_lib",
         "//source/extensions/filters/http/jwt_authn:filter_config_lib",
         "//source/extensions/filters/http/jwt_authn:matchers_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_proto_library(
+    name = "jwt_authn_fuzz_proto",
+    srcs = ["jwt_authn_fuzz.proto"],
+    deps = [
+        "//test/fuzz:common_proto",
+        "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg",
+    ],
+)
+
+envoy_cc_fuzz_test(
+    name = "jwt_authn_fuzz_test",
+    srcs = ["jwt_authn_fuzz_test.cc"],
+    corpus = "jwt_authn_corpus",
+    deps = [
+        ":jwt_authn_fuzz_proto_cc_proto",
+        "//source/common/common:regex_lib",
+        "//source/common/router:string_accessor_lib",
+        "//source/extensions/filters/http/jwt_authn:filter_lib",
+        "//test/extensions/filters/http/common:mock_lib",
+        "//test/extensions/filters/http/common/fuzz:http_filter_fuzzer_lib",
+        "//test/fuzz:utility_lib",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/allow_missing_remote_jwks.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/allow_missing_remote_jwks.txtpb
@@ -1,0 +1,45 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# use local_jwks
+# extract jwt from auth header
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      audiences: ["example_service"]
+      remote_jwks {
+        http_uri {
+          uri: "https://pubkey_server/pubkey_path"
+          cluster: "pubkey_cluster"
+          timeout {
+            seconds: 5
+          }
+        }
+      }
+    }
+  }
+  rules {
+    match {
+      prefix: "/"
+    }
+    requires {
+      allow_missing {}
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "authorization"
+      value: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+    headers {
+      key: ":path"
+      value: "/foo/bar"
+    }
+  }
+}
+remote_jwks: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/cors_bypass.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/cors_bypass.txtpb
@@ -1,0 +1,28 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# bypass_cors_preflight
+config {
+  bypass_cors_preflight: true
+}
+request_data {
+  headers {
+    headers {
+      key: "access-control-request-method"
+      value: "GET,POST"
+    }
+    headers {
+      key: ":path"
+      value: "/foo/bar"
+    }
+    headers {
+      key: "origin"
+      value: "abc.com"
+    }
+    headers {
+      key: ":method"
+      value: "OPTIONS"
+    }
+  }
+}
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/filter_state_local_jwks.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/filter_state_local_jwks.txtpb
@@ -1,0 +1,50 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# use local_jwks
+# extract jwt from cookie
+# use per_rounte config and requirement_map
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      local_jwks {
+        inline_string: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+      }
+      from_cookies: ["token"]
+    }
+  }
+  filter_state_rules {
+    name: "jwt_selector"
+    requires {
+      key: "selector1"
+      value: {
+        provider_and_audiences {
+          provider_name: "provider1"
+          audiences: ["example_service"]
+        }
+      }
+    }
+    requires {
+      key: "selector2"
+      value: {
+        provider_name: "provider1"
+      }
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "cookie"
+      value: "token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+    headers {
+      key: ":path"
+      value: "/foo/bar"
+    }
+  }
+}
+filter_state_selector: "selector1"
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/match_rule_local_jwks.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/match_rule_local_jwks.txtpb
@@ -1,0 +1,38 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# use local_jwks
+# extract jwt from auth header
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      local_jwks {
+        inline_string: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+      }
+      audiences: ["example_service"]
+    }
+  }
+  rules {
+    match {
+      prefix: "/"
+    }
+    requires {
+      provider_name: "provider1"
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "authorization"
+      value: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+    headers {
+      key: ":path"
+      value: "/foo/bar"
+    }
+  }
+}
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/match_rule_remote_jwks_custom_header.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/match_rule_remote_jwks_custom_header.txtpb
@@ -1,0 +1,48 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# use remote_jwks
+# extract jwt from custom header
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      audiences: ["example_service"]
+      remote_jwks {
+        http_uri {
+          uri: "https://pubkey_server/pubkey_path"
+          cluster: "pubkey_cluster"
+          timeout {
+            seconds: 5
+          }
+        }
+      }
+      from_headers {
+        name: "x-goog-iap-jwt-assertion"
+      }
+    }
+  }
+  rules {
+    match {
+      prefix: "/"
+    }
+    requires {
+      provider_name: "provider1"
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "x-goog-iap-jwt-assertion"
+      value: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+    headers {
+      key: ":path"
+      value: "/foo/bar"
+    }
+  }
+}
+remote_jwks: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/per_route_local_jwks.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/per_route_local_jwks.txtpb
@@ -1,0 +1,37 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# use local_jwks
+# extract jwt from query parameter
+# use per_rounte config and requirement_map
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      audiences: ["example_service"]
+      local_jwks {
+        inline_string: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+      }
+      from_params: ["token"]
+    }
+  }
+  requirement_map {
+    key: "requirement1"
+    value: {
+      provider_name: "provider1"
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: ":path"
+      value: "/foo/bar?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+  }
+}
+per_route {
+  requirement_name: "requirement1"
+}
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/require_any_remote_jwks.txtpb
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/require_any_remote_jwks.txtpb
@@ -1,0 +1,68 @@
+# proto-file: third_party/envoy/src/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+# proto-message: JwtAuthnFuzzInput
+
+# use local_jwks
+# extract jwt from auth header
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      audiences: ["example_service"]
+      remote_jwks {
+        http_uri {
+          uri: "https://pubkey_server/pubkey_path"
+          cluster: "pubkey_cluster"
+          timeout {
+            seconds: 5
+          }
+        }
+      }
+    }
+  }
+  providers {
+    key: "provider2"
+    value {
+      issuer: "https://example.com22"
+      audiences: ["example_service22"]
+      remote_jwks {
+        http_uri {
+          uri: "https://pubkey_server/pubkey_path"
+          cluster: "pubkey_cluster"
+          timeout {
+            seconds: 5
+          }
+        }
+      }
+    }
+  }
+  rules {
+    match {
+      prefix: "/"
+    }
+    requires {
+      requires_any {
+        requirements {
+          provider_name: "provider1"
+        }
+        requirements {
+          provider_name: "provider2"
+        }
+      }
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "authorization"
+      value: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+    headers {
+      key: ":path"
+      value: "/foo/bar"
+    }
+  }
+}
+remote_jwks: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+num_calls: 3

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.jwt_authn;
+
+import "envoy/extensions/filters/http/jwt_authn/v3/config.proto";
+import "test/fuzz/common.proto";
+import "validate/validate.proto";
+
+message JwtAuthnFuzzInput {
+  envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication config = 1
+      [(validate.rules).message = { required: true }];
+
+  // HTTP request data.
+  test.fuzz.HttpData request_data = 2
+      [(validate.rules).message = { required: true }];
+
+  // If empty, remote_jwks_fetch fails.
+  string remote_jwks = 3;
+
+  // per_route
+  envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig per_route = 4;
+
+  // the selector for the fitler state
+  string filter_state_selector = 6;
+
+  bool force_jwt_expired = 7;
+  bool filter_on_destroy = 8;
+
+  // number of times to make the call, 0 < x < 5
+  uint32 num_calls = 5 [(validate.rules).uint32 = { gt: 0 lt: 5 }];
+}

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
@@ -19,7 +19,7 @@ message JwtAuthnFuzzInput {
   // per_route
   envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig per_route = 4;
 
-  // the selector for the fitler state
+  // the selector for the filter state
   string filter_state_selector = 6;
 
   bool force_jwt_expired = 7;

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
@@ -27,3 +27,4 @@ message JwtAuthnFuzzInput {
 
   // number of times to make the call, 0 < x < 5
   uint32 num_calls = 5 [(validate.rules).uint32 = {gt: 0 lt: 5}];
+}

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.proto
@@ -8,11 +8,10 @@ import "validate/validate.proto";
 
 message JwtAuthnFuzzInput {
   envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication config = 1
-      [(validate.rules).message = { required: true }];
+      [(validate.rules).message = {required: true}];
 
   // HTTP request data.
-  test.fuzz.HttpData request_data = 2
-      [(validate.rules).message = { required: true }];
+  test.fuzz.HttpData request_data = 2 [(validate.rules).message = {required: true}];
 
   // If empty, remote_jwks_fetch fails.
   string remote_jwks = 3;
@@ -27,5 +26,4 @@ message JwtAuthnFuzzInput {
   bool filter_on_destroy = 8;
 
   // number of times to make the call, 0 < x < 5
-  uint32 num_calls = 5 [(validate.rules).uint32 = { gt: 0 lt: 5 }];
-}
+  uint32 num_calls = 5 [(validate.rules).uint32 = {gt: 0 lt: 5}];

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -1,0 +1,154 @@
+#include "envoy/extensions/filters/http/jwt_authn/v3/config.pb.validate.h"
+
+#include <memory>
+
+#include "source/common/common/regex.h"
+#include "source/common/http/message_impl.h"
+#include "source/common/router/string_accessor_impl.h"
+#include "source/extensions/filters/http/jwt_authn/filter.h"
+#include "source/extensions/filters/http/jwt_authn/filter_config.h"
+
+#include "test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h"
+#include "test/extensions/filters/http/jwt_authn/jwt_authn_fuzz.pb.validate.h"
+#include "test/fuzz/fuzz_runner.h"
+#include "test/mocks/server/factory_context.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace JwtAuthn {
+namespace {
+
+using envoy::extensions::filters::http::jwt_authn::JwtAuthnFuzzInput;
+using envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig;
+using testing::NiceMock;
+
+class MockJwksUpstream {
+ public:
+  MockJwksUpstream(Upstream::MockClusterManager& mock_cm,
+                   const std::string& remote_jwks)
+      : remote_jwks_(remote_jwks),
+        jwks_request_(&mock_cm.thread_local_cluster_.async_client_) {
+    ON_CALL(mock_cm, getThreadLocalCluster(_))
+        .WillByDefault(Return(&thread_local_cluster_));
+    ON_CALL(thread_local_cluster_.async_client_, send_(_, _, _))
+        .WillByDefault(Invoke([this](const Http::RequestMessagePtr&,
+                                     Http::AsyncClient::Callbacks& callback,
+                                     const Http::AsyncClient::RequestOptions&)
+                                  -> Http::AsyncClient::Request* {
+          if (remote_jwks_.empty()) {
+            callback.onFailure(jwks_request_,
+                               Http::AsyncClient::FailureReason::Reset);
+          } else {
+            Http::ResponseMessagePtr response_message(
+                new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
+                    new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
+            response_message->body().add(remote_jwks_);
+            callback.onSuccess(jwks_request_, std::move(response_message));
+          }
+          return &jwks_request_;
+        }));
+  }
+
+ private:
+  std::string remote_jwks_;
+  NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster_;
+  NiceMock<Http::MockAsyncClientRequest> jwks_request_;
+};
+
+class MockPerRouteConfig {
+ public:
+  MockPerRouteConfig(Http::MockStreamDecoderFilterCallbacks& mock_callback,
+                     const PerRouteConfig& per_route) {
+    per_route_config_ = std::make_shared<PerRouteFilterConfig>(per_route);
+    mock_route_ = std::make_shared<NiceMock<Envoy::Router::MockRoute>>();
+    ON_CALL(mock_callback, route()).WillByDefault(Return(mock_route_));
+    ON_CALL(*mock_route_, mostSpecificPerFilterConfig(_))
+        .WillByDefault(Return(per_route_config_.get()));
+  }
+
+ private:
+  std::shared_ptr<NiceMock<Envoy::Router::MockRoute>> mock_route_;
+  std::shared_ptr<PerRouteFilterConfig> per_route_config_;
+};
+
+DEFINE_PROTO_FUZZER(const JwtAuthnFuzzInput& input) {
+  // regex matcher requires such engine init.
+  ScopedInjectableLoader<Regex::Engine> engine(
+      std::make_unique<Regex::GoogleReEngine>());
+
+  try {
+    TestUtility::validate(input);
+  } catch (const EnvoyException& e) {
+    ENVOY_LOG_MISC(debug, "EnvoyException during validation: {}", e.what());
+    return;
+  }
+
+  NiceMock<Server::Configuration::MockFactoryContext> mock_factory_ctx;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks;
+
+  // Test the expired token.
+  // The jwt token in the corpus files expired at 2001001001 (at year 2033).
+  if (input.force_jwt_expired()) {
+    // 20 years == 615168000 seconds.
+    mock_factory_ctx.time_system_.advanceTimeWait(Envoy::Seconds(615168000));
+  }
+
+  MockJwksUpstream mock_jwks(mock_factory_ctx.cluster_manager_,
+                             input.remote_jwks());
+
+  // Mock per route config.
+  std::unique_ptr<MockPerRouteConfig> mock_per_route;
+  if (input.has_per_route()) {
+    mock_per_route = std::make_unique<MockPerRouteConfig>(filter_callbacks,
+                                                          input.per_route());
+  }
+
+  // Set filter_state_selector only there is a valid filter_state_rules.
+  // Otherwise filter_state take over, and there is not filter_state_rules, it
+  // just bail out.
+  if (input.config().has_filter_state_rules()) {
+    const auto& rules = input.config().filter_state_rules();
+    if (!rules.name().empty() && rules.requires().size() > 0) {
+      filter_callbacks.stream_info_.filter_state_->setData(
+          rules.name(),
+          std::make_unique<Router::StringAccessorImpl>(
+              input.filter_state_selector()),
+          StreamInfo::FilterState::StateType::ReadOnly,
+          StreamInfo::FilterState::LifeSpan::FilterChain);
+    }
+  }
+
+  std::shared_ptr<FilterConfigImpl> filter_config;
+  try {
+    filter_config = std::make_shared<FilterConfigImpl>(input.config(), "",
+                                                       mock_factory_ctx);
+  } catch (const EnvoyException& e) {
+    ENVOY_LOG_MISC(debug,
+                   "EnvoyException during filter config construction: {}",
+                   e.what());
+    return;
+  }
+
+  // Simulate multiple calls to execute jwt_cache and jwks_cache codes
+  for (uint32_t i = 0; i < input.num_calls(); i++) {
+    auto filter = std::make_unique<Filter>(filter_config);
+    filter->setDecoderFilterCallbacks(filter_callbacks);
+
+    HttpFilterFuzzer fuzzer;
+    fuzzer.runData(static_cast<Http::StreamDecoderFilter*>(filter.get()),
+                   input.request_data());
+
+    if (input.filter_on_destroy()) {
+      filter->onDestroy();
+    }
+  }
+}
+
+}  // namespace
+}  // namespace JwtAuthn
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -70,7 +70,7 @@ private:
 };
 
 DEFINE_PROTO_FUZZER(const JwtAuthnFuzzInput& input) {
-  // regex matcher requires such engine init.
+  // Regex matcher requires this engine init.
   ScopedInjectableLoader<Regex::Engine> engine(std::make_unique<Regex::GoogleReEngine>());
 
   try {

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -103,7 +103,7 @@ DEFINE_PROTO_FUZZER(const JwtAuthnFuzzInput& input) {
   // just bail out.
   if (input.config().has_filter_state_rules()) {
     const auto& rules = input.config().filter_state_rules();
-    if (!rules.name().empty() && rules.requires().size() > 0) {
+    if (!rules.name().empty() && !rules.requires().empty()) {
       filter_callbacks.stream_info_.filter_state_->setData(
           rules.name(), std::make_unique<Router::StringAccessorImpl>(input.filter_state_selector()),
           StreamInfo::FilterState::StateType::ReadOnly,

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -130,6 +130,8 @@ DEFINE_PROTO_FUZZER(const JwtAuthnFuzzInput& input) {
     if (input.filter_on_destroy()) {
       filter->onDestroy();
     }
+
+    fuzzer.reset();
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Add a fuzz test.   It is for https://github.com/envoyproxy/envoy/pull/23617

Risk Level: None
Testing:  Add fuzz tests
Docs Changes: None
Release Notes:  None
