### PR TITLE
Reduce Route memory utilization by avoiding RuntimeData instances when not needed

### DIFF
--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -967,7 +967,8 @@ private:
   absl::InlinedVector<const HeaderParser*, 3>
   getResponseHeaderParsers(bool specificity_ascend) const;
 
-  absl::optional<RuntimeData> loadRuntimeData(const envoy::config::route::v3::RouteMatch& route);
+  std::unique_ptr<const RuntimeData>
+  loadRuntimeData(const envoy::config::route::v3::RouteMatch& route);
 
   static std::multimap<std::string, std::string>
   parseOpaqueConfig(const envoy::config::route::v3::Route& route);
@@ -1033,7 +1034,7 @@ private:
   const absl::optional<std::chrono::milliseconds> max_grpc_timeout_;
   const absl::optional<std::chrono::milliseconds> grpc_timeout_offset_;
   Runtime::Loader& loader_;
-  const absl::optional<RuntimeData> runtime_;
+  std::unique_ptr<const RuntimeData> runtime_;
   const std::string scheme_redirect_;
   const std::string host_redirect_;
   const std::string port_redirect_;


### PR DESCRIPTION
Reduce Route memory utilization by avoiding RuntimeData instances when not needed

Currently an instance of RuntimeData is created in each route, even if no runtime fractions are configured. This PR switches the instance to unique_ptr and only creates RuntimeData objects when actually configured.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
