### PR TITLE
ci: run DrString against Xcode 14.1

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: true
       - name: 'Run DrString'
         env:
-          DEVELOPER_DIR: /Applications/Xcode_14.0.app
+          DEVELOPER_DIR: /Applications/Xcode_14.1.app
         run: cd mobile && ./bazelw run @DrString//:drstring check
   kotlinlint:
     name: kotlin_lint


### PR DESCRIPTION
Commit Message: ci: run DrString against Xcode 14.1
Additional Description: Matching the Xcode version used for other `mobile/**` CI jobs.
Risk Level: None
Testing: Previously set on envoyproxy/envoy-mobile
Docs Changes: None
Release Notes: None
Platform Specific Features: Only runs on changes to `mobile/**`