### PR TITLE
ci: only set up mobile docs deploy key for main repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Generate docs
       run: mobile/docs/build.sh
     - name: Set up deploy key
+      if: ${{ env.GITHUB_REPOSITORY_OWNER }} == 'envoyproxy'
       uses: shimataro/ssh-key-action@193316a178ec055fcc7b018f7f76bbf64085c628
       with:
         key: ${{ secrets.ENVOY_MOBILE_WEBSITE_DEPLOY_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Generate docs
       run: mobile/docs/build.sh
     - name: Set up deploy key
-      if: ${{ env.GITHUB_REPOSITORY_OWNER }} == 'envoyproxy'
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: shimataro/ssh-key-action@193316a178ec055fcc7b018f7f76bbf64085c628
       with:
         key: ${{ secrets.ENVOY_MOBILE_WEBSITE_DEPLOY_KEY }}


### PR DESCRIPTION
Skip this step for forks, since secrets aren't available to PRs from forks.

<img width="924" alt="image" src="https://user-images.githubusercontent.com/474794/206790878-2892af5e-28fc-4d13-af86-15a67dbd9f10.png">

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Signed-off-by: JP Simard <jp@jpsim.com>