### PR TITLE
kafka: cleanup librdkafka utils

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/BUILD
@@ -145,11 +145,11 @@ envoy_cc_library(
     ],
     tags = ["skip_on_windows"],
     deps = [
+        ":librdkafka_utils_impl_lib",
         ":outbound_record_lib",
         ":upstream_kafka_client_lib",
         "//envoy/event:dispatcher_interface",
         "//source/common/common:minimal_logger_lib",
-        envoy_external_dep_path("librdkafka"),
     ],
 )
 
@@ -166,5 +166,34 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "librdkafka_utils_lib",
+    srcs = [
+    ],
+    hdrs = [
+        "librdkafka_utils.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        envoy_external_dep_path("librdkafka"),
+    ],
+)
+
+envoy_cc_library(
+    name = "librdkafka_utils_impl_lib",
+    srcs = [
+        "librdkafka_utils_impl.cc",
+    ],
+    hdrs = [
+        "librdkafka_utils_impl.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":librdkafka_utils_lib",
+        envoy_external_dep_path("librdkafka"),
+        "//source/common/common:macros",
     ],
 )

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
+#include "librdkafka/rdkafkacpp.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+/**
+ * Helper class responsible for creating librdkafka entities, so we can have mocks in tests.
+ */
+class LibRdKafkaUtils {
+public:
+  virtual ~LibRdKafkaUtils() = default;
+
+  virtual RdKafka::Conf::ConfResult setConfProperty(RdKafka::Conf& conf, const std::string& name,
+                                                    const std::string& value,
+                                                    std::string& errstr) const PURE;
+
+  virtual RdKafka::Conf::ConfResult setConfDeliveryCallback(RdKafka::Conf& conf,
+                                                            RdKafka::DeliveryReportCb* dr_cb,
+                                                            std::string& errstr) const PURE;
+
+  virtual std::unique_ptr<RdKafka::Producer> createProducer(RdKafka::Conf* conf,
+                                                            std::string& errstr) const PURE;
+
+  virtual std::unique_ptr<RdKafka::KafkaConsumer> createConsumer(RdKafka::Conf* conf,
+                                                                 std::string& errstr) const PURE;
+
+  // Returned type is a raw pointer, as librdkafka does the deletion on successful produce call.
+  virtual RdKafka::Headers* convertHeaders(
+      const std::vector<std::pair<absl::string_view, absl::string_view>>& headers) const PURE;
+
+  // In case of produce failures, we need to dispose of headers manually.
+  virtual void deleteHeaders(RdKafka::Headers* librdkafka_headers) const PURE;
+};
+
+using RawKafkaConfig = std::map<std::string, std::string>;
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.cc
@@ -1,0 +1,62 @@
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h"
+
+#include "source/common/common/macros.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+RdKafka::Conf::ConfResult LibRdKafkaUtilsImpl::setConfProperty(RdKafka::Conf& conf,
+                                                               const std::string& name,
+                                                               const std::string& value,
+                                                               std::string& errstr) const {
+  return conf.set(name, value, errstr);
+}
+
+RdKafka::Conf::ConfResult
+LibRdKafkaUtilsImpl::setConfDeliveryCallback(RdKafka::Conf& conf, RdKafka::DeliveryReportCb* dr_cb,
+                                             std::string& errstr) const {
+  return conf.set("dr_cb", dr_cb, errstr);
+}
+
+std::unique_ptr<RdKafka::Producer> LibRdKafkaUtilsImpl::createProducer(RdKafka::Conf* conf,
+                                                                       std::string& errstr) const {
+  return std::unique_ptr<RdKafka::Producer>(RdKafka::Producer::create(conf, errstr));
+}
+
+std::unique_ptr<RdKafka::KafkaConsumer>
+LibRdKafkaUtilsImpl::createConsumer(RdKafka::Conf* conf, std::string& errstr) const {
+  return std::unique_ptr<RdKafka::KafkaConsumer>(RdKafka::KafkaConsumer::create(conf, errstr));
+}
+
+RdKafka::Headers* LibRdKafkaUtilsImpl::convertHeaders(
+    const std::vector<std::pair<absl::string_view, absl::string_view>>& headers) const {
+  RdKafka::Headers* result = RdKafka::Headers::create();
+  for (const auto& header : headers) {
+    const RdKafka::Headers::Header librdkafka_header = {
+        std::string(header.first), header.second.data(), header.second.length()};
+    const auto ec = result->add(librdkafka_header);
+    // This should never happen ('add' in 1.7.0 does not return any other error codes).
+    if (RdKafka::ERR_NO_ERROR != ec) {
+      delete result;
+      return nullptr;
+    }
+  }
+  return result;
+}
+
+void LibRdKafkaUtilsImpl::deleteHeaders(RdKafka::Headers* librdkafka_headers) const {
+  delete librdkafka_headers;
+}
+
+const LibRdKafkaUtils& LibRdKafkaUtilsImpl::getDefaultInstance() {
+  CONSTRUCT_ON_FIRST_USE(LibRdKafkaUtilsImpl);
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+/**
+ * Real implementation that just performs librdkafka operations.
+ */
+class LibRdKafkaUtilsImpl : public LibRdKafkaUtils {
+public:
+  // LibRdKafkaUtils
+  RdKafka::Conf::ConfResult setConfProperty(RdKafka::Conf& conf, const std::string& name,
+                                            const std::string& value,
+                                            std::string& errstr) const override;
+
+  // LibRdKafkaUtils
+  RdKafka::Conf::ConfResult setConfDeliveryCallback(RdKafka::Conf& conf,
+                                                    RdKafka::DeliveryReportCb* dr_cb,
+                                                    std::string& errstr) const override;
+
+  // LibRdKafkaUtils
+  std::unique_ptr<RdKafka::Producer> createProducer(RdKafka::Conf* conf,
+                                                    std::string& errstr) const override;
+
+  // LibRdKafkaUtils
+  std::unique_ptr<RdKafka::KafkaConsumer> createConsumer(RdKafka::Conf* conf,
+                                                         std::string& errstr) const override;
+
+  // LibRdKafkaUtils
+  RdKafka::Headers* convertHeaders(
+      const std::vector<std::pair<absl::string_view, absl::string_view>>& headers) const override;
+
+  // LibRdKafkaUtils
+  void deleteHeaders(RdKafka::Headers* librdkafka_headers) const override;
+
+  // Default singleton accessor.
+  static const LibRdKafkaUtils& getDefaultInstance();
+};
+
+using RawKafkaConfig = std::map<std::string, std::string>;
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.cc
@@ -1,70 +1,22 @@
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.h"
 
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-class LibRdKafkaUtilsImpl : public LibRdKafkaUtils {
-
-  // LibRdKafkaUtils
-  RdKafka::Conf::ConfResult setConfProperty(RdKafka::Conf& conf, const std::string& name,
-                                            const std::string& value,
-                                            std::string& errstr) const override {
-    return conf.set(name, value, errstr);
-  }
-
-  // LibRdKafkaUtils
-  RdKafka::Conf::ConfResult setConfDeliveryCallback(RdKafka::Conf& conf,
-                                                    RdKafka::DeliveryReportCb* dr_cb,
-                                                    std::string& errstr) const override {
-    return conf.set("dr_cb", dr_cb, errstr);
-  }
-
-  // LibRdKafkaUtils
-  std::unique_ptr<RdKafka::Producer> createProducer(RdKafka::Conf* conf,
-                                                    std::string& errstr) const override {
-    return std::unique_ptr<RdKafka::Producer>(RdKafka::Producer::create(conf, errstr));
-  }
-
-  // LibRdKafkaUtils
-  RdKafka::Headers* convertHeaders(
-      const std::vector<std::pair<absl::string_view, absl::string_view>>& headers) const override {
-    RdKafka::Headers* result = RdKafka::Headers::create();
-    for (const auto& header : headers) {
-      const RdKafka::Headers::Header librdkafka_header = {
-          std::string(header.first), header.second.data(), header.second.length()};
-      const auto ec = result->add(librdkafka_header);
-      // This should never happen ('add' in 1.7.0 does not return any other error codes).
-      if (RdKafka::ERR_NO_ERROR != ec) {
-        delete result;
-        return nullptr;
-      }
-    }
-    return result;
-  }
-
-  // LibRdKafkaUtils
-  void deleteHeaders(RdKafka::Headers* librdkafka_headers) const override {
-    delete librdkafka_headers;
-  }
-
-public:
-  static const LibRdKafkaUtils& getDefaultInstance() {
-    CONSTRUCT_ON_FIRST_USE(LibRdKafkaUtilsImpl);
-  }
-};
-
 RichKafkaProducer::RichKafkaProducer(Event::Dispatcher& dispatcher,
                                      Thread::ThreadFactory& thread_factory,
-                                     const RawKafkaProducerConfig& configuration)
+                                     const RawKafkaConfig& configuration)
     : RichKafkaProducer(dispatcher, thread_factory, configuration,
                         LibRdKafkaUtilsImpl::getDefaultInstance()){};
 
 RichKafkaProducer::RichKafkaProducer(Event::Dispatcher& dispatcher,
                                      Thread::ThreadFactory& thread_factory,
-                                     const RawKafkaProducerConfig& configuration,
+                                     const RawKafkaConfig& configuration,
                                      const LibRdKafkaUtils& utils)
     : dispatcher_{dispatcher}, utils_{utils} {
 

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.h
@@ -4,42 +4,14 @@
 
 #include "envoy/event/dispatcher.h"
 
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_client.h"
-#include "librdkafka/rdkafkacpp.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
-
-/**
- * Helper class responsible for creating librdkafka entities, so we can have mocks in tests.
- */
-class LibRdKafkaUtils {
-public:
-  virtual ~LibRdKafkaUtils() = default;
-
-  virtual RdKafka::Conf::ConfResult setConfProperty(RdKafka::Conf& conf, const std::string& name,
-                                                    const std::string& value,
-                                                    std::string& errstr) const PURE;
-
-  virtual RdKafka::Conf::ConfResult setConfDeliveryCallback(RdKafka::Conf& conf,
-                                                            RdKafka::DeliveryReportCb* dr_cb,
-                                                            std::string& errstr) const PURE;
-
-  virtual std::unique_ptr<RdKafka::Producer> createProducer(RdKafka::Conf* conf,
-                                                            std::string& errstr) const PURE;
-
-  // Returned type is a raw pointer, as librdkafka does the deletion on successful produce call.
-  virtual RdKafka::Headers* convertHeaders(
-      const std::vector<std::pair<absl::string_view, absl::string_view>>& headers) const PURE;
-
-  // In case of produce failures, we need to dispose of headers manually.
-  virtual void deleteHeaders(RdKafka::Headers* librdkafka_headers) const PURE;
-};
-
-using RawKafkaProducerConfig = std::map<std::string, std::string>;
 
 /**
  * Combines the librdkafka producer and its dedicated monitoring thread.
@@ -53,11 +25,11 @@ class RichKafkaProducer : public KafkaProducer,
 public:
   // Main constructor.
   RichKafkaProducer(Event::Dispatcher& dispatcher, Thread::ThreadFactory& thread_factory,
-                    const RawKafkaProducerConfig& configuration);
+                    const RawKafkaConfig& configuration);
 
   // Visible for testing (allows injection of LibRdKafkaUtils).
   RichKafkaProducer(Event::Dispatcher& dispatcher, Thread::ThreadFactory& thread_factory,
-                    const RawKafkaProducerConfig& configuration, const LibRdKafkaUtils& utils);
+                    const RawKafkaConfig& configuration, const LibRdKafkaUtils& utils);
 
   // More complex than usual.
   // Marks that monitoring thread should finish and waits for it to join.

--- a/contrib/kafka/filters/network/test/mesh/BUILD
+++ b/contrib/kafka/filters/network/test/mesh/BUILD
@@ -81,6 +81,7 @@ envoy_cc_test_library(
     tags = ["skip_on_windows"],
     deps = [
         envoy_external_dep_path("librdkafka"),
+        "//contrib/kafka/filters/network/source/mesh:librdkafka_utils_lib",
     ],
 )
 

--- a/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
+++ b/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
 #include "gmock/gmock.h"
 #include "librdkafka/rdkafkacpp.h"
 
@@ -8,6 +9,31 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
+
+// This file defines all librdkafka-related mocks.
+
+class MockLibRdKafkaUtils : public LibRdKafkaUtils {
+public:
+  MOCK_METHOD(RdKafka::Conf::ConfResult, setConfProperty,
+              (RdKafka::Conf&, const std::string&, const std::string&, std::string&), (const));
+  MOCK_METHOD(RdKafka::Conf::ConfResult, setConfDeliveryCallback,
+              (RdKafka::Conf&, RdKafka::DeliveryReportCb*, std::string&), (const));
+  MOCK_METHOD((std::unique_ptr<RdKafka::Producer>), createProducer,
+              (RdKafka::Conf*, std::string& errstr), (const));
+  MOCK_METHOD((std::unique_ptr<RdKafka::KafkaConsumer>), createConsumer,
+              (RdKafka::Conf*, std::string& errstr), (const));
+  MOCK_METHOD(RdKafka::Headers*, convertHeaders,
+              ((const std::vector<std::pair<absl::string_view, absl::string_view>>&)), (const));
+  MOCK_METHOD(void, deleteHeaders, (RdKafka::Headers * librdkafka_headers), (const));
+
+  MockLibRdKafkaUtils() {
+    ON_CALL(*this, convertHeaders(testing::_))
+        .WillByDefault(testing::Return(headers_holder_.get()));
+  }
+
+private:
+  std::unique_ptr<RdKafka::Headers> headers_holder_{RdKafka::Headers::create()};
+};
 
 class MockKafkaProducer : public RdKafka::Producer {
 public:

--- a/contrib/kafka/filters/network/test/mesh/upstream_kafka_client_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/upstream_kafka_client_impl_unit_test.cc
@@ -2,6 +2,7 @@
 #include "test/test_common/thread_factory_for_test.h"
 
 #include "absl/synchronization/blocking_counter.h"
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.h"
 #include "contrib/kafka/filters/network/test/mesh/kafka_mocks.h"
 #include "gmock/gmock.h"
@@ -20,26 +21,6 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-class MockLibRdKafkaUtils : public LibRdKafkaUtils {
-public:
-  MOCK_METHOD(RdKafka::Conf::ConfResult, setConfProperty,
-              (RdKafka::Conf&, const std::string&, const std::string&, std::string&), (const));
-  MOCK_METHOD(RdKafka::Conf::ConfResult, setConfDeliveryCallback,
-              (RdKafka::Conf&, RdKafka::DeliveryReportCb*, std::string&), (const));
-  MOCK_METHOD((std::unique_ptr<RdKafka::Producer>), createProducer,
-              (RdKafka::Conf*, std::string& errstr), (const));
-  MOCK_METHOD(RdKafka::Headers*, convertHeaders,
-              ((const std::vector<std::pair<absl::string_view, absl::string_view>>&)), (const));
-  MOCK_METHOD(void, deleteHeaders, (RdKafka::Headers * librdkafka_headers), (const));
-
-  MockLibRdKafkaUtils() {
-    ON_CALL(*this, convertHeaders(_)).WillByDefault(Return(headers_holder_.get()));
-  }
-
-private:
-  std::unique_ptr<RdKafka::Headers> headers_holder_{RdKafka::Headers::create()};
-};
-
 class MockProduceFinishCb : public ProduceFinishCb {
 public:
   MOCK_METHOD(bool, accept, (const DeliveryMemento&));
@@ -50,7 +31,7 @@ protected:
   Event::MockDispatcher dispatcher_;
   Thread::ThreadFactory& thread_factory_ = Thread::threadFactoryForTest();
   NiceMock<MockLibRdKafkaUtils> kafka_utils_{};
-  RawKafkaProducerConfig config_ = {{"key1", "value1"}, {"key2", "value2"}};
+  RawKafkaConfig config_ = {{"key1", "value1"}, {"key2", "value2"}};
 
   std::unique_ptr<MockKafkaProducer> producer_ptr = std::make_unique<MockKafkaProducer>();
   MockKafkaProducer& producer = *producer_ptr;


### PR DESCRIPTION
Commit Message: kafka: cleanup librdkafka utils
Additional Description: Extract "librdkafka utilities" to dedicated headers/libs so they can be referenced by (future) consumer code (as we are going to have create-conf + set-conf + create-consumer steps all over again) for https://github.com/envoyproxy/envoy/issues/24372 . Same happens in tests.
Risk Level: Low
Testing: unit tests, integration tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A