### PR TITLE
kafka: add upstream-kafka-consumer

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/BUILD
@@ -111,6 +111,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "inbound_record_lib",
+    srcs = [
+    ],
+    hdrs = [
+        "inbound_record.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+    ],
+)
+
+envoy_cc_library(
     name = "outbound_record_lib",
     srcs = [
     ],
@@ -148,6 +160,36 @@ envoy_cc_library(
         ":librdkafka_utils_impl_lib",
         ":outbound_record_lib",
         ":upstream_kafka_client_lib",
+        "//envoy/event:dispatcher_interface",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "upstream_kafka_consumer_lib",
+    srcs = [
+    ],
+    hdrs = [
+        "upstream_kafka_consumer.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":inbound_record_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "upstream_kafka_consumer_impl_lib",
+    srcs = [
+        "upstream_kafka_consumer_impl.cc",
+    ],
+    hdrs = [
+        "upstream_kafka_consumer_impl.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":librdkafka_utils_impl_lib",
+        ":upstream_kafka_consumer_lib",
         "//envoy/event:dispatcher_interface",
         "//source/common/common:minimal_logger_lib",
     ],

--- a/contrib/kafka/filters/network/source/mesh/inbound_record.h
+++ b/contrib/kafka/filters/network/source/mesh/inbound_record.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -14,20 +16,25 @@ namespace Mesh {
  */
 struct InboundRecord {
 
-  std::string topic_;
-  int32_t partition_;
-  int64_t offset_;
+  const std::string topic_;
+  const int32_t partition_;
+  const int64_t offset_;
 
-  // XXX (adam.kotwasinski) Get data in here.
+  // XXX (adam.kotwasinski) Get data in here in the next commits.
 
-  std::string topic_name() { return topic_; }
+  std::string topic_name() const { return topic_; }
 
-  int32_t partition() { return partition_; }
+  int32_t partition() const { return partition_; }
 
-  int64_t offset() { return offset_; }
+  int64_t offset() const { return offset_; }
 
   InboundRecord(std::string topic, int32_t partition, int64_t offset)
       : topic_{topic}, partition_{partition}, offset_{offset} {};
+
+  // Used in logging.
+  std::string toString() const {
+    return absl::StrCat("[", topic_, "-", partition_, "/", offset_, "]");
+  }
 };
 
 using InboundRecordSharedPtr = std::shared_ptr<InboundRecord>;

--- a/contrib/kafka/filters/network/source/mesh/inbound_record.h
+++ b/contrib/kafka/filters/network/source/mesh/inbound_record.h
@@ -20,13 +20,7 @@ struct InboundRecord {
   const int32_t partition_;
   const int64_t offset_;
 
-  // XXX (adam.kotwasinski) Get data in here in the next commits.
-
-  std::string topic_name() const { return topic_; }
-
-  int32_t partition() const { return partition_; }
-
-  int64_t offset() const { return offset_; }
+  // TODO (adam.kotwasinski) Get data in here in the next commits.
 
   InboundRecord(std::string topic, int32_t partition, int64_t offset)
       : topic_{topic}, partition_{partition}, offset_{offset} {};

--- a/contrib/kafka/filters/network/source/mesh/inbound_record.h
+++ b/contrib/kafka/filters/network/source/mesh/inbound_record.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+/**
+ * Simple structure representing the record received from upstream Kafka cluster.
+ */
+struct InboundRecord {
+
+  std::string topic_;
+  int32_t partition_;
+  int64_t offset_;
+
+  // XXX (adam.kotwasinski) Get data in here.
+
+  std::string topic_name() { return topic_; }
+
+  int32_t partition() { return partition_; }
+
+  int64_t offset() { return offset_; }
+
+  InboundRecord(std::string topic, int32_t partition, int64_t offset)
+      : topic_{topic}, partition_{partition}, offset_{offset} {};
+};
+
+using InboundRecordSharedPtr = std::shared_ptr<InboundRecord>;
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
@@ -16,19 +16,22 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
+// Used by librdkafka API.
 using RdKafkaMessageRawPtr = RdKafka::Message*;
+
 using RdKafkaMessagePtr = std::unique_ptr<RdKafka::Message>;
 
 /**
- * Helper class to wrap librdkafka consumer partition assignment with its custom destroy method.
+ * Helper class to wrap librdkafka consumer partition assignment.
  * This object has to live longer than whatever consumer that uses its "raw" data.
+ * On its own it does not expose any public API, as it is not intended to be interacted with.
  */
 class ConsumerAssignment {
 public:
   virtual ~ConsumerAssignment() = default;
 };
 
-using ConsumerAssignmentPtr = std::unique_ptr<ConsumerAssignment>;
+using ConsumerAssignmentConstPtr = std::unique_ptr<const ConsumerAssignment>;
 
 /**
  * Helper class responsible for creating librdkafka entities, so we can have mocks in tests.
@@ -60,9 +63,9 @@ public:
 
   // Assigns partitions to a consumer.
   // Impl: this method was extracted so that raw-pointer vector does not appear in real code.
-  virtual ConsumerAssignmentPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
-                                                         const std::string& topic,
-                                                         const int32_t partitions) const PURE;
+  virtual ConsumerAssignmentConstPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
+                                                              const std::string& topic,
+                                                              const int32_t partitions) const PURE;
 };
 
 using RawKafkaConfig = std::map<std::string, std::string>;

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
@@ -62,7 +62,7 @@ public:
   // Impl: this method was extracted so that raw-pointer vector does not appear in real code.
   virtual ConsumerAssignmentPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
                                                          const std::string& topic,
-                                                         int32_t partitions) const PURE;
+                                                         const int32_t partitions) const PURE;
 };
 
 using RawKafkaConfig = std::map<std::string, std::string>;

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.cc
@@ -25,7 +25,7 @@ private:
 
 ConsumerAssignmentImpl::~ConsumerAssignmentImpl() { RdKafka::TopicPartition::destroy(assignment_); }
 
-void ConsumerAssignmentImpl::add(const std::string& topic, int32_t partition) {
+void ConsumerAssignmentImpl::add(const std::string& topic, const int32_t partition) {
   // We consume records from the beginning of each partition.
   const int64_t initial_offset = 0;
   const RdKafkaPartitionRawPtr topic_partition =
@@ -85,9 +85,8 @@ void LibRdKafkaUtilsImpl::deleteHeaders(RdKafka::Headers* librdkafka_headers) co
   delete librdkafka_headers;
 }
 
-ConsumerAssignmentPtr
-LibRdKafkaUtilsImpl::assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
-                                              const std::string& topic, int32_t partitions) const {
+ConsumerAssignmentPtr LibRdKafkaUtilsImpl::assignConsumerPartitions(
+    RdKafka::KafkaConsumer& consumer, const std::string& topic, const int32_t partitions) const {
   std::unique_ptr<ConsumerAssignmentImpl> result = std::make_unique<ConsumerAssignmentImpl>();
   for (auto pt = 0; pt < partitions; ++pt) {
     result->add(topic, pt);

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
@@ -10,8 +10,8 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-using RdKafkaPartitionRawPtr = RdKafka::TopicPartition*;
-using RdKafkaPartitionVector = std::vector<RdKafkaPartitionRawPtr>;
+using RdKafkaPartitionPtr = std::unique_ptr<RdKafka::TopicPartition>;
+using RdKafkaPartitionVector = std::vector<RdKafka::TopicPartition*>;
 
 /**
  * Real implementation that just performs librdkafka operations.
@@ -44,9 +44,9 @@ public:
   void deleteHeaders(RdKafka::Headers* librdkafka_headers) const override;
 
   // LibRdKafkaUtils
-  ConsumerAssignmentPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
-                                                 const std::string& topic,
-                                                 const int32_t partitions) const override;
+  ConsumerAssignmentConstPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
+                                                      const std::string& topic,
+                                                      const int32_t partitions) const override;
 
   // Default singleton accessor.
   static const LibRdKafkaUtils& getDefaultInstance();

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
 
 namespace Envoy {
@@ -7,6 +9,9 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
+
+using RdKafkaPartitionRawPtr = RdKafka::TopicPartition*;
+using RdKafkaPartitionVector = std::vector<RdKafkaPartitionRawPtr>;
 
 /**
  * Real implementation that just performs librdkafka operations.
@@ -38,11 +43,14 @@ public:
   // LibRdKafkaUtils
   void deleteHeaders(RdKafka::Headers* librdkafka_headers) const override;
 
+  // LibRdKafkaUtils
+  ConsumerAssignmentPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
+                                                 const std::string& topic,
+                                                 int32_t partitions) const override;
+
   // Default singleton accessor.
   static const LibRdKafkaUtils& getDefaultInstance();
 };
-
-using RawKafkaConfig = std::map<std::string, std::string>;
 
 } // namespace Mesh
 } // namespace Kafka

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
@@ -46,7 +46,7 @@ public:
   // LibRdKafkaUtils
   ConsumerAssignmentPtr assignConsumerPartitions(RdKafka::KafkaConsumer& consumer,
                                                  const std::string& topic,
-                                                 int32_t partitions) const override;
+                                                 const int32_t partitions) const override;
 
   // Default singleton accessor.
   static const LibRdKafkaUtils& getDefaultInstance();

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/pure.h"
+
+#include "contrib/kafka/filters/network/source/mesh/inbound_record.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+/**
+ * An entity that is interested in inbound records delivered by Kafka consumer.
+ */
+class InboundRecordProcessor {
+public:
+  virtual ~InboundRecordProcessor() = default;
+
+  /**
+   * Passes the record to the processor.
+   */
+  virtual void receive(InboundRecordSharedPtr message) PURE;
+
+  /**
+   * Blocks until there is interest in records in a given topic, or timeout expires.
+   * Conceptually a thick condition variable.
+   * @return true if there was interest.
+   */
+  virtual bool waitUntilInterest(const std::string& topic, const int32_t timeout_ms) const PURE;
+};
+
+using InboundRecordProcessorPtr = std::unique_ptr<InboundRecordProcessor>;
+
+/**
+ * Kafka consumer pointing to some upstream Kafka cluster.
+ */
+class KafkaConsumer {
+public:
+  virtual ~KafkaConsumer() = default;
+};
+
+using KafkaConsumerPtr = std::unique_ptr<KafkaConsumer>;
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.cc
@@ -1,0 +1,160 @@
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h"
+
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+RichKafkaConsumer::RichKafkaConsumer(InboundRecordProcessor& record_processor,
+                                     Thread::ThreadFactory& thread_factory,
+                                     const std::string& topic, int32_t partition_count,
+                                     const RawKafkaConfig& configuration)
+    : RichKafkaConsumer(record_processor, thread_factory, topic, partition_count, configuration,
+                        LibRdKafkaUtilsImpl::getDefaultInstance()){};
+
+RichKafkaConsumer::RichKafkaConsumer(InboundRecordProcessor& record_processor,
+                                     Thread::ThreadFactory& thread_factory,
+                                     const std::string& topic, int32_t partition_count,
+                                     const RawKafkaConfig& configuration,
+                                     const LibRdKafkaUtils& utils)
+    : record_processor_{record_processor}, topic_{topic} {
+
+  // Create consumer configuration object.
+  std::unique_ptr<RdKafka::Conf> conf =
+      std::unique_ptr<RdKafka::Conf>(RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
+
+  std::string errstr;
+
+  // Setup consumer custom properties.
+  for (const auto& e : configuration) {
+    ENVOY_LOG(info, "Setting consumer property {}={}", e.first, e.second);
+    if (utils.setConfProperty(*conf, e.first, e.second, errstr) != RdKafka::Conf::CONF_OK) {
+      throw EnvoyException(absl::StrCat("Could not set consumer property [", e.first, "] to [",
+                                        e.second, "]:", errstr));
+    }
+  }
+
+  // We create the consumer.
+  consumer_ = utils.createConsumer(conf.get(), errstr);
+  if (!consumer_) {
+    throw EnvoyException(absl::StrCat("Could not create consumer:", errstr));
+  }
+
+  // We assign all topic partitions to the consumer.
+  for (auto pt = 0; pt < partition_count; ++pt) {
+    // We consume records from the beginning of each partition.
+    const int64_t initial_offset = 0;
+    const RdKafkaPartitionRawPtr topic_partition =
+        RdKafka::TopicPartition::create(topic, pt, initial_offset);
+    ENVOY_LOG(info, "Assigning {}-{}", topic, pt);
+    assignment_.push_back(topic_partition);
+  }
+  consumer_->assign(assignment_);
+
+  // Start the poller thread.
+  poller_thread_active_ = true;
+  std::function<void()> thread_routine = [this]() -> void { pollContinuously(); };
+  poller_thread_ = thread_factory.createThread(thread_routine);
+}
+
+RichKafkaConsumer::~RichKafkaConsumer() {
+  ENVOY_LOG(debug, "Closing Kafka consumer [{}]", topic_);
+
+  poller_thread_active_ = false;
+  poller_thread_->join();
+
+  consumer_->unassign();
+  consumer_->close();
+  RdKafka::TopicPartition::destroy(assignment_); // XXX
+
+  ENVOY_LOG(debug, "Kafka consumer [{}] closed succesfully", topic_);
+}
+
+// How long a thread should wait for interest before checking if it's cancelled.
+constexpr int32_t INTEREST_TIMEOUT_MS = 1000;
+
+// How long a consumer should poll Kafka for messages.
+constexpr int32_t POLL_TIMEOUT_MS = 1000;
+
+// Large values are okay, but make the Envoy shutdown take longer
+// (as there is no good way to interrupt a 'consume' call).
+// XXX (adam.kotwasinski) This should be made configurable.
+
+void RichKafkaConsumer::pollContinuously() {
+  while (poller_thread_active_) {
+
+    // It makes no sense to poll and receive records if there is no interest right now,
+    // so we can just block instead.
+    bool can_poll = record_processor_.waitUntilInterest(topic_, INTEREST_TIMEOUT_MS);
+    if (!can_poll) {
+      // There is nothing to do, so we keep checking again.
+      // Also we happen to check if we were closed - this makes Envoy shutdown bit faster.
+      continue;
+    }
+
+    // There is interest in messages present in this topic, so we can start polling.
+    std::vector<InboundRecordSharedPtr> records = receiveRecordBatch();
+    for (auto& record : records) {
+      record_processor_.receive(record);
+    }
+  }
+  ENVOY_LOG(debug, "Poller thread for consumer [{}] finished", topic_);
+}
+
+static InboundRecordSharedPtr copy(const RdKafka::Message& arg) {
+  auto topic = arg.topic_name();
+  auto partition = arg.partition();
+  auto offset = arg.offset();
+  return std::make_shared<InboundRecord>(topic, partition, offset);
+}
+
+// How many records should be drained out of consumer in one go.
+constexpr int32_t BUFFER_DRAIN_VOLUME = 4;
+
+std::vector<InboundRecordSharedPtr> RichKafkaConsumer::receiveRecordBatch() {
+  // This message kicks off librdkafka consumer's Fetch requests and delivers a message.
+  auto message = std::unique_ptr<RdKafka::Message>(consumer_->consume(POLL_TIMEOUT_MS));
+  switch (message->err()) {
+  case RdKafka::ERR_NO_ERROR: {
+    ENVOY_LOG(info, "Received message: {}-{}, offset={}", message->topic_name(),
+              message->partition(), message->offset());
+    std::vector<InboundRecordSharedPtr> result;
+    result.push_back(copy(*message));
+
+    // We got a message, there could be something left in the buffer, so we try to drain it by
+    // consuming without waiting. See: https://github.com/edenhill/librdkafka/discussions/3897
+    while (result.size() < BUFFER_DRAIN_VOLUME) {
+      auto buffered_message = std::unique_ptr<RdKafka::Message>(consumer_->consume(0));
+      if (RdKafka::ERR_NO_ERROR == buffered_message->err()) {
+        // There was a message in the buffer.
+        ENVOY_LOG(info, "Received buffered message: {}-{}, offset={}",
+                  buffered_message->topic_name(), buffered_message->partition(),
+                  buffered_message->offset());
+        result.push_back(copy(*buffered_message));
+      } else {
+        // Buffer is empty / consumer is failing - there is nothing more to consume.
+        break;
+      }
+    }
+    return result;
+  }
+  case RdKafka::ERR__TIMED_OUT: {
+    ENVOY_LOG(info, "Timed out in [{}]", topic_);
+    return {};
+  }
+  default: {
+    ENVOY_LOG(info, "Received other error in [{}]: {} / {}", topic_, message->err(),
+              RdKafka::err2str(message->err()));
+    return {};
+  }
+  }
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h
@@ -25,12 +25,12 @@ class RichKafkaConsumer : public KafkaConsumer, private Logger::Loggable<Logger:
 public:
   // Main constructor.
   RichKafkaConsumer(InboundRecordProcessor& record_processor, Thread::ThreadFactory& thread_factory,
-                    const std::string& topic, int32_t partition_count,
+                    const std::string& topic, const int32_t partition_count,
                     const RawKafkaConfig& configuration);
 
   // Visible for testing (allows injection of LibRdKafkaUtils).
   RichKafkaConsumer(InboundRecordProcessor& record_processor, Thread::ThreadFactory& thread_factory,
-                    const std::string& topic, int32_t partition_count,
+                    const std::string& topic, const int32_t partition_count,
                     const RawKafkaConfig& configuration, const LibRdKafkaUtils& utils);
 
   // More complex than usual - closes the real Kafka consumer and disposes of the assignment object.

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h
@@ -56,7 +56,7 @@ private:
   std::unique_ptr<RdKafka::KafkaConsumer> consumer_;
 
   // Consumer's partition assignment.
-  ConsumerAssignmentPtr assignment_;
+  ConsumerAssignmentConstPtr assignment_;
 
   // Flag controlling worker threads's execution.
   std::atomic<bool> worker_thread_active_;

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <atomic>
+#include <list>
+#include <vector>
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/thread/thread.h"
+
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+using RdKafkaPartitionRawPtr = RdKafka::TopicPartition*;
+using RdKafkaPartitionVector = std::vector<RdKafkaPartitionRawPtr>;
+
+/**
+ * Combines the librdkafka consumer and its dedicated thread.
+ * The thread receives the records, and pushes them to the processor.
+ */
+class RichKafkaConsumer : public KafkaConsumer, private Logger::Loggable<Logger::Id::kafka> {
+public:
+  // Main constructor.
+  RichKafkaConsumer(InboundRecordProcessor& record_processor, Thread::ThreadFactory& thread_factory,
+                    const std::string& topic, int32_t partition_count,
+                    const RawKafkaConfig& configuration);
+
+  // Visible for testing (allows injection of LibRdKafkaUtils).
+  RichKafkaConsumer(InboundRecordProcessor& record_processor, Thread::ThreadFactory& thread_factory,
+                    const std::string& topic, int32_t partition_count,
+                    const RawKafkaConfig& configuration, const LibRdKafkaUtils& utils);
+
+  // More complex than usual - closes the real Kafka consumer and disposes of the assignment object.
+  ~RichKafkaConsumer() override;
+
+private:
+  // This method continuously fetches new records and passes them to processor.
+  // Does not finish until this object gets destroyed.
+  // Executed in the dedicated thread.
+  void pollContinuously();
+
+  // Uses internal consumer to receive records from upstream.
+  std::vector<InboundRecordSharedPtr> receiveRecordBatch();
+
+  // The record processor (provides info whether it wants records and consumes them).
+  InboundRecordProcessor& record_processor_;
+
+  // The topic we are consuming from.
+  std::string topic_;
+
+  // Real Kafka consumer (NOT thread-safe).
+  // All access to this thing happens in the poller thread.
+  std::unique_ptr<RdKafka::KafkaConsumer> consumer_;
+
+  // Consumer's assignment.
+  // These are raw librdkafka pointers that need to be freed manually in the destructor.
+  RdKafkaPartitionVector assignment_;
+
+  // Flag controlling poller threads's execution.
+  std::atomic<bool> poller_thread_active_;
+
+  // Real worker thread.
+  // Responsible for polling for records with consumer,
+  // and passing these records to awaiting requests.
+  Thread::ThreadPtr poller_thread_;
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/test/mesh/BUILD
+++ b/contrib/kafka/filters/network/test/mesh/BUILD
@@ -74,6 +74,17 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "upstream_kafka_consumer_impl_unit_test",
+    srcs = ["upstream_kafka_consumer_impl_unit_test.cc"],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":kafka_mocks_lib",
+        "//contrib/kafka/filters/network/source/mesh:upstream_kafka_consumer_impl_lib",
+        "//test/test_common:thread_factory_for_test_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "kafka_mocks_lib",
     srcs = [],

--- a/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
+++ b/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
@@ -27,9 +27,7 @@ public:
   MOCK_METHOD(RdKafka::Headers*, convertHeaders,
               ((const std::vector<std::pair<absl::string_view, absl::string_view>>&)), (const));
   MOCK_METHOD(void, deleteHeaders, (RdKafka::Headers * librdkafka_headers), (const));
-  MOCK_METHOD(ConsumerAssignmentPtr, createAssignment, (const std::string&, int32_t), (const));
-
-  MOCK_METHOD(ConsumerAssignmentPtr, assignConsumerPartitions,
+  MOCK_METHOD(ConsumerAssignmentConstPtr, assignConsumerPartitions,
               (RdKafka::KafkaConsumer&, const std::string&, int32_t), (const));
 
   MockLibRdKafkaUtils() {
@@ -125,7 +123,7 @@ public:
   MOCK_METHOD(int32_t, broker_id, (), (const));
 };
 
-class MockKafkaConsumer : public MockKafkaHandle, public RdKafka::KafkaConsumer {
+class MockKafkaConsumer : public RdKafka::KafkaConsumer, public MockKafkaHandle {
 public:
   MOCK_METHOD(RdKafka::ErrorCode, assignment, (std::vector<RdKafka::TopicPartition*>&), ());
   MOCK_METHOD(RdKafka::ErrorCode, subscription, (std::vector<std::string>&), ());

--- a/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
+++ b/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
@@ -12,6 +12,8 @@ namespace Mesh {
 
 // This file defines all librdkafka-related mocks.
 
+class MockConsumerAssignment : public ConsumerAssignment {};
+
 class MockLibRdKafkaUtils : public LibRdKafkaUtils {
 public:
   MOCK_METHOD(RdKafka::Conf::ConfResult, setConfProperty,
@@ -25,6 +27,10 @@ public:
   MOCK_METHOD(RdKafka::Headers*, convertHeaders,
               ((const std::vector<std::pair<absl::string_view, absl::string_view>>&)), (const));
   MOCK_METHOD(void, deleteHeaders, (RdKafka::Headers * librdkafka_headers), (const));
+  MOCK_METHOD(ConsumerAssignmentPtr, createAssignment, (const std::string&, int32_t), (const));
+
+  MOCK_METHOD(ConsumerAssignmentPtr, assignConsumerPartitions,
+              (RdKafka::KafkaConsumer&, const std::string&, int32_t), (const));
 
   MockLibRdKafkaUtils() {
     ON_CALL(*this, convertHeaders(testing::_))
@@ -35,7 +41,7 @@ private:
   std::unique_ptr<RdKafka::Headers> headers_holder_{RdKafka::Headers::create()};
 };
 
-// Base class for librdkafka objects (we do not use this API, but still need to mock it).
+// Base class for librdkafka objects.
 class MockKafkaHandle : public virtual RdKafka::Handle {
 public:
   MOCK_METHOD(const std::string, name, (), (const));

--- a/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
+++ b/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
@@ -117,6 +117,69 @@ public:
   MOCK_METHOD(int32_t, broker_id, (), (const));
 };
 
+class MockKafkaConsumer : public RdKafka::KafkaConsumer {
+public:
+  // Consumer API.
+  MOCK_METHOD(RdKafka::ErrorCode, assignment, (std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, subscription, (std::vector<std::string>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, subscribe, (const std::vector<std::string>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, unsubscribe, (), ());
+  MOCK_METHOD(RdKafka::ErrorCode, assign, (const std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, unassign, (), ());
+  MOCK_METHOD(RdKafka::Message*, consume, (int), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitSync, (), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitAsync, (), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitSync, (RdKafka::Message*), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitAsync, (RdKafka::Message*), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitSync, (std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitAsync, (const std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitSync, (RdKafka::OffsetCommitCb*), ());
+  MOCK_METHOD(RdKafka::ErrorCode, commitSync,
+              (std::vector<RdKafka::TopicPartition*>&, RdKafka::OffsetCommitCb*), ());
+  MOCK_METHOD(RdKafka::ErrorCode, committed, (std::vector<RdKafka::TopicPartition*>&, int), ());
+  MOCK_METHOD(RdKafka::ErrorCode, position, (std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, close, (), ());
+  MOCK_METHOD(RdKafka::ErrorCode, seek, (const RdKafka::TopicPartition&, int), ());
+  MOCK_METHOD(RdKafka::ErrorCode, offsets_store, (std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ConsumerGroupMetadata*, groupMetadata, (), ());
+  MOCK_METHOD(bool, assignment_lost, (), ());
+  MOCK_METHOD(std::string, rebalance_protocol, (), ());
+  MOCK_METHOD(RdKafka::Error*, incremental_assign, (const std::vector<RdKafka::TopicPartition*>&),
+              ());
+  MOCK_METHOD(RdKafka::Error*, incremental_unassign, (const std::vector<RdKafka::TopicPartition*>&),
+              ());
+
+  // Handle API (unused by us).
+  MOCK_METHOD(const std::string, name, (), (const));
+  MOCK_METHOD(const std::string, memberid, (), (const));
+  MOCK_METHOD(int, poll, (int), ());
+  MOCK_METHOD(int, outq_len, (), ());
+  MOCK_METHOD(RdKafka::ErrorCode, metadata,
+              (bool, const RdKafka::Topic*, RdKafka::Metadata**, int timout_ms), ());
+  MOCK_METHOD(RdKafka::ErrorCode, pause, (std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, resume, (std::vector<RdKafka::TopicPartition*>&), ());
+  MOCK_METHOD(RdKafka::ErrorCode, query_watermark_offsets,
+              (const std::string&, int32_t, int64_t*, int64_t*, int), ());
+  MOCK_METHOD(RdKafka::ErrorCode, get_watermark_offsets,
+              (const std::string&, int32_t, int64_t*, int64_t*), ());
+  MOCK_METHOD(RdKafka::ErrorCode, offsetsForTimes, (std::vector<RdKafka::TopicPartition*>&, int),
+              ());
+  MOCK_METHOD(RdKafka::Queue*, get_partition_queue, (const RdKafka::TopicPartition*), ());
+  MOCK_METHOD(RdKafka::ErrorCode, set_log_queue, (RdKafka::Queue*), ());
+  MOCK_METHOD(void, yield, (), ());
+  MOCK_METHOD(const std::string, clusterid, (int), ());
+  MOCK_METHOD(struct rd_kafka_s*, c_ptr, (), ());
+  MOCK_METHOD(int32_t, controllerid, (int), ());
+  MOCK_METHOD(RdKafka::ErrorCode, fatal_error, (std::string&), (const));
+  MOCK_METHOD(RdKafka::ErrorCode, oauthbearer_set_token,
+              (const std::string&, int64_t, const std::string&, const std::list<std::string>&,
+               std::string&),
+              ());
+  MOCK_METHOD(RdKafka::ErrorCode, oauthbearer_set_token_failure, (const std::string&), ());
+  MOCK_METHOD(void*, mem_malloc, (size_t), ());
+  MOCK_METHOD(void, mem_free, (void*), ());
+};
+
 } // namespace Mesh
 } // namespace Kafka
 } // namespace NetworkFilters

--- a/contrib/kafka/filters/network/test/mesh/upstream_kafka_consumer_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/upstream_kafka_consumer_impl_unit_test.cc
@@ -1,0 +1,164 @@
+#include "test/test_common/thread_factory_for_test.h"
+
+#include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h"
+#include "contrib/kafka/filters/network/test/mesh/kafka_mocks.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::AtLeast;
+using testing::ByMove;
+using testing::Exactly;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnNull;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+class MockInboundRecordProcessor : public InboundRecordProcessor {
+public:
+  MOCK_METHOD(void, receive, (InboundRecordSharedPtr), ());
+  MOCK_METHOD(bool, waitUntilInterest, (const std::string&, const int32_t), (const));
+};
+
+class UpstreamKafkaConsumerTest : public testing::Test {
+protected:
+  Thread::ThreadFactory& thread_factory_ = Thread::threadFactoryForTest();
+  NiceMock<MockLibRdKafkaUtils> kafka_utils_;
+  RawKafkaConfig config_ = {{"key1", "value1"}, {"key2", "value2"}};
+
+  std::unique_ptr<NiceMock<MockKafkaConsumer>> consumer_ptr_ =
+      std::make_unique<NiceMock<MockKafkaConsumer>>();
+  MockKafkaConsumer& consumer_ = *consumer_ptr_;
+
+  NiceMock<MockInboundRecordProcessor> record_processor_;
+
+  // Helper method - allows creation of RichKafkaConsumer without problems.
+  void setupConstructorExpectations() {
+    EXPECT_CALL(kafka_utils_, setConfProperty(_, "key1", "value1", _))
+        .WillOnce(Return(RdKafka::Conf::CONF_OK));
+    EXPECT_CALL(kafka_utils_, setConfProperty(_, "key2", "value2", _))
+        .WillOnce(Return(RdKafka::Conf::CONF_OK));
+
+    EXPECT_CALL(consumer_, poll(_)).Times(AnyNumber());
+
+    EXPECT_CALL(kafka_utils_, createConsumer(_, _))
+        .WillOnce(Return(ByMove(std::move(consumer_ptr_))));
+  }
+};
+
+#define TESTEE_ARGS record_processor_, thread_factory_, "topic", 42, config_, kafka_utils_
+
+TEST_F(UpstreamKafkaConsumerTest, ShouldConstructWithoutProblems) {
+  // given
+  setupConstructorExpectations();
+
+  // when, then - consumer_ got created without problems.
+  RichKafkaConsumer testee = {TESTEE_ARGS};
+}
+
+// This handles situations when users pass bad config to raw consumer_.
+TEST_F(UpstreamKafkaConsumerTest, ShouldThrowIfSettingPropertiesFails) {
+  // given
+  EXPECT_CALL(kafka_utils_, setConfProperty(_, _, _, _))
+      .WillOnce(Return(RdKafka::Conf::CONF_INVALID));
+
+  // when, then - exception gets thrown during construction.
+  EXPECT_THROW(RichKafkaConsumer(TESTEE_ARGS), EnvoyException);
+}
+
+TEST_F(UpstreamKafkaConsumerTest, ShouldThrowIfRawConsumerConstructionFails) {
+  // given
+  EXPECT_CALL(kafka_utils_, setConfProperty(_, _, _, _))
+      .WillRepeatedly(Return(RdKafka::Conf::CONF_OK));
+  EXPECT_CALL(kafka_utils_, createConsumer(_, _)).WillOnce(ReturnNull());
+
+  // when, then - exception gets thrown during construction.
+  EXPECT_THROW(RichKafkaConsumer(TESTEE_ARGS), EnvoyException);
+}
+
+// Rich consumer's constructor starts a worker thread.
+// We are going to wait for at least one request for interest, and then destroy the consumer.
+TEST_F(UpstreamKafkaConsumerTest, ShouldCheckInterestUntilShutdown) {
+  // given
+  setupConstructorExpectations();
+
+  // Because there will be no interest, there won't be any reading from upstream.
+  EXPECT_CALL(consumer_, consume(_)).Times(Exactly(0));
+
+  // Mutex for conditional critical section - at least one processor call has been invoked.
+  absl::Mutex mt;
+  int interest_calls = 0;
+
+  EXPECT_CALL(record_processor_, waitUntilInterest(_, _))
+      .Times(AtLeast(1))
+      .WillRepeatedly([&mt, &interest_calls]() {
+        absl::MutexLock lock(&mt);
+        interest_calls++;
+        return false; // There is no interest, but keep churning until shutdown.
+      });
+
+  // when
+  {
+    std::unique_ptr<RichKafkaConsumer> testee = std::make_unique<RichKafkaConsumer>(TESTEE_ARGS);
+
+    const auto at_least_one_interest_call_has_occurred = [&interest_calls]() -> bool {
+      return interest_calls > 0;
+    };
+    // We just want to block until a call happens.
+    // So this lock will be immediately released.
+    absl::MutexLock lock(&mt, absl::Condition(&at_least_one_interest_call_has_occurred));
+  }
+
+  // then - the above block actually finished,
+  // what means that the worker thread interacted with the request processor.
+}
+
+// Rich consumer's constructor starts a worker thread.
+// We are going to wait for at least one invocation of consumer 'consume', so we are confident that
+// it does polling. Then we are going to destroy the testee, and expect the thread to finish.
+TEST_F(UpstreamKafkaConsumerTest, ShouldConsumeUntilShutdown) {
+  // given
+  setupConstructorExpectations();
+
+  // In this scenario there are requests waiting for data, so we want to consume from upstream.
+  EXPECT_CALL(record_processor_, waitUntilInterest(_, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return(true));
+
+  // Mutex for conditional critical section - at least one consumer 'consume' call has been invoked.
+  absl::Mutex mt;
+  int consume_calls = 0;
+  EXPECT_CALL(consumer_, consume(_)).Times(AtLeast(1)).WillRepeatedly([&mt, &consume_calls]() {
+    absl::MutexLock lock(&mt);
+    consume_calls++;
+    return new NiceMock<MockKafkaMessage>(); // Will be freed by the testee in its destructor.
+  });
+
+  // when
+  {
+    std::unique_ptr<RichKafkaConsumer> testee = std::make_unique<RichKafkaConsumer>(TESTEE_ARGS);
+
+    const auto at_least_one_consume_call_has_occurred = [&consume_calls]() -> bool {
+      return consume_calls > 0;
+    };
+    // We just want to block until a consume-call happens.
+    // So this lock will be immediately released.
+    absl::MutexLock lock(&mt, absl::Condition(&at_least_one_consume_call_has_occurred));
+  }
+
+  // then - the above block actually finished,
+  // what means that the worker thread interacted with underlying Kafka consumer.
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: kafka: add upstream-kafka-consumer
Additional Description: Add the upstream Kafka consumer (analogous to already existing upstream Kafka producer). As it is performing blocking operations (`consume`) it needs to run in a dedicated worker thread to consume the records. Compared to the producer it is a bit more complex, as it does not always need to consume the records - first it needs to check whether there is anyone interested in these topics (== if there are unfinished `Fetch` requests received by the mesh filter). Part of https://github.com/envoyproxy/envoy/issues/24372.
Risk Level: Low
Testing: unit tests, integration tests with full stack
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A