### PR TITLE
Change OpenTelemetry grpc access logger to use unary RPCs rather than streaming

### DIFF
--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -83,8 +83,8 @@ public:
 
 protected:
   GrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
-                               const Protobuf::MethodDescriptor& service_method,
-                               OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
+                      const Protobuf::MethodDescriptor& service_method,
+                      OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
       : client_(client), service_method_(service_method),
         opts_(createRequestOptionsForRetry(retry_policy)) {}
 
@@ -115,16 +115,14 @@ public:
   UnaryGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
                            const Protobuf::MethodDescriptor& service_method,
                            OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
-      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method,
-                                                              retry_policy) {}
+      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method, retry_policy) {}
 
   bool isConnected() override { return false; }
 
   bool log(const LogRequest& request) override {
     GrpcAccessLogClient<LogRequest, LogResponse>::client_->send(
-        GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, request,
-        request_cb_, Tracing::NullSpan::instance(),
-        GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
+        GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, request, request_cb_,
+        Tracing::NullSpan::instance(), GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
     return true;
   }
 
@@ -143,10 +141,9 @@ template <typename LogRequest, typename LogResponse>
 class StreamingGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
 public:
   StreamingGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
-                      const Protobuf::MethodDescriptor& service_method,
-                      OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
-      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method,
-                                                              retry_policy) {}
+                               const Protobuf::MethodDescriptor& service_method,
+                               OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
+      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method, retry_policy) {}
 
 public:
   struct LocalStream : public Grpc::AsyncStreamCallbacks<LogResponse> {

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -13,6 +13,7 @@
 #include "source/common/grpc/typed_async_client.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/tracing/null_span_impl.h"
 #include "source/extensions/access_loggers/common/grpc_access_logger_utils.h"
 
 #include "absl/container/flat_hash_map.h"
@@ -76,24 +77,80 @@ public:
 
 template <typename LogRequest, typename LogResponse> class GrpcAccessLogClient {
 public:
+  virtual ~GrpcAccessLogClient() = default;
+  virtual bool isConnected() PURE;
+  virtual bool log(const LogRequest& request) PURE;
+
+protected:
   GrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
+                               const Protobuf::MethodDescriptor& service_method,
+                               OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
+      : client_(client), service_method_(service_method),
+        opts_(createRequestOptionsForRetry(retry_policy)) {}
+
+  Grpc::AsyncClient<LogRequest, LogResponse> client_;
+  const Protobuf::MethodDescriptor& service_method_;
+  const Http::AsyncClient::RequestOptions opts_;
+
+private:
+  Http::AsyncClient::RequestOptions createRequestOptionsForRetry(
+      const absl::optional<envoy::config::core::v3::RetryPolicy>&& retry_policy) {
+    auto opt = Http::AsyncClient::RequestOptions();
+
+    if (!retry_policy) {
+      return opt;
+    }
+
+    const auto grpc_retry_policy =
+        Http::Utility::convertCoreToRouteRetryPolicy(*retry_policy, "connect-failure");
+    opt.setBufferBodyForRetry(true);
+    opt.setRetryPolicy(grpc_retry_policy);
+    return opt;
+  }
+};
+
+template <typename LogRequest, typename LogResponse>
+class UnaryGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
+public:
+  UnaryGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
+                           const Protobuf::MethodDescriptor& service_method,
+                           OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
+      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method,
+                                                              retry_policy) {}
+
+  bool isConnected() override { return false; }
+
+  bool log(const LogRequest& request) override {
+    GrpcAccessLogClient<LogRequest, LogResponse>::client_->send(
+        GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, request,
+        request_cb_, Tracing::NullSpan::instance(),
+        GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
+    return true;
+  }
+
+  struct RequestCallbacks : public Grpc::AsyncRequestCallbacks<LogResponse> {
+    // Grpc::AsyncRequestCallbacks
+    void onSuccess(Grpc::ResponsePtr<LogResponse>&&, Tracing::Span&) override {}
+    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
+    void onFailure(Grpc::Status::GrpcStatus, const std::string&, Tracing::Span&) override {}
+  };
+
+private:
+  RequestCallbacks request_cb_;
+};
+
+template <typename LogRequest, typename LogResponse>
+class StreamingGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
+public:
+  StreamingGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
                       const Protobuf::MethodDescriptor& service_method,
                       OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
-      : client_(client), service_method_(service_method),
-        grpc_stream_retry_policy_(
-            [retry_policy]() -> absl::optional<envoy::config::route::v3::RetryPolicy> {
-              if (!retry_policy) {
-                return absl::nullopt;
-              }
-              Http::Utility::validateCoreRetryPolicy(*retry_policy);
-              const auto route_retry =
-                  Http::Utility::convertCoreToRouteRetryPolicy(*retry_policy, "connect-failure");
-              return absl::optional<envoy::config::route::v3::RetryPolicy>{route_retry};
-            }()) {}
+      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method,
+                                                              retry_policy) {}
 
 public:
   struct LocalStream : public Grpc::AsyncStreamCallbacks<LogResponse> {
-    LocalStream(GrpcAccessLogClient& parent) : parent_(parent) {}
+    LocalStream(StreamingGrpcAccessLogClient& parent) : parent_(parent) {}
 
     // Grpc::AsyncStreamCallbacks
     void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
@@ -109,19 +166,21 @@ public:
       }
     }
 
-    GrpcAccessLogClient& parent_;
+    StreamingGrpcAccessLogClient& parent_;
     Grpc::AsyncStream<LogRequest> stream_{};
   };
 
-  bool isStreamStarted() { return stream_ != nullptr && stream_->stream_ != nullptr; }
+  bool isConnected() override { return stream_ != nullptr && stream_->stream_ != nullptr; }
 
-  bool log(const LogRequest& request) {
+  bool log(const LogRequest& request) override {
     if (!stream_) {
       stream_ = std::make_unique<LocalStream>(*this);
     }
 
     if (stream_->stream_ == nullptr) {
-      stream_->stream_ = client_->start(service_method_, *stream_, createStreamOptionsForRetry());
+      stream_->stream_ = GrpcAccessLogClient<LogRequest, LogResponse>::client_->start(
+          GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, *stream_,
+          GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
     }
 
     if (stream_->stream_ != nullptr) {
@@ -136,22 +195,7 @@ public:
     return true;
   }
 
-  Http::AsyncClient::StreamOptions createStreamOptionsForRetry() {
-    auto opt = Http::AsyncClient::StreamOptions();
-
-    if (!grpc_stream_retry_policy_) {
-      return opt;
-    }
-
-    opt.setBufferBodyForRetry(true);
-    opt.setRetryPolicy(*grpc_stream_retry_policy_);
-    return opt;
-  }
-
-  Grpc::AsyncClient<LogRequest, LogResponse> client_;
   std::unique_ptr<LocalStream> stream_;
-  const Protobuf::MethodDescriptor& service_method_;
-  const absl::optional<envoy::config::route::v3::RetryPolicy> grpc_stream_retry_policy_;
 };
 
 } // namespace Detail
@@ -180,14 +224,12 @@ template <typename HttpLogProto, typename TcpLogProto, typename LogRequest, type
 class GrpcAccessLogger : public Detail::GrpcAccessLogger<HttpLogProto, TcpLogProto> {
 public:
   using Interface = Detail::GrpcAccessLogger<HttpLogProto, TcpLogProto>;
-
   GrpcAccessLogger(
       const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
       Event::Dispatcher& dispatcher, Stats::Scope& scope, std::string access_log_prefix,
-      const Protobuf::MethodDescriptor& service_method)
-      : client_(client, service_method, GrpcCommon::optionalRetryPolicy(config)),
-        buffer_flush_interval_msec_(
+      const Protobuf::MethodDescriptor& service_method, bool stream = true)
+      : buffer_flush_interval_msec_(
             PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),
         flush_timer_(dispatcher.createTimer([this]() {
           flush();
@@ -195,6 +237,13 @@ public:
         })),
         max_buffer_size_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384)),
         stats_({ALL_GRPC_ACCESS_LOGGER_STATS(POOL_COUNTER_PREFIX(scope, access_log_prefix))}) {
+    if (stream) {
+      client_ = std::make_unique<Detail::StreamingGrpcAccessLogClient<LogRequest, LogResponse>>(
+          client, service_method, GrpcCommon::optionalRetryPolicy(config));
+    } else {
+      client_ = std::make_unique<Detail::UnaryGrpcAccessLogClient<LogRequest, LogResponse>>(
+          client, service_method, GrpcCommon::optionalRetryPolicy(config));
+    }
     flush_timer_->enableTimer(buffer_flush_interval_msec_);
   }
 
@@ -218,7 +267,7 @@ public:
   }
 
 protected:
-  Detail::GrpcAccessLogClient<LogRequest, LogResponse> client_;
+  std::unique_ptr<Detail::GrpcAccessLogClient<LogRequest, LogResponse>> client_;
   LogRequest message_;
 
 private:
@@ -234,11 +283,11 @@ private:
       return;
     }
 
-    if (!client_.isStreamStarted()) {
+    if (!client_->isConnected()) {
       initMessage();
     }
 
-    if (client_.log(message_)) {
+    if (client_->log(message_)) {
       // Clear the message regardless of the success.
       approximate_message_size_bytes_ = 0;
       clearMessage();

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -27,7 +27,8 @@ GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
     Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope)
     : GrpcAccessLogger(client, config.common_config(), dispatcher, scope, GRPC_LOG_STATS_PREFIX,
                        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-                           "opentelemetry.proto.collector.logs.v1.LogsService.Export")) {
+                           "opentelemetry.proto.collector.logs.v1.LogsService.Export"),
+                       false) {
   initMessageRoot(config, local_info);
 }
 

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -52,9 +52,9 @@ public:
       const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
       Event::Dispatcher& dispatcher, Stats::Scope& scope, std::string access_log_prefix,
-      const Protobuf::MethodDescriptor& service_method)
+      const Protobuf::MethodDescriptor& service_method, bool stream)
       : GrpcAccessLogger(std::move(client), config, dispatcher, scope, access_log_prefix,
-                         service_method) {}
+                         service_method, stream) {}
 
   int numInits() const { return num_inits_; }
 
@@ -99,7 +99,7 @@ private:
   int num_clears_ = 0;
 };
 
-class GrpcAccessLogTest : public testing::Test {
+class StreamingGrpcAccessLogTest : public testing::Test {
 public:
   using MockAccessLogStream = Grpc::MockAsyncStream;
   using AccessLogCallbacks = Grpc::AsyncStreamCallbacks<ProtobufWkt::Struct>;
@@ -121,7 +121,7 @@ public:
 
     logger_ = std::make_unique<MockGrpcAccessLoggerImpl>(
         Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, stats_store_,
-        "mock_access_log_prefix.", mockMethodDescriptor());
+        "mock_access_log_prefix.", mockMethodDescriptor(), true);
   }
 
   void expectStreamStart(MockAccessLogStream& stream, AccessLogCallbacks** callbacks_to_set) {
@@ -156,7 +156,7 @@ public:
 };
 
 // Test basic stream logging flow.
-TEST_F(GrpcAccessLogTest, BasicFlow) {
+TEST_F(StreamingGrpcAccessLogTest, BasicFlow) {
   initLogger(FlushInterval, 0);
 
   // Start a stream for the first log.
@@ -199,7 +199,7 @@ TEST_F(GrpcAccessLogTest, BasicFlow) {
             TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_written")->value());
 }
 
-TEST_F(GrpcAccessLogTest, WatermarksOverrun) {
+TEST_F(StreamingGrpcAccessLogTest, WatermarksOverrun) {
   InSequence s;
   initLogger(FlushInterval, 1);
 
@@ -247,7 +247,7 @@ TEST_F(GrpcAccessLogTest, WatermarksOverrun) {
 }
 
 // Test that stream failure is handled correctly.
-TEST_F(GrpcAccessLogTest, StreamFailure) {
+TEST_F(StreamingGrpcAccessLogTest, StreamFailure) {
   initLogger(FlushInterval, 0);
 
   EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
@@ -262,7 +262,7 @@ TEST_F(GrpcAccessLogTest, StreamFailure) {
   EXPECT_EQ(1, logger_->numInits());
 }
 
-TEST_F(GrpcAccessLogTest, StreamFailureAndRetry) {
+TEST_F(StreamingGrpcAccessLogTest, StreamFailureAndRetry) {
   config_.mutable_grpc_stream_retry_policy()->mutable_num_retries()->set_value(2);
   config_.mutable_grpc_stream_retry_policy()
       ->mutable_retry_back_off()
@@ -283,7 +283,7 @@ TEST_F(GrpcAccessLogTest, StreamFailureAndRetry) {
 }
 
 // Test that log entries are batched.
-TEST_F(GrpcAccessLogTest, Batching) {
+TEST_F(StreamingGrpcAccessLogTest, Batching) {
   // The approximate log size for buffering is calculated based on each entry's byte size.
   const int max_buffer_size = 3 * mockHttpEntry().ByteSizeLong();
   initLogger(FlushInterval, max_buffer_size);
@@ -310,7 +310,7 @@ TEST_F(GrpcAccessLogTest, Batching) {
 }
 
 // Test that log entries are flushed periodically.
-TEST_F(GrpcAccessLogTest, Flushing) {
+TEST_F(StreamingGrpcAccessLogTest, Flushing) {
   initLogger(FlushInterval, 100);
 
   // Nothing to do yet.
@@ -324,6 +324,143 @@ TEST_F(GrpcAccessLogTest, Flushing) {
   AccessLogCallbacks* callbacks;
   expectStreamStart(stream, &callbacks);
   expectFlushedLogEntriesCount(stream, MOCK_HTTP_LOG_FIELD_NAME, 1);
+  EXPECT_CALL(*timer_, enableTimer(FlushInterval, _));
+  timer_->invokeCallback();
+  EXPECT_EQ(1, logger_->numInits());
+
+  // Flush on empty message does nothing.
+  EXPECT_CALL(*timer_, enableTimer(FlushInterval, _));
+  timer_->invokeCallback();
+}
+
+class UnaryGrpcAccessLogTest : public testing::Test {
+public:
+  using MockAccessLogStream = Grpc::MockAsyncStream;
+  using AccessLogCallbacks = Grpc::AsyncRequestCallbacks<ProtobufWkt::Struct>;
+
+  // We log a non empty entry (even though not used) so that we can trigger buffering mechanisms,
+  // which are based on the entry size.
+  ProtobufWkt::Struct mockHttpEntry() {
+    ProtobufWkt::Struct entry;
+    entry.mutable_fields()->insert({"test-key", ProtobufWkt::Value()});
+    return entry;
+  }
+
+  void initLogger(std::chrono::milliseconds buffer_flush_interval_msec, size_t buffer_size_bytes) {
+    timer_ = new Event::MockTimer(&dispatcher_);
+    EXPECT_CALL(*timer_, enableTimer(buffer_flush_interval_msec, _));
+    config_.mutable_buffer_size_bytes()->set_value(buffer_size_bytes);
+    config_.mutable_buffer_flush_interval()->set_nanos(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(buffer_flush_interval_msec).count());
+
+    logger_ = std::make_unique<MockGrpcAccessLoggerImpl>(
+        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, stats_store_,
+        "mock_access_log_prefix.", mockMethodDescriptor(), false);
+  }
+
+  void expectFlushedLogEntriesCount(const std::string& key, int count) {
+    EXPECT_CALL(*async_client_, sendRaw(_, _, _, _, _, _))
+        .WillOnce(
+            Invoke([key, count](absl::string_view, absl::string_view, Buffer::InstancePtr&& request,
+                                Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                                const Http::AsyncClient::RequestOptions&) {
+              ProtobufWkt::Struct message;
+              Buffer::ZeroCopyInputStreamImpl request_stream(std::move(request));
+              EXPECT_TRUE(message.ParseFromZeroCopyStream(&request_stream));
+              EXPECT_TRUE(message.fields().contains(key));
+              EXPECT_EQ(message.fields().at(key).number_value(), count);
+              return nullptr; // We don't care about the returned request.
+            }));
+  }
+
+  Stats::IsolatedStoreImpl stats_store_;
+  Event::MockTimer* timer_ = nullptr;
+  Event::MockDispatcher dispatcher_;
+  Grpc::MockAsyncClient* async_client_{new Grpc::MockAsyncClient};
+  std::unique_ptr<MockGrpcAccessLoggerImpl> logger_;
+  envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig config_;
+};
+
+// Test basic stream logging flow.
+TEST_F(UnaryGrpcAccessLogTest, BasicFlow) {
+  initLogger(FlushInterval, 0);
+  // Log an HTTP entry.
+  expectFlushedLogEntriesCount(MOCK_HTTP_LOG_FIELD_NAME, 1);
+  logger_->log(mockHttpEntry());
+  // Message should be initialized and cleared every time a request is sent.
+  EXPECT_EQ(1, logger_->numInits());
+  EXPECT_EQ(1, logger_->numClears());
+  EXPECT_EQ(1,
+            TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_written")->value());
+
+  // Log a TCP entry.
+  expectFlushedLogEntriesCount(MOCK_TCP_LOG_FIELD_NAME, 1);
+  logger_->log(ProtobufWkt::Empty());
+  // Message should be initialized and cleared every time a request is sent.
+  EXPECT_EQ(2, logger_->numInits());
+  EXPECT_EQ(2, logger_->numClears());
+  // TCP logging doesn't change the logs_written counter.
+  EXPECT_EQ(1,
+            TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_written")->value());
+  // No dropped logs expected.
+  EXPECT_EQ(0,
+            TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_dropped")->value());
+}
+
+TEST_F(UnaryGrpcAccessLogTest, FailureAndRetry) {
+  config_.mutable_grpc_stream_retry_policy()->mutable_num_retries()->set_value(2);
+  config_.mutable_grpc_stream_retry_policy()
+      ->mutable_retry_back_off()
+      ->mutable_base_interval()
+      ->set_seconds(1);
+  initLogger(FlushInterval, 1);
+  EXPECT_CALL(*async_client_, sendRaw(_, _, _, _, _, _))
+      .WillOnce(Invoke([](absl::string_view, absl::string_view, Buffer::InstancePtr&&,
+                          Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                          const Http::AsyncClient::RequestOptions& options) -> Grpc::AsyncRequest* {
+        EXPECT_TRUE(options.retry_policy.has_value());
+        EXPECT_TRUE(options.retry_policy.value().has_num_retries());
+        EXPECT_EQ(PROTOBUF_GET_WRAPPED_REQUIRED(options.retry_policy.value(), num_retries), 2);
+        return nullptr;
+      }));
+  logger_->log(mockHttpEntry());
+}
+
+// Test that log entries are batched.
+TEST_F(UnaryGrpcAccessLogTest, Batching) {
+  // The approximate log size for buffering is calculated based on each entry's byte size.
+  const int max_buffer_size = 3 * mockHttpEntry().ByteSizeLong();
+  initLogger(FlushInterval, max_buffer_size);
+
+  expectFlushedLogEntriesCount(MOCK_HTTP_LOG_FIELD_NAME, 3);
+  logger_->log(mockHttpEntry());
+  logger_->log(mockHttpEntry());
+  logger_->log(mockHttpEntry());
+  // The entries were batched and logged together so we expect a single init and clear.
+  EXPECT_EQ(1, logger_->numInits());
+  EXPECT_EQ(1, logger_->numClears());
+
+  // Logging an entry that's bigger than the buffer size should trigger another flush.
+  expectFlushedLogEntriesCount(MOCK_HTTP_LOG_FIELD_NAME, 1);
+  ProtobufWkt::Struct big_entry = mockHttpEntry();
+  const std::string big_key(max_buffer_size, 'a');
+  big_entry.mutable_fields()->insert({big_key, ProtobufWkt::Value()});
+  logger_->log(std::move(big_entry));
+  EXPECT_EQ(2, logger_->numClears());
+}
+
+// Test that log entries are flushed periodically.
+TEST_F(UnaryGrpcAccessLogTest, Flushing) {
+  initLogger(FlushInterval, 100);
+
+  // Nothing to do yet.
+  EXPECT_CALL(*timer_, enableTimer(FlushInterval, _));
+  timer_->invokeCallback();
+
+  // Not enough data yet to trigger flush on batch size.
+  logger_->log(mockHttpEntry());
+
+  expectFlushedLogEntriesCount(MOCK_HTTP_LOG_FIELD_NAME, 1);
   EXPECT_CALL(*timer_, enableTimer(FlushInterval, _));
   timer_->invokeCallback();
   EXPECT_EQ(1, logger_->numInits());
@@ -351,7 +488,7 @@ private:
                       ->createUncachedRawAsyncClient();
     return std::make_shared<MockGrpcAccessLoggerImpl>(std::move(client), config, dispatcher, scope_,
                                                       "mock_access_log_prefix.",
-                                                      mockMethodDescriptor());
+                                                      mockMethodDescriptor(), true);
   }
 };
 

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -21,7 +21,6 @@
 using testing::_;
 using testing::Invoke;
 using testing::NiceMock;
-using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -36,43 +35,35 @@ const std::string ZONE_NAME = "zone_name";
 const std::string CLUSTER_NAME = "cluster_name";
 const std::string NODE_NAME = "node_name";
 
-// A helper test class to mock and intercept GrpcAccessLoggerImpl streams.
+// A helper test class to mock and intercept GrpcAccessLoggerImpl requests.
 class GrpcAccessLoggerImplTestHelper {
 public:
-  using MockAccessLogStream = Grpc::MockAsyncStream;
-  using AccessLogCallbacks = Grpc::AsyncStreamCallbacks<
-      opentelemetry::proto::collector::logs::v1::ExportLogsServiceResponse>;
-
   GrpcAccessLoggerImplTestHelper(LocalInfo::MockLocalInfo& local_info,
-                                 Grpc::MockAsyncClient* async_client) {
+                                 Grpc::MockAsyncClient* async_client)
+      : async_client_(async_client) {
     EXPECT_CALL(local_info, zoneName()).WillOnce(ReturnRef(ZONE_NAME));
     EXPECT_CALL(local_info, clusterName()).WillOnce(ReturnRef(CLUSTER_NAME));
     EXPECT_CALL(local_info, nodeName()).WillOnce(ReturnRef(NODE_NAME));
-    EXPECT_CALL(*async_client, startRaw(_, _, _, _))
-        .WillOnce(
-            Invoke([this](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& cbs,
-                          const Http::AsyncClient::StreamOptions&) {
-              this->callbacks_ = dynamic_cast<AccessLogCallbacks*>(&cbs);
-              return &this->stream_;
-            }));
   }
 
-  void expectStreamMessage(const std::string& expected_message_yaml) {
+  void expectSentMessage(const std::string& expected_message_yaml) {
     opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest expected_message;
     TestUtility::loadFromYaml(expected_message_yaml, expected_message);
-    EXPECT_CALL(stream_, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-    EXPECT_CALL(stream_, sendMessageRaw_(_, false))
-        .WillOnce(Invoke([expected_message](Buffer::InstancePtr& request, bool) {
+    EXPECT_CALL(*async_client_, sendRaw(_, _, _, _, _, _))
+        .WillOnce(Invoke([expected_message](absl::string_view, absl::string_view,
+                                            Buffer::InstancePtr&& request,
+                                            Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                                            const Http::AsyncClient::RequestOptions&) {
           opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest message;
           Buffer::ZeroCopyInputStreamImpl request_stream(std::move(request));
           EXPECT_TRUE(message.ParseFromZeroCopyStream(&request_stream));
           EXPECT_EQ(message.DebugString(), expected_message.DebugString());
+          return nullptr; // We don't care about the returned request.
         }));
   }
 
 private:
-  MockAccessLogStream stream_;
-  AccessLogCallbacks* callbacks_;
+  Grpc::MockAsyncClient* async_client_;
 };
 
 class GrpcAccessLoggerImplTest : public testing::Test {
@@ -100,7 +91,7 @@ public:
 };
 
 TEST_F(GrpcAccessLoggerImplTest, Log) {
-  grpc_access_logger_impl_test_helper_.expectStreamMessage(R"EOF(
+  grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
   resource_logs:
     resource:
       attributes:
@@ -163,7 +154,7 @@ TEST_F(GrpcAccessLoggerCacheImplTest, LoggerCreation) {
 
   GrpcAccessLoggerSharedPtr logger =
       logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);
-  grpc_access_logger_impl_test_helper_.expectStreamMessage(R"EOF(
+  grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
   resource_logs:
     resource:
       attributes:
@@ -214,7 +205,7 @@ values:
 
   GrpcAccessLoggerSharedPtr logger =
       logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);
-  grpc_access_logger_impl_test_helper_.expectStreamMessage(R"EOF(
+  grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
   resource_logs:
     resource:
       attributes:


### PR DESCRIPTION
Commit Message: Change OpenTelemetry grpc access logger to use unary RPCs rather than streaming, to match the [non streaming OTLP RPC service](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto#L30-L34).
Additional Description: The OTel access logger used the existing Envoy GRPC client libraries which sent streamed messages, on a non-streaming RPC service. The result is usually that after every request->response the server closes the connection and the stream is reset. Sometimes, Envoy tries to send another log before the response from the server returns (and closes the stream), so the 2nd log is sent on a closed stream and gets lost.
Using unary RPCs, this shouldn't happen (tested and verified).
Risk Level: Low
Testing: Unit tests, and I ran Envoy with and without this change in an environment where some logs were dropped because of it and the issue is fixed.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
