### PR TITLE
http_11_proxy: fixing a bug with buggy proxies

### DIFF
--- a/source/extensions/transport_sockets/http_11_proxy/connect.cc
+++ b/source/extensions/transport_sockets/http_11_proxy/connect.cc
@@ -15,7 +15,8 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Http11Connect {
 
-bool UpstreamHttp11ConnectSocket::isValidConnectResponse(absl::string_view data, bool& error, unsigned long& len) {
+bool UpstreamHttp11ConnectSocket::isValidConnectResponse(absl::string_view data, bool& error,
+                                                         unsigned long& len) {
   SelfContainedParser parser;
 
   len = parser.parser().execute(data.data(), data.length());
@@ -83,8 +84,8 @@ Network::IoResult UpstreamHttp11ConnectSocket::doRead(Buffer::Instance& buffer) 
       return {Network::PostIoAction::Close, 0, false};
     }
     if (!is_valid_connect_response) {
-      ENVOY_CONN_LOG(trace, "Incomplete CONECT header: {} bytes received",
-                     callbacks_->connection(), peek_data.size());
+      ENVOY_CONN_LOG(trace, "Incomplete CONECT header: {} bytes received", callbacks_->connection(),
+                     peek_data.size());
       return Network::IoResult{Network::PostIoAction::KeepOpen, 0, false};
     }
 
@@ -95,7 +96,8 @@ Network::IoResult UpstreamHttp11ConnectSocket::doRead(Buffer::Instance& buffer) 
     }
     buffer.drain(len);
 
-    ENVOY_CONN_LOG(trace, "Successfully stripped {} bytes of CONNECT header", callbacks_->connection(), len);
+    ENVOY_CONN_LOG(trace, "Successfully stripped {} bytes of CONNECT header",
+                   callbacks_->connection(), len);
     need_to_strip_connect_response_ = false;
   }
   return transport_socket_->doRead(buffer);

--- a/source/extensions/transport_sockets/http_11_proxy/connect.cc
+++ b/source/extensions/transport_sockets/http_11_proxy/connect.cc
@@ -15,12 +15,12 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Http11Connect {
 
-bool UpstreamHttp11ConnectSocket::isValidConnectResponse(absl::string_view data,
+bool UpstreamHttp11ConnectSocket::isValidConnectResponse(absl::string_view response_payload,
                                                          bool& headers_complete,
                                                          size_t& bytes_processed) {
   SelfContainedParser parser;
 
-  bytes_processed = parser.parser().execute(data.data(), data.length());
+  bytes_processed = parser.parser().execute(response_payload.data(), response_payload.length());
   headers_complete = parser.headersComplete();
 
   return parser.parser().getStatus() != Http::Http1::ParserStatus::Error &&
@@ -78,8 +78,8 @@ Network::IoResult UpstreamHttp11ConnectSocket::doRead(Buffer::Instance& buffer) 
                        callbacks_->connection(), MAX_RESPONSE_HEADER_SIZE);
         return {Network::PostIoAction::Close, 0, false};
       }
-      ENVOY_CONN_LOG(trace, "Incomplete CONECT header: {} bytes received", callbacks_->connection(),
-                     peek_data.size());
+      ENVOY_CONN_LOG(trace, "Incomplete CONNECT header: {} bytes received",
+                     callbacks_->connection(), peek_data.size());
       return Network::IoResult{Network::PostIoAction::KeepOpen, 0, false};
     }
     if (!is_valid_connect_response) {

--- a/source/extensions/transport_sockets/http_11_proxy/connect.h
+++ b/source/extensions/transport_sockets/http_11_proxy/connect.h
@@ -19,7 +19,12 @@ namespace Http11Connect {
 class UpstreamHttp11ConnectSocket : public TransportSockets::PassthroughSocket,
                                     public Logger::Loggable<Logger::Id::connection> {
 public:
-  static bool isValidConnectResponse(absl::string_view data, bool& error, unsigned long& len);
+  // Processes request_payload and returns true if it is a valid connect
+  // response with status code 200.
+  // @param header_complete will be set to true if the request payload contains complete headers.
+  // @param bytes_processed will return how many bytes of request_payload were processed.
+  static bool isValidConnectResponse(absl::string_view request_payload, bool& headers_complete,
+                                     size_t& bytes_processed);
 
   UpstreamHttp11ConnectSocket(Network::TransportSocketPtr&& transport_socket,
                               Network::TransportSocketOptionsConstSharedPtr options);

--- a/source/extensions/transport_sockets/http_11_proxy/connect.h
+++ b/source/extensions/transport_sockets/http_11_proxy/connect.h
@@ -19,11 +19,12 @@ namespace Http11Connect {
 class UpstreamHttp11ConnectSocket : public TransportSockets::PassthroughSocket,
                                     public Logger::Loggable<Logger::Id::connection> {
 public:
-  // Processes request_payload and returns true if it is a valid connect
+  // Processes response_payload and returns true if it is a valid connect
   // response with status code 200.
-  // @param header_complete will be set to true if the request payload contains complete headers.
-  // @param bytes_processed will return how many bytes of request_payload were processed.
-  static bool isValidConnectResponse(absl::string_view request_payload, bool& headers_complete,
+  // @param response_payload the HTTP response bytes
+  // @param header_complete will be set to true if the response payload contains complete headers.
+  // @param bytes_processed will return how many bytes of response_payload were processed.
+  static bool isValidConnectResponse(absl::string_view response_payload, bool& headers_complete,
                                      size_t& bytes_processed);
 
   UpstreamHttp11ConnectSocket(Network::TransportSocketPtr&& transport_socket,

--- a/source/extensions/transport_sockets/http_11_proxy/connect.h
+++ b/source/extensions/transport_sockets/http_11_proxy/connect.h
@@ -19,7 +19,7 @@ namespace Http11Connect {
 class UpstreamHttp11ConnectSocket : public TransportSockets::PassthroughSocket,
                                     public Logger::Loggable<Logger::Id::connection> {
 public:
-  static bool isValidConnectResponse(Buffer::Instance& buffer);
+  static bool isValidConnectResponse(absl::string_view data, bool& error, unsigned long& len);
 
   UpstreamHttp11ConnectSocket(Network::TransportSocketPtr&& transport_socket,
                               Network::TransportSocketOptionsConstSharedPtr options);

--- a/test/extensions/transport_sockets/http_11_proxy/connect_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_test.cc
@@ -384,58 +384,58 @@ TEST_F(SocketFactoryTest, CreateSocketReturnsNullWhenInnerFactoryReturnsNull) {
 }
 
 TEST(ParseTest, TestValidResponse) {
-  unsigned long len;
+  size_t bytes_processed;
   bool headers_complete;
   {
     std::string response("HTTP/1.0 200 OK\r\n\r\n");
-    ASSERT_TRUE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
-    EXPECT_EQ(response.length(), len);
+    ASSERT_TRUE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                    bytes_processed));
+    EXPECT_EQ(response.length(), bytes_processed);
   }
   {
     std::string response("HTTP/1.0 200 OK\n\r\n");
-    ASSERT_TRUE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
-    EXPECT_EQ(response.length(), len);
+    ASSERT_TRUE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                    bytes_processed));
+    EXPECT_EQ(response.length(), bytes_processed);
   }
   {
     std::string response("HTTP/1.0 200 OK\n\n");
-    ASSERT_TRUE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
-    EXPECT_EQ(response.length(), len);
+    ASSERT_TRUE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                    bytes_processed));
+    EXPECT_EQ(response.length(), bytes_processed);
   }
   {
     std::string response("HTTP/1.0 200 OK\r\n\n");
-    ASSERT_TRUE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
-    EXPECT_EQ(response.length(), len);
+    ASSERT_TRUE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                    bytes_processed));
+    EXPECT_EQ(response.length(), bytes_processed);
   }
   {
     // Extra headers are OK.
     std::string response("HTTP/1.0 200 OK\r\nFoo: Bar\r\n\r\n");
-    ASSERT_TRUE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
-    EXPECT_EQ(response.length(), len);
+    ASSERT_TRUE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                    bytes_processed));
+    EXPECT_EQ(response.length(), bytes_processed);
   }
   {
     // Extra whitespace and extra payload are OK.
     std::string response("HTTP/1.1   200  OK \r\n\r\nasdf");
-    ASSERT_TRUE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
-    EXPECT_EQ(response.length(), len + 4);
+    ASSERT_TRUE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                    bytes_processed));
+    EXPECT_EQ(response.length(), bytes_processed + 4);
   }
   {
     // 300 is not OK.
     std::string response("HTTP/1.0 300 OK\r\n\r\n");
-    ASSERT_FALSE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
+    ASSERT_FALSE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                     bytes_processed));
     EXPECT_TRUE(headers_complete);
   }
   {
     // Only one CRLF: incomplete headers.
     std::string response("HTTP/1.0 200 OK\r\n");
-    ASSERT_FALSE(
-        UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete, len));
+    ASSERT_FALSE(UpstreamHttp11ConnectSocket::isValidConnectResponse(response, headers_complete,
+                                                                     bytes_processed));
     EXPECT_FALSE(headers_complete);
   }
 }


### PR DESCRIPTION
By the HTTP/1.1 spec, all headers are supposed to end with CRLF (\r\n)
Turns out the HTTP/1.1 spec also call out some broken legacy servers only return LF (\n")
Removing a performance optimization that was breaking on proxies with this bug.

Risk Level: low
Testing: new unit test
Docs Changes: n/a
Release Notes: not included