### PR TITLE
Reduce VHDS overhead in RDS update

### DIFF
--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -20,9 +20,10 @@ namespace {
 
 // Resets 'route_config::virtual_hosts' by merging VirtualHost contained in
 // 'rds_vhosts' and 'vhds_vhosts'.
-void rebuildRouteConfigVirtualHosts(const VirtualHostMap& rds_vhosts,
-                                    const VirtualHostMap& vhds_vhosts,
-                                    envoy::config::route::v3::RouteConfiguration& route_config) {
+void rebuildRouteConfigVirtualHosts(
+    const RouteConfigUpdateReceiverImpl::VirtualHostMap& rds_vhosts,
+    const RouteConfigUpdateReceiverImpl::VirtualHostMap& vhds_vhosts,
+    envoy::config::route::v3::RouteConfiguration& route_config) {
   route_config.clear_virtual_hosts();
   for (const auto& vhost : rds_vhosts) {
     route_config.mutable_virtual_hosts()->Add()->CopyFrom(vhost.second);

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -81,15 +81,11 @@ bool RouteConfigUpdateReceiverImpl::onVhdsUpdate(
     const VirtualHostRefVector& added_vhosts, const std::set<std::string>& added_resource_ids,
     const Protobuf::RepeatedPtrField<std::string>& removed_resources,
     const std::string& version_info) {
-  std::unique_ptr<std::map<std::string, envoy::config::route::v3::VirtualHost>>
-      vhosts_after_this_update;
+  std::unique_ptr<VirtualHostMap> vhosts_after_this_update;
   if (vhds_virtual_hosts_ != nullptr) {
-    vhosts_after_this_update =
-        std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>(
-            *vhds_virtual_hosts_);
+    vhosts_after_this_update = std::make_unique<VirtualHostMap>(*vhds_virtual_hosts_);
   } else {
-    vhosts_after_this_update =
-        std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>();
+    vhosts_after_this_update = std::make_unique<VirtualHostMap>();
   }
   const bool removed = removeVhosts(*vhosts_after_this_update, removed_resources);
   const bool updated = updateVhosts(*vhosts_after_this_update, added_vhosts);

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -84,11 +84,11 @@ bool RouteConfigUpdateReceiverImpl::onVhdsUpdate(
   std::unique_ptr<std::map<std::string, envoy::config::route::v3::VirtualHost>>
       vhosts_after_this_update;
   if (vhds_virtual_hosts_ != nullptr) {
-    vhds_virtual_hosts_ =
+    vhosts_after_this_update =
         std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>(
             *vhds_virtual_hosts_);
   } else {
-    vhds_virtual_hosts_ =
+    vhosts_after_this_update =
         std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>();
   }
   const bool removed = removeVhosts(*vhosts_after_this_update, removed_resources);

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -63,8 +63,7 @@ bool RouteConfigUpdateReceiverImpl::onRdsUpdate(const Protobuf::Message& rc,
     // When using VHDS, stash away RDS vhosts, so that they can be merged with VHDS vhosts in
     // onVhdsUpdate.
     if (rds_virtual_hosts_ == nullptr) {
-      rds_virtual_hosts_ =
-          std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>();
+      rds_virtual_hosts_ = std::make_unique<VirtualHostMap>();
     } else {
       rds_virtual_hosts_->clear();
     }
@@ -96,8 +95,7 @@ bool RouteConfigUpdateReceiverImpl::onVhdsUpdate(
     vhosts_after_this_update = std::make_unique<VirtualHostMap>();
   }
   if (rds_virtual_hosts_ == nullptr) {
-    rds_virtual_hosts_ =
-        std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>();
+    rds_virtual_hosts_ = std::make_unique<VirtualHostMap>();
   }
   const bool removed = removeVhosts(*vhosts_after_this_update, removed_resources);
   const bool updated = updateVhosts(*vhosts_after_this_update, added_vhosts);

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -81,11 +81,16 @@ bool RouteConfigUpdateReceiverImpl::onVhdsUpdate(
     const VirtualHostRefVector& added_vhosts, const std::set<std::string>& added_resource_ids,
     const Protobuf::RepeatedPtrField<std::string>& removed_resources,
     const std::string& version_info) {
-  auto vhosts_after_this_update =
-      vhds_virtual_hosts_ == nullptr
-          ? std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>()
-          : std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>(
-                *vhds_virtual_hosts_);
+  std::unique_ptr<std::map<std::string, envoy::config::route::v3::VirtualHost>>
+      vhosts_after_this_update;
+  if (vhds_virtual_hosts_ != nullptr) {
+    vhds_virtual_hosts_ =
+        std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>(
+            *vhds_virtual_hosts_);
+  } else {
+    vhds_virtual_hosts_ =
+        std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>();
+  }
   const bool removed = removeVhosts(*vhosts_after_this_update, removed_resources);
   const bool updated = updateVhosts(*vhosts_after_this_update, added_vhosts);
 

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -41,8 +41,7 @@ public:
                                 const OptionalHttpFilters& optional_http_filters)
       : config_traits_(optional_http_filters,
                        factory_context.messageValidationContext().dynamicValidationVisitor()),
-        base_(config_traits_, proto_traits, factory_context), last_vhds_config_hash_(0ul),
-        vhds_configuration_changed_(true) {}
+        base_(config_traits_, proto_traits, factory_context) {}
 
   using VirtualHostMap = std::map<std::string, envoy::config::route::v3::VirtualHost>;
 
@@ -84,11 +83,11 @@ private:
 
   Rds::RouteConfigUpdateReceiverImpl base_;
 
-  uint64_t last_vhds_config_hash_;
+  uint64_t last_vhds_config_hash_{0ul};
   VirtualHostMap rds_virtual_hosts_;
   std::unique_ptr<VirtualHostMap> vhds_virtual_hosts_;
   std::set<std::string> resource_ids_in_last_update_;
-  bool vhds_configuration_changed_;
+  bool vhds_configuration_changed_{true};
 };
 
 } // namespace Router

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -34,6 +34,8 @@ private:
   ProtobufMessage::ValidationVisitor& validator_;
 };
 
+using VirtualHostMap = std::map<std::string, envoy::config::route::v3::VirtualHost>;
+
 class RouteConfigUpdateReceiverImpl : public RouteConfigUpdateReceiver {
 public:
   RouteConfigUpdateReceiverImpl(Rds::ProtoTraits& proto_traits,
@@ -42,7 +44,7 @@ public:
       : config_traits_(optional_http_filters,
                        factory_context.messageValidationContext().dynamicValidationVisitor()),
         base_(config_traits_, proto_traits, factory_context), last_vhds_config_hash_(0ul),
-        vhds_virtual_hosts_(nullptr), vhds_configuration_changed_(true) {}
+        vhds_configuration_changed_(true) {}
 
   bool removeVhosts(std::map<std::string, envoy::config::route::v3::VirtualHost>& vhosts,
                     const Protobuf::RepeatedPtrField<std::string>& removed_vhost_names);
@@ -84,8 +86,8 @@ private:
   Rds::RouteConfigUpdateReceiverImpl base_;
 
   uint64_t last_vhds_config_hash_;
-  std::map<std::string, envoy::config::route::v3::VirtualHost> rds_virtual_hosts_;
-  std::unique_ptr<std::map<std::string, envoy::config::route::v3::VirtualHost>> vhds_virtual_hosts_;
+  VirtualHostMap rds_virtual_hosts_;
+  std::unique_ptr<VirtualHostMap> vhds_virtual_hosts_;
   std::set<std::string> resource_ids_in_last_update_;
   bool vhds_configuration_changed_;
 };

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -42,9 +42,7 @@ public:
       : config_traits_(optional_http_filters,
                        factory_context.messageValidationContext().dynamicValidationVisitor()),
         base_(config_traits_, proto_traits, factory_context), last_vhds_config_hash_(0ul),
-        vhds_virtual_hosts_(
-            std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>()),
-        vhds_configuration_changed_(true) {}
+        vhds_virtual_hosts_(nullptr), vhds_configuration_changed_(true) {}
 
   bool removeVhosts(std::map<std::string, envoy::config::route::v3::VirtualHost>& vhosts,
                     const Protobuf::RepeatedPtrField<std::string>& removed_vhost_names);

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -84,7 +84,9 @@ private:
   Rds::RouteConfigUpdateReceiverImpl base_;
 
   uint64_t last_vhds_config_hash_{0ul};
-  VirtualHostMap rds_virtual_hosts_;
+  // vhosts supplied by RDS, to be merged with VHDS vhosts in onVhdsUpdate.
+  std::unique_ptr<VirtualHostMap> rds_virtual_hosts_;
+  // vhosts supplied by VHDS, to be merged with RDS vhosts in onRdsUpdate.
   std::unique_ptr<VirtualHostMap> vhds_virtual_hosts_;
   std::set<std::string> resource_ids_in_last_update_;
   bool vhds_configuration_changed_{true};

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -34,8 +34,6 @@ private:
   ProtobufMessage::ValidationVisitor& validator_;
 };
 
-using VirtualHostMap = std::map<std::string, envoy::config::route::v3::VirtualHost>;
-
 class RouteConfigUpdateReceiverImpl : public RouteConfigUpdateReceiver {
 public:
   RouteConfigUpdateReceiverImpl(Rds::ProtoTraits& proto_traits,
@@ -46,10 +44,11 @@ public:
         base_(config_traits_, proto_traits, factory_context), last_vhds_config_hash_(0ul),
         vhds_configuration_changed_(true) {}
 
-  bool removeVhosts(std::map<std::string, envoy::config::route::v3::VirtualHost>& vhosts,
+  using VirtualHostMap = std::map<std::string, envoy::config::route::v3::VirtualHost>;
+
+  bool removeVhosts(VirtualHostMap& vhosts,
                     const Protobuf::RepeatedPtrField<std::string>& removed_vhost_names);
-  bool updateVhosts(std::map<std::string, envoy::config::route::v3::VirtualHost>& vhosts,
-                    const VirtualHostRefVector& added_vhosts);
+  bool updateVhosts(VirtualHostMap& vhosts, const VirtualHostRefVector& added_vhosts);
   bool onDemandFetchFailed(const envoy::service::discovery::v3::Resource& resource) const;
 
   // Router::RouteConfigUpdateReceiver


### PR DESCRIPTION
If there is no VHDS, do not allocate a map and do not clear/reset RDS vhosts during RDS update.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
