### PR TITLE
jwt_authn: fix jwt cache bug with requirement_with_audiences

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -61,6 +61,9 @@ bug_fixes:
 - area: validation
   change: |
     fixed a crash which could happen when optional ``engine_type`` is not provided in regex.
+- area: jwt_authn
+  change: |
+    fix a bug that jwt_cache breaks the :ref:`provider_and_audiences <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.provider_and_audiences>` JWT requirement.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/jwt_authn/stats.h
+++ b/source/extensions/filters/http/jwt_authn/stats.h
@@ -15,7 +15,9 @@ namespace JwtAuthn {
   COUNTER(cors_preflight_bypassed)                                                                 \
   COUNTER(denied)                                                                                  \
   COUNTER(jwks_fetch_success)                                                                      \
-  COUNTER(jwks_fetch_failed)
+  COUNTER(jwks_fetch_failed)                                                                       \
+  COUNTER(jwt_cache_hit)                                                                           \
+  COUNTER(jwt_cache_miss)
 
 /**
  * Wrapper struct for jwt_authn filter stats. @see stats_macros.h


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

If jwt_cache is enabled, it may break [ProviderWithAudiences](https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto#L398) feature. 

The `ProviderWithAudiences` may need to check different audiences. But when a cached jwt is used, the audiences will not be checked.  

Risk Level:  Low
Testing:  Unit-test
Docs Changes: No
Release Notes: Yes
