### PR TITLE
ci: fix check for forks in `mobile_docs` job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,12 +19,13 @@ jobs:
     - name: Generate docs
       run: mobile/docs/build.sh
     - name: Set up deploy key
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: ${{ !github.event.pull_request.head.repo.fork }}
       uses: shimataro/ssh-key-action@193316a178ec055fcc7b018f7f76bbf64085c628
       with:
         key: ${{ secrets.ENVOY_MOBILE_WEBSITE_DEPLOY_KEY }}
         known_hosts: unnecessary
     - name: Publish docs
+      if: ${{ !github.event.pull_request.head.repo.fork }}
       run: mobile/docs/publish.sh
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
The previous logic meant that we were never installing the deploy key.

E.g.: https://github.com/envoyproxy/envoy/actions/runs/3673844011/jobs/6211361666#step:7:7

Commit Message:
Additional Description:
Risk Level: No Envoy code changes, moderate risk of keeping this CI job broken in some cases.
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]