### PR TITLE
Switching "grpc-message-encoding" to "grpc-message-type" in headers.h.

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -74,7 +74,7 @@ public:
   const LowerCaseString Expires{"expires"};
   const LowerCaseString GrpcAcceptEncoding{"grpc-accept-encoding"};
   const LowerCaseString GrpcEncoding{"grpc-encoding"};
-  const LowerCaseString GrpcMessageEncoding{"grpc-message-encoding"};
+  const LowerCaseString GrpcMessageType{"grpc-message-type"};
   const LowerCaseString IfMatch{"if-match"};
   const LowerCaseString IfNoneMatch{"if-none-match"};
   const LowerCaseString IfModifiedSince{"if-modified-since"};


### PR DESCRIPTION
This fixes a mistake made in https://github.com/envoyproxy/envoy/pull/23723/.

Signed-off-by: Bootsie Heffernan <bheff@google.com>

Commit Message:  N/A
Additional Description: N/A
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
