### PR TITLE
ci: run mobile GitHub Actions on every PR

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   androidbuild:
@@ -19,15 +13,21 @@ jobs:
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Build envoy.aar distributable'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -43,20 +43,27 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
         architecture: x64
         distribution: zulu
     - run: cd mobile && ./ci/mac_ci_setup.sh --android
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
     - name: 'Start simulator'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
     # Return to using:
     #   cd mobile && ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
     - name: 'Start java app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -68,6 +75,7 @@ jobs:
           adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
     - name: 'Check connectivity'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 200" -m 1
   kotlinhelloworld:
     name: kotlin_helloworld
@@ -76,20 +84,27 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Start simulator'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
     - name: 'Start kotlin app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -101,6 +116,7 @@ jobs:
           adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
     - name: 'Check connectivity'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 200" -m 1
   kotlinbaselineapp:
     name: kotlin_baseline_app
@@ -109,20 +125,27 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Start simulator'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
     - name: 'Start kotlin app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -134,6 +157,7 @@ jobs:
           adb install -r --no-incremental bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
     - name: 'Check connectivity'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 301" -m 1
   kotlinexperimentalapp:
     name: kotlin_experimental_app
@@ -142,20 +166,27 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh --android
     - name: 'Start simulator'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
     - name: 'Start kotlin app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -167,4 +198,5 @@ jobs:
           adb install -r --no-incremental bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity
     - name: 'Check connectivity'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 200" -m 1

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   kotlintestsmac:
@@ -21,18 +15,11 @@ jobs:
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v1
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/android_tests.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Java setup'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
@@ -40,10 +27,10 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
     - name: 'Run Kotlin library tests'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -59,18 +46,11 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v1
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/android_tests.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Java setup'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
@@ -78,10 +58,10 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
     - name: 'Run Java library tests'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -107,18 +87,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/android_tests.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Java setup'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
       with:
         java-version: '8'
@@ -126,10 +99,10 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/linux_ci_setup.sh
     - name: 'Run Kotlin library integration tests'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   asan:
@@ -26,18 +20,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/asan.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
-      if: steps.check-cache.outputs.cache-hit != 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
@@ -46,7 +33,7 @@ jobs:
     - name: 'Run tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: |
         cd mobile && ./bazelw test --test_output=all \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   unittests:
@@ -19,9 +13,14 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
     - name: 'Run tests'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   coverage:
@@ -26,18 +20,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e ^.github/workflows/coverage.yml ; then
-            echo "Coverage will run."
-            echo "run_coverage=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping coverage."
-            echo "run_coverage=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Run coverage'
-      if: steps.check_context.outputs.run_coverage == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       continue-on-error: true
       run: |
         echo "build --remote_header=\"Authorization=Bearer ${{ secrets.GITHUB_TOKEN }}\"" > ~/.bazelrc
@@ -46,11 +33,11 @@ jobs:
             COVERAGE_THRESHOLD=95 \
             ../test/run_envoy_bazel_coverage.sh //test/common/...
     - name: 'Package coverage'
-      if: steps.check_context.outputs.run_coverage == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: |
         cd mobile && tar -czvf coverage.tar.gz generated/coverage
     - name: 'Upload report'
-      if: steps.check_context.outputs.run_coverage == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: coverage.tar.gz

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,6 +20,8 @@ jobs:
         ENVOY_BAZEL_PREFIX: "@envoy"
     steps:
     - uses: actions/checkout@v1
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy/envoy
     - id: should_run
       name: 'Check whether to run'
       run: ./mobile/tools/should_run_ci.sh

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -49,11 +49,7 @@ jobs:
       image: ghcr.io/realm/swiftlint:0.50.1
     steps:
     - uses: actions/checkout@v1
-    - id: should_run
-      name: 'Check whether to run'
-      run: ./mobile/tools/should_run_ci.sh
     - name: 'Run Swift Lint (SwiftLint)'
-      if: steps.should_run.outputs.run_ci_job == 'true'
       run: swiftlint lint --strict
       working-directory: mobile
   drstring:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   formatall:
@@ -26,7 +20,11 @@ jobs:
         ENVOY_BAZEL_PREFIX: "@envoy"
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Run formatters'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./tools/check_format.sh
   precommit:
     name: precommit
@@ -34,9 +32,14 @@ jobs:
     timeout-minutes: 45
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Install precommit'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: brew install pre-commit
     - name: 'Run precommit'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && find mobile/* | pre-commit run --files
   swiftlint:
     name: swift_lint
@@ -46,7 +49,11 @@ jobs:
       image: ghcr.io/realm/swiftlint:0.50.1
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Run Swift Lint (SwiftLint)'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: swiftlint lint --strict
       working-directory: mobile
   drstring:
@@ -55,7 +62,11 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Run DrString'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         DEVELOPER_DIR: /Applications/Xcode_14.1.app
       run: cd mobile && ./bazelw run @DrString//:drstring check
@@ -65,15 +76,21 @@ jobs:
     timeout-minutes: 45
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
         architecture: x64
         distribution: zulu
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
     - name: 'Run Kotlin Lint (Detekt)'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -83,5 +100,5 @@ jobs:
             //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
             //examples/kotlin/hello_world:hello_envoy_kt_lint
     - name: 'Run Kotlin Formatter (ktlint)'
-      run: |
-        cd mobile && ./bazelw build kotlin_format
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      run: cd mobile && ./bazelw build kotlin_format

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   iosbuild:
@@ -19,9 +13,15 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build Envoy.framework distributable'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw shutdown
@@ -30,7 +30,6 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //library/swift:ios_framework
-      name: 'Build Envoy.framework distributable'
   swifthelloworld:
     name: swift_helloworld
     needs: iosbuild
@@ -38,9 +37,15 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw build \
@@ -48,9 +53,10 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/hello_world:app
-      name: 'Build swift app'
     # Run the app in the background and redirect logs.
-    - env:
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw run \
@@ -58,8 +64,8 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/hello_world:app &> /tmp/envoy.log &
-      name: 'Run swift app'
     - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
@@ -71,9 +77,15 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw build \
@@ -81,9 +93,10 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/baseline:app
-      name: 'Build swift app'
     # Run the app in the background and redirect logs.
-    - env:
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw run \
@@ -91,8 +104,8 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/baseline:app &> /tmp/envoy.log &
-      name: 'Run swift app'
     - run: sed '/received headers with status 301/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
@@ -104,9 +117,15 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw build \
@@ -114,9 +133,10 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/experimental:app
-      name: 'Build swift app'
     # Run the app in the background and redirect logs.
-    - env:
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw run \
@@ -124,8 +144,8 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/experimental:app &> /tmp/envoy.log &
-      name: 'Run swift app'
     - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
@@ -137,9 +157,15 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw build \
@@ -147,9 +173,10 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/async_await:app
-      name: 'Build swift app'
     # Run the app in the background and redirect logs.
-    - env:
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw run \
@@ -157,8 +184,8 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/async_await:app &> /tmp/envoy.log &
-      name: 'Run swift app'
     - run: sed '/\[2\] Uploaded 7 MB of data/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check upload succeeded'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
@@ -170,9 +197,15 @@ jobs:
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw build \
@@ -180,9 +213,10 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
-      name: 'Build objective-c app'
     # Run the app in the background and redirect logs.
-    - env:
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw run \
@@ -190,8 +224,8 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-      name: 'Run objective-c app'
     - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   swifttests:
@@ -19,20 +13,14 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v1
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/ios_tests.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
     - name: 'Run swift library tests'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -50,20 +38,14 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v1
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/ios_tests.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
     - name: 'Run Objective-C library tests'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   pythontests:
@@ -23,18 +17,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e cc/ -e python/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/python_tests.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - name: 'Run tests'
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   validate_swiftpm_example:
@@ -19,9 +13,15 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
     - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Install dependencies'
-    - env:
+    - name: 'Build xcframework'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile && ./bazelw build \
@@ -29,10 +29,11 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //:ios_xcframework
-      name: 'Build xcframework'
     # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
     - run: unzip mobile/bazel-bin/library/swift/Envoy.xcframework.zip -d mobile/examples/swift/swiftpm/Packages || true
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Unzip xcframework'
     - run: xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 13 Pro Max,OS=16.1"
+      if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Build app'
     # TODO(jpsim): Run app and inspect logs to validate

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
   pull_request:
-    paths:
-    - 'mobile/**'
-    - '.github/workflows/**'
 
 jobs:
   tsan:
@@ -26,18 +20,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - id: check_context
+    - id: should_run
       name: 'Check whether to run'
-      run: |
-        if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/tsan.yml$ ; then
-            echo "Tests will run."
-            echo "run_tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping tests."
-            echo "run_tests=false" >> $GITHUB_OUTPUT
-          fi
+      run: ./mobile/tools/should_run_ci.sh
     - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
-      if: steps.check-cache.outputs.cache-hit != 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       with:
         java-version: '8'
         java-package: jdk
@@ -46,7 +33,7 @@ jobs:
     - name: 'Run tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: steps.check_context.outputs.run_tests == 'true'
+      if: steps.should_run.outputs.run_ci_job == 'true'
       run: |
         cd mobile && ./bazelw test \
             --test_output=all \

--- a/mobile/tools/should_run_ci.sh
+++ b/mobile/tools/should_run_ci.sh
@@ -9,23 +9,23 @@ set -euo pipefail
 # jobs should be run.
 ########################################################################
 
-job_name="$GITHUB_ACTION"
-branch_name="$(git rev-parse --abbrev-ref HEAD)"
+job="$GITHUB_JOB"
+branch_name="$GITHUB_REF_NAME"
 
 function success() {
-  echo "Running $job_name because there are $1 changes on $branch_name"
+  echo "Running $job because there are $1 changes on $branch_name"
   echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
 }
 
 function failure() {
-  echo "Skipping $job_name because there are no mobile changes on $branch_name"
+  echo "Skipping $job because there are no mobile changes on $branch_name"
   echo "run_ci_job=false" >> "$GITHUB_OUTPUT"
 }
 
 # TODO(jpsim): Consider enabling this if the load on EngFlow is ok
 # if [[ $branch_name == "main" ]]; then
 #   # Run all mobile CI jobs on `main`
-#   echo "Running $job_name because current branch is main"
+#   echo "Running $job because current branch is main"
 #   echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
 #   exit 0
 # fi

--- a/mobile/tools/should_run_ci.sh
+++ b/mobile/tools/should_run_ci.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+########################################################################
+# should_run_ci.sh
+#
+# Checks current branch and changed PR paths to determine if mobile CI
+# jobs should be run.
+########################################################################
+
+job_name="$GITHUB_ACTION"
+branch_name="$(git rev-parse --abbrev-ref HEAD)"
+
+function success() {
+  echo "Running $job_name because there are $1 changes on $branch_name"
+  echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
+}
+
+function failure() {
+  echo "Skipping $job_name because there are no mobile changes on $branch_name"
+  echo "run_ci_job=false" >> "$GITHUB_OUTPUT"
+}
+
+# TODO(jpsim): Consider enabling this if the load on EngFlow is ok
+# if [[ $branch_name == "main" ]]; then
+#   # Run all mobile CI jobs on `main`
+#   echo "Running $job_name because current branch is main"
+#   echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
+#   exit 0
+# fi
+
+base_commit="$(git merge-base origin/main HEAD)"
+changed_files="$(git diff "$base_commit" --name-only)"
+
+if grep -q "^mobile/" <<< "$changed_files"; then
+  success "mobile"
+elif grep -q "^bazel/repository_locations\.bzl" <<< "$changed_files"; then
+  success "bazel/repository_locations.bzl"
+elif grep -q "^\.github/workflows/" <<< "$changed_files"; then
+  success "GitHub Workflows"
+else
+  failure
+fi


### PR DESCRIPTION
But early-exit for changes that shouldn't impact Envoy Mobile.

On top of `mobile/**` changes and changes to workflow files, now when Envoy dependencies are updated in `bazel/repository_locations.bzl`, mobile CI jobs will run too.

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Might cause issues with CI if a mistake was made
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
