### PR TITLE
generic proxy: update codeowners of generic proxy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -312,4 +312,4 @@ extensions/filters/http/oauth2 @derekargueta @snowp
 /contrib/language/ @diceride @diceride
 /contrib/dlb/ @mattklein123 @daixiang0
 /contrib/qat/ @ipuustin @VillePihlava
-/contrib/generic_proxy/ @wbpcode @zhaohuabing @rojkov @htuch
+/contrib/generic_proxy/ @wbpcode @soulxu @zhaohuabing @rojkov @htuch


### PR DESCRIPTION

Commit Message: generic proxy: update codeowners of generic proxy
Additional Description:

There was only one active contributor (me) for the generic proxy in the past.
Now the @soulxu is glad to help review and maintain code of generic proxy.

He is active contributor of Envoy and has done lots of great contributions. Thanks. 🌹 

Risk Level: n/a.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.