### PR TITLE
Reduce Route memory utilization by reducing  alignment overhead

### DIFF
--- a/envoy/http/codes.h
+++ b/envoy/http/codes.h
@@ -11,7 +11,7 @@ namespace Http {
  * HTTP response codes.
  * http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
  */
-enum class Code : int16_t {
+enum class Code : uint16_t {
   // clang-format off
   Continue                      = 100,
   SwitchingProtocols            = 101,

--- a/envoy/http/codes.h
+++ b/envoy/http/codes.h
@@ -11,7 +11,7 @@ namespace Http {
  * HTTP response codes.
  * http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
  */
-enum class Code {
+enum class Code : int16_t {
   // clang-format off
   Continue                      = 100,
   SwitchingProtocols            = 101,

--- a/envoy/upstream/resource_manager.h
+++ b/envoy/upstream/resource_manager.h
@@ -14,7 +14,7 @@ namespace Upstream {
  * Resource priority classes. The parallel NumResourcePriorities constant allows defining fixed
  * arrays for each priority, but does not pollute the enum.
  */
-enum class ResourcePriority : int8_t { Default, High };
+enum class ResourcePriority : uint8_t { Default, High };
 const size_t NumResourcePriorities = 2;
 
 /**

--- a/envoy/upstream/resource_manager.h
+++ b/envoy/upstream/resource_manager.h
@@ -14,7 +14,7 @@ namespace Upstream {
  * Resource priority classes. The parallel NumResourcePriorities constant allows defining fixed
  * arrays for each priority, but does not pollute the enum.
  */
-enum class ResourcePriority { Default, High };
+enum class ResourcePriority : int8_t { Default, High };
 const size_t NumResourcePriorities = 2;
 
 /**

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2057,11 +2057,11 @@ ConfigImpl::ConfigImpl(const envoy::config::route::v3::RouteConfiguration& confi
                        ProtobufMessage::ValidationVisitor& validator,
                        bool validate_clusters_default)
     : name_(config.name()), symbol_table_(factory_context.scope().symbolTable()),
+      per_filter_configs_(config.typed_per_filter_config(), optional_http_filters, factory_context,
+                          validator),
       max_direct_response_body_size_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_direct_response_body_size_bytes,
                                           DEFAULT_MAX_DIRECT_RESPONSE_BODY_SIZE_BYTES)),
-      per_filter_configs_(config.typed_per_filter_config(), optional_http_filters, factory_context,
-                          validator),
       uses_vhds_(config.has_vhds()),
       most_specific_header_mutations_wins_(config.most_specific_header_mutations_wins()),
       ignore_path_parameters_in_path_matching_(config.ignore_path_parameters_in_path_matching()) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -504,8 +504,6 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       internal_redirect_policy_(
           buildInternalRedirectPolicy(route.route(), validator, route.name())),
       config_headers_(Http::HeaderUtility::buildHeaderDataVector(route.match().headers())),
-      retry_shadow_buffer_limit_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          route, per_request_buffer_limit_bytes, vhost.retryShadowBufferLimit())),
       dynamic_metadata_(route.match().dynamic_metadata().begin(),
                         route.match().dynamic_metadata().end()),
       opaque_config_(parseOpaqueConfig(route)), decorator_(parseDecorator(route)),
@@ -517,6 +515,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                           validator),
       route_name_(route.name()), time_source_(factory_context.mainThreadDispatcher().timeSource()),
       random_value_header_name_(route.route().weighted_clusters().header_name()),
+      retry_shadow_buffer_limit_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          route, per_request_buffer_limit_bytes, vhost.retryShadowBufferLimit())),
       direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
       cluster_not_found_response_code_(ConfigUtility::parseClusterNotFoundResponseCode(
           route.route().cluster_not_found_response_code())),

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -463,12 +463,10 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                        const OptionalHttpFilters& optional_http_filters,
                                        Server::Configuration::ServerFactoryContext& factory_context,
                                        ProtobufMessage::ValidationVisitor& validator)
-    : case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.match(), case_sensitive, true)),
-      prefix_rewrite_(route.route().prefix_rewrite()),
+    : prefix_rewrite_(route.route().prefix_rewrite()),
       path_matcher_(buildPathMatcher(route, validator)),
       path_rewriter_(buildPathRewriter(route, validator)),
       host_rewrite_(route.route().host_rewrite_literal()), vhost_(vhost),
-      auto_host_rewrite_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.route(), auto_host_rewrite, false)),
       auto_host_rewrite_header_(!route.route().host_rewrite_header().empty()
                                     ? absl::optional<Http::LowerCaseString>(Http::LowerCaseString(
                                           route.route().host_rewrite_header()))
@@ -481,10 +479,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
           route.route().has_host_rewrite_path_regex()
               ? route.route().host_rewrite_path_regex().substitution()
               : ""),
-      append_xfh_(route.route().append_x_forwarded_host()), cluster_name_(route.route().cluster()),
-      cluster_header_name_(route.route().cluster_header()),
-      cluster_not_found_response_code_(ConfigUtility::parseClusterNotFoundResponseCode(
-          route.route().cluster_not_found_response_code())),
+      cluster_name_(route.route().cluster()), cluster_header_name_(route.route().cluster_header()),
       timeout_(PROTOBUF_GET_MS_OR_DEFAULT(route.route(), timeout, DEFAULT_ROUTE_TIMEOUT_MS)),
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), idle_timeout)),
       max_stream_duration_(
@@ -502,33 +497,37 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                          ? ":" + std::to_string(route.redirect().port_redirect())
                          : ""),
       path_redirect_(route.redirect().path_redirect()),
-      path_redirect_has_query_(path_redirect_.find('?') != absl::string_view::npos),
-      https_redirect_(route.redirect().https_redirect()),
-      using_new_timeouts_(route.route().has_max_stream_duration()),
       prefix_rewrite_redirect_(route.redirect().prefix_rewrite()),
-      strip_query_(route.redirect().strip_query()),
       hedge_policy_(buildHedgePolicy(vhost.hedgePolicy(), route.route())),
       retry_policy_(
           buildRetryPolicy(vhost.retryPolicy(), route.route(), validator, factory_context)),
       internal_redirect_policy_(
           buildInternalRedirectPolicy(route.route(), validator, route.name())),
-      priority_(ConfigUtility::parsePriority(route.route().priority())),
       config_headers_(Http::HeaderUtility::buildHeaderDataVector(route.match().headers())),
       retry_shadow_buffer_limit_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           route, per_request_buffer_limit_bytes, vhost.retryShadowBufferLimit())),
-      match_grpc_(route.match().has_grpc()),
       dynamic_metadata_(route.match().dynamic_metadata().begin(),
                         route.match().dynamic_metadata().end()),
       opaque_config_(parseOpaqueConfig(route)), decorator_(parseDecorator(route)),
       route_tracing_(parseRouteTracing(route)),
-      direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
       direct_response_body_(ConfigUtility::parseDirectResponseBody(
           route, factory_context.api(),
           vhost_.globalRouteConfig().maxDirectResponseBodySizeBytes())),
       per_filter_configs_(route.typed_per_filter_config(), optional_http_filters, factory_context,
                           validator),
       route_name_(route.name()), time_source_(factory_context.mainThreadDispatcher().timeSource()),
-      random_value_header_name_(route.route().weighted_clusters().header_name()) {
+      random_value_header_name_(route.route().weighted_clusters().header_name()),
+      direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
+      cluster_not_found_response_code_(ConfigUtility::parseClusterNotFoundResponseCode(
+          route.route().cluster_not_found_response_code())),
+      priority_(ConfigUtility::parsePriority(route.route().priority())),
+      auto_host_rewrite_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.route(), auto_host_rewrite, false)),
+      append_xfh_(route.route().append_x_forwarded_host()),
+      path_redirect_has_query_(path_redirect_.find('?') != absl::string_view::npos),
+      https_redirect_(route.redirect().https_redirect()),
+      using_new_timeouts_(route.route().has_max_stream_duration()),
+      strip_query_(route.redirect().strip_query()), match_grpc_(route.match().has_grpc()),
+      case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.match(), case_sensitive, true)) {
   if (!route.request_headers_to_add().empty() || !route.request_headers_to_remove().empty()) {
     request_headers_parser_ =
         HeaderParser::configure(route.request_headers_to_add(), route.request_headers_to_remove());
@@ -976,8 +975,8 @@ absl::optional<std::string> RouteEntryImplBase::currentUrlPathAfterRewriteWithMa
       auto just_path(Http::PathUtil::removeQueryAndFragment(path));
       return path.replace(0, just_path.size(), rewrite);
     }
-    ASSERT(case_sensitive_ ? absl::StartsWith(path, matched_path)
-                           : absl::StartsWithIgnoreCase(path, matched_path));
+    ASSERT(case_sensitive() ? absl::StartsWith(path, matched_path)
+                            : absl::StartsWithIgnoreCase(path, matched_path));
     return path.replace(0, matched_path.size(), rewrite);
   }
 
@@ -1515,8 +1514,8 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(
     Server::Configuration::ServerFactoryContext& factory_context,
     ProtobufMessage::ValidationVisitor& validator)
     : RouteEntryImplBase(vhost, route, optional_http_filters, factory_context, validator),
-      path_matcher_(Matchers::PathMatcher::createPrefix(route.match().prefix(), !case_sensitive_)) {
-}
+      path_matcher_(
+          Matchers::PathMatcher::createPrefix(route.match().prefix(), !case_sensitive())) {}
 
 void PrefixRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                              bool insert_envoy_original_path) const {
@@ -1544,7 +1543,7 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
                                        Server::Configuration::ServerFactoryContext& factory_context,
                                        ProtobufMessage::ValidationVisitor& validator)
     : RouteEntryImplBase(vhost, route, optional_http_filters, factory_context, validator),
-      path_matcher_(Matchers::PathMatcher::createExact(route.match().path(), !case_sensitive_)) {}
+      path_matcher_(Matchers::PathMatcher::createExact(route.match().path(), !case_sensitive())) {}
 
 void PathRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                            bool insert_envoy_original_path) const {
@@ -1640,7 +1639,7 @@ PathSeparatedPrefixRouteEntryImpl::PathSeparatedPrefixRouteEntryImpl(
     ProtobufMessage::ValidationVisitor& validator)
     : RouteEntryImplBase(vhost, route, optional_http_filters, factory_context, validator),
       path_matcher_(Matchers::PathMatcher::createPrefix(route.match().path_separated_prefix(),
-                                                        !case_sensitive_)) {}
+                                                        !case_sensitive())) {}
 
 void PathSeparatedPrefixRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                                           bool insert_envoy_original_path) const {
@@ -2058,14 +2057,14 @@ ConfigImpl::ConfigImpl(const envoy::config::route::v3::RouteConfiguration& confi
                        ProtobufMessage::ValidationVisitor& validator,
                        bool validate_clusters_default)
     : name_(config.name()), symbol_table_(factory_context.scope().symbolTable()),
-      uses_vhds_(config.has_vhds()),
-      most_specific_header_mutations_wins_(config.most_specific_header_mutations_wins()),
       max_direct_response_body_size_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_direct_response_body_size_bytes,
                                           DEFAULT_MAX_DIRECT_RESPONSE_BODY_SIZE_BYTES)),
-      ignore_path_parameters_in_path_matching_(config.ignore_path_parameters_in_path_matching()),
       per_filter_configs_(config.typed_per_filter_config(), optional_http_filters, factory_context,
-                          validator) {
+                          validator),
+      uses_vhds_(config.has_vhds()),
+      most_specific_header_mutations_wins_(config.most_specific_header_mutations_wins()),
+      ignore_path_parameters_in_path_matching_(config.ignore_path_parameters_in_path_matching()) {
   if (!config.request_mirror_policies().empty()) {
     shadow_policies_.reserve(config.request_mirror_policies().size());
     for (const auto& mirror_policy_config : config.request_mirror_policies()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -278,7 +278,7 @@ public:
       std::function<void(const Router::RouteSpecificFilterConfig&)> cb) const override;
 
 private:
-  enum class SslRequirements : int8_t { None, ExternalOnly, All };
+  enum class SslRequirements : uint8_t { None, ExternalOnly, All };
 
   struct StatNameProvider {
     StatNameProvider(absl::string_view name, Stats::SymbolTable& symbol_table)
@@ -1133,8 +1133,8 @@ private:
   const bool using_new_timeouts_ : 1;
   const bool strip_query_ : 1;
   const bool match_grpc_ : 1;
-  bool include_vh_rate_limits_ : 1;
   const bool case_sensitive_ : 1;
+  bool include_vh_rate_limits_ : 1;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1502,12 +1502,12 @@ private:
   HeaderParserPtr response_headers_parser_;
   const std::string name_;
   Stats::SymbolTable& symbol_table_;
-  const uint32_t max_direct_response_body_size_bytes_;
   std::vector<ShadowPolicyPtr> shadow_policies_;
   // Cluster specifier plugins/providers.
   absl::flat_hash_map<std::string, ClusterSpecifierPluginSharedPtr> cluster_specifier_plugins_;
   PerFilterConfigs per_filter_configs_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  const uint32_t max_direct_response_body_size_bytes_;
   const bool uses_vhds_ : 1;
   const bool most_specific_header_mutations_wins_ : 1;
   const bool ignore_path_parameters_in_path_matching_ : 1;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -333,12 +333,12 @@ private:
   HeaderParserPtr request_headers_parser_;
   HeaderParserPtr response_headers_parser_;
   PerFilterConfigs per_filter_configs_;
-  uint32_t retry_shadow_buffer_limit_{std::numeric_limits<uint32_t>::max()};
   std::unique_ptr<envoy::config::route::v3::RetryPolicy> retry_policy_;
   std::unique_ptr<envoy::config::route::v3::HedgePolicy> hedge_policy_;
   std::unique_ptr<const CatchAllVirtualCluster> virtual_cluster_catch_all_;
   Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  uint32_t retry_shadow_buffer_limit_{std::numeric_limits<uint32_t>::max()};
   SslRequirements ssl_requirements_;
   const bool include_attempt_count_in_request_ : 1;
   const bool include_attempt_count_in_response_ : 1;
@@ -538,10 +538,10 @@ private:
 
   const std::string current_route_name_;
   const absl::flat_hash_set<Http::Code> redirect_response_codes_;
-  const uint32_t max_internal_redirects_{1};
   std::vector<std::pair<InternalRedirectPredicateFactory*, ProtobufTypes::MessagePtr>>
       predicate_factories_;
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  const uint32_t max_internal_redirects_{1};
   const bool enabled_{false};
   const bool allow_cross_scheme_redirect_{false};
 };
@@ -1105,7 +1105,6 @@ private:
   TlsContextMatchCriteriaConstPtr tls_context_match_criteria_;
   HeaderParserPtr request_headers_parser_;
   HeaderParserPtr response_headers_parser_;
-  uint32_t retry_shadow_buffer_limit_{std::numeric_limits<uint32_t>::max()};
   std::unique_ptr<const envoy::config::core::v3::Metadata> metadata_;
   std::unique_ptr<const RouteTypedMetadata> typed_metadata_;
   const std::vector<Envoy::Matchers::MetadataMatcher> dynamic_metadata_;
@@ -1123,6 +1122,7 @@ private:
   EarlyDataPolicyPtr early_data_policy_;
 
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  uint32_t retry_shadow_buffer_limit_{std::numeric_limits<uint32_t>::max()};
   const absl::optional<Http::Code> direct_response_code_;
   const Http::Code cluster_not_found_response_code_;
   const Upstream::ResourcePriority priority_;


### PR DESCRIPTION
Reduce Route memory utilization by reducing  alignment overhead.

The PR re-arranges class members so that small ones (bools and enums) are last members, instead of being sprayed between larger data types. This reduces alignment overhead, and shrinks Route size by 72 bytes.

For additional size reduction, small enum classes are qualified with smaller integer types, so that they use 1 or 2 bytes, instead of the default 4.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
