### PR TITLE
mobile tools: add missing .bazelproject files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !\.bazelci
 !\.bazelignore
 !\.bazelrc
+!\.bazelproject
 !\.bazelversion
 !\.clang-format
 !\.clang-tidy
@@ -20,7 +21,6 @@
 !\.yapfignore
 !\.zuul
 !\.zuul.yaml
-!\.bazelproject
 
 /bazel-*
 /mobile/bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 !\.yapfignore
 !\.zuul
 !\.zuul.yaml
+!\.bazelproject
 
 /bazel-*
 /mobile/bazel-*

--- a/mobile/examples/java/hello_world/.bazelproject
+++ b/mobile/examples/java/hello_world/.bazelproject
@@ -1,0 +1,25 @@
+workspace_type: android
+
+bazel_binary: bazelw
+
+directories:
+  -bazel-bin
+  -bazel-instant-android
+  -bazel-out
+  -bazel-testlogs
+  -buck-out
+  -build
+  examples/java/hello_world
+
+import_run_configurations:
+  examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+
+targets:
+  //examples/java/hello_world:hello_envoy
+
+additional_languages:
+  kotlin
+  java
+  android
+  c

--- a/mobile/examples/kotlin/hello_world/.bazelproject
+++ b/mobile/examples/kotlin/hello_world/.bazelproject
@@ -1,0 +1,25 @@
+workspace_type: android
+
+bazel_binary: bazelw
+
+directories:
+  -bazel-bin
+  -bazel-instant-android
+  -bazel-out
+  -bazel-testlogs
+  -buck-out
+  -build
+  examples/kotlin/hello_world
+
+import_run_configurations:
+  examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+
+targets:
+  //examples/kotlin/hello_world:hello_envoy_kt
+
+additional_languages:
+  kotlin
+  java
+  android
+  c

--- a/mobile/test/kotlin/apps/baseline/.bazelproject
+++ b/mobile/test/kotlin/apps/baseline/.bazelproject
@@ -1,0 +1,25 @@
+workspace_type: android
+
+bazel_binary: bazelw
+
+directories:
+  -bazel-bin
+  -bazel-instant-android
+  -bazel-out
+  -bazel-testlogs
+  -buck-out
+  -build
+  test/kotlin/apps/baseline/
+
+import_run_configurations:
+  test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+
+targets:
+  //test/kotlin/apps/baseline:hello_envoy_kt
+
+additional_languages:
+  kotlin
+  java
+  android
+  c

--- a/mobile/test/kotlin/apps/experimental/.bazelproject
+++ b/mobile/test/kotlin/apps/experimental/.bazelproject
@@ -1,0 +1,23 @@
+workspace_type: android
+
+directories:
+  -bazel-bin
+  -bazel-instant-android
+  -bazel-out
+  -bazel-testlogs
+  -buck-out
+  -build
+  test/kotlin/apps/experimental
+
+import_run_configurations:
+  test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+
+targets:
+  //test/kotlin/apps/experimental:hello_envoy_kt
+
+additional_languages:
+  kotlin
+  java
+  android
+  c


### PR DESCRIPTION
Commit Message: Add missing `.bazelproject` files. This fixes a dev workflow which allows us to run example/test applications from within Android Studio IDE. The addition of the `.bazelrpoject` was most probably missed in https://github.com/envoyproxy/envoy/pull/24104 as dot files are ignored by default in Envoy repo.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
