### PR TITLE
Remove duplicate paragraph in rate limiting docs

### DIFF
--- a/docs/root/configuration/other_features/rate_limit.rst
+++ b/docs/root/configuration/other_features/rate_limit.rst
@@ -17,11 +17,6 @@ Envoy expects the rate limit service to support the gRPC IDL specified in
 for more information on how the API works. See Envoy's reference implementation
 `here <https://github.com/envoyproxy/ratelimit>`_.
 
-Envoy expects the rate limit service to support the gRPC IDL specified in
-:ref:`rls.proto <envoy_v3_api_file_envoy/service/ratelimit/v3/rls.proto>`. See the IDL documentation
-for more information on how the API works. See Envoy's reference implementation
-`here <https://github.com/envoyproxy/ratelimit>`_.
-
 .. _config_rate_limit_quota_service:
 
 Rate limit quota service


### PR DESCRIPTION
Signed-off-by: Erik Engberg <ejohansson@spotify.com>

Commit Message: Remove duplicate paragraph in rate limiting docs
Additional Description: Lines 15-18 are duplicates of lines 20-23.
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
