### PR TITLE
Improve RouteConfigUpdateReceiverImpl::onRdsUpdate performance when t…

### DIFF
--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -63,7 +63,7 @@ bool RouteConfigUpdateReceiverImpl::onRdsUpdate(const Protobuf::Message& rc,
   for (const auto& vhost : new_route_config->virtual_hosts()) {
     rds_virtual_hosts.emplace(vhost.name(), vhost);
   }
-  if(vhds_virtual_hosts_->size() > 0) {
+  if (vhds_virtual_hosts_->size() > 0) {
     // If there are vhosts that were provided by VHDS, merge them with RDS vhosts.
     rebuildRouteConfigVirtualHosts(rds_virtual_hosts, *vhds_virtual_hosts_, *new_route_config);
   }

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -63,7 +63,10 @@ bool RouteConfigUpdateReceiverImpl::onRdsUpdate(const Protobuf::Message& rc,
   for (const auto& vhost : new_route_config->virtual_hosts()) {
     rds_virtual_hosts.emplace(vhost.name(), vhost);
   }
-  rebuildRouteConfigVirtualHosts(rds_virtual_hosts, *vhds_virtual_hosts_, *new_route_config);
+  if(vhds_virtual_hosts_->size() > 0) {
+    // If there are vhosts that were provided by VHDS, merge them with RDS vhosts.
+    rebuildRouteConfigVirtualHosts(rds_virtual_hosts, *vhds_virtual_hosts_, *new_route_config);
+  }
   base_.updateConfig(std::move(new_route_config));
   base_.updateHash(new_hash);
   rds_virtual_hosts_ = std::move(rds_virtual_hosts);


### PR DESCRIPTION
…here is no VHDS

Avoid unnecessary proto merging during RDS update if there is no VHDS.  Currently, if VHDS is not being used, RDS update clears are re-populates vhosts with the same set of hosts. 



Signed-off-by: yurykats <yurykats@yahoo.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
