### PR TITLE
ci: only publish mobile docs from `main` branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,13 +19,13 @@ jobs:
     - name: Generate docs
       run: mobile/docs/build.sh
     - name: Set up deploy key
-      if: ${{ !github.event.pull_request.head.repo.fork }}
+      if: github.ref == 'refs/heads/main'
       uses: shimataro/ssh-key-action@193316a178ec055fcc7b018f7f76bbf64085c628
       with:
         key: ${{ secrets.ENVOY_MOBILE_WEBSITE_DEPLOY_KEY }}
         known_hosts: unnecessary
     - name: Publish docs
-      if: ${{ !github.event.pull_request.head.repo.fork }}
+      if: github.ref == 'refs/heads/main'
       run: mobile/docs/publish.sh
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/24526

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]