### PR TITLE
Fix mobile/vscode_compdb script for repo merge

### DIFF
--- a/mobile/tools/vscode_compdb.sh
+++ b/mobile/tools/vscode_compdb.sh
@@ -5,7 +5,7 @@
 # the correct envoy-mobile Bazel targets.
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-CC=clang TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-mobile-compdb envoy/tools/gen_compilation_database.py --vscode --bazel ./bazelw //library/cc/... //library/common/... //test/cc/... //test/common/...
+CC=clang TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-mobile-compdb ../tools/gen_compilation_database.py --vscode --bazel ./bazelw //library/cc/... //library/common/... //test/cc/... //test/common/...
 
 # Kill clangd to reload the compilation database
 pkill clangd || :


### PR DESCRIPTION
This script is still necessary for now because mobile can only be built from the mobile directory due to bazelrc magic. Let's fix the script in-place for now and hopefully clean it up later once mobile can be built from the top-level directory.

Verified that it runs successfully and seems to make vscode happy.