### PR TITLE
utility: fix broken URL in checkTransportVersion() utility method

### DIFF
--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -208,13 +208,12 @@ public:
     const auto transport_api_version = api_config_source.transport_api_version();
     ASSERT_IS_MAIN_OR_TEST_THREAD();
     if (transport_api_version != envoy::config::core::v3::ApiVersion::V3) {
-      const ApiVersion version = ApiVersionInfo::apiVersion();
       const std::string& warning = fmt::format(
           "V2 (and AUTO) xDS transport protocol versions are deprecated in {}. "
           "The v2 xDS major version has been removed and is no longer supported. "
           "You may be missing explicit V3 configuration of the transport API version, "
-          "see the advice in https://www.envoyproxy.io/docs/envoy/v{}.{}.{}/faq/api/envoy_v3.",
-          api_config_source.DebugString(), version.major, version.minor, version.patch);
+          "see the advice in https://www.envoyproxy.io/docs/envoy/latest/faq/api/envoy_v3.",
+          api_config_source.DebugString());
       ENVOY_LOG_MISC(warn, warning);
       throw DeprecatedMajorVersionException(warning);
     }


### PR DESCRIPTION
This PR fixes the broken URL link in `checkTransportVersion()` method inside utility file by pointing it to `/latest` so that it points to the correct page i.e. https://www.envoyproxy.io/docs/envoy/latest/faq/api/envoy_v3

**Commit Message:** Fixes broken URL in `checkTransportVersion()`.
**Additional Description:** This PR fixes the broken URL for the warning that gets printed while using xDS v2.
**Risk Level:** Very Low
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>