### PR TITLE
ci: revert disable running the Objective-C integration app (#24478)"

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -213,21 +213,20 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
-    # TODO(jpsim): Re-enable running the app
     # Run the app in the background and redirect logs.
-    # - name: 'Run app'
-    #   if: steps.should_run.outputs.run_ci_job == 'true'
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   run: |
-    #     cd mobile && ./bazelw run \
-    #         --config=ios \
-    #         $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
-    #         --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-    #         //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-    # - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
-    #   if: steps.should_run.outputs.run_ci_job == 'true'
-    #   name: 'Check connectivity'
-    # - run: cat /tmp/envoy.log
-    #   if: ${{ failure() || cancelled() }}
-    #   name: 'Log app run'
+    - name: 'Run app'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd mobile && ./bazelw run \
+            --config=ios \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+    - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Check connectivity'
+    - run: cat /tmp/envoy.log
+      if: ${{ failure() || cancelled() }}
+      name: 'Log app run'

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -14,7 +14,6 @@ envoy_cc_library(
     deps = [
         "extension_registry_platform_additions",
         "@envoy//source/common/network:socket_lib",
-        "@envoy//source/common/quic:quic_transport_socket_factory_lib",
         "@envoy//source/common/router:upstream_codec_filter_lib",
         "@envoy//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "@envoy//source/extensions/clusters/logical_dns:logical_dns_cluster_lib",
@@ -46,7 +45,9 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
         "@envoy_mobile//library/common/extensions/filters/http/socket_tag:config",
         "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
-    ],
+    ] + envoy_select_enable_http3([
+        "@envoy//source/common/quic:quic_transport_socket_factory_lib",
+    ])
 )
 
 envoy_cc_library(

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -45,9 +45,12 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
         "@envoy_mobile//library/common/extensions/filters/http/socket_tag:config",
         "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
-    ] + envoy_select_enable_http3([
-        "@envoy//source/common/quic:quic_transport_socket_factory_lib",
-    ]),
+    ] + envoy_select_enable_http3(
+        [
+            "@envoy//source/common/quic:quic_transport_socket_factory_lib",
+        ],
+        "@envoy",
+    ),
 )
 
 envoy_cc_library(

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     deps = [
         "extension_registry_platform_additions",
         "@envoy//source/common/network:socket_lib",
+        "@envoy//source/common/quic:quic_transport_socket_factory_lib",
         "@envoy//source/common/router:upstream_codec_filter_lib",
         "@envoy//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "@envoy//source/extensions/clusters/logical_dns:logical_dns_cluster_lib",

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -47,7 +47,7 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
     ] + envoy_select_enable_http3([
         "@envoy//source/common/quic:quic_transport_socket_factory_lib",
-    ])
+    ]),
 )
 
 envoy_cc_library(

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package", "envoy_select_enable_http3")
 
 licenses(["notice"])  # Apache 2
 

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -82,9 +82,9 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
   Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
 
-  #ifdef ENVOY_ENABLE_QUIC
+#ifdef ENVOY_ENABLE_QUIC
   Quic::forceRegisterQuicServerTransportSocketConfigFactory();
-  #endif
+#endif
 
   // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code
   // in such a way that does not depend on the statically initialized variable.

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -26,6 +26,10 @@
 #include "source/extensions/transport_sockets/tls/config.h"
 #include "source/extensions/upstreams/http/generic/config.h"
 
+#ifdef ENVOY_ENABLE_QUIC
+#include "source/common/quic/quic_transport_socket_factory.h"
+#endif
+
 #include "extension_registry_platform_additions.h"
 #include "library/common/extensions/cert_validator/platform_bridge/config.h"
 #include "library/common/extensions/filters/http/assertion/config.h"
@@ -77,6 +81,10 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Network::forceRegisterGetAddrInfoDnsResolverFactory();
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
   Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
+
+  #ifdef ENVOY_ENABLE_QUIC
+  Quic::forceRegisterQuicServerTransportSocketConfigFactory();
+  #endif
 
   // TODO: add a "force initialize" function to the upstream code, or clean up the upstream code
   // in such a way that does not depend on the statically initialized variable.

--- a/source/common/quic/quic_transport_socket_factory.h
+++ b/source/common/quic/quic_transport_socket_factory.h
@@ -185,6 +185,7 @@ public:
 };
 
 DECLARE_FACTORY(QuicClientTransportSocketConfigFactory);
+DECLARE_FACTORY(QuicServerTransportSocketConfigFactory);
 
 } // namespace Quic
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
Additional Description: Re-enables CI job as it should be green again as https://github.com/envoyproxy/envoy/pull/24490 was merged
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
