### PR TITLE
ci/mobile: register listener

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -213,21 +213,20 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
-    # TODO(jpsim): Re-enable running the app
     # Run the app in the background and redirect logs.
-    # - name: 'Run app'
-    #   if: steps.should_run.outputs.run_ci_job == 'true'
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   run: |
-    #     cd mobile && ./bazelw run \
-    #         --config=ios \
-    #         $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
-    #         --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-    #         //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-    # - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
-    #   if: steps.should_run.outputs.run_ci_job == 'true'
-    #   name: 'Check connectivity'
-    # - run: cat /tmp/envoy.log
-    #   if: ${{ failure() || cancelled() }}
-    #   name: 'Log app run'
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd mobile && ./bazelw run \
+            --config=ios \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+    - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Check connectivity'
+    - run: cat /tmp/envoy.log
+      if: ${{ failure() || cancelled() }}
+      name: 'Log app run'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -213,20 +213,21 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
+    # TODO(jpsim): Re-enable running the app
     # Run the app in the background and redirect logs.
-    - name: 'Run app'
-      if: steps.should_run.outputs.run_ci_job == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd mobile && ./bazelw run \
-            --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
-            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-    - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
-      if: steps.should_run.outputs.run_ci_job == 'true'
-      name: 'Check connectivity'
-    - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
-      name: 'Log app run'
+    # - name: 'Run app'
+    #   if: steps.should_run.outputs.run_ci_job == 'true'
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   run: |
+    #     cd mobile && ./bazelw run \
+    #         --config=ios \
+    #         $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+    #         --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+    #         //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+    # - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+    #   if: steps.should_run.outputs.run_ci_job == 'true'
+    #   name: 'Check connectivity'
+    # - run: cat /tmp/envoy.log
+    #   if: ${{ failure() || cancelled() }}
+    #   name: 'Log app run'

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "@envoy//source/extensions/filters/http/router:config",
         "@envoy//source/extensions/filters/network/http_connection_manager:config",
         "@envoy//source/extensions/http/header_formatters/preserve_case:config",
+        "@envoy//source/extensions/listener_managers/listener_manager:listener_manager_lib",
         "@envoy//source/extensions/network/dns_resolver/getaddrinfo:config",
         "@envoy//source/extensions/request_id/uuid:config",
         "@envoy//source/extensions/stat_sinks/metrics_service:config",

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -27,7 +27,6 @@ envoy_cc_library(
         "@envoy//source/extensions/filters/http/router:config",
         "@envoy//source/extensions/filters/network/http_connection_manager:config",
         "@envoy//source/extensions/http/header_formatters/preserve_case:config",
-        "@envoy//source/extensions/listener_managers/listener_manager:listener_manager_lib",
         "@envoy//source/extensions/network/dns_resolver/getaddrinfo:config",
         "@envoy//source/extensions/request_id/uuid:config",
         "@envoy//source/extensions/stat_sinks/metrics_service:config",

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -24,7 +24,6 @@
 #include "source/extensions/transport_sockets/tls/cert_validator/default_validator.h"
 #include "source/extensions/transport_sockets/tls/config.h"
 #include "source/extensions/upstreams/http/generic/config.h"
-#include "source/extensions/listener_managers/listener_manager/listener_manager_impl.h"
 
 #include "extension_registry_platform_additions.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"
@@ -76,7 +75,6 @@ void ExtensionRegistry::registerFactories() {
   Router::forceRegisterUpstreamCodecFilterFactory();
   Envoy::Network::forceRegisterGetAddrInfoDnsResolverFactory();
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
-  Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
 
   // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code
   // in such a way that does not depend on the statically initialized variable.

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -24,7 +24,7 @@
 #include "source/extensions/transport_sockets/tls/cert_validator/default_validator.h"
 #include "source/extensions/transport_sockets/tls/config.h"
 #include "source/extensions/upstreams/http/generic/config.h"
-#include "source/listener_manager/listener_manager_impl.h"
+#include "source/extensions/listener_managers/listener_manager/listener_manager_impl.h"
 
 #include "extension_registry_platform_additions.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -16,6 +16,7 @@
 #include "source/extensions/filters/network/http_connection_manager/config.h"
 #include "source/extensions/http/header_formatters/preserve_case/config.h"
 #include "source/extensions/http/original_ip_detection/xff/config.h"
+#include "source/extensions/listener_managers/listener_manager/listener_manager_impl.h"
 #include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 #include "source/extensions/request_id/uuid/config.h"
 #include "source/extensions/stat_sinks/metrics_service/config.h"
@@ -24,7 +25,6 @@
 #include "source/extensions/transport_sockets/tls/cert_validator/default_validator.h"
 #include "source/extensions/transport_sockets/tls/config.h"
 #include "source/extensions/upstreams/http/generic/config.h"
-#include "source/extensions/listener_managers/listener_manager/listener_manager_impl.h"
 
 #include "extension_registry_platform_additions.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -24,6 +24,7 @@
 #include "source/extensions/transport_sockets/tls/cert_validator/default_validator.h"
 #include "source/extensions/transport_sockets/tls/config.h"
 #include "source/extensions/upstreams/http/generic/config.h"
+#include "source/listener_manager/listener_manager_impl.h"
 
 #include "extension_registry_platform_additions.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"
@@ -75,6 +76,7 @@ void ExtensionRegistry::registerFactories() {
   Router::forceRegisterUpstreamCodecFilterFactory();
   Envoy::Network::forceRegisterGetAddrInfoDnsResolverFactory();
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
+  Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
 
   // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code
   // in such a way that does not depend on the statically initialized variable.

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -24,6 +24,7 @@
 #include "source/extensions/transport_sockets/tls/cert_validator/default_validator.h"
 #include "source/extensions/transport_sockets/tls/config.h"
 #include "source/extensions/upstreams/http/generic/config.h"
+#include "source/extensions/listener_managers/listener_manager/listener_manager_impl.h"
 
 #include "extension_registry_platform_additions.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"
@@ -75,6 +76,7 @@ void ExtensionRegistry::registerFactories() {
   Router::forceRegisterUpstreamCodecFilterFactory();
   Envoy::Network::forceRegisterGetAddrInfoDnsResolverFactory();
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
+  Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
 
   // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code
   // in such a way that does not depend on the statically initialized variable.

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
@@ -369,5 +369,7 @@ public:
   }
 };
 
+DECLARE_FACTORY(DefaultListenerManagerFactoryImpl);
+
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
Additional Description: Register default listener. Envoy Mobile crashes in optimized builds without this change. The crash was introduced in https://github.com/envoyproxy/envoy/pull/24294. The objc hello world app CI job was disabled in https://github.com/envoyproxy/envoy/pull/24363 to make main green again.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
