### PR TITLE
[backport/1.24] ci: disable non-RBE cache for release branches (#22745)

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -55,7 +55,6 @@ steps:
       BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
-      BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
   displayName: "Run CI script ${{ parameters.ciTarget }}"
 

--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -15,12 +15,12 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     com_envoyproxy_protoc_gen_validate = dict(
         project_name = "protoc-gen-validate (PGV)",
         project_desc = "protoc plugin to generate polyglot message validators",
-        project_url = "https://github.com/envoyproxy/protoc-gen-validate",
+        project_url = "https://github.com/bufbuild/protoc-gen-validate",
         version = "0.6.7",
         sha256 = "4c692c62e16c168049bca2b2972b0a25222870cf53e61be30b50d761e58728bd",
         release_date = "2022-03-04",
         strip_prefix = "protoc-gen-validate-{version}",
-        urls = ["https://github.com/envoyproxy/protoc-gen-validate/archive/v{version}.tar.gz"],
+        urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/v{version}.tar.gz"],
         use_category = ["api"],
         implied_untracked_deps = [
             "com_github_iancoleman_strcase",
@@ -30,7 +30,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "org_golang_x_text",
         ],
         license = "Apache-2.0",
-        license_url = "https://github.com/envoyproxy/protoc-gen-validate/blob/v{version}/LICENSE",
+        license_url = "https://github.com/bufbuild/protoc-gen-validate/blob/v{version}/LICENSE",
     ),
     com_github_cncf_udpa = dict(
         project_name = "xDS API",


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
