### PR TITLE
Fix for the SDS exception during the removal of the SDS resource

### DIFF
--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -92,7 +92,7 @@ protected:
   Api::Api& api_;
 
 private:
-  void validateUpdateSize(int num_resources);
+  bool validateUpdateSize(int num_resources);
   void initialize();
   FileContentMap loadFiles();
   uint64_t getHashForFiles(const FileContentMap& files);

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -778,7 +778,7 @@ generic_secret:
             Config::DataSource::read(generic_secret.secret(), true, *api_));
 }
 
-// Validate that SdsApi throws exception if an empty secret is passed to onConfigUpdate().
+// Validate that SdsApi returns w/o exception if an empty secret is passed to onConfigUpdate().
 TEST_F(SdsApiTest, EmptyResource) {
   envoy::config::core::v3::ConfigSource config_source;
   setupMocks();
@@ -788,9 +788,7 @@ TEST_F(SdsApiTest, EmptyResource) {
   init_manager_.add(*sds_api.initTarget());
 
   initialize();
-  EXPECT_THROW_WITH_MESSAGE(subscription_factory_.callbacks_->onConfigUpdate({}, ""),
-                            EnvoyException,
-                            "Missing SDS resources for abc.com in onConfigUpdate()");
+  EXPECT_NO_THROW(subscription_factory_.callbacks_->onConfigUpdate({}, ""));
 }
 
 // Validate that SdsApi throws exception if multiple secrets are passed to onConfigUpdate().


### PR DESCRIPTION
<!--

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

### Commit Message: 
Fix for the SDS exception during the removal of the SDS resource
### Additional Description: 
During the deletion of SDS resource, go-control-plane is sending the delta response with zero resources to add and the deleted resource to be removed. However, the existing implementation was throwing an exception, if the number of resources to be added is zero.   
Risk Level:
### Testing: 
Not done as I was not able to compile the envoy on my MAC. Tried compiling the source code with ubuntu VM using the docker CI but the build is stuck with below logs. However, I could successfully compile the envoy proxy for MAC and Arm architecture.

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/95272694/207101527-9564ba72-eaaf-465f-881b-93b4fd448000.png">
 
Docs Changes: NA
Release Notes: NA
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
