### PR TITLE
[balsa] Fix 304WithBody test and add new one.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -226,8 +226,8 @@ void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
 
 void BalsaParser::OnResponseFirstLineInput(absl::string_view /*line_input*/,
                                            absl::string_view /*version_input*/,
-                                           absl::string_view /*status_input*/,
-                                           absl::string_view reason_input) {
+                                           absl::string_view status_input,
+                                           absl::string_view /*reason_input*/) {
   if (status_ == ParserStatus::Error) {
     return;
   }
@@ -235,7 +235,7 @@ void BalsaParser::OnResponseFirstLineInput(absl::string_view /*line_input*/,
   if (status_ == ParserStatus::Error) {
     return;
   }
-  status_ = convertResult(connection_->onStatus(reason_input.data(), reason_input.size()));
+  status_ = convertResult(connection_->onStatus(status_input.data(), status_input.size()));
 }
 
 void BalsaParser::OnChunkLength(size_t chunk_length) {

--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -271,10 +271,5 @@ void EnvoyQuicClientConnection::EnvoyPathValidationResultDelegate::OnPathValidat
   connection_.onPathValidationFailure(std::move(context));
 }
 
-void EnvoyQuicClientConnection::OnCanWrite() {
-  quic::QuicConnection::OnCanWrite();
-  onWriteEventDone();
-}
-
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_client_connection.h
+++ b/source/common/quic/envoy_quic_client_connection.h
@@ -67,10 +67,8 @@ public:
   // Switch underlying socket with the given one. This is used in connection migration.
   void switchConnectionSocket(Network::ConnectionSocketPtr&& connection_socket);
 
-  // quic::QuicConnection
   // Potentially trigger migration.
   void OnPathDegradingDetected() override;
-  void OnCanWrite() override;
 
   // Called when port migration probing succeeds. Attempts to migrate this connection onto the new
   // socket extracted from context.

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -102,14 +102,12 @@ void EnvoyQuicClientSession::OnConnectionClosed(const quic::QuicConnectionCloseF
 void EnvoyQuicClientSession::Initialize() {
   quic::QuicSpdyClientSession::Initialize();
   initialized_ = true;
-  network_connection_->setEnvoyConnection(*this, *this);
+  network_connection_->setEnvoyConnection(*this);
 }
 
 void EnvoyQuicClientSession::OnCanWrite() {
-  uint64_t old_bytes_to_send = bytesToSend();
   quic::QuicSpdyClientSession::OnCanWrite();
-  const bool has_sent_any_data = bytesToSend() != old_bytes_to_send;
-  maybeUpdateDelayCloseTimer(has_sent_any_data);
+  maybeApplyDelayClosePolicy();
 }
 
 void EnvoyQuicClientSession::OnHttp3GoAway(uint64_t stream_id) {

--- a/source/common/quic/envoy_quic_server_connection.cc
+++ b/source/common/quic/envoy_quic_server_connection.cc
@@ -47,10 +47,5 @@ bool EnvoyQuicServerConnection::OnPacketHeader(const quic::QuicPacketHeader& hea
   return true;
 }
 
-void EnvoyQuicServerConnection::OnCanWrite() {
-  quic::QuicConnection::OnCanWrite();
-  onWriteEventDone();
-}
-
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_server_connection.h
+++ b/source/common/quic/envoy_quic_server_connection.h
@@ -26,7 +26,6 @@ public:
   // quic::QuicConnection
   // Overridden to set connection_socket_ with initialized self address and retrieve filter chain.
   bool OnPacketHeader(const quic::QuicPacketHeader& header) override;
-  void OnCanWrite() override;
 
   bool deferSend() const { return defer_send_; }
 

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -114,16 +114,14 @@ void EnvoyQuicServerSession::OnConnectionClosed(const quic::QuicConnectionCloseF
 void EnvoyQuicServerSession::Initialize() {
   quic::QuicServerSessionBase::Initialize();
   initialized_ = true;
-  quic_connection_->setEnvoyConnection(*this, *this);
+  quic_connection_->setEnvoyConnection(*this);
 }
 
 void EnvoyQuicServerSession::OnCanWrite() {
-  uint64_t old_bytes_to_send = bytesToSend();
   quic::QuicServerSessionBase::OnCanWrite();
-  // Do not update delay close timer according to connection level packet egress because that is
+  // Do not update delay close state according to connection level packet egress because that is
   // equivalent to TCP transport layer egress. But only do so if the session gets chance to write.
-  const bool has_sent_any_data = bytesToSend() != old_bytes_to_send;
-  maybeUpdateDelayCloseTimer(has_sent_any_data);
+  maybeApplyDelayClosePolicy();
 }
 
 bool EnvoyQuicServerSession::hasDataToWrite() { return HasDataToWrite(); }

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -28,8 +28,7 @@ class QuicNetworkConnectionTest;
 
 // Act as a Network::Connection to HCM and a FilterManager to FilterFactoryCb.
 class QuicFilterManagerConnectionImpl : public Network::ConnectionImplBase,
-                                        public SendBufferMonitor,
-                                        public QuicWriteEventCallback {
+                                        public SendBufferMonitor {
 public:
   QuicFilterManagerConnectionImpl(QuicNetworkConnection& connection,
                                   const quic::QuicConnectionId& connection_id,
@@ -141,8 +140,8 @@ public:
   // streams, and run watermark check.
   void updateBytesBuffered(uint64_t old_buffered_bytes, uint64_t new_buffered_bytes) override;
 
-  // QuicWriteEventCallback
-  void onWriteEventDone() override;
+  // Called after each write when a previous connection close call is postponed.
+  void maybeApplyDelayClosePolicy();
 
   uint64_t bytesToSend() { return bytes_to_send_; }
 
@@ -171,8 +170,6 @@ protected:
   // Returns a QuicConnection interface if initialized_ is true, otherwise nullptr.
   virtual const quic::QuicConnection* quicConnection() const PURE;
   virtual quic::QuicConnection* quicConnection() PURE;
-
-  void maybeUpdateDelayCloseTimer(bool has_sent_any_data);
 
   void maybeHandleCloseDuringInitialize();
 

--- a/source/common/quic/quic_network_connection.cc
+++ b/source/common/quic/quic_network_connection.cc
@@ -15,17 +15,5 @@ QuicNetworkConnection::~QuicNetworkConnection() {
 
 uint64_t QuicNetworkConnection::id() const { return envoy_connection_->id(); }
 
-void QuicNetworkConnection::setEnvoyConnection(Network::Connection& connection,
-                                               QuicWriteEventCallback& write_callback) {
-  envoy_connection_ = &connection;
-  write_callback_ = &write_callback;
-}
-
-void QuicNetworkConnection::onWriteEventDone() {
-  if (write_callback_ != nullptr) {
-    write_callback_->onWriteEventDone();
-  }
-}
-
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/quic_network_connection.h
+++ b/source/common/quic/quic_network_connection.h
@@ -12,13 +12,6 @@ namespace Quic {
 // Read ~32k bytes per connection by default, which is about the same as TCP.
 static const uint32_t DEFAULT_PACKETS_TO_READ_PER_CONNECTION = 32u;
 
-class QuicWriteEventCallback {
-public:
-  virtual ~QuicWriteEventCallback() = default;
-  // Called when QUIC finishes a write.
-  virtual void onWriteEventDone() PURE;
-};
-
 // A base class of both the client and server connections which keeps stats and
 // connection socket.
 class QuicNetworkConnection : protected Logger::Loggable<Logger::Id::connection> {
@@ -33,7 +26,7 @@ public:
   }
 
   // Called in session Initialize().
-  void setEnvoyConnection(Network::Connection& connection, QuicWriteEventCallback& write_callback);
+  void setEnvoyConnection(Network::Connection& connection) { envoy_connection_ = &connection; }
 
   const Network::ConnectionSocketPtr& connectionSocket() const {
     return connection_sockets_.back();
@@ -51,8 +44,6 @@ protected:
     connection_sockets_.push_back(std::move(connection_socket));
   }
 
-  void onWriteEventDone();
-
 private:
   // TODO(danzh): populate stats.
   std::unique_ptr<Network::Connection::ConnectionStats> connection_stats_;
@@ -63,7 +54,6 @@ private:
   std::vector<Network::ConnectionSocketPtr> connection_sockets_;
   // Points to an instance of EnvoyQuicServerSession or EnvoyQuicClientSession.
   Network::Connection* envoy_connection_{nullptr};
-  QuicWriteEventCallback* write_callback_{nullptr};
 };
 
 } // namespace Quic

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -3784,5 +3784,24 @@ TEST_P(Http1ClientConnectionImplTest, ResponseHttpVersion) {
   }
 }
 
+// 304 responses must not have a body.
+TEST_P(Http1ClientConnectionImplTest, 304WithBody) {
+  initialize();
+
+  NiceMock<MockResponseDecoder> response_decoder;
+  Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
+  Buffer::OwnedImpl response("HTTP/1.1 304 Not Modified\r\n"
+                             "Content-Length: 2\r\n"
+                             "\r\n"
+                             "blah");
+  auto status = codec_->dispatch(response);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ("http/1.1 protocol error: extraneous data after response complete", status.message());
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -70,7 +70,7 @@ public:
 
   void SetUp() override {
     quic_session_.Initialize();
-    quic_connection_->setEnvoyConnection(quic_session_, quic_session_);
+    quic_connection_->setEnvoyConnection(quic_session_);
     quic_connection_->SetEncrypter(
         quic::ENCRYPTION_FORWARD_SECURE,
         std::make_unique<quic::NullEncrypter>(quic::Perspective::IS_CLIENT));

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -499,7 +499,7 @@ TEST_F(EnvoyQuicServerSessionTest, FlushCloseWithDataToWrite) {
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Unblock that stream to trigger actual connection close.
-  quic_connection_->OnCanWrite();
+  envoy_quic_session_.OnCanWrite();
   EXPECT_EQ(Network::Connection::State::Closed, envoy_quic_session_.state());
   EXPECT_FALSE(quic_connection_->connected());
 }
@@ -518,6 +518,7 @@ TEST_F(EnvoyQuicServerSessionTest, WriteUpdatesDelayCloseTimer) {
       .WillRepeatedly(Return(quic::QuicBandwidth::Zero()));
 
   EXPECT_CALL(*quic_connection_, SendControlFrame(_)).Times(AnyNumber());
+
   // Bump connection flow control window large enough not to interfere
   // stream writing.
   envoy_quic_session_.flow_controller()->UpdateSendWindowOffset(
@@ -567,15 +568,10 @@ TEST_F(EnvoyQuicServerSessionTest, WriteUpdatesDelayCloseTimer) {
 
   time_system_.advanceTimeAndRun(std::chrono::milliseconds(10), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
-  // Another write event with updated flow control window should unblock the stream and flush some
-  // stream data and update the timer. But it shouldn't close connection because there should still
-  // be data buffered.
-  quic::QuicWindowUpdateFrame window_update(quic::kInvalidControlFrameId, stream->id(),
-                                            quic::kDefaultFlowControlSendWindow + 1);
-  stream->OnWindowUpdateFrame(window_update);
-  quic_connection_->OnCanWrite();
+  // Another write event without updating flow control window shouldn't trigger
+  // connection close, but it should update the timer.
+  envoy_quic_session_.OnCanWrite();
   EXPECT_TRUE(envoy_quic_session_.HasDataToWrite());
-  EXPECT_TRUE(stream->IsFlowControlBlocked());
 
   // Timer shouldn't fire at original deadline.
   time_system_.advanceTimeAndRun(std::chrono::milliseconds(90), *dispatcher_,
@@ -664,7 +660,7 @@ TEST_F(EnvoyQuicServerSessionTest, FlushCloseNoTimeout) {
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
   // Another write event without updating flow control window shouldn't trigger
   // connection close.
-  quic_connection_->OnCanWrite();
+  envoy_quic_session_.OnCanWrite();
   EXPECT_TRUE(envoy_quic_session_.HasDataToWrite());
 
   // No timeout set, so alarm shouldn't fire.
@@ -729,15 +725,18 @@ TEST_F(EnvoyQuicServerSessionTest, FlushAndWaitForCloseWithTimeout) {
   // delayed.
   time_system_.advanceTimeAndRun(std::chrono::milliseconds(10), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
-  quic_connection_->OnCanWrite();
+  envoy_quic_session_.OnCanWrite();
+  // delay close alarm should have been rescheduled.
+  time_system_.advanceTimeAndRun(std::chrono::milliseconds(90), *dispatcher_,
+                                 Event::Dispatcher::RunType::NonBlock);
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
-  // Advance the time to fire connection close timer.
   EXPECT_CALL(*quic_connection_,
               SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
-  time_system_.advanceTimeAndRun(std::chrono::milliseconds(90), *dispatcher_,
+  // Advance the time to fire connection close timer.
+  time_system_.advanceTimeAndRun(std::chrono::milliseconds(10), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
   EXPECT_EQ(Network::Connection::State::Closed, envoy_quic_session_.state());
   EXPECT_FALSE(quic_connection_->connected());
@@ -762,7 +761,11 @@ TEST_F(EnvoyQuicServerSessionTest, FlusWriteTransitToFlushWriteWithDelay) {
   envoy_quic_session_.close(Network::ConnectionCloseType::FlushWriteAndDelay);
   // Unblocking the stream shouldn't close the connection as it should be
   // delayed.
-  quic_connection_->OnCanWrite();
+  envoy_quic_session_.OnCanWrite();
+
+  // delay close alarm should have been rescheduled.
+  time_system_.advanceTimeAndRun(std::chrono::milliseconds(90), *dispatcher_,
+                                 Event::Dispatcher::RunType::NonBlock);
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
   EXPECT_CALL(*quic_connection_,
@@ -770,7 +773,7 @@ TEST_F(EnvoyQuicServerSessionTest, FlusWriteTransitToFlushWriteWithDelay) {
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Advance the time to fire connection close timer.
-  time_system_.advanceTimeAndRun(std::chrono::milliseconds(90), *dispatcher_,
+  time_system_.advanceTimeAndRun(std::chrono::milliseconds(10), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
   EXPECT_EQ(Network::Connection::State::Closed, envoy_quic_session_.state());
   EXPECT_FALSE(quic_connection_->connected());

--- a/test/extensions/filters/http/health_check/BUILD
+++ b/test/extensions/filters/http/health_check/BUILD
@@ -45,6 +45,7 @@ envoy_extension_cc_test(
         "health_check_integration_test.cc",
     ],
     extension_names = ["envoy.filters.http.health_check"],
+    shard_count = 4,
     deps = [
         "//source/extensions/filters/http/buffer:config",
         "//source/extensions/filters/http/health_check:config",

--- a/test/extensions/filters/http/health_check/health_check_integration_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_integration_test.cc
@@ -145,6 +145,12 @@ TEST_P(HealthCheckIntegrationTest, HealthCheck) {
 
 TEST_P(HealthCheckIntegrationTest, HealthCheckWithoutServerStats) {
   DISABLE_IF_ADMIN_DISABLED;
+
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   envoy::config::metrics::v3::StatsMatcher stats_matcher;
   stats_matcher.mutable_exclusion_list()->add_patterns()->set_prefix("server.");
   config_helper_.addConfigModifier(

--- a/test/extensions/http/header_formatters/preserve_case/BUILD
+++ b/test/extensions/http/header_formatters/preserve_case/BUILD
@@ -50,7 +50,6 @@ envoy_extension_cc_test(
         "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
         "//test/integration:http_integration_lib",
         "//test/integration:http_protocol_integration_lib",
-        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_reason_phrase_integration_test.cc
@@ -3,27 +3,18 @@
 #include "test/integration/filters/common.h"
 #include "test/integration/http_integration.h"
 #include "test/test_common/registry.h"
-#include "test/test_common/test_runtime.h"
 
 namespace Envoy {
 namespace {
 
-// See https://github.com/envoyproxy/envoy/issues/21245.
-enum class ParserImpl {
-  HttpParser, // http-parser from node.js
-  BalsaParser // Balsa from QUICHE
-};
-
 struct TestParams {
   Network::Address::IpVersion ip_version;
-  ParserImpl parser_impl;
   bool forward_reason_phrase;
 };
 
 std::string testParamsToString(const ::testing::TestParamInfo<TestParams>& p) {
-  return fmt::format("{}_{}_{}",
+  return fmt::format("{}_{}",
                      p.param.ip_version == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6",
-                     p.param.parser_impl == ParserImpl::HttpParser ? "HttpParser" : "BalsaParser",
                      p.param.forward_reason_phrase ? "enabled" : "disabled");
 }
 
@@ -31,10 +22,8 @@ std::vector<TestParams> getTestsParams() {
   std::vector<TestParams> ret;
 
   for (auto ip_version : TestEnvironment::getIpVersionsForTest()) {
-    for (auto parser_impl : {ParserImpl::HttpParser, ParserImpl::BalsaParser}) {
-      ret.push_back(TestParams{ip_version, parser_impl, true});
-      ret.push_back(TestParams{ip_version, parser_impl, false});
-    }
+    ret.push_back(TestParams{ip_version, true});
+    ret.push_back(TestParams{ip_version, false});
   }
 
   return ret;
@@ -49,11 +38,6 @@ public:
   void SetUp() override {
     setDownstreamProtocol(Http::CodecType::HTTP1);
     setUpstreamProtocol(Http::CodecType::HTTP1);
-    if (GetParam().parser_impl == ParserImpl::BalsaParser) {
-      scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_use_balsa_parser", "true"}});
-    } else {
-      scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_use_balsa_parser", "false"}});
-    }
   }
 
   void initialize() override {
@@ -79,9 +63,6 @@ public:
 
     HttpIntegrationTest::initialize();
   }
-
-private:
-  TestScopedRuntime scoped_runtime_;
 };
 
 INSTANTIATE_TEST_SUITE_P(CaseFormatter, PreserveCaseFormatterReasonPhraseIntegrationTest,

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1259,7 +1259,7 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "overload_integration_test",
     srcs = ["overload_integration_test.cc"],
-    shard_count = 4,
+    shard_count = 8,
     deps = [
         ":base_overload_integration_test_lib",
         ":http_protocol_integration_lib",

--- a/test/integration/buffer_accounting_integration_test.cc
+++ b/test/integration/buffer_accounting_integration_test.cc
@@ -131,7 +131,8 @@ public:
     }
 
     const HttpProtocolTestParams& protocol_test_params = std::get<0>(GetParam());
-    setupHttp2Overrides(protocol_test_params.http2_implementation);
+    setupHttpImplOverrides(protocol_test_params.http1_implementation,
+                           protocol_test_params.http2_implementation);
     config_helper_.addRuntimeOverride(
         Runtime::defer_processing_backedup_streams,
         protocol_test_params.defer_processing_backedup_streams ? "true" : "false");
@@ -418,7 +419,8 @@ public:
       buffer_factory_ = std::make_shared<Buffer::TrackedWatermarkBufferFactory>();
     }
     const HttpProtocolTestParams& protocol_test_params = std::get<0>(GetParam());
-    setupHttp2Overrides(protocol_test_params.http2_implementation);
+    setupHttpImplOverrides(protocol_test_params.http1_implementation,
+                           protocol_test_params.http2_implementation);
     setServerBufferFactory(buffer_factory_);
     setUpstreamProtocol(protocol_test_params.upstream_protocol);
   }

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -72,7 +72,14 @@ TEST_P(DrainCloseIntegrationTest, DrainCloseImmediate) {
   }
 }
 
-TEST_P(DrainCloseIntegrationTest, AdminDrain) { testAdminDrain(downstreamProtocol()); }
+TEST_P(DrainCloseIntegrationTest, AdminDrain) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
+  testAdminDrain(downstreamProtocol());
+}
 
 TEST_P(DrainCloseIntegrationTest, AdminGracefulDrain) {
   drain_strategy_ = Server::DrainStrategy::Immediate;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -375,8 +375,17 @@ void HttpIntegrationTest::initialize() {
 #endif
 }
 
-void HttpIntegrationTest::setupHttp2Overrides(Http2Impl implementation) {
-  switch (implementation) {
+void HttpIntegrationTest::setupHttpImplOverrides(Http1Impl http1_implementation,
+                                                 Http2Impl http2_implementation) {
+  switch (http1_implementation) {
+  case Http1Impl::HttpParser:
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.http1_use_balsa_parser", "false");
+    break;
+  case Http1Impl::BalsaParser:
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.http1_use_balsa_parser", "true");
+    break;
+  }
+  switch (http2_implementation) {
   case Http2Impl::Nghttp2:
     config_helper_.addRuntimeOverride("envoy.reloadable_features.http2_use_oghttp2", "false");
     break;

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -20,6 +20,12 @@ namespace Envoy {
 
 using ::Envoy::Http::Http2::Http2Frame;
 
+// See https://github.com/envoyproxy/envoy/issues/21245.
+enum class Http1Impl {
+  HttpParser, // http-parser from node.js
+  BalsaParser // Balsa from QUICHE
+};
+
 enum class Http2Impl {
   Nghttp2,
   Oghttp2,
@@ -137,7 +143,7 @@ public:
   ~HttpIntegrationTest() override;
 
   void initialize() override;
-  void setupHttp2Overrides(Http2Impl implementation);
+  void setupHttpImplOverrides(Http1Impl http1_implementation, Http2Impl http2_implementation);
 
 protected:
   void useAccessLog(absl::string_view format = "",

--- a/test/integration/http_protocol_integration.cc
+++ b/test/integration/http_protocol_integration.cc
@@ -8,42 +8,40 @@ std::vector<HttpProtocolTestParams> HttpProtocolIntegrationTest::getProtocolTest
     const std::vector<Http::CodecType>& upstream_protocols) {
   std::vector<HttpProtocolTestParams> ret;
 
-  const auto addHttp2TestParametersWithDeferredProcessing =
-      [&ret](Network::Address::IpVersion ip_version, Http::CodecType downstream_protocol,
-             Http::CodecType upstream_protocol) {
-        ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol, upstream_protocol,
-                                             Http2Impl::Oghttp2, false});
-        ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol, upstream_protocol,
-                                             Http2Impl::Oghttp2, true});
-        ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol, upstream_protocol,
-                                             Http2Impl::Nghttp2, true});
-      };
-
   for (auto ip_version : TestEnvironment::getIpVersionsForTest()) {
     for (auto downstream_protocol : downstream_protocols) {
       for (auto upstream_protocol : upstream_protocols) {
-#ifdef ENVOY_ENABLE_QUIC
-        ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol, upstream_protocol,
-                                             Http2Impl::Nghttp2, false});
-        if (downstream_protocol == Http::CodecType::HTTP2 ||
-            upstream_protocol == Http::CodecType::HTTP2) {
-          addHttp2TestParametersWithDeferredProcessing(ip_version, downstream_protocol,
-                                                       upstream_protocol);
-        }
-#else
+#ifndef ENVOY_ENABLE_QUIC
         if (downstream_protocol == Http::CodecType::HTTP3 ||
             upstream_protocol == Http::CodecType::HTTP3) {
           ENVOY_LOG_MISC(warn, "Skipping HTTP/3 as support is compiled out");
-        } else {
-          ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol, upstream_protocol,
-                                               Http2Impl::Nghttp2, false});
-          if (downstream_protocol == Http::CodecType::HTTP2 ||
-              upstream_protocol == Http::CodecType::HTTP2) {
-            addHttp2TestParametersWithDeferredProcessing(ip_version, downstream_protocol,
-                                                         upstream_protocol);
-          }
+          continue;
         }
 #endif
+
+        std::vector<Http1Impl> http1_implementations = {Http1Impl::HttpParser};
+        if (downstream_protocol == Http::CodecType::HTTP1 ||
+            upstream_protocol == Http::CodecType::HTTP1) {
+          http1_implementations.push_back(Http1Impl::BalsaParser);
+        }
+
+        std::vector<Http2Impl> http2_implementations = {Http2Impl::Nghttp2};
+        std::vector<bool> defer_processing_values = {false};
+        if (downstream_protocol == Http::CodecType::HTTP2 ||
+            upstream_protocol == Http::CodecType::HTTP2) {
+          http2_implementations.push_back(Http2Impl::Oghttp2);
+          defer_processing_values.push_back(true);
+        }
+
+        for (Http1Impl http1_implementation : http1_implementations) {
+          for (Http2Impl http2_implementation : http2_implementations) {
+            for (bool defer_processing : defer_processing_values) {
+              ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol,
+                                                   upstream_protocol, http1_implementation,
+                                                   http2_implementation, defer_processing});
+            }
+          }
+        }
       }
     }
   }
@@ -74,7 +72,17 @@ absl::string_view downstreamToString(Http::CodecType type) {
   return "UnknownDownstream";
 }
 
-absl::string_view implementationToString(Http2Impl impl) {
+absl::string_view http1ImplementationToString(Http1Impl impl) {
+  switch (impl) {
+  case Http1Impl::HttpParser:
+    return "HttpParser";
+  case Http1Impl::BalsaParser:
+    return "BalsaParser";
+  }
+  return "UnknownHttp1Impl";
+}
+
+absl::string_view http2ImplementationToString(Http2Impl impl) {
   switch (impl) {
   case Http2Impl::Nghttp2:
     return "Nghttp2";
@@ -89,7 +97,8 @@ std::string HttpProtocolIntegrationTest::protocolTestParamsToString(
   return absl::StrCat((params.param.version == Network::Address::IpVersion::v4 ? "IPv4_" : "IPv6_"),
                       downstreamToString(params.param.downstream_protocol),
                       upstreamToString(params.param.upstream_protocol),
-                      implementationToString(params.param.http2_implementation),
+                      http1ImplementationToString(params.param.http1_implementation),
+                      http2ImplementationToString(params.param.http2_implementation),
                       params.param.defer_processing_backedup_streams ? "WithDeferredProcessing"
                                                                      : "NoDeferredProcessing");
 }

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -10,6 +10,7 @@ struct HttpProtocolTestParams {
   Network::Address::IpVersion version;
   Http::CodecType downstream_protocol;
   Http::CodecType upstream_protocol;
+  Http1Impl http1_implementation;
   Http2Impl http2_implementation;
   bool defer_processing_backedup_streams;
 };
@@ -56,7 +57,7 @@ public:
             GetParam().downstream_protocol, GetParam().version,
             ConfigHelper::httpProxyConfig(/*downstream_is_quic=*/GetParam().downstream_protocol ==
                                           Http::CodecType::HTTP3)) {
-    setupHttp2Overrides(GetParam().http2_implementation);
+    setupHttpImplOverrides(GetParam().http1_implementation, GetParam().http2_implementation);
     config_helper_.addRuntimeOverride(Runtime::defer_processing_backedup_streams,
                                       GetParam().defer_processing_backedup_streams ? "true"
                                                                                    : "false");
@@ -85,7 +86,8 @@ public:
             std::get<0>(GetParam()).downstream_protocol, std::get<0>(GetParam()).version,
             ConfigHelper::httpProxyConfig(std::get<0>(GetParam()).downstream_protocol ==
                                           Http::CodecType::HTTP3)) {
-    setupHttp2Overrides(std::get<0>(GetParam()).http2_implementation);
+    setupHttpImplOverrides(std::get<0>(GetParam()).http1_implementation,
+                           std::get<0>(GetParam()).http2_implementation);
     config_helper_.addRuntimeOverride(
         Runtime::defer_processing_backedup_streams,
         std::get<0>(GetParam()).defer_processing_backedup_streams ? "true" : "false");

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -464,6 +464,11 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutUnconfiguredDoesNotTriggerOnBod
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestWithHeaders) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   // Omitting \r\n\r\n does not indicate incomplete request in HTTP2
   if (downstreamProtocol() == Envoy::Http::CodecType::HTTP2) {
     return;

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1629,6 +1629,11 @@ TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {
 // Test we're following https://tools.ietf.org/html/rfc7230#section-3.3.2
 // as best we can.
 TEST_P(ProtocolIntegrationTest, 304WithBody) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1993,6 +1998,11 @@ name: local-reply-during-encode-data
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestUrlRejected) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   // Send one 95 kB URL with limit 60 kB headers.
   testLargeRequestUrl(95, 60);
 }
@@ -2003,11 +2013,21 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestUrlAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   // Send one 95 kB header with limit 60 kB and 100 headers.
   testLargeRequestHeaders(95, 1, 60, 100);
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, VeryLargeRequestHeadersRejected) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   // Send one very large 600 kB header with limit 500 kB and 100 headers.
   // The limit and the header size are set in such a way to accommodate for flow control limits.
   // If the headers are too large and the flow control blocks the response is truncated and the test
@@ -2107,6 +2127,11 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersRejected) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   testLargeRequestTrailers(66, 60);
 }
@@ -2114,6 +2139,11 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersRejected) {
 // This test uses an Http::HeaderMapImpl instead of an Http::TestHeaderMapImpl to avoid
 // time-consuming byte size verification that will cause this test to timeout.
 TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   setMaxRequestHeadersKb(96);
   setMaxRequestHeadersCount(20005);
 
@@ -2801,6 +2831,11 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/12131
 TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnect) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
@@ -3874,7 +3909,12 @@ TEST_P(ProtocolIntegrationTest, LocalInterfaceNameForUpstreamConnection) {
 #ifdef NDEBUG
 // These tests send invalid request and response header names which violate ASSERT while creating
 // such request/response headers. So they can only be run in NDEBUG mode.
-TEST_P(DownstreamProtocolIntegrationTest, InvalidReqestHeaderName) {
+TEST_P(DownstreamProtocolIntegrationTest, InvalidRequestHeaderName) {
+  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+    // TODO(#21245): Re-enable this test for BalsaParser.
+    return;
+  }
+
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1629,11 +1629,6 @@ TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {
 // Test we're following https://tools.ietf.org/html/rfc7230#section-3.3.2
 // as best we can.
 TEST_P(ProtocolIntegrationTest, 304WithBody) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1656,7 +1651,10 @@ TEST_P(ProtocolIntegrationTest, 304WithBody) {
     ASSERT_FALSE(response->complete());
   }
 
-  upstream_request_->encodeData(2, true);
+  // Note that at this point the parser is expecting a new response, and it
+  // signals an error because it cannot parse the received data as a valid
+  // status line.
+  upstream_request_->encodeData("aa\r\n", true);
   if (upstreamProtocol() == Http::CodecType::HTTP1) {
     // Any body sent after the request is considered complete will not be handled as part of the
     // active request, but will be flagged as a protocol error for the no-longer-associated


### PR DESCRIPTION
Add //test/common/http/http1:codec_impl_test test case for 304 response
with body for both BalsaParser and http-parser.  In this test, the body
is dispatched to the parser in the same Parser::execute() call as the
headers.

Modify ProtocolIntegrationTest.304WithBody by appending '\r\n' to the
end of the "body" of the 304 response, necessary for BalsaParser to
signal an error.

Tracking issue: #21245

Also include #24003 (GitHub does not support dependent PRs)

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Fix 304WithBody test and add new one.
Additional Description:
Risk Level: low, test-only change
Testing: //test/integration:protocol_integration_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a