### PR TITLE
Store DNS answers in map instead of unordered map

### DIFF
--- a/source/extensions/filters/udp/dns_filter/dns_parser.h
+++ b/source/extensions/filters/udp/dns_filter/dns_parser.h
@@ -73,7 +73,7 @@ public:
 };
 
 using DnsAnswerRecordPtr = std::unique_ptr<DnsAnswerRecord>;
-using DnsAnswerMap = std::unordered_multimap<std::string, DnsAnswerRecordPtr>;
+using DnsAnswerMap = std::multimap<std::string, DnsAnswerRecordPtr>;
 
 /**
  * DnsSrvRecord represents a single answer record for a service which is to be serialized and

--- a/test/extensions/filters/udp/dns_filter/dns_filter_test_utils.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test_utils.cc
@@ -237,7 +237,6 @@ bool DnsResponseValidator::validateDnsResponseObject(DnsQueryContextPtr& context
 
 bool DnsResponseValidator::parseAnswerRecords(DnsAnswerMap& answers, const uint16_t answer_count,
                                               const Buffer::InstancePtr& buffer, uint64_t& offset) {
-  answers.reserve(answer_count);
   for (auto index = 0; index < answer_count; index++) {
     ENVOY_LOG(trace, "Parsing [{}/{}] answers", index, answer_count);
     auto rec = parseDnsAnswerRecord(buffer, offset);


### PR DESCRIPTION
The current code assumes the order when iterating over the map is the same as when elements are inserted. This is not true when using an unordered map.

In particular there's one test that relies on this behavior: https://github.com/envoyproxy/envoy/blob/de2548820518e06b36a82e486cd13158f44abd31/test/extensions/filters/udp/dns_filter/dns_filter_test.cc#L1929 This test is always failing in my environment because the first entry of `response_ctx_->answers_` is always `"10.0.16.1"`.

One possible solution would be to just remove that test as this behavior cannot be guaranteed. Not sure if this is the right thing to do as current code (e.g. here:
https://github.com/envoyproxy/envoy/blob/de2548820518e06b36a82e486cd13158f44abd31/source/extensions/filters/udp/dns_filter/dns_parser.cc#L493) assumes on this behavior.

Signed-off-by: Jonh Wendell <jwendell@redhat.com>
