### PR TITLE
Validate core retry policy at config parsing time

### DIFF
--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -578,6 +578,9 @@ struct AuthorityAttributes {
 AuthorityAttributes parseAuthority(absl::string_view host);
 
 /**
+ * WARNING: This function will throw exception. Please call it in the config
+ * parsing time in the main thread to validate the core retry policy.
+ *
  * It returns RetryPolicy defined in core api to route api.
  * @param retry_policy core retry policy
  * @param retry_on this specifies when retry should be invoked.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -578,9 +578,13 @@ struct AuthorityAttributes {
 AuthorityAttributes parseAuthority(absl::string_view host);
 
 /**
- * WARNING: This function will throw exception. Please call it in the config
- * parsing time in the main thread to validate the core retry policy.
- *
+ * It validates RetryPolicy defined in core api. It should be called at the main thread as
+ * it may throw exception.
+ * @param retry_policy core retry policy
+ */
+void validateCoreRetryPolicy(const envoy::config::core::v3::RetryPolicy& retry_policy);
+
+/**
  * It returns RetryPolicy defined in core api to route api.
  * @param retry_policy core retry policy
  * @param retry_on this specifies when retry should be invoked.

--- a/source/extensions/filters/http/gcp_authn/filter_config.cc
+++ b/source/extensions/filters/http/gcp_authn/filter_config.cc
@@ -6,6 +6,8 @@
 #include "envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.pb.validate.h"
 #include "envoy/registry/registry.h"
 
+#include "source/common/http/utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -20,6 +22,11 @@ Http::FilterFactoryCb GcpAuthnFilterFactory::createFilterFactoryFromProtoTyped(
   if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.cache_config(), cache_size, 0) > 0) {
     token_cache = std::make_shared<TokenCache>(config.cache_config(), context);
   }
+  // Validate retry_policy is valid in the config parsing time.
+  if (config.has_retry_policy()) {
+    Http::Utility::convertCoreToRouteRetryPolicy(config.retry_policy(), "");
+  }
+
   FilterConfigSharedPtr filter_config =
       std::make_shared<envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig>(
           config);

--- a/source/extensions/filters/http/gcp_authn/filter_config.cc
+++ b/source/extensions/filters/http/gcp_authn/filter_config.cc
@@ -22,9 +22,10 @@ Http::FilterFactoryCb GcpAuthnFilterFactory::createFilterFactoryFromProtoTyped(
   if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.cache_config(), cache_size, 0) > 0) {
     token_cache = std::make_shared<TokenCache>(config.cache_config(), context);
   }
-  // Validate retry_policy is valid in the config parsing time.
+  // config.retry_policy has an invalid case that could not be validated by the
+  // proto validation annotation. It has to be validated by the code.
   if (config.has_retry_policy()) {
-    Http::Utility::convertCoreToRouteRetryPolicy(config.retry_policy(), "");
+    Http::Utility::validateCoreRetryPolicy(config.retry_policy());
   }
 
   FilterConfigSharedPtr filter_config =

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -9,6 +9,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/config/datasource.h"
+#include "source/common/http/utility.h"
 
 #include "absl/container/node_hash_map.h"
 #include "jwt_verify_lib/check_audience.h"
@@ -30,6 +31,11 @@ public:
                CreateJwksFetcherCb fetcher_cb, JwtAuthnFilterStats& stats)
       : jwt_provider_(jwt_provider), time_source_(context.timeSource()),
         tls_(context.threadLocal()) {
+
+    // To validate remote_jwks.retry_policy in the config parsing thread.
+    if (jwt_provider_.has_remote_jwks() && jwt_provider_.remote_jwks().has_retry_policy()) {
+      Http::Utility::convertCoreToRouteRetryPolicy(jwt_provider_.remote_jwks().retry_policy(), "");
+    }
 
     std::vector<std::string> audiences;
     for (const auto& aud : jwt_provider_.audiences()) {

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -32,9 +32,10 @@ public:
       : jwt_provider_(jwt_provider), time_source_(context.timeSource()),
         tls_(context.threadLocal()) {
 
-    // To validate remote_jwks.retry_policy in the config parsing thread.
+    // remote_jwks.retry_policy has an invalid case that could not be validated by the
+    // proto validation annotation. It has to be validated by the code.
     if (jwt_provider_.has_remote_jwks() && jwt_provider_.remote_jwks().has_retry_policy()) {
-      Http::Utility::convertCoreToRouteRetryPolicy(jwt_provider_.remote_jwks().retry_policy(), "");
+      Http::Utility::validateCoreRetryPolicy(jwt_provider_.remote_jwks().retry_policy());
     }
 
     std::vector<std::string> audiences;

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -1199,8 +1199,7 @@ num_retries: 10
 
   envoy::config::core::v3::RetryPolicy core_retry_policy2;
   TestUtility::loadFromYaml(core_policy2, core_retry_policy2);
-  EXPECT_THROW_WITH_MESSAGE(Utility::convertCoreToRouteRetryPolicy(core_retry_policy2, "5xx"),
-                            EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(Utility::validateCoreRetryPolicy(core_retry_policy2), EnvoyException,
                             "max_interval must be greater than or equal to the base_interval");
 }
 

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/clusterfuzz-testcase-minimized-jwt_authn_fuzz_test-5696765294936064
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/clusterfuzz-testcase-minimized-jwt_authn_fuzz_test-5696765294936064
@@ -1,0 +1,58 @@
+config {
+  providers {
+    key: "provider1"
+    value {
+      remote_jwks {
+      }
+      payload_in_metadata: "provider1"
+      clock_skew_seconds: 3
+      header_in_metadata: "D"
+    }
+  }
+  providers {
+    key: "provider2"
+    value {
+      issuer: "https://example.com"
+      remote_jwks {
+        retry_policy {
+          retry_back_off {
+            base_interval {
+              nanos: 16645888
+            }
+            max_interval {
+              nanos: 2048
+            }
+          }
+        }
+      }
+      payload_in_metadata: "provider1"
+      pad_forward_payload_header: true
+      header_in_metadata: "D"
+    }
+  }
+  rules {
+    match {
+      prefix: "/"
+    }
+    requires {
+      requires_any {
+        requirements {
+          provider_name: "provider1"
+        }
+        requirements {
+          provider_name: "provider2"
+        }
+      }
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "authorization"
+      value: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11upstream_rq_pending_activeG34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+  }
+}
+remote_jwks: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+num_calls: 3


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

This issue is found by newly added fuzz test from jwt_authn filter.  The root course is 
```
Utility::convertCoreToRouteRetryPolicy 
```
may throw an exception [here](https://github.com/envoyproxy/envoy/blob/main/source/common/http/utility.cc#L1088)

This function is called by `jwt_authn` filter and `gcp_authn` filters in the worker thread.   

The changes:
* change the `throw EnvoyException` to `ENVOY_BUG`.  It should not throw exception if it may be called at worker threads.
* Add a new function `validate` to be called at main thread.
* 

Risk Level: None
Testing:  None
Docs Changes: None
Release Notes:  None
