### PR TITLE
build: Set -gdwarf-4 for clang and gcc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,7 +65,6 @@ build:sanitizer --test_tag_filters=-no_san
 build:clang --action_env=BAZEL_COMPILER=clang
 build:clang --action_env=CC=clang --action_env=CXX=clang++
 build:clang --linkopt=-fuse-ld=lld
-build:clang --copt=-gdwarf-4
 
 # Flags for Clang + PCH
 build:clang-pch --spawn_strategy=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -65,6 +65,7 @@ build:sanitizer --test_tag_filters=-no_san
 build:clang --action_env=BAZEL_COMPILER=clang
 build:clang --action_env=CC=clang --action_env=CXX=clang++
 build:clang --linkopt=-fuse-ld=lld
+build:clang --copt=-gdwarf-4
 
 # Flags for Clang + PCH
 build:clang-pch --spawn_strategy=local

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -51,9 +51,12 @@ def envoy_copts(repository, test = False):
                # debugging info detailing some 1600 test binaries would be wasteful.
                # targets listed in order from generic to increasing specificity.
                # Bazel adds an implicit -DNDEBUG for opt targets.
-               repository + "//bazel:opt_build": [] if test else ["-ggdb3"],
+               #
+               # The GDB currently in the CI build container chokes on dwarf-5, so
+               # force dwarf-4.
+               repository + "//bazel:opt_build": [] if test else ["-ggdb3", "-gdwarf-4"],
                repository + "//bazel:fastbuild_build": [],
-               repository + "//bazel:dbg_build": ["-ggdb3"],
+               repository + "//bazel:dbg_build": ["-ggdb3", "-gdwarf-4"],
                repository + "//bazel:windows_opt_build": [] if test else ["-Z7"],
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],


### PR DESCRIPTION


Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: This makes the clang debug information be compatible with the gdb in the envoyproxy build container.
Additional Description:
Risk Level: Very low
Testing: Can use gdb against tests in the build container and get expected debug info
Docs Changes: none
Release Notes: none
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
