### PR TITLE
Use switch in http1ParserImplToString().

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -542,7 +542,13 @@ public:
 
   // Allows pretty printed test names.
   static std::string http1ParserImplToString(Http1ParserImpl impl) {
-    return impl == Http1ParserImpl::HttpParser ? "HttpParser" : "BalsaParser";
+    switch (impl) {
+    case Http1ParserImpl::HttpParser:
+      return "HttpParser";
+    case Http1ParserImpl::BalsaParser:
+      return "BalsaParser";
+    }
+    return "UnknownHttp1Impl";
   }
 
   // Allows pretty printed test names for TEST_P using TestEnvironment::getIpVersionsForTest().


### PR DESCRIPTION
This is to make the compiler enforce that an (unlikely) new Http1ParserImpl value is handled.

Follow-up on
https://github.com/envoyproxy/envoy/pull/24146/files/bbb1683342ad670a380fb4fbebc370c1ca5c43d8#r1033605725.

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: Use switch in http1ParserImplToString().
Additional Description:
Risk Level: low, test-only change
Testing: test-only change
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a