### PR TITLE
Recommend filters not decrease buffer limits

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -662,6 +662,12 @@ public:
   /**
    * This routine may be called to change the buffer limit for decoder filters.
    *
+   * It is recommended (but not required) that filters calling this function should
+   * generally only perform increases to the buffer limit, to avoid potentially
+   * conflicting with the buffer requirements of other filters in the chain, i.e.
+   *
+   * if (desired_limit > decoderBufferLimit()) {setDecoderBufferLimit(desired_limit);}
+   *
    * @param limit supplies the desired buffer limit.
    */
   virtual void setDecoderBufferLimit(uint32_t limit) PURE;
@@ -996,6 +1002,12 @@ public:
 
   /**
    * This routine may be called to change the buffer limit for encoder filters.
+   *
+   * It is recommended (but not required) that filters calling this function should
+   * generally only perform increases to the buffer limit, to avoid potentially
+   * conflicting with the buffer requirements of other filters in the chain, i.e.
+   *
+   * if (desired_limit > encoderBufferLimit()) {setEncoderBufferLimit(desired_limit);}
    *
    * @param limit supplies the desired buffer limit.
    */

--- a/source/docs/flow_control.md
+++ b/source/docs/flow_control.md
@@ -153,6 +153,9 @@ an error response.
 Filters may override the default limit with calls to `setDecoderBufferLimit()`
 and `setEncoderBufferLimit()`. These limits are applied as filters are created
 so filters later in the chain can override the limits set by prior filters.
+It is recommended that filters calling these functions should generally only
+perform increases to the buffer limit, to avoid potentially conflicting with
+the buffer requirements of other filters in the chain.
 
 Most filters do not buffer internally, but instead push back on data by
 returning a FilterDataStatus on `encodeData()`/`decodeData()` calls.


### PR DESCRIPTION
Commit Message: Recommend filters not decrease buffer limits
Additional Description: Just changing `flow_control.md` to recommend not calling `set(En|De)coderBufferLimit` when it would decrease the buffer limit, as that's likely to conflict with other filters, vs. increasing the limit is unlikely to cause conflicts. This is inspired by #23774, in which it turned out that a code solution to this awkwardness is not reasonable, so a documentation solution is the next best thing.
Risk Level: None, it's documentation.
Testing: No, it's documentation.
Docs Changes: Yes, it is.
Release Notes: n/a
Platform Specific Features: n/a
