### PR TITLE
jwt_authn: adjust remote_jwks.async_fetch refetch timer

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -314,7 +314,7 @@ message RemoteJwks {
   config.core.v3.HttpUri http_uri = 1;
 
   // Duration after which the cached JWKS should be expired. If not specified, default cache
-  // duration is 5 minutes.
+  // duration is 10 minutes.
   google.protobuf.Duration cache_duration = 2;
 
   // Fetch Jwks asynchronously in the main thread before the listener is activated.

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -377,7 +377,7 @@ message JwksAsyncFetch {
   // Default is false.
   bool fast_listener = 1;
 
-  // The duration to refetch after a failed fetch. If not specified, default is 1 secnod.
+  // The duration to refetch after a failed fetch. If not specified, default is 1 second.
   google.protobuf.Duration failed_refetch_duration = 2;
 }
 

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -376,6 +376,9 @@ message JwksAsyncFetch {
   // If true, it is activated without waiting for the initial fetch to complete.
   // Default is false.
   bool fast_listener = 1;
+
+  // The duration to refetch after a failed fetch. If not specified, default is 1 secnod.
+  google.protobuf.Duration failed_refetch_duration = 2;
 }
 
 // This message specifies a header location to extract JWT token.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -34,7 +34,7 @@ minor_behavior_changes:
     add ``MONTH`` and ``YEAR`` to the unit of time for rate limit.
 - area: jwt_authn
   change: |
-    adjust the refetch time for remote_jwks async_fetch feature, 1 second after a failed fetch, refetch 5 seconds before jwks cache duration for a good fetch.
+    adjust the refetch time for remote_jwks async_fetch feature. For a good fetch, refetch 5 seconds before jwks cache duration. For a failed fetch, refetch time can be specified by :ref:`failed_refetch_duration <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwksAsyncFetch.failed_refetch_duration>` with default 1 second.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -32,6 +32,9 @@ minor_behavior_changes:
 - area: rate_limit
   change: |
     add ``MONTH`` and ``YEAR`` to the unit of time for rate limit.
+- area: jwt_authn
+  change: |
+    adjust the refetch time for remote_jwks async_fetch feature, 1 second after a failed fetch, refetch 5 seconds before jwks cache duration for a good fetch.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
@@ -18,15 +18,15 @@ constexpr std::chrono::seconds DefaultCacheExpirationSec{600};
 // Number of seconds to refetch before a cached jwks is expired.
 constexpr std::chrono::seconds RefetchBeforeExpiredSec{5};
 
-// Number of seconds to refetch after a failed fetch.
-constexpr std::chrono::seconds RefetchAfterFailedSec{1};
+// Default number of seconds to refetch after a failed fetch.
+constexpr std::chrono::seconds DefaultRefetchAfterFailedSec{1};
 
 std::chrono::seconds getFailedRefetchDuration(const JwksAsyncFetch& async_fetch) {
   if (async_fetch.has_failed_refetch_duration()) {
     return std::chrono::seconds(
         DurationUtil::durationToMilliseconds(async_fetch.failed_refetch_duration()));
   }
-  return RefetchAfterFailedSec;
+  return DefaultRefetchAfterFailedSec;
 }
 
 } // namespace

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
@@ -24,7 +24,7 @@ constexpr std::chrono::seconds DefaultRefetchAfterFailedSec{1};
 std::chrono::seconds getFailedRefetchDuration(const JwksAsyncFetch& async_fetch) {
   if (async_fetch.has_failed_refetch_duration()) {
     return std::chrono::seconds(
-        DurationUtil::durationToMilliseconds(async_fetch.failed_refetch_duration()));
+        DurationUtil::durationToSeconds(async_fetch.failed_refetch_duration()));
   }
   return DefaultRefetchAfterFailedSec;
 }

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
@@ -11,7 +11,7 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
-// Default cache expiration time in 5 minutes.
+// Default cache expiration time in 10 minutes.
 constexpr std::chrono::seconds DefaultCacheExpirationSec{600};
 
 // Number of seconds to refetch before a cached jwks is expired.

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
@@ -66,7 +66,9 @@ private:
   Common::JwksFetcherPtr fetcher_;
 
   // The next refetch duration after a good fetch.
-  std::chrono::seconds refetch_duration_;
+  std::chrono::seconds good_refetch_duration_;
+  // The next refetch duration after a failed fetch.
+  std::chrono::seconds failed_refetch_duration_;
   // The timer to trigger a refetch.
   Envoy::Event::TimerPtr refetch_timer_;
 

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
@@ -65,10 +65,10 @@ private:
   // The Jwks fetcher object
   Common::JwksFetcherPtr fetcher_;
 
-  // The cache duration.
-  const std::chrono::seconds cache_duration_;
-  // The timer to trigger fetch due to cache duration.
-  Envoy::Event::TimerPtr cache_duration_timer_;
+  // The next refetch duration after a good fetch.
+  std::chrono::seconds refetch_duration_;
+  // The timer to trigger a refetch.
+  Envoy::Event::TimerPtr refetch_timer_;
 
   // The init target.
   std::unique_ptr<Init::TargetImpl> init_target_;

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -44,8 +44,8 @@ std::string getAsyncFetchFilterConfig(const std::string& config_str, bool fast_l
   auto* async_fetch = provider0.mutable_remote_jwks()->mutable_async_fetch();
   async_fetch->set_fast_listener(fast_listener);
   // Set failed_refetch_duration to a big value to disable failed refetch.
-  // as it interfares the two FailedAsyncFetch integration tests.
-  async_fetch->mutable_failed_refetch_duration()->set_seconds(60);
+  // as it interferes the two FailedAsyncFetch integration tests.
+  async_fetch->mutable_failed_refetch_duration()->set_seconds(600);
 
   HttpFilter filter;
   filter.set_name("envoy.filters.http.jwt_authn");

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -43,6 +43,9 @@ std::string getAsyncFetchFilterConfig(const std::string& config_str, bool fast_l
   auto& provider0 = (*proto_config.mutable_providers())[std::string(ProviderName)];
   auto* async_fetch = provider0.mutable_remote_jwks()->mutable_async_fetch();
   async_fetch->set_fast_listener(fast_listener);
+  // Set failed_refetch_duration to a big value to disable failed refetch.
+  // as it interfares the two FailedAsyncFetch integration tests.
+  async_fetch->mutable_failed_refetch_duration()->set_seconds(60);
 
   HttpFilter filter;
   filter.set_name("envoy.filters.http.jwt_authn");


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

This is just an improvement to async_fetch feature of remote jwks.

*  For a successful fetch,  adjust its re_fetch time to be the jwks_cache_duration - 5s.   This is to avoid of triggering on-demand fetching.   During authentication,  if jwks is not fetched, or is expired,  it will trigger an on-demand fetching.  If async_fetch can refetch the jwks a little bit earlier, it will avoid the on-demand fetch. 

* For a failed fetch,  trigger a re_fetch after 1 second.  Getting jwks is important.  We should keep retrying.  This retrying is after [remote_jwks.retry_policy](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto#L366).  


Risk Level: Low, added more frequence refetch for a failed remote jwks uri. 
Testing:  unit-tested
Docs Changes: None
Release Notes: Yes

