### PR TITLE
jwt_authn: Fix a jwt_authn fuzz bug about too big remote_jwks.duration

### DIFF
--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
@@ -21,10 +21,12 @@ constexpr std::chrono::seconds RefetchBeforeExpiredSec{5};
 // Default number of seconds to refetch after a failed fetch.
 constexpr std::chrono::seconds DefaultRefetchAfterFailedSec{1};
 
-std::chrono::seconds getFailedRefetchDuration(const JwksAsyncFetch& async_fetch) {
+std::chrono::milliseconds getFailedRefetchDuration(const JwksAsyncFetch& async_fetch) {
   if (async_fetch.has_failed_refetch_duration()) {
-    return std::chrono::seconds(
-        DurationUtil::durationToSeconds(async_fetch.failed_refetch_duration()));
+    // Use `durationToMilliseconds` as it has stricter max boundary to the `seconds` value to avoid
+    // overflow.
+    return std::chrono::milliseconds(
+        DurationUtil::durationToMilliseconds(async_fetch.failed_refetch_duration()));
   }
   return DefaultRefetchAfterFailedSec;
 }

--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.h
@@ -66,9 +66,9 @@ private:
   Common::JwksFetcherPtr fetcher_;
 
   // The next refetch duration after a good fetch.
-  std::chrono::seconds good_refetch_duration_;
+  std::chrono::milliseconds good_refetch_duration_;
   // The next refetch duration after a failed fetch.
-  std::chrono::seconds failed_refetch_duration_;
+  std::chrono::milliseconds failed_refetch_duration_;
   // The timer to trigger a refetch.
   Envoy::Event::TimerPtr refetch_timer_;
 

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -32,10 +32,23 @@ public:
       : jwt_provider_(jwt_provider), time_source_(context.timeSource()),
         tls_(context.threadLocal()) {
 
-    // remote_jwks.retry_policy has an invalid case that could not be validated by the
-    // proto validation annotation. It has to be validated by the code.
-    if (jwt_provider_.has_remote_jwks() && jwt_provider_.remote_jwks().has_retry_policy()) {
-      Http::Utility::validateCoreRetryPolicy(jwt_provider_.remote_jwks().retry_policy());
+    if (jwt_provider_.has_remote_jwks()) {
+      // remote_jwks.retry_policy has an invalid case that could not be validated by the
+      // proto validation annotation. It has to be validated by the code.
+      if (jwt_provider_.remote_jwks().has_retry_policy()) {
+        Http::Utility::validateCoreRetryPolicy(jwt_provider_.remote_jwks().retry_policy());
+      }
+      if (jwt_provider_.remote_jwks().has_cache_duration()) {
+        // Use `durationToMilliseconds` as it has stricter max boundary to the `seconds` value to
+        // avoid overflow.
+        ProtobufWkt::Duration duration_copy(jwt_provider_.remote_jwks().cache_duration());
+        (void)DurationUtil::durationToMilliseconds(duration_copy);
+
+        // remote_jwks.duration is used as: now + remote_jwks.duration.
+        // need to verify twice of its `seconds` value.
+        duration_copy.set_seconds(2 * duration_copy.seconds());
+        (void)DurationUtil::durationToMilliseconds(duration_copy);
+      }
     }
 
     std::vector<std::string> audiences;

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/clusterfuzz-testcase-minimized-jwt_authn_fuzz_test-5019912976596992
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_corpus/clusterfuzz-testcase-minimized-jwt_authn_fuzz_test-5019912976596992
@@ -1,0 +1,37 @@
+config {
+  providers {
+    key: "provider1"
+    value {
+      issuer: "https://example.com"
+      remote_jwks {
+        cache_duration {
+          seconds: 21474836480
+        }
+      }
+    }
+  }
+  rules {
+    match {
+      prefix: "/"
+    }
+    requires {
+      requires_any {
+        requirements {
+          provider_name: "provider1"
+        }
+        requirements {
+        }
+      }
+    }
+  }
+}
+request_data {
+  headers {
+    headers {
+      key: "authorization"
+      value: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIsImV4cCI6MjAwMTAwMTAwMX0.n45uWZfIBZwCIPiL0K8Ca3tmm-ZlsDrC79_vXCspPwk5oxdSn983tuC9GfVWKXWUMHe11DsB02b19Ow-fmoEzooTFn65Ml7G34nW07amyM6lETiMhNzyiunctplOr6xKKJHmzTUhfTirvDeG-q9n24-8lH7GP8GgHvDlgSM9OY7TGp81bRcnZBmxim_UzHoYO3_c8OP4ZX3xG5PfihVk5G0g6wcHrO70w0_64JgkKRCrLHMJSrhIgp9NHel_CNOnL0AjQKe9IGblJrMuouqYYS0zEWwmOVUWUSxQkoLpldQUVefcfjQeGjz8IlvktRa77FYexfP590ACPyXrivtsxg"
+    }
+  }
+}
+remote_jwks: "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"62a93512c9ee4c7f8067b5a216dade2763d32a47\",\"n\":\"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"b3319a147514df7ee5e4bcdee51350cc890cc89e\",\"n\":\"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q\",\"e\":\"AQAB\"}]}"
+num_calls: 3


### PR DESCRIPTION
Fix jwt_auth_fuzz [bug](https://oss-fuzz.com/testcase-detail/5019912976596992)

It complains about the config `remote_jwks.duration.seconds` field is too big.



Risk Level: None
Testing:  Unit-tested
Docs Changes: None
Release Notes:  None
