### PR TITLE
mobile: add CircleCI docs generation CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+executors:
+  ubuntu-build:
+    description: "A regular build executor based on ubuntu image"
+    docker:
+      - image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682
+    # TODO(mattklein123): Get xlarge class enabled
+    resource_class: medium
+    working_directory: /source
+
+jobs:
+  docs:
+    executor: ubuntu-build
+    steps:
+      - checkout
+      - run: mobile/docs/build.sh
+      - add_ssh_keys:
+          fingerprints:
+            - "a2:f7:59:f0:01:8b:91:31:ab:0c:3f:9f:25:4c:1e:e5"
+      - run: mobile/docs/publish.sh
+      - store_artifacts:
+          path: generated/docs
+
+workflows:
+  version: 2
+  all:
+    jobs:
+      - docs:
+          filters:
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: mobile/docs/build.sh
       - add_ssh_keys:
           fingerprints:
-            - "a2:f7:59:f0:01:8b:91:31:ab:0c:3f:9f:25:4c:1e:e5"
+            - "33:78:4d:5c:bd:62:2e:43:9d:79:2c:3e:dc:45:c0:98"
       - run: mobile/docs/publish.sh
       - store_artifacts:
           path: generated/docs

--- a/mobile/docs/build.sh
+++ b/mobile/docs/build.sh
@@ -3,20 +3,20 @@
 set -e
 
 # shellcheck disable=SC1091
-. envoy/tools/shell_utils.sh
+. tools/shell_utils.sh
 
 # We need to set ENVOY_DOCS_VERSION_STRING and ENVOY_DOCS_RELEASE_LEVEL for Sphinx.
 # We also validate that the tag and version match at this point if needed.
 
 # Docs for release tags are reserved for vX.Y.Z versions.
 # vX.Y.Z.ddmmyy do not publish tagged docs.
-VERSION_NUMBER=$(cat VERSION)
+VERSION_NUMBER=$(cat mobile/VERSION)
 if [[ -n "$CIRCLE_TAG" ]] && [[ "${VERSION_NUMBER}" =~ ^[0-9]+\.[0-9]+\.[0-9]$ ]]
 then
   # Check the git tag matches the version number in the VERSION file.
   if [ "v${VERSION_NUMBER}" != "${CIRCLE_TAG}" ]; then
     echo "Given git tag does not match the VERSION file content:"
-    echo "${CIRCLE_TAG} vs $(cat VERSION)"
+    echo "${CIRCLE_TAG} vs $(cat mobile/VERSION)"
     exit 1
   fi
   # Check the version_history.rst contains current release version.

--- a/mobile/docs/publish.sh
+++ b/mobile/docs/publish.sh
@@ -20,8 +20,10 @@ elif [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" == "main" ]
 then
   PUBLISH_DIR="$CHECKOUT_DIR"/docs/envoy-mobile/latest
 else
-  echo "Ignoring docs push"
-  exit 0
+  # TODO(jpsim): Revert
+  PUBLISH_DIR="$CHECKOUT_DIR"/docs/envoy-mobile/latest
+  # echo "Ignoring docs push"
+  # exit 0
 fi
 
 echo 'cloning'

--- a/mobile/docs/publish.sh
+++ b/mobile/docs/publish.sh
@@ -20,10 +20,8 @@ elif [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" == "main" ]
 then
   PUBLISH_DIR="$CHECKOUT_DIR"/docs/envoy-mobile/latest
 else
-  # TODO(jpsim): Revert
-  PUBLISH_DIR="$CHECKOUT_DIR"/docs/envoy-mobile/latest
-  # echo "Ignoring docs push"
-  # exit 0
+  echo "Ignoring docs push"
+  exit 0
 fi
 
 echo 'cloning'


### PR DESCRIPTION
This is the CI job that's responsible for building the public website docs at https://envoymobile.io.

Commit Message: mobile: add CircleCI docs generation CI job
Additional Description: This is the CI job that's responsible for building the public website docs at https://envoymobile.io.
Risk Level: Low
Testing: In Envoy Mobile repo.
Docs Changes: Yes :)
Release Notes: None.
Platform Specific Features: Only relevant to mobile.

Part of https://github.com/envoyproxy/envoy/issues/23758