### PR TITLE
mobile: Enable BaseClientIntegrationTest to bypass stream metrics checks

### DIFF
--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -108,7 +108,9 @@ void BaseClientIntegrationTest::initialize() {
   });
   stream_prototype_->setOnComplete(
       [this](envoy_stream_intel, envoy_final_stream_intel final_intel) {
-        validateStreamIntel(final_intel, expect_dns_, upstream_tls_, cc_.on_complete_calls == 0);
+        if (expect_data_streams_) {
+          validateStreamIntel(final_intel, expect_dns_, upstream_tls_, cc_.on_complete_calls == 0);
+        }
         cc_.on_complete_received_byte_count = final_intel.received_byte_count;
         cc_.on_complete_calls++;
         cc_.terminal_callback->setReady();

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -61,6 +61,8 @@ protected:
   bool explicit_flow_control_ = false;
   bool expect_dns_ = true;
   bool override_builder_config_ = false;
+  // True if data plane requests are expected in the test; false otherwise.
+  bool expect_data_streams_ = true;
 };
 
 } // namespace Envoy


### PR DESCRIPTION
Some integration tests do not send data plane requests (we are building one such test now), so optionally allow those tests to skip stream metrics validation, controlled by a test knob.

Signed-off-by: Ali Beyad <abeyad@google.com>