### PR TITLE
Ignore *.s?? intead of *.sw* to make sure git does not ignore .swift 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ cscope.*
 *.pyc
 **/pyformat
 SOURCE_VERSION
-*.sw*
+*.s??
 tags
 TAGS
 /test/coverage/BUILD


### PR DESCRIPTION
Ignore *.s?? instead of *.sw* to make sure git does not ignore .swift files

Part of #23758

Signed-off-by: Ryan Hamilton <rch@google.com>