### PR TITLE
[Bandwidth-Limit] Fix bandwidth delay calculation logic

### DIFF
--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -75,7 +75,7 @@ message BandwidthLimit {
   //   If set true, the following 4 trailers will be added, prefixed by ``response_trailer_prefix``:
   //   * bandwidth-request-delay-ms: delay time in milliseconds it took for the request stream transfer including request body transfer time and the time added by the filter.
   //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time and the time added by the filter.
-  //   * bandwidth-request-filter-delay-ms: delay time in milliseconds that added by the filter.
+  //   * bandwidth-request-filter-delay-ms: delay time in milliseconds in request stream transfer added by the filter.
   //   * bandwidth-response-filter-delay-ms: delay time in milliseconds that added by the filter.
   //   * If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.
   //   * If both the request and response delay time is 0, the trailers will not be set.

--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -77,7 +77,6 @@ message BandwidthLimit {
   //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time and the time added by the filter.
   //   * bandwidth-request-filter-delay-ms: delay time in milliseconds in request stream transfer added by the filter.
   //   * bandwidth-response-filter-delay-ms: delay time in milliseconds that added by the filter.
-  //
   //   If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.
   //   If both the request and response delay time is 0, the trailers will not be set.
   //

--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -74,7 +74,7 @@ message BandwidthLimit {
   //
   //   If set true, the following 4 trailers will be added, prefixed by ``response_trailer_prefix``:
   //   * bandwidth-request-delay-ms: delay time in milliseconds it took for the request stream transfer including request body transfer time and the time added by the filter.
-  //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time the time added by the filter.
+  //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time and the time added by the filter.
   //   * bandwidth-request-filter-delay-ms: delay time in milliseconds that added by the filter.
   //   * bandwidth-response-filter-delay-ms: delay time in milliseconds that added by the filter.
   //   * If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.

--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -72,7 +72,7 @@ message BandwidthLimit {
   //
   // .. note::
   //
-  //   * If set true, the following 4 trailers will be added, prefixed by ``response_trailer_prefix``.
+  //   If set true, the following 4 trailers will be added, prefixed by ``response_trailer_prefix``:
   //   * bandwidth-request-delay-ms: delay time in milliseconds it took for the request stream transfer including request body transfer time and the time added by the filter.
   //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time the time added by the filter.
   //   * bandwidth-request-filter-delay-ms: delay time in milliseconds that added by the filter.

--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -77,8 +77,9 @@ message BandwidthLimit {
   //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time and the time added by the filter.
   //   * bandwidth-request-filter-delay-ms: delay time in milliseconds in request stream transfer added by the filter.
   //   * bandwidth-response-filter-delay-ms: delay time in milliseconds that added by the filter.
-  //   * If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.
-  //   * If both the request and response delay time is 0, the trailers will not be set.
+  //
+  //   If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.
+  //   If both the request and response delay time is 0, the trailers will not be set.
   //
   bool enable_response_trailers = 6;
 

--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -72,9 +72,11 @@ message BandwidthLimit {
   //
   // .. note::
   //
-  //   * If set true, the response trailers ``bandwidth-request-delay-ms`` and ``bandwidth-response-delay-ms`` will be added, prefixed by ``response_trailer_prefix``.
-  //   * bandwidth-request-delay-ms: delay time in milliseconds it took for the request stream transfer.
-  //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer.
+  //   * If set true, the following 4 trailers will be added, prefixed by ``response_trailer_prefix``.
+  //   * bandwidth-request-delay-ms: delay time in milliseconds it took for the request stream transfer including request body transfer time and the time added by the filter.
+  //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including respone body transfer time the time added by the filter.
+  //   * bandwidth-request-filter-delay-ms: delay time in milliseconds that added by the filter.
+  //   * bandwidth-response-filter-delay-ms: delay time in milliseconds that added by the filter.
   //   * If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.
   //   * If both the request and response delay time is 0, the trailers will not be set.
   //

--- a/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
+++ b/api/envoy/extensions/filters/http/bandwidth_limit/v3/bandwidth_limit.proto
@@ -74,7 +74,7 @@ message BandwidthLimit {
   //
   //   * If set true, the following 4 trailers will be added, prefixed by ``response_trailer_prefix``.
   //   * bandwidth-request-delay-ms: delay time in milliseconds it took for the request stream transfer including request body transfer time and the time added by the filter.
-  //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including respone body transfer time the time added by the filter.
+  //   * bandwidth-response-delay-ms: delay time in milliseconds it took for the response stream transfer including response body transfer time the time added by the filter.
   //   * bandwidth-request-filter-delay-ms: delay time in milliseconds that added by the filter.
   //   * bandwidth-response-filter-delay-ms: delay time in milliseconds that added by the filter.
   //   * If :ref:`enable_mode <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_mode>` is ``DISABLED`` or ``REQUEST``, the trailers will not be set.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -110,6 +110,9 @@ new_features:
 - area: thrift_proxy
   change: |
     added ``envoy.reloadable_features.thrift_allow_negative_field_ids`` to support negative field ids for legacy thrift service.
+- area: bandwidth_limit
+  change: |
+    added two new response trailers ``bandwidth-request-filter-delay-ms`` and ``bandwidth-response-filter-delay-ms`` to measure the delays added by this filter.
 - area: udp_proxy
   change: |
     added support for :ref:`proxy_access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.

--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.cc
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.cc
@@ -21,7 +21,6 @@ const Http::LowerCaseString DefaultRequestDelayTrailer =
     Http::LowerCaseString("bandwidth-request-delay-ms");
 const Http::LowerCaseString DefaultResponseDelayTrailer =
     Http::LowerCaseString("bandwidth-response-delay-ms");
-const std::chrono::milliseconds ZeroMilliseconds = std::chrono::milliseconds(0);
 } // namespace
 
 FilterConfig::FilterConfig(const BandwidthLimit& config, Stats::Scope& scope,

--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.cc
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.cc
@@ -216,13 +216,13 @@ void BandwidthLimiter::updateStatsOnEncodeFinish() {
     const auto& config = getConfig();
 
     if (config.enableResponseTrailers() && trailers_ != nullptr) {
-      if (request_delay_ > ZeroMilliseconds) {
+      if (request_delay_ > zero_milliseconds_) {
         trailers_->setCopy(config.requestDelayTrailer(), std::to_string(request_delay_.count()));
-        request_delay_ = ZeroMilliseconds;
+        request_delay_ = zero_milliseconds_;
       }
-      if (response_delay_ > ZeroMilliseconds) {
+      if (response_delay_ > zero_milliseconds_) {
         trailers_->setCopy(config.responseDelayTrailer(), std::to_string(response_delay_.count()));
-        response_delay_ = ZeroMilliseconds;
+        response_delay_ = zero_milliseconds_;
       }
     }
 

--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
@@ -74,6 +74,12 @@ public:
   std::chrono::milliseconds fillInterval() const { return fill_interval_; }
   const Http::LowerCaseString& requestDelayTrailer() const { return request_delay_trailer_; }
   const Http::LowerCaseString& responseDelayTrailer() const { return response_delay_trailer_; }
+  const Http::LowerCaseString& requestFilterDelayTrailer() const {
+    return request_filter_delay_trailer_;
+  }
+  const Http::LowerCaseString& responseFilterDelayTrailer() const {
+    return response_filter_delay_trailer_;
+  }
   bool enableResponseTrailers() const { return enable_response_trailers_; }
 
 private:
@@ -92,6 +98,8 @@ private:
   std::shared_ptr<SharedTokenBucketImpl> token_bucket_;
   const Http::LowerCaseString request_delay_trailer_;
   const Http::LowerCaseString response_delay_trailer_;
+  const Http::LowerCaseString request_filter_delay_trailer_;
+  const Http::LowerCaseString response_filter_delay_trailer_;
   const bool enable_response_trailers_;
 };
 
@@ -150,6 +158,7 @@ private:
   std::unique_ptr<Envoy::Extensions::HttpFilters::Common::StreamRateLimiter> response_limiter_;
   Stats::TimespanPtr request_latency_;
   Stats::TimespanPtr response_latency_;
+  std::chrono::milliseconds request_duration_;
   std::chrono::milliseconds request_delay_ = zero_milliseconds_;
   std::chrono::milliseconds response_delay_ = zero_milliseconds_;
   Http::ResponseTrailerMap* trailers_;

--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
@@ -138,6 +138,7 @@ public:
 private:
   friend class FilterTest;
   const FilterConfig& getConfig() const;
+  const std::chrono::milliseconds ZeroMilliseconds = std::chrono::milliseconds(0);
 
   void updateStatsOnDecodeFinish();
   void updateStatsOnEncodeFinish();
@@ -149,8 +150,8 @@ private:
   std::unique_ptr<Envoy::Extensions::HttpFilters::Common::StreamRateLimiter> response_limiter_;
   Stats::TimespanPtr request_latency_;
   Stats::TimespanPtr response_latency_;
-  std::chrono::milliseconds request_delay_;
-  std::chrono::milliseconds response_delay_;
+  std::chrono::milliseconds request_delay_ = ZeroMilliseconds;
+  std::chrono::milliseconds response_delay_ = ZeroMilliseconds;
   Http::ResponseTrailerMap* trailers_;
 };
 

--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
@@ -149,7 +149,8 @@ private:
   std::unique_ptr<Envoy::Extensions::HttpFilters::Common::StreamRateLimiter> response_limiter_;
   Stats::TimespanPtr request_latency_;
   Stats::TimespanPtr response_latency_;
-  std::chrono::milliseconds request_duration_;
+  std::chrono::milliseconds request_delay_;
+  std::chrono::milliseconds response_delay_;
   Http::ResponseTrailerMap* trailers_;
 };
 

--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.h
@@ -138,7 +138,7 @@ public:
 private:
   friend class FilterTest;
   const FilterConfig& getConfig() const;
-  const std::chrono::milliseconds ZeroMilliseconds = std::chrono::milliseconds(0);
+  const std::chrono::milliseconds zero_milliseconds_ = std::chrono::milliseconds(0);
 
   void updateStatsOnDecodeFinish();
   void updateStatsOnEncodeFinish();
@@ -150,8 +150,8 @@ private:
   std::unique_ptr<Envoy::Extensions::HttpFilters::Common::StreamRateLimiter> response_limiter_;
   Stats::TimespanPtr request_latency_;
   Stats::TimespanPtr response_latency_;
-  std::chrono::milliseconds request_delay_ = ZeroMilliseconds;
-  std::chrono::milliseconds response_delay_ = ZeroMilliseconds;
+  std::chrono::milliseconds request_delay_ = zero_milliseconds_;
+  std::chrono::milliseconds response_delay_ = zero_milliseconds_;
   Http::ResponseTrailerMap* trailers_;
 };
 

--- a/source/extensions/filters/http/common/stream_rate_limiter.h
+++ b/source/extensions/filters/http/common/stream_rate_limiter.h
@@ -50,8 +50,9 @@ public:
                     std::function<void()> pause_data_cb, std::function<void()> resume_data_cb,
                     std::function<void(Buffer::Instance&, bool)> write_data_cb,
                     std::function<void()> continue_cb,
-                    std::function<void(uint64_t, bool)> write_stats_cb, TimeSource& time_source,
-                    Event::Dispatcher& dispatcher, const ScopeTrackedObject& scope,
+                    std::function<void(uint64_t, bool, std::chrono::milliseconds)> write_stats_cb,
+                    TimeSource& time_source, Event::Dispatcher& dispatcher,
+                    const ScopeTrackedObject& scope,
                     std::shared_ptr<TokenBucket> token_bucket = nullptr,
                     std::chrono::milliseconds fill_interval = DefaultFillInterval);
 
@@ -83,7 +84,7 @@ private:
   const std::chrono::milliseconds fill_interval_;
   const std::function<void(Buffer::Instance&, bool)> write_data_cb_;
   const std::function<void()> continue_cb_;
-  const std::function<void(uint64_t, bool)> write_stats_cb_;
+  const std::function<void(uint64_t, bool, std::chrono::milliseconds)> write_stats_cb_;
   const ScopeTrackedObject& scope_;
   std::shared_ptr<TokenBucket> token_bucket_;
   Event::TimerPtr token_timer_;

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -212,7 +212,7 @@ void FaultFilter::maybeSetupResponseRateLimit(const Http::RequestHeaderMap& requ
         encoder_callbacks_->injectEncodedDataToFilterChain(data, end_stream);
       },
       [this] { encoder_callbacks_->continueEncoding(); },
-      [](uint64_t, bool) {
+      [](uint64_t, bool, std::chrono::milliseconds) {
         // write stats callback.
       },
       config_->timeSource(), decoder_callbacks_->dispatcher(), decoder_callbacks_->scope());

--- a/test/extensions/filters/http/bandwidth_limit/filter_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/filter_test.cc
@@ -514,6 +514,7 @@ TEST_F(FilterTest, WithTrailers) {
               injectEncodedDataToFilterChain(BufferStringEqual(std::string(5, 'e')), false));
   response_timer->invokeCallback();
   EXPECT_EQ(0, findGauge("test.http_bandwidth_limit.response_pending"));
+  // No delay triggers since enable_response_trailers is false by default
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-delay-ms"));
 }

--- a/test/extensions/filters/http/bandwidth_limit/filter_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/filter_test.cc
@@ -86,6 +86,8 @@ TEST_F(FilterTest, Disabled) {
   EXPECT_EQ(0U, findCounter("test.http_bandwidth_limit.response_enabled"));
   EXPECT_EQ(false, response_trailers_.has("bandwidth-request-delay-ms"));
   EXPECT_EQ(false, response_trailers_.has("bandwidth-response-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("bandwidth-request-filter-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("bandwidth-response-filter-delay-ms"));
 }
 
 TEST_F(FilterTest, LimitOnDecode) {
@@ -193,6 +195,8 @@ TEST_F(FilterTest, LimitOnDecode) {
   EXPECT_EQ(0, findGauge("test.http_bandwidth_limit.request_pending"));
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-filter-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-filter-delay-ms"));
 
   filter_->onDestroy();
 }
@@ -304,7 +308,9 @@ TEST_F(FilterTest, LimitOnEncode) {
   EXPECT_EQ(1024, findGauge("test.http_bandwidth_limit.response_allowed_size"));
 
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
-  EXPECT_EQ("150", trailers_.get_("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ("2150", trailers_.get_("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-filter-delay-ms"));
+  EXPECT_EQ("150", trailers_.get_("test-bandwidth-response-filter-delay-ms"));
 
   filter_->onDestroy();
 }
@@ -437,10 +443,12 @@ TEST_F(FilterTest, LimitOnDecodeAndEncode) {
 
   request_timer->invokeCallback();
   response_timer->invokeCallback();
+  EXPECT_EQ("2200", trailers_.get_("test-bandwidth-request-delay-ms"));
+  EXPECT_EQ("2200", trailers_.get_("test-bandwidth-response-delay-ms"));
   // Only waiting for 1 unit
-  EXPECT_EQ("50", trailers_.get_("test-bandwidth-request-delay-ms"));
+  EXPECT_EQ("50", trailers_.get_("test-bandwidth-request-filter-delay-ms"));
   // Waiting for 4 units
-  EXPECT_EQ("200", trailers_.get_("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ("200", trailers_.get_("test-bandwidth-response-filter-delay-ms"));
 
   filter_->onDestroy();
 }
@@ -517,6 +525,8 @@ TEST_F(FilterTest, WithTrailers) {
   // No delay triggers since enable_response_trailers is false by default
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-filter-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-filter-delay-ms"));
 }
 
 TEST_F(FilterTest, WithTrailersNoEndStream) {
@@ -590,7 +600,9 @@ TEST_F(FilterTest, WithTrailersNoEndStream) {
   EXPECT_EQ(0, findGauge("test.http_bandwidth_limit.response_pending"));
 
   EXPECT_EQ("50", response_trailers_.get_("bandwidth-request-delay-ms"));
-  EXPECT_EQ("50", response_trailers_.get_("bandwidth-response-delay-ms"));
+  EXPECT_EQ("150", response_trailers_.get_("bandwidth-response-delay-ms"));
+  EXPECT_EQ("50", response_trailers_.get_("bandwidth-request-filter-delay-ms"));
+  EXPECT_EQ("50", response_trailers_.get_("bandwidth-response-filter-delay-ms"));
 }
 
 } // namespace BandwidthLimitFilter

--- a/test/extensions/filters/http/bandwidth_limit/filter_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/filter_test.cc
@@ -304,7 +304,7 @@ TEST_F(FilterTest, LimitOnEncode) {
   EXPECT_EQ(1024, findGauge("test.http_bandwidth_limit.response_allowed_size"));
 
   EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
-  EXPECT_EQ("2150", trailers_.get_("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ("150", trailers_.get_("test-bandwidth-response-delay-ms"));
 
   filter_->onDestroy();
 }
@@ -437,8 +437,10 @@ TEST_F(FilterTest, LimitOnDecodeAndEncode) {
 
   request_timer->invokeCallback();
   response_timer->invokeCallback();
-  EXPECT_EQ("2200", trailers_.get_("test-bandwidth-request-delay-ms"));
-  EXPECT_EQ("2200", trailers_.get_("test-bandwidth-response-delay-ms"));
+  // Only waiting for 1 unit
+  EXPECT_EQ("50", trailers_.get_("test-bandwidth-request-delay-ms"));
+  // Waiting for 4 units
+  EXPECT_EQ("200", trailers_.get_("test-bandwidth-response-delay-ms"));
 
   filter_->onDestroy();
 }
@@ -512,8 +514,8 @@ TEST_F(FilterTest, WithTrailers) {
               injectEncodedDataToFilterChain(BufferStringEqual(std::string(5, 'e')), false));
   response_timer->invokeCallback();
   EXPECT_EQ(0, findGauge("test.http_bandwidth_limit.response_pending"));
-  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
-  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ("50", response_trailers_.get_("test-bandwidth-request-delay-ms"));
+  EXPECT_EQ("50", response_trailers_.get_("test-bandwidth-response-delay-ms"));
 }
 
 TEST_F(FilterTest, WithTrailersNoEndStream) {
@@ -587,7 +589,7 @@ TEST_F(FilterTest, WithTrailersNoEndStream) {
   EXPECT_EQ(0, findGauge("test.http_bandwidth_limit.response_pending"));
 
   EXPECT_EQ("50", response_trailers_.get_("bandwidth-request-delay-ms"));
-  EXPECT_EQ("150", response_trailers_.get_("bandwidth-response-delay-ms"));
+  EXPECT_EQ("50", response_trailers_.get_("bandwidth-response-delay-ms"));
 }
 
 } // namespace BandwidthLimitFilter

--- a/test/extensions/filters/http/bandwidth_limit/filter_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/filter_test.cc
@@ -514,8 +514,8 @@ TEST_F(FilterTest, WithTrailers) {
               injectEncodedDataToFilterChain(BufferStringEqual(std::string(5, 'e')), false));
   response_timer->invokeCallback();
   EXPECT_EQ(0, findGauge("test.http_bandwidth_limit.response_pending"));
-  EXPECT_EQ("50", response_trailers_.get_("test-bandwidth-request-delay-ms"));
-  EXPECT_EQ("50", response_trailers_.get_("test-bandwidth-response-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-request-delay-ms"));
+  EXPECT_EQ(false, response_trailers_.has("test-bandwidth-response-delay-ms"));
 }
 
 TEST_F(FilterTest, WithTrailersNoEndStream) {

--- a/test/extensions/filters/http/common/stream_rate_limiter_test.cc
+++ b/test/extensions/filters/http/common/stream_rate_limiter_test.cc
@@ -40,7 +40,7 @@ public:
           decoder_callbacks_.injectDecodedDataToFilterChain(data, end_stream);
         },
         [this] { decoder_callbacks_.continueDecoding(); },
-        [](uint64_t /*len*/, bool) {
+        [](uint64_t /*len*/, bool, std::chrono::milliseconds) {
           // config->stats().decode_allowed_size_.set(len);
         },
         time_system_, decoder_callbacks_.dispatcher_, decoder_callbacks_.scope(), token_bucket,
@@ -59,7 +59,7 @@ public:
           decoder_callbacks_.injectDecodedDataToFilterChain(data, end_stream);
         },
         [this] { decoder_callbacks_.continueDecoding(); },
-        [](uint64_t /*len*/, bool) {
+        [](uint64_t /*len*/, bool, std::chrono::milliseconds) {
           // config->stats().decode_allowed_size_.set(len);
         },
         time_system_, decoder_callbacks_.dispatcher_, decoder_callbacks_.scope());


### PR DESCRIPTION
The original bandwidth delay use envoy histogram metric which include the data moving time, when payload is large, the original logic is not accurate, fix this bug by only calculate the waiting time for available tokens.

Risk Level: Low