### PR TITLE
listener: reject specifying an endpoint id for envoy internal address

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -45,7 +45,8 @@ message EnvoyInternalAddress {
 
   // Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a
   // single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for
-  // example, may be set to the final destination IP for the target internal listener.
+  // example, may be set to the final destination IP for the target internal listener. This endpoint identifier is only
+  // used for upstream endpoint, if specifying it in the listener, it will be rejected.
   string endpoint_id = 2;
 }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -27,6 +27,9 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: listener
+  change: |
+    Previously the endpoint ID can be specified when using Envoy internal address in the listener. A rejection is added for this case since it is meanless.
 - area: tls
   change: |
     added support for intermediate CA as trusted ca. The peer certificate issued by an intermediate CA will be trusted by

--- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
@@ -366,6 +366,10 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
     addresses_.emplace_back(
         std::make_shared<Network::Address::EnvoyInternalInstance>(config.name()));
     address_opts_list.emplace_back(std::ref(config_.socket_options()));
+
+    if (!addresses_.back()->envoyInternalAddress()->endpointId().empty()) {
+      throw EnvoyException(fmt::format("listener {}: doesn't support specifying an endpoint ID for Envoy internal address for a listener", name_));
+    }
   } else {
     // All the addresses should be same socket type, so get the first address's socket type is
     // enough.

--- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
@@ -368,7 +368,9 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
     address_opts_list.emplace_back(std::ref(config_.socket_options()));
 
     if (!addresses_.back()->envoyInternalAddress()->endpointId().empty()) {
-      throw EnvoyException(fmt::format("listener {}: doesn't support specifying an endpoint ID for Envoy internal address for a listener", name_));
+      throw EnvoyException(fmt::format("listener {}: doesn't support specifying an endpoint ID for "
+                                       "Envoy internal address for a listener",
+                                       name_));
     }
   } else {
     // All the addresses should be same socket type, so get the first address's socket type is

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
@@ -789,6 +789,23 @@ TEST_P(ListenerManagerImplTest, MultipleSocketTypeSpecifiedInAddresses) {
                             "support same socket type for all the addresses.");
 }
 
+TEST_P(ListenerManagerImplTest, RejectInternalAddressesWithEndpointID) {
+  const std::string yaml = R"EOF(
+    name: "foo"
+    address:
+      envoy_internal_address:
+        server_listener_name: a_listener_name_1
+        endpoint_id: foo
+    filter_chains:
+    - filters: []
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(yaml), "", true),
+                            EnvoyException,
+                            "error adding listener named 'foo': use internal_listener field "
+                            "instead of address for internal listeners");
+}
+
 TEST_P(ListenerManagerImplTest, RejectMutlipleInternalAddresses) {
   const std::string yaml = R"EOF(
     name: "foo"


### PR DESCRIPTION
Commit Message: listener: reject specifying an endpoint id for envoy internal address 
Additional Description:
According to the discussion at https://github.com/envoyproxy/envoy/pull/24198#discussion_r1040147664, specifying endpoint id for listener is meanless and we want to have a consistent hash for all type addresses.

Risk Level: low
Testing: unittest
Docs Changes: API doc
Release Notes: minor behavior change

