### PR TITLE
listener: enable socket_options for multiple addresses

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -37,7 +37,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message AdditionalAddress {
   core.v3.Address address = 1;
 
-  // [#not-implemented-hide:]
   // Additional socket options that may not be present in Envoy source code or
   // precompiled binaries. If specified, this will override the
   // :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -125,6 +125,9 @@ new_features:
     added :ref:`generic rds support <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.generic_rds>`.
 - area: listener
   change: |
+    added a new field :ref:`socket_options <envoy_v3_api_field_config.core.v3.AdditionalAddress.socket_options>` to the AdditionalAddress, allowing specifying discrete socket options for each listen address.
+- area: listener
+  change: |
     added ``continueFilterChain()`` and ``dispatcher()`` methods to the ``ListenerFilterCallback``. This allows listener filters to continue listener filter iteration after stopping iteration e.g. if the listener filter depends on an async process.
 - area: thrift_proxy
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -125,7 +125,7 @@ new_features:
     added :ref:`generic rds support <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.generic_rds>`.
 - area: listener
   change: |
-    added a new field :ref:`socket_options <envoy_v3_api_field_config.core.v3.AdditionalAddress.socket_options>` to the AdditionalAddress, allowing specifying discrete socket options for each listen address.
+    added a new field :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.AdditionalAddress.socket_options>` to the AdditionalAddress, allowing specifying discrete socket options for each listen address.
 - area: listener
   change: |
     added ``continueFilterChain()`` and ``dispatcher()`` methods to the ``ListenerFilterCallback``. This allows listener filters to continue listener filter iteration after stopping iteration e.g. if the listener filter depends on an async process.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -125,7 +125,7 @@ new_features:
     added :ref:`generic rds support <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.generic_rds>`.
 - area: listener
   change: |
-    added a new field :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.AdditionalAddress.socket_options>` to the AdditionalAddress, allowing specifying discrete socket options for each listen address.
+    added a new field :ref:`socket_options <envoy_v3_api_field_config.listener.v3.AdditionalAddress.socket_options>` to the AdditionalAddress, allowing specifying discrete socket options for each listen address.
 - area: listener
   change: |
     added ``continueFilterChain()`` and ``dispatcher()`` methods to the ``ListenerFilterCallback``. This allows listener filters to continue listener filter iteration after stopping iteration e.g. if the listener filter depends on an async process.

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -386,7 +386,8 @@ public:
   void ensureSocketOptions(uint32_t address_index) {
     ASSERT(listen_socket_options_list_.size() > address_index);
     if (listen_socket_options_list_[address_index] == nullptr) {
-      listen_socket_options_list_[address_index] = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+      listen_socket_options_list_[address_index] =
+          std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
     }
   }
 
@@ -453,7 +454,8 @@ private:
   void buildUdpListenerWorkerRouter(const Network::Address::Instance& address,
                                     uint32_t concurrency);
   void buildUdpListenerFactory(uint32_t concurrency);
-  void buildListenSocketOptions(std::vector<std::reference_wrapper<const Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketOption>>>& address_opts_list);
+  void buildListenSocketOptions(std::vector<std::reference_wrapper<const Protobuf::RepeatedPtrField<
+                                    envoy::config::core::v3::SocketOption>>>& address_opts_list);
   void createListenerFilterFactories();
   void validateFilterChains();
   void buildFilterChains();
@@ -464,7 +466,8 @@ private:
   void checkIpv4CompatAddress(const Network::Address::InstanceConstSharedPtr& address,
                               const envoy::config::core::v3::Address& proto_address);
 
-  void addListenSocketOptions(uint32_t address_index, const Network::Socket::OptionsSharedPtr& options) {
+  void addListenSocketOptions(uint32_t address_index,
+                              const Network::Socket::OptionsSharedPtr& options) {
     ASSERT(listen_socket_options_list_.size() > address_index);
     ensureSocketOptions(address_index);
     Network::Socket::appendOptions(listen_socket_options_list_[address_index], options);

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -383,11 +383,9 @@ public:
     return config().traffic_direction();
   }
 
-  void ensureSocketOptions(uint32_t address_index) {
-    ASSERT(listen_socket_options_list_.size() > address_index);
-    if (listen_socket_options_list_[address_index] == nullptr) {
-      listen_socket_options_list_[address_index] =
-          std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+  void ensureSocketOptions(Network::Socket::OptionsSharedPtr& options) {
+    if (options == nullptr) {
+      options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
     }
   }
 
@@ -466,11 +464,10 @@ private:
   void checkIpv4CompatAddress(const Network::Address::InstanceConstSharedPtr& address,
                               const envoy::config::core::v3::Address& proto_address);
 
-  void addListenSocketOptions(uint32_t address_index,
-                              const Network::Socket::OptionsSharedPtr& options) {
-    ASSERT(listen_socket_options_list_.size() > address_index);
-    ensureSocketOptions(address_index);
-    Network::Socket::appendOptions(listen_socket_options_list_[address_index], options);
+  void addListenSocketOptions(Network::Socket::OptionsSharedPtr& options,
+                              const Network::Socket::OptionsSharedPtr& append_options) {
+    ensureSocketOptions(options);
+    Network::Socket::appendOptions(options, append_options);
   }
 
   ListenerManagerImpl& parent_;

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -457,7 +457,7 @@ private:
   void buildUdpListenerWorkerRouter(const Network::Address::Instance& address,
                                     uint32_t concurrency);
   void buildUdpListenerFactory(uint32_t concurrency);
-  void buildListenSocketOptions();
+  void buildListenSocketOptions(std::vector<std::pair<const Network::Address::InstanceConstSharedPtr, const Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketOption>&>>& address_opts_list);
   void createListenerFilterFactories();
   void validateFilterChains();
   void buildFilterChains();

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1089,10 +1089,9 @@ void ListenerManagerImpl::createListenSocketFactory(ListenerImpl& listener) {
   TRY_ASSERT_MAIN_THREAD {
     Network::SocketCreationOptions creation_options;
     creation_options.mptcp_enabled_ = listener.mptcpEnabled();
-    for (auto& address : listener.addresses()) {
-      auto socket_opts = listener.listenSocketOptions(address);
+    for (std::vector<Network::Address::InstanceConstSharedPtr>::size_type i = 0; i < listener.addresses().size(); i++) {
       listener.addSocketFactory(std::make_unique<ListenSocketFactoryImpl>(
-          factory_, address, socket_type, socket_opts == absl::nullopt ? nullptr : socket_opts.ref(), listener.name(),
+          factory_, listener.addresses()[i], socket_type, listener.listenSocketOptions(i), listener.name(),
           listener.tcpBacklogSize(), bind_type, creation_options, server_.options().concurrency()));
     }
   }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1090,8 +1090,9 @@ void ListenerManagerImpl::createListenSocketFactory(ListenerImpl& listener) {
     Network::SocketCreationOptions creation_options;
     creation_options.mptcp_enabled_ = listener.mptcpEnabled();
     for (auto& address : listener.addresses()) {
+      auto socket_opts = listener.listenSocketOptions(address);
       listener.addSocketFactory(std::make_unique<ListenSocketFactoryImpl>(
-          factory_, address, socket_type, listener.listenSocketOptions(), listener.name(),
+          factory_, address, socket_type, socket_opts == absl::nullopt ? nullptr : socket_opts.ref(), listener.name(),
           listener.tcpBacklogSize(), bind_type, creation_options, server_.options().concurrency()));
     }
   }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1089,10 +1089,12 @@ void ListenerManagerImpl::createListenSocketFactory(ListenerImpl& listener) {
   TRY_ASSERT_MAIN_THREAD {
     Network::SocketCreationOptions creation_options;
     creation_options.mptcp_enabled_ = listener.mptcpEnabled();
-    for (std::vector<Network::Address::InstanceConstSharedPtr>::size_type i = 0; i < listener.addresses().size(); i++) {
+    for (std::vector<Network::Address::InstanceConstSharedPtr>::size_type i = 0;
+         i < listener.addresses().size(); i++) {
       listener.addSocketFactory(std::make_unique<ListenSocketFactoryImpl>(
-          factory_, listener.addresses()[i], socket_type, listener.listenSocketOptions(i), listener.name(),
-          listener.tcpBacklogSize(), bind_type, creation_options, server_.options().concurrency()));
+          factory_, listener.addresses()[i], socket_type, listener.listenSocketOptions(i),
+          listener.name(), listener.tcpBacklogSize(), bind_type, creation_options,
+          server_.options().concurrency()));
     }
   }
   END_TRY

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -344,7 +344,7 @@ void BaseIntegrationTest::setUpstreamAddress(
 }
 
 bool BaseIntegrationTest::getSocketOption(const std::string& listener_name, int level, int optname,
-                                          void* optval, socklen_t* optlen) {
+                                          void* optval, socklen_t* optlen, int address_index) {
   bool listeners_ready = false;
   absl::Mutex l;
   std::vector<std::reference_wrapper<Network::ListenerConfig>> listeners;
@@ -359,11 +359,10 @@ bool BaseIntegrationTest::getSocketOption(const std::string& listener_name, int 
 
   for (auto& listener : listeners) {
     if (listener.get().name() == listener_name) {
-      for (auto& socket_factory : listener.get().listenSocketFactories()) {
-        auto socket = socket_factory->getListenSocket(0);
-        if (socket->getSocketOption(level, optname, optval, optlen).return_value_ != 0) {
-          return false;
-        }
+      auto& socket_factory = listener.get().listenSocketFactories()[address_index];
+      auto socket = socket_factory->getListenSocket(0);
+      if (socket->getSocketOption(level, optname, optval, optlen).return_value_ != 0) {
+        return false;
       }
       return true;
     }

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -99,7 +99,7 @@ public:
   void setDeterministicValue(uint64_t value = 0) { deterministic_value_ = value; }
   // Get socket option for a specific listener's socket.
   bool getSocketOption(const std::string& listener_name, int level, int optname, void* optval,
-                       socklen_t* optlen);
+                       socklen_t* optlen, int address_index = 0);
 
   Http::CodecType upstreamProtocol() const { return upstream_config_.upstream_protocol_; }
 

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -481,6 +481,88 @@ TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddresses) {
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
 }
 
+TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddressesAndSocketOpts) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    auto* socket_option = listener_config_.add_socket_options();
+    socket_option->set_level(IPPROTO_IP);
+    socket_option->set_name(IP_TOS);
+    socket_option->set_int_value(8); // IPTOS_THROUGHPUT
+    socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_LISTENING);
+    auto* additional_socket_option = listener_config_.mutable_additional_addresses(0)->mutable_socket_options()->add_socket_options();
+    additional_socket_option->set_level(IPPROTO_IP);
+    additional_socket_option->set_name(IP_TOS);
+    additional_socket_option->set_int_value(4); // IPTOS_RELIABILITY
+    additional_socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_LISTENING);
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "1");
+    createRdsStream(route_table_name_);
+  };
+  initialize();
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 1);
+  // testing-listener-0 is not initialized as we haven't pushed any RDS yet.
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
+  // Workers not started, the LDS added listener 0 is in active_listeners_ list.
+  EXPECT_EQ(test_server_->server().listenerManager().listeners().size(), 1);
+  registerTestServerPorts({"address1", "address2"});
+
+  const std::string route_config_tmpl = R"EOF(
+      name: {}
+      virtual_hosts:
+      - name: integration
+        domains: ["*"]
+        routes:
+        - match: {{ prefix: "/" }}
+          route: {{ cluster: {} }}
+)EOF";
+  sendRdsResponse(fmt::format(route_config_tmpl, route_table_name_, "cluster_0"), "1");
+  test_server_->waitForCounterGe(
+      fmt::format("http.config_test.rds.{}.update_success", route_table_name_), 1);
+  // Now testing-listener-0 finishes initialization, Server initManager will be ready.
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initialized);
+
+  test_server_->waitUntilListenersReady();
+  // NOTE: The line above doesn't tell you if listener is up and listening.
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 1);
+  // Request is sent to cluster_0.
+
+  int response_size = 800;
+  int request_size = 10;
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"server_id", "cluster_0, backend_0"}};
+
+  codec_client_ = makeHttpConnection(lookupPort("address1"));
+  auto response = sendRequestAndWaitForResponse(
+      Http::TestResponseHeaderMapImpl{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {":scheme", "http"}},
+      request_size, response_headers, response_size, /*cluster_0*/ 0);
+  verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(request_size, upstream_request_->bodyLength());
+  codec_client_->close();
+  // Wait for the client to be disconnected.
+  ASSERT_TRUE(codec_client_->waitForDisconnect());
+
+  codec_client_ = makeHttpConnection(lookupPort("address2"));
+  auto response2 = sendRequestAndWaitForResponse(
+      Http::TestResponseHeaderMapImpl{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {":scheme", "http"}},
+      request_size, response_headers, response_size, /*cluster_0*/ 0);
+  verifyResponse(std::move(response2), "200", response_headers, std::string(response_size, 'a'));
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(request_size, upstream_request_->bodyLength());
+
+  int opt_value = 0;
+  socklen_t opt_len = sizeof(opt_value);
+  // Verify first address.
+  EXPECT_TRUE(getSocketOption("testing-listener-0", IPPROTO_IP, IP_TOS, &opt_value, &opt_len, 0));
+  EXPECT_EQ(opt_len, sizeof(opt_value));
+  EXPECT_EQ(8, opt_value);
+  // Verify second address.
+  EXPECT_TRUE(getSocketOption("testing-listener-0", IPPROTO_IP, IP_TOS, &opt_value, &opt_len, 1));
+  EXPECT_EQ(opt_len, sizeof(opt_value));
+  EXPECT_EQ(4, opt_value);
+}
+
 // Tests that a LDS adding listener works as expected.
 TEST_P(ListenerIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [&]() {

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -489,7 +489,9 @@ TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddressesAndS
     socket_option->set_name(IP_TOS);
     socket_option->set_int_value(8); // IPTOS_THROUGHPUT
     socket_option->set_state(envoy::config::core::v3::SocketOption::STATE_LISTENING);
-    auto* additional_socket_option = listener_config_.mutable_additional_addresses(0)->mutable_socket_options()->add_socket_options();
+    auto* additional_socket_option = listener_config_.mutable_additional_addresses(0)
+                                         ->mutable_socket_options()
+                                         ->add_socket_options();
     additional_socket_option->set_level(IPPROTO_IP);
     additional_socket_option->set_name(IP_TOS);
     additional_socket_option->set_int_value(4); // IPTOS_RELIABILITY

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -481,6 +481,7 @@ TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddresses) {
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
 }
 
+#ifdef __linux__
 TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddressesAndSocketOpts) {
   on_server_init_function_ = [&]() {
     createLdsStream();
@@ -564,6 +565,7 @@ TEST_P(ListenerMultiAddressesIntegrationTest, BasicSuccessWithMultiAddressesAndS
   EXPECT_EQ(opt_len, sizeof(opt_value));
   EXPECT_EQ(4, opt_value);
 }
+#endif
 
 // Tests that a LDS adding listener works as expected.
 TEST_P(ListenerIntegrationTest, BasicSuccess) {

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -6021,6 +6021,161 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabled) {
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
+TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWithMultiAddressesNoOverrideOpts) {
+  const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
+    name: SockoptsListener
+    address:
+      socket_address: { address: 127.0.0.1, port_value: 1111 }
+    additional_addresses:
+    - address:
+        socket_address: { address: 127.0.0.1, port_value: 2222 }
+    enable_reuse_port: false
+    filter_chains:
+    - filters: []
+      name: foo
+    socket_options: [
+      # The socket goes through socket() and bind() but never listen(), so if we
+      # ever saw (7, 8, 9) being applied it would cause a EXPECT_CALL failure.
+      { level: 1, name: 2, int_value: 3, state: STATE_PREBIND },
+      { level: 4, name: 5, int_value: 6, state: STATE_BOUND },
+      { level: 7, name: 8, int_value: 9, state: STATE_LISTENING },
+    ]
+  )EOF");
+
+  // Second address.
+  expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                           /* expected_num_options */ 3,
+                           ListenerComponentFactory::BindType::NoReusePort);
+  // First address.
+  expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                           /* expected_num_options */ 3,
+                           ListenerComponentFactory::BindType::NoReusePort);
+
+  expectSetsockopt(
+      /* expected_sockopt_level */ 1,
+      /* expected_sockopt_name */ 2,
+      /* expected_value */ 3,
+      /* expected_num_calls */ 2);
+  expectSetsockopt(
+      /* expected_sockopt_level */ 4,
+      /* expected_sockopt_name */ 5,
+      /* expected_value */ 6,
+      /* expected_num_calls */ 2);
+
+  addOrUpdateListener(listener);
+  EXPECT_EQ(1U, manager_->listeners().size());
+}
+
+TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWithMultiAddressesOverrideOpts) {
+  const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
+    name: SockoptsListener
+    address:
+      socket_address: { address: 127.0.0.1, port_value: 1111 }
+    additional_addresses:
+    - address:
+        socket_address: { address: 127.0.0.1, port_value: 2222 }
+      socket_options:
+        socket_options: [
+          # The socket goes through socket() and bind() but never listen(), so if we
+          # ever saw (7, 8, 9) being applied it would cause a EXPECT_CALL failure.
+          { level: 11, name: 12, int_value: 13, state: STATE_PREBIND },
+          { level: 14, name: 15, int_value: 16, state: STATE_BOUND },
+          { level: 17, name: 18, int_value: 19, state: STATE_LISTENING },
+        ]
+    enable_reuse_port: false
+    filter_chains:
+    - filters: []
+      name: foo
+    socket_options: [
+      # The socket goes through socket() and bind() but never listen(), so if we
+      # ever saw (7, 8, 9) being applied it would cause a EXPECT_CALL failure.
+      { level: 1, name: 2, int_value: 3, state: STATE_PREBIND },
+      { level: 4, name: 5, int_value: 6, state: STATE_BOUND },
+      { level: 7, name: 8, int_value: 9, state: STATE_LISTENING },
+    ]
+  )EOF");
+
+  // Second address.
+  expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                           /* expected_num_options */ 3,
+                           ListenerComponentFactory::BindType::NoReusePort);
+  // First address.
+  expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                           /* expected_num_options */ 3,
+                           ListenerComponentFactory::BindType::NoReusePort);
+
+  // First address' prebind options.
+  expectSetsockopt(
+      /* expected_sockopt_level */ 1,
+      /* expected_sockopt_name */ 2,
+      /* expected_value */ 3);
+  // Second address' prebind options.
+  expectSetsockopt(
+      /* expected_sockopt_level */ 11,
+      /* expected_sockopt_name */ 12,
+      /* expected_value */ 13);
+  // First address' bind options.
+  expectSetsockopt(
+      /* expected_sockopt_level */ 4,
+      /* expected_sockopt_name */ 5,
+      /* expected_value */ 6);
+  // Second address' bind options.
+  expectSetsockopt(
+      /* expected_sockopt_level */ 14,
+      /* expected_sockopt_name */ 15,
+      /* expected_value */ 16);
+  addOrUpdateListener(listener);
+  EXPECT_EQ(1U, manager_->listeners().size());
+}
+
+TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWithMultiAddressesEmptyOverrideOpts) {
+  const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
+    name: SockoptsListener
+    address:
+      socket_address: { address: 127.0.0.1, port_value: 1111 }
+    additional_addresses:
+    - address:
+        socket_address: { address: 127.0.0.1, port_value: 2222 }
+      socket_options:
+        socket_options: [ ]
+    enable_reuse_port: false
+    filter_chains:
+    - filters: []
+      name: foo
+    socket_options: [
+      # The socket goes through socket() and bind() but never listen(), so if we
+      # ever saw (7, 8, 9) being applied it would cause a EXPECT_CALL failure.
+      { level: 1, name: 2, int_value: 3, state: STATE_PREBIND },
+      { level: 4, name: 5, int_value: 6, state: STATE_BOUND },
+      { level: 7, name: 8, int_value: 9, state: STATE_LISTENING },
+    ]
+  )EOF");
+
+  // Second address.
+  expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                           /* expected_num_options */ 0,
+                           ListenerComponentFactory::BindType::NoReusePort);
+  // First address.
+  expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
+                           /* expected_num_options */ 3,
+                           ListenerComponentFactory::BindType::NoReusePort);
+  
+
+  // First address' prebind options.
+  expectSetsockopt(
+      /* expected_sockopt_level */ 1,
+      /* expected_sockopt_name */ 2,
+      /* expected_value */ 3);
+  // First address' bind options.
+  expectSetsockopt(
+      /* expected_sockopt_level */ 4,
+      /* expected_sockopt_name */ 5,
+      /* expected_value */ 6);
+
+  addOrUpdateListener(listener);
+  EXPECT_EQ(1U, manager_->listeners().size());
+}
+
 // This test relies on linux-only code, and a linux-only name IPPROTO_MPTCP
 #if defined(__linux__)
 TEST_P(ListenerManagerImplWithRealFiltersTest, Mptcp) {

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -2070,6 +2070,59 @@ filter_chains:
   testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(listener_origin, listener_updated);
 }
 
+TEST_P(ListenerManagerImplTest, UpdateListenerWithDifferentSocketOptionsWithMultiAddressesDeprecatedBehavior) {
+  const std::string listener_origin = R"EOF(
+name: foo
+address:
+  socket_address:
+      address: 127.0.0.1
+      port_value: 1234
+additional_addresses:
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 5678
+  socket_options:
+    socket_options:
+    - level: 1
+      name: 9
+      int_value: 2
+enable_reuse_port: true
+socket_options:
+    - level: 1
+      name: 9
+      int_value: 1
+filter_chains:
+- filters: []
+  )EOF";
+
+  const std::string listener_updated = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+additional_addresses:
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 5678
+  socket_options:
+    socket_options:
+    - level: 1
+      name: 9
+      int_value: 3
+enable_reuse_port: true
+socket_options:
+    - level: 1
+      name: 9
+      int_value: 1
+filter_chains:
+- filters: []
+  )EOF";
+  testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(listener_origin, listener_updated, true);
+}
+
 // The socket options update is only available when enable_reuse_port as true.
 // Linux is the only platform allowing the enable_reuse_port as true.
 #ifdef __linux__
@@ -2104,6 +2157,61 @@ filter_chains:
 - filters: []
   )EOF";
   testListenerUpdateWithSocketOptionsChange(listener_origin, listener_updated);
+}
+#endif
+
+#ifdef __linux__
+TEST_P(ListenerManagerImplTest, UpdateListenerWithDifferentSocketOptionsWithMultiAddresses) {
+  const std::string listener_origin = R"EOF(
+name: foo
+address:
+  socket_address:
+      address: 127.0.0.1
+      port_value: 1234
+additional_addresses:
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 5678
+  socket_options:
+    socket_options:
+    - level: 1
+      name: 9
+      int_value: 2
+enable_reuse_port: true
+socket_options:
+    - level: 1
+      name: 9
+      int_value: 1
+filter_chains:
+- filters: []
+  )EOF";
+
+  const std::string listener_updated = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+additional_addresses:
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 5678
+  socket_options:
+    socket_options:
+    - level: 1
+      name: 9
+      int_value: 3
+enable_reuse_port: true
+socket_options:
+    - level: 1
+      name: 9
+      int_value: 1
+filter_chains:
+- filters: []
+  )EOF";
+  testListenerUpdateWithSocketOptionsChange(listener_origin, listener_updated, true);
 }
 #endif
 

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -2070,7 +2070,8 @@ filter_chains:
   testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(listener_origin, listener_updated);
 }
 
-TEST_P(ListenerManagerImplTest, UpdateListenerWithDifferentSocketOptionsWithMultiAddressesDeprecatedBehavior) {
+TEST_P(ListenerManagerImplTest,
+       UpdateListenerWithDifferentSocketOptionsWithMultiAddressesDeprecatedBehavior) {
   const std::string listener_origin = R"EOF(
 name: foo
 address:
@@ -2120,7 +2121,8 @@ socket_options:
 filter_chains:
 - filters: []
   )EOF";
-  testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(listener_origin, listener_updated, true);
+  testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(listener_origin, listener_updated,
+                                                              true);
 }
 
 // The socket options update is only available when enable_reuse_port as true.
@@ -6129,7 +6131,8 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabled) {
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
-TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWithMultiAddressesNoOverrideOpts) {
+TEST_P(ListenerManagerImplWithRealFiltersTest,
+       LiteralSockoptListenerEnabledWithMultiAddressesNoOverrideOpts) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
     name: SockoptsListener
     address:
@@ -6174,7 +6177,8 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWith
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
-TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWithMultiAddressesOverrideOpts) {
+TEST_P(ListenerManagerImplWithRealFiltersTest,
+       LiteralSockoptListenerEnabledWithMultiAddressesOverrideOpts) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
     name: SockoptsListener
     address:
@@ -6236,7 +6240,8 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWith
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
-TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWithMultiAddressesEmptyOverrideOpts) {
+TEST_P(ListenerManagerImplWithRealFiltersTest,
+       LiteralSockoptListenerEnabledWithMultiAddressesEmptyOverrideOpts) {
   const envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
     name: SockoptsListener
     address:
@@ -6267,7 +6272,6 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabledWith
   expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
                            /* expected_num_options */ 3,
                            ListenerComponentFactory::BindType::NoReusePort);
-  
 
   // First address' prebind options.
   expectSetsockopt(

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -254,7 +254,8 @@ protected:
               EXPECT_TRUE(Network::Socket::applyOptions(options, *listener_factory_.socket_,
                                                         expected_state));
               return listener_factory_.socket_;
-            })).RetiresOnSaturation();
+            }))
+        .RetiresOnSaturation();
   }
 
   /**
@@ -355,8 +356,9 @@ protected:
 
     ListenerHandle* listener_origin = expectListenerCreate(true, true);
     if (multiple_addresses) {
-      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2)
-        .WillRepeatedly(Return(socket));
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
+          .Times(2)
+          .WillRepeatedly(Return(socket));
     } else {
       EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
           .WillOnce(Return(socket));
@@ -372,8 +374,9 @@ protected:
 
     ListenerHandle* listener_updated = expectListenerCreate(true, true);
     if (multiple_addresses) {
-      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2)
-        .WillRepeatedly(Return(socket));
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
+          .Times(2)
+          .WillRepeatedly(Return(socket));
     } else {
       EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
           .WillOnce(Return(socket));
@@ -420,9 +423,8 @@ protected:
     EXPECT_CALL(*listener_origin, onDestroy());
   }
 
-  void testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(const std::string& origin,
-                                                                   const std::string& updated,
-                                                                   bool multiple_addresses = false) {
+  void testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(
+      const std::string& origin, const std::string& updated, bool multiple_addresses = false) {
     TestScopedRuntime scoped_runtime;
     scoped_runtime.mergeValues(
         {{"envoy.reloadable_features.enable_update_listener_socket_options", "false"}});

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -254,7 +254,7 @@ protected:
               EXPECT_TRUE(Network::Socket::applyOptions(options, *listener_factory_.socket_,
                                                         expected_state));
               return listener_factory_.socket_;
-            }));
+            })).RetiresOnSaturation();
   }
 
   /**

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -344,7 +344,8 @@ protected:
   }
 
   void testListenerUpdateWithSocketOptionsChange(const std::string& origin,
-                                                 const std::string& updated) {
+                                                 const std::string& updated,
+                                                 bool multiple_addresses = false) {
     InSequence s;
 
     EXPECT_CALL(*worker_, start(_, _));
@@ -353,8 +354,13 @@ protected:
     auto socket = std::make_shared<testing::NiceMock<Network::MockListenSocket>>();
 
     ListenerHandle* listener_origin = expectListenerCreate(true, true);
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
-        .WillOnce(Return(socket));
+    if (multiple_addresses) {
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2)
+        .WillRepeatedly(Return(socket));
+    } else {
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
+          .WillOnce(Return(socket));
+    }
     EXPECT_CALL(listener_origin->target_, initialize());
     EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(origin)));
     checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
@@ -365,8 +371,13 @@ protected:
     checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
     ListenerHandle* listener_updated = expectListenerCreate(true, true);
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
-        .WillOnce(Return(socket));
+    if (multiple_addresses) {
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2)
+        .WillRepeatedly(Return(socket));
+    } else {
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0))
+          .WillOnce(Return(socket));
+    }
     EXPECT_CALL(listener_updated->target_, initialize());
     EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(updated)));
 
@@ -410,7 +421,8 @@ protected:
   }
 
   void testListenerUpdateWithSocketOptionsChangeDeprecatedBehavior(const std::string& origin,
-                                                                   const std::string& updated) {
+                                                                   const std::string& updated,
+                                                                   bool multiple_addresses = false) {
     TestScopedRuntime scoped_runtime;
     scoped_runtime.mergeValues(
         {{"envoy.reloadable_features.enable_update_listener_socket_options", "false"}});
@@ -420,7 +432,11 @@ protected:
     manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
 
     ListenerHandle* listener_origin = expectListenerCreate(true, true);
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+    if (multiple_addresses) {
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0)).Times(2);
+    } else {
+      EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+    }
     EXPECT_CALL(listener_origin->target_, initialize());
     EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(origin)));
     checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
@@ -431,7 +447,11 @@ protected:
     checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
     ListenerHandle* listener_updated = expectListenerCreate(true, true);
-    EXPECT_CALL(*listener_factory_.socket_, duplicate());
+    if (multiple_addresses) {
+      EXPECT_CALL(*listener_factory_.socket_, duplicate()).Times(2);
+    } else {
+      EXPECT_CALL(*listener_factory_.socket_, duplicate());
+    }
     EXPECT_CALL(listener_updated->target_, initialize());
     EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(updated)));
 


### PR DESCRIPTION
Commit Message: listener: enable socket_options for multiple addresses
Additional Description:
This PR enables specifying socket_options for each additional address. Since when using dual-stack, the IPv4 and IPv6 address have different socket option, then we need a way to specify different socket option for multiple addresses.

notes for implementation:
* To simplify the implementation, the new listener will only clone the old listener's socket when all the addresses' socket_options are equal when updating the listener. This is the same as when updating additional addresses, we only clone the socket when all the addresses are the same.

* For updating socket options for additional addresses, it is also under the runtime guard protection of "envoy.reloadable_features.enable_update_listener_socket_options". This is same as https://github.com/envoyproxy/envoy/pull/23189

Risk Level: high
Testing: unittest and integration test
Docs Changes: API doc
Release Notes: new feature
Platform Specific Features: n/a
