### PR TITLE
Remove uneccessary `this->` from mobile engine builder

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -271,7 +271,7 @@ std::string EngineBuilder::generateConfigStr() const {
 
   const std::string& cert_validation_template =
       (platform_certificates_validation_on_ ? platform_cert_validation_context_template
-                                                  : default_cert_validation_context_template);
+                                            : default_cert_validation_context_template);
   config_builder << cert_validation_template << std::endl;
 
   std::string config_template = config_template_;

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -25,167 +25,167 @@ EngineBuilder::EngineBuilder(std::string config_template)
 EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {}
 
 EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
-  this->log_level_ = log_level;
+  log_level_ = log_level;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setOnEngineRunning(std::function<void()> closure) {
-  this->callbacks_->on_engine_running = closure;
+  callbacks_->on_engine_running = closure;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addStatsSinks(const std::vector<std::string>& stat_sinks) {
-  this->stat_sinks_ = stat_sinks;
+  stat_sinks_ = stat_sinks;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addGrpcStatsDomain(std::string stats_domain) {
-  this->stats_domain_ = std::move(stats_domain);
+  stats_domain_ = std::move(stats_domain);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addConnectTimeoutSeconds(int connect_timeout_seconds) {
-  this->connect_timeout_seconds_ = connect_timeout_seconds;
+  connect_timeout_seconds_ = connect_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsRefreshSeconds(int dns_refresh_seconds) {
-  this->dns_refresh_seconds_ = dns_refresh_seconds;
+  dns_refresh_seconds_ = dns_refresh_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsMinRefreshSeconds(int dns_min_refresh_seconds) {
-  this->dns_min_refresh_seconds_ = dns_min_refresh_seconds;
+  dns_min_refresh_seconds_ = dns_min_refresh_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsFailureRefreshSeconds(int base, int max) {
-  this->dns_failure_refresh_seconds_base_ = base;
-  this->dns_failure_refresh_seconds_max_ = max;
+  dns_failure_refresh_seconds_base_ = base;
+  dns_failure_refresh_seconds_max_ = max;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds) {
-  this->dns_query_timeout_seconds_ = dns_query_timeout_seconds;
+  dns_query_timeout_seconds_ = dns_query_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsPreresolveHostnames(std::string dns_preresolve_hostnames) {
-  this->dns_preresolve_hostnames_ = std::move(dns_preresolve_hostnames);
+  dns_preresolve_hostnames_ = std::move(dns_preresolve_hostnames);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addMaxConnectionsPerHost(int max_connections_per_host) {
-  this->max_connections_per_host_ = max_connections_per_host;
+  max_connections_per_host_ = max_connections_per_host;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::useDnsSystemResolver(bool use_system_resolver) {
-  this->use_system_resolver_ = use_system_resolver;
+  use_system_resolver_ = use_system_resolver;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
     int h2_connection_keepalive_idle_interval_milliseconds) {
-  this->h2_connection_keepalive_idle_interval_milliseconds_ =
+  h2_connection_keepalive_idle_interval_milliseconds_ =
       h2_connection_keepalive_idle_interval_milliseconds;
   return *this;
 }
 
 EngineBuilder&
 EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
-  this->h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
+  h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addStatsFlushSeconds(int stats_flush_seconds) {
-  this->stats_flush_seconds_ = stats_flush_seconds;
+  stats_flush_seconds_ = stats_flush_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addVirtualClusters(std::string virtual_clusters) {
-  this->virtual_clusters_ = std::move(virtual_clusters);
+  virtual_clusters_ = std::move(virtual_clusters);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addKeyValueStore(std::string name,
                                                KeyValueStoreSharedPtr key_value_store) {
-  this->key_value_stores_[std::move(name)] = std::move(key_value_store);
+  key_value_stores_[std::move(name)] = std::move(key_value_store);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setAppVersion(std::string app_version) {
-  this->app_version_ = std::move(app_version);
+  app_version_ = std::move(app_version);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setAppId(std::string app_id) {
-  this->app_id_ = std::move(app_id);
+  app_id_ = std::move(app_id);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setDeviceOs(std::string device_os) {
-  this->device_os_ = std::move(device_os);
+  device_os_ = std::move(device_os);
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds) {
-  this->stream_idle_timeout_seconds_ = stream_idle_timeout_seconds;
+  stream_idle_timeout_seconds_ = stream_idle_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds) {
-  this->per_try_idle_timeout_seconds_ = per_try_idle_timeout_seconds;
+  per_try_idle_timeout_seconds_ = per_try_idle_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableGzip(bool gzip_on) {
-  this->gzip_filter_ = gzip_on;
+  gzip_filter_ = gzip_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableBrotli(bool brotli_on) {
-  this->brotli_filter_ = brotli_on;
+  brotli_filter_ = brotli_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableSocketTagging(bool socket_tagging_on) {
-  this->socket_tagging_filter_ = socket_tagging_on;
+  socket_tagging_filter_ = socket_tagging_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableAdminInterface(bool admin_interface_on) {
-  this->admin_interface_enabled_ = admin_interface_on;
+  admin_interface_enabled_ = admin_interface_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableHappyEyeballs(bool happy_eyeballs_on) {
-  this->enable_happy_eyeballs_ = happy_eyeballs_on;
+  enable_happy_eyeballs_ = happy_eyeballs_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableHttp3(bool http3_on) {
-  this->enable_http3_ = http3_on;
+  enable_http3_ = http3_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableInterfaceBinding(bool interface_binding_on) {
-  this->enable_interface_binding_ = interface_binding_on;
+  enable_interface_binding_ = interface_binding_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on) {
-  this->enable_drain_post_dns_refresh_ = drain_post_dns_refresh_on;
+  enable_drain_post_dns_refresh_ = drain_post_dns_refresh_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enforceTrustChainVerification(bool trust_chain_verification_on) {
-  this->enforce_trust_chain_verification_ = trust_chain_verification_on;
+  enforce_trust_chain_verification_ = trust_chain_verification_on;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::enableH2ExtendKeepaliveTimeout(bool h2_extend_keepalive_timeout_on) {
-  this->h2_extend_keepalive_timeout_ = h2_extend_keepalive_timeout_on;
+  h2_extend_keepalive_timeout_ = h2_extend_keepalive_timeout_on;
   return *this;
 }
 
@@ -196,7 +196,7 @@ EngineBuilder::enablePlatformCertificatesValidation(bool platform_certificates_v
     PANIC("Certificates validation using platform provided APIs is not supported in IOS.");
   }
 #endif
-  this->platform_certificates_validation_on_ = platform_certificates_validation_on;
+  platform_certificates_validation_on_ = platform_certificates_validation_on;
   return *this;
 }
 
@@ -218,35 +218,35 @@ EngineBuilder& EngineBuilder::addPlatformFilter(std::string name) {
 
 std::string EngineBuilder::generateConfigStr() const {
   std::vector<std::pair<std::string, std::string>> replacements {
-    {"connect_timeout", fmt::format("{}s", this->connect_timeout_seconds_)},
-        {"dns_fail_base_interval", fmt::format("{}s", this->dns_failure_refresh_seconds_base_)},
-        {"dns_fail_max_interval", fmt::format("{}s", this->dns_failure_refresh_seconds_max_)},
+    {"connect_timeout", fmt::format("{}s", connect_timeout_seconds_)},
+        {"dns_fail_base_interval", fmt::format("{}s", dns_failure_refresh_seconds_base_)},
+        {"dns_fail_max_interval", fmt::format("{}s", dns_failure_refresh_seconds_max_)},
         {"dns_lookup_family", enable_happy_eyeballs_ ? "ALL" : "V4_PREFERRED"},
-        {"dns_min_refresh_rate", fmt::format("{}s", this->dns_min_refresh_seconds_)},
+        {"dns_min_refresh_rate", fmt::format("{}s", dns_min_refresh_seconds_)},
         {"dns_multiple_addresses", enable_happy_eyeballs_ ? "true" : "false"},
-        {"dns_preresolve_hostnames", this->dns_preresolve_hostnames_},
-        {"dns_refresh_rate", fmt::format("{}s", this->dns_refresh_seconds_)},
-        {"dns_query_timeout", fmt::format("{}s", this->dns_query_timeout_seconds_)},
+        {"dns_preresolve_hostnames", dns_preresolve_hostnames_},
+        {"dns_refresh_rate", fmt::format("{}s", dns_refresh_seconds_)},
+        {"dns_query_timeout", fmt::format("{}s", dns_query_timeout_seconds_)},
         {"enable_drain_post_dns_refresh", enable_drain_post_dns_refresh_ ? "true" : "false"},
         {"enable_interface_binding", enable_interface_binding_ ? "true" : "false"},
         {"h2_connection_keepalive_idle_interval",
-         fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
+         fmt::format("{}s", h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
         {"h2_connection_keepalive_timeout",
-         fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
+         fmt::format("{}s", h2_connection_keepalive_timeout_seconds_)},
         {"h2_delay_keepalive_timeout", h2_extend_keepalive_timeout_ ? "true" : "false"},
         {
             "metadata",
-            fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,
-                        this->app_version_, this->app_id_),
+            fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", device_os_,
+                        app_version_, app_id_),
         },
-        {"max_connections_per_host", fmt::format("{}", this->max_connections_per_host_)},
-        {"stats_domain", this->stats_domain_},
-        {"stats_flush_interval", fmt::format("{}s", this->stats_flush_seconds_)},
-        {"stream_idle_timeout", fmt::format("{}s", this->stream_idle_timeout_seconds_)},
+        {"max_connections_per_host", fmt::format("{}", max_connections_per_host_)},
+        {"stats_domain", stats_domain_},
+        {"stats_flush_interval", fmt::format("{}s", stats_flush_seconds_)},
+        {"stream_idle_timeout", fmt::format("{}s", stream_idle_timeout_seconds_)},
         {"trust_chain_verification",
          enforce_trust_chain_verification_ ? "VERIFY_TRUST_CHAIN" : "ACCEPT_UNTRUSTED"},
-        {"per_try_idle_timeout", fmt::format("{}s", this->per_try_idle_timeout_seconds_)},
-        {"virtual_clusters", this->virtual_clusters_},
+        {"per_try_idle_timeout", fmt::format("{}s", per_try_idle_timeout_seconds_)},
+        {"virtual_clusters", virtual_clusters_},
 #if defined(__ANDROID_API__)
         {"force_ipv6", "true"},
 #endif
@@ -270,21 +270,21 @@ std::string EngineBuilder::generateConfigStr() const {
   }
 
   const std::string& cert_validation_template =
-      (this->platform_certificates_validation_on_ ? platform_cert_validation_context_template
+      (platform_certificates_validation_on_ ? platform_cert_validation_context_template
                                                   : default_cert_validation_context_template);
   config_builder << cert_validation_template << std::endl;
 
   std::string config_template = config_template_;
-  if (this->gzip_filter_) {
+  if (gzip_filter_) {
     insertCustomFilter(gzip_config_insert, config_template);
   }
-  if (this->brotli_filter_) {
+  if (brotli_filter_) {
     insertCustomFilter(brotli_config_insert, config_template);
   }
-  if (this->socket_tagging_filter_) {
+  if (socket_tagging_filter_) {
     insertCustomFilter(socket_tag_config_insert, config_template);
   }
-  if (this->enable_http3_) {
+  if (enable_http3_) {
     insertCustomFilter(alternate_protocols_cache_filter_insert, config_template);
   }
 
@@ -324,12 +324,12 @@ EngineSharedPtr EngineBuilder::build() {
 
   std::string config_str;
   if (config_override_for_tests_.empty()) {
-    config_str = this->generateConfigStr();
+    config_str = generateConfigStr();
   } else {
     config_str = config_override_for_tests_;
   }
   envoy_engine_t envoy_engine =
-      init_engine(this->callbacks_->asEnvoyEngineCallbacks(), null_logger, null_tracker);
+      init_engine(callbacks_->asEnvoyEngineCallbacks(), null_logger, null_tracker);
 
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.
@@ -345,8 +345,8 @@ EngineSharedPtr EngineBuilder::build() {
     register_platform_api(name.c_str(), api);
   }
 
-  run_engine(envoy_engine, config_str.c_str(), logLevelToString(this->log_level_).c_str(),
-             this->admin_address_path_for_tests_.c_str());
+  run_engine(envoy_engine, config_str.c_str(), logLevelToString(log_level_).c_str(),
+             admin_address_path_for_tests_.c_str());
 
   // we can't construct via std::make_shared
   // because Engine is only constructible as a friend


### PR DESCRIPTION
This file uses `this->` whenever referencing class members but it doesn't need to. Let's just ctrl-f and delete them all.

Unit tests still work!