### PR TITLE
bazel: add version check to WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,3 +23,11 @@ envoy_python_dependencies()
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()
+
+load("//bazel:bazel_version_check.bzl", "setup_bazel_version_check")
+
+setup_bazel_version_check(name = "bazel_version_check")
+
+load("@bazel_version_check//:version.bzl", "check_bazel_version")
+
+check_bazel_version()

--- a/bazel/bazel_version_check.bzl
+++ b/bazel/bazel_version_check.bzl
@@ -1,0 +1,22 @@
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+def _impl(repository_ctx):
+    expected_version = repository_ctx.read(repository_ctx.attr._version_file).strip()
+    current_version = native.bazel_version
+
+    if current_version.split(".") < expected_version.split("."):
+        fail("Current bazel version '{}' is too old, expected at least '{}'. Install and use bazelisk for easier bazel version management: https://github.com/bazelbuild/bazelisk".format(current_version, expected_version))
+
+    # Create a function for calling in the WORKSPACE to force evaluation
+    repository_ctx.file("BUILD.bazel", "")
+    repository_ctx.file("version.bzl", """
+def check_bazel_version():
+    pass
+""")
+
+setup_bazel_version_check = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "_version_file": attr.label(default = Label("@//:.bazelversion")),
+    },
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -74,6 +74,7 @@ def _envoy_repo_impl(repository_ctx):
     api_version_path = repository_ctx.path(repository_ctx.attr.envoy_api_version)
     version = repository_ctx.read(repo_version_path).strip()
     api_version = repository_ctx.read(api_version_path).strip()
+    fail("hi")
     repository_ctx.file("version.bzl", "VERSION = '%s'\nAPI_VERSION = '%s'" % (version, api_version))
     repository_ctx.file("path.bzl", "PATH = '%s'" % repo_version_path.dirname)
     repository_ctx.file("__init__.py", "PATH = '%s'\nVERSION = '%s'\nAPI_VERSION = '%s'" % (repo_version_path.dirname, version, api_version))


### PR DESCRIPTION
This ensures that the minimum bazel version you can use is the one in the .bazelversion file. The default function for this doesn't work because it doesn't compare anything after the version so `6.0.0rc3` == `6.0.0rc4`, which isn't realistic, especially for rolling releases.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>