### PR TITLE
test: Add clarifying comments to BaseClientIntegrationTest

### DIFF
--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -75,6 +75,7 @@ Platform::LogLevel getPlatformLogLevelFromOptions() {
 
 // Use the Envoy mobile default config as much as possible in this test.
 // There are some config modifiers below which do result in deltas.
+// Note: This function is only used to build the Engine if `override_builder_config_` is true.
 std::string defaultConfig() {
   Platform::EngineBuilder builder;
   std::string config_str = absl::StrCat(config_header, builder.generateConfigStr());

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -28,6 +28,7 @@ typedef struct {
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers);
 
 // Creates a default bootstrap config from the EngineBuilder.
+// Only used to build the Engine if `override_builder_config_` is set to true.
 std::string defaultConfig();
 
 // A base class for Envoy Mobile client integration tests which interact with Envoy through the


### PR DESCRIPTION
We clarify that BaseClientIntegrationTest::defaultConfig *only* gets used if `override_builder_config_` is set to true.
The code is very confusing to read without knowing this.

Signed-off-by: Ali Beyad <abeyad@google.com>
