### PR TITLE
kafka: inbound record distributor/store

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
@@ -19,6 +19,13 @@ class SharedConsumerManager {
 public:
   virtual ~SharedConsumerManager() = default;
 
+  // Process an inbound record callback by passing cached records to it
+  // and (if needed) registering the callback.
+  virtual void processCallback(const RecordCbSharedPtr& callback) PURE;
+
+  // Remove the callback (usually invoked by the callback timing out downstream).
+  virtual void removeCallback(const RecordCbSharedPtr& callback) PURE;
+
   // Start the consumer (if there is none) to make sure that records can be received from the topic.
   virtual void registerConsumerIfAbsent(const std::string& topic) PURE;
 };

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
@@ -12,12 +12,11 @@ namespace Kafka {
 namespace Mesh {
 
 /**
- * Manages (raw) Kafka consumers pointing to upstream Kafka clusters.
- * It is expected to have only one instance of this object per mesh-filter type.
+ * Processes incoming record callbacks (i.e. Fetch requests).
  */
-class SharedConsumerManager {
+class RecordCallbackProcessor {
 public:
-  virtual ~SharedConsumerManager() = default;
+  virtual ~RecordCallbackProcessor() = default;
 
   // Process an inbound record callback by passing cached records to it
   // and (if needed) registering the callback.
@@ -25,9 +24,21 @@ public:
 
   // Remove the callback (usually invoked by the callback timing out downstream).
   virtual void removeCallback(const RecordCbSharedPtr& callback) PURE;
+};
+
+using RecordCallbackProcessorSharedPtr = std::shared_ptr<RecordCallbackProcessor>;
+
+/**
+ * Manages (raw) Kafka consumers pointing to upstream Kafka clusters.
+ * It is expected to have only one instance of this object per mesh-filter type.
+ */
+class SharedConsumerManager {
+public:
+  virtual ~SharedConsumerManager() = default;
 
   // Start the consumer (if there is none) to make sure that records can be received from the topic.
-  virtual void registerConsumerIfAbsent(const std::string& topic) PURE;
+  virtual void registerConsumerIfAbsent(const std::string& topic,
+                                        InboundRecordProcessor& processor) PURE;
 };
 
 using SharedConsumerManagerPtr = std::unique_ptr<SharedConsumerManager>;

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
@@ -12,12 +12,11 @@ namespace Kafka {
 namespace Mesh {
 
 /**
- * Manages (raw) Kafka consumers pointing to upstream Kafka clusters.
- * It is expected to have only one instance of this object per mesh-filter type.
+ * Processes incoming record callbacks (i.e. Fetch requests).
  */
-class SharedConsumerManager {
+class RecordCallbackProcessor {
 public:
-  virtual ~SharedConsumerManager() = default;
+  virtual ~RecordCallbackProcessor() = default;
 
   // Process an inbound record callback by passing cached records to it
   // and (if needed) registering the callback.
@@ -25,6 +24,15 @@ public:
 
   // Remove the callback (usually invoked by the callback timing out downstream).
   virtual void removeCallback(const RecordCbSharedPtr& callback) PURE;
+};
+
+/**
+ * Manages (raw) Kafka consumers pointing to upstream Kafka clusters.
+ * It is expected to have only one instance of this object per mesh-filter type.
+ */
+class SharedConsumerManager {
+public:
+  virtual ~SharedConsumerManager() = default;
 
   // Start the consumer (if there is none) to make sure that records can be received from the topic.
   virtual void registerConsumerIfAbsent(const std::string& topic) PURE;

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h
@@ -12,23 +12,6 @@ namespace Kafka {
 namespace Mesh {
 
 /**
- * Processes incoming record callbacks (i.e. Fetch requests).
- */
-class RecordCallbackProcessor {
-public:
-  virtual ~RecordCallbackProcessor() = default;
-
-  // Process an inbound record callback by passing cached records to it
-  // and (if needed) registering the callback.
-  virtual void processCallback(const RecordCbSharedPtr& callback) PURE;
-
-  // Remove the callback (usually invoked by the callback timing out downstream).
-  virtual void removeCallback(const RecordCbSharedPtr& callback) PURE;
-};
-
-using RecordCallbackProcessorSharedPtr = std::shared_ptr<RecordCallbackProcessor>;
-
-/**
  * Manages (raw) Kafka consumers pointing to upstream Kafka clusters.
  * It is expected to have only one instance of this object per mesh-filter type.
  */
@@ -36,9 +19,15 @@ class SharedConsumerManager {
 public:
   virtual ~SharedConsumerManager() = default;
 
+  // Process an inbound record callback by passing cached records to it
+  // and (if needed) registering the callback.
+  virtual void processCallback(const RecordCbSharedPtr& callback) PURE;
+
+  // Remove the callback (usually invoked by the callback timing out downstream).
+  virtual void removeCallback(const RecordCbSharedPtr& callback) PURE;
+
   // Start the consumer (if there is none) to make sure that records can be received from the topic.
-  virtual void registerConsumerIfAbsent(const std::string& topic,
-                                        InboundRecordProcessor& processor) PURE;
+  virtual void registerConsumerIfAbsent(const std::string& topic) PURE;
 };
 
 using SharedConsumerManagerPtr = std::unique_ptr<SharedConsumerManager>;

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h"
 
+#include <functional>
+
 #include "source/common/common/fmt.h"
 
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h"
@@ -50,6 +52,25 @@ SharedConsumerManagerImpl::SharedConsumerManagerImpl(
     : distributor_{std::make_unique<RecordDistributor>()}, configuration_{configuration},
       thread_factory_{thread_factory}, consumer_factory_{consumer_factory} {}
 
+void SharedConsumerManagerImpl::processCallback(const RecordCbSharedPtr& callback) {
+
+  // For every fetch topic, figure out the upstream cluster,
+  // create consumer if needed ...
+  const TopicToPartitionsMap interest = callback->interest();
+  for (const auto& fetch : interest) {
+    const std::string& topic = fetch.first;
+    registerConsumerIfAbsent(topic);
+  }
+
+  // ... and start processing.
+  distributor_->processCallback(callback);
+}
+
+void SharedConsumerManagerImpl::removeCallback(const RecordCbSharedPtr& callback) {
+  // Real work - let's remove the callback.
+  distributor_->removeCallback(callback);
+}
+
 void SharedConsumerManagerImpl::registerConsumerIfAbsent(const std::string& topic) {
   absl::MutexLock lock(&consumers_mutex_);
   const auto it = topic_to_consumer_.find(topic);
@@ -86,13 +107,171 @@ size_t SharedConsumerManagerImpl::getConsumerCountForTest() const {
 
 // RecordDistributor
 
-bool RecordDistributor::waitUntilInterest(const std::string&, const int32_t) const {
-  // TODO (adam.kotwasinski) To implement in future commits.
+bool RecordDistributor::waitUntilInterest(const std::string& topic,
+                                          const int32_t timeout_ms) const {
+
+  auto distributor_has_interest = std::bind(&RecordDistributor::hasInterest, this, topic);
+  // Effectively this means "has an interest appeared within timeout".
+  // If not, we let the user know so they could do something else
+  // instead of being infinitely blocked.
+  bool can_poll = callbacks_mutex_.LockWhenWithTimeout(absl::Condition(&distributor_has_interest),
+                                                       absl::Milliseconds(timeout_ms));
+  callbacks_mutex_.Unlock(); // Lock...WithTimeout always locks, so we need to unlock.
+  return can_poll;
+}
+
+bool RecordDistributor::hasInterest(const std::string& topic) const {
+  for (const auto& e : partition_to_callbacks_) {
+    if (topic == e.first.first && !e.second.empty()) {
+      return true;
+    }
+  }
   return false;
 }
 
-void RecordDistributor::receive(InboundRecordSharedPtr) {
-  // TODO (adam.kotwasinski) To implement in future commits.
+void RecordDistributor::processCallback(const RecordCbSharedPtr& callback) {
+
+  TopicToPartitionsMap requested = callback->interest();
+  ENVOY_LOG(trace, "Processing callback {}", callback->toString());
+
+  bool fulfilled_at_startup = false;
+
+  {
+    absl::MutexLock lock(&messages_mutex_);
+    for (const auto& topic_and_partitions : requested) {
+      const std::string topic = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        const KafkaPartition kp = {topic, partition};
+
+        auto& stored_messages = messages_waiting_for_interest_[kp];
+        if (0 != stored_messages.size()) {
+          ENVOY_LOG(trace, "Early notification for callback {}, as there are {} messages available",
+                    callback->toString(), stored_messages.size());
+        }
+
+        for (auto it = stored_messages.begin(); it != stored_messages.end();) {
+          CallbackReply callback_status = callback->receive(*it);
+          bool callback_finished;
+          switch (callback_status) {
+          case CallbackReply::ACCEPTED_AND_FINISHED: {
+            // We had a callback that wanted records, and got all it wanted in the initial
+            // processing (== everything it needed was buffered), so we won't need to register it.
+            callback_finished = true;
+            it = stored_messages.erase(it);
+            break;
+          }
+          case CallbackReply::ACCEPTED_AND_WANT_MORE: {
+            callback_finished = false;
+            it = stored_messages.erase(it);
+            break;
+          }
+          case CallbackReply::REJECTED: {
+            callback_finished = true;
+            break;
+          }
+          } /* switch */
+          if (callback_finished) {
+            fulfilled_at_startup = true;
+            break; // Callback does not want any messages anymore.
+          }
+        } /* for-messages */
+      }   /* for-partitions */
+    }     /* for-topic_and_partitions */
+  }       /* lock on messages_mutex_ */
+
+  if (!fulfilled_at_startup) {
+    // Usual path: the request was not fulfilled at receive time (there were no buffered messages).
+    // So we just register the callback.
+    absl::MutexLock lock(&callbacks_mutex_);
+
+    for (const auto& topic_and_partitions : requested) {
+      const std::string topic = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        const KafkaPartition kp = {topic, partition};
+        auto& partition_callbacks = partition_to_callbacks_[kp];
+        partition_callbacks.push_back(callback);
+      }
+    }
+  } else {
+    ENVOY_LOG(trace, "No registration for callback {} due to successful early processing",
+              callback->toString());
+  }
+}
+
+// XXX (adam.kotwasinski) Inefficient: locks aquired per message.
+void RecordDistributor::receive(InboundRecordSharedPtr message) {
+
+  const KafkaPartition kafka_partition = {message->topic_, message->partition_};
+
+  // Whether this message has been consumed by any of the callbacks.
+  // Because then we can safely throw it away instead of storing.
+  bool consumed_by_callback = false;
+
+  {
+    absl::MutexLock lock(&callbacks_mutex_);
+    auto& callbacks = partition_to_callbacks_[kafka_partition];
+
+    std::vector<RecordCbSharedPtr> satisfied_callbacks = {};
+
+    // Typical case: there is some interest in messages for given partition. Notify the callback and
+    // remove it.
+    for (const auto& callback : callbacks) {
+      CallbackReply callback_status = callback->receive(message);
+      switch (callback_status) {
+      case CallbackReply::ACCEPTED_AND_FINISHED: {
+        consumed_by_callback = true;
+        // A callback is finally satisfied, it will never want more messages.
+        satisfied_callbacks.push_back(callback);
+        break;
+      }
+      case CallbackReply::ACCEPTED_AND_WANT_MORE: {
+        consumed_by_callback = true;
+        break;
+      }
+      case CallbackReply::REJECTED: {
+        break;
+      }
+      } /* switch */
+
+      /* Some callback has taken the message - this is good, no more iterating. */
+      if (consumed_by_callback) {
+        break;
+      }
+    }
+
+    for (const auto& callback : satisfied_callbacks) {
+      // Lock was acquired at the beggining of the block.
+      removeCallbackWithoutLocking(callback, partition_to_callbacks_);
+    }
+  }
+
+  // Noone is interested in our message, so we are going to store it in a local cache.
+  if (!consumed_by_callback) {
+    absl::MutexLock lock(&messages_mutex_);
+    auto& stored_messages = messages_waiting_for_interest_[kafka_partition];
+    // XXX (adam.kotwasinski) Implement some kind of limit.
+    stored_messages.push_back(message);
+    ENVOY_LOG(trace, "Stored message [{}]", message->toString());
+  }
+}
+
+void RecordDistributor::removeCallback(const RecordCbSharedPtr& callback) {
+  absl::MutexLock lock(&callbacks_mutex_);
+  removeCallbackWithoutLocking(callback, partition_to_callbacks_);
+}
+
+void RecordDistributor::removeCallbackWithoutLocking(
+    const RecordCbSharedPtr& callback,
+    std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>& partition_to_callbacks) {
+
+  ENVOY_LOG(info, "Removing callback {}", callback->toString());
+  for (auto& e : partition_to_callbacks) {
+    auto& partition_callbacks = e.second;
+    partition_callbacks.erase(
+        std::remove(partition_callbacks.begin(), partition_callbacks.end(), callback),
+        partition_callbacks.end());
+  }
+  ENVOY_LOG(info, "Removed callback {}", callback->toString());
 }
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
@@ -12,188 +12,6 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-// InboundRecordDistributor
-
-InboundRecordDistributor::InboundRecordDistributor(SharedConsumerManagerPtr&& consumer_manager)
-    : consumer_manager_{std::move(consumer_manager)} {};
-
-void InboundRecordDistributor::processCallback(const RecordCbSharedPtr& callback) {
-
-  // For each topic this callback is interested in, make sure we have a consumer active.
-  const TopicToPartitionsMap interest = callback->interest();
-  for (const auto& fetch : interest) {
-    const std::string& topic = fetch.first;
-    consumer_manager_->registerConsumerIfAbsent(topic, *this);
-  }
-
-  // Then do the real processing.
-  doProcessCallback(callback);
-}
-
-void InboundRecordDistributor::doProcessCallback(const RecordCbSharedPtr& callback) {
-
-  const TopicToPartitionsMap requested = callback->interest();
-  ENVOY_LOG(trace, "Processing callback {}", callback->toString());
-
-  bool fulfilled_at_startup = false;
-
-  {
-    absl::MutexLock lock(&records_mutex_);
-    for (const auto& topic_and_partitions : requested) {
-      const std::string topic = topic_and_partitions.first;
-      for (const int32_t partition : topic_and_partitions.second) {
-        const KafkaPartition kp = {topic, partition};
-
-        auto& stored_messages = records_waiting_for_interest_[kp];
-        if (0 != stored_messages.size()) {
-          ENVOY_LOG(trace, "Early notification for callback {}, as there are {} messages available",
-                    callback->toString(), stored_messages.size());
-        }
-
-        for (auto it = stored_messages.begin(); it != stored_messages.end();) {
-          CallbackReply callback_status = callback->receive(*it);
-          bool callback_finished;
-          switch (callback_status) {
-          case CallbackReply::ACCEPTED_AND_FINISHED: {
-            // We had a callback that wanted records, and got all it wanted in the initial
-            // processing (== everything it needed was buffered), so we won't need to register it.
-            callback_finished = true;
-            it = stored_messages.erase(it);
-            break;
-          }
-          case CallbackReply::ACCEPTED_AND_WANT_MORE: {
-            callback_finished = false;
-            it = stored_messages.erase(it);
-            break;
-          }
-          case CallbackReply::REJECTED: {
-            callback_finished = true;
-            break;
-          }
-          } /* switch */
-          if (callback_finished) {
-            fulfilled_at_startup = true;
-            break; // Callback does not want any messages anymore.
-          }
-        } /* for-messages */
-      }   /* for-partitions */
-    }     /* for-topic_and_partitions */
-  }       /* lock on records_mutex_ */
-
-  if (!fulfilled_at_startup) {
-    // Usual path: the request was not fulfilled at receive time (there were no buffered messages).
-    // So we just register the callback.
-    absl::MutexLock lock(&callbacks_mutex_);
-
-    for (const auto& topic_and_partitions : requested) {
-      const std::string topic = topic_and_partitions.first;
-      for (const int32_t partition : topic_and_partitions.second) {
-        const KafkaPartition kp = {topic, partition};
-        auto& partition_callbacks = partition_to_callbacks_[kp];
-        partition_callbacks.push_back(callback);
-      }
-    }
-  } else {
-    ENVOY_LOG(trace, "No registration for callback {} due to successful early processing",
-              callback->toString());
-  }
-}
-
-void InboundRecordDistributor::removeCallback(const RecordCbSharedPtr& callback) {
-  absl::MutexLock lock(&callbacks_mutex_);
-  doRemoveCallback(callback);
-}
-
-void InboundRecordDistributor::doRemoveCallback(const RecordCbSharedPtr& callback) {
-  ENVOY_LOG(trace, "Removing callback {}", callback->toString());
-  for (auto& e : partition_to_callbacks_) {
-    auto& partition_callbacks = e.second;
-    partition_callbacks.erase(
-        std::remove(partition_callbacks.begin(), partition_callbacks.end(), callback),
-        partition_callbacks.end());
-  }
-}
-
-bool InboundRecordDistributor::waitUntilInterest(const std::string& topic,
-                                                 const int32_t timeout_ms) const {
-
-  auto distributor_has_interest = std::bind(&InboundRecordDistributor::hasInterest, this, topic);
-  // Effectively this means "has an interest appeared within timeout".
-  // If not, we let the user know so they could do something else
-  // instead of being infinitely blocked.
-  bool can_poll = callbacks_mutex_.LockWhenWithTimeout(absl::Condition(&distributor_has_interest),
-                                                       absl::Milliseconds(timeout_ms));
-  callbacks_mutex_.Unlock(); // Lock...WithTimeout always locks, so we need to unlock.
-  return can_poll;
-}
-
-bool InboundRecordDistributor::hasInterest(const std::string& topic) const {
-  for (const auto& e : partition_to_callbacks_) {
-    if (topic == e.first.first && !e.second.empty()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// XXX (adam.kotwasinski) Inefficient: locks are acquired per message, change it to collection.
-void InboundRecordDistributor::receive(InboundRecordSharedPtr message) {
-
-  const KafkaPartition kafka_partition = {message->topic_, message->partition_};
-
-  // Whether this message has been consumed by any of the callbacks.
-  // Because then we can safely throw it away instead of storing.
-  bool consumed_by_callback = false;
-
-  {
-    absl::MutexLock lock(&callbacks_mutex_);
-    auto& callbacks = partition_to_callbacks_[kafka_partition];
-
-    // Callbacks that have been satisfied by this delivery.
-    std::vector<RecordCbSharedPtr> satisfied_callbacks = {};
-
-    // Typical case: there is some interest in messages for given partition.
-    // Notify the callback and remove it.
-    for (const auto& callback : callbacks) {
-      const CallbackReply callback_status = callback->receive(message);
-      switch (callback_status) {
-      case CallbackReply::ACCEPTED_AND_FINISHED: {
-        consumed_by_callback = true;
-        // A callback is finally satisfied, it will never want more messages.
-        satisfied_callbacks.push_back(callback);
-        break;
-      }
-      case CallbackReply::ACCEPTED_AND_WANT_MORE: {
-        consumed_by_callback = true;
-        break;
-      }
-      case CallbackReply::REJECTED: {
-        break;
-      }
-      } /* switch */
-
-      /* Some callback has taken the message - this is good, no more iterating. */
-      if (consumed_by_callback) {
-        break;
-      }
-    }
-
-    for (const auto& callback : satisfied_callbacks) {
-      // Lock was acquired at the beggining of the block.
-      doRemoveCallback(callback);
-    }
-  }
-
-  // Noone is interested in our message, so we are going to store it in a local cache.
-  if (!consumed_by_callback) {
-    absl::MutexLock lock(&records_mutex_);
-    auto& stored_messages = records_waiting_for_interest_[kafka_partition];
-    // XXX (adam.kotwasinski) Implement some kind of limit.
-    stored_messages.push_back(message);
-    ENVOY_LOG(trace, "Stored message [{}]", message->toString());
-  }
-}
-
 // KafkaConsumerFactoryImpl
 
 class KafkaConsumerFactoryImpl : public KafkaConsumerFactory {
@@ -231,21 +49,38 @@ SharedConsumerManagerImpl::SharedConsumerManagerImpl(
 SharedConsumerManagerImpl::SharedConsumerManagerImpl(
     const UpstreamKafkaConfiguration& configuration, Thread::ThreadFactory& thread_factory,
     const KafkaConsumerFactory& consumer_factory)
-    : configuration_{configuration}, thread_factory_{thread_factory}, consumer_factory_{
-                                                                          consumer_factory} {}
+    : distributor_{std::make_unique<RecordDistributor>()}, configuration_{configuration},
+      thread_factory_{thread_factory}, consumer_factory_{consumer_factory} {}
 
-void SharedConsumerManagerImpl::registerConsumerIfAbsent(const std::string& topic,
-                                                         InboundRecordProcessor& processor) {
+void SharedConsumerManagerImpl::processCallback(const RecordCbSharedPtr& callback) {
+
+  // For every fetch topic, figure out the upstream cluster,
+  // create consumer if needed ...
+  const TopicToPartitionsMap interest = callback->interest();
+  for (const auto& fetch : interest) {
+    const std::string& topic = fetch.first;
+    registerConsumerIfAbsent(topic);
+  }
+
+  // ... and start processing.
+  distributor_->processCallback(callback);
+}
+
+void SharedConsumerManagerImpl::removeCallback(const RecordCbSharedPtr& callback) {
+  // Real work - let's remove the callback.
+  distributor_->removeCallback(callback);
+}
+
+void SharedConsumerManagerImpl::registerConsumerIfAbsent(const std::string& topic) {
   absl::MutexLock lock(&consumers_mutex_);
   const auto it = topic_to_consumer_.find(topic);
   // Return consumer already present or create new one and register it.
   if (topic_to_consumer_.end() == it) {
-    registerNewConsumer(topic, processor);
+    registerNewConsumer(topic);
   }
 }
 
-void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic,
-                                                    InboundRecordProcessor& processor) {
+void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic) {
   ENVOY_LOG(debug, "Creating consumer for topic [{}]", topic);
 
   // Compute which upstream cluster corresponds to the topic.
@@ -258,7 +93,7 @@ void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic,
 
   // Create the consumer and register it.
   KafkaConsumerPtr new_consumer = consumer_factory_.createConsumer(
-      processor, thread_factory_, topic, cluster_config->partition_count_,
+      *distributor_, thread_factory_, topic, cluster_config->partition_count_,
       cluster_config->upstream_consumer_properties_);
   ENVOY_LOG(debug, "Registering new Kafka consumer for topic [{}], consuming from cluster [{}]",
             topic, cluster_config->name_);
@@ -268,6 +103,175 @@ void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic,
 size_t SharedConsumerManagerImpl::getConsumerCountForTest() const {
   absl::MutexLock lock(&consumers_mutex_);
   return topic_to_consumer_.size();
+}
+
+// RecordDistributor
+
+bool RecordDistributor::waitUntilInterest(const std::string& topic,
+                                          const int32_t timeout_ms) const {
+
+  auto distributor_has_interest = std::bind(&RecordDistributor::hasInterest, this, topic);
+  // Effectively this means "has an interest appeared within timeout".
+  // If not, we let the user know so they could do something else
+  // instead of being infinitely blocked.
+  bool can_poll = callbacks_mutex_.LockWhenWithTimeout(absl::Condition(&distributor_has_interest),
+                                                       absl::Milliseconds(timeout_ms));
+  callbacks_mutex_.Unlock(); // Lock...WithTimeout always locks, so we need to unlock.
+  return can_poll;
+}
+
+bool RecordDistributor::hasInterest(const std::string& topic) const {
+  for (const auto& e : partition_to_callbacks_) {
+    if (topic == e.first.first && !e.second.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void RecordDistributor::processCallback(const RecordCbSharedPtr& callback) {
+
+  TopicToPartitionsMap requested = callback->interest();
+  ENVOY_LOG(trace, "Processing callback {}", callback->toString());
+
+  bool fulfilled_at_startup = false;
+
+  {
+    absl::MutexLock lock(&messages_mutex_);
+    for (const auto& topic_and_partitions : requested) {
+      const std::string topic = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        const KafkaPartition kp = {topic, partition};
+
+        auto& stored_messages = messages_waiting_for_interest_[kp];
+        if (0 != stored_messages.size()) {
+          ENVOY_LOG(trace, "Early notification for callback {}, as there are {} messages available",
+                    callback->toString(), stored_messages.size());
+        }
+
+        for (auto it = stored_messages.begin(); it != stored_messages.end();) {
+          CallbackReply callback_status = callback->receive(*it);
+          bool callback_finished;
+          switch (callback_status) {
+          case CallbackReply::ACCEPTED_AND_FINISHED: {
+            // We had a callback that wanted records, and got all it wanted in the initial
+            // processing (== everything it needed was buffered), so we won't need to register it.
+            callback_finished = true;
+            it = stored_messages.erase(it);
+            break;
+          }
+          case CallbackReply::ACCEPTED_AND_WANT_MORE: {
+            callback_finished = false;
+            it = stored_messages.erase(it);
+            break;
+          }
+          case CallbackReply::REJECTED: {
+            callback_finished = true;
+            break;
+          }
+          } /* switch */
+          if (callback_finished) {
+            fulfilled_at_startup = true;
+            break; // Callback does not want any messages anymore.
+          }
+        } /* for-messages */
+      }   /* for-partitions */
+    }     /* for-topic_and_partitions */
+  }       /* lock on messages_mutex_ */
+
+  if (!fulfilled_at_startup) {
+    // Usual path: the request was not fulfilled at receive time (there were no buffered messages).
+    // So we just register the callback.
+    absl::MutexLock lock(&callbacks_mutex_);
+
+    for (const auto& topic_and_partitions : requested) {
+      const std::string topic = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        const KafkaPartition kp = {topic, partition};
+        auto& partition_callbacks = partition_to_callbacks_[kp];
+        partition_callbacks.push_back(callback);
+      }
+    }
+  } else {
+    ENVOY_LOG(trace, "No registration for callback {} due to successful early processing",
+              callback->toString());
+  }
+}
+
+// XXX (adam.kotwasinski) Inefficient: locks aquired per message.
+void RecordDistributor::receive(InboundRecordSharedPtr message) {
+
+  const KafkaPartition kafka_partition = {message->topic_, message->partition_};
+
+  // Whether this message has been consumed by any of the callbacks.
+  // Because then we can safely throw it away instead of storing.
+  bool consumed_by_callback = false;
+
+  {
+    absl::MutexLock lock(&callbacks_mutex_);
+    auto& callbacks = partition_to_callbacks_[kafka_partition];
+
+    std::vector<RecordCbSharedPtr> satisfied_callbacks = {};
+
+    // Typical case: there is some interest in messages for given partition. Notify the callback and
+    // remove it.
+    for (const auto& callback : callbacks) {
+      CallbackReply callback_status = callback->receive(message);
+      switch (callback_status) {
+      case CallbackReply::ACCEPTED_AND_FINISHED: {
+        consumed_by_callback = true;
+        // A callback is finally satisfied, it will never want more messages.
+        satisfied_callbacks.push_back(callback);
+        break;
+      }
+      case CallbackReply::ACCEPTED_AND_WANT_MORE: {
+        consumed_by_callback = true;
+        break;
+      }
+      case CallbackReply::REJECTED: {
+        break;
+      }
+      } /* switch */
+
+      /* Some callback has taken the message - this is good, no more iterating. */
+      if (consumed_by_callback) {
+        break;
+      }
+    }
+
+    for (const auto& callback : satisfied_callbacks) {
+      // Lock was acquired at the beggining of the block.
+      removeCallbackWithoutLocking(callback, partition_to_callbacks_);
+    }
+  }
+
+  // Noone is interested in our message, so we are going to store it in a local cache.
+  if (!consumed_by_callback) {
+    absl::MutexLock lock(&messages_mutex_);
+    auto& stored_messages = messages_waiting_for_interest_[kafka_partition];
+    // XXX (adam.kotwasinski) Implement some kind of limit.
+    stored_messages.push_back(message);
+    ENVOY_LOG(trace, "Stored message [{}]", message->toString());
+  }
+}
+
+void RecordDistributor::removeCallback(const RecordCbSharedPtr& callback) {
+  absl::MutexLock lock(&callbacks_mutex_);
+  removeCallbackWithoutLocking(callback, partition_to_callbacks_);
+}
+
+void RecordDistributor::removeCallbackWithoutLocking(
+    const RecordCbSharedPtr& callback,
+    std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>& partition_to_callbacks) {
+
+  ENVOY_LOG(info, "Removing callback {}", callback->toString());
+  for (auto& e : partition_to_callbacks) {
+    auto& partition_callbacks = e.second;
+    partition_callbacks.erase(
+        std::remove(partition_callbacks.begin(), partition_callbacks.end(), callback),
+        partition_callbacks.end());
+  }
+  ENVOY_LOG(info, "Removed callback {}", callback->toString());
 }
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
@@ -12,6 +12,188 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
+// InboundRecordDistributor
+
+InboundRecordDistributor::InboundRecordDistributor(SharedConsumerManagerPtr&& consumer_manager)
+    : consumer_manager_{std::move(consumer_manager)} {};
+
+void InboundRecordDistributor::processCallback(const RecordCbSharedPtr& callback) {
+
+  // For each topic this callback is interested in, make sure we have a consumer active.
+  const TopicToPartitionsMap interest = callback->interest();
+  for (const auto& fetch : interest) {
+    const std::string& topic = fetch.first;
+    consumer_manager_->registerConsumerIfAbsent(topic, *this);
+  }
+
+  // Then do the real processing.
+  doProcessCallback(callback);
+}
+
+void InboundRecordDistributor::doProcessCallback(const RecordCbSharedPtr& callback) {
+
+  const TopicToPartitionsMap requested = callback->interest();
+  ENVOY_LOG(trace, "Processing callback {}", callback->toString());
+
+  bool fulfilled_at_startup = false;
+
+  {
+    absl::MutexLock lock(&records_mutex_);
+    for (const auto& topic_and_partitions : requested) {
+      const std::string topic = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        const KafkaPartition kp = {topic, partition};
+
+        auto& stored_messages = records_waiting_for_interest_[kp];
+        if (0 != stored_messages.size()) {
+          ENVOY_LOG(trace, "Early notification for callback {}, as there are {} messages available",
+                    callback->toString(), stored_messages.size());
+        }
+
+        for (auto it = stored_messages.begin(); it != stored_messages.end();) {
+          CallbackReply callback_status = callback->receive(*it);
+          bool callback_finished;
+          switch (callback_status) {
+          case CallbackReply::ACCEPTED_AND_FINISHED: {
+            // We had a callback that wanted records, and got all it wanted in the initial
+            // processing (== everything it needed was buffered), so we won't need to register it.
+            callback_finished = true;
+            it = stored_messages.erase(it);
+            break;
+          }
+          case CallbackReply::ACCEPTED_AND_WANT_MORE: {
+            callback_finished = false;
+            it = stored_messages.erase(it);
+            break;
+          }
+          case CallbackReply::REJECTED: {
+            callback_finished = true;
+            break;
+          }
+          } /* switch */
+          if (callback_finished) {
+            fulfilled_at_startup = true;
+            break; // Callback does not want any messages anymore.
+          }
+        } /* for-messages */
+      }   /* for-partitions */
+    }     /* for-topic_and_partitions */
+  }       /* lock on records_mutex_ */
+
+  if (!fulfilled_at_startup) {
+    // Usual path: the request was not fulfilled at receive time (there were no buffered messages).
+    // So we just register the callback.
+    absl::MutexLock lock(&callbacks_mutex_);
+
+    for (const auto& topic_and_partitions : requested) {
+      const std::string topic = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        const KafkaPartition kp = {topic, partition};
+        auto& partition_callbacks = partition_to_callbacks_[kp];
+        partition_callbacks.push_back(callback);
+      }
+    }
+  } else {
+    ENVOY_LOG(trace, "No registration for callback {} due to successful early processing",
+              callback->toString());
+  }
+}
+
+void InboundRecordDistributor::removeCallback(const RecordCbSharedPtr& callback) {
+  absl::MutexLock lock(&callbacks_mutex_);
+  doRemoveCallback(callback);
+}
+
+void InboundRecordDistributor::doRemoveCallback(const RecordCbSharedPtr& callback) {
+  ENVOY_LOG(trace, "Removing callback {}", callback->toString());
+  for (auto& e : partition_to_callbacks_) {
+    auto& partition_callbacks = e.second;
+    partition_callbacks.erase(
+        std::remove(partition_callbacks.begin(), partition_callbacks.end(), callback),
+        partition_callbacks.end());
+  }
+}
+
+bool InboundRecordDistributor::waitUntilInterest(const std::string& topic,
+                                                 const int32_t timeout_ms) const {
+
+  auto distributor_has_interest = std::bind(&InboundRecordDistributor::hasInterest, this, topic);
+  // Effectively this means "has an interest appeared within timeout".
+  // If not, we let the user know so they could do something else
+  // instead of being infinitely blocked.
+  bool can_poll = callbacks_mutex_.LockWhenWithTimeout(absl::Condition(&distributor_has_interest),
+                                                       absl::Milliseconds(timeout_ms));
+  callbacks_mutex_.Unlock(); // Lock...WithTimeout always locks, so we need to unlock.
+  return can_poll;
+}
+
+bool InboundRecordDistributor::hasInterest(const std::string& topic) const {
+  for (const auto& e : partition_to_callbacks_) {
+    if (topic == e.first.first && !e.second.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// XXX (adam.kotwasinski) Inefficient: locks are acquired per message, change it to collection.
+void InboundRecordDistributor::receive(InboundRecordSharedPtr message) {
+
+  const KafkaPartition kafka_partition = {message->topic_, message->partition_};
+
+  // Whether this message has been consumed by any of the callbacks.
+  // Because then we can safely throw it away instead of storing.
+  bool consumed_by_callback = false;
+
+  {
+    absl::MutexLock lock(&callbacks_mutex_);
+    auto& callbacks = partition_to_callbacks_[kafka_partition];
+
+    // Callbacks that have been satisfied by this delivery.
+    std::vector<RecordCbSharedPtr> satisfied_callbacks = {};
+
+    // Typical case: there is some interest in messages for given partition.
+    // Notify the callback and remove it.
+    for (const auto& callback : callbacks) {
+      const CallbackReply callback_status = callback->receive(message);
+      switch (callback_status) {
+      case CallbackReply::ACCEPTED_AND_FINISHED: {
+        consumed_by_callback = true;
+        // A callback is finally satisfied, it will never want more messages.
+        satisfied_callbacks.push_back(callback);
+        break;
+      }
+      case CallbackReply::ACCEPTED_AND_WANT_MORE: {
+        consumed_by_callback = true;
+        break;
+      }
+      case CallbackReply::REJECTED: {
+        break;
+      }
+      } /* switch */
+
+      /* Some callback has taken the message - this is good, no more iterating. */
+      if (consumed_by_callback) {
+        break;
+      }
+    }
+
+    for (const auto& callback : satisfied_callbacks) {
+      // Lock was acquired at the beggining of the block.
+      doRemoveCallback(callback);
+    }
+  }
+
+  // Noone is interested in our message, so we are going to store it in a local cache.
+  if (!consumed_by_callback) {
+    absl::MutexLock lock(&records_mutex_);
+    auto& stored_messages = records_waiting_for_interest_[kafka_partition];
+    // XXX (adam.kotwasinski) Implement some kind of limit.
+    stored_messages.push_back(message);
+    ENVOY_LOG(trace, "Stored message [{}]", message->toString());
+  }
+}
+
 // KafkaConsumerFactoryImpl
 
 class KafkaConsumerFactoryImpl : public KafkaConsumerFactory {
@@ -49,38 +231,21 @@ SharedConsumerManagerImpl::SharedConsumerManagerImpl(
 SharedConsumerManagerImpl::SharedConsumerManagerImpl(
     const UpstreamKafkaConfiguration& configuration, Thread::ThreadFactory& thread_factory,
     const KafkaConsumerFactory& consumer_factory)
-    : distributor_{std::make_unique<RecordDistributor>()}, configuration_{configuration},
-      thread_factory_{thread_factory}, consumer_factory_{consumer_factory} {}
+    : configuration_{configuration}, thread_factory_{thread_factory}, consumer_factory_{
+                                                                          consumer_factory} {}
 
-void SharedConsumerManagerImpl::processCallback(const RecordCbSharedPtr& callback) {
-
-  // For every fetch topic, figure out the upstream cluster,
-  // create consumer if needed ...
-  const TopicToPartitionsMap interest = callback->interest();
-  for (const auto& fetch : interest) {
-    const std::string& topic = fetch.first;
-    registerConsumerIfAbsent(topic);
-  }
-
-  // ... and start processing.
-  distributor_->processCallback(callback);
-}
-
-void SharedConsumerManagerImpl::removeCallback(const RecordCbSharedPtr& callback) {
-  // Real work - let's remove the callback.
-  distributor_->removeCallback(callback);
-}
-
-void SharedConsumerManagerImpl::registerConsumerIfAbsent(const std::string& topic) {
+void SharedConsumerManagerImpl::registerConsumerIfAbsent(const std::string& topic,
+                                                         InboundRecordProcessor& processor) {
   absl::MutexLock lock(&consumers_mutex_);
   const auto it = topic_to_consumer_.find(topic);
   // Return consumer already present or create new one and register it.
   if (topic_to_consumer_.end() == it) {
-    registerNewConsumer(topic);
+    registerNewConsumer(topic, processor);
   }
 }
 
-void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic) {
+void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic,
+                                                    InboundRecordProcessor& processor) {
   ENVOY_LOG(debug, "Creating consumer for topic [{}]", topic);
 
   // Compute which upstream cluster corresponds to the topic.
@@ -93,7 +258,7 @@ void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic) {
 
   // Create the consumer and register it.
   KafkaConsumerPtr new_consumer = consumer_factory_.createConsumer(
-      *distributor_, thread_factory_, topic, cluster_config->partition_count_,
+      processor, thread_factory_, topic, cluster_config->partition_count_,
       cluster_config->upstream_consumer_properties_);
   ENVOY_LOG(debug, "Registering new Kafka consumer for topic [{}], consuming from cluster [{}]",
             topic, cluster_config->name_);
@@ -103,175 +268,6 @@ void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic) {
 size_t SharedConsumerManagerImpl::getConsumerCountForTest() const {
   absl::MutexLock lock(&consumers_mutex_);
   return topic_to_consumer_.size();
-}
-
-// RecordDistributor
-
-bool RecordDistributor::waitUntilInterest(const std::string& topic,
-                                          const int32_t timeout_ms) const {
-
-  auto distributor_has_interest = std::bind(&RecordDistributor::hasInterest, this, topic);
-  // Effectively this means "has an interest appeared within timeout".
-  // If not, we let the user know so they could do something else
-  // instead of being infinitely blocked.
-  bool can_poll = callbacks_mutex_.LockWhenWithTimeout(absl::Condition(&distributor_has_interest),
-                                                       absl::Milliseconds(timeout_ms));
-  callbacks_mutex_.Unlock(); // Lock...WithTimeout always locks, so we need to unlock.
-  return can_poll;
-}
-
-bool RecordDistributor::hasInterest(const std::string& topic) const {
-  for (const auto& e : partition_to_callbacks_) {
-    if (topic == e.first.first && !e.second.empty()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void RecordDistributor::processCallback(const RecordCbSharedPtr& callback) {
-
-  TopicToPartitionsMap requested = callback->interest();
-  ENVOY_LOG(trace, "Processing callback {}", callback->toString());
-
-  bool fulfilled_at_startup = false;
-
-  {
-    absl::MutexLock lock(&messages_mutex_);
-    for (const auto& topic_and_partitions : requested) {
-      const std::string topic = topic_and_partitions.first;
-      for (const int32_t partition : topic_and_partitions.second) {
-        const KafkaPartition kp = {topic, partition};
-
-        auto& stored_messages = messages_waiting_for_interest_[kp];
-        if (0 != stored_messages.size()) {
-          ENVOY_LOG(trace, "Early notification for callback {}, as there are {} messages available",
-                    callback->toString(), stored_messages.size());
-        }
-
-        for (auto it = stored_messages.begin(); it != stored_messages.end();) {
-          CallbackReply callback_status = callback->receive(*it);
-          bool callback_finished;
-          switch (callback_status) {
-          case CallbackReply::ACCEPTED_AND_FINISHED: {
-            // We had a callback that wanted records, and got all it wanted in the initial
-            // processing (== everything it needed was buffered), so we won't need to register it.
-            callback_finished = true;
-            it = stored_messages.erase(it);
-            break;
-          }
-          case CallbackReply::ACCEPTED_AND_WANT_MORE: {
-            callback_finished = false;
-            it = stored_messages.erase(it);
-            break;
-          }
-          case CallbackReply::REJECTED: {
-            callback_finished = true;
-            break;
-          }
-          } /* switch */
-          if (callback_finished) {
-            fulfilled_at_startup = true;
-            break; // Callback does not want any messages anymore.
-          }
-        } /* for-messages */
-      }   /* for-partitions */
-    }     /* for-topic_and_partitions */
-  }       /* lock on messages_mutex_ */
-
-  if (!fulfilled_at_startup) {
-    // Usual path: the request was not fulfilled at receive time (there were no buffered messages).
-    // So we just register the callback.
-    absl::MutexLock lock(&callbacks_mutex_);
-
-    for (const auto& topic_and_partitions : requested) {
-      const std::string topic = topic_and_partitions.first;
-      for (const int32_t partition : topic_and_partitions.second) {
-        const KafkaPartition kp = {topic, partition};
-        auto& partition_callbacks = partition_to_callbacks_[kp];
-        partition_callbacks.push_back(callback);
-      }
-    }
-  } else {
-    ENVOY_LOG(trace, "No registration for callback {} due to successful early processing",
-              callback->toString());
-  }
-}
-
-// XXX (adam.kotwasinski) Inefficient: locks aquired per message.
-void RecordDistributor::receive(InboundRecordSharedPtr message) {
-
-  const KafkaPartition kafka_partition = {message->topic_, message->partition_};
-
-  // Whether this message has been consumed by any of the callbacks.
-  // Because then we can safely throw it away instead of storing.
-  bool consumed_by_callback = false;
-
-  {
-    absl::MutexLock lock(&callbacks_mutex_);
-    auto& callbacks = partition_to_callbacks_[kafka_partition];
-
-    std::vector<RecordCbSharedPtr> satisfied_callbacks = {};
-
-    // Typical case: there is some interest in messages for given partition. Notify the callback and
-    // remove it.
-    for (const auto& callback : callbacks) {
-      CallbackReply callback_status = callback->receive(message);
-      switch (callback_status) {
-      case CallbackReply::ACCEPTED_AND_FINISHED: {
-        consumed_by_callback = true;
-        // A callback is finally satisfied, it will never want more messages.
-        satisfied_callbacks.push_back(callback);
-        break;
-      }
-      case CallbackReply::ACCEPTED_AND_WANT_MORE: {
-        consumed_by_callback = true;
-        break;
-      }
-      case CallbackReply::REJECTED: {
-        break;
-      }
-      } /* switch */
-
-      /* Some callback has taken the message - this is good, no more iterating. */
-      if (consumed_by_callback) {
-        break;
-      }
-    }
-
-    for (const auto& callback : satisfied_callbacks) {
-      // Lock was acquired at the beggining of the block.
-      removeCallbackWithoutLocking(callback, partition_to_callbacks_);
-    }
-  }
-
-  // Noone is interested in our message, so we are going to store it in a local cache.
-  if (!consumed_by_callback) {
-    absl::MutexLock lock(&messages_mutex_);
-    auto& stored_messages = messages_waiting_for_interest_[kafka_partition];
-    // XXX (adam.kotwasinski) Implement some kind of limit.
-    stored_messages.push_back(message);
-    ENVOY_LOG(trace, "Stored message [{}]", message->toString());
-  }
-}
-
-void RecordDistributor::removeCallback(const RecordCbSharedPtr& callback) {
-  absl::MutexLock lock(&callbacks_mutex_);
-  removeCallbackWithoutLocking(callback, partition_to_callbacks_);
-}
-
-void RecordDistributor::removeCallbackWithoutLocking(
-    const RecordCbSharedPtr& callback,
-    std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>& partition_to_callbacks) {
-
-  ENVOY_LOG(info, "Removing callback {}", callback->toString());
-  for (auto& e : partition_to_callbacks) {
-    auto& partition_callbacks = e.second;
-    partition_callbacks.erase(
-        std::remove(partition_callbacks.begin(), partition_callbacks.end(), callback),
-        partition_callbacks.end());
-  }
-  ENVOY_LOG(info, "Removed callback {}", callback->toString());
 }
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <vector>
 
 #include "envoy/thread/thread.h"
 
@@ -19,19 +20,47 @@ namespace Kafka {
 namespace Mesh {
 
 /**
- * Placeholder interface for now.
- * In future:
  * Processor implementation that stores received records (that had no interest), and callbacks
  * waiting for records (that had no matching records delivered yet).
  * Basically core of Fetch-handling business logic.
  */
-class RecordDistributor : public InboundRecordProcessor {
+class RecordDistributor : public InboundRecordProcessor,
+                          private Logger::Loggable<Logger::Id::kafka> {
 public:
   // InboundRecordProcessor
   bool waitUntilInterest(const std::string& topic, const int32_t timeout_ms) const override;
 
   // InboundRecordProcessor
   void receive(InboundRecordSharedPtr message) override;
+
+  // Process an inbound record callback by passing cached records to it
+  // and (if needed) registering the callback.
+  void processCallback(const RecordCbSharedPtr& callback);
+
+  // Remove the callback (usually invoked by the callback timing out downstream).
+  void removeCallback(const RecordCbSharedPtr& callback);
+
+private:
+  // Checks whether any of the callbacks stored right now are interested in the topic.
+  bool hasInterest(const std::string& topic) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(callbacks_mutex_);
+
+  // HAX!
+  void removeCallbackWithoutLocking(
+      const RecordCbSharedPtr& callback,
+      std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>& partition_to_callbacks);
+
+  /**
+   * Invariant: for every i: KafkaPartition, the following holds:
+   * !(partition_to_callbacks_[i].size() >= 0 && messages_waiting_for_interest_[i].size() >= 0)
+   */
+
+  mutable absl::Mutex callbacks_mutex_;
+  std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>
+      partition_to_callbacks_ ABSL_GUARDED_BY(callbacks_mutex_);
+
+  mutable absl::Mutex messages_mutex_;
+  std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>
+      messages_waiting_for_interest_ ABSL_GUARDED_BY(messages_mutex_);
 };
 
 using RecordDistributorPtr = std::unique_ptr<RecordDistributor>;
@@ -52,6 +81,7 @@ public:
 
 /**
  * Maintains a collection of Kafka consumers (one per topic).
+ * Maintains a message cache for messages that had no interest but might be requested later.
  */
 class SharedConsumerManagerImpl : public SharedConsumerManager,
                                   private Logger::Loggable<Logger::Id::kafka> {
@@ -64,6 +94,12 @@ public:
   SharedConsumerManagerImpl(const UpstreamKafkaConfiguration& configuration,
                             Thread::ThreadFactory& thread_factory,
                             const KafkaConsumerFactory& consumer_factory);
+
+  // SharedConsumerManager
+  void processCallback(const RecordCbSharedPtr& callback) override;
+
+  // SharedConsumerManager
+  void removeCallback(const RecordCbSharedPtr& callback) override;
 
   // SharedConsumerManager
   void registerConsumerIfAbsent(const std::string& topic) override;

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h
@@ -49,16 +49,21 @@ public:
   // RecordCallbackProcessor
   void removeCallback(const RecordCbSharedPtr& callback) override;
 
-  size_t getCallbackCountForTest(const std::string& topic, const int32_t partition) const;
+  int32_t getCallbackCountForTest(const std::string& topic, const int32_t partition) const;
 
-  size_t getRecordCountForTest(const std::string& topic, const int32_t partition) const;
+  int32_t getRecordCountForTest(const std::string& topic, const int32_t partition) const;
 
 private:
   // Checks whether any of the callbacks stored right now are interested in the topic.
   bool hasInterest(const std::string& topic) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(callbacks_mutex_);
 
-  // Helper function (passes records to callback).
+  // Helper function (passes all stored records to callback).
   bool passRecordsToCallback(const RecordCbSharedPtr& callback);
+
+  // Helper function (passes partition records to callback).
+  bool passPartitionRecordsToCallback(const RecordCbSharedPtr& callback,
+                                      const KafkaPartition& kafka_partition)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(stored_records_mutex_);
 
   // Helper function (real callback removal).
   void doRemoveCallback(const RecordCbSharedPtr& callback)

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h
@@ -24,30 +24,36 @@ namespace Mesh {
  * waiting for records (that had no matching records delivered yet).
  * Basically core of Fetch-handling business logic.
  */
-class RecordDistributor : public InboundRecordProcessor,
-                          private Logger::Loggable<Logger::Id::kafka> {
+class InboundRecordDistributor : public RecordCallbackProcessor,
+                                 public InboundRecordProcessor,
+                                 private Logger::Loggable<Logger::Id::kafka> {
 public:
+  InboundRecordDistributor(SharedConsumerManagerPtr&& consumer_manager);
+
+  // RecordCallbackProcessor
+  void processCallback(const RecordCbSharedPtr& callback) override;
+
+  // RecordCallbackProcessor
+  void removeCallback(const RecordCbSharedPtr& callback) override;
+
   // InboundRecordProcessor
   bool waitUntilInterest(const std::string& topic, const int32_t timeout_ms) const override;
 
   // InboundRecordProcessor
   void receive(InboundRecordSharedPtr message) override;
 
-  // Process an inbound record callback by passing cached records to it
-  // and (if needed) registering the callback.
-  void processCallback(const RecordCbSharedPtr& callback);
-
-  // Remove the callback (usually invoked by the callback timing out downstream).
-  void removeCallback(const RecordCbSharedPtr& callback);
-
 private:
+  // Helper function (real processing: finding matching records, registering callback).
+  void doProcessCallback(const RecordCbSharedPtr& callback);
+
+  // Helper function (real lock removal).
+  void doRemoveCallback(const RecordCbSharedPtr& callback)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(callbacks_mutex_);
+
   // Checks whether any of the callbacks stored right now are interested in the topic.
   bool hasInterest(const std::string& topic) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(callbacks_mutex_);
 
-  // HAX!
-  void removeCallbackWithoutLocking(
-      const RecordCbSharedPtr& callback,
-      std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>& partition_to_callbacks);
+  SharedConsumerManagerPtr consumer_manager_;
 
   /**
    * Invariant: for every i: KafkaPartition, the following holds:
@@ -58,12 +64,10 @@ private:
   std::map<KafkaPartition, std::vector<RecordCbSharedPtr>>
       partition_to_callbacks_ ABSL_GUARDED_BY(callbacks_mutex_);
 
-  mutable absl::Mutex messages_mutex_;
+  mutable absl::Mutex records_mutex_;
   std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>
-      messages_waiting_for_interest_ ABSL_GUARDED_BY(messages_mutex_);
+      records_waiting_for_interest_ ABSL_GUARDED_BY(records_mutex_);
 };
-
-using RecordDistributorPtr = std::unique_ptr<RecordDistributor>;
 
 /**
  * Injectable for tests.
@@ -81,7 +85,6 @@ public:
 
 /**
  * Maintains a collection of Kafka consumers (one per topic).
- * Maintains a message cache for messages that had no interest but might be requested later.
  */
 class SharedConsumerManagerImpl : public SharedConsumerManager,
                                   private Logger::Loggable<Logger::Id::kafka> {
@@ -96,22 +99,15 @@ public:
                             const KafkaConsumerFactory& consumer_factory);
 
   // SharedConsumerManager
-  void processCallback(const RecordCbSharedPtr& callback) override;
-
-  // SharedConsumerManager
-  void removeCallback(const RecordCbSharedPtr& callback) override;
-
-  // SharedConsumerManager
-  void registerConsumerIfAbsent(const std::string& topic) override;
+  void registerConsumerIfAbsent(const std::string& topic,
+                                InboundRecordProcessor& processor) override;
 
   size_t getConsumerCountForTest() const;
 
 private:
   // Mutates 'topic_to_consumer_'.
-  void registerNewConsumer(const std::string& topic)
+  void registerNewConsumer(const std::string& topic, InboundRecordProcessor& processor)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(consumers_mutex_);
-
-  RecordDistributorPtr distributor_;
 
   const UpstreamKafkaConfiguration& configuration_;
   Thread::ThreadFactory& thread_factory_;

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h
@@ -22,12 +22,13 @@ using TopicToPartitionsMap = std::map<std::string, std::vector<int32_t>>;
  * Callback's response when it is provided with a record.
  */
 enum class CallbackReply {
-  // Callback is not interested in this record.
-  REJECTED,
+  // Callback is not interested in any record anymore.
+  // Impl note: this can be caused by callback timing out in between.
+  Rejected,
   // Callback consumed the record and is capable of accepting more.
-  ACCEPTED_AND_WANT_MORE,
+  AcceptedAndWantMore,
   // Callback consumed the record and will not receive more (allows us to optimize a little).
-  ACCEPTED_AND_FINISHED,
+  AcceptedAndFinished,
 };
 
 /**

--- a/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
@@ -28,12 +28,6 @@ public:
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };
 
-class MockInboundRecordProcessor : public InboundRecordProcessor {
-public:
-  MOCK_METHOD(void, receive, (InboundRecordSharedPtr), ());
-  MOCK_METHOD(bool, waitUntilInterest, (const std::string&, const int32_t), (const));
-};
-
 class MockKafkaConsumerFactory : public KafkaConsumerFactory {
 public:
   MOCK_METHOD(KafkaConsumerPtr, createConsumer,
@@ -47,7 +41,6 @@ protected:
   MockThreadFactory thread_factory_;
   MockUpstreamKafkaConfiguration configuration_;
   MockKafkaConsumerFactory consumer_factory_;
-  MockInboundRecordProcessor processor_;
 
   std::unique_ptr<SharedConsumerManagerImpl> makeTestee() {
     return std::make_unique<SharedConsumerManagerImpl>(configuration_, thread_factory_,
@@ -74,10 +67,10 @@ TEST_F(SharedConsumerManagerTest, ShouldRegisterTopicOnlyOnce) {
 
   // when
   for (int i = 0; i < 3; ++i) {
-    testee->registerConsumerIfAbsent(topic1, processor_);
+    testee->registerConsumerIfAbsent(topic1);
   }
   for (int i = 0; i < 3; ++i) {
-    testee->registerConsumerIfAbsent(topic2, processor_);
+    testee->registerConsumerIfAbsent(topic2);
   }
 
   // then
@@ -95,7 +88,7 @@ TEST_F(SharedConsumerManagerTest, ShouldHandleMissingConfig) {
   auto testee = makeTestee();
 
   // when, then - construction throws and nothing gets registered.
-  EXPECT_THROW(testee->registerConsumerIfAbsent(topic, processor_), EnvoyException);
+  EXPECT_THROW(testee->registerConsumerIfAbsent(topic), EnvoyException);
   ASSERT_EQ(testee->getConsumerCountForTest(), 0);
 }
 

--- a/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "envoy/common/exception.h"
 #include "envoy/thread/thread.h"
 
@@ -13,6 +15,7 @@ namespace Mesh {
 namespace {
 
 using testing::_;
+using testing::NiceMock;
 using testing::Return;
 
 class MockThreadFactory : public Thread::ThreadFactory {
@@ -90,6 +93,251 @@ TEST_F(SharedConsumerManagerTest, ShouldHandleMissingConfig) {
   // when, then - construction throws and nothing gets registered.
   EXPECT_THROW(testee->registerConsumerIfAbsent(topic), EnvoyException);
   ASSERT_EQ(testee->getConsumerCountForTest(), 0);
+}
+
+// RecordDistributorTest
+
+class MockRecordCb : public RecordCb {
+public:
+  MOCK_METHOD(CallbackReply, receive, (InboundRecordSharedPtr), ());
+  MOCK_METHOD(TopicToPartitionsMap, interest, (), (const));
+  MOCK_METHOD(std::string, toString, (), (const));
+};
+
+class RecordDistributorTest : public testing::Test {
+protected:
+  RecordDistributorPtr makeTestee() { return std::make_unique<RecordDistributor>(); }
+
+  RecordDistributorPtr makeTestee(const PartitionMap<RecordCbSharedPtr>& callbacks) {
+    return std::make_unique<RecordDistributor>(callbacks, PartitionMap<InboundRecordSharedPtr>());
+  }
+
+  RecordDistributorPtr makeTestee(const PartitionMap<InboundRecordSharedPtr>& records) {
+    return std::make_unique<RecordDistributor>(PartitionMap<RecordCbSharedPtr>(), records);
+  }
+
+  std::shared_ptr<MockRecordCb> makeCb() {
+    auto result = std::make_shared<NiceMock<MockRecordCb>>();
+    ON_CALL(*result, receive(_)).WillByDefault(Return(CallbackReply::Rejected));
+    return result;
+  }
+
+  InboundRecordSharedPtr makeRecord(const std::string& topic, const int32_t partition) {
+    return std::make_shared<InboundRecord>(topic, partition, 0);
+  }
+};
+
+TEST_F(RecordDistributorTest, ShouldNotWaitUntilInterestIfThereIsAny) {
+  // given
+  const std::string topic = "aaa";
+  PartitionMap<RecordCbSharedPtr> callbacks;
+  callbacks[{topic, 0}] = {makeCb()};
+  callbacks[{"bbb", 0}] = {makeCb()};
+  const auto testee = makeTestee(callbacks);
+
+  // when
+  const auto result = testee->waitUntilInterest(topic, 500);
+
+  // then
+  ASSERT_TRUE(result);
+}
+
+TEST_F(RecordDistributorTest, ShouldWaitUntilInterestIfThereIsNone) {
+  // given
+  const auto timeout_ms = 500;
+  PartitionMap<RecordCbSharedPtr> callbacks;
+  callbacks[{"bbb", 0}] = {makeCb()};
+  const auto testee = makeTestee(callbacks);
+
+  // when
+  namespace ch = std::chrono;
+  const auto start = ch::high_resolution_clock::now();
+  const auto result = testee->waitUntilInterest("aaa", timeout_ms);
+  const auto stop = ch::high_resolution_clock::now();
+
+  // then
+  ASSERT_FALSE(result);
+  const auto duration_ms = (ch::duration_cast<ch::milliseconds>(stop - start)).count();
+  ASSERT_GT(duration_ms, timeout_ms * 0.8);
+}
+
+TEST_F(RecordDistributorTest, ShouldStoreRecords) {
+  // given
+  const auto testee = makeTestee();
+
+  // when
+  for (int i = 0; i < 10; ++i) {
+    const auto record = makeRecord("topic", 13);
+    testee->receive(record);
+  }
+
+  // then
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 13), 10);
+}
+
+TEST_F(RecordDistributorTest, ShouldPassRecordToCallbacksAndRemoveIfFinished) {
+  // given
+  PartitionMap<RecordCbSharedPtr> callbacks;
+  auto callback = makeCb();
+  EXPECT_CALL(*callback, receive(_)).WillOnce(Return(CallbackReply::AcceptedAndFinished));
+  callbacks[{"topic", 0}] = {callback};
+  callbacks[{"topic", 1}] = {makeCb(), callback};
+  callbacks[{"topic", 2}] = {callback, makeCb()};
+  callbacks[{"topic", 3}] = {makeCb(), callback, makeCb()};
+  const auto testee = makeTestee(callbacks);
+  const auto record = makeRecord("topic", 2);
+
+  // when
+  testee->receive(record);
+
+  // then
+  // Record was not stored.
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 2), 0);
+  // Our callback got removed, others stay.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 0);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 1);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 2), 1);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 3), 2);
+}
+
+// Compared to previous test - callback does not get removed here.
+TEST_F(RecordDistributorTest, ShouldPassRecordToCallbacksAndKeepThem) {
+  // given
+  PartitionMap<RecordCbSharedPtr> callbacks;
+  auto callback = makeCb();
+  EXPECT_CALL(*callback, receive(_)).WillOnce(Return(CallbackReply::AcceptedAndWantMore));
+  callbacks[{"topic", 0}] = {callback};
+  callbacks[{"topic", 1}] = {makeCb(), callback};
+  callbacks[{"topic", 2}] = {callback, makeCb()};
+  callbacks[{"topic", 3}] = {makeCb(), callback, makeCb()};
+  const auto testee = makeTestee(callbacks);
+  const auto record = makeRecord("topic", 2);
+
+  // when
+  testee->receive(record);
+
+  // then
+  // Record was not stored.
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 2), 0);
+  // All records stay.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 1);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 2);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 2), 2);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 3), 3);
+}
+
+TEST_F(RecordDistributorTest, ShouldPassRecordToCallbacksAndKeepItIfNoneAccepts) {
+  // given
+  PartitionMap<RecordCbSharedPtr> callbacks;
+  callbacks[{"topic", 0}] = {makeCb()};
+  callbacks[{"topic", 1}] = {makeCb(), makeCb()};
+  const auto testee = makeTestee(callbacks);
+  const auto record = makeRecord("topic", 1);
+
+  // when
+  testee->receive(record);
+
+  // then
+  // Record was stored.
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 1), 1);
+  // No changes in callbacks.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 1);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 2);
+}
+
+TEST_F(RecordDistributorTest, ShouldProcessCallbackAndRegisterItIfThereAreNoMessages) {
+  // given
+  const auto cb = makeCb();
+  const TopicToPartitionsMap tp = {{"topic", {0, 1}}};
+  EXPECT_CALL(*cb, interest).WillRepeatedly(Return(tp));
+
+  const auto testee = makeTestee();
+
+  // when
+  testee->processCallback(cb);
+
+  // then - Callback got registered.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 1);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 1);
+}
+
+// Compared to previous tests, there were interesting records before.
+TEST_F(RecordDistributorTest, ShouldRegisterCallbackAndPassItMatchingMessages) {
+  // given
+  const auto cb = makeCb();
+  const TopicToPartitionsMap tp = {{"topic", {0, 1}}};
+  EXPECT_CALL(*cb, interest).WillRepeatedly(Return(tp));
+  EXPECT_CALL(*cb, receive(_)).Times(4).WillRepeatedly(Return(CallbackReply::AcceptedAndWantMore));
+
+  PartitionMap<InboundRecordSharedPtr> records;
+  records[{"topic", 0}] = {makeRecord("topic", 0), makeRecord("topic", 1)};
+  records[{"topic", 1}] = {makeRecord("topic", 1), makeRecord("topic", 1)};
+  const auto testee = makeTestee(records);
+
+  // when
+  testee->processCallback(cb);
+
+  // then
+  // Messages got consumed.
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 0), 0);
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 1), 0);
+  // Callback got registered.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 1);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 1);
+}
+
+TEST_F(RecordDistributorTest, ShouldNotRegisterCallbackIfItGotSatisfied) {
+  // given
+  const auto cb = makeCb();
+  const TopicToPartitionsMap tp = {{"topic", {0, 1}}};
+  EXPECT_CALL(*cb, interest).WillRepeatedly(Return(tp));
+  EXPECT_CALL(*cb, receive(_))
+      .Times(2)
+      .WillOnce(Return(CallbackReply::AcceptedAndWantMore))
+      .WillOnce(Return(CallbackReply::AcceptedAndFinished));
+
+  PartitionMap<InboundRecordSharedPtr> records;
+  records[{"topic", 0}] = {makeRecord("topic", 0), makeRecord("topic", 0), makeRecord("topic", 0)};
+  records[{"topic", 1}] = {makeRecord("topic", 1), makeRecord("topic", 1)};
+  const auto testee = makeTestee(records);
+
+  // when
+  testee->processCallback(cb);
+
+  // then
+  // Some messages got consumed.
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 0), 1);
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 1), 2);
+  // Callback got registered.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 0);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 0);
+}
+
+TEST_F(RecordDistributorTest, ShouldNotRegisterCallbackIfItRejectsRecords) {
+  // given
+  const auto cb = makeCb();
+  const TopicToPartitionsMap tp = {{"topic", {0, 1}}};
+  EXPECT_CALL(*cb, interest).WillRepeatedly(Return(tp));
+  EXPECT_CALL(*cb, receive(_))
+      .Times(2)
+      .WillOnce(Return(CallbackReply::AcceptedAndWantMore))
+      .WillOnce(Return(CallbackReply::Rejected)); // Callback cancelled / abandoned / timed out.
+
+  PartitionMap<InboundRecordSharedPtr> records;
+  records[{"topic", 0}] = {makeRecord("topic", 0), makeRecord("topic", 0), makeRecord("topic", 0)};
+  records[{"topic", 1}] = {makeRecord("topic", 1), makeRecord("topic", 1)};
+  const auto testee = makeTestee(records);
+
+  // when
+  testee->processCallback(cb);
+
+  // then
+  // Some messages got consumed.
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 0), 2);
+  ASSERT_EQ(testee->getRecordCountForTest("topic", 1), 2);
+  // Callback got registered.
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 0), 0);
+  ASSERT_EQ(testee->getCallbackCountForTest("topic", 1), 0);
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: kafka: inbound record distributor/store
Additional Description: `RecordDistributor` object that's responsible for routing records to callbacks (downstream Fetch requests) that are waiting for these requests. Needs to be thread-safe just like it's owner SHM, as it's going to be accessed by multiple threads (from the callback side: multiple filters -> multiple worker threads, from the message side: kafka consumer's worker thread that pushes the messages in). Part of https://github.com/envoyproxy/envoy/issues/24372
Risk Level: Low
Testing: unit tests, integration test with a full stack
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A