### PR TITLE
feat(hds): allow to configure upstream bind address for HDS

### DIFF
--- a/api/envoy/service/health/v3/hds.proto
+++ b/api/envoy/service/health/v3/hds.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.service.health.v3;
 
 import "envoy/config/cluster/v3/cluster.proto";
+import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/health_check.proto";
 import "envoy/config/endpoint/v3/endpoint_components.proto";
@@ -176,6 +177,10 @@ message ClusterHealthCheck {
   // on connection when health checking. For more details, see
   // :ref:`config.cluster.v3.Cluster.transport_socket_matches <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket_matches>`.
   repeated config.cluster.v3.Cluster.TransportSocketMatch transport_socket_matches = 4;
+
+  // Optional configuration used to bind newly established upstream connections.
+  // If the address and port are empty, no bind will be performed.
+  config.core.v3.BindConfig upstream_bind_config = 5;
 }
 
 message HealthCheckSpecifier {

--- a/api/envoy/service/health/v3/hds.proto
+++ b/api/envoy/service/health/v3/hds.proto
@@ -163,6 +163,7 @@ message LocalityEndpoints {
 // health checks to support statistics reporting, logging and debugging by the
 // Envoy instance (outside of HDS). For maximum usefulness, it should match the
 // same cluster structure as that provided by EDS.
+// [#next-free-field: 6]
 message ClusterHealthCheck {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v2.ClusterHealthCheck";

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -343,7 +343,7 @@ HdsCluster::HdsCluster(Server::Configuration::ServerFactoryContext& server_conte
   socket_match_hash_ = RepeatedPtrUtil::hash(cluster_.transport_socket_matches());
 
   info_ = info_factory.createClusterInfo(
-      {server_context, cluster_, bind_config_, stats_, ssl_context_manager_, added_via_api_, tls});
+      {server_context, cluster_, bind_config, stats_, ssl_context_manager_, added_via_api_, tls});
 
   // Temporary structure to hold Host pointers grouped by locality, to build
   // initial_hosts_per_locality_.

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -333,8 +333,8 @@ HdsCluster::HdsCluster(Server::Configuration::ServerFactoryContext& server_conte
                        const envoy::config::core::v3::BindConfig& bind_config, Stats::Store& stats,
                        Ssl::ContextManager& ssl_context_manager, bool added_via_api,
                        ClusterInfoFactory& info_factory, ThreadLocal::SlotAllocator& tls)
-    : server_context_(server_context), cluster_(std::move(cluster)), bind_config_(bind_config),
-      stats_(stats), ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
+    : server_context_(server_context), cluster_(std::move(cluster)), stats_(stats),
+      ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
       hosts_(new HostVector()), time_source_(server_context_.mainThreadDispatcher().timeSource()) {
   ENVOY_LOG(debug, "Creating an HdsCluster");
   priority_set_.getOrCreateHostSet(0);

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -196,14 +196,14 @@ envoy::config::cluster::v3::Cluster HdsDelegate::createClusterConfig(
 }
 
 void HdsDelegate::updateHdsCluster(HdsClusterPtr cluster,
-                                   const envoy::config::cluster::v3::Cluster& cluster_config) {
-  cluster->update(cluster_config, info_factory_, tls_);
+                                   const envoy::config::cluster::v3::Cluster& cluster_config,
+                                   const envoy::config::core::v3::BindConfig& bind_config) {
+  cluster->update(cluster_config, bind_config, info_factory_, tls_);
 }
 
 HdsClusterPtr
-HdsDelegate::createHdsCluster(const envoy::config::cluster::v3::Cluster& cluster_config) {
-  static const envoy::config::core::v3::BindConfig bind_config;
-
+HdsDelegate::createHdsCluster(const envoy::config::cluster::v3::Cluster& cluster_config,
+                              const envoy::config::core::v3::BindConfig& bind_config) {
   // Create HdsCluster.
   auto new_cluster =
       std::make_shared<HdsCluster>(server_context_, std::move(cluster_config), bind_config,
@@ -239,11 +239,11 @@ void HdsDelegate::processMessage(
       if (cluster_map_pair != hds_clusters_name_map_.end()) {
         // We have a previous cluster with this name, update.
         cluster_ptr = cluster_map_pair->second;
-        updateHdsCluster(cluster_ptr, cluster_config);
+        updateHdsCluster(cluster_ptr, cluster_config, cluster_health_check.upstream_bind_config());
       } else {
         // There is no cluster with this name previously or its an empty string, so just create a
         // new cluster.
-        cluster_ptr = createHdsCluster(cluster_config);
+        cluster_ptr = createHdsCluster(cluster_config, cluster_health_check.upstream_bind_config());
       }
 
       // If this cluster does not have a name, do not add it to the name map since cluster_name is
@@ -378,6 +378,7 @@ HdsCluster::HdsCluster(Server::Configuration::ServerFactoryContext& server_conte
 }
 
 void HdsCluster::update(envoy::config::cluster::v3::Cluster cluster,
+                        const envoy::config::core::v3::BindConfig& bind_config,
                         ClusterInfoFactory& info_factory, ThreadLocal::SlotAllocator& tls) {
 
   // check to see if the config changed. If it did, update.
@@ -393,7 +394,7 @@ void HdsCluster::update(envoy::config::cluster::v3::Cluster cluster,
     if (socket_match_hash_ != socket_match_hash) {
       socket_match_hash_ = socket_match_hash;
       update_cluster_info = true;
-      info_ = info_factory.createClusterInfo({server_context_, cluster_, bind_config_, stats_,
+      info_ = info_factory.createClusterInfo({server_context_, cluster_, bind_config, stats_,
                                               ssl_context_manager_, added_via_api_, tls});
     }
 

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -83,7 +83,6 @@ private:
 
   Server::Configuration::ServerFactoryContext& server_context_;
   envoy::config::cluster::v3::Cluster cluster_;
-  const envoy::config::core::v3::BindConfig& bind_config_;
   Stats::Store& stats_;
   Ssl::ContextManager& ssl_context_manager_;
   bool added_via_api_;

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -64,8 +64,9 @@ public:
   const Outlier::Detector* outlierDetector() const override { return outlier_detector_.get(); }
   void initialize(std::function<void()> callback) override;
   // Compare changes in the cluster proto, and update parts of the cluster as needed.
-  void update(envoy::config::cluster::v3::Cluster cluster, ClusterInfoFactory& info_factory,
-              ThreadLocal::SlotAllocator& tls);
+  void update(envoy::config::cluster::v3::Cluster cluster,
+              const envoy::config::core::v3::BindConfig& bind_config,
+              ClusterInfoFactory& info_factory, ThreadLocal::SlotAllocator& tls);
   // Creates healthcheckers and adds them to the list, then does initial start.
   void initHealthchecks();
 
@@ -161,8 +162,10 @@ private:
   envoy::config::cluster::v3::Cluster
   createClusterConfig(const envoy::service::health::v3::ClusterHealthCheck& cluster_health_check);
   void updateHdsCluster(HdsClusterPtr cluster,
-                        const envoy::config::cluster::v3::Cluster& cluster_health_check);
-  HdsClusterPtr createHdsCluster(const envoy::config::cluster::v3::Cluster& cluster_health_check);
+                        const envoy::config::cluster::v3::Cluster& cluster_health_check,
+                        const envoy::config::core::v3::BindConfig& bind_config);
+  HdsClusterPtr createHdsCluster(const envoy::config::cluster::v3::Cluster& cluster_health_check,
+                                 const envoy::config::core::v3::BindConfig& bind_config);
   HdsDelegateStats stats_;
   const Protobuf::MethodDescriptor& service_method_;
 

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -320,9 +320,7 @@ TEST_F(HdsTest, TestHdsCluster) {
 
   auto* health_check = message->add_cluster_health_checks();
   health_check->set_cluster_name("test_cluster");
-  health_check->mutable_upstream_bind_config()
-      ->mutable_source_address()
-      ->set_address("1.1.1.1");
+  health_check->mutable_upstream_bind_config()->mutable_source_address()->set_address("1.1.1.1");
   auto* address = health_check->add_locality_endpoints()->add_endpoints()->mutable_address();
   address->mutable_socket_address()->set_address("127.0.0.2");
   address->mutable_socket_address()->set_port_value(1234);

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -320,6 +320,9 @@ TEST_F(HdsTest, TestHdsCluster) {
 
   auto* health_check = message->add_cluster_health_checks();
   health_check->set_cluster_name("test_cluster");
+  health_check->mutable_upstream_bind_config()
+      ->mutable_source_address()
+      ->set_address("1.1.1.1");
   auto* address = health_check->add_locality_endpoints()->add_endpoints()->mutable_address();
   address->mutable_socket_address()->set_address("127.0.0.2");
   address->mutable_socket_address()->set_port_value(1234);


### PR DESCRIPTION
Commit Message: feat(hds): allow to configure upstream bind address for hds
Additional Description: Sometimes when an application doesn't bind to localhost and the machine uses iptables for traffic redirection, HDS might need to override the source address for iptables to redirect traffic to the application instead of getting into the loop.
Risk Level: Low
Testing: small unit test configuration, upstream cluster tests binding functionality, manual testing
Docs Changes: API docs
Release Notes: 
Platform Specific Features: no
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
