### PR TITLE
ci: update `actions/setup-java` from v1 to v3.8

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -24,6 +24,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Build envoy.aar distributable'
@@ -47,6 +48,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - run: cd mobile && ./ci/mac_ci_setup.sh --android
       name: 'Install dependencies'
     - name: 'Start simulator'
@@ -79,6 +81,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Start simulator'
@@ -111,6 +114,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Start simulator'
@@ -143,6 +147,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Start simulator'

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -33,7 +33,7 @@ jobs:
           fi
     - name: 'Java setup'
       if: steps.check_context.outputs.run_tests == 'true'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk
@@ -70,7 +70,7 @@ jobs:
           fi
     - name: 'Java setup'
       if: steps.check_context.outputs.run_tests == 'true'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk
@@ -117,7 +117,7 @@ jobs:
           fi
     - name: 'Java setup'
       if: steps.check_context.outputs.run_tests == 'true'
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -38,6 +38,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       if: steps.check_context.outputs.run_tests == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
@@ -75,6 +76,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       if: steps.check_context.outputs.run_tests == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
@@ -122,6 +124,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Install dependencies'
       if: steps.check_context.outputs.run_tests == 'true'
       run: cd mobile && ./ci/linux_ci_setup.sh

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -36,7 +36,7 @@ jobs:
             echo "Skipping tests."
             echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       if: steps.check-cache.outputs.cache-hit != 'true'
       with:
         java-version: '8'

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -42,6 +42,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Run tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -70,6 +70,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - run: cd mobile && ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Run Kotlin Lint (Detekt)'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 45
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
         java-package: jdk

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -36,7 +36,7 @@ jobs:
             echo "Skipping tests."
             echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       if: steps.check-cache.outputs.cache-hit != 'true'
       with:
         java-version: '8'

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -42,6 +42,7 @@ jobs:
         java-version: '8'
         java-package: jdk
         architecture: x64
+        distribution: zulu
     - name: 'Run tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/actions/setup-java/releases/tag/v3.8.0

This should fix a number of GitHub Actions deprecations:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-java@v1
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]