### PR TITLE
http2: use getStreamUnchecked wherever possible

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1007,7 +1007,6 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
 }
 
 const ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) const {
-
   // Delegate to the non-const version.
   return const_cast<ConnectionImpl*>(this)->getStream(stream_id);
 }
@@ -1436,7 +1435,7 @@ int ConnectionImpl::onMetadataReceived(int32_t stream_id, const uint8_t* data, s
   StreamImpl* stream = getStreamUnchecked(stream_id);
   if (!stream || stream->remote_end_stream_) {
     if (!stream) {
-      ENVOY_CONN_LOG(trace, "no stream for stream_id {} while receiving METADATA", connection_,
+      ENVOY_CONN_LOG(debug, "no stream for stream_id {} while receiving METADATA", connection_,
                      stream_id);
     }
     return 0;
@@ -1453,7 +1452,7 @@ int ConnectionImpl::onMetadataFrameComplete(int32_t stream_id, bool end_metadata
   StreamImpl* stream = getStreamUnchecked(stream_id);
   if (!stream || stream->remote_end_stream_) {
     if (!stream) {
-      ENVOY_CONN_LOG(trace, "no stream for stream_id {} while completing METADATA", connection_,
+      ENVOY_CONN_LOG(debug, "no stream for stream_id {} while completing METADATA", connection_,
                      stream_id);
     }
     return 0;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -801,7 +801,7 @@ void ConnectionImpl::StreamImpl::resetStream(StreamResetReason reason) {
   // resources.
   if (useDeferredReset() && local_end_stream_ && !local_end_stream_sent_ &&
       reason != StreamResetReason::OverloadManager) {
-    ASSERT(parent_.getStream(stream_id_) != nullptr);
+    ASSERT(parent_.getStreamUnchecked(stream_id_) != nullptr);
     parent_.pending_deferred_reset_streams_.emplace(stream_id_, this);
     deferred_reset_ = reason;
     ENVOY_CONN_LOG(trace, "deferred reset stream", parent_.connection_);
@@ -1007,18 +1007,24 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
 }
 
 const ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) const {
+
   // Delegate to the non-const version.
   return const_cast<ConnectionImpl*>(this)->getStream(stream_id);
-}
-
-ConnectionImpl::StreamImpl* ConnectionImpl::getStreamUnchecked(int32_t stream_id) {
-  return static_cast<StreamImpl*>(adapter_->GetStreamUserData(stream_id));
 }
 
 ConnectionImpl::StreamImpl* ConnectionImpl::getStream(int32_t stream_id) {
   StreamImpl* stream = getStreamUnchecked(stream_id);
   SLOW_ASSERT(stream != nullptr || !slowContainsStreamId(stream_id));
   return stream;
+}
+
+const ConnectionImpl::StreamImpl* ConnectionImpl::getStreamUnchecked(int32_t stream_id) const {
+  // Delegate to the non-const version.
+  return const_cast<ConnectionImpl*>(this)->getStreamUnchecked(stream_id);
+}
+
+ConnectionImpl::StreamImpl* ConnectionImpl::getStreamUnchecked(int32_t stream_id) {
+  return static_cast<StreamImpl*>(adapter_->GetStreamUserData(stream_id));
 }
 
 int ConnectionImpl::onData(int32_t stream_id, const uint8_t* data, size_t len) {
@@ -1141,7 +1147,7 @@ Status ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
     onSettings(frame->settings);
   }
 
-  StreamImpl* stream = getStream(frame->hd.stream_id);
+  StreamImpl* stream = getStreamUnchecked(frame->hd.stream_id);
   if (!stream) {
     return okStatus();
   }
@@ -1427,8 +1433,12 @@ Status ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
 int ConnectionImpl::onMetadataReceived(int32_t stream_id, const uint8_t* data, size_t len) {
   ENVOY_CONN_LOG(trace, "recv {} bytes METADATA", connection_, len);
 
-  StreamImpl* stream = getStream(stream_id);
+  StreamImpl* stream = getStreamUnchecked(stream_id);
   if (!stream || stream->remote_end_stream_) {
+    if (!stream) {
+      ENVOY_CONN_LOG(trace, "no stream for stream_id {} while receiving METADATA", connection_,
+                     stream_id);
+    }
     return 0;
   }
 
@@ -1440,8 +1450,12 @@ int ConnectionImpl::onMetadataFrameComplete(int32_t stream_id, bool end_metadata
   ENVOY_CONN_LOG(trace, "recv METADATA frame on stream {}, end_metadata: {}", connection_,
                  stream_id, end_metadata);
 
-  StreamImpl* stream = getStream(stream_id);
+  StreamImpl* stream = getStreamUnchecked(stream_id);
   if (!stream || stream->remote_end_stream_) {
+    if (!stream) {
+      ENVOY_CONN_LOG(trace, "no stream for stream_id {} while completing METADATA", connection_,
+                     stream_id);
+    }
     return 0;
   }
 
@@ -1451,7 +1465,7 @@ int ConnectionImpl::onMetadataFrameComplete(int32_t stream_id, bool end_metadata
 
 int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
                                HeaderString&& value) {
-  StreamImpl* stream = getStream(frame->hd.stream_id);
+  StreamImpl* stream = getStreamUnchecked(frame->hd.stream_id);
   if (!stream) {
     // We have seen 1 or 2 crashes where we get a headers callback but there is no associated
     // stream data. I honestly am not sure how this can happen. However, from reading the nghttp2
@@ -1894,7 +1908,7 @@ void ClientConnectionImpl::dumpStreams(std::ostream& os, int indent_level) const
      << current_stream_id_.value() << ":\n";
 
   const ClientStreamImpl* client_stream =
-      static_cast<const ClientStreamImpl*>(getStream(current_stream_id_.value()));
+      static_cast<const ClientStreamImpl*>(getStreamUnchecked(current_stream_id_.value()));
   if (client_stream) {
     client_stream->response_decoder_.dumpState(os, indent_level + 1);
   } else {
@@ -2026,9 +2040,12 @@ Status ClientConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length
     ENVOY_CONN_LOG(trace, "error reading frame: {} received in this HTTP/2 session.", connection_,
                    result.message());
     if (isInboundFramesWithEmptyPayloadError(result)) {
-      ConnectionImpl::StreamImpl* stream = getStream(stream_id);
+      ConnectionImpl::StreamImpl* stream = getStreamUnchecked(stream_id);
       if (stream) {
         stream->setDetails(Http2ResponseCodeDetails::get().inbound_empty_frame_flood);
+      } else {
+        ENVOY_CONN_LOG(debug, "no stream for stream_id {} while tracking inbound frames",
+                       connection_, hd->stream_id);
       }
     }
   }
@@ -2119,9 +2136,13 @@ Status ServerConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length
     ENVOY_CONN_LOG(trace, "error reading frame: {} received in this HTTP/2 session.", connection_,
                    result.message());
     if (isInboundFramesWithEmptyPayloadError(result)) {
-      ConnectionImpl::StreamImpl* stream = getStream(stream_id);
+      ConnectionImpl::StreamImpl* stream = getStreamUnchecked(stream_id);
       if (stream) {
         stream->setDetails(Http2ResponseCodeDetails::get().inbound_empty_frame_flood);
+      } else {
+        ENVOY_CONN_LOG(
+            debug, "no stream for stream_id {} while tracking inbound frames on server connection",
+            connection_, hd->stream_id);
       }
     }
   }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -2042,10 +2042,9 @@ Status ClientConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length
       ConnectionImpl::StreamImpl* stream = getStreamUnchecked(stream_id);
       if (stream) {
         stream->setDetails(Http2ResponseCodeDetails::get().inbound_empty_frame_flood);
-      } else {
-        ENVOY_CONN_LOG(debug, "no stream for stream_id {} while tracking inbound frames",
-                       connection_, hd->stream_id);
       }
+      // Above if is defensive, because the stream has just been created and therefore always
+      // exists.
     }
   }
   return result;
@@ -2138,11 +2137,9 @@ Status ServerConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length
       ConnectionImpl::StreamImpl* stream = getStreamUnchecked(stream_id);
       if (stream) {
         stream->setDetails(Http2ResponseCodeDetails::get().inbound_empty_frame_flood);
-      } else {
-        ENVOY_CONN_LOG(
-            debug, "no stream for stream_id {} while tracking inbound frames on server connection",
-            connection_, hd->stream_id);
       }
+      // Above if is defensive, because the stream has just been created and therefore always
+      // exists.
     }
   }
   return result;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1214,7 +1214,7 @@ int ConnectionImpl::onFrameSend(int32_t stream_id, size_t length, uint8_t type, 
   // an outgoing frame of this type, we will return an error code so that we can abort execution.
   ENVOY_CONN_LOG(trace, "sent frame type={}, stream_id={}, length={}", connection_,
                  static_cast<uint64_t>(type), stream_id, length);
-  StreamImpl* stream = getStream(stream_id);
+  StreamImpl* stream = getStreamUnchecked(stream_id);
   if (stream != nullptr) {
     if (type != METADATA_FRAME_TYPE) {
       stream->bytes_meter_->addWireBytesSent(length + H2_FRAME_HEADER_SIZE);

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -519,9 +519,10 @@ protected:
   // edge cases (such as for METADATA frames) where nghttp2 will issue a callback for a stream_id
   // that is not associated with an existing stream.
   const StreamImpl* getStream(int32_t stream_id) const;
-  // Same as getStream, but without the ASSERT.
-  StreamImpl* getStreamUnchecked(int32_t stream_id);
   StreamImpl* getStream(int32_t stream_id);
+  // Same as getStream, but without the ASSERT.
+  const StreamImpl* getStreamUnchecked(int32_t stream_id) const;
+  StreamImpl* getStreamUnchecked(int32_t stream_id);
   int saveHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value);
 
   /**

--- a/test/common/http/codec_impl_corpus/oss-fuzz-47120-codec_impl_fuzz_test-6205436203761664
+++ b/test/common/http/codec_impl_corpus/oss-fuzz-47120-codec_impl_fuzz_test-6205436203761664
@@ -1,0 +1,1 @@
+actions {   new_stream {     request_headers {       headers {         key: ":method"         value: "CONNECT"       }     }   } } actions {   new_stream {     request_headers {       headers {         key: ":scheme"             e: "    "       }       headers {         key: ":path"         value: "/"       }     }     end_stream: true   } } 


### PR DESCRIPTION
Commit Message: http2: use getStreamUnchecked wherever possible
Additional Description:
Let h2 codec use the non-asserting getStream() function, because it
handles no stream gracefully, but the asserting one blocks fuzzing.

- Use getStreamUnchecked() more often where stream == nullptr is in
    place anyway.
- Add logging for some places.
- Add const getStreamUnchecked().
    
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
