### PR TITLE
Clean up mobile/library/common/jni/BUILD targets

### DIFF
--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -27,10 +27,26 @@ cc_library(
 )
 
 cc_library(
+    name = "jni_interface_lib",
+    srcs = [
+        "jni_interface.cc",
+    ],
+    deps = [
+        ":android_network_utility_lib",
+        ":jni_utility_lib",
+        ":ndk_jni_support",
+        "//library/common:envoy_main_interface_lib",
+        "//library/common/api:c_types",
+        "//library/common/types:managed_types_lib",
+    ],
+    # We need this to ensure that we link this into the .so even though there are no code references.
+    alwayslink = True,
+)
+
+cc_library(
     name = "envoy_jni_lib",
     srcs = [
         "android_jni_interface.cc",
-        "jni_interface.cc",
     ],
     linkopts = [
         "-lm",
@@ -44,6 +60,7 @@ cc_library(
     }),
     deps = [
         ":android_network_utility_lib",
+        ":jni_interface_lib",
         ":jni_utility_lib",
         ":ndk_jni_support",
         "//library/common:envoy_main_interface_lib",
@@ -102,7 +119,6 @@ cc_binary(
     name = "libndk_envoy_jni.so",
     srcs = [
         "android_test_jni_interface.cc",
-        "jni_interface.cc",
     ],
     linkopts = [
     ],
@@ -111,6 +127,7 @@ cc_binary(
         ":android_network_utility_lib",
         ":base_java_jni_lib",
         ":java_jni_support",
+        ":jni_interface_lib",
         "//library/common:envoy_main_interface_lib",
         "//library/common/api:c_types",
         "//library/common/jni/import:jni_import_lib",
@@ -126,12 +143,10 @@ envoy_mobile_so_to_jni_lib(
 
 cc_library(
     name = "java_jni_base_lib",
-    srcs = [
-        "jni_interface.cc",
-    ],
     deps = [
         ":android_network_utility_lib",
         ":base_java_jni_lib",
+        ":jni_interface_lib",
     ],
     alwayslink = True,
 )

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -32,7 +32,6 @@ cc_library(
         "android_jni_interface.cc",
         "jni_interface.cc",
     ],
-    copts = ["-std=c++17"],
     linkopts = [
         "-lm",
         "-ldl",
@@ -66,7 +65,6 @@ config_setting(
 # Main dynamic library for the Envoy Mobile aar
 cc_binary(
     name = "libenvoy_jni.so",
-    copts = ["-std=c++17"],
     linkopts = [
         "-lm",
     ] + select({
@@ -95,7 +93,7 @@ android_debug_info(
 ## Targets for local execution
 # OS X binary (.jnilib) for NDK testing
 envoy_mobile_so_to_jni_lib(
-    name = "libndk_envoy_jni.jnilib",
+    name = "libndk_envoy_jni_jnilib",
     native_dep = "libndk_envoy_jni.so",
 )
 
@@ -106,13 +104,12 @@ cc_binary(
         "android_test_jni_interface.cc",
         "jni_interface.cc",
     ],
-    copts = ["-std=c++17"],
     linkopts = [
     ],
     linkshared = True,
     deps = [
-        "base_java_jni_lib",
         ":android_network_utility_lib",
+        ":base_java_jni_lib",
         ":java_jni_support",
         "//library/common:envoy_main_interface_lib",
         "//library/common/api:c_types",
@@ -133,8 +130,8 @@ cc_library(
         "jni_interface.cc",
     ],
     deps = [
-        "base_java_jni_lib",
         ":android_network_utility_lib",
+        ":base_java_jni_lib",
     ],
     alwayslink = True,
 )
@@ -142,7 +139,6 @@ cc_library(
 # Base binary (.so) for JVM testing
 cc_binary(
     name = "libjava_jni_lib.so",
-    copts = ["-std=c++17"],
     linkopts = [
         "-lm",
     ],
@@ -155,20 +151,12 @@ cc_binary(
 
 cc_library(
     name = "base_java_jni_lib",
-    srcs = [
-        "jni_utility.cc",
-        "jni_version.cc",
-    ],
-    hdrs = [
-        "jni_utility.h",
-        "jni_version.h",
-    ],
-    copts = ["-std=c++14"],
     linkopts = [
         "-lm",
     ],
     deps = [
         ":java_jni_support",
+        ":jni_utility_lib",
         "//library/common/jni/import:jni_import_lib",
         "//library/common:envoy_main_interface_lib",
         "//library/common/types:c_types_lib",
@@ -184,7 +172,6 @@ cc_library(
         "java_jni_support.cc",
     ],
     hdrs = ["jni_support.h"],
-    copts = ["-std=c++14"],
     linkopts = [
         "-lm",
     ],
@@ -202,7 +189,6 @@ cc_library(
         "//conditions:default": [],
     }),
     hdrs = ["jni_support.h"],
-    copts = ["-std=c++14"],
     linkopts = [
         "-lm",
     ] + select({

--- a/mobile/test/java/integration/BUILD
+++ b/mobile/test/java/integration/BUILD
@@ -16,7 +16,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
@@ -34,7 +34,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
@@ -53,7 +53,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
@@ -72,7 +72,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -39,7 +39,7 @@ envoy_mobile_android_test(
     ],
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",

--- a/mobile/test/java/org/chromium/net/BUILD
+++ b/mobile/test/java/org/chromium/net/BUILD
@@ -23,7 +23,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
@@ -43,7 +43,7 @@ envoy_mobile_android_test(
     ],
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
@@ -63,7 +63,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
@@ -87,7 +87,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
@@ -111,7 +111,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",

--- a/mobile/test/java/org/chromium/net/impl/BUILD
+++ b/mobile/test/java/org/chromium/net/impl/BUILD
@@ -20,7 +20,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",

--- a/mobile/test/java/org/chromium/net/testing/BUILD
+++ b/mobile/test/java/org/chromium/net/testing/BUILD
@@ -61,7 +61,7 @@ envoy_mobile_android_test(
     ],
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         ":testing",
@@ -84,7 +84,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         ":testing",
@@ -103,7 +103,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         ":testing",

--- a/mobile/test/java/org/chromium/net/urlconnection/BUILD
+++ b/mobile/test/java/org/chromium/net/urlconnection/BUILD
@@ -23,7 +23,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -214,7 +214,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",

--- a/mobile/test/kotlin/integration/proxying/BUILD
+++ b/mobile/test/kotlin/integration/proxying/BUILD
@@ -23,7 +23,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
@@ -44,7 +44,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
@@ -65,7 +65,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
@@ -86,7 +86,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
@@ -107,7 +107,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
@@ -128,7 +128,7 @@ envoy_mobile_android_test(
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
+        "//library/common/jni:libndk_envoy_jni_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",


### PR DESCRIPTION
Signed-off-by: Ryan Hamilton <rch@google.com>

- Remove unnecessary copts now that c++17 is the default.
- Rename libndk_envoy_jni.jnilib -> libndk_envoy_jni_jnilib to squelch warning
- Use ":base_java_jni_lib" instead of "base_java_jni_lib", per standards
- Depend on jni_utility_lib in base_java_jni_lib instead of duplicating the srcs

Fixes #24544