### PR TITLE
bazel: remove unnecessary sizeopt configs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -159,9 +159,7 @@ build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread
 build:libc++ --define force_libcpp=enabled
 
 # Optimize build for binary size reduction.
-build:sizeopt-sections -c opt --copt -Os --linkopt=-Wl,--gc-sections
 build:sizeopt -c opt --copt -Os
-build:sizeopt-strip -c opt --copt -Os --linkopt=-Wl,-dead_strip
 
 # Test options
 build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH


### PR DESCRIPTION
Bazel automatically applies `--gc-sections` when supported:

https://github.com/bazelbuild/bazel/blob/8bd2d97fd143b4b8a6fc96ce300820e6e422c03a/tools/cpp/unix_cc_configure.bzl#L620-L625

and `-dead_strip` on darwin:

https://github.com/bazelbuild/bazel/blob/4caae75b49e815ad2cf1d805f316bc374f03f2ae/tools/osx/crosstool/cc_toolchain_config.bzl#L2159-L2173

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>