### PR TITLE
Break dependency loop in UHV headers

### DIFF
--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -13,19 +13,66 @@ envoy_cc_library(
     name = "header_validator_common",
     srcs = [
         "header_validator.cc",
+    ],
+    hdrs = [
+        "header_validator.h",
+    ],
+    visibility = [
+        "//test/common/http/http1:__subpackages__",
+        "//test/extensions/http/header_validators/envoy_default:__subpackages__",
+    ],
+    deps = [
+        ":character_tables",
+        ":error_codes",
+        ":path_normalizer",
+        "//envoy/http:header_validator_interface",
+        "//external:abseil_node_hash_set",
+        "//source/common/http:headers_lib",
+        "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "character_tables",
+    hdrs = [
+        "character_tables.h",
+    ],
+    visibility = [
+        "//test/common/http/http1:__subpackages__",
+        "//test/extensions/http/header_validators/envoy_default:__subpackages__",
+    ],
+)
+
+envoy_cc_library(
+    name = "error_codes",
+    hdrs = [
+        "error_codes.h",
+    ],
+    visibility = [
+        "//test/common/http/http1:__subpackages__",
+        "//test/extensions/http/header_validators/envoy_default:__subpackages__",
+    ],
+    deps = [
+        "//source/common/singleton:const_singleton",
+    ],
+)
+
+envoy_cc_library(
+    name = "path_normalizer",
+    srcs = [
         "path_normalizer.cc",
     ],
     hdrs = [
-        "character_tables.h",
-        "header_validator.h",
         "path_normalizer.h",
     ],
     visibility = [
         "//test/common/http/http1:__subpackages__",
+        "//test/extensions/http/header_validators/envoy_default:__subpackages__",
     ],
     deps = [
+        ":character_tables",
+        ":error_codes",
         "//envoy/http:header_validator_interface",
-        "//external:abseil_node_hash_set",
         "//source/common/http:headers_lib",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],
@@ -41,8 +88,10 @@ envoy_cc_library(
     ],
     visibility = [
         "//test/common/http/http1:__subpackages__",
+        "//test/extensions/http/header_validators/envoy_default:__subpackages__",
     ],
     deps = [
+        ":error_codes",
         ":header_validator_common",
         "//envoy/http:header_validator_interface",
         "//external:abseil_node_hash_set",
@@ -61,8 +110,10 @@ envoy_cc_library(
     ],
     visibility = [
         "//test/common/http/http1:__subpackages__",
+        "//test/extensions/http/header_validators/envoy_default:__subpackages__",
     ],
     deps = [
+        ":error_codes",
         ":header_validator_common",
         "//envoy/http:header_validator_interface",
         "//external:abseil_node_hash_map",

--- a/source/extensions/http/header_validators/envoy_default/error_codes.h
+++ b/source/extensions/http/header_validators/envoy_default/error_codes.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "source/common/singleton/const_singleton.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Http {
+namespace HeaderValidators {
+namespace EnvoyDefault {
+
+struct UhvResponseCodeDetailValues {
+  const std::string InvalidNameCharacters = "uhv.invalid_name_characters";
+  const std::string InvalidValueCharacters = "uhv.invalid_value_characters";
+  const std::string InvalidUrl = "uhv.invalid_url";
+  const std::string InvalidHost = "uhv.invalid_host";
+  const std::string InvalidScheme = "uhv.invalid_scheme";
+  const std::string InvalidMethod = "uhv.invalid_method";
+  const std::string InvalidContentLength = "uhv.invalid_content_length";
+  const std::string InvalidUnderscore = "uhv.unexpected_underscore";
+  const std::string InvalidStatus = "uhv.invalid_status";
+  const std::string EmptyHeaderName = "uhv.empty_header_name";
+  const std::string InvalidPseudoHeader = "uhv.invalid_pseudo_header";
+  const std::string InvalidHostDeprecatedUserInfo = "uhv.invalid_host_deprecated_user_info";
+};
+
+using UhvResponseCodeDetail = ConstSingleton<UhvResponseCodeDetailValues>;
+
+} // namespace EnvoyDefault
+} // namespace HeaderValidators
+} // namespace Http
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/http/header_validators/envoy_default/error_codes.h
+++ b/source/extensions/http/header_validators/envoy_default/error_codes.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "source/common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -3,6 +3,7 @@
 #include <charconv>
 
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 
 #include "absl/container/node_hash_set.h"
 

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -139,23 +139,6 @@ protected:
   const PathNormalizer path_normalizer_;
 };
 
-struct UhvResponseCodeDetailValues {
-  const std::string InvalidNameCharacters = "uhv.invalid_name_characters";
-  const std::string InvalidValueCharacters = "uhv.invalid_value_characters";
-  const std::string InvalidUrl = "uhv.invalid_url";
-  const std::string InvalidHost = "uhv.invalid_host";
-  const std::string InvalidScheme = "uhv.invalid_scheme";
-  const std::string InvalidMethod = "uhv.invalid_method";
-  const std::string InvalidContentLength = "uhv.invalid_content_length";
-  const std::string InvalidUnderscore = "uhv.unexpected_underscore";
-  const std::string InvalidStatus = "uhv.invalid_status";
-  const std::string EmptyHeaderName = "uhv.empty_header_name";
-  const std::string InvalidPseudoHeader = "uhv.invalid_pseudo_header";
-  const std::string InvalidHostDeprecatedUserInfo = "uhv.invalid_host_deprecated_user_info";
-};
-
-using UhvResponseCodeDetail = ConstSingleton<UhvResponseCodeDetailValues>;
-
 } // namespace EnvoyDefault
 } // namespace HeaderValidators
 } // namespace Http

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -2,6 +2,7 @@
 
 #include "source/common/http/utility.h"
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 
 #include "absl/container/node_hash_set.h"
 #include "absl/strings/string_view.h"

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/http/header_validators/envoy_default/http2_header_validator.h"
 
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 
 #include "absl/container/node_hash_map.h"
 #include "absl/container/node_hash_set.h"

--- a/source/extensions/http/header_validators/envoy_default/path_normalizer.cc
+++ b/source/extensions/http/header_validators/envoy_default/path_normalizer.cc
@@ -1,7 +1,8 @@
 #include "source/extensions/http/header_validators/envoy_default/path_normalizer.h"
 
+#include "source/common/http/headers.h"
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
-#include "source/extensions/http/header_validators/envoy_default/header_validator.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/http/header_validators/envoy_default/BUILD
+++ b/test/extensions/http/header_validators/envoy_default/BUILD
@@ -5,6 +5,7 @@ load(
 load(
     "//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
+    "envoy_extension_cc_test_library",
 )
 
 licenses(["notice"])  # Apache 2
@@ -14,12 +15,62 @@ envoy_package()
 envoy_extension_cc_test(
     name = "header_validator_test",
     srcs = [
-        "header_validator_factory_test.cc",
         "header_validator_test.cc",
-        "header_validator_test.h",
+    ],
+    extension_names = ["envoy.http.header_validators.envoy_default"],
+    deps = [
+        ":header_validator_test_lib",
+        "//source/common/network:utility_lib",
+        "//source/extensions/http/header_validators/envoy_default:character_tables",
+        "//source/extensions/http/header_validators/envoy_default:error_codes",
+        "//source/extensions/http/header_validators/envoy_default:header_validator_common",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "http1_header_validator_test",
+    srcs = [
         "http1_header_validator_test.cc",
+    ],
+    extension_names = ["envoy.http.header_validators.envoy_default"],
+    deps = [
+        ":header_validator_test_lib",
+        "//source/extensions/http/header_validators/envoy_default:error_codes",
+        "//source/extensions/http/header_validators/envoy_default:http1_header_validator",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "http2_header_validator_test",
+    srcs = [
         "http2_header_validator_test.cc",
-        "path_normalizer_test.cc",
+    ],
+    extension_names = ["envoy.http.header_validators.envoy_default"],
+    deps = [
+        ":header_validator_test_lib",
+        "//source/extensions/http/header_validators/envoy_default:character_tables",
+        "//source/extensions/http/header_validators/envoy_default:error_codes",
+        "//source/extensions/http/header_validators/envoy_default:http2_header_validator",
+    ],
+)
+
+envoy_extension_cc_test_library(
+    name = "header_validator_test_lib",
+    hdrs = [
+        "header_validator_test.h",
+    ],
+    extension_names = ["envoy.http.header_validators.envoy_default"],
+    deps = [
+        "//source/extensions/http/header_validators/envoy_default:config",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "header_validator_factory_test",
+    srcs = [
+        "header_validator_factory_test.cc",
     ],
     extension_names = ["envoy.http.header_validators.envoy_default"],
     deps = [
@@ -38,8 +89,7 @@ envoy_extension_cc_test(
     ],
     extension_names = ["envoy.http.header_validators.envoy_default"],
     deps = [
-        # "//source/common/network:utility_lib",
-        "//source/extensions/http/header_validators/envoy_default:config",
+        "//source/extensions/http/header_validators/envoy_default:path_normalizer",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
@@ -1,6 +1,7 @@
 #include "test/extensions/http/header_validators/envoy_default/header_validator_test.h"
 
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 #include "source/extensions/http/header_validators/envoy_default/header_validator.h"
 
 namespace Envoy {

--- a/test/extensions/http/header_validators/envoy_default/header_validator_test.h
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_test.h
@@ -1,7 +1,5 @@
 #include "envoy/extensions/http/header_validators/envoy_default/v3/header_validator.pb.h"
 
-#include "source/extensions/http/header_validators/envoy_default/config.h"
-
 #include "test/mocks/stream_info/mocks.h"
 
 #include "gtest/gtest.h"

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -1,3 +1,4 @@
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 #include "source/extensions/http/header_validators/envoy_default/http1_header_validator.h"
 
 #include "test/extensions/http/header_validators/envoy_default/header_validator_test.h"

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -1,4 +1,5 @@
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 #include "source/extensions/http/header_validators/envoy_default/http2_header_validator.h"
 
 #include "test/extensions/http/header_validators/envoy_default/header_validator_test.h"

--- a/test/extensions/http/header_validators/envoy_default/path_normalizer_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/path_normalizer_test.cc
@@ -1,4 +1,4 @@
-#include "source/extensions/http/header_validators/envoy_default/header_validator.h"
+#include "source/extensions/http/header_validators/envoy_default/error_codes.h"
 #include "source/extensions/http/header_validators/envoy_default/path_normalizer.h"
 
 #include "test/test_common/utility.h"


### PR DESCRIPTION
Additional Description:
Makes adding fuzz test targets easier.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
