### PR TITLE
bazel: remove unused rust setup

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -33,17 +33,9 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     rules_pkg_dependencies()
     rules_rust_dependencies()
     rust_register_toolchains(
-        include_rustc_srcs = True,
         extra_target_triples = [
-            "aarch64-apple-ios",
-            "aarch64-apple-ios-sim",
-            "aarch64-linux-android",
-            "armv7-linux-androideabi",
-            "i686-linux-android",
             "wasm32-unknown-unknown",
             "wasm32-wasi",
-            "x86_64-apple-ios",
-            "x86_64-linux-android",
         ],
     )
     shellcheck_dependencies()


### PR DESCRIPTION
The include_rustc_srcs causes a warning now. If we setup rust_analyzer we should use the `rust_analyzer_toolchain_repository` for this. We also aren't using these mobile triples for now. We can add them back as needed.

Fixes https://github.com/envoyproxy/envoy/issues/24548

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>