### PR TITLE
rate_limit: Add time unit month and year

### DIFF
--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -92,6 +92,12 @@ message RateLimitResponse {
 
       // The time unit representing a day.
       DAY = 4;
+
+      // The time unit representing a month.
+      MONTH = 5;
+
+      // The time unit representing a year.
+      YEAR = 6;
     }
 
     // A name or description of this limit.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -29,6 +29,9 @@ minor_behavior_changes:
 - area: oauth2
   change: |
     Requests which match the passthrough header now have their own metric ``oauth_passthrough`` and aren't included in ``oauth_success`` anymore.
+- area: rate_limit
+  change: |
+    add `MONTH` and `YEAR` to the unit of time for rate limit.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,7 +31,7 @@ minor_behavior_changes:
     Requests which match the passthrough header now have their own metric ``oauth_passthrough`` and aren't included in ``oauth_success`` anymore.
 - area: rate_limit
   change: |
-    add `MONTH` and `YEAR` to the unit of time for rate limit.
+    add ``MONTH`` and ``YEAR`` to the unit of time for rate limit.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/ratelimit/ratelimit_headers.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit_headers.cc
@@ -75,6 +75,10 @@ uint32_t XRateLimitHeaderUtils::convertRateLimitUnit(
     return 60 * 60;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::DAY:
     return 24 * 60 * 60;
+  case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::MONTH:
+    return 30 * 24 * 60 * 60;
+  case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::YEAR:
+    return 365 * 24 * 60 * 60;
   case envoy::service::ratelimit::v3::RateLimitResponse::RateLimit::UNKNOWN:
   default:
     return 0;


### PR DESCRIPTION
Per #23844 and #24031,  @renuka-fernando wants to have time unit `month` and `year` for his business need

Release note added.
Signed-off-by: Tianyu Xia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
