### PR TITLE
mobile: add `./remote` helper

### DIFF
--- a/mobile/bazelw
+++ b/mobile/bazelw
@@ -12,7 +12,10 @@ fi
 
 raw_arch="$(uname -m)"
 readonly raw_arch
-if [[ "$raw_arch" == "aarch64" || "$raw_arch" == "arm64" ]]; then
+
+if [[ -n "$BAZELW_ARCH" ]]; then
+  readonly bazel_arch="${BAZELW_ARCH}"
+elif [[ "$raw_arch" == "aarch64" || "$raw_arch" == "arm64" ]]; then
   readonly bazel_arch="arm64"
 else
   readonly bazel_arch="amd64"

--- a/mobile/bazelw
+++ b/mobile/bazelw
@@ -13,7 +13,7 @@ fi
 raw_arch="$(uname -m)"
 readonly raw_arch
 
-if [[ -n "$BAZELW_ARCH" ]]; then
+if [[ -n "${BAZELW_ARCH+x}" ]]; then
   readonly bazel_arch="${BAZELW_ARCH}"
 elif [[ "$raw_arch" == "aarch64" || "$raw_arch" == "arm64" ]]; then
   readonly bazel_arch="arm64"

--- a/mobile/remote
+++ b/mobile/remote
@@ -15,7 +15,7 @@ else
 fi
 
 if [[ $OSTYPE == darwin* ]]; then
-  # TODO(jpsim): RBE fails with arm64 versions of Bazel on macOS
+  # TODO(#24605): RBE fails with arm64 versions of Bazel on macOS
   BAZELW_ARCH=amd64 ./bazelw "$@" \
     --tls_client_certificate="$certificate" \
     --tls_client_key="$key" \

--- a/mobile/remote
+++ b/mobile/remote
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+certificate="$script_root/tmp/certs/engflow.crt"
+key="$script_root/tmp/certs/engflow.key"
+
+if [[ -f "$certificate" && -f "$key" ]]; then
+  echo "Using EngFlow RBE"
+else
+  echo "EngFlow RBE certificate and key not installed in $certificate and $key"
+  echo "Contact Andrés Felipe Barco Santa <andres@engflow.com> for access to these files"
+  exit 1
+fi
+
+if [[ $OSTYPE == darwin* ]]; then
+  # TODO(jpsim): RBE fails with arm64 versions of Bazel on macOS
+  BAZELW_ARCH=amd64 ./bazelw "$@" \
+    --tls_client_certificate="$certificate" \
+    --tls_client_key="$key" \
+    --config remote-ci-macos
+else
+  ./bazelw "$@" \
+    --tls_client_certificate="$certificate" \
+    --tls_client_key="$key" \
+    --config remote-ci-linux
+fi


### PR DESCRIPTION
Envoy Mobile project developers can use EngFlow's RBE to speed up and offload local builds to EngFlow's remote execution cluster.

Most bazel commands should work by replacing `./bazelw` with `./remote`.

For example:

```console
$ ./remote build --config ios ios_dist
$ ./remote build --config android android_dist
```

With certificates places in the `mobile/tmp/certs` directory (which is ignored by git), it should "just work".

Note that `protoc` commands fail with a "Bad CPU type in executable" error message when using RBE on an M1 Mac with an arm64 bazel binary, so to work around this we tell `bazelw` to use the amd64 version, which appears to work just fine.

Commit Message:
Additional Description:
Risk Level: Low, only used for local development.
Testing: Local on an M1 Mac.
Docs Changes: Not adding docs for this since it's only going to be used by Envoy Mobile maintainers.
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]