### PR TITLE
Move header-merging from simple_http_cache to cache_entry_utils

### DIFF
--- a/source/extensions/filters/http/cache/cache_entry_utils.cc
+++ b/source/extensions/filters/http/cache/cache_entry_utils.cc
@@ -28,6 +28,58 @@ std::ostream& operator<<(std::ostream& os, CacheEntryStatus status) {
   return os << cacheEntryStatusString(status);
 }
 
+namespace {
+const absl::flat_hash_set<Http::LowerCaseString> headersNotToUpdate() {
+  CONSTRUCT_ON_FIRST_USE(
+      absl::flat_hash_set<Http::LowerCaseString>,
+      // Content range should not be changed upon validation
+      Http::Headers::get().ContentRange,
+
+      // Headers that describe the body content should never be updated.
+      Http::Headers::get().ContentLength,
+
+      // It does not make sense for this level of the code to be updating the ETag, when
+      // presumably the cached_response_headers reflect this specific ETag.
+      Http::CustomHeaders::get().Etag,
+
+      // We don't update the cached response on a Vary; we just delete it
+      // entirely. So don't bother copying over the Vary header.
+      Http::CustomHeaders::get().Vary);
+}
+} // namespace
+
+void applyHeaderUpdate(const Http::ResponseHeaderMap& new_headers,
+                       Http::ResponseHeaderMap& headers_to_update) {
+  // Assumptions:
+  // 1. The internet is fast, i.e. we get the result as soon as the server sends it.
+  //    Race conditions would not be possible because we are always processing up-to-date data.
+  // 2. No key collision for etag. Therefore, if etag matches it's the same resource.
+  // 3. Backend is correct. etag is being used as a unique identifier to the resource
+
+  // use other header fields provided in the new response to replace all instances
+  // of the corresponding header fields in the stored response
+
+  // `updatedHeaderFields` makes sure each field is only removed when we update the header
+  // field for the first time to handle the case where incoming headers have repeated values
+  absl::flat_hash_set<Http::LowerCaseString> updatedHeaderFields;
+  new_headers.iterate(
+      [&headers_to_update, &updatedHeaderFields](
+          const Http::HeaderEntry& incoming_response_header) -> Http::HeaderMap::Iterate {
+        Http::LowerCaseString lower_case_key{incoming_response_header.key().getStringView()};
+        absl::string_view incoming_value{incoming_response_header.value().getStringView()};
+        if (headersNotToUpdate().contains(lower_case_key)) {
+          return Http::HeaderMap::Iterate::Continue;
+        }
+        if (!updatedHeaderFields.contains(lower_case_key)) {
+          headers_to_update.setCopy(lower_case_key, incoming_value);
+          updatedHeaderFields.insert(lower_case_key);
+        } else {
+          headers_to_update.addCopy(lower_case_key, incoming_value);
+        }
+        return Http::HeaderMap::Iterate::Continue;
+      });
+}
+
 } // namespace Cache
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/cache/cache_entry_utils.h
+++ b/source/extensions/filters/http/cache/cache_entry_utils.h
@@ -44,6 +44,17 @@ enum class CacheEntryStatus {
 absl::string_view cacheEntryStatusString(CacheEntryStatus s);
 std::ostream& operator<<(std::ostream& os, CacheEntryStatus status);
 
+// For an updateHeaders operation, new headers must be merged into existing headers
+// for the cache entry. This helper function performs that merge correctly, i.e.
+// - if a header appears in new_headers, prior values for that header are erased
+//   from headers_to_update.
+// - if a header appears more than once in new_headers, all new values are added
+//   to headers_to_update.
+// - headers that are not supposed to be updated during updateHeaders operations
+//   (etag, content-length, content-range, vary) are ignored.
+void applyHeaderUpdate(const Http::ResponseHeaderMap& new_headers,
+                       Http::ResponseHeaderMap& headers_to_update);
+
 } // namespace Cache
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.cc
@@ -123,24 +123,6 @@ LookupContextPtr SimpleHttpCache::makeLookupContext(LookupRequest&& request,
   return std::make_unique<SimpleLookupContext>(*this, std::move(request));
 }
 
-const absl::flat_hash_set<Http::LowerCaseString> SimpleHttpCache::headersNotToUpdate() {
-  CONSTRUCT_ON_FIRST_USE(
-      absl::flat_hash_set<Http::LowerCaseString>,
-      // Content range should not be changed upon validation
-      Http::Headers::get().ContentRange,
-
-      // Headers that describe the body content should never be updated.
-      Http::Headers::get().ContentLength,
-
-      // It does not make sense for this level of the code to be updating the ETag, when
-      // presumably the cached_response_headers reflect this specific ETag.
-      Http::CustomHeaders::get().Etag,
-
-      // We don't update the cached response on a Vary; we just delete it
-      // entirely. So don't bother copying over the Vary header.
-      Http::CustomHeaders::get().Vary);
-}
-
 void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
                                     const Http::ResponseHeaderMap& response_headers,
                                     const ResponseMetadata& metadata,
@@ -162,34 +144,7 @@ void SimpleHttpCache::updateHeaders(const LookupContext& lookup_context,
     return;
   }
 
-  // Assumptions:
-  // 1. The internet is fast, i.e. we get the result as soon as the server sends it.
-  //    Race conditions would not be possible because we are always processing up-to-date data.
-  // 2. No key collision for etag. Therefore, if etag matches it's the same resource.
-  // 3. Backend is correct. etag is being used as a unique identifier to the resource
-
-  // use other header fields provided in the new response to replace all instances
-  // of the corresponding header fields in the stored response
-
-  // `updatedHeaderFields` makes sure each field is only removed when we update the header
-  // field for the first time to handle the case where incoming headers have repeated values
-  absl::flat_hash_set<Http::LowerCaseString> updatedHeaderFields;
-  response_headers.iterate(
-      [&entry, &updatedHeaderFields](
-          const Http::HeaderEntry& incoming_response_header) -> Http::HeaderMap::Iterate {
-        Http::LowerCaseString lower_case_key{incoming_response_header.key().getStringView()};
-        absl::string_view incoming_value{incoming_response_header.value().getStringView()};
-        if (headersNotToUpdate().contains(lower_case_key)) {
-          return Http::HeaderMap::Iterate::Continue;
-        }
-        if (!updatedHeaderFields.contains(lower_case_key)) {
-          entry.response_headers_->setCopy(lower_case_key, incoming_value);
-          updatedHeaderFields.insert(lower_case_key);
-        } else {
-          entry.response_headers_->addCopy(lower_case_key, incoming_value);
-        }
-        return Http::HeaderMap::Iterate::Continue;
-      });
+  applyHeaderUpdate(response_headers, *entry.response_headers_);
   entry.metadata_ = metadata;
   on_complete(true);
 }

--- a/test/extensions/filters/http/cache/cache_entry_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_entry_utils_test.cc
@@ -26,6 +26,81 @@ TEST(Coverage, CacheEntryStatusStream) {
   EXPECT_EQ(stream.str(), "Ok");
 }
 
+TEST(CacheEntryUtils, ApplyHeaderUpdateReplacesMultiValues) {
+  Http::TestResponseHeaderMapImpl headers{
+      {"test_header", "test_value"},
+      {"second_header", "second_value"},
+      {"second_header", "additional_value"},
+  };
+  Http::TestResponseHeaderMapImpl new_headers{
+      {"second_header", "new_second_value"},
+  };
+  applyHeaderUpdate(new_headers, headers);
+  Http::TestResponseHeaderMapImpl expected{
+      {"test_header", "test_value"},
+      {"second_header", "new_second_value"},
+  };
+  EXPECT_THAT(&headers, HeaderMapEqualIgnoreOrder(&expected));
+}
+
+TEST(CacheEntryUtils, ApplyHeaderUpdateAppliesMultiValues) {
+  Http::TestResponseHeaderMapImpl headers{
+      {"test_header", "test_value"},
+      {"second_header", "second_value"},
+  };
+  Http::TestResponseHeaderMapImpl new_headers{
+      {"second_header", "new_second_value"},
+      {"second_header", "another_new_second_value"},
+  };
+  applyHeaderUpdate(new_headers, headers);
+  Http::TestResponseHeaderMapImpl expected{
+      {"test_header", "test_value"},
+      {"second_header", "new_second_value"},
+      {"second_header", "another_new_second_value"},
+  };
+  EXPECT_THAT(&headers, HeaderMapEqualIgnoreOrder(&expected));
+}
+
+TEST(CacheEntryUtils, ApplyHeaderUpdateIgnoresIgnoredValues) {
+  Http::TestResponseHeaderMapImpl headers{
+      {"test_header", "test_value"}, {"etag", "original_etag"}, {"content-length", "123456"},
+      {"content-range", "654321"},   {"vary", "original_vary"},
+  };
+  Http::TestResponseHeaderMapImpl new_headers{
+      {"etag", "updated_etag"},
+      {"content-length", "999999"},
+      {"content-range", "999999"},
+      {"vary", "updated_vary"},
+  };
+  applyHeaderUpdate(new_headers, headers);
+  Http::TestResponseHeaderMapImpl expected{
+      {"test_header", "test_value"}, {"etag", "original_etag"}, {"content-length", "123456"},
+      {"content-range", "654321"},   {"vary", "original_vary"},
+  };
+  EXPECT_THAT(&headers, HeaderMapEqualIgnoreOrder(&expected));
+}
+
+TEST(CacheEntryUtils, ApplyHeaderUpdateCorrectlyMixesOverwriteIgnoreAddAndPersist) {
+  Http::TestResponseHeaderMapImpl headers{
+      {"persisted_header", "1"},
+      {"persisted_header", "2"},
+      {"overwritten_header", "old"},
+  };
+  Http::TestResponseHeaderMapImpl new_headers{
+      {"overwritten_header", "new"},
+      {"added_header", "also_new"},
+      {"etag", "ignored"},
+  };
+  applyHeaderUpdate(new_headers, headers);
+  Http::TestResponseHeaderMapImpl expected{
+      {"persisted_header", "1"},
+      {"persisted_header", "2"},
+      {"overwritten_header", "new"},
+      {"added_header", "also_new"},
+  };
+  EXPECT_THAT(&headers, HeaderMapEqualIgnoreOrder(&expected));
+}
+
 } // namespace
 } // namespace Cache
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message: Move header-merging from simple_http_cache to cache_entry_utils
Additional Description: This operation should behave the same for all cache implementations, and is non-trivial, so it should be a shared function.
Risk Level: Low; WIP filter only, no behavior change.
Testing: Unit tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
