### PR TITLE
Replace set..coderBufferLimit with set..coderBufferLimitLowerBound

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -27,6 +27,13 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: http_filters
+  change: |
+    setEncoderBufferLimit and setDecoderBufferLimit changed to setEncoderBufferLimitLowerBound and
+    setDecoderBufferLimitLowerBound. Custom extensions calling these functions will need to be updated.
+    If for some reason a filter actually needs to *lower* the buffer limit, it now must be set to zero
+    before being set to the new lower limit.
+
 - area: tls
   change: |
     added support for intermediate CA as trusted ca. The peer certificate issued by an intermediate CA will be trusted by

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -660,15 +660,19 @@ public:
   virtual void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& callbacks) PURE;
 
   /**
-   * This routine may be called to change the buffer limit for decoder filters.
+   * This routine may be called to increase the buffer limit for decoder filters.
+   * Note, it is possible to decrease the limit by setting it to 0 then the desired
+   * value. In general filters should not decrease the buffer limit, as if another
+   * filter has specified it needs a buffer of size X, another filter decreasing the
+   * limit would prevent the first filter from functioning as configured.
    *
-   * @param limit supplies the desired buffer limit.
+   * @param limit supplies the desired buffer limit. 0 for unlimited.
    */
-  virtual void setDecoderBufferLimit(uint32_t limit) PURE;
+  virtual void setDecoderBufferLimitLowerBound(uint32_t limit) PURE;
 
   /**
    * This routine returns the current buffer limit for decoder filters. Filters should abide by
-   * this limit or change it via setDecoderBufferLimit.
+   * this limit or increase it via setDecoderBufferLimitLowerBound.
    * A buffer limit of 0 bytes indicates no limits are applied.
    *
    * @return the buffer limit the filter should apply.
@@ -995,15 +999,19 @@ public:
   virtual void onEncoderFilterBelowWriteBufferLowWatermark() PURE;
 
   /**
-   * This routine may be called to change the buffer limit for encoder filters.
+   * This routine may be called to increase the buffer limit for encoder filters.
+   * Note, it is possible to decrease the limit by setting it to 0 then the desired
+   * value. In general filters should not decrease the buffer limit, as if another
+   * filter has specified it needs a buffer of size X, another filter decreasing the
+   * limit would prevent the first filter from functioning as configured.
    *
-   * @param limit supplies the desired buffer limit.
+   * @param limit supplies the desired buffer limit. 0 for unlimited.
    */
-  virtual void setEncoderBufferLimit(uint32_t limit) PURE;
+  virtual void setEncoderBufferLimitLowerBound(uint32_t limit) PURE;
 
   /**
    * This routine returns the current buffer limit for encoder filters. Filters should abide by
-   * this limit or change it via setEncoderBufferLimit.
+   * this limit or increase it via setEncoderBufferLimitLowerBound.
    * A buffer limit of 0 bytes indicates no limits are applied.
    *
    * @return the buffer limit the filter should apply.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -418,7 +418,7 @@ private:
   }
   void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
   void removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks&) override {}
-  void setDecoderBufferLimit(uint32_t) override {}
+  void setDecoderBufferLimitLowerBound(uint32_t) override {}
   uint32_t decoderBufferLimit() override { return 0; }
   bool recreateStream(const ResponseHeaderMap*) override { return false; }
   const ScopeTrackedObject& scope() override { return *this; }

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1411,8 +1411,10 @@ void ActiveStreamDecoderFilter::removeDownstreamWatermarkCallbacks(
   parent_.watermark_callbacks_.remove(&watermark_callbacks);
 }
 
-void ActiveStreamDecoderFilter::setDecoderBufferLimit(uint32_t limit) {
-  parent_.setBufferLimit(limit);
+void ActiveStreamDecoderFilter::setDecoderBufferLimitLowerBound(uint32_t limit) {
+  if (limit > decoderBufferLimit() || limit == 0) {
+    parent_.setBufferLimit(limit);
+  }
 }
 
 uint32_t ActiveStreamDecoderFilter::decoderBufferLimit() { return parent_.buffer_limit_; }
@@ -1539,8 +1541,10 @@ void ActiveStreamEncoderFilter::onEncoderFilterBelowWriteBufferLowWatermark() {
   parent_.callLowWatermarkCallbacks();
 }
 
-void ActiveStreamEncoderFilter::setEncoderBufferLimit(uint32_t limit) {
-  parent_.setBufferLimit(limit);
+void ActiveStreamEncoderFilter::setEncoderBufferLimitLowerBound(uint32_t limit) {
+  if (limit > encoderBufferLimit() || limit == 0) {
+    parent_.setBufferLimit(limit);
+  }
 }
 
 uint32_t ActiveStreamEncoderFilter::encoderBufferLimit() { return parent_.buffer_limit_; }

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -228,7 +228,7 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
   void addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
   void
   removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
-  void setDecoderBufferLimit(uint32_t limit) override;
+  void setDecoderBufferLimitLowerBound(uint32_t limit) override;
   uint32_t decoderBufferLimit() override;
   bool recreateStream(const Http::ResponseHeaderMap* original_response_headers) override;
 
@@ -298,7 +298,7 @@ struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
   void addEncodedMetadata(MetadataMapPtr&& metadata_map) override;
   void onEncoderFilterAboveWriteBufferHighWatermark() override;
   void onEncoderFilterBelowWriteBufferLowWatermark() override;
-  void setEncoderBufferLimit(uint32_t limit) override;
+  void setEncoderBufferLimitLowerBound(uint32_t limit) override;
   uint32_t encoderBufferLimit() override;
   void continueEncoding() override;
   const Buffer::Instance* encodingBuffer() override;

--- a/source/docs/flow_control.md
+++ b/source/docs/flow_control.md
@@ -150,9 +150,11 @@ Each HTTP and HTTP/2 filter has an opportunity to call `decoderBufferLimit()` or
 configured bytes without calling the appropriate watermark callbacks or sending
 an error response.
 
-Filters may override the default limit with calls to `setDecoderBufferLimit()`
-and `setEncoderBufferLimit()`. These limits are applied as filters are created
-so filters later in the chain can override the limits set by prior filters.
+Filters may increase the default limit with calls to `setDecoderBufferLimitLowerBound()`
+and `setEncoderBufferLimitLowerBound()`. It is also possible to set the limit to unbounded
+with 0, but this is not recommended as if another, later filter sets a small value, it
+could leave the buffer limit at a smaller value than the original minimum. Instead, if
+unlimited buffering is desired, simply set a very large value.
 
 Most filters do not buffer internally, but instead push back on data by
 returning a FilterDataStatus on `encodeData()`/`decodeData()` calls.

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -60,7 +60,7 @@ Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::RequestHeaderMap& he
     return Http::FilterHeadersStatus::Continue;
   }
 
-  callbacks_->setDecoderBufferLimit(settings_->maxRequestBytes());
+  callbacks_->setDecoderBufferLimitLowerBound(settings_->maxRequestBytes());
   request_headers_ = &headers;
 
   return Http::FilterHeadersStatus::StopIteration;

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -116,7 +116,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   if (buffer_data_) {
     ENVOY_STREAM_LOG(debug, "ext_authz filter is buffering the request", *decoder_callbacks_);
     if (!config_->allowPartialMessage()) {
-      decoder_callbacks_->setDecoderBufferLimit(config_->maxRequestBytes());
+      decoder_callbacks_->setDecoderBufferLimitLowerBound(config_->maxRequestBytes());
     }
     return Http::FilterHeadersStatus::StopIteration;
   }

--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -66,7 +66,8 @@ Http::FilterHeadersStatus FileSystemBufferFilter::decodeHeaders(Http::RequestHea
   // means we still have the thread potentially using twice the memory that the user configured as
   // the memory limit, once in our own buffer and once in the outgoing buffer. (Plus overflow
   // because the limit isn't hard.)
-  request_callbacks_->setDecoderBufferLimit(request_state_.config_->memoryBufferBytesLimit());
+  request_callbacks_->setDecoderBufferLimitLowerBound(
+      request_state_.config_->memoryBufferBytesLimit());
   // If we're going to buffer everything, don't even start sending the data until we're ready.
   if (request_state_.injecting_content_length_header_ ||
       request_state_.config_->behavior().alwaysFullyBuffer()) {
@@ -99,7 +100,8 @@ Http::FilterHeadersStatus FileSystemBufferFilter::encodeHeaders(Http::ResponseHe
   // means we still have the thread potentially using twice the memory that the user configured as
   // the memory limit, once in our own buffer and once in the outgoing buffer. (Plus overflow
   // because the limit isn't hard.)
-  response_callbacks_->setEncoderBufferLimit(response_state_.config_->memoryBufferBytesLimit());
+  response_callbacks_->setEncoderBufferLimitLowerBound(
+      response_state_.config_->memoryBufferBytesLimit());
   // If we're going to buffer everything, don't even start sending the data until we're ready.
   if (response_state_.injecting_content_length_header_ ||
       response_state_.config_->behavior().alwaysFullyBuffer()) {

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -128,7 +128,7 @@ TEST_F(BufferFilterTest, PerFilterConfigOverride) {
   BufferFilterSettings route_settings(per_route_cfg);
 
   EXPECT_CALL(*callbacks_.route_, mostSpecificPerFilterConfig(_)).WillOnce(Return(&route_settings));
-  EXPECT_CALL(callbacks_, setDecoderBufferLimit(123ULL));
+  EXPECT_CALL(callbacks_, setDecoderBufferLimitLowerBound(123ULL));
 
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -462,7 +462,7 @@ TEST_F(HttpFilterTest, RequestDataIsTooLarge) {
 
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_));
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_));
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -494,7 +494,7 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(*client_, check(_, _, _, _));
@@ -537,7 +537,7 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessageThenContinueDecoding) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
 
@@ -594,7 +594,7 @@ TEST_F(HttpFilterTest, RequestDataWithSmallBuffer) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(*client_, check(_, _, _, _));
@@ -1697,8 +1697,8 @@ TEST_P(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
   test_disable(false);
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
-  // When filter is not disabled, setDecoderBufferLimit is called.
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_));
+  // When filter is not disabled, setDecoderBufferLimitLowerBound is called.
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_));
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -1707,8 +1707,8 @@ TEST_P(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
   // To test that disabling the filter works.
   test_disable(true);
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
-  // Make sure that setDecoderBufferLimit is skipped.
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
+  // Make sure that setDecoderBufferLimitLowerBound is skipped.
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
@@ -2527,16 +2527,16 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
   test_disable_request_body_buffering(false);
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
-  // When request body buffering is not skipped, setDecoderBufferLimit is called.
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_));
+  // When request body buffering is not skipped, setDecoderBufferLimitLowerBound is called.
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_));
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
 
   test_disable_request_body_buffering(true);
-  // When request body buffering is skipped, setDecoderBufferLimit is not called.
-  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
+  // When request body buffering is skipped, setDecoderBufferLimitLowerBound is not called.
+  EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimitLowerBound(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(*client_, check(_, _, _, _));

--- a/test/integration/filters/decode_headers_return_stop_all_filter.cc
+++ b/test/integration/filters/decode_headers_return_stop_all_filter.cc
@@ -46,7 +46,7 @@ public:
     } else {
       watermark_enabled_ = true;
       buffer_limit_ = std::stoul(std::string(entry_buffer[0]->value().getStringView()));
-      decoder_callbacks_->setDecoderBufferLimit(buffer_limit_);
+      decoder_callbacks_->setDecoderBufferLimitLowerBound(buffer_limit_);
       header_map.remove(Http::LowerCaseString("buffer_limit"));
       return Http::FilterHeadersStatus::StopAllIterationAndWatermark;
     }

--- a/test/integration/filters/encode_headers_return_stop_all_filter.cc
+++ b/test/integration/filters/encode_headers_return_stop_all_filter.cc
@@ -43,7 +43,7 @@ public:
       return Http::FilterHeadersStatus::StopAllIterationAndBuffer;
     } else {
       watermark_enabled_ = true;
-      encoder_callbacks_->setEncoderBufferLimit(
+      encoder_callbacks_->setEncoderBufferLimitLowerBound(
           std::stoul(std::string(entry_buffer[0]->value().getStringView())));
       return Http::FilterHeadersStatus::StopAllIterationAndWatermark;
     }

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -258,7 +258,7 @@ public:
   MOCK_METHOD(void, onDecoderFilterBelowWriteBufferLowWatermark, ());
   MOCK_METHOD(void, addDownstreamWatermarkCallbacks, (DownstreamWatermarkCallbacks&));
   MOCK_METHOD(void, removeDownstreamWatermarkCallbacks, (DownstreamWatermarkCallbacks&));
-  MOCK_METHOD(void, setDecoderBufferLimit, (uint32_t));
+  MOCK_METHOD(void, setDecoderBufferLimitLowerBound, (uint32_t));
   MOCK_METHOD(uint32_t, decoderBufferLimit, ());
   MOCK_METHOD(bool, recreateStream, (const ResponseHeaderMap* headers));
   MOCK_METHOD(void, addUpstreamSocketOptions, (const Network::Socket::OptionsSharedPtr& options));
@@ -351,7 +351,7 @@ public:
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, onEncoderFilterAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onEncoderFilterBelowWriteBufferLowWatermark, ());
-  MOCK_METHOD(void, setEncoderBufferLimit, (uint32_t));
+  MOCK_METHOD(void, setEncoderBufferLimitLowerBound, (uint32_t));
   MOCK_METHOD(uint32_t, encoderBufferLimit, ());
   MOCK_METHOD(void, restoreContextOnContinue, (ScopeTrackedObjectStack&));
   MOCK_METHOD(const Router::RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (), (const));


### PR DESCRIPTION
Commit Message: Replace set..coderBufferLimit with set..coderBufferLimitLowerBound
Additional Description: Per #23774 the current behavior of setDecoderBufferLimit and setEncoderBufferLimit can be surprising if two filters both try to use it. This more reasonable implementation recognizes that there's no reason for a filter to want a *smaller* buffer, so if two filters both ask for a size, whichever requires the larger size should take priority. Making these function only act to increase the buffer-limit solves this, while renaming the functions makes it clear that the change has happened.
Risk Level: Low. There are few calls to these functions.
Testing: Tests modified slightly to cover the change.
Docs Changes: Updated flow_control.md
Release Notes: Yes, in changelogs.
Platform Specific Features: n/a
