### PR TITLE
bazel: download Go SDKs for each supported platform

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -27,11 +27,29 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     go_register_toolchains(go_version)
     go_download_sdk(
         name = "go_sdk",
+        goos = "linux",
+        goarch = "amd64",
+        version = go_version,
+    )
+    go_download_sdk(
+        name = "go_sdk",
+        goos = "linux",
+        goarch = "arm64",
+        version = go_version,
+    )
+    go_download_sdk(
+        name = "go_sdk",
         goos = "darwin",
         goarch = "amd64",
         version = go_version,
     )
-    gazelle_dependencies()
+    go_download_sdk(
+        name = "go_sdk",
+        goos = "darwin",
+        goarch = "arm64",
+        version = go_version,
+    )
+    gazelle_dependencies(go_sdk = "go_sdk")
     apple_rules_dependencies()
     pip_dependencies()
     pip_fuzzing_dependencies()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -26,25 +26,25 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     go_rules_dependencies()
     go_register_toolchains(go_version)
     go_download_sdk(
-        name = "go_sdk",
+        name = "go_linux_amd64",
         goos = "linux",
         goarch = "amd64",
         version = go_version,
     )
     go_download_sdk(
-        name = "go_sdk",
+        name = "go_linux_arm64",
         goos = "linux",
         goarch = "arm64",
         version = go_version,
     )
     go_download_sdk(
-        name = "go_sdk",
+        name = "go_darwin_amd64",
         goos = "darwin",
         goarch = "amd64",
         version = go_version,
     )
     go_download_sdk(
-        name = "go_sdk",
+        name = "go_darwin_arm64",
         goos = "darwin",
         goarch = "arm64",
         version = go_version,

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -1,5 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
@@ -25,6 +25,12 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
     go_rules_dependencies()
     go_register_toolchains(go_version)
+    go_download_sdk(
+        name = "go_sdk",
+        goos = "darwin",
+        goarch = "amd64",
+        version = go_version,
+    )
     gazelle_dependencies()
     apple_rules_dependencies()
     pip_dependencies()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -25,30 +25,7 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
     go_rules_dependencies()
     go_register_toolchains(go_version)
-    go_download_sdk(
-        name = "go_linux_amd64",
-        goos = "linux",
-        goarch = "amd64",
-        version = go_version,
-    )
-    go_download_sdk(
-        name = "go_linux_arm64",
-        goos = "linux",
-        goarch = "arm64",
-        version = go_version,
-    )
-    go_download_sdk(
-        name = "go_darwin_amd64",
-        goos = "darwin",
-        goarch = "amd64",
-        version = go_version,
-    )
-    go_download_sdk(
-        name = "go_darwin_arm64",
-        goos = "darwin",
-        goarch = "arm64",
-        version = go_version,
-    )
+    envoy_download_go_sdks(go_version)
     gazelle_dependencies(go_sdk = "go_sdk")
     apple_rules_dependencies()
     pip_dependencies()
@@ -150,4 +127,30 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
         # last_update = "2020-11-22"
         # use_category = ["api"],
         # source = "https://github.com/bufbuild/protoc-gen-validate/blob/v0.6.1/dependencies.bzl#L23-L28"
+    )
+
+def envoy_download_go_sdks(go_version):
+    go_download_sdk(
+        name = "go_linux_amd64",
+        goos = "linux",
+        goarch = "amd64",
+        version = go_version,
+    )
+    go_download_sdk(
+        name = "go_linux_arm64",
+        goos = "linux",
+        goarch = "arm64",
+        version = go_version,
+    )
+    go_download_sdk(
+        name = "go_darwin_amd64",
+        goos = "darwin",
+        goarch = "amd64",
+        version = go_version,
+    )
+    go_download_sdk(
+        name = "go_darwin_arm64",
+        goos = "darwin",
+        goarch = "arm64",
+        version = go_version,
     )


### PR DESCRIPTION
So we can do cross-compilation on macOS hosts.

This is how the rules_go folks recommend to do this in https://github.com/bazelbuild/rules_go/issues/3402.

Commit Message:
Additional Description:
Risk Level: Low, CI should 
Testing: Tested on CI and with RBE locally on an M1 Mac.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]