### PR TITLE
Remove inheritance from base_client_integration_test to engine_builder

### DIFF
--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -16,8 +16,6 @@ namespace Envoy {
 namespace Platform {
 
 class EngineBuilder {
-  friend Envoy::BaseClientIntegrationTest;
-
 public:
   EngineBuilder(std::string config_template);
   EngineBuilder();
@@ -74,6 +72,7 @@ protected:
   void setAdminAddressPathForTests(std::string admin) { admin_address_path_for_tests_ = admin; }
 
 private:
+  friend BaseClientIntegrationTest;
   struct NativeFilterConfig {
     NativeFilterConfig(std::string name, std::string typed_config)
         : name_(std::move(name)), typed_config_(std::move(typed_config)) {}

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -66,8 +66,6 @@ public:
   std::string generateConfigStr() const;
 
   EngineSharedPtr build();
-
-protected:
   void setOverrideConfigForTests(std::string config) { config_override_for_tests_ = config; }
   void setAdminAddressPathForTests(std::string admin) { admin_address_path_for_tests_ = admin; }
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -16,6 +16,8 @@ namespace Envoy {
 namespace Platform {
 
 class EngineBuilder {
+  friend Envoy::BaseClientIntegrationTest;
+
 public:
   EngineBuilder(std::string config_template);
   EngineBuilder();
@@ -66,6 +68,8 @@ public:
   std::string generateConfigStr() const;
 
   EngineSharedPtr build();
+
+protected:
   void setOverrideConfigForTests(std::string config) { config_override_for_tests_ = config; }
   void setAdminAddressPathForTests(std::string admin) { admin_address_path_for_tests_ = admin; }
 

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -90,7 +90,7 @@ BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion
   autonomous_upstream_ = true;
   defer_listener_finalization_ = true;
 
-  addLogLevel(getPlatformLogLevelFromOptions());
+  builder_.addLogLevel(getPlatformLogLevelFromOptions());
 }
 
 void BaseClientIntegrationTest::initialize() {
@@ -162,8 +162,8 @@ std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobi
 }
 
 void BaseClientIntegrationTest::threadRoutine(absl::Notification& engine_running) {
-  setOnEngineRunning([&]() { engine_running.Notify(); });
-  engine_ = build();
+  builder_.setOnEngineRunning([&]() { engine_running.Notify(); });
+  engine_ = builder_.build();
   full_dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
@@ -187,7 +187,8 @@ void BaseClientIntegrationTest::createEnvoy() {
   finalizeConfigWithPorts(config_helper_, ports, use_lds_);
 
   if (override_builder_config_) {
-    setOverrideConfigForTests(MessageUtil::getYamlStringFromMessage(config_helper_.bootstrap()));
+    builder_.setOverrideConfigForTests(
+        MessageUtil::getYamlStringFromMessage(config_helper_.bootstrap()));
   } else {
     ENVOY_LOG_MISC(warn, "Using builder config and ignoring config modifiers");
   }

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -49,6 +49,13 @@ protected:
   void threadRoutine(absl::Notification& engine_running);
   // Must be called manually by subclasses in their TearDown();
   void TearDown();
+  // helpers to access protected functions in the friend class
+  void setOverrideConfigForTests(Platform::EngineBuilder builder, std::string config) {
+    builder.setOverrideConfigForTests(config);
+  }
+  void setAdminAddressPathForTests(Platform::EngineBuilder& builder, std::string admin) {
+    builder.setAdminAddressPathForTests(admin);
+  }
   // Converts TestRequestHeaderMapImpl to Envoy::Platform::RequestHeadersSharedPtr
   Envoy::Platform::RequestHeadersSharedPtr
   envoyToMobileHeaders(const Http::TestRequestHeaderMapImpl& request_headers);
@@ -68,13 +75,6 @@ protected:
   // True if data plane requests are expected in the test; false otherwise.
   bool expect_data_streams_ = true;
   Platform::EngineBuilder builder_;
-  // helpers to access protected functions in the friend class
-  void setOverrideConfigForTests(Platform::EngineBuilder builder, std::string config) {
-    builder.setOverrideConfigForTests(config);
-  }
-  void setAdminAddressPathForTests(Platform::EngineBuilder& builder, std::string admin) {
-    builder.setAdminAddressPathForTests(admin);
-  }
 };
 
 } // namespace Envoy

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -35,7 +35,7 @@ std::string defaultConfig();
 //
 // TODO(junr03): move this to derive from the ApiListenerIntegrationTest after moving that class
 // into a test lib.
-class BaseClientIntegrationTest : public BaseIntegrationTest, public Platform::EngineBuilder {
+class BaseClientIntegrationTest : public BaseIntegrationTest {
 public:
   BaseClientIntegrationTest(Network::Address::IpVersion ip_version,
                             const std::string& bootstrap_config = defaultConfig());
@@ -67,6 +67,7 @@ protected:
   bool override_builder_config_ = false;
   // True if data plane requests are expected in the test; false otherwise.
   bool expect_data_streams_ = true;
+  Platform::EngineBuilder builder_;
 };
 
 } // namespace Envoy

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -72,7 +72,7 @@ protected:
   void setOverrideConfigForTests(Platform::EngineBuilder builder, std::string config) {
     builder.setOverrideConfigForTests(config);
   }
-  void setAdminAddressPathForTests(Platform::EngineBuilder builder, std::string admin) {
+  void setAdminAddressPathForTests(Platform::EngineBuilder& builder, std::string admin) {
     builder.setAdminAddressPathForTests(admin);
   }
 };

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -68,6 +68,13 @@ protected:
   // True if data plane requests are expected in the test; false otherwise.
   bool expect_data_streams_ = true;
   Platform::EngineBuilder builder_;
+  // helpers to access protected functions in the friend class
+  void setOverrideConfigForTests(Platform::EngineBuilder builder, std::string config) {
+    builder.setOverrideConfigForTests(config);
+  }
+  void setAdminAddressPathForTests(Platform::EngineBuilder builder, std::string admin) {
+    builder.setAdminAddressPathForTests(admin);
+  }
 };
 
 } // namespace Envoy

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -241,7 +241,7 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
 }
 
 TEST_P(ClientIntegrationTest, TimeoutOnRequestPath) {
-  setStreamIdleTimeoutSeconds(1);
+  builder_.setStreamIdleTimeoutSeconds(1);
 
   autonomous_upstream_ = false;
   initialize();
@@ -263,7 +263,7 @@ TEST_P(ClientIntegrationTest, TimeoutOnRequestPath) {
 }
 
 TEST_P(ClientIntegrationTest, TimeoutOnResponsePath) {
-  setStreamIdleTimeoutSeconds(1);
+  builder_.setStreamIdleTimeoutSeconds(1);
   autonomous_upstream_ = false;
   initialize();
 
@@ -291,7 +291,7 @@ TEST_P(ClientIntegrationTest, TimeoutOnResponsePath) {
 
 // TODO(alyssawilk) get this working in a follow-up.
 TEST_P(ClientIntegrationTest, DISABLED_Proxying) {
-  addLogLevel(Platform::LogLevel::trace);
+  builder_.addLogLevel(Platform::LogLevel::trace);
   initialize();
   if (version_ == Network::Address::IpVersion::v6) {
     // Localhost only resolves to an ipv4 address - alas no kernel happy eyeballs.

--- a/mobile/test/common/integration/xds_integration_test.cc
+++ b/mobile/test/common/integration/xds_integration_test.cc
@@ -51,7 +51,7 @@ XdsIntegrationTest::XdsIntegrationTest() : BaseClientIntegrationTest(ipVersion()
     bootstrap.mutable_admin()->MergeFrom(adminConfig());
   });
   admin_filename_ = TestEnvironment::temporaryPath("admin_address.txt");
-  setAdminAddressPathForTests(admin_filename_);
+  builder_.setAdminAddressPathForTests(admin_filename_);
 }
 
 void XdsIntegrationTest::initialize() {

--- a/mobile/test/common/integration/xds_integration_test.cc
+++ b/mobile/test/common/integration/xds_integration_test.cc
@@ -51,7 +51,7 @@ XdsIntegrationTest::XdsIntegrationTest() : BaseClientIntegrationTest(ipVersion()
     bootstrap.mutable_admin()->MergeFrom(adminConfig());
   });
   admin_filename_ = TestEnvironment::temporaryPath("admin_address.txt");
-  builder_.setAdminAddressPathForTests(admin_filename_);
+  setAdminAddressPathForTests(builder_, admin_filename_);
 }
 
 void XdsIntegrationTest::initialize() {


### PR DESCRIPTION
Currently the unit test fixture inherits from the engine builder. This is mostly just a readability win and also allows setting up multiple builders within one test.