### PR TITLE
Increase shard count for //test/integration:websocket_integration_test.

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1149,6 +1149,7 @@ envoy_cc_test(
         "websocket_integration_test.cc",
         "websocket_integration_test.h",
     ],
+    shard_count = 4,
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",


### PR DESCRIPTION
I have seen TSAN test timeouts, for example, in #24108.  This is presumably due to #24003 increasing the test parameter space two-fold for HttpProtocolIntegrationTest and its derived classes, like WebsocketIntegrationTest.  Increase shard count to prevent timeouts.

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: Increase shard count for //test/integration:websocket_integration_test.
Additional Description:
Risk Level: low, test-only change
Testing: //test/integration:websocket_integration_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a