### PR TITLE
Use getaddrinfo to parse IPv6 addresses to allow link local addresses

### DIFF
--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -140,6 +140,7 @@ TEST(NetworkUtility, ParseInternetAddress) {
   EXPECT_THROW(Utility::parseInternetAddress("fffff::"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddress("/foo"), EnvoyException);
 
+  // TODO(#24326): make windows getaddrinfo more strict. See below example.
 #ifndef WIN32
   EXPECT_THROW(Utility::parseInternetAddress("[::]"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddress("[::1]:1"), EnvoyException);
@@ -234,6 +235,7 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
   EXPECT_THROW(Utility::parseInternetAddressAndPort("::1"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("::"), EnvoyException);
 
+  // TODO(#24326): make windows getaddrinfo more strict. See above example.
 #ifndef WIN32
   EXPECT_THROW(Utility::parseInternetAddressAndPort("[[::]]:1"), EnvoyException);
 #endif
@@ -250,6 +252,7 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("::1"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("::"));
 
+  // TODO(#24326): make windows getaddrinfo more strict. See above example.
 #ifndef WIN32
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("[[::]]:1"));
 #endif

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -153,10 +153,12 @@ TEST(NetworkUtility, ParseInternetAddress) {
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("0:0:0:0"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("fffff::"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("/foo"));
+
 #ifndef WIN32
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::]"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::1]:1"));
 #else
+  // TODO(#24326): make windows getaddrinfo more strict.
   EXPECT_EQ("[::]:0", Utility::parseInternetAddressNoThrow("[::]")->asString());
   EXPECT_EQ("[::1]:0", Utility::parseInternetAddressNoThrow("[::1]:1")->asString());
 #endif
@@ -231,6 +233,7 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
   EXPECT_THROW(Utility::parseInternetAddressAndPort(""), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("::1"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("::"), EnvoyException);
+
 #ifndef WIN32
   EXPECT_THROW(Utility::parseInternetAddressAndPort("[[::]]:1"), EnvoyException);
 #endif
@@ -246,6 +249,7 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow(""));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("::1"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("::"));
+
 #ifndef WIN32
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("[[::]]:1"));
 #endif

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -156,6 +156,9 @@ TEST(NetworkUtility, ParseInternetAddress) {
 #ifndef WIN32
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::]"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::1]:1"));
+#else
+  EXPECT_EQ("[::]:0", Utility::parseInternetAddressNoThrow("[::]")->asString());
+  EXPECT_EQ("[::1]:1", Utility::parseInternetAddressNoThrow("[::1]:1")->asString());
 #endif
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("fe80::1%"));
 

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -139,8 +139,11 @@ TEST(NetworkUtility, ParseInternetAddress) {
   EXPECT_THROW(Utility::parseInternetAddress("0:0:0:0"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddress("fffff::"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddress("/foo"), EnvoyException);
+
+#ifndef WIN32
   EXPECT_THROW(Utility::parseInternetAddress("[::]"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddress("[::1]:1"), EnvoyException);
+#endif
 
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow(""));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("1.2.3"));
@@ -150,8 +153,10 @@ TEST(NetworkUtility, ParseInternetAddress) {
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("0:0:0:0"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("fffff::"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("/foo"));
+#ifndef WIN32
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::]"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::1]:1"));
+#endif
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("fe80::1%"));
 
   EXPECT_EQ("1.2.3.4:0", Utility::parseInternetAddress("1.2.3.4")->asString());
@@ -223,7 +228,9 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
   EXPECT_THROW(Utility::parseInternetAddressAndPort(""), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("::1"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("::"), EnvoyException);
+#ifndef WIN32
   EXPECT_THROW(Utility::parseInternetAddressAndPort("[[::]]:1"), EnvoyException);
+#endif
   EXPECT_THROW(Utility::parseInternetAddressAndPort("[::]:1]:2"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("]:[::1]:2"), EnvoyException);
   EXPECT_THROW(Utility::parseInternetAddressAndPort("[1.2.3.4:0"), EnvoyException);
@@ -236,7 +243,9 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow(""));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("::1"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("::"));
+#ifndef WIN32
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("[[::]]:1"));
+#endif
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("[::]:1]:2"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("]:[::1]:2"));
   EXPECT_EQ(nullptr, Utility::parseInternetAddressAndPortNoThrow("[1.2.3.4:0"));

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -158,7 +158,7 @@ TEST(NetworkUtility, ParseInternetAddress) {
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("[::1]:1"));
 #else
   EXPECT_EQ("[::]:0", Utility::parseInternetAddressNoThrow("[::]")->asString());
-  EXPECT_EQ("[::1]:1", Utility::parseInternetAddressNoThrow("[::1]:1")->asString());
+  EXPECT_EQ("[::1]:0", Utility::parseInternetAddressNoThrow("[::1]:1")->asString());
 #endif
   EXPECT_EQ(nullptr, Utility::parseInternetAddressNoThrow("fe80::1%"));
 

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -3,6 +3,7 @@
 #include "envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.pb.h"
 #include "envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.pb.validate.h"
 
+#include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/common/hash.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/network/socket_option_impl.h"
@@ -1128,6 +1129,12 @@ TEST_F(UdpProxyFilterIpv6Test, SocketOptionForUseOriginalSrcIpInCaseOfIpv6) {
     GTEST_SKIP();
   }
   EXPECT_CALL(os_sys_calls_, supportsIpTransparent());
+  EXPECT_CALL(os_sys_calls_, getaddrinfo(_, _, _, _))
+      .WillRepeatedly(Invoke([&](const char* node, const char* service,
+                                 const struct addrinfo* hints, struct addrinfo** res) {
+        Api::OsSysCallsImpl real;
+        return real.getaddrinfo(node, service, hints, res);
+      }));
 
   InSequence s;
 

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -1148,6 +1148,13 @@ TEST_F(UdpProxyFilterIpv4Ipv6Test, NoSocketOptionIfUseOriginalSrcIpIsNotSet) {
     GTEST_SKIP();
   }
 
+  EXPECT_CALL(os_sys_calls_, getaddrinfo(_, _, _, _))
+      .WillRepeatedly(Invoke([&](const char* node, const char* service,
+                                 const struct addrinfo* hints, struct addrinfo** res) {
+        Api::OsSysCallsImpl real;
+        return real.getaddrinfo(node, service, hints, res);
+      }));
+
   InSequence s;
 
   setup(readConfig(R"EOF(

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.h
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.h
@@ -125,6 +125,11 @@ protected:
         .WillRepeatedly(Invoke([this](os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen) {
           return os_sys_calls_actual_.getsockname(sockfd, addr, addrlen);
         }));
+    EXPECT_CALL(os_sys_calls_, getaddrinfo(_, _, _, _))
+        .WillRepeatedly(Invoke([&](const char* node, const char* service,
+                                   const struct addrinfo* hints, struct addrinfo** res) {
+          return os_sys_calls_actual_.getaddrinfo(node, service, hints, res);
+        }));
     socket_ = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
   }
 

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -904,6 +904,11 @@ public:
     EXPECT_CALL(os_sys_calls, close(_))
         .WillRepeatedly(Invoke(
             [&](os_fd_t sockfd) -> Api::SysCallIntResult { return real_syscall.close(sockfd); }));
+    EXPECT_CALL(os_sys_calls, getaddrinfo(_, _, _, _))
+        .WillRepeatedly(Invoke([&](const char* node, const char* service,
+                                   const struct addrinfo* hints, struct addrinfo** res) {
+          return real_syscall.getaddrinfo(node, service, hints, res);
+        }));
 
     resolveWithExpectations("some.good.domain", lookup_family, resolution_status,
                             expected_addresses, {}, absl::nullopt);


### PR DESCRIPTION
Commit Message: use only `getaddrinfo` to parse IPv6
Risk Level: low
Testing: unit tests