### PR TITLE
sni proxy: disable read while waiting for DNS

### DIFF
--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -59,6 +59,7 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
   case LoadDnsCacheEntryStatus::Loading:
     ASSERT(cache_load_handle_ != nullptr);
     ENVOY_CONN_LOG(debug, "waiting to load DNS cache entry", read_callbacks_->connection());
+    read_callbacks_->connection().readDisable(true);
     return Network::FilterStatus::StopIteration;
   case LoadDnsCacheEntryStatus::Overflow:
     ASSERT(cache_load_handle_ == nullptr);
@@ -74,6 +75,7 @@ void ProxyFilter::onLoadDnsCacheComplete(const Common::DynamicForwardProxy::DnsH
   ENVOY_CONN_LOG(debug, "load DNS cache complete, continuing", read_callbacks_->connection());
   ASSERT(circuit_breaker_ != nullptr);
   circuit_breaker_.reset();
+  read_callbacks_->connection().readDisable(false);
   read_callbacks_->continueReading();
 }
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Explicitly disable read during async DNS call. 
Additional Description: tcp_proxy implicitly disables read before this filter during `initialize`, but we cannot always assume it is going to do that. Context: https://github.com/envoyproxy/envoy/pull/23944
Risk Level: low
Testing: regression