### PR TITLE
Use per_route_config_ in grpc_json_transcoder

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -455,7 +455,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
                      status.message());
 
     if (status.code() == StatusCode::kNotFound &&
-        !config_.request_validation_options_.reject_unknown_method()) {
+        !per_route_config_->request_validation_options_.reject_unknown_method()) {
       ENVOY_STREAM_LOG(debug,
                        "Request is passed through without transcoding because it cannot be mapped "
                        "to a gRPC method.",
@@ -464,7 +464,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
     }
 
     if (status.code() == StatusCode::kInvalidArgument &&
-        !config_.request_validation_options_.reject_unknown_query_parameters()) {
+        !per_route_config_->request_validation_options_.reject_unknown_query_parameters()) {
       ENVOY_STREAM_LOG(debug,
                        "Request is passed through without transcoding because it contains unknown "
                        "query parameters.",


### PR DESCRIPTION
Commit Message: Use per_route_config_ in grpc_json_transcoder
Additional Description: Fixes a minor bug in grpc_json_transcoder; if configured per-route with an empty config at the listener level, the request_validation_options fields at the route level would be ignored.
Risk Level: Low (bug fix only)
Testing: Tested live. I don't think adding a unit test to cover this error would be meaningful *after* the bug is fixed. The fix is trivial, the test is hard.
Docs Changes: No, the docs already describe the 'after' behavior.
Release Notes: n/a
Platform Specific Features: n/a
