### PR TITLE
Make IsOkAndHolds matcher work with submatchers

### DIFF
--- a/test/test_common/status_utility.h
+++ b/test/test_common/status_utility.h
@@ -7,19 +7,20 @@
 namespace Envoy {
 namespace StatusHelpers {
 
-// Check that a StatusOr is OK and has a value equal to its argument.
+// Check that a StatusOr is OK and has a value equal to or matching its argument.
 //
 // For example:
 //
 // StatusOr<int> status(3);
 // EXPECT_THAT(status, IsOkAndHolds(3));
+// EXPECT_THAT(status, IsOkAndHolds(Gt(2)));
 MATCHER_P(IsOkAndHolds, expected, "") {
   if (!arg.ok()) {
     *result_listener << "which has unexpected status: " << arg.status();
     return false;
   }
-  if (*arg != expected) {
-    *result_listener << "which has wrong value: " << *arg;
+  if (!::testing::Matches(expected)(*arg)) {
+    *result_listener << "which has wrong value: " << ::testing::PrintToString(*arg);
     return false;
   }
   return true;

--- a/test/test_common/status_utility_test.cc
+++ b/test/test_common/status_utility_test.cc
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "test/test_common/status_utility.h"
 
 namespace Envoy {
@@ -126,7 +128,14 @@ TEST(StatusUtilityTest, IsOkAndHoldsSuccess) {
 
 TEST(StatusUtilityTest, IsOkAndHoldsFailureByValue) {
   ::testing::StringMatchResultListener listener;
-  ::testing::ExplainMatchResult(IsOkAndHolds(5), absl::StatusOr<int>{6}, &listener);
+  EXPECT_FALSE(::testing::ExplainMatchResult(IsOkAndHolds(5), absl::StatusOr<int>{6}, &listener));
+  EXPECT_EQ("which has wrong value: 6", listener.str());
+}
+
+TEST(StatusUtilityTest, IsOkAndHoldsFailureByValueMatcher) {
+  ::testing::StringMatchResultListener listener;
+  EXPECT_FALSE(::testing::ExplainMatchResult(IsOkAndHolds(::testing::Lt(4)), absl::StatusOr<int>{6},
+                                             &listener));
   EXPECT_EQ("which has wrong value: 6", listener.str());
 }
 


### PR DESCRIPTION
Commit Message: Make IsOkAndHolds matcher work with submatchers
Additional Description: Before this change you can do `IsOkAndHolds(5)` but not `IsOkAndHolds(Eq(5))`. Also, `IsOkAndHolds(unprintable_but_equality_comparable_value)` wouldn't build before this change, and will after.
Risk Level: None, test-only.
Testing: Test-only.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
