### PR TITLE
swift: stop using loopback for direct responses

### DIFF
--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -267,7 +267,6 @@ const char* config_template = R"(
             - name: remote_service
               domains: ["*"]
               routes:
-#{fake_remote_responses}
               - match: { prefix: "/" }
                 direct_response: { status: 404, body: { inline_string: "not found" } }
                 request_headers_to_remove:
@@ -375,6 +374,15 @@ static_resources:
           route_config:
             name: api_router
             virtual_hosts:
+            - name: remote_service
+              domains: ["127.0.0.1"]
+              routes:
+#{fake_remote_responses}
+              - match: { prefix: "/" }
+                direct_response: { status: 404, body: { inline_string: "not found" } }
+                request_headers_to_remove:
+                - x-forwarded-proto
+                - x-envoy-mobile-cluster
 )"
 // The list of virtual hosts impacts directly the number of virtual cluster stats.
 // That's because we create a separate set of virtual clusters stats for every

--- a/mobile/library/common/extensions/filters/http/local_error/BUILD
+++ b/mobile/library/common/extensions/filters/http/local_error/BUILD
@@ -21,6 +21,7 @@ envoy_cc_extension(
     repository = "@envoy",
     deps = [
         ":filter_cc_proto",
+        "//library/common/http:header_utility_lib",
         "//library/common/http:internal_headers_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/http:codes_interface",

--- a/mobile/library/common/extensions/filters/http/local_error/filter.cc
+++ b/mobile/library/common/extensions/filters/http/local_error/filter.cc
@@ -2,6 +2,8 @@
 
 #include "envoy/server/filter_config.h"
 
+#include "library/common/http/header_utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -18,7 +20,7 @@ Http::LocalErrorStatus LocalErrorFilter::onLocalReply(const LocalReplyData& repl
   // ASSERT(reply.details_ == info.responseCodeDetails().value());
   info.setResponseCode(static_cast<uint32_t>(reply.code_));
 
-  return Http::LocalErrorStatus::ContinueAndResetStream;
+  return Http::Utility::statusForOnLocalReply(reply, decoder_callbacks_->streamInfo());
 }
 
 } // namespace LocalError

--- a/mobile/library/common/extensions/filters/http/network_configuration/BUILD
+++ b/mobile/library/common/extensions/filters/http/network_configuration/BUILD
@@ -21,6 +21,7 @@ envoy_cc_extension(
     repository = "@envoy",
     deps = [
         ":filter_cc_proto",
+        "//library/common/http:header_utility_lib",
         "//library/common/http:internal_headers_lib",
         "//library/common/network:connectivity_manager_lib",
         "//library/common/stream_info:extra_stream_info_lib",

--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -4,6 +4,8 @@
 
 #include "source/common/network/filter_state_proxy_info.h"
 
+#include "library/common/http/header_utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -159,7 +161,7 @@ Http::LocalErrorStatus NetworkConfigurationFilter::onLocalReply(const LocalReply
   connectivity_manager_->reportNetworkUsage(extra_stream_info_->configuration_key_.value(),
                                             network_fault);
 
-  return Http::LocalErrorStatus::ContinueAndResetStream;
+  return Http::Utility::statusForOnLocalReply(reply, decoder_callbacks_->streamInfo());
 }
 
 void NetworkConfigurationFilter::onDestroy() { dns_cache_handle_.reset(); }

--- a/mobile/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/mobile/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -214,7 +214,7 @@ Http::LocalErrorStatus PlatformBridgeFilter::onLocalReply(const LocalReplyData& 
                               finalStreamIntel(), platform_filter_.instance_context);
   }
 
-  return Http::LocalErrorStatus::ContinueAndResetStream;
+  return Http::Utility::statusForOnLocalReply(reply, decoder_callbacks_->streamInfo());
 }
 
 envoy_final_stream_intel PlatformBridgeFilter::finalStreamIntel() {

--- a/mobile/library/common/http/BUILD
+++ b/mobile/library/common/http/BUILD
@@ -55,6 +55,7 @@ envoy_cc_library(
         "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/buffer:buffer_interface",
+        "@envoy//envoy/http:filter_interface",
         "@envoy//envoy/http:header_map_interface",
         "@envoy//source/common/http:header_map_lib",
         "@envoy//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",

--- a/mobile/library/common/http/header_utility.cc
+++ b/mobile/library/common/http/header_utility.cc
@@ -9,6 +9,17 @@ namespace Envoy {
 namespace Http {
 namespace Utility {
 
+Http::LocalErrorStatus statusForOnLocalReply(const StreamDecoderFilter::LocalReplyData& reply,
+                                             const StreamInfo::StreamInfo& info) {
+  // This is a horrible hack to work around legacy swift direct response API.
+  // TODO(https://github.com/envoyproxy/envoy/issues/24428) remove.
+  if (reply.details_ == "direct_response" && info.getRequestHeaders() &&
+      info.getRequestHeaders()->getHostValue() == "127.0.0.1") {
+    return Http::LocalErrorStatus::Continue;
+  }
+  return Http::LocalErrorStatus::ContinueAndResetStream;
+}
+
 void toEnvoyHeaders(HeaderMap& envoy_result_headers, envoy_headers headers) {
   Envoy::Http::StatefulHeaderKeyFormatter& formatter = envoy_result_headers.formatter().value();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {

--- a/mobile/library/common/http/header_utility.h
+++ b/mobile/library/common/http/header_utility.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 
 #include "library/common/types/c_types.h"
@@ -8,6 +9,14 @@
 namespace Envoy {
 namespace Http {
 namespace Utility {
+
+/*
+ * Returns the proper status code for onLocalReply
+ * @param reply the local reply data for the stream.
+ * @param stream_info the info for the stream.
+ */
+Http::LocalErrorStatus statusForOnLocalReply(const StreamDecoderFilter::LocalReplyData& reply,
+                                             const StreamInfo::StreamInfo& stream_info);
 
 /**
  * Transform envoy_headers to the supplied HeaderMap


### PR DESCRIPTION
This changes swift's direct responses from being proxied upstream and handled by the "fake" (real) listener, to being handled locally, and bypassing the "do not forward local replies" logic in the onLocalReply classes

Commit Message: na/a
Additional Description: n/a
Risk Level: medium (mobile only)
Testing: existing tests
part of https://github.com/envoyproxy/envoy/issues/24428
