### PR TITLE
Move Http1ParserImpl and pretty-printer to test_common/utility.h.

### DIFF
--- a/test/common/http/http1/BUILD
+++ b/test/common/http/http1/BUILD
@@ -40,6 +40,7 @@ envoy_cc_test(
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:logging_lib",
         "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],
 )

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -23,6 +23,7 @@
 #include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/test_runtime.h"
+#include "test/test_common/utility.h"
 
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
@@ -42,14 +43,8 @@ namespace Envoy {
 namespace Http {
 namespace {
 
-// See https://github.com/envoyproxy/envoy/issues/21245.
-enum class ParserImpl {
-  HttpParser, // http-parser from node.js
-  BalsaParser // Balsa from QUICHE
-};
-
-std::string testParamToString(const ::testing::TestParamInfo<ParserImpl>& info) {
-  return info.param == ParserImpl::HttpParser ? "HttpParser" : "BalsaParser";
+std::string testParamToString(const ::testing::TestParamInfo<Http1ParserImpl>& info) {
+  return TestUtility::http1ParserImplToString(info.param);
 }
 
 std::string createHeaderFragment(int num_headers) {
@@ -81,12 +76,12 @@ Buffer::OwnedImpl createBufferWithNByteSlices(absl::string_view input, size_t ma
 }
 } // namespace
 
-class Http1CodecTestBase : public testing::TestWithParam<ParserImpl> {
+class Http1CodecTestBase : public testing::TestWithParam<Http1ParserImpl> {
 protected:
   Http1CodecTestBase() : parser_impl_(GetParam()) {}
 
   void SetUp() override {
-    if (parser_impl_ == ParserImpl::BalsaParser) {
+    if (parser_impl_ == Http1ParserImpl::BalsaParser) {
       scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_use_balsa_parser", "true"}});
     } else {
       scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_use_balsa_parser", "false"}});
@@ -98,7 +93,7 @@ protected:
   }
 
   TestScopedRuntime scoped_runtime_;
-  const ParserImpl parser_impl_;
+  const Http1ParserImpl parser_impl_;
   Stats::TestUtil::TestStore store_;
   Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
 };
@@ -448,7 +443,8 @@ void Http1ServerConnectionImplTest::testServerAllowChunkedContentLength(uint32_t
 }
 
 INSTANTIATE_TEST_SUITE_P(Parsers, Http1ServerConnectionImplTest,
-                         ::testing::Values(ParserImpl::HttpParser, ParserImpl::BalsaParser),
+                         ::testing::Values(Http1ParserImpl::HttpParser,
+                                           Http1ParserImpl::BalsaParser),
                          testParamToString);
 
 TEST_P(Http1ServerConnectionImplTest, EmptyHeader) {
@@ -980,7 +976,7 @@ TEST_P(Http1ServerConnectionImplTest, Http11InvalidRequest) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     // BalsaParser only validates trailers if `enable_trailers_` is set.
     codec_settings_.enable_trailers_ = true;
   }
@@ -1011,7 +1007,7 @@ TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailersIgnored) {
-  if (parser_impl_ == ParserImpl::HttpParser) {
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
     // HttpParser signals error even if `enable_trailers_` is false.
     return;
   }
@@ -2225,7 +2221,7 @@ TEST_P(Http1ServerConnectionImplTest, TestSmugglingAllowChunkedContentLength100)
 
 TEST_P(Http1ServerConnectionImplTest,
        ShouldDumpParsedAndPartialHeadersWithoutAllocatingMemoryIfProcessingHeaders) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2264,7 +2260,7 @@ TEST_P(Http1ServerConnectionImplTest,
 }
 
 TEST_P(Http1ServerConnectionImplTest, ShouldDumpDispatchBufferWithoutAllocatingMemory) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2378,7 +2374,8 @@ void Http1ClientConnectionImplTest::testClientAllowChunkedContentLength(
 }
 
 INSTANTIATE_TEST_SUITE_P(Parsers, Http1ClientConnectionImplTest,
-                         ::testing::Values(ParserImpl::HttpParser, ParserImpl::BalsaParser),
+                         ::testing::Values(Http1ParserImpl::HttpParser,
+                                           Http1ParserImpl::BalsaParser),
                          testParamToString);
 
 TEST_P(Http1ClientConnectionImplTest, SimpleGet) {
@@ -3374,7 +3371,7 @@ TEST_P(Http1ServerConnectionImplTest, Utf8Path) {
   bool strict = true;
 #endif
 
-  if (parser_impl_ == ParserImpl::BalsaParser) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     strict = true;
   }
 
@@ -3563,7 +3560,7 @@ TEST_P(Http1ClientConnectionImplTest, TestResponseSplitAllowChunkedLength100) {
 
 TEST_P(Http1ClientConnectionImplTest,
        ShouldDumpParsedAndPartialHeadersWithoutAllocatingMemoryIfProcessingHeaders) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -3595,7 +3592,7 @@ TEST_P(Http1ClientConnectionImplTest,
 }
 
 TEST_P(Http1ClientConnectionImplTest, ShouldDumpDispatchBufferWithoutAllocatingMemory) {
-  if (parser_impl_ == ParserImpl::BalsaParser) {
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }

--- a/test/extensions/filters/http/health_check/health_check_integration_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_integration_test.cc
@@ -1,4 +1,5 @@
 #include "test/integration/http_protocol_integration.h"
+#include "test/test_common/utility.h"
 
 using testing::HasSubstr;
 using testing::Not;
@@ -146,7 +147,7 @@ TEST_P(HealthCheckIntegrationTest, HealthCheck) {
 TEST_P(HealthCheckIntegrationTest, HealthCheckWithoutServerStats) {
   DISABLE_IF_ADMIN_DISABLED;
 
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }

--- a/test/extensions/http/header_formatters/preserve_case/BUILD
+++ b/test/extensions/http/header_formatters/preserve_case/BUILD
@@ -51,6 +51,7 @@ envoy_extension_cc_test(
         "//test/integration:http_integration_lib",
         "//test/integration:http_protocol_integration_lib",
         "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
     ],
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -788,6 +788,7 @@ envoy_cc_test(
         "//test/integration/filters:reset_idle_timer_filter_lib",
         "//test/integration/filters:set_route_filter_lib",
         "//test/test_common:test_time_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -753,6 +753,7 @@ envoy_cc_test_library(
         "//test/integration/filters:wait_for_whole_request_and_response_config_lib",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
@@ -771,6 +772,7 @@ envoy_cc_test_library(
         ":http_integration_lib",
         "//test/common/upstream:utility_lib",
         "//test/integration/filters:stream_info_to_headers_filter_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -1,4 +1,5 @@
 #include "test/integration/http_protocol_integration.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace {
@@ -73,7 +74,7 @@ TEST_P(DrainCloseIntegrationTest, DrainCloseImmediate) {
 }
 
 TEST_P(DrainCloseIntegrationTest, AdminDrain) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -375,12 +375,12 @@ void HttpIntegrationTest::initialize() {
 #endif
 }
 
-void HttpIntegrationTest::setupHttp1ImplOverrides(Http1Impl http1_implementation) {
+void HttpIntegrationTest::setupHttp1ImplOverrides(Http1ParserImpl http1_implementation) {
   switch (http1_implementation) {
-  case Http1Impl::HttpParser:
+  case Http1ParserImpl::HttpParser:
     config_helper_.addRuntimeOverride("envoy.reloadable_features.http1_use_balsa_parser", "false");
     break;
-  case Http1Impl::BalsaParser:
+  case Http1ParserImpl::BalsaParser:
     config_helper_.addRuntimeOverride("envoy.reloadable_features.http1_use_balsa_parser", "true");
     break;
   }

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -11,6 +11,7 @@
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
 
 #ifdef ENVOY_ENABLE_QUIC
 #include "quiche/quic/core/deterministic_connection_id_generator.h"
@@ -19,12 +20,6 @@
 namespace Envoy {
 
 using ::Envoy::Http::Http2::Http2Frame;
-
-// See https://github.com/envoyproxy/envoy/issues/21245.
-enum class Http1Impl {
-  HttpParser, // http-parser from node.js
-  BalsaParser // Balsa from QUICHE
-};
 
 enum class Http2Impl {
   Nghttp2,
@@ -143,7 +138,7 @@ public:
   ~HttpIntegrationTest() override;
 
   void initialize() override;
-  void setupHttp1ImplOverrides(Http1Impl http1_implementation);
+  void setupHttp1ImplOverrides(Http1ParserImpl http1_implementation);
   void setupHttp2ImplOverrides(Http2Impl http2_implementation);
 
 protected:

--- a/test/integration/http_protocol_integration.cc
+++ b/test/integration/http_protocol_integration.cc
@@ -19,10 +19,10 @@ std::vector<HttpProtocolTestParams> HttpProtocolIntegrationTest::getProtocolTest
         }
 #endif
 
-        std::vector<Http1Impl> http1_implementations = {Http1Impl::HttpParser};
+        std::vector<Http1ParserImpl> http1_implementations = {Http1ParserImpl::HttpParser};
         if (downstream_protocol == Http::CodecType::HTTP1 ||
             upstream_protocol == Http::CodecType::HTTP1) {
-          http1_implementations.push_back(Http1Impl::BalsaParser);
+          http1_implementations.push_back(Http1ParserImpl::BalsaParser);
         }
 
         std::vector<Http2Impl> http2_implementations = {Http2Impl::Nghttp2};
@@ -33,7 +33,7 @@ std::vector<HttpProtocolTestParams> HttpProtocolIntegrationTest::getProtocolTest
           defer_processing_values.push_back(true);
         }
 
-        for (Http1Impl http1_implementation : http1_implementations) {
+        for (Http1ParserImpl http1_implementation : http1_implementations) {
           for (Http2Impl http2_implementation : http2_implementations) {
             for (bool defer_processing : defer_processing_values) {
               ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol,
@@ -72,16 +72,6 @@ absl::string_view downstreamToString(Http::CodecType type) {
   return "UnknownDownstream";
 }
 
-absl::string_view http1ImplementationToString(Http1Impl impl) {
-  switch (impl) {
-  case Http1Impl::HttpParser:
-    return "HttpParser";
-  case Http1Impl::BalsaParser:
-    return "BalsaParser";
-  }
-  return "UnknownHttp1Impl";
-}
-
 absl::string_view http2ImplementationToString(Http2Impl impl) {
   switch (impl) {
   case Http2Impl::Nghttp2:
@@ -97,7 +87,7 @@ std::string HttpProtocolIntegrationTest::protocolTestParamsToString(
   return absl::StrCat((params.param.version == Network::Address::IpVersion::v4 ? "IPv4_" : "IPv6_"),
                       downstreamToString(params.param.downstream_protocol),
                       upstreamToString(params.param.upstream_protocol),
-                      http1ImplementationToString(params.param.http1_implementation),
+                      TestUtility::http1ParserImplToString(params.param.http1_implementation),
                       http2ImplementationToString(params.param.http2_implementation),
                       params.param.defer_processing_backedup_streams ? "WithDeferredProcessing"
                                                                      : "NoDeferredProcessing");

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "test/integration/http_integration.h"
-
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -2,6 +2,8 @@
 
 #include "test/integration/http_integration.h"
 
+#include "test/test_common/utility.h"
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -10,7 +12,7 @@ struct HttpProtocolTestParams {
   Network::Address::IpVersion version;
   Http::CodecType downstream_protocol;
   Http::CodecType upstream_protocol;
-  Http1Impl http1_implementation;
+  Http1ParserImpl http1_implementation;
   Http2Impl http2_implementation;
   bool defer_processing_backedup_streams;
 };

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -3,6 +3,7 @@
 
 #include "test/integration/http_protocol_integration.h"
 #include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
 
 using testing::HasSubstr;
 
@@ -464,7 +465,7 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutUnconfiguredDoesNotTriggerOnBod
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestWithHeaders) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1629,7 +1629,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {
 // Test we're following https://tools.ietf.org/html/rfc7230#section-3.3.2
 // as best we can.
 TEST_P(ProtocolIntegrationTest, 304WithBody) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -1998,7 +1998,7 @@ name: local-reply-during-encode-data
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestUrlRejected) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2013,7 +2013,7 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestUrlAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2023,7 +2023,7 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, VeryLargeRequestHeadersRejected) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2127,7 +2127,7 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersRejected) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2139,7 +2139,7 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersRejected) {
 // This test uses an Http::HeaderMapImpl instead of an Http::TestHeaderMapImpl to avoid
 // time-consuming byte size verification that will cause this test to timeout.
 TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -2831,7 +2831,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/12131
 TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnect) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }
@@ -3910,7 +3910,7 @@ TEST_P(ProtocolIntegrationTest, LocalInterfaceNameForUpstreamConnection) {
 // These tests send invalid request and response header names which violate ASSERT while creating
 // such request/response headers. So they can only be run in NDEBUG mode.
 TEST_P(DownstreamProtocolIntegrationTest, InvalidRequestHeaderName) {
-  if (GetParam().http1_implementation == Http1Impl::BalsaParser) {
+  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
     // TODO(#21245): Re-enable this test for BalsaParser.
     return;
   }

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -143,6 +143,12 @@ private:
   RealTimeSource real_time_source_;
 };
 
+// See https://github.com/envoyproxy/envoy/issues/21245.
+enum class Http1ParserImpl {
+  HttpParser, // http-parser from node.js
+  BalsaParser // Balsa from QUICHE
+};
+
 class TestUtility {
 public:
   /**
@@ -532,6 +538,11 @@ public:
     MessageType message;
     TestUtility::loadFromYaml(yaml, message);
     return message;
+  }
+
+  // Allows pretty printed test names.
+  static std::string http1ParserImplToString(Http1ParserImpl impl) {
+    return impl == Http1ParserImpl::HttpParser ? "HttpParser" : "BalsaParser";
   }
 
   // Allows pretty printed test names for TEST_P using TestEnvironment::getIpVersionsForTest().


### PR DESCRIPTION
Consolidate these existing implementations.

Tracking issue: https://github.com/envoyproxy/envoy/issues/21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: Move Http1ParserImpl and pretty-printer to test_common/utility.h.
Additional Description:
Risk Level: low, test-only refactor
Testing: test-only change
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a