### PR TITLE
[backport/1.22] listener: fix flaky listener integration test (#22383)

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -558,10 +558,16 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterInPlaceUpdate) {
 
   // All the listen socket are closed. include the sockets in the active listener and
   // the sockets in the filter chain draining listener. The new connection should be reset.
-  auto codec =
+  auto codec1 =
       makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  EXPECT_FALSE(codec->connected());
-  EXPECT_THAT(codec->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+  // The socket are closed asynchronously, so waiting the connection closed here.
+  ASSERT_TRUE(codec1->waitForDisconnect());
+
+  // Test the connection again to ensure the socket is closed.
+  auto codec2 =
+      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
+  EXPECT_FALSE(codec2->connected());
+  EXPECT_THAT(codec2->connection()->transportFailureReason(), StartsWith("delayed connect error"));
 
   // Ensure the old listener is still in filter chain draining.
   test_server_->waitForGaugeEq("listener_manager.total_filter_chains_draining", 1);
@@ -644,10 +650,16 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterMultipleInPlaceUpdate) {
 
   // All the listen socket are closed. include the sockets in the active listener and
   // the sockets in the filter chain draining listener. The new connection should be reset.
-  auto codec =
+  auto codec1 =
       makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  EXPECT_FALSE(codec->connected());
-  EXPECT_THAT(codec->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+  // The socket are closed asynchronously, so waiting the connection closed here.
+  ASSERT_TRUE(codec1->waitForDisconnect());
+
+  // Test the connection again to ensure the socket is closed.
+  auto codec2 =
+      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
+  EXPECT_FALSE(codec2->connected());
+  EXPECT_THAT(codec2->connection()->transportFailureReason(), StartsWith("delayed connect error"));
 
   // Ensure the old listener is still in filter chain draining.
   test_server_->waitForGaugeEq("listener_manager.total_filter_chains_draining", 2);


### PR DESCRIPTION
Signed-off-by: He Jie Xu <hejie.xu@intel.com>

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
