### PR TITLE
kafka: fetch request

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/BUILD
@@ -88,6 +88,7 @@ envoy_cc_library(
     deps = [
         "//contrib/kafka/filters/network/source:kafka_response_lib",
         "//contrib/kafka/filters/network/source:tagged_fields_lib",
+        "//envoy/event:dispatcher_interface",
     ],
 )
 

--- a/contrib/kafka/filters/network/source/mesh/abstract_command.h
+++ b/contrib/kafka/filters/network/source/mesh/abstract_command.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/event/dispatcher.h"
+
 #include "source/common/common/logger.h"
 
 #include "contrib/kafka/filters/network/source/kafka_response.h"
@@ -57,18 +59,23 @@ public:
   // Notifies the listener that a new request has been received.
   virtual void onRequest(InFlightRequestSharedPtr request) PURE;
 
-  // Notified the listener, that the request finally has an answer ready.
+  // Notifies the listener, that the request finally has an answer ready.
   // Usually this means that the request has been sent to upstream Kafka clusters and we got answers
   // (unless it's something that could be responded to locally).
   // IMPL: we do not need to pass request here, as filters need to answer in-order.
   // What means that we always need to check if first answer is ready, even if the latter are
   // already finished.
   virtual void onRequestReadyForAnswer() PURE;
+
+  // Accesses listener's dispatcher.
+  // Used by non-Envoy threads that need to communicate with listeners.
+  virtual Event::Dispatcher& dispatcher() PURE;
 };
 
 /**
  * Helper base class for all in flight requests.
  * Binds request to its origin filter.
+ * All the fields can be accessed only by the owning dispatcher thread.
  */
 class BaseInFlightRequest : public InFlightRequest, protected Logger::Loggable<Logger::Id::kafka> {
 public:

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
@@ -46,6 +46,41 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "fetch_lib",
+    srcs = [
+        "fetch.cc",
+    ],
+    hdrs = [
+        "fetch.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        ":fetch_record_converter_lib",
+        "//contrib/kafka/filters/network/source:kafka_request_parser_lib",
+        "//contrib/kafka/filters/network/source:kafka_response_parser_lib",
+        "//contrib/kafka/filters/network/source/mesh:abstract_command_lib",
+        "//contrib/kafka/filters/network/source/mesh:shared_consumer_manager_lib",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "fetch_record_converter_lib",
+    srcs = [
+        "fetch_record_converter.cc",
+    ],
+    hdrs = [
+        "fetch_record_converter.h",
+    ],
+    tags = ["skip_on_windows"],
+    deps = [
+        "//contrib/kafka/filters/network/source:kafka_response_parser_lib",
+        "//contrib/kafka/filters/network/source/mesh:inbound_record_lib",
+        "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "list_offsets_lib",
     srcs = [
         "list_offsets.cc",

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/BUILD
@@ -76,7 +76,6 @@ envoy_cc_library(
     deps = [
         "//contrib/kafka/filters/network/source:kafka_response_parser_lib",
         "//contrib/kafka/filters/network/source/mesh:inbound_record_lib",
-        "//source/common/buffer:buffer_lib",
     ],
 )
 

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
@@ -1,0 +1,186 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h"
+
+#include <thread>
+
+#include "absl/synchronization/mutex.h"
+#include "contrib/kafka/filters/network/source/external/responses.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+FetchRequestHolder::FetchRequestHolder(AbstractRequestListener& filter,
+                                       RecordCallbackProcessor& consumer_manager,
+                                       const std::shared_ptr<Request<FetchRequest>> request)
+    : BaseInFlightRequest{filter}, consumer_manager_{consumer_manager}, request_{request},
+      dispatcher_{filter.dispatcher()} {}
+
+FetchRequestHolder::~FetchRequestHolder() { ENVOY_LOG(info, "Fetch {} DTOR", toString()); }
+
+// XXX (adam.kotwasinski) This should be made configurable in future.
+constexpr uint32_t FETCH_TIMEOUT_MS = 5000;
+
+static Event::TimerPtr registerTimeoutCallback(Event::Dispatcher& dispatcher,
+                                               Event::TimerCb callback, int32_t timeout) {
+  auto event = dispatcher.createTimer(callback);
+  event->enableTimer(std::chrono::milliseconds(timeout));
+  return event;
+}
+
+void FetchRequestHolder::startProcessing() {
+  const TopicToPartitionsMap requested_topics = interest();
+
+  {
+    absl::MutexLock lock(&state_mutex_);
+    for (const auto& topic_and_partitions : requested_topics) {
+      const std::string& topic_name = topic_and_partitions.first;
+      for (const int32_t partition : topic_and_partitions.second) {
+        // This makes sure that all requested KafkaPartitions are tracked,
+        // so then output generation is simpler.
+        messages_[{topic_name, partition}] = {};
+      }
+    }
+  }
+
+  const auto self_reference = shared_from_this();
+  consumer_manager_.processCallback(self_reference);
+
+  // Event::TimerCb callback = [self_reference]() -> void {
+  Event::TimerCb callback = [this]() -> void {
+    // Fun fact: if the request is degenerate (no partitions requested), this will make it be
+    // processed. self_reference->markFinishedByTimer();
+    markFinishedByTimer();
+  };
+  timer_ = registerTimeoutCallback(dispatcher_, callback, FETCH_TIMEOUT_MS);
+}
+
+TopicToPartitionsMap FetchRequestHolder::interest() const {
+  TopicToPartitionsMap result;
+  const std::vector<FetchTopic>& topics = request_->data_.topics_;
+  for (const FetchTopic& topic : topics) {
+    const std::string topic_name = topic.topic_;
+    const std::vector<FetchPartition> partitions = topic.partitions_;
+    for (const FetchPartition& partition : partitions) {
+      result[topic_name].push_back(partition.partition_);
+    }
+  }
+  return result;
+}
+
+// This method is called by a Envoy-worker thread.
+void FetchRequestHolder::markFinishedByTimer() {
+  ENVOY_LOG(info, "Fetch request {} timed out", toString());
+  bool doCleanup = false;
+  {
+    absl::MutexLock lock(&state_mutex_);
+    timer_ = nullptr;
+    if (!finished_) {
+      finished_ = true;
+      doCleanup = true;
+    }
+  }
+  if (doCleanup) {
+    cleanup(true);
+  }
+}
+
+// XXX temporary solution only
+constexpr int32_t MINIMAL_MSG_CNT = 3;
+
+// This method is called by:
+// - Kafka-consumer thread - when have the records delivered,
+// - dispatcher thread  - when we start processing and check whether anything was cached.
+CallbackReply FetchRequestHolder::receive(InboundRecordSharedPtr message) {
+  absl::MutexLock lock(&state_mutex_);
+  if (!finished_) {
+    const KafkaPartition kp = {message->topic_, message->partition_};
+    messages_[kp].push_back(message);
+
+    uint32_t current_messages = 0;
+    for (const auto& e : messages_) {
+      current_messages += e.second.size();
+    }
+
+    if (current_messages < MINIMAL_MSG_CNT) {
+      ENVOY_LOG(info, "Fetch request {} processed message (and wants more {}): {}", toString(),
+                current_messages, message->toString());
+      return CallbackReply::AcceptedAndWantMore;
+    } else {
+      ENVOY_LOG(info, "Fetch request {} processed message (and is finished with {}): {}",
+                toString(), current_messages, message->toString());
+      // We have all we needed, we can finish processing.
+      finished_ = true;
+      cleanup(false);
+      return CallbackReply::AcceptedAndFinished;
+    }
+  } else {
+    ENVOY_LOG(info, "Fetch request {} rejected message: {}", toString(), message->toString());
+    return CallbackReply::Rejected;
+  }
+}
+
+std::string FetchRequestHolder::toString() const {
+  std::ostringstream oss;
+  oss << "["
+      << "?"
+      << "/" << request_->request_header_.correlation_id_ << "]";
+  return oss.str();
+}
+
+void FetchRequestHolder::cleanup(bool unregister) {
+  ENVOY_LOG(info, "Cleanup starting for {}", toString());
+  if (unregister) {
+    const auto self_reference = shared_from_this();
+    consumer_manager_.removeCallback(self_reference);
+  }
+
+  // Our request is ready and can be sent downstream.
+  // However, the caller here could be a Kafka-consumer worker thread (not an Envoy worker one),
+  // so we need to use dispatcher to notify the filter that we are finished.
+  auto notifyCallback = [this]() -> void {
+    timer_ = nullptr;
+    filter_.onRequestReadyForAnswer();
+  };
+  // Impl note: usually this will be invoked by non-Envoy thread,
+  // so let's not optimize that this might be invoked by dispatcher callback.
+  dispatcher_.post(notifyCallback);
+  ENVOY_LOG(info, "Cleanup finished for {}", toString());
+}
+
+bool FetchRequestHolder::finished() const {
+  absl::MutexLock lock(&state_mutex_);
+  return finished_;
+}
+
+void FetchRequestHolder::abandon() {
+  // We remove the timeout-callback and unregister this request so no deliveries happen to it.
+  timer_ = nullptr;
+  const auto self_reference = shared_from_this();
+  consumer_manager_.removeCallback(self_reference);
+  BaseInFlightRequest::abandon();
+  // XXX (adam.kotwasinski) Might want to "push-back" records that are already in this request.
+  // Replication path: make a Fetch that wants 10 records, provide 8, kill connection.
+  // Part 2: might escalate even higher, what if we finish okay, but cannot send serialized form?
+}
+
+AbstractResponseSharedPtr FetchRequestHolder::computeAnswer() const {
+  const auto& header = request_->request_header_;
+  const ResponseMetadata metadata = {header.api_key_, header.api_version_, header.correlation_id_};
+
+  const int32_t throttle_time_ms = 0;
+  std::vector<FetchableTopicResponse> responses;
+  {
+    absl::MutexLock lock(&state_mutex_);
+    responses = processor_.transform(messages_);
+  }
+  const FetchResponse data = {throttle_time_ms, responses};
+  return std::make_shared<Response<FetchResponse>>(metadata, data);
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
@@ -16,8 +16,15 @@ namespace Mesh {
 FetchRequestHolder::FetchRequestHolder(AbstractRequestListener& filter,
                                        RecordCallbackProcessor& consumer_manager,
                                        const std::shared_ptr<Request<FetchRequest>> request)
+    : FetchRequestHolder{filter, consumer_manager, request,
+                         FetchRecordConverterImpl::getDefaultInstance()} {}
+
+FetchRequestHolder::FetchRequestHolder(AbstractRequestListener& filter,
+                                       RecordCallbackProcessor& consumer_manager,
+                                       const std::shared_ptr<Request<FetchRequest>> request,
+                                       const FetchRecordConverter& converter)
     : BaseInFlightRequest{filter}, consumer_manager_{consumer_manager}, request_{request},
-      dispatcher_{filter.dispatcher()} {}
+      dispatcher_{filter.dispatcher()}, converter_{converter} {}
 
 // XXX (adam.kotwasinski) This should be made configurable in future.
 constexpr uint32_t FETCH_TIMEOUT_MS = 5000;

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
@@ -95,6 +95,8 @@ void FetchRequestHolder::markFinishedByTimer() {
 
 // XXX (adam.kotwasinski) This should be made configurable in future.
 // Right now the Fetch request is going to send up to 3 records.
+// In future this should tranform into some kind of method that's invoked inside 'receive' calls,
+// as Kafka can have limits on records per partition.
 constexpr int32_t MINIMAL_MSG_CNT = 3;
 
 // This method is called by:

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.cc
@@ -172,13 +172,12 @@ AbstractResponseSharedPtr FetchRequestHolder::computeAnswer() const {
   const auto& header = request_->request_header_;
   const ResponseMetadata metadata = {header.api_key_, header.api_version_, header.correlation_id_};
 
-  const int32_t throttle_time_ms = 0;
   std::vector<FetchableTopicResponse> responses;
   {
     absl::MutexLock lock(&state_mutex_);
     responses = converter_.convert(messages_);
   }
-  const FetchResponse data = {throttle_time_ms, responses};
+  const FetchResponse data = {responses};
   return std::make_shared<Response<FetchResponse>>(metadata, data);
 }
 

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/timer.h"
+
+#include "absl/synchronization/mutex.h"
+#include "contrib/kafka/filters/network/source/external/requests.h"
+#include "contrib/kafka/filters/network/source/mesh/abstract_command.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h"
+#include "contrib/kafka/filters/network/source/mesh/inbound_record.h"
+#include "contrib/kafka/filters/network/source/mesh/shared_consumer_manager.h"
+#include "contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+class FetchRequestHolder : public BaseInFlightRequest,
+                           public RecordCb,
+                           public std::enable_shared_from_this<FetchRequestHolder> {
+public:
+  FetchRequestHolder(AbstractRequestListener& filter, RecordCallbackProcessor& consumer_manager,
+                     const std::shared_ptr<Request<FetchRequest>> request);
+
+  ~FetchRequestHolder();
+
+  void startProcessing() override;
+
+  bool finished() const override;
+
+  void abandon() override;
+
+  AbstractResponseSharedPtr computeAnswer() const override;
+
+  // Invoked by timer as this requests's time runs out.
+  // It is possible that this request has already been finished (there was data to send),
+  // then this method does nothing.
+  void markFinishedByTimer();
+
+  // RecordCb
+  CallbackReply receive(InboundRecordSharedPtr message) override;
+
+  // RecordCb
+  TopicToPartitionsMap interest() const override;
+
+  // RecordCb
+  // InFlightRequest
+  std::string toString() const override;
+
+private:
+  // Invoked internally when we want to mark this Fetch request as done.
+  // This means: we are no longer interested in future messages and might need to unregister
+  // ourselves.
+  void cleanup(bool unregister);
+
+  // Provides access to upstream-pointing consumers.
+  RecordCallbackProcessor& consumer_manager_;
+  // Original request.
+  const std::shared_ptr<Request<FetchRequest>> request_;
+
+  mutable absl::Mutex state_mutex_;
+  // Whether this request has finished processing and is ready for sending upstream.
+  bool finished_ ABSL_GUARDED_BY(state_mutex_) = false;
+  // The messages to send downstream.
+  std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>
+      messages_ ABSL_GUARDED_BY(state_mutex_);
+
+  // Filter's dispatcher.
+  Event::Dispatcher& dispatcher_;
+  // Timeout timer (invalidated when request is finished).
+  Event::TimerPtr timer_;
+
+  // Translates librdkafka objects into bytes to be sent downstream.
+  const FetchResponsePayloadProcessor processor_;
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
@@ -29,12 +29,16 @@ public:
                      const std::shared_ptr<Request<FetchRequest>>,
                      const FetchRecordConverter& converter);
 
+  // AbstractInFlightRequest
   void startProcessing() override;
 
+  // AbstractInFlightRequest
   bool finished() const override;
 
+  // AbstractInFlightRequest
   void abandon() override;
 
+  // AbstractInFlightRequest
   AbstractResponseSharedPtr computeAnswer() const override;
 
   // Invoked by timer as this requests's time runs out.

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
@@ -24,6 +24,11 @@ public:
   FetchRequestHolder(AbstractRequestListener& filter, RecordCallbackProcessor& consumer_manager,
                      const std::shared_ptr<Request<FetchRequest>> request);
 
+  // Visible for testing.
+  FetchRequestHolder(AbstractRequestListener& filter, RecordCallbackProcessor& consumer_manager,
+                     const std::shared_ptr<Request<FetchRequest>>,
+                     const FetchRecordConverter& converter);
+
   void startProcessing() override;
 
   bool finished() const override;
@@ -70,7 +75,7 @@ private:
   Event::TimerPtr timer_;
 
   // Translates librdkafka objects into bytes to be sent downstream.
-  const FetchRecordConverter converter_;
+  const FetchRecordConverter& converter_;
 };
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h
@@ -24,8 +24,6 @@ public:
   FetchRequestHolder(AbstractRequestListener& filter, RecordCallbackProcessor& consumer_manager,
                      const std::shared_ptr<Request<FetchRequest>> request);
 
-  ~FetchRequestHolder();
-
   void startProcessing() override;
 
   bool finished() const override;
@@ -46,7 +44,6 @@ public:
   TopicToPartitionsMap interest() const override;
 
   // RecordCb
-  // InFlightRequest
   std::string toString() const override;
 
 private:
@@ -73,7 +70,7 @@ private:
   Event::TimerPtr timer_;
 
   // Translates librdkafka objects into bytes to be sent downstream.
-  const FetchResponsePayloadProcessor processor_;
+  const FetchRecordConverter converter_;
 };
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -1,0 +1,21 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h"
+
+#include "source/common/buffer/buffer_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+std::vector<FetchableTopicResponse> FetchResponsePayloadProcessor::transform(
+    const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>&) const {
+
+  return {};
+}
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -8,7 +8,8 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-std::vector<FetchableTopicResponse> FetchRecordConverterImpl::convert(const INPUT&) const {
+std::vector<FetchableTopicResponse>
+FetchRecordConverterImpl::convert(const InboundRecordsMap&) const {
 
   // TODO (adam.kotwasinski) This needs to be actually implemented.
   return {};

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -1,7 +1,5 @@
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h"
 
-#include "source/common/buffer/buffer_impl.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -8,11 +8,14 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-std::vector<FetchableTopicResponse> FetchRecordConverter::convert(
-    const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>&) const {
+std::vector<FetchableTopicResponse> FetchRecordConverterImpl::convert(const INPUT&) const {
 
-  // TODO (adam.kotwasinski) This needs to be implemented.
+  // TODO (adam.kotwasinski) This needs to be actually implemented.
   return {};
+}
+
+const FetchRecordConverter& FetchRecordConverterImpl::getDefaultInstance() {
+  CONSTRUCT_ON_FIRST_USE(FetchRecordConverterImpl);
 }
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -8,9 +8,10 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-std::vector<FetchableTopicResponse> FetchResponsePayloadProcessor::transform(
+std::vector<FetchableTopicResponse> FetchRecordConverter::convert(
     const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>&) const {
 
+  // TODO (adam.kotwasinski) This needs to be implemented.
   return {};
 }
 

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "contrib/kafka/filters/network/source/external/responses.h"
+#include "contrib/kafka/filters/network/source/kafka_types.h"
+#include "contrib/kafka/filters/network/source/mesh/inbound_record.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+
+class FetchResponsePayloadProcessor {
+public:
+  std::vector<FetchableTopicResponse>
+  transform(const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>& arg) const;
+};
+
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
@@ -13,10 +13,14 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-class FetchResponsePayloadProcessor {
+/**
+ * Dependency injection class responsible for converting received records into serializable form
+ * that we can put into Fetch responses.
+ */
+class FetchRecordConverter {
 public:
   std::vector<FetchableTopicResponse>
-  transform(const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>& arg) const;
+  convert(const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>& arg) const;
 };
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -13,14 +14,30 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
+using INPUT = std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>;
+
 /**
  * Dependency injection class responsible for converting received records into serializable form
  * that we can put into Fetch responses.
  */
 class FetchRecordConverter {
 public:
-  std::vector<FetchableTopicResponse>
-  convert(const std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>& arg) const;
+  virtual ~FetchRecordConverter() = default;
+
+  // Converts received records into the serialized form.
+  virtual std::vector<FetchableTopicResponse> convert(const INPUT& arg) const PURE;
+};
+
+/**
+ * Proper implementation.
+ */
+class FetchRecordConverterImpl : public FetchRecordConverter {
+public:
+  // FetchRecordConverter
+  std::vector<FetchableTopicResponse> convert(const INPUT& arg) const override;
+
+  // Default singleton accessor.
+  static const FetchRecordConverter& getDefaultInstance();
 };
 
 } // namespace Mesh

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
@@ -14,7 +14,7 @@ namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
 
-using INPUT = std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>;
+using InboundRecordsMap = std::map<KafkaPartition, std::vector<InboundRecordSharedPtr>>;
 
 /**
  * Dependency injection class responsible for converting received records into serializable form
@@ -25,7 +25,7 @@ public:
   virtual ~FetchRecordConverter() = default;
 
   // Converts received records into the serialized form.
-  virtual std::vector<FetchableTopicResponse> convert(const INPUT& arg) const PURE;
+  virtual std::vector<FetchableTopicResponse> convert(const InboundRecordsMap& arg) const PURE;
 };
 
 /**
@@ -34,7 +34,7 @@ public:
 class FetchRecordConverterImpl : public FetchRecordConverter {
 public:
   // FetchRecordConverter
-  std::vector<FetchableTopicResponse> convert(const INPUT& arg) const override;
+  std::vector<FetchableTopicResponse> convert(const InboundRecordsMap& arg) const override;
 
   // Default singleton accessor.
   static const FetchRecordConverter& getDefaultInstance();

--- a/contrib/kafka/filters/network/source/mesh/filter.cc
+++ b/contrib/kafka/filters/network/source/mesh/filter.cc
@@ -90,6 +90,10 @@ void KafkaMeshFilter::onRequestReadyForAnswer() {
   }
 }
 
+Event::Dispatcher& KafkaMeshFilter::dispatcher() {
+  return read_filter_callbacks_->connection().dispatcher();
+}
+
 void KafkaMeshFilter::abandonAllInFlightRequests() {
   for (const auto& request : requests_in_flight_) {
     request->abandon();

--- a/contrib/kafka/filters/network/source/mesh/filter.h
+++ b/contrib/kafka/filters/network/source/mesh/filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/time.h"
+#include "envoy/event/dispatcher.h"
 #include "envoy/network/filter.h"
 #include "envoy/stats/scope.h"
 
@@ -75,6 +76,7 @@ public:
   // AbstractRequestListener
   void onRequest(InFlightRequestSharedPtr request) override;
   void onRequestReadyForAnswer() override;
+  Event::Dispatcher& dispatcher() override;
 
   std::list<InFlightRequestSharedPtr>& getRequestsInFlightForTest();
 

--- a/contrib/kafka/filters/network/test/mesh/abstract_command_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/abstract_command_unit_test.cc
@@ -13,6 +13,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
 };
 
 class Testee : public BaseInFlightRequest {

--- a/contrib/kafka/filters/network/test/mesh/abstract_command_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/abstract_command_unit_test.cc
@@ -13,7 +13,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
 class Testee : public BaseInFlightRequest {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/BUILD
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/BUILD
@@ -29,6 +29,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "fetch_unit_test",
+    srcs = ["fetch_unit_test.cc"],
+    tags = ["skip_on_windows"],
+    deps = [
+        "//contrib/kafka/filters/network/source/mesh/command_handlers:fetch_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "list_offsets_unit_test",
     srcs = ["list_offsets_unit_test.cc"],
     tags = ["skip_on_windows"],

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/api_versions_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/api_versions_unit_test.cc
@@ -13,6 +13,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
 };
 
 TEST(ApiVersionsTest, shouldBeAlwaysReadyForAnswer) {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/api_versions_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/api_versions_unit_test.cc
@@ -13,7 +13,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
 TEST(ApiVersionsTest, shouldBeAlwaysReadyForAnswer) {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/fetch_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/fetch_unit_test.cc
@@ -1,0 +1,26 @@
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Mesh {
+namespace {
+
+class MockAbstractRequestListener : public AbstractRequestListener {
+public:
+  MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
+  MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+};
+
+TEST(FetchTest, shouldTest) {}
+
+} // namespace
+} // namespace Mesh
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/fetch_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/fetch_unit_test.cc
@@ -1,4 +1,7 @@
+#include "test/mocks/event/mocks.h"
+
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h"
+#include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -9,14 +12,66 @@ namespace Kafka {
 namespace Mesh {
 namespace {
 
+using testing::NiceMock;
+using testing::ReturnRef;
+
 class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
-TEST(FetchTest, shouldTest) {}
+class MockRecordCallbackProcessor : public RecordCallbackProcessor {
+public:
+  MOCK_METHOD(void, processCallback, (const RecordCbSharedPtr&));
+  MOCK_METHOD(void, removeCallback, (const RecordCbSharedPtr&));
+};
+
+class MockFetchRecordConverter : public FetchRecordConverter {
+public:
+  MOCK_METHOD(std::vector<FetchableTopicResponse>, convert, (const INPUT&), (const));
+};
+
+class FetchUnitTest : public testing::Test {
+protected:
+  NiceMock<MockAbstractRequestListener> filter_;
+  Event::MockDispatcher dispatcher_;
+  MockRecordCallbackProcessor callback_processor_;
+  MockFetchRecordConverter converter_;
+
+  FetchUnitTest() { ON_CALL(filter_, dispatcher).WillByDefault(ReturnRef(dispatcher_)); }
+
+  std::shared_ptr<FetchRequestHolder> makeTestee() {
+    const RequestHeader header = {0, 0, 0, absl::nullopt};
+    const FetchRequest data = {0, 0, 0, {}};
+    const auto message = std::make_shared<Request<FetchRequest>>(header, data);
+    return std::make_shared<FetchRequestHolder>(filter_, callback_processor_, message, converter_);
+  }
+};
+
+TEST_F(FetchUnitTest, shouldRegisterCallbackAndTimer) {
+  auto testee = makeTestee();
+  EXPECT_CALL(callback_processor_, processCallback(_));
+  EXPECT_CALL(dispatcher_, createTimer_(_));
+  testee->startProcessing();
+}
+
+// interest
+
+// markFinishedByTimer
+
+// markFinishedByTimer x2
+
+// receive (more)
+
+// receive (finish)
+
+// receive (reject)
+
+// abandon
+
+// computeAnswer
 
 } // namespace
 } // namespace Mesh

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
@@ -13,6 +13,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
 };
 
 TEST(ListOffsetsTest, shouldBeAlwaysReadyForAnswer) {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
@@ -13,7 +13,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
 TEST(ListOffsetsTest, shouldBeAlwaysReadyForAnswer) {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/metadata_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/metadata_unit_test.cc
@@ -16,6 +16,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
 };
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/metadata_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/metadata_unit_test.cc
@@ -16,7 +16,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
@@ -23,6 +23,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
 };
 
 class MockRecordExtractor : public RecordExtractor {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
@@ -54,7 +54,6 @@ protected:
 // (as ProduceRequests with no topics/records make no sense).
 TEST_F(ProduceUnitTest, ShouldHandleProduceRequestWithNoRecords) {
   // given
-  MockRecordExtractor extractor;
   const std::vector<OutboundRecord> records = {};
   EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
 

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
@@ -23,7 +23,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
 class MockRecordExtractor : public RecordExtractor {

--- a/contrib/kafka/filters/network/test/mesh/request_processor_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/request_processor_unit_test.cc
@@ -23,6 +23,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
 };
 
 class MockUpstreamKafkaFacade : public UpstreamKafkaFacade {

--- a/contrib/kafka/filters/network/test/mesh/request_processor_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/request_processor_unit_test.cc
@@ -23,7 +23,7 @@ class MockAbstractRequestListener : public AbstractRequestListener {
 public:
   MOCK_METHOD(void, onRequest, (InFlightRequestSharedPtr));
   MOCK_METHOD(void, onRequestReadyForAnswer, ());
-  MOCK_METHOD(Event::Dispatcher&, dispatcher, (), ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };
 
 class MockUpstreamKafkaFacade : public UpstreamKafkaFacade {


### PR DESCRIPTION
Commit Message: kafka: add Fetch request handling
Additional Description: Fetch request represents a single request coming from downstream clients "_please give me records for partitions p1, p2, ... pN_". In our implementation this will mean we will ask SharedConsumerManager to [process](https://github.com/adamkotwasinski/envoy/blob/59cfbef8571472ed7f37b741b59304e687dca3fc/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc#L55) our request (== fill it with records, if any stored; register as callback if nothing). When our processing is finished (which can happen in one of two ways: record times out (no records!) / stuff got provided (either [initial seeding](https://github.com/adamkotwasinski/envoy/blob/59cfbef8571472ed7f37b741b59304e687dca3fc/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc#L198) or by SCM's [consumer workers](https://github.com/adamkotwasinski/envoy/blob/59cfbef8571472ed7f37b741b59304e687dca3fc/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc#L156)), we finally let the filter/dispatcher know we are ready to go downstream. Part of https://github.com/envoyproxy/envoy/issues/24372.
Risk Level: Low
Testing: unit tests, integration tests with full stack
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A