### PR TITLE
rate_limit_quota: [API] Support Envoy node info in `RateLimitQuotaUsageReports`

### DIFF
--- a/api/envoy/service/rate_limit_quota/v3/BUILD
+++ b/api/envoy/service/rate_limit_quota/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     has_services = True,
     deps = [
+        "//envoy/config/core/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
         "@com_github_cncf_udpa//xds/annotations/v3:pkg",

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -64,7 +64,6 @@ message RateLimitQuotaUsageReports {
   // .. note::
   //   Note that the first report sent for a ``BucketId`` indicates to the RLQS server that
   //   the RLQS client is subscribing for the future assignments for this ``BucketId``.
-  // [#next-free-field: 5]
   message BucketQuotaUsage {
     // ``BucketId`` for which request quota usage is reported.
     BucketId bucket_id = 1 [(validate.rules).message = {required: true}];

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.service.rate_limit_quota.v3;
 
+import "envoy/config/core/v3/base.proto";
 import "envoy/type/v3/ratelimit_strategy.proto";
 
 import "google/protobuf/duration.proto";
@@ -63,6 +64,7 @@ message RateLimitQuotaUsageReports {
   // .. note::
   //   Note that the first report sent for a ``BucketId`` indicates to the RLQS server that
   //   the RLQS client is subscribing for the future assignments for this ``BucketId``.
+  // [#next-free-field: 6]
   message BucketQuotaUsage {
     // ``BucketId`` for which request quota usage is reported.
     BucketId bucket_id = 1 [(validate.rules).message = {required: true}];
@@ -78,6 +80,9 @@ message RateLimitQuotaUsageReports {
 
     // Requests throttled.
     uint64 num_requests_denied = 4;
+
+    // An optional info for the list of Envoy instances that send the usage report ``BucketQuotaUsage``.
+    repeated config.core.v3.Node nodes = 5;
   }
 
   // All quota requests must specify the domain. This enables sharing the quota

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -82,6 +82,7 @@ message RateLimitQuotaUsageReports {
     uint64 num_requests_denied = 4;
 
     // An optional info for the list of Envoy instances that send the usage report ``BucketQuotaUsage``.
+    // This field should only be provided in the first report, the subsequent messages will have the same Envoy node inforamtion.
     repeated config.core.v3.Node nodes = 5;
   }
 

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -80,10 +80,6 @@ message RateLimitQuotaUsageReports {
 
     // Requests throttled.
     uint64 num_requests_denied = 4;
-
-    // An optional info for the list of Envoy instances that send the usage report ``BucketQuotaUsage``.
-    // This field should only be provided in the first report, the subsequent messages will have the same Envoy node inforamtion.
-    repeated config.core.v3.Node nodes = 5;
   }
 
   // All quota requests must specify the domain. This enables sharing the quota
@@ -98,6 +94,10 @@ message RateLimitQuotaUsageReports {
   // A list of quota usage reports. The list is processed by the RLQS server in the same order
   // it's provided by the client.
   repeated BucketQuotaUsage bucket_quota_usages = 2 [(validate.rules).repeated = {min_items: 1}];
+
+  // An optional info of the Envoy instance that sends the usage report ``BucketQuotaUsage``.
+  // This field should only be provided in the first report, the subsequent reports will have the same information.
+  config.core.v3.Node node = 3;
 }
 
 message RateLimitQuotaResponse {

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -64,7 +64,7 @@ message RateLimitQuotaUsageReports {
   // .. note::
   //   Note that the first report sent for a ``BucketId`` indicates to the RLQS server that
   //   the RLQS client is subscribing for the future assignments for this ``BucketId``.
-  // [#next-free-field: 6]
+  // [#next-free-field: 5]
   message BucketQuotaUsage {
     // ``BucketId`` for which request quota usage is reported.
     BucketId bucket_id = 1 [(validate.rules).message = {required: true}];


### PR DESCRIPTION
Even though our (Google) RLQS server doesn't need this, there are needs/use cases from other RLQS customers that the RQLS server will receive reports from many envoy nodes across various regions, clusters and tenants. And the customers will use this Envoy node which contains all of this information to distinguish the tenant/region/cluster and to apply the appropriate rate limiting policies. 

This PR addresses #23585. 

Signed-off-by: tyxia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: LOW
Testing: N/A 
