### PR TITLE
ci: Increase coverage timeout

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -341,7 +341,7 @@ stages:
   - job: coverage
     displayName: "linux_x64"
     dependsOn: []
-    timeoutInMinutes: 120
+    timeoutInMinutes: 180
     pool: "x64-large"
     strategy:
       maxParallel: 2


### PR DESCRIPTION
ci mostly passing coverage but occasionally timesout, sometimes when it has already completed the actual coverage tests.

the problem is worse on postsubmit and release branches due to less caching.

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
