### PR TITLE
ci: disable running the Objective-C integration app

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -213,20 +213,21 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
+    # TODO(jpsim): Re-enable running the app
     # Run the app in the background and redirect logs.
-    - name: 'Run app'
-      if: steps.should_run.outputs.run_ci_job == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd mobile && ./bazelw run \
-            --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
-            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-    - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
-      if: steps.should_run.outputs.run_ci_job == 'true'
-      name: 'Check connectivity'
-    - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
-      name: 'Log app run'
+    # - name: 'Run app'
+    #   if: steps.should_run.outputs.run_ci_job == 'true'
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   run: |
+    #     cd mobile && ./bazelw run \
+    #         --config=ios \
+    #         $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+    #         --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+    #         //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+    # - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+    #   if: steps.should_run.outputs.run_ci_job == 'true'
+    #   name: 'Check connectivity'
+    # - run: cat /tmp/envoy.log
+    #   if: ${{ failure() || cancelled() }}
+    #   name: 'Log app run'


### PR DESCRIPTION
Failing due to a missing extension: https://envoyproxy.slack.com/archives/C02F93EEJCE/p1670613863641819

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]