### PR TITLE
stats: properly extract the http.ext_authz stat_prefix

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -132,6 +132,11 @@ TagNameValues::TagNameValues() {
   // internal state of the regex which performs better.
   addRe2(HTTP_CONN_MANAGER_PREFIX, R"(^listener\..*?\.http\.((<TAG_VALUE>)\.))", ".http.");
 
+  // Extract ext_authz stat_prefix field
+  // cluster.[<cluster>.]ext_authz.[<ext_authz_prefix>.]*
+  // http.[<http_conn_mgr_prefix>.]ext_authz.[<ext_authz_prefix>.]*
+  addRe2(EXT_AUTHZ_PREFIX, R"(^(?:cluster|http)\.(?:[^\.]+\.)?ext_authz\.((<TAG_VALUE>)\.))");
+
   // http.(<stat_prefix>.)*
   addTokenized(HTTP_CONN_MANAGER_PREFIX, "http.$.**");
 

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -137,6 +137,8 @@ public:
   const std::string RDS_ROUTE_CONFIG = "envoy.rds_route_config";
   // Request route given by the Router http filter
   const std::string ROUTE = "envoy.route";
+  // Stats prefix for the ext_authz HTTP filter
+  const std::string EXT_AUTHZ_PREFIX = "envoy.auth_prefix";
   // Listener manager worker id
   const std::string WORKER_ID = "envoy.worker_id";
   // Stats prefix for the Thrift Proxy network filter

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -430,6 +430,15 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   redis_prefix.name_ = tag_names.REDIS_PREFIX;
   redis_prefix.value_ = "my_redis_prefix";
   regex_tester.testRegex("redis.my_redis_prefix.response", "redis.response", {redis_prefix});
+
+  // ExtAuthz Prefix
+  Tag ext_authz_prefix;
+  ext_authz_prefix.name_ = tag_names.EXT_AUTHZ_PREFIX;
+  ext_authz_prefix.value_ = "authpfx";
+  regex_tester.testRegex("http.http_prefix.ext_authz.authpfx.denied", "http.ext_authz.denied",
+                         {listener_http_prefix, ext_authz_prefix});
+  regex_tester.testRegex("cluster.grpc_cluster.ext_authz.authpfx.ok", "cluster.ext_authz.ok",
+                         {grpc_cluster, ext_authz_prefix});
 }
 
 TEST(TagExtractorTest, ExtractRegexPrefix) {


### PR DESCRIPTION
Signed-off-by: Neal Turett <neal.turett@datadoghq.com>

## Standard fields

Commit Message: stats: properly extract the http.ext_authz stat_prefix
Risk Level: low
Testing:  added unit tests to confirm extraction works properly
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Fixes part of #21595.

## Additional Description:

### Normal behavior
When adding a stat_prefix to a filter, in general the emitted prometheus stat doesn't change, and instead a tag is added.  For example, adding a stat_prefix to a local rate limiter turns:
```
envoy_http_local_rate_limit_enabled{} 6
```
into
```
envoy_http_local_rate_limit_enabled{envoy_local_http_ratelimit_prefix="puppies"} 6
```

Likewise, adding a stat_prefix to a http_connection_manager turns:
```
envoy_http_downstream_cx_delayed_close_timeout{} 0
```
into
```
envoy_http_downstream_cx_delayed_close_timeout{envoy_http_conn_manager_prefix="admin"} 0
```

### Current behavior
It appears the stat_prefix extractor for http.ext_authz metrics was overlooked.  Added a stat_prefix to http.ext_authz turns:
```
envoy_http_ext_authz_ok{envoy_http_conn_manager_prefix="http"} 35459
```
into
```
envoy_http_ext_authz_foo_ok{envoy_http_conn_manager_prefix="http"} 35459
```

### Corrected behavior
This PR adds a tag extractor to so that the the output follows the pattern all the other stat_prefix supporting filters do:
```
envoy_http_ext_authz_ok{envoy_auth_prefix="foo",envoy_http_conn_manager_prefix="http"} 35459
```