### PR TITLE
[backport/1.23] test: fix a race in tcp_tunneling_integration_test (#22883)

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -754,6 +754,7 @@ TEST_P(TcpTunnelingIntegrationTest, HeaderEvaluatorConfigUpdate) {
   new_config_helper.setLds("1");
 
   test_server_->waitForCounterEq("listener_manager.listener_modified", 1);
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_warming", 0);
   test_server_->waitForGaugeEq("listener_manager.total_listeners_draining", 0);
 
   // Start a connection, and verify the upgrade headers are received upstream.


### PR DESCRIPTION
The HeaderEvaluatorConfigUpdate test needs to wait for a listener to be replaced. Its previous attempt to achieve that did not account for the intermediate warming state of new listeners, which could lead to the test continuing prematurely and failing.

Signed-off-by: Benjamin Peterson <benjamin@engflow.com>
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
