### PR TITLE
docker: Don't include su-exec in the distroless image

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -45,7 +45,6 @@ CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
 FROM gcr.io/distroless/base-debian11:nonroot@sha256:4b22ca3c68018333c56f8dddcf1f8b55f32889f2dd12d28ab60856eba1130d04 AS envoy-distroless
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
-COPY --from=binary /usr/local/bin/su-exec /usr/local/bin/
 COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000


### PR DESCRIPTION
Signed-off-by: Michael Kaufmann <michael.kaufmann@ergon.ch>

Risk Level: Low