### PR TITLE
stats: setting default value for returned values

### DIFF
--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -70,7 +70,7 @@ private:
   std::vector<uint64_t> computed_buckets_;
   uint64_t sample_count_{0};
   double sample_sum_{0};
-  const Histogram::Unit unit_;
+  const Histogram::Unit unit_{Histogram::Unit::Unspecified};
 };
 
 class HistogramImplHelper : public MetricImpl<Histogram> {

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -68,8 +68,8 @@ private:
   ConstSupportedBuckets& supported_buckets_;
   std::vector<double> computed_quantiles_;
   std::vector<uint64_t> computed_buckets_;
-  uint64_t sample_count_;
-  double sample_sum_;
+  uint64_t sample_count_{0};
+  double sample_sum_{0};
   const Histogram::Unit unit_;
 };
 


### PR DESCRIPTION
Commit Message: stats: setting default value for returned values
Additional Description:
Our internal msan test fails here, because the 2 data-members could be directly fetched without these values being explicitly initialized. Initializing the values solves the issue.
There should not be any impact, as the explicit values are the also the default ones.

Risk Level: Low
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>