### PR TITLE
Support multi region routing for AWS Lambda Filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -37,7 +37,7 @@ bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
 - area: aws_lambda
   change: |
-    fix a bug when :ref:`PerRouteConfig <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.PerRouteConfig>` is defined and was routing to a target cluster's AWS Lambda endpoint
+    fix a bug when :ref:`PerRouteConfig <envoy_v3_api_msg_extensions.filters.http.aws_lambda.v3.PerRouteConfig>` is defined and was routing to a target cluster's AWS Lambda endpoint
     in a region that is different from the region obtained in :ref:`arn <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.arn>` of aws_lambda http_filter configuration
     then the authorization header included in the request towards AWS Lambda was not signed with the region specified in PerRouteConfig.
 - area: grpc_json_transcoder

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -35,6 +35,11 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- aws_lambda:
+  change: |
+    fix a bug when :ref:`PerRouteConfig <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.PerRouteConfig>` is defined and was routing to a target cluster's AWS Lambda endpoint
+    in a region that is different from the region obtained in :ref:`arn <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.arn>` of aws_lambda http_filter configuration
+    then the authorization header included in the request towards AWS Lambda was not signed with the region specified in PerRouteConfig.
 - area: grpc_json_transcoder
   change: |
     fix a bug when using http2, request body has google.api.HttpBody and the size is < 16KB, it will cause EOF from the backend grpc server.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -35,7 +35,7 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
-- aws_lambda:
+- area: aws_lambda
   change: |
     fix a bug when :ref:`PerRouteConfig <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.PerRouteConfig>` is defined and was routing to a target cluster's AWS Lambda endpoint
     in a region that is different from the region obtained in :ref:`arn <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.arn>` of aws_lambda http_filter configuration

--- a/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
@@ -26,19 +26,19 @@ is set to ``false``, then the HTTP request is transformed to a JSON payload with
    :force:
 
     {
-        "rawPath": "/path/to/resource",
+        "raw_path": "/path/to/resource",
         "method": "GET|POST|HEAD|...",
         "headers": {"header-key": "header-value", ... },
-        "queryStringParameters": {"key": "value", ...},
+        "query_string_parameters": {"key": "value", ...},
         "body": "...",
-        "isBase64Encoded": true|false
+        "is_base64_encoded": true|false
     }
 
-- ``rawPath`` is the HTTP request resource path (including the query string)
+- ``raw_path`` is the HTTP request resource path (including the query string)
 - ``method`` is the HTTP request method. For example ``GET``, ``PUT``, etc.
 - ``headers`` are the HTTP request headers. If multiple headers share the same name, their values are
   coalesced into a single comma-separated value.
-- ``queryStringParameters`` are the HTTP request query string parameters. If multiple parameters share the same name,
+- ``query_string_parameters`` are the HTTP request query string parameters. If multiple parameters share the same name,
   the last one wins. That is, parameters are _not_ coalesced into a single value if they share the same key name.
 - ``body`` the body of the HTTP request is base64-encoded by the filter if the ``content-type`` header exists and is _not_ one of the following:
 
@@ -55,14 +55,14 @@ On the other end, the response of the Lambda function must conform to the follow
    :force:
 
     {
-        "statusCode": ...
+        "status_code": ...
         "headers": {"header-key": "header-value", ... },
         "cookies": ["key1=value1; HttpOnly; ...", "key2=value2; Secure; ...", ...],
         "body": "...",
-        "isBase64Encoded": true|false
+        "is_base64_encoded": true|false
     }
 
-- The ``statusCode`` field is an integer used as the HTTP response code. If this key is missing, Envoy returns a ``200
+- The ``status_code`` field is an integer used as the HTTP response code. If this key is missing, Envoy returns a ``200
   OK``.
 - The ``headers`` are used as the HTTP response headers.
 - The ``cookies`` are used as ``Set-Cookie`` response headers. Unlike the request headers, cookies are _not_ part of the
@@ -85,7 +85,7 @@ On the other end, the response of the Lambda function must conform to the follow
 The filter supports :ref:`per-filter configuration
 <envoy_v3_api_msg_extensions.filters.http.aws_lambda.v3.PerRouteConfig>`.
 
-If you use the per-filter configuration, the target cluster _must_ have the following metadata:
+If you use the per-filter configuration, the target cluster *must* have the following metadata:
 
 .. code-block:: yaml
 
@@ -139,7 +139,8 @@ in us-west-2:
 
 
 The filter can also be configured per virtual-host, route or weighted-cluster. In that case, the target cluster *must*
-have specific Lambda metadata.
+have specific Lambda metadata and target cluster's endpoint should point to a region where the Lambda function is present.
+
 
 .. code-block:: yaml
 
@@ -151,7 +152,7 @@ have specific Lambda metadata.
         envoy.filters.http.aws_lambda:
           "@type": type.googleapis.com/envoy.extensions.filters.http.aws_lambda.v3.PerRouteConfig
           invoke_config:
-            arn: "arn:aws:lambda:us-west-2:987654321:function:hello_envoy"
+            arn: "arn:aws:lambda:us-west-1:987654321:function:hello_envoy"
             payload_passthrough: false
 
 
@@ -176,7 +177,7 @@ An example with the Lambda metadata applied to a weighted-cluster:
         - endpoint:
             address:
               socket_address:
-                address: lambda.us-west-2.amazonaws.com
+                address: lambda.us-west-1.amazonaws.com
                 port_value: 443
     transport_socket:
       name: envoy.transport_sockets.tls

--- a/source/extensions/common/aws/signer.h
+++ b/source/extensions/common/aws/signer.h
@@ -16,31 +16,39 @@ public:
    * Sign an AWS request.
    * @param message an AWS API request message.
    * @param sign_body include the message body in the signature. The body must be fully buffered.
+   * @param override_region override the default region that has to be used to sign the request
    * @throws EnvoyException if the request cannot be signed.
    */
-  virtual void sign(Http::RequestMessage& message, bool sign_body) PURE;
+  virtual void sign(Http::RequestMessage& message, bool sign_body,
+                    const absl::string_view override_region = "") PURE;
 
   /**
    * Sign an AWS request without a payload (empty string used as content hash).
    * @param headers AWS API request headers.
+   * @param override_region override the default region that has to be used to sign the request
    * @throws EnvoyException if the request cannot be signed.
    */
-  virtual void signEmptyPayload(Http::RequestHeaderMap& headers) PURE;
+  virtual void signEmptyPayload(Http::RequestHeaderMap& headers,
+                                const absl::string_view override_region = "") PURE;
 
   /**
    * Sign an AWS request using the literal string UNSIGNED-PAYLOAD in the canonical request.
    * @param headers AWS API request headers.
+   * @param override_region override the default region that has to be used to sign the request
    * @throws EnvoyException if the request cannot be signed.
    */
-  virtual void signUnsignedPayload(Http::RequestHeaderMap& headers) PURE;
+  virtual void signUnsignedPayload(Http::RequestHeaderMap& headers,
+                                   const absl::string_view override_region = "") PURE;
 
   /**
    * Sign an AWS request.
    * @param headers AWS API request headers.
    * @param content_hash The Hex encoded SHA-256 of the body of the AWS API request.
+   * @param override_region override the default region that has to be used to sign the request
    * @throws EnvoyException if the request cannot be signed.
    */
-  virtual void sign(Http::RequestHeaderMap& headers, const std::string& content_hash) PURE;
+  virtual void sign(Http::RequestHeaderMap& headers, const std::string& content_hash,
+                    const absl::string_view override_region = "") PURE;
 };
 
 using SignerPtr = std::unique_ptr<Signer>;

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -63,21 +63,27 @@ public:
     }
   }
 
-  void sign(Http::RequestMessage& message, bool sign_body = false) override;
-  void sign(Http::RequestHeaderMap& headers, const std::string& content_hash) override;
-  void signEmptyPayload(Http::RequestHeaderMap& headers) override;
-  void signUnsignedPayload(Http::RequestHeaderMap& headers) override;
+  void sign(Http::RequestMessage& message, bool sign_body = false,
+            const absl::string_view override_region = "") override;
+  void sign(Http::RequestHeaderMap& headers, const std::string& content_hash,
+            const absl::string_view override_region = "") override;
+  void signEmptyPayload(Http::RequestHeaderMap& headers,
+                        const absl::string_view override_region = "") override;
+  void signUnsignedPayload(Http::RequestHeaderMap& headers,
+                           const absl::string_view override_region = "") override;
 
 private:
   std::string createContentHash(Http::RequestMessage& message, bool sign_body) const;
 
-  std::string createCredentialScope(absl::string_view short_date) const;
+  std::string createCredentialScope(absl::string_view short_date,
+                                    const absl::string_view override_region) const;
 
   std::string createStringToSign(absl::string_view canonical_request, absl::string_view long_date,
                                  absl::string_view credential_scope) const;
 
   std::string createSignature(absl::string_view secret_access_key, absl::string_view short_date,
-                              absl::string_view string_to_sign) const;
+                              absl::string_view string_to_sign,
+                              const absl::string_view override_region) const;
 
   std::string createAuthorizationHeader(absl::string_view access_key_id,
                                         absl::string_view credential_scope,

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -23,10 +23,10 @@ public:
   MockSigner();
   ~MockSigner() override;
 
-  MOCK_METHOD(void, sign, (Http::RequestMessage&, bool));
-  MOCK_METHOD(void, sign, (Http::RequestHeaderMap&, const std::string&));
-  MOCK_METHOD(void, signEmptyPayload, (Http::RequestHeaderMap&));
-  MOCK_METHOD(void, signUnsignedPayload, (Http::RequestHeaderMap&));
+  MOCK_METHOD(void, sign, (Http::RequestMessage&, bool, absl::string_view));
+  MOCK_METHOD(void, sign, (Http::RequestHeaderMap&, const std::string&, absl::string_view));
+  MOCK_METHOD(void, signEmptyPayload, (Http::RequestHeaderMap&, absl::string_view));
+  MOCK_METHOD(void, signUnsignedPayload, (Http::RequestHeaderMap&, absl::string_view));
 };
 
 class MockFetchMetadata {

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -74,7 +74,7 @@ TEST_F(AwsLambdaFilterTest, DecodingHeaderStopIteration) {
  */
 TEST_F(AwsLambdaFilterTest, HeaderOnlyShouldContinue) {
   setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/});
-  EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>()));
+  EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
   Http::TestRequestHeaderMapImpl input_headers;
   const auto result = filter_->decodeHeaders(input_headers, true /*end_stream*/);
   EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
@@ -132,6 +132,28 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectClusterMetadata) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, result);
 }
 
+/**
+ * If there's a per route config which has lambda function arn from different region
+ * then the sigv4 signer will sign with the region where the lambda function is present.
+ */
+TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectRegionForSigning) {
+  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/});
+  const absl::string_view override_region = "us-west-1";
+  const auto per_route_arn =
+      parseArn(fmt::format("arn:aws:lambda:{}:1337:function:fun", override_region)).value();
+  FilterSettings route_settings{per_route_arn, InvocationMode::Synchronous, true /*passthrough*/};
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillByDefault(Return(&route_settings));
+
+  EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>(), override_region));
+  Http::TestRequestHeaderMapImpl headers;
+  const auto result = filter_->decodeHeaders(headers, true /*end_stream*/);
+  EXPECT_EQ(fmt::format("/2015-03-31/functions/arn:aws:lambda:{}:1337:function:fun/invocations",
+                        override_region),
+            headers.getPathValue());
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+}
+
 TEST_F(AwsLambdaFilterTest, DecodeDataRecordsPayloadSize) {
   FilterSettings settings{arn_, InvocationMode::Synchronous, true /*passthrough*/};
   NiceMock<Stats::MockStore> store;
@@ -179,10 +201,39 @@ TEST_F(AwsLambdaFilterTest, DecodeDataShouldSign) {
   InSequence seq;
   EXPECT_CALL(decoder_callbacks_, addDecodedData(_, false));
   EXPECT_CALL(decoder_callbacks_, decodingBuffer).WillOnce(Return(&buffer));
-  EXPECT_CALL(*signer_, sign(An<Http::RequestHeaderMap&>(), An<const std::string&>()));
+  EXPECT_CALL(*signer_, sign(An<Http::RequestHeaderMap&>(), An<const std::string&>(),
+                             An<absl::string_view>()));
 
   const auto data_result = filter_->decodeData(buffer, true /*end_stream*/);
   EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
+            headers.getPathValue());
+  EXPECT_EQ(Http::FilterDataStatus::Continue, data_result);
+}
+
+TEST_F(AwsLambdaFilterTest, DecodeDataSigningWithPerRouteConfig) {
+  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/});
+
+  const absl::string_view override_region = "us-west-1";
+  const auto per_route_arn =
+      parseArn(fmt::format("arn:aws:lambda:{}:1337:function:fun", override_region)).value();
+  FilterSettings route_settings{per_route_arn, InvocationMode::Synchronous, true /*passthrough*/};
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillByDefault(Return(&route_settings));
+
+  Http::TestRequestHeaderMapImpl headers;
+  const auto header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, header_result);
+  Buffer::OwnedImpl buffer;
+
+  InSequence seq;
+  EXPECT_CALL(decoder_callbacks_, addDecodedData(_, false));
+  EXPECT_CALL(decoder_callbacks_, decodingBuffer).WillOnce(Return(&buffer));
+  EXPECT_CALL(*signer_,
+              sign(An<Http::RequestHeaderMap&>(), An<const std::string&>(), override_region));
+
+  const auto data_result = filter_->decodeData(buffer, true /*end_stream*/);
+  EXPECT_EQ(fmt::format("/2015-03-31/functions/arn:aws:lambda:{}:1337:function:fun/invocations",
+                        override_region),
             headers.getPathValue());
   EXPECT_EQ(Http::FilterDataStatus::Continue, data_result);
 }

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -134,7 +134,7 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectClusterMetadata) {
 
 /**
  * If there's a per route config which has lambda function arn from different region
- * then the sigv4 signer will sign with the region where the lambda function is present.
+ * then the SigV4 signer will sign with the region where the lambda function is present.
  */
 TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectRegionForSigning) {
   setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/});


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Support multi region routing for AWS Lambda Filter
Additional Description: Expose a variable to take a string to override the AWS region to sign the headers
Risk Level: Low
Testing: UT
Docs Changes: Yes, plus includes the update needed for #22213
Release Notes: bug fix
Platform Specific Features:
Fixes: https://github.com/envoyproxy/envoy/issues/23076
