### PR TITLE
ci: Dont checkout repo for dependent/required jobs

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -318,6 +318,7 @@ stages:
     #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-to-job-dependencies-within-one-stage
     condition: in(dependencies.release.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     steps:
+    - checkout: none
     - bash: |
         echo "linux_x64 released"
 
@@ -349,6 +350,7 @@ stages:
     #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-to-job-dependencies-within-one-stage
     condition: in(dependencies.release.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     steps:
+    - checkout: none
     - bash: |
         echo "linux_arm64 released"
 
@@ -437,6 +439,7 @@ stages:
         in(dependencies.verify_x64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
         in(dependencies.verify_arm64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
     steps:
+    - checkout: none
     - bash: |
         echo "checks complete"
 
@@ -521,6 +524,7 @@ stages:
         in(dependencies.bazel.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
         in(dependencies.coverage.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
     steps:
+    - checkout: none
     - bash: |
         echo "checks complete"
 
@@ -607,6 +611,7 @@ stages:
     #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-to-job-dependencies-within-one-stage
     condition: in(dependencies.docker.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     steps:
+    - checkout: none
     - bash: |
         echo "Docker linux built"
 
@@ -776,6 +781,7 @@ stages:
     #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-to-job-dependencies-within-one-stage
     condition: in(dependencies.examples.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     steps:
+    - checkout: none
     - bash: |
         echo "examples verifiied"
 
@@ -825,6 +831,7 @@ stages:
     #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-to-job-dependencies-within-one-stage
     condition: in(dependencies.test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     steps:
+    - checkout: none
     - bash: |
         echo "macos tested"
 
@@ -931,5 +938,6 @@ stages:
         in(dependencies.release.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
         in(dependencies.docker.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
     steps:
+    - checkout: none
     - bash: |
         echo "windows released"


### PR DESCRIPTION
prevent azp from checking out the repo when only echoing a success message

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
