### PR TITLE
transport socket: trigger onConnect for downstream transport sockets

### DIFF
--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -164,7 +164,7 @@ protected:
 
   // This is called when the underlying socket is connected, not when the
   // connected event is raised.
-  virtual void onConnected() {}
+  virtual void onConnected();
 
   void setFailureReason(absl::string_view failure_reason);
   const std::string& failureReason() const { return failure_reason_; }
@@ -244,6 +244,7 @@ public:
   void setTransportSocketConnectTimeout(std::chrono::milliseconds timeout,
                                         Stats::Counter& timeout_stat) override;
   void raiseEvent(ConnectionEvent event) override;
+  bool initializeReadFilters() override;
 
 private:
   void onTransportSocketConnectTimeout();

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -11,13 +11,14 @@ namespace TransportSockets {
 namespace Alts {
 
 TsiSocket::TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator,
-                     Network::TransportSocketPtr&& raw_socket)
+                     Network::TransportSocketPtr&& raw_socket, bool downstream)
     : handshaker_factory_(handshaker_factory), handshake_validator_(handshake_validator),
-      raw_buffer_socket_(std::move(raw_socket)) {}
+      raw_buffer_socket_(std::move(raw_socket)), downstream_(downstream) {}
 
-TsiSocket::TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator)
+TsiSocket::TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator,
+                     bool downstream)
     : TsiSocket(handshaker_factory, handshake_validator,
-                std::make_unique<Network::RawBufferSocket>()) {
+                std::make_unique<Network::RawBufferSocket>(), downstream) {
   raw_read_buffer_.setWatermarks(default_max_frame_size_);
 }
 
@@ -361,7 +362,9 @@ void TsiSocket::closeSocket(Network::ConnectionEvent) {
 
 void TsiSocket::onConnected() {
   ASSERT(!handshake_complete_);
-  doHandshakeNext();
+  if (!downstream_) {
+    doHandshakeNext();
+  }
 }
 
 void TsiSocket::onNextDone(NextResultPtr&& result) {
@@ -383,11 +386,11 @@ bool TsiSocketFactory::implementsSecureTransport() const { return true; }
 Network::TransportSocketPtr
 TsiSocketFactory::createTransportSocket(Network::TransportSocketOptionsConstSharedPtr,
                                         Upstream::HostDescriptionConstSharedPtr) const {
-  return std::make_unique<TsiSocket>(handshaker_factory_, handshake_validator_);
+  return std::make_unique<TsiSocket>(handshaker_factory_, handshake_validator_, false);
 }
 
 Network::TransportSocketPtr TsiSocketFactory::createDownstreamTransportSocket() const {
-  return std::make_unique<TsiSocket>(handshaker_factory_, handshake_validator_);
+  return std::make_unique<TsiSocket>(handshaker_factory_, handshake_validator_, true);
 }
 
 } // namespace Alts

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -362,6 +362,7 @@ void TsiSocket::closeSocket(Network::ConnectionEvent) {
 
 void TsiSocket::onConnected() {
   ASSERT(!handshake_complete_);
+  // Client initiates the handshake, so ignore onConnect call on the downstream.
   if (!downstream_) {
     doHandshakeNext();
   }

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -51,15 +51,17 @@ class TsiSocket : public Network::TransportSocket,
 public:
   // For Test
   TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator,
-            Network::TransportSocketPtr&& raw_socket_ptr);
+            Network::TransportSocketPtr&& raw_socket_ptr, bool downstream);
 
   /**
    * @param handshaker_factory a function to initiate a TsiHandshaker
    * @param handshake_validator a function to validate the peer. Called right
    * after the handshake completed with peer data to do the peer validation.
    * The connection will be closed immediately if it returns false.
+   * @param downstream is true for downstream transport socket.
    */
-  TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator);
+  TsiSocket(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator,
+            bool downstream);
   ~TsiSocket() override;
 
   // Network::TransportSocket
@@ -118,6 +120,7 @@ private:
   Envoy::Network::TransportSocketCallbacks* callbacks_{};
   std::unique_ptr<TsiTransportSocketCallbacks> tsi_callbacks_;
   Network::TransportSocketPtr raw_buffer_socket_;
+  const bool downstream_;
 
   Buffer::WatermarkBuffer raw_read_buffer_{[]() {}, []() {}, []() {}};
   Envoy::Buffer::OwnedImpl raw_write_buffer_;

--- a/test/extensions/transport_sockets/alts/tsi_socket_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_socket_test.cc
@@ -56,13 +56,13 @@ protected:
 
     server_.tsi_socket_ =
         std::make_unique<TsiSocket>(server_.handshaker_factory_, server_validator,
-                                    Network::TransportSocketPtr{server_.raw_socket_});
+                                    Network::TransportSocketPtr{server_.raw_socket_}, true);
 
     client_.raw_socket_ = new Network::MockTransportSocket();
 
     client_.tsi_socket_ =
         std::make_unique<TsiSocket>(client_.handshaker_factory_, client_validator,
-                                    Network::TransportSocketPtr{client_.raw_socket_});
+                                    Network::TransportSocketPtr{client_.raw_socket_}, false);
     ON_CALL(client_.callbacks_.connection_, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
     ON_CALL(server_.callbacks_.connection_, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Trigger downstream transport socket `onConnect`. Server connections start out as socket connected, but not necessarily transport socket connected. The server socket may need this event to trigger the transport socket connected event (e.g. raw_buffer). 
Some server downstream transport sockets may share implementation with the upstream transport socket and not expect this event, in which case these custom downstream transport sockets may need to ignore this event after this change.

Risk Level: medium (for downstream integrations, no functional change in this repo)
Testing: done
Docs Changes: none
Release Notes:
Issue: https://github.com/envoyproxy/envoy/issues/9023