### PR TITLE
generic proxy: added support for custom read filter

### DIFF
--- a/contrib/generic_proxy/filters/network/source/BUILD
+++ b/contrib/generic_proxy/filters/network/source/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         ":rds_lib",
         ":route_lib",
         "//contrib/generic_proxy/filters/network/source/interface:codec_interface",
+        "//contrib/generic_proxy/filters/network/source/interface:proxy_config_interface",
         "//contrib/generic_proxy/filters/network/source/router:router_lib",
         "//envoy/network:filter_interface",
         "//envoy/server:factory_context_interface",

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -160,8 +160,8 @@ ResponsePtr DubboMessageCreator::response(Status status, const Request& origin_r
 }
 
 CodecFactoryPtr
-DubboCodecFactoryConfig::createFactory(const Protobuf::Message&,
-                                       Envoy::Server::Configuration::FactoryContext&) {
+DubboCodecFactoryConfig::createCodecFactory(const Protobuf::Message&,
+                                            Envoy::Server::Configuration::FactoryContext&) {
   return std::make_unique<DubboCodecFactory>();
 }
 

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -197,9 +197,13 @@ public:
 
 class DubboCodecFactoryConfig : public CodecFactoryConfig {
 public:
+  // CodecFactoryConfig
   CodecFactoryPtr createFactory(const Protobuf::Message& config,
                                 Envoy::Server::Configuration::FactoryContext& context) override;
-
+  FilterFactoryPtr filterFactory(const Protobuf::Message&,
+                                 Server::Configuration::FactoryContext&) override {
+    return nullptr;
+  }
   std::string name() const override { return "envoy.generic_proxy.codecs.dubbo"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ProtoConfig>();

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -198,12 +198,9 @@ public:
 class DubboCodecFactoryConfig : public CodecFactoryConfig {
 public:
   // CodecFactoryConfig
-  CodecFactoryPtr createFactory(const Protobuf::Message& config,
-                                Envoy::Server::Configuration::FactoryContext& context) override;
-  FilterFactoryPtr filterFactory(const Protobuf::Message&,
-                                 Server::Configuration::FactoryContext&) override {
-    return nullptr;
-  }
+  CodecFactoryPtr
+  createCodecFactory(const Protobuf::Message& config,
+                     Envoy::Server::Configuration::FactoryContext& context) override;
   std::string name() const override { return "envoy.generic_proxy.codecs.dubbo"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ProtoConfig>();

--- a/contrib/generic_proxy/filters/network/source/config.cc
+++ b/contrib/generic_proxy/filters/network/source/config.cc
@@ -2,8 +2,6 @@
 
 #include "contrib/generic_proxy/filters/network/source/rds.h"
 #include "contrib/generic_proxy/filters/network/source/rds_impl.h"
-#include "interface/codec.h"
-#include "proxy.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/contrib/generic_proxy/filters/network/source/config.cc
+++ b/contrib/generic_proxy/filters/network/source/config.cc
@@ -21,9 +21,9 @@ Factory::createFilterFactoryFromProtoTyped(const ProxyConfig& proto_config,
 
   const auto config =
       std::make_shared<FilterConfig>(proto_config, context, *route_config_provider_manager);
-  return [route_config_provider_manager, config,
-          &context](Envoy::Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(std::make_shared<Filter>(config, context));
+  return [route_config_provider_manager,
+          config](Envoy::Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(std::make_shared<Filter>(config));
   };
 }
 

--- a/contrib/generic_proxy/filters/network/source/config.cc
+++ b/contrib/generic_proxy/filters/network/source/config.cc
@@ -18,7 +18,8 @@ Factory::factoriesFromProto(const envoy::config::core::v3::TypedExtensionConfig&
   ProtobufTypes::MessagePtr message = factory.createEmptyConfigProto();
   Envoy::Config::Utility::translateOpaqueConfig(codec_config.typed_config(),
                                                 context.messageValidationVisitor(), *message);
-  return {factory.createFactory(*message, context), factory.filterFactory(*message, context)};
+  return {factory.createCodecFactory(*message, context),
+          factory.createProxyFactory(*message, context)};
 }
 
 Rds::RouteConfigProviderSharedPtr

--- a/contrib/generic_proxy/filters/network/source/config.cc
+++ b/contrib/generic_proxy/filters/network/source/config.cc
@@ -2,6 +2,8 @@
 
 #include "contrib/generic_proxy/filters/network/source/rds.h"
 #include "contrib/generic_proxy/filters/network/source/rds_impl.h"
+#include "interface/codec.h"
+#include "proxy.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -9,6 +11,75 @@ namespace NetworkFilters {
 namespace GenericProxy {
 
 SINGLETON_MANAGER_REGISTRATION(generic_route_config_provider_manager);
+
+std::pair<CodecFactoryPtr, FilterFactoryPtr>
+Factory::factoriesFromProto(const envoy::config::core::v3::TypedExtensionConfig& codec_config,
+                            Envoy::Server::Configuration::FactoryContext& context) {
+  auto& factory = Config::Utility::getAndCheckFactory<CodecFactoryConfig>(codec_config);
+
+  ProtobufTypes::MessagePtr message = factory.createEmptyConfigProto();
+  Envoy::Config::Utility::translateOpaqueConfig(codec_config.typed_config(),
+                                                context.messageValidationVisitor(), *message);
+  return {factory.createFactory(*message, context), factory.filterFactory(*message, context)};
+}
+
+Rds::RouteConfigProviderSharedPtr
+Factory::routeConfigProviderFromProto(const ProxyConfig& config,
+                                      Server::Configuration::FactoryContext& context,
+                                      RouteConfigProviderManager& route_config_provider_manager) {
+  if (config.has_generic_rds()) {
+    if (config.generic_rds().config_source().config_source_specifier_case() ==
+        envoy::config::core::v3::ConfigSource::kApiConfigSource) {
+      const auto api_type = config.generic_rds().config_source().api_config_source().api_type();
+      if (api_type != envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC &&
+          api_type != envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC) {
+        throw EnvoyException("genericrds supports only aggregated api_type in api_config_source");
+      }
+    }
+
+    return route_config_provider_manager.createRdsRouteConfigProvider(
+        config.generic_rds(), context.getServerFactoryContext(), config.stat_prefix(),
+        context.initManager());
+  } else {
+    return route_config_provider_manager.createStaticRouteConfigProvider(
+        config.route_config(), context.getServerFactoryContext());
+  }
+}
+
+std::vector<NamedFilterFactoryCb> Factory::filtersFactoryFromProto(
+    const ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>& filters,
+    const std::string stats_prefix, Envoy::Server::Configuration::FactoryContext& context) {
+
+  std::vector<NamedFilterFactoryCb> factories;
+  bool has_terminal_filter = false;
+  std::string terminal_filter_name;
+  for (const auto& filter : filters) {
+    if (has_terminal_filter) {
+      throw EnvoyException(fmt::format("Terminal filter: {} must be the last generic L7 filter",
+                                       terminal_filter_name));
+    }
+
+    auto& factory = Config::Utility::getAndCheckFactory<NamedFilterConfigFactory>(filter);
+
+    ProtobufTypes::MessagePtr message = factory.createEmptyConfigProto();
+    ASSERT(message != nullptr);
+    Envoy::Config::Utility::translateOpaqueConfig(filter.typed_config(),
+                                                  context.messageValidationVisitor(), *message);
+
+    factories.push_back(
+        {filter.name(), factory.createFilterFactoryFromProto(*message, stats_prefix, context)});
+
+    if (factory.isTerminalFilter()) {
+      terminal_filter_name = filter.name();
+      has_terminal_filter = true;
+    }
+  }
+
+  if (!has_terminal_filter) {
+    throw EnvoyException("A terminal L7 filter is necessary for generic proxy");
+  }
+  return factories;
+}
 
 Envoy::Network::FilterFactoryCb
 Factory::createFilterFactoryFromProtoTyped(const ProxyConfig& proto_config,
@@ -19,10 +90,22 @@ Factory::createFilterFactoryFromProtoTyped(const ProxyConfig& proto_config,
           SINGLETON_MANAGER_REGISTERED_NAME(generic_route_config_provider_manager),
           [&context] { return std::make_shared<RouteConfigProviderManagerImpl>(context.admin()); });
 
-  const auto config =
-      std::make_shared<FilterConfig>(proto_config, context, *route_config_provider_manager);
-  return [route_config_provider_manager,
-          config](Envoy::Network::FilterManager& filter_manager) -> void {
+  auto factories = factoriesFromProto(proto_config.codec_config(), context);
+  std::shared_ptr<FilterFactory> custom_filter_factory = std::move(factories.second);
+
+  const FilterConfigSharedPtr config = std::make_shared<FilterConfigImpl>(
+      proto_config.stat_prefix(), std::move(factories.first),
+      routeConfigProviderFromProto(proto_config, context, *route_config_provider_manager),
+      filtersFactoryFromProto(proto_config.filters(), proto_config.stat_prefix(), context));
+
+  return [route_config_provider_manager, config,
+          custom_filter_factory](Envoy::Network::FilterManager& filter_manager) -> void {
+    // Create filter by the custom filter factory if the custom filter factory is not null.
+    if (custom_filter_factory != nullptr) {
+      custom_filter_factory->createFilter(filter_manager, config);
+      return;
+    }
+
     filter_manager.addReadFilter(std::make_shared<Filter>(config));
   };
 }

--- a/contrib/generic_proxy/filters/network/source/config.h
+++ b/contrib/generic_proxy/filters/network/source/config.h
@@ -23,7 +23,7 @@ public:
   createFilterFactoryFromProtoTyped(const ProxyConfig& proto_config,
                                     Envoy::Server::Configuration::FactoryContext& context) override;
 
-  static std::pair<CodecFactoryPtr, FilterFactoryPtr>
+  static std::pair<CodecFactoryPtr, ProxyFactoryPtr>
   factoriesFromProto(const envoy::config::core::v3::TypedExtensionConfig& codec_config,
                      Server::Configuration::FactoryContext& context);
 

--- a/contrib/generic_proxy/filters/network/source/config.h
+++ b/contrib/generic_proxy/filters/network/source/config.h
@@ -7,6 +7,7 @@
 
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.pb.h"
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.pb.validate.h"
+#include "contrib/generic_proxy/filters/network/source/interface/config.h"
 #include "contrib/generic_proxy/filters/network/source/proxy.h"
 
 namespace Envoy {
@@ -21,6 +22,19 @@ public:
   Envoy::Network::FilterFactoryCb
   createFilterFactoryFromProtoTyped(const ProxyConfig& proto_config,
                                     Envoy::Server::Configuration::FactoryContext& context) override;
+
+  static std::pair<CodecFactoryPtr, FilterFactoryPtr>
+  factoriesFromProto(const envoy::config::core::v3::TypedExtensionConfig& codec_config,
+                     Server::Configuration::FactoryContext& context);
+
+  static Rds::RouteConfigProviderSharedPtr
+  routeConfigProviderFromProto(const ProxyConfig& config,
+                               Server::Configuration::FactoryContext& context,
+                               RouteConfigProviderManager& route_config_provider_manager);
+
+  static std::vector<NamedFilterFactoryCb> filtersFactoryFromProto(
+      const ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>& filters,
+      const std::string stats_prefix, Server::Configuration::FactoryContext& context);
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/source/interface/BUILD
+++ b/contrib/generic_proxy/filters/network/source/interface/BUILD
@@ -16,14 +16,27 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "codec_callbacks_interface",
+    hdrs = [
+        "codec_callbacks.h",
+    ],
+    deps = [
+        ":stream_interface",
+        "//envoy/buffer:buffer_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "codec_interface",
     hdrs = [
         "codec.h",
     ],
     deps = [
+        ":codec_callbacks_interface",
         ":stream_interface",
         "//envoy/buffer:buffer_interface",
         "//envoy/config:typed_config_interface",
+        "//envoy/network:filter_interface",
         "//envoy/server:factory_context_interface",
     ],
 )
@@ -65,5 +78,17 @@ envoy_cc_library(
         ":filter_interface",
         "//envoy/config:typed_config_interface",
         "//envoy/server:factory_context_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "proxy_config_interface",
+    hdrs = [
+        "proxy_config.h",
+    ],
+    deps = [
+        ":codec_interface",
+        ":filter_interface",
+        ":route_interface",
     ],
 )

--- a/contrib/generic_proxy/filters/network/source/interface/codec.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec.h
@@ -123,12 +123,12 @@ public:
   virtual ~ProxyFactory() = default;
 
   /**
-   * Create a custom read filter instance.
+   * Create a custom proxy instance.
    * @param filter_manager the filter manager of the network filter chain.
-   * @param filter_config supplies the filter config.
+   * @param filter_config supplies the read filter config.
    */
-  virtual void createFilter(Network::FilterManager& filter_manager,
-                            const FilterConfigSharedPtr& filter_config) const PURE;
+  virtual void createProxy(Network::FilterManager& filter_manager,
+                           const FilterConfigSharedPtr& filter_config) const PURE;
 };
 using ProxyFactoryPtr = std::unique_ptr<ProxyFactory>;
 

--- a/contrib/generic_proxy/filters/network/source/interface/codec.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec.h
@@ -2,82 +2,16 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/config/typed_config.h"
+#include "envoy/network/filter.h"
 #include "envoy/server/factory_context.h"
 
+#include "contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h"
 #include "contrib/generic_proxy/filters/network/source/interface/stream.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
-
-/**
- * Decoder callback of request.
- */
-class RequestDecoderCallback {
-public:
-  virtual ~RequestDecoderCallback() = default;
-
-  /**
-   * If request decoding success then this method will be called.
-   * @param request request from decoding.
-   */
-  virtual void onDecodingSuccess(RequestPtr request) PURE;
-
-  /**
-   * If request decoding failure then this method will be called.
-   */
-  virtual void onDecodingFailure() PURE;
-};
-
-/**
- * Decoder callback of Response.
- */
-class ResponseDecoderCallback {
-public:
-  virtual ~ResponseDecoderCallback() = default;
-
-  /**
-   * If response decoding success then this method will be called.
-   * @param response response from decoding.
-   */
-  virtual void onDecodingSuccess(ResponsePtr response) PURE;
-
-  /**
-   * If response decoding failure then this method will be called.
-   */
-  virtual void onDecodingFailure() PURE;
-};
-
-/**
- * Encoder callback of request.
- */
-class RequestEncoderCallback {
-public:
-  virtual ~RequestEncoderCallback() = default;
-
-  /**
-   * If request encoding success then this method will be called.
-   * @param buffer encoding result buffer.
-   * @param expect_response whether the current request requires an upstream response.
-   */
-  virtual void onEncodingSuccess(Buffer::Instance& buffer, bool expect_response) PURE;
-};
-
-/**
- * Encoder callback of Response.
- */
-class ResponseEncoderCallback {
-public:
-  virtual ~ResponseEncoderCallback() = default;
-
-  /**
-   * If response encoding success then this method will be called.
-   * @param buffer encoding result buffer.
-   * @param close_connection whether the downstream connection should be closed.
-   */
-  virtual void onEncodingSuccess(Buffer::Instance& buffer, bool close_connection) PURE;
-};
 
 /**
  * Decoder of request.
@@ -178,13 +112,49 @@ public:
 
 using CodecFactoryPtr = std::unique_ptr<CodecFactory>;
 
+class FilterConfig;
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
+
+/**
+ * Custom read filter factory for generic proxy.
+ */
+class FilterFactory {
+public:
+  virtual ~FilterFactory() = default;
+
+  /**
+   * Create a custom read filter instance.
+   * @param filter_manager the filter manager of the network filter chain.
+   * @param filter_config supplies the filter config.
+   */
+  virtual void createFilter(Network::FilterManager& filter_manager,
+                            const FilterConfigSharedPtr& filter_config) const PURE;
+};
+using FilterFactoryPtr = std::unique_ptr<FilterFactory>;
+
 /**
  * Factory config for codec factory. This class is used to register and create codec factories.
  */
 class CodecFactoryConfig : public Envoy::Config::TypedFactory {
 public:
+  /**
+   * Create a codec factory. This should never return nullptr.
+   * @param config supplies the config.
+   * @param context supplies the server context.
+   * @return CodecFactoryPtr the codec factory.
+   */
   virtual CodecFactoryPtr createFactory(const Protobuf::Message& config,
                                         Envoy::Server::Configuration::FactoryContext& context) PURE;
+
+  /**
+   * Create a optional custom filter factory.
+   * @param config supplies the config.
+   * @param context supplies the server context.
+   * @return FilterFactoryPtr the filter factory.
+   */
+  virtual FilterFactoryPtr
+  filterFactory(const Protobuf::Message& config,
+                Envoy::Server::Configuration::FactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.generic_proxy.codecs"; }
 };

--- a/contrib/generic_proxy/filters/network/source/interface/codec.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec.h
@@ -118,9 +118,9 @@ using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 /**
  * Custom read filter factory for generic proxy.
  */
-class FilterFactory {
+class ProxyFactory {
 public:
-  virtual ~FilterFactory() = default;
+  virtual ~ProxyFactory() = default;
 
   /**
    * Create a custom read filter instance.
@@ -130,7 +130,7 @@ public:
   virtual void createFilter(Network::FilterManager& filter_manager,
                             const FilterConfigSharedPtr& filter_config) const PURE;
 };
-using FilterFactoryPtr = std::unique_ptr<FilterFactory>;
+using ProxyFactoryPtr = std::unique_ptr<ProxyFactory>;
 
 /**
  * Factory config for codec factory. This class is used to register and create codec factories.
@@ -143,18 +143,20 @@ public:
    * @param context supplies the server context.
    * @return CodecFactoryPtr the codec factory.
    */
-  virtual CodecFactoryPtr createFactory(const Protobuf::Message& config,
-                                        Envoy::Server::Configuration::FactoryContext& context) PURE;
+  virtual CodecFactoryPtr createCodecFactory(const Protobuf::Message&,
+                                             Envoy::Server::Configuration::FactoryContext&) PURE;
 
   /**
-   * Create a optional custom filter factory.
+   * Create a optional custom proxy factory.
    * @param config supplies the config.
    * @param context supplies the server context.
-   * @return FilterFactoryPtr the filter factory.
+   * @return ProxyFactoryPtr the proxy factory to create generic proxy instance or nullptr if no
+   * custom proxy is needed and the default generic proxy will be used.
    */
-  virtual FilterFactoryPtr
-  filterFactory(const Protobuf::Message& config,
-                Envoy::Server::Configuration::FactoryContext& context) PURE;
+  virtual ProxyFactoryPtr createProxyFactory(const Protobuf::Message&,
+                                             Envoy::Server::Configuration::FactoryContext&) {
+    return nullptr;
+  }
 
   std::string category() const override { return "envoy.generic_proxy.codecs"; }
 };

--- a/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
@@ -1,0 +1,84 @@
+
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+
+#include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+/**
+ * Decoder callback of request.
+ */
+class RequestDecoderCallback {
+public:
+  virtual ~RequestDecoderCallback() = default;
+
+  /**
+   * If request decoding success then this method will be called.
+   * @param request request from decoding.
+   */
+  virtual void onDecodingSuccess(RequestPtr request) PURE;
+
+  /**
+   * If request decoding failure then this method will be called.
+   */
+  virtual void onDecodingFailure() PURE;
+};
+
+/**
+ * Decoder callback of Response.
+ */
+class ResponseDecoderCallback {
+public:
+  virtual ~ResponseDecoderCallback() = default;
+
+  /**
+   * If response decoding success then this method will be called.
+   * @param response response from decoding.
+   */
+  virtual void onDecodingSuccess(ResponsePtr response) PURE;
+
+  /**
+   * If response decoding failure then this method will be called.
+   */
+  virtual void onDecodingFailure() PURE;
+};
+
+/**
+ * Encoder callback of request.
+ */
+class RequestEncoderCallback {
+public:
+  virtual ~RequestEncoderCallback() = default;
+
+  /**
+   * If request encoding success then this method will be called.
+   * @param buffer encoding result buffer.
+   * @param expect_response whether the current request requires an upstream response.
+   */
+  virtual void onEncodingSuccess(Buffer::Instance& buffer, bool expect_response) PURE;
+};
+
+/**
+ * Encoder callback of Response.
+ */
+class ResponseEncoderCallback {
+public:
+  virtual ~ResponseEncoderCallback() = default;
+
+  /**
+   * If response encoding success then this method will be called.
+   * @param buffer encoding result buffer.
+   * @param close_connection whether the downstream connection should be closed.
+   */
+  virtual void onEncodingSuccess(Buffer::Instance& buffer, bool close_connection) PURE;
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
+++ b/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "contrib/generic_proxy/filters/network/source/interface/codec.h"
+#include "contrib/generic_proxy/filters/network/source/interface/filter.h"
+#include "contrib/generic_proxy/filters/network/source/interface/route.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+/**
+ * Filter config interface for generic proxy read filter.
+ */
+class FilterConfig : public FilterChainFactory {
+public:
+  /**
+   * Get route entry by generic request.
+   * @param request request.
+   * @return RouteEntryConstSharedPtr route entry.
+   */
+  virtual RouteEntryConstSharedPtr routeEntry(const Request& request) const PURE;
+
+  /**
+   * Get codec factory for  decoding/encoding of request/response.
+   * @return CodecFactory codec factory.
+   */
+  virtual const CodecFactory& codecFactory() const PURE;
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -16,8 +16,8 @@
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.pb.h"
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.pb.validate.h"
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/route.pb.h"
-#include "contrib/generic_proxy/filters/network/source/interface/codec.h"
 #include "contrib/generic_proxy/filters/network/source/interface/filter.h"
+#include "contrib/generic_proxy/filters/network/source/interface/proxy_config.h"
 #include "contrib/generic_proxy/filters/network/source/interface/route.h"
 #include "contrib/generic_proxy/filters/network/source/interface/stream.h"
 #include "contrib/generic_proxy/filters/network/source/rds.h"
@@ -41,25 +41,21 @@ struct NamedFilterFactoryCb {
   FilterFactoryCb callback_;
 };
 
-class FilterConfig : public FilterChainFactory {
+class FilterConfigImpl : public FilterConfig {
 public:
-  FilterConfig(const std::string& stat_prefix, CodecFactoryPtr codec,
-               Rds::RouteConfigProviderSharedPtr route_config_provider,
-               std::vector<NamedFilterFactoryCb> factories)
+  FilterConfigImpl(const std::string& stat_prefix, CodecFactoryPtr codec,
+                   Rds::RouteConfigProviderSharedPtr route_config_provider,
+                   std::vector<NamedFilterFactoryCb> factories)
       : stat_prefix_(stat_prefix), codec_factory_(std::move(codec)),
         route_config_provider_(std::move(route_config_provider)), factories_(std::move(factories)) {
   }
 
-  FilterConfig(const ProxyConfig& config, Server::Configuration::FactoryContext& context,
-               RouteConfigProviderManager& route_config_provider_manager)
-      : FilterConfig(config.stat_prefix(), codecFactoryFromProto(config.codec_config(), context),
-                     routeConfigProviderFromProto(config, context, route_config_provider_manager),
-                     filtersFactoryFromProto(config.filters(), config.stat_prefix(), context)) {}
-
-  RouteEntryConstSharedPtr routeEntry(const Request& request) const {
+  // FilterConfig
+  RouteEntryConstSharedPtr routeEntry(const Request& request) const override {
     auto config = std::static_pointer_cast<const RouteMatcher>(route_config_provider_->config());
     return config->routeEntry(request);
   }
+  const CodecFactory& codecFactory() const override { return *codec_factory_; }
 
   // FilterChainFactory
   void createFilterChain(FilterChainManager& manager) override {
@@ -67,21 +63,6 @@ public:
       manager.applyFilterFactoryCb({factory.config_name_}, factory.callback_);
     }
   }
-
-  const CodecFactory& codecFactory() { return *codec_factory_; }
-
-  static CodecFactoryPtr
-  codecFactoryFromProto(const envoy::config::core::v3::TypedExtensionConfig& codec_config,
-                        Server::Configuration::FactoryContext& context);
-
-  static Rds::RouteConfigProviderSharedPtr
-  routeConfigProviderFromProto(const ProxyConfig& config,
-                               Server::Configuration::FactoryContext& context,
-                               RouteConfigProviderManager& route_config_provider_manager);
-
-  static std::vector<NamedFilterFactoryCb> filtersFactoryFromProto(
-      const ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>& filters,
-      const std::string stats_prefix, Server::Configuration::FactoryContext& context);
 
 private:
   friend class ActiveStream;
@@ -95,7 +76,6 @@ private:
 
   std::vector<NamedFilterFactoryCb> factories_;
 };
-using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 class ActiveStream : public FilterChainManager,
                      public LinkedObject<ActiveStream>,

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -251,8 +251,7 @@ class Filter : public Envoy::Network::ReadFilter,
                public Envoy::Logger::Loggable<Envoy::Logger::Id::filter>,
                public RequestDecoderCallback {
 public:
-  Filter(FilterConfigSharedPtr config, Server::Configuration::FactoryContext& context)
-      : config_(std::move(config)), context_(context) {
+  Filter(FilterConfigSharedPtr config) : config_(std::move(config)) {
     decoder_ = config_->codecFactory().requestDecoder();
     decoder_->setDecoderCallback(*this);
     response_encoder_ = config_->codecFactory().responseEncoder();
@@ -291,8 +290,6 @@ public:
     return callbacks_->connection();
   }
 
-  Server::Configuration::FactoryContext& factoryContext() { return context_; }
-
   void newDownstreamRequest(RequestPtr request);
   void deferredStream(ActiveStream& stream);
 
@@ -318,8 +315,6 @@ private:
   MessageCreatorPtr creator_;
 
   Buffer::OwnedImpl response_buffer_;
-
-  Server::Configuration::FactoryContext& context_;
 
   std::list<ActiveStreamPtr> active_streams_;
 };

--- a/contrib/generic_proxy/filters/network/test/BUILD
+++ b/contrib/generic_proxy/filters/network/test/BUILD
@@ -64,7 +64,11 @@ envoy_cc_test(
     deps = [
         ":fake_codec_lib",
         "//contrib/generic_proxy/filters/network/source:config",
+        "//contrib/generic_proxy/filters/network/test/mocks:codec_mocks",
+        "//contrib/generic_proxy/filters/network/test/mocks:filter_mocks",
+        "//contrib/generic_proxy/filters/network/test/mocks:route_mocks",
         "//source/common/buffer:buffer_lib",
+        "//test/mocks/network:network_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",

--- a/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
@@ -439,7 +439,7 @@ TEST(DubboCodecFactoryConfigTest, DubboCodecFactoryConfigTest) {
 
   Server::Configuration::MockFactoryContext context;
 
-  EXPECT_NE(nullptr, config.createFactory(*proto_config, context));
+  EXPECT_NE(nullptr, config.createCodecFactory(*proto_config, context));
 }
 
 } // namespace

--- a/contrib/generic_proxy/filters/network/test/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/config_test.cc
@@ -210,7 +210,7 @@ TEST(FactoryTest, CustomReadFilterFactory) {
   auto raw_mock_filter_factory = mock_filter_factory.get();
   EXPECT_CALL(*raw_mock_filter_factory, createFilter(_, _));
 
-  EXPECT_CALL(codec_factory_config, createFactory(_, _))
+  EXPECT_CALL(codec_factory_config, createCodecFactory(_, _))
       .WillOnce(Return(testing::ByMove(std::move(mock_codec_factory))));
   EXPECT_CALL(codec_factory_config, filterFactory(_, _))
       .WillOnce(Return(testing::ByMove(std::move(mock_filter_factory))));

--- a/contrib/generic_proxy/filters/network/test/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/config_test.cc
@@ -206,14 +206,14 @@ TEST(FactoryTest, CustomReadFilterFactory) {
 
   auto mock_codec_factory = std::make_unique<MockCodecFactory>();
 
-  auto mock_filter_factory = std::make_unique<MockFilterFactory>();
-  auto raw_mock_filter_factory = mock_filter_factory.get();
-  EXPECT_CALL(*raw_mock_filter_factory, createFilter(_, _));
+  auto mock_proxy_factory = std::make_unique<MockProxyFactory>();
+  auto raw_mock_proxy_factory = mock_proxy_factory.get();
+  EXPECT_CALL(*raw_mock_proxy_factory, createProxy(_, _));
 
   EXPECT_CALL(codec_factory_config, createCodecFactory(_, _))
       .WillOnce(Return(testing::ByMove(std::move(mock_codec_factory))));
-  EXPECT_CALL(codec_factory_config, filterFactory(_, _))
-      .WillOnce(Return(testing::ByMove(std::move(mock_filter_factory))));
+  EXPECT_CALL(codec_factory_config, createProxyFactory(_, _))
+      .WillOnce(Return(testing::ByMove(std::move(mock_proxy_factory))));
 
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, factory_context);
   EXPECT_NE(nullptr, cb);

--- a/contrib/generic_proxy/filters/network/test/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/config_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/admin/v3/config_dump_shared.pb.h"
 #include "envoy/admin/v3/config_dump_shared.pb.validate.h"
 
+#include "test/mocks/network/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
@@ -11,6 +12,9 @@
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/route.pb.validate.h"
 #include "contrib/generic_proxy/filters/network/source/config.h"
 #include "contrib/generic_proxy/filters/network/test/fake_codec.h"
+#include "contrib/generic_proxy/filters/network/test/mocks/codec.h"
+#include "contrib/generic_proxy/filters/network/test/mocks/filter.h"
+#include "contrib/generic_proxy/filters/network/test/mocks/route.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -162,6 +166,168 @@ TEST(FactoryTest, GenericRdsApiConfigSource) {
   EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, factory_context),
                           EnvoyException,
                           "genericrds supports only aggregated api_type in api_config_source");
+}
+
+TEST(FactoryTest, CustomReadFilterFactory) {
+  const std::string config_yaml = R"EOF(
+    stat_prefix: ingress
+    filters:
+    - name: envoy.filters.generic.router
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.network.generic_proxy.router.v3.Router
+    codec_config:
+      name: mock
+      typed_config:
+        "@type": type.googleapis.com/xds.type.v3.TypedStruct
+        type_url: envoy.generic_proxy.codecs.mock.type
+        value: {}
+    generic_rds:
+      config_source: { resource_api_version: V3, ads: {} }
+      route_config_name: test_route
+    )EOF";
+
+  const std::string response_yaml = (R"EOF(
+    version_info: "1"
+    resources:
+      - "@type": type.googleapis.com/envoy.extensions.filters.network.generic_proxy.v3.RouteConfiguration
+        name: test_route
+        routes: {}
+    )EOF");
+
+  MockStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+
+  Factory factory;
+
+  envoy::extensions::filters::network::generic_proxy::v3::GenericProxy config;
+  TestUtility::loadFromYaml(config_yaml, config);
+
+  auto mock_codec_factory = std::make_unique<MockCodecFactory>();
+
+  auto mock_filter_factory = std::make_unique<MockFilterFactory>();
+  auto raw_mock_filter_factory = mock_filter_factory.get();
+  EXPECT_CALL(*raw_mock_filter_factory, createFilter(_, _));
+
+  EXPECT_CALL(codec_factory_config, createFactory(_, _))
+      .WillOnce(Return(testing::ByMove(std::move(mock_codec_factory))));
+  EXPECT_CALL(codec_factory_config, filterFactory(_, _))
+      .WillOnce(Return(testing::ByMove(std::move(mock_filter_factory))));
+
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, factory_context);
+  EXPECT_NE(nullptr, cb);
+  Network::MockFilterManager filter_manager;
+  cb(filter_manager);
+}
+
+/**
+ * Test creating codec factory from typed extension config.
+ */
+TEST(BasicFilterConfigTest, CreatingCodecFactory) {
+
+  {
+    const std::string yaml_config = R"EOF(
+      name: envoy.generic_proxy.codecs.fake
+      typed_config:
+        "@type": type.googleapis.com/xds.type.v3.TypedStruct
+        type_url: envoy.generic_proxy.codecs.fake.type
+        value: {}
+      )EOF";
+    NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+
+    envoy::config::core::v3::TypedExtensionConfig proto_config;
+    TestUtility::loadFromYaml(yaml_config, proto_config);
+
+    EXPECT_THROW(Factory::factoriesFromProto(proto_config, factory_context), EnvoyException);
+  }
+
+  {
+    FakeStreamCodecFactoryConfig codec_factory_config;
+    Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+
+    const std::string yaml_config = R"EOF(
+      name: envoy.generic_proxy.codecs.fake
+      typed_config:
+        "@type": type.googleapis.com/xds.type.v3.TypedStruct
+        type_url: envoy.generic_proxy.codecs.fake.type
+        value: {}
+      )EOF";
+    NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+
+    envoy::config::core::v3::TypedExtensionConfig proto_config;
+    TestUtility::loadFromYaml(yaml_config, proto_config);
+
+    EXPECT_NE(nullptr, Factory::factoriesFromProto(proto_config, factory_context).first);
+    EXPECT_EQ(nullptr, Factory::factoriesFromProto(proto_config, factory_context).second);
+  }
+}
+
+/**
+ * Test creating L7 filter factories from proto config.
+ */
+TEST(BasicFilterConfigTest, CreatingFilterFactories) {
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+
+  ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig> filters_proto_config;
+
+  const std::string yaml_config_0 = R"EOF(
+    name: mock_generic_proxy_filter_name_0
+    typed_config:
+      "@type": type.googleapis.com/xds.type.v3.TypedStruct
+      type_url: mock_generic_proxy_filter_name_0
+      value: {}
+  )EOF";
+
+  const std::string yaml_config_1 = R"EOF(
+    name: mock_generic_proxy_filter_name_1
+    typed_config:
+      "@type": type.googleapis.com/xds.type.v3.TypedStruct
+      type_url: mock_generic_proxy_filter_name_1
+      value: {}
+  )EOF";
+
+  TestUtility::loadFromYaml(yaml_config_0, *filters_proto_config.Add());
+  TestUtility::loadFromYaml(yaml_config_1, *filters_proto_config.Add());
+
+  NiceMock<MockStreamFilterConfig> mock_filter_config_0;
+  NiceMock<MockStreamFilterConfig> mock_filter_config_1;
+
+  ON_CALL(mock_filter_config_0, name()).WillByDefault(Return("mock_generic_proxy_filter_name_0"));
+  ON_CALL(mock_filter_config_1, name()).WillByDefault(Return("mock_generic_proxy_filter_name_1"));
+  ON_CALL(mock_filter_config_0, configTypes())
+      .WillByDefault(Return(std::set<std::string>{"mock_generic_proxy_filter_name_0"}));
+  ON_CALL(mock_filter_config_1, configTypes())
+      .WillByDefault(Return(std::set<std::string>{"mock_generic_proxy_filter_name_1"}));
+
+  Registry::InjectFactory<NamedFilterConfigFactory> registration_0(mock_filter_config_0);
+  Registry::InjectFactory<NamedFilterConfigFactory> registration_1(mock_filter_config_1);
+
+  // No terminal filter.
+  {
+    EXPECT_THROW_WITH_MESSAGE(
+        Factory::filtersFactoryFromProto(filters_proto_config, "test", factory_context),
+        EnvoyException, "A terminal L7 filter is necessary for generic proxy");
+  }
+
+  // Error terminal filter position.
+  {
+    ON_CALL(mock_filter_config_0, isTerminalFilter()).WillByDefault(Return(true));
+
+    EXPECT_THROW_WITH_MESSAGE(
+        Factory::filtersFactoryFromProto(filters_proto_config, "test", factory_context),
+        EnvoyException,
+        "Terminal filter: mock_generic_proxy_filter_name_0 must be the last generic L7 "
+        "filter");
+  }
+
+  {
+    ON_CALL(mock_filter_config_0, isTerminalFilter()).WillByDefault(Return(false));
+    ON_CALL(mock_filter_config_1, isTerminalFilter()).WillByDefault(Return(true));
+    auto factories =
+        Factory::filtersFactoryFromProto(filters_proto_config, "test", factory_context);
+    EXPECT_EQ(2, factories.size());
+  }
 }
 
 } // namespace

--- a/contrib/generic_proxy/filters/network/test/fake_codec.cc
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.cc
@@ -25,8 +25,8 @@ MessageCreatorPtr FakeStreamCodecFactory::messageCreator() const {
 }
 
 CodecFactoryPtr
-FakeStreamCodecFactoryConfig::createFactory(const Protobuf::Message&,
-                                            Envoy::Server::Configuration::FactoryContext&) {
+FakeStreamCodecFactoryConfig::createCodecFactory(const Protobuf::Message&,
+                                                 Envoy::Server::Configuration::FactoryContext&) {
   return std::make_unique<FakeStreamCodecFactory>();
 }
 

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -258,12 +258,9 @@ public:
 class FakeStreamCodecFactoryConfig : public CodecFactoryConfig {
 public:
   // CodecFactoryConfig
-  CodecFactoryPtr createFactory(const Protobuf::Message& config,
-                                Envoy::Server::Configuration::FactoryContext& context) override;
-  FilterFactoryPtr filterFactory(const Protobuf::Message&,
-                                 Server::Configuration::FactoryContext&) override {
-    return nullptr;
-  }
+  CodecFactoryPtr
+  createCodecFactory(const Protobuf::Message& config,
+                     Envoy::Server::Configuration::FactoryContext& context) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ProtobufWkt::Struct>();
   }

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -257,14 +257,17 @@ public:
 
 class FakeStreamCodecFactoryConfig : public CodecFactoryConfig {
 public:
+  // CodecFactoryConfig
   CodecFactoryPtr createFactory(const Protobuf::Message& config,
                                 Envoy::Server::Configuration::FactoryContext& context) override;
+  FilterFactoryPtr filterFactory(const Protobuf::Message&,
+                                 Server::Configuration::FactoryContext&) override {
+    return nullptr;
+  }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ProtobufWkt::Struct>();
   }
-
   std::set<std::string> configTypes() override { return {"envoy.generic_proxy.codecs.fake.type"}; }
-
   std::string name() const override { return "envoy.generic_proxy.codecs.fake"; }
 };
 

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.cc
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.cc
@@ -24,6 +24,10 @@ MockCodecFactory::MockCodecFactory() {
       .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockMessageCreator>>())));
 }
 
+MockFilterFactory::MockFilterFactory() = default;
+
+MockStreamCodecFactoryConfig::MockStreamCodecFactoryConfig() = default;
+
 } // namespace GenericProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.cc
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.cc
@@ -24,7 +24,7 @@ MockCodecFactory::MockCodecFactory() {
       .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockMessageCreator>>())));
 }
 
-MockFilterFactory::MockFilterFactory() = default;
+MockProxyFactory::MockProxyFactory() = default;
 
 MockStreamCodecFactoryConfig::MockStreamCodecFactoryConfig() = default;
 

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.h
@@ -82,9 +82,9 @@ class MockStreamCodecFactoryConfig : public CodecFactoryConfig {
 public:
   MockStreamCodecFactoryConfig();
 
-  MOCK_METHOD(CodecFactoryPtr, createFactory,
+  MOCK_METHOD(CodecFactoryPtr, createCodecFactory,
               (const Protobuf::Message&, Envoy::Server::Configuration::FactoryContext&));
-  MOCK_METHOD(FilterFactoryPtr, filterFactory,
+  MOCK_METHOD(FilterFactoryPtr, createProxyFactory,
               (const Protobuf::Message&, Envoy::Server::Configuration::FactoryContext&));
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.h
@@ -71,11 +71,11 @@ public:
   MOCK_METHOD(MessageCreatorPtr, messageCreator, (), (const));
 };
 
-class MockFilterFactory : public FilterFactory {
+class MockProxyFactory : public ProxyFactory {
 public:
-  MockFilterFactory();
+  MockProxyFactory();
 
-  MOCK_METHOD(void, createFilter, (Network::FilterManager&, const FilterConfigSharedPtr&), (const));
+  MOCK_METHOD(void, createProxy, (Network::FilterManager&, const FilterConfigSharedPtr&), (const));
 };
 
 class MockStreamCodecFactoryConfig : public CodecFactoryConfig {
@@ -84,7 +84,7 @@ public:
 
   MOCK_METHOD(CodecFactoryPtr, createCodecFactory,
               (const Protobuf::Message&, Envoy::Server::Configuration::FactoryContext&));
-  MOCK_METHOD(FilterFactoryPtr, createProxyFactory,
+  MOCK_METHOD(ProxyFactoryPtr, createProxyFactory,
               (const Protobuf::Message&, Envoy::Server::Configuration::FactoryContext&));
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.h
@@ -71,6 +71,29 @@ public:
   MOCK_METHOD(MessageCreatorPtr, messageCreator, (), (const));
 };
 
+class MockFilterFactory : public FilterFactory {
+public:
+  MockFilterFactory();
+
+  MOCK_METHOD(void, createFilter, (Network::FilterManager&, const FilterConfigSharedPtr&), (const));
+};
+
+class MockStreamCodecFactoryConfig : public CodecFactoryConfig {
+public:
+  MockStreamCodecFactoryConfig();
+
+  MOCK_METHOD(CodecFactoryPtr, createFactory,
+              (const Protobuf::Message&, Envoy::Server::Configuration::FactoryContext&));
+  MOCK_METHOD(FilterFactoryPtr, filterFactory,
+              (const Protobuf::Message&, Envoy::Server::Configuration::FactoryContext&));
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ProtobufWkt::Struct>();
+  }
+  std::set<std::string> configTypes() override { return {"envoy.generic_proxy.codecs.mock.type"}; }
+  std::string name() const override { return "envoy.generic_proxy.codecs.mock"; }
+};
+
 } // namespace GenericProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -261,7 +261,7 @@ public:
         .WillOnce(
             Invoke([this](RequestDecoderCallback& callback) { decoder_callback_ = &callback; }));
 
-    filter_ = std::make_shared<Filter>(filter_config_, factory_context_);
+    filter_ = std::make_shared<Filter>(filter_config_);
 
     EXPECT_EQ(filter_.get(), decoder_callback_);
 
@@ -375,11 +375,6 @@ TEST_F(FilterTest, GetConnection) {
   initializeFilter();
 
   EXPECT_EQ(&(filter_callbacks_.connection_), &filter_->connection());
-}
-
-TEST_F(FilterTest, GetFactoryContext) {
-  initializeFilter();
-  EXPECT_EQ(&factory_context_, &filter_->factoryContext());
 }
 
 TEST_F(FilterTest, NewStreamAndResetStream) {

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -36,115 +36,6 @@ public:
   std::shared_ptr<NiceMock<MockRouteMatcher>> route_config_{new NiceMock<MockRouteMatcher>()};
 };
 
-/**
- * Test creating codec factory from typed extension config.
- */
-TEST(BasicFilterConfigTest, CreatingCodecFactory) {
-
-  {
-    const std::string yaml_config = R"EOF(
-      name: envoy.generic_proxy.codecs.fake
-      typed_config:
-        "@type": type.googleapis.com/xds.type.v3.TypedStruct
-        type_url: envoy.generic_proxy.codecs.fake.type
-        value: {}
-      )EOF";
-    NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-
-    envoy::config::core::v3::TypedExtensionConfig proto_config;
-    TestUtility::loadFromYaml(yaml_config, proto_config);
-
-    EXPECT_THROW(FilterConfig::codecFactoryFromProto(proto_config, factory_context),
-                 EnvoyException);
-  }
-
-  {
-    FakeStreamCodecFactoryConfig codec_factory_config;
-    Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
-
-    const std::string yaml_config = R"EOF(
-      name: envoy.generic_proxy.codecs.fake
-      typed_config:
-        "@type": type.googleapis.com/xds.type.v3.TypedStruct
-        type_url: envoy.generic_proxy.codecs.fake.type
-        value: {}
-      )EOF";
-    NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-
-    envoy::config::core::v3::TypedExtensionConfig proto_config;
-    TestUtility::loadFromYaml(yaml_config, proto_config);
-
-    EXPECT_NE(nullptr, FilterConfig::codecFactoryFromProto(proto_config, factory_context));
-  }
-}
-
-/**
- * Test creating L7 filter factories from proto config.
- */
-TEST(BasicFilterConfigTest, CreatingFilterFactories) {
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-
-  ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig> filters_proto_config;
-
-  const std::string yaml_config_0 = R"EOF(
-    name: mock_generic_proxy_filter_name_0
-    typed_config:
-      "@type": type.googleapis.com/xds.type.v3.TypedStruct
-      type_url: mock_generic_proxy_filter_name_0
-      value: {}
-  )EOF";
-
-  const std::string yaml_config_1 = R"EOF(
-    name: mock_generic_proxy_filter_name_1
-    typed_config:
-      "@type": type.googleapis.com/xds.type.v3.TypedStruct
-      type_url: mock_generic_proxy_filter_name_1
-      value: {}
-  )EOF";
-
-  TestUtility::loadFromYaml(yaml_config_0, *filters_proto_config.Add());
-  TestUtility::loadFromYaml(yaml_config_1, *filters_proto_config.Add());
-
-  NiceMock<MockStreamFilterConfig> mock_filter_config_0;
-  NiceMock<MockStreamFilterConfig> mock_filter_config_1;
-
-  ON_CALL(mock_filter_config_0, name()).WillByDefault(Return("mock_generic_proxy_filter_name_0"));
-  ON_CALL(mock_filter_config_1, name()).WillByDefault(Return("mock_generic_proxy_filter_name_1"));
-  ON_CALL(mock_filter_config_0, configTypes())
-      .WillByDefault(Return(std::set<std::string>{"mock_generic_proxy_filter_name_0"}));
-  ON_CALL(mock_filter_config_1, configTypes())
-      .WillByDefault(Return(std::set<std::string>{"mock_generic_proxy_filter_name_1"}));
-
-  Registry::InjectFactory<NamedFilterConfigFactory> registration_0(mock_filter_config_0);
-  Registry::InjectFactory<NamedFilterConfigFactory> registration_1(mock_filter_config_1);
-
-  // No terminal filter.
-  {
-    EXPECT_THROW_WITH_MESSAGE(
-        FilterConfig::filtersFactoryFromProto(filters_proto_config, "test", factory_context),
-        EnvoyException, "A terminal L7 filter is necessary for generic proxy");
-  }
-
-  // Error terminal filter position.
-  {
-    ON_CALL(mock_filter_config_0, isTerminalFilter()).WillByDefault(Return(true));
-
-    EXPECT_THROW_WITH_MESSAGE(
-        FilterConfig::filtersFactoryFromProto(filters_proto_config, "test", factory_context),
-        EnvoyException,
-        "Terminal filter: mock_generic_proxy_filter_name_0 must be the last generic L7 "
-        "filter");
-  }
-
-  {
-    ON_CALL(mock_filter_config_0, isTerminalFilter()).WillByDefault(Return(false));
-    ON_CALL(mock_filter_config_1, isTerminalFilter()).WillByDefault(Return(true));
-    auto factories =
-        FilterConfig::filtersFactoryFromProto(filters_proto_config, "test", factory_context);
-    EXPECT_EQ(2, factories.size());
-  }
-}
-
 class FilterConfigTest : public testing::Test {
 public:
   void initializeFilterConfig() {
@@ -172,8 +63,8 @@ public:
 
     mock_route_entry_ = std::make_shared<NiceMock<MockRouteEntry>>();
 
-    filter_config_ = std::make_shared<FilterConfig>("test_prefix", std::move(codec_factory),
-                                                    route_config_provider_, factories);
+    filter_config_ = std::make_shared<FilterConfigImpl>("test_prefix", std::move(codec_factory),
+                                                        route_config_provider_, factories);
   }
 
   std::shared_ptr<FilterConfig> filter_config_;


### PR DESCRIPTION
Commit Message: generic proxy: added support for custom read filter
Additional Description:

Developers could add new protocol proxying function to the Envoy by implementing a codec for the related protocol.
In the previous implementation, although the codec is extensible but the implementation of L4 read filter is fixed.

This PR added new extension point to make the implementation of L4 read filter customizable based on the codec config.


Risk Level: Low. contrib code update.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.