### PR TITLE
kafka: add support for list-offsets request

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/BUILD
@@ -69,6 +69,7 @@ envoy_cc_library(
         "//contrib/kafka/filters/network/source:kafka_request_codec_lib",
         "//contrib/kafka/filters/network/source:kafka_request_parser_lib",
         "//contrib/kafka/filters/network/source/mesh/command_handlers:api_versions_lib",
+        "//contrib/kafka/filters/network/source/mesh/command_handlers:list_offsets_lib",
         "//contrib/kafka/filters/network/source/mesh/command_handlers:metadata_lib",
         "//contrib/kafka/filters/network/source/mesh/command_handlers:produce_lib",
         "//source/common/common:minimal_logger_lib",

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
@@ -46,6 +46,23 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "list_offsets_lib",
+    srcs = [
+        "list_offsets.cc",
+    ],
+    hdrs = [
+        "list_offsets.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        "//contrib/kafka/filters/network/source:kafka_request_parser_lib",
+        "//contrib/kafka/filters/network/source:kafka_response_parser_lib",
+        "//contrib/kafka/filters/network/source/mesh:abstract_command_lib",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "metadata_lib",
     srcs = [
         "metadata.cc",

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/api_versions.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/api_versions.cc
@@ -15,6 +15,10 @@ namespace Mesh {
 // going to handle only produce requests with versions higher than 5.
 constexpr int16_t MIN_PRODUCE_SUPPORTED = 5;
 constexpr int16_t MAX_PRODUCE_SUPPORTED = PRODUCE_REQUEST_MAX_VERSION; /* Generated value. */
+// List-offsets version 0 uses old-style offsets.
+constexpr int16_t MIN_LIST_OFFSETS_SUPPORTED = 1;
+constexpr int16_t MAX_LIST_OFFSETS_SUPPORTED =
+    LIST_OFFSETS_REQUEST_MAX_VERSION; /* Generated value. */
 // Right now we do not want to handle old version 0 request, as it expects us to enumerate all
 // topics if list of requested topics is empty.
 // Impl note: if filter gains knowledge of upstream cluster topics (e.g. thru admin clients), we
@@ -40,9 +44,12 @@ AbstractResponseSharedPtr ApiVersionsRequestHolder::computeAnswer() const {
   const int16_t error_code = 0;
   const ApiVersion produce_entry = {PRODUCE_REQUEST_API_KEY, MIN_PRODUCE_SUPPORTED,
                                     MAX_PRODUCE_SUPPORTED};
+  const ApiVersion list_offsets_entry = {LIST_OFFSETS_REQUEST_API_KEY, MIN_LIST_OFFSETS_SUPPORTED,
+                                         MAX_LIST_OFFSETS_SUPPORTED};
   const ApiVersion metadata_entry = {METADATA_REQUEST_API_KEY, MIN_METADATA_SUPPORTED,
                                      MAX_METADATA_SUPPORTED};
-  const ApiVersionsResponse real_response = {error_code, {produce_entry, metadata_entry}};
+  const ApiVersionsResponse real_response = {error_code,
+                                             {produce_entry, list_offsets_entry, metadata_entry}};
 
   return std::make_shared<Response<ApiVersionsResponse>>(metadata, real_response);
 }

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.cc
@@ -1,0 +1,52 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.h"
+
+#include "contrib/kafka/filters/network/source/external/responses.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+ListOffsetsRequestHolder::ListOffsetsRequestHolder(
+    AbstractRequestListener& filter, const std::shared_ptr<Request<ListOffsetsRequest>> request)
+    : BaseInFlightRequest{filter}, request_{request} {}
+
+void ListOffsetsRequestHolder::startProcessing() { notifyFilter(); }
+
+bool ListOffsetsRequestHolder::finished() const { return true; }
+
+AbstractResponseSharedPtr ListOffsetsRequestHolder::computeAnswer() const {
+  const auto& header = request_->request_header_;
+  const ResponseMetadata metadata = {header.api_key_, header.api_version_, header.correlation_id_};
+
+  // The response contains all the requested topics (we do not do any filtering here).
+  const auto& topics = request_->data_.topics_;
+  std::vector<ListOffsetsTopicResponse> topic_responses;
+  topic_responses.reserve(topics.size());
+  for (const auto& topic : topics) {
+    const auto& partitions = topic.partitions_;
+    std::vector<ListOffsetsPartitionResponse> partition_responses;
+    partition_responses.reserve(partitions.size());
+    for (const auto& partition : partitions) {
+      const int16_t error_code = 0;
+      const int64_t timestamp = 0;
+      /* As we are going to ignore consumer offset requests, we can reply with dummy values. */
+      const int64_t offset = 0;
+      const ListOffsetsPartitionResponse partition_response = {partition.partition_index_,
+                                                               error_code, timestamp, offset};
+      partition_responses.push_back(partition_response);
+    }
+    const ListOffsetsTopicResponse topic_response = {topic.name_, partition_responses};
+    topic_responses.push_back(topic_response);
+  }
+
+  const ListOffsetsResponse data = {topic_responses};
+  return std::make_shared<Response<ListOffsetsResponse>>(metadata, data);
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "contrib/kafka/filters/network/source/external/requests.h"
+#include "contrib/kafka/filters/network/source/mesh/abstract_command.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+class ListOffsetsRequestHolder : public BaseInFlightRequest {
+public:
+  ListOffsetsRequestHolder(AbstractRequestListener& filter,
+                           const std::shared_ptr<Request<ListOffsetsRequest>> request);
+
+  void startProcessing() override;
+
+  bool finished() const override;
+
+  AbstractResponseSharedPtr computeAnswer() const override;
+
+private:
+  // Original request.
+  const std::shared_ptr<Request<ListOffsetsRequest>> request_;
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/request_processor.cc
+++ b/contrib/kafka/filters/network/source/mesh/request_processor.cc
@@ -3,6 +3,7 @@
 #include "envoy/common/exception.h"
 
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/api_versions.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.h"
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/metadata.h"
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/produce.h"
 
@@ -29,6 +30,9 @@ void RequestProcessor::onMessage(AbstractRequestSharedPtr arg) {
   case PRODUCE_REQUEST_API_KEY:
     process(std::dynamic_pointer_cast<Request<ProduceRequest>>(arg));
     break;
+  case LIST_OFFSETS_REQUEST_API_KEY:
+    process(std::dynamic_pointer_cast<Request<ListOffsetsRequest>>(arg));
+    break;
   case METADATA_REQUEST_API_KEY:
     process(std::dynamic_pointer_cast<Request<MetadataRequest>>(arg));
     break;
@@ -44,6 +48,11 @@ void RequestProcessor::onMessage(AbstractRequestSharedPtr arg) {
 
 void RequestProcessor::process(const std::shared_ptr<Request<ProduceRequest>> request) const {
   auto res = std::make_shared<ProduceRequestHolder>(origin_, upstream_kafka_facade_, request);
+  origin_.onRequest(res);
+}
+
+void RequestProcessor::process(const std::shared_ptr<Request<ListOffsetsRequest>> request) const {
+  auto res = std::make_shared<ListOffsetsRequestHolder>(origin_, request);
   origin_.onRequest(res);
 }
 

--- a/contrib/kafka/filters/network/source/mesh/request_processor.h
+++ b/contrib/kafka/filters/network/source/mesh/request_processor.h
@@ -28,6 +28,7 @@ public:
 
 private:
   void process(const std::shared_ptr<Request<ProduceRequest>> request) const;
+  void process(const std::shared_ptr<Request<ListOffsetsRequest>> request) const;
   void process(const std::shared_ptr<Request<MetadataRequest>> request) const;
   void process(const std::shared_ptr<Request<ApiVersionsRequest>> request) const;
 

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/BUILD
@@ -29,6 +29,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "list_offsets_unit_test",
+    srcs = ["list_offsets_unit_test.cc"],
+    tags = ["skip_on_windows"],
+    deps = [
+        "//contrib/kafka/filters/network/source/mesh/command_handlers:list_offsets_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "metadata_unit_test",
     srcs = ["metadata_unit_test.cc"],
     tags = ["skip_on_windows"],

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
@@ -1,0 +1,46 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+namespace {
+
+class MockAbstractRequestListener : public AbstractRequestListener {
+public:
+  MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
+  MOCK_METHOD(void, onRequestReadyForAnswer, ());
+};
+
+TEST(ListOffsetsTest, shouldBeAlwaysReadyForAnswer) {
+  // given
+  MockAbstractRequestListener filter;
+  EXPECT_CALL(filter, onRequestReadyForAnswer());
+  const RequestHeader header = {LIST_OFFSETS_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const ListOffsetsRequest data = {0, {}};
+  const auto message = std::make_shared<Request<ListOffsetsRequest>>(header, data);
+  ListOffsetsRequestHolder testee = {filter, message};
+
+  // when, then - invoking should immediately notify the filter.
+  testee.startProcessing();
+
+  // when, then - should always be considered finished.
+  const bool finished = testee.finished();
+  EXPECT_TRUE(finished);
+
+  // when, then - the computed result is always contains correct data (confirmed by integration
+  // tests).
+  const auto answer = testee.computeAnswer();
+  EXPECT_EQ(answer->metadata_.api_key_, header.api_key_);
+  EXPECT_EQ(answer->metadata_.correlation_id_, header.correlation_id_);
+}
+
+} // namespace
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: kafka: add support for list-offsets request
Additional Description: When Kafka consumer starts getting records from upstream Kafka cluster, the first request it sends to upstream is actually asking for its position (this data is then used in following requests, updated as records are received). As the offset management is going to be left to proxy/Envoy we can send a trivial `0` here, simplifying the code.
Required for https://github.com/envoyproxy/envoy/issues/24372
Risk Level: Low
Testing: unit tests, full integration stack with Fetch requets
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A