### PR TITLE
Make round trip time accessible through streaminfo

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -107,6 +107,11 @@ public:
    * @return ja3 fingerprint hash of the downstream connection, if any.
    */
   virtual absl::string_view ja3Hash() const PURE;
+
+  /**
+   * @return roundTripTime of the connection
+   */
+  virtual const absl::optional<std::chrono::milliseconds>& roundTripTime() const PURE;
 };
 
 class ConnectionInfoSetter : public ConnectionInfoProvider {
@@ -168,6 +173,11 @@ public:
    * @param JA3 fingerprint.
    */
   virtual void setJA3Hash(const absl::string_view ja3_hash) PURE;
+
+  /**
+   * @param  milliseconds of round trip time of previous connection
+   */
+  virtual void setRoundTripTime(std::chrono::milliseconds roundTripTime) PURE;
 };
 
 using ConnectionInfoSetterSharedPtr = std::shared_ptr<ConnectionInfoSetter>;

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -582,6 +582,9 @@ public:
   absl::string_view ja3Hash() const override {
     return StreamInfoImpl::downstreamAddressProvider().ja3Hash();
   }
+  const absl::optional<std::chrono::milliseconds>& roundTripTime() const override {
+    return StreamInfoImpl::downstreamAddressProvider().roundTripTime();
+  }
 
 private:
   Network::Address::InstanceConstSharedPtr overridden_downstream_remote_address_;

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -67,6 +67,12 @@ public:
   }
   absl::string_view ja3Hash() const override { return ja3_hash_; }
   void setJA3Hash(const absl::string_view ja3_hash) override { ja3_hash_ = std::string(ja3_hash); }
+  const absl::optional<std::chrono::milliseconds>& roundTripTime() const override {
+    return round_trip_time_;
+  }
+  void setRoundTripTime(std::chrono::milliseconds round_trip_time) override {
+    round_trip_time_ = round_trip_time;
+  }
 
 private:
   Address::InstanceConstSharedPtr local_address_;
@@ -79,6 +85,7 @@ private:
   absl::optional<std::string> interface_name_;
   Ssl::ConnectionInfoConstSharedPtr ssl_info_;
   std::string ja3_hash_;
+  absl::optional<std::chrono::milliseconds> round_trip_time_;
 };
 
 class SocketImpl : public virtual Socket {

--- a/source/server/active_tcp_listener.cc
+++ b/source/server/active_tcp_listener.cc
@@ -101,6 +101,12 @@ void ActiveTcpListener::onReject(RejectCause cause) {
 void ActiveTcpListener::onAcceptWorker(Network::ConnectionSocketPtr&& socket,
                                        bool hand_off_restored_destination_connections,
                                        bool rebalanced) {
+  // Get Round Trip Time
+  absl::optional<std::chrono::milliseconds> t = socket->lastRoundTripTime();
+  if (t.has_value()) {
+    socket->connectionInfoProvider().setRoundTripTime(t.value());
+  }
+
   if (!rebalanced) {
     Network::BalancedConnectionHandler& target_handler =
         connection_balancer_.pickTargetHandler(*this);

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -198,6 +198,29 @@ TEST_P(FilterIntegrationTest, MissingHeadersLocalReplyDownstreamBytesCount) {
   }
 }
 
+TEST_P(FilterIntegrationTest, RoundTripTimeForUpstreamConnection) {
+  config_helper_.prependFilter(R"EOF(
+  name: stream-info-to-headers-filter
+  )EOF");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Send a headers only request.
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+
+  // Make sure that the body was injected to the request.
+  EXPECT_TRUE(upstream_request_->complete());
+
+  // Send a headers only response.
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Make sure that round trip time was populated
+  EXPECT_FALSE(response->headers().get(Http::LowerCaseString("round_trip_time")).empty());
+}
+
 TEST_P(FilterIntegrationTest, MissingHeadersLocalReplyUpstreamBytesCount) {
   useAccessLog("%UPSTREAM_WIRE_BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% "
                "%UPSTREAM_HEADER_BYTES_SENT% %UPSTREAM_HEADER_BYTES_RECEIVED%");

--- a/test/integration/filters/stream_info_to_headers_filter.cc
+++ b/test/integration/filters/stream_info_to_headers_filter.cc
@@ -38,6 +38,10 @@ public:
       headers.addCopy(Http::LowerCaseString("dns_end"),
                       toUsec(stream_info.downstreamTiming().getValue(dns_end).value()));
     }
+    if (stream_info.downstreamAddressProvider().roundTripTime().has_value()) {
+      headers.addCopy(Http::LowerCaseString("round_trip_time"),
+                      stream_info.downstreamAddressProvider().roundTripTime().value().count());
+    }
     if (conn_stream_info.downstreamTiming().has_value() &&
         conn_stream_info.downstreamTiming()->downstreamHandshakeComplete().has_value()) {
       headers.addCopy(


### PR DESCRIPTION
Signed-off-by: AlanDiaz <diazalan@google.com>

Commit Message: Make round trip time accessible through stream info
Additional Description: Make the last round trip time of the previous handshake accessible through stream info. This will allow us to make it accessible in access logs,
Risk Level: Low
Testing: Added an integration test in filter integration test that adds roundtriptime to the header and checks if it exists
Docs Changes: NA
Release Notes:  NA
Platform Specific Features: NA
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
