### PR TITLE
Clean up: Move sendLocalReply utility just used in this test file to the test file.

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -551,25 +551,6 @@ bool Utility::isWebSocketUpgradeRequest(const RequestHeaderMap& headers) {
                                  Http::Headers::get().UpgradeValues.WebSocket));
 }
 
-void Utility::sendLocalReply(const bool& is_reset, StreamDecoderFilterCallbacks& callbacks,
-                             const LocalReplyData& local_reply_data) {
-  absl::string_view details;
-  if (callbacks.streamInfo().responseCodeDetails().has_value()) {
-    details = callbacks.streamInfo().responseCodeDetails().value();
-  };
-
-  sendLocalReply(
-      is_reset,
-      Utility::EncodeFunctions{nullptr, nullptr,
-                               [&](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
-                                 callbacks.encodeHeaders(std::move(headers), end_stream, details);
-                               },
-                               [&](Buffer::Instance& data, bool end_stream) -> void {
-                                 callbacks.encodeData(data, end_stream);
-                               }},
-      local_reply_data);
-}
-
 void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode_functions,
                              const LocalReplyData& local_reply_data) {
   // encode_headers() may reset the stream, so the stream must not be reset before calling it.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -380,17 +380,6 @@ struct LocalReplyData {
 };
 
 /**
- * Create a locally generated response using filter callbacks.
- * @param is_reset boolean reference that indicates whether a stream has been reset. It is the
- *        responsibility of the caller to ensure that this is set to false if onDestroy()
- *        is invoked in the context of sendLocalReply().
- * @param callbacks supplies the filter callbacks to use.
- * @param local_reply_data struct which keeps data related to generate reply.
- */
-void sendLocalReply(const bool& is_reset, StreamDecoderFilterCallbacks& callbacks,
-                    const LocalReplyData& local_reply_data);
-
-/**
  * Create a locally generated response using the provided lambdas.
 
  * @param is_reset boolean reference that indicates whether a stream has been reset. It is the

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -27,6 +27,28 @@ using testing::Return;
 
 namespace Envoy {
 namespace Http {
+namespace {
+
+void sendLocalReplyTestHelper(const bool& is_reset, StreamDecoderFilterCallbacks& callbacks,
+                              const Utility::LocalReplyData& local_reply_data) {
+  absl::string_view details;
+  if (callbacks.streamInfo().responseCodeDetails().has_value()) {
+    details = callbacks.streamInfo().responseCodeDetails().value();
+  };
+
+  Utility::sendLocalReply(
+      is_reset,
+      Utility::EncodeFunctions{nullptr, nullptr,
+                               [&](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
+                                 callbacks.encodeHeaders(std::move(headers), end_stream, details);
+                               },
+                               [&](Buffer::Instance& data, bool end_stream) -> void {
+                                 callbacks.encodeData(data, end_stream);
+                               }},
+      local_reply_data);
+}
+
+} // namespace
 
 TEST(HttpUtility, parseQueryString) {
   EXPECT_EQ(Utility::QueryParams(), Utility::parseQueryString("/hello"));
@@ -843,7 +865,7 @@ TEST(HttpUtility, SendLocalReply) {
   EXPECT_CALL(callbacks, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks, encodeData(_, true));
   EXPECT_CALL(callbacks, streamInfo());
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       is_reset, callbacks,
       Utility::LocalReplyData{false, Http::Code::PayloadTooLarge, "large", absl::nullopt, false});
 }
@@ -862,7 +884,7 @@ TEST(HttpUtility, SendLocalGrpcReply) {
         EXPECT_NE(headers.GrpcMessage(), nullptr);
         EXPECT_EQ(headers.getGrpcMessageValue(), "large");
       }));
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       is_reset, callbacks,
       Utility::LocalReplyData{true, Http::Code::PayloadTooLarge, "large", absl::nullopt, false});
 }
@@ -881,7 +903,7 @@ TEST(HttpUtility, SendLocalGrpcReplyGrpcStatusAlreadyExists) {
         EXPECT_NE(headers.GrpcMessage(), nullptr);
         EXPECT_EQ(headers.getGrpcMessageValue(), "large");
       }));
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       is_reset, callbacks,
       Utility::LocalReplyData{true, Http::Code::PayloadTooLarge, "large",
                               Grpc::Status::WellKnownGrpcStatus::InvalidArgument, false});
@@ -940,7 +962,7 @@ TEST(HttpUtility, SendLocalGrpcReplyWithUpstreamJsonPayload) {
         const auto& encoded = Utility::PercentEncoding::encode(json);
         EXPECT_EQ(headers.getGrpcMessageValue(), encoded);
       }));
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       is_reset, callbacks,
       Utility::LocalReplyData{true, Http::Code::Unauthorized, json, absl::nullopt, false});
 }
@@ -955,7 +977,7 @@ TEST(HttpUtility, RateLimitedGrpcStatus) {
         EXPECT_EQ(headers.getGrpcStatusValue(),
                   std::to_string(enumToInt(Grpc::Status::WellKnownGrpcStatus::Unavailable)));
       }));
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       false, callbacks,
       Utility::LocalReplyData{true, Http::Code::TooManyRequests, "", absl::nullopt, false});
 
@@ -965,7 +987,7 @@ TEST(HttpUtility, RateLimitedGrpcStatus) {
         EXPECT_EQ(headers.getGrpcStatusValue(),
                   std::to_string(enumToInt(Grpc::Status::WellKnownGrpcStatus::ResourceExhausted)));
       }));
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       false, callbacks,
       Utility::LocalReplyData{true, Http::Code::TooManyRequests, "",
                               absl::make_optional<Grpc::Status::GrpcStatus>(
@@ -982,7 +1004,7 @@ TEST(HttpUtility, SendLocalReplyDestroyedEarly) {
     is_reset = true;
   }));
   EXPECT_CALL(callbacks, encodeData(_, true)).Times(0);
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       is_reset, callbacks,
       Utility::LocalReplyData{false, Http::Code::PayloadTooLarge, "large", absl::nullopt, false});
 }
@@ -995,7 +1017,7 @@ TEST(HttpUtility, SendLocalReplyHeadRequest) {
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.getContentLengthValue(), fmt::format("{}", strlen("large")));
       }));
-  Utility::sendLocalReply(
+  sendLocalReplyTestHelper(
       is_reset, callbacks,
       Utility::LocalReplyData{false, Http::Code::PayloadTooLarge, "large", absl::nullopt, true});
 }


### PR DESCRIPTION
One of the overloads of sendLocalReply was only used by the utility test file. Move it there to avoid having users to decide which to use.

See coverage from another PR; only used in this test file: 
![Screenshot 2022-11-11 2 14 30 PM](https://user-images.githubusercontent.com/3191890/201435563-a5a05c1f-7288-4fb1-adae-be06b433e8f6.png)


Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Cleanup: Move sendLocalReply utility to test file where it was only being used
Additional Description:
Risk Level: low
Testing: ran tests
Docs Changes: n/a
Release Notes: n/a
