### PR TITLE
ci: fix check for forks in `mobile_docs` job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,12 +19,13 @@ jobs:
     - name: Generate docs
       run: mobile/docs/build.sh
     - name: Set up deploy key
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: ${{ !github.event.pull_request.head.repo.fork }}
       uses: shimataro/ssh-key-action@193316a178ec055fcc7b018f7f76bbf64085c628
       with:
         key: ${{ secrets.ENVOY_MOBILE_WEBSITE_DEPLOY_KEY }}
         known_hosts: unnecessary
     - name: Publish docs
+      if: ${{ !github.event.pull_request.head.repo.fork }}
       run: mobile/docs/publish.sh
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
This is the same as https://github.com/envoyproxy/envoy/pull/24486 but from a forked repo to validate that the check to see if the job is running from a fork is working correctly.