### PR TITLE
ci: Fix change detection (part 2)

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -35,7 +35,7 @@ stages:
   #
   # To use a variable as a condition for a `stage` you can specify it as follows:
   #
-  # condition: and(not(canceled()), succeeded(), ne(dependencies.env.repo.outputs['changed.mobileOnly'], 'true'))
+  # condition: and(not(canceled()), succeeded(), ne(dependencies.env.outputs['repo.changed.mobileOnly'], 'true'))
   #
   # To use a variable as a condition for a `job` you can specify it as follows:
   #

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -72,7 +72,8 @@ stages:
         fi
 
         echo "Comparing changes ${CHANGE_TARGET}...HEAD"
-        CHANGED_PATHS="$(git diff --name-only ${CHANGE_TARGET}...HEAD | cut -d/ -f1 | sort -u | jq -R 'split("\n")')"
+        CHANGED_PATHS="$(git diff --name-only ${CHANGE_TARGET}...HEAD | cut -d/ -f1 | sort -u | jq -sR 'rtrimstr("\n") | split("\n")')"
+        echo "$CHANGED_PATHS" | jq '.'
         CHANGED_PATH_COUNT=$(echo $CHANGED_PATHS | jq '. | length')
         CHANGED_MOBILE_ONLY=false
         CHANGED_DOCS_ONLY=false
@@ -91,6 +92,10 @@ stages:
       displayName: "Detect repo changes"
       workingDirectory: $(Build.SourcesDirectory)
       name: changed
+    - bash: |
+        echo "env.outputs['changed.mobileOnly']: $(changed.mobileOnly)"
+        echo "env.outputs['changed.docsOnly']: $(changed.docsOnly)"
+      displayName: "Print build environment"
 
 - stage: precheck
   dependsOn: ["env"]
@@ -374,11 +379,12 @@ stages:
 
 - stage: check
   dependsOn: ["env", "linux_x64"]
-  condition: or(eq(variables['PostSubmit'], true), and(ne(dependencies.env.repo.outputs['changed.mobileOnly'], 'true'), ne(dependencies.env.repo.outputs['changed.docsOnly'], 'true')))
   jobs:
   - job: bazel
     displayName: "linux_x64"
     dependsOn: []
+    # Skip checks if only mobile/ or docs/ have changed.
+    condition: and(not(canceled()), succeeded(), ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.docsOnly'], 'true'))
     strategy:
       maxParallel: 3
       matrix:
@@ -410,6 +416,8 @@ stages:
   - job: coverage
     displayName: "linux_x64"
     dependsOn: []
+    # Skip checks if only mobile/ or docs/ have changed.
+    condition: and(not(canceled()), succeeded(), ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.docsOnly'], 'true'))
     timeoutInMinutes: 180
     pool: "x64-large"
     strategy:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -35,14 +35,17 @@ stages:
   #
   # To use a variable as a condition for a `stage` you can specify it as follows:
   #
-  # condition: ne(dependencies.env.outputs['repo.changed.mobileOnly'], 'true')
+  # condition: and(not(canceled()), succeeded(), ne(dependencies.env.repo.outputs['changed.mobileOnly'], 'true'))
   #
   # To use a variable as a condition for a `job` you can specify it as follows:
   #
   # job:
-  #   condition: ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true')
+  #   condition: and(not(canceled()), succeeded(), ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true'))
   #
   # Note the difference in name resolution when used in stages and jobs.
+  #
+  # Note also, other conditions such as `not(canceled())` are not assumed and so need to be added to
+  # any conditions explicitly.
   #
   # NB: Avoid using _inclusive_ lists to trigger CI - eg _dont_ only trigger mobile CI if `mobile/` changed.
   #  Instead use _exclusive_ bools - eg _do_ suppress other CI if only `mobile/` changed
@@ -64,12 +67,16 @@ stages:
       vmImage: "ubuntu-20.04"
     steps:
     - bash: |
-        if [[ $(Build.Reason) == "PullRequest" ]]; then
-            CHANGE_TARGET="origin/$(System.PullRequest.TargetBranch)"
-        else
-            # This may not work so well on release branches where multiple commits are rebased to the branch
-            CHANGE_TARGET=$(git log --format="%H" -2 | tail -n1)
+        set -e
+
+        # Only exclude checks in pull requests.
+        if [[ $(Build.Reason) != "PullRequest" ]]; then
+            echo "##vso[task.setvariable variable=mobileOnly;isoutput=true]false"
+            echo "##vso[task.setvariable variable=docsOnly;isoutput=true]false"
+            exit 0
         fi
+
+        CHANGE_TARGET="origin/$(System.PullRequest.TargetBranch)"
 
         echo "Comparing changes ${CHANGE_TARGET}...HEAD"
         CHANGED_PATHS="$(git diff --name-only ${CHANGE_TARGET}...HEAD | cut -d/ -f1 | sort -u | jq -sR 'rtrimstr("\n") | split("\n")')"


### PR DESCRIPTION
- fix stage dependency
- fix change detection
 - add some debugging information
    
Signed-off-by: Ryan Northey <ryan@synca.io>

---


This fixes the `jq` expression to use "slurp" to ensure the json is a single list (and works with subsequent code), and adds some debugging info

also adds a `not(cancelled())` condition to the `check` stage as the dep on `env` is triggering this when the run is cancelled

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
