### PR TITLE
Remove unused linkopt on libenvoy_jni.so

### DIFF
--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -90,10 +90,6 @@ cc_binary(
     }) + select({
         "@envoy//bazel:android": ["-llog"],
         "//conditions:default": [],
-    }) + select({
-        # TODO(keith): https://github.com/rust-lang/compiler-builtins/issues/353
-        ":android_armeabi": ["-Wl,--allow-multiple-definition"],
-        "//conditions:default": [],
     }),
     linkshared = True,
     deps = [


### PR DESCRIPTION
Signed-off-by: Ryan Hamilton <rch@google.com>

Remove unused linkopt on libenvoy_jni.so

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A