### PR TITLE
tcp proxy: enable to specify a path for HTTP tunneling with POST method

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -105,7 +105,7 @@ message TcpProxy {
     // by the network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_headers``.
     bool propagate_response_headers = 4;
 
-    // The path used with POST method. Default path is ``\``. If post path is specified and
+    // The path used with POST method. Default path is ``/``. If post path is specified and
     // :ref:`use_post field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>`
     // isn't true, it will be rejected.
     string post_path = 5;

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -103,6 +103,11 @@ message TcpProxy {
     // Save the response headers to the downstream info filter state for consumption
     // by the network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_headers``.
     bool propagate_response_headers = 4;
+  
+    // The path used with POST method. Default path is ``\``. If post path is specified and
+    // :ref:`use_post field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>`
+    // isn't true, it will be rejected.
+    string post_path = 5;
   }
 
   message OnDemand {

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -64,6 +64,7 @@ message TcpProxy {
   // Configuration for tunneling TCP over other transports or application layers.
   // Tunneling is supported over both HTTP/1.1 and HTTP/2. Upstream protocol is
   // determined by the cluster configuration.
+  // [#next-free-field: 6]
   message TunnelingConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.tcp_proxy.v2.TcpProxy.TunnelingConfig";
@@ -103,7 +104,7 @@ message TcpProxy {
     // Save the response headers to the downstream info filter state for consumption
     // by the network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_headers``.
     bool propagate_response_headers = 4;
-  
+
     // The path used with POST method. Default path is ``\``. If post path is specified and
     // :ref:`use_post field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>`
     // isn't true, it will be rejected.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -113,6 +113,9 @@ new_features:
 - area: udp_proxy
   change: |
     added support for :ref:`proxy_access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.
+- area: tcp_proxy
+  change: |
+    added new config :ref:`post_path field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.post_path>` to specifiy a custom path for HTTP tunneling with POST method.
 - area: health_check
   change: |
     added an optional bool flag :ref:`disable_active_health_check <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.disable_active_health_check>` to disable the active health check for the endpoint.

--- a/envoy/tcp/upstream.h
+++ b/envoy/tcp/upstream.h
@@ -33,6 +33,9 @@ public:
   // The method of the upstream HTTP request. True if using POST method, CONNECT otherwise.
   virtual bool usePost() const PURE;
 
+  // The path used for POST method.
+  virtual const std::string& postPath() const PURE;
+
   // The evaluator to add additional HTTP request headers to the upstream request.
   virtual Envoy::Http::HeaderEvaluator& headerEvaluator() const PURE;
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -564,7 +564,13 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
     Server::Configuration::FactoryContext& context)
     : use_post_(config_message.use_post()),
       header_parser_(Envoy::Router::HeaderParser::configure(config_message.headers_to_add())),
-      propagate_response_headers_(config_message.propagate_response_headers()) {
+      propagate_response_headers_(config_message.propagate_response_headers()),
+      post_path_(config_message.post_path()) {
+  if (!post_path_.empty() && !use_post_) {
+    throw EnvoyException("Can't set a post path when POST method isn't used");
+  }
+  post_path_ = post_path_.empty() ? "/" : post_path_;
+
   envoy::config::core::v3::SubstitutionFormatString substitution_format_config;
   substitution_format_config.mutable_text_format_source()->set_inline_string(
       config_message.hostname());

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -136,6 +136,7 @@ public:
       Server::Configuration::FactoryContext& context);
   std::string host(const StreamInfo::StreamInfo& stream_info) const override;
   bool usePost() const override { return use_post_; }
+  const std::string& postPath() const override { return post_path_; }
   Envoy::Http::HeaderEvaluator& headerEvaluator() const override { return *header_parser_; }
   void
   propagateResponseHeaders(Http::ResponseHeaderMapPtr&& headers,
@@ -146,6 +147,7 @@ private:
   std::unique_ptr<Envoy::Router::HeaderParser> header_parser_;
   Formatter::FormatterPtr hostname_fmt_;
   const bool propagate_response_headers_;
+  std::string post_path_;
 };
 
 /**

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -290,7 +290,7 @@ void Http2Upstream::setRequestEncoder(Http::RequestEncoder& request_encoder, boo
     headers->addReference(Http::Headers::get().Path, config_.postPath());
     headers->addReference(Http::Headers::get().Scheme, scheme);
   } else if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_rfc_connect")) {
-    headers->addReference(Http::Headers::get().Path, config_.postPath());
+    headers->addReference(Http::Headers::get().Path, "/");
     headers->addReference(Http::Headers::get().Scheme, scheme);
     headers->addReference(Http::Headers::get().Protocol,
                           Http::Headers::get().ProtocolValues.Bytestream);

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -287,10 +287,10 @@ void Http2Upstream::setRequestEncoder(Http::RequestEncoder& request_encoder, boo
   });
 
   if (config_.usePost()) {
-    headers->addReference(Http::Headers::get().Path, "/");
+    headers->addReference(Http::Headers::get().Path, config_.postPath());
     headers->addReference(Http::Headers::get().Scheme, scheme);
   } else if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_rfc_connect")) {
-    headers->addReference(Http::Headers::get().Path, "/");
+    headers->addReference(Http::Headers::get().Path, config_.postPath());
     headers->addReference(Http::Headers::get().Scheme, scheme);
     headers->addReference(Http::Headers::get().Protocol,
                           Http::Headers::get().ProtocolValues.Bytestream);
@@ -325,7 +325,7 @@ void Http1Upstream::setRequestEncoder(Http::RequestEncoder& request_encoder, boo
 
   if (config_.usePost()) {
     // Path is required for POST requests.
-    headers->addReference(Http::Headers::get().Path, "/");
+    headers->addReference(Http::Headers::get().Path, config_.postPath());
   }
 
   config_.headerEvaluator().evaluateHeaders(*headers,


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Commit Message: tcp proxy: enable to specify a path for HTTP tunneling with POST method
Additional Description:
Risk Level: low
Testing: unittest
Docs Changes: API doc
Release Notes: new feature
Fixes #24038
