### PR TITLE
Reduce Route memory utilization by avoiding `absl::optional` overhead for optional timeouts

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -458,6 +458,43 @@ const envoy::type::v3::FractionalPercent& RouteTracingImpl::getOverallSampling()
 }
 const Tracing::CustomTagMap& RouteTracingImpl::getCustomTags() const { return custom_tags_; }
 
+OptionalTimeouts::OptionalTimeouts(const envoy::config::route::v3::RouteAction& route)
+    : has_idle_timeout_(false), has_max_stream_duration_(false),
+      has_grpc_timeout_header_max_(false), has_grpc_timeout_header_offset_(false),
+      has_max_grpc_timeout_(false), has_grpc_timeout_offset_(false) {
+  if (route.has_idle_timeout()) {
+    has_idle_timeout_ = true;
+    idle_timeout_ = std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(route, idle_timeout));
+  }
+  if (route.has_max_grpc_timeout()) {
+    has_max_grpc_timeout_ = true;
+    max_grpc_timeout_ =
+        std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(route, max_grpc_timeout));
+  }
+  if (route.has_grpc_timeout_offset()) {
+    has_grpc_timeout_offset_ = true;
+    grpc_timeout_offset_ =
+        std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(route, grpc_timeout_offset));
+  }
+  if (route.has_max_stream_duration()) {
+    if (route.max_stream_duration().has_max_stream_duration()) {
+      has_max_stream_duration_ = true;
+      max_stream_duration_ = std::chrono::milliseconds(
+          PROTOBUF_GET_MS_REQUIRED(route.max_stream_duration(), max_stream_duration));
+    }
+    if (route.max_stream_duration().has_grpc_timeout_header_max()) {
+      has_grpc_timeout_header_max_ = true;
+      grpc_timeout_header_max_ = std::chrono::milliseconds(
+          PROTOBUF_GET_MS_REQUIRED(route.max_stream_duration(), grpc_timeout_header_max));
+    }
+    if (route.max_stream_duration().has_grpc_timeout_header_offset()) {
+      has_grpc_timeout_header_offset_ = true;
+      grpc_timeout_header_offset_ = std::chrono::milliseconds(
+          PROTOBUF_GET_MS_REQUIRED(route.max_stream_duration(), grpc_timeout_header_offset));
+    }
+  }
+}
+
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                        const envoy::config::route::v3::Route& route,
                                        const OptionalHttpFilters& optional_http_filters,
@@ -481,16 +518,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
               : ""),
       cluster_name_(route.route().cluster()), cluster_header_name_(route.route().cluster_header()),
       timeout_(PROTOBUF_GET_MS_OR_DEFAULT(route.route(), timeout, DEFAULT_ROUTE_TIMEOUT_MS)),
-      idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), idle_timeout)),
-      max_stream_duration_(
-          PROTOBUF_GET_OPTIONAL_MS(route.route().max_stream_duration(), max_stream_duration)),
-      grpc_timeout_header_max_(
-          PROTOBUF_GET_OPTIONAL_MS(route.route().max_stream_duration(), grpc_timeout_header_max)),
-      grpc_timeout_header_offset_(PROTOBUF_GET_OPTIONAL_MS(route.route().max_stream_duration(),
-                                                           grpc_timeout_header_offset)),
-      max_grpc_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), max_grpc_timeout)),
-      grpc_timeout_offset_(PROTOBUF_GET_OPTIONAL_MS(route.route(), grpc_timeout_offset)),
-      loader_(factory_context.runtime()), runtime_(loadRuntimeData(route.match())),
+      optional_timeouts_(buildOptionalTimeouts(route.route())), loader_(factory_context.runtime()),
+      runtime_(loadRuntimeData(route.match())),
       scheme_redirect_(route.redirect().scheme_redirect()),
       host_redirect_(route.redirect().host_redirect()),
       port_redirect_(route.redirect().port_redirect()
@@ -1192,6 +1221,16 @@ std::unique_ptr<InternalRedirectPolicyImpl> RouteEntryImplBase::buildInternalRed
   }
   return std::make_unique<InternalRedirectPolicyImpl>(policy_config, validator, current_route_name);
 }
+
+std::unique_ptr<OptionalTimeouts> RouteEntryImplBase::buildOptionalTimeouts(
+    const envoy::config::route::v3::RouteAction& route) const {
+  if (route.has_idle_timeout() || route.has_max_grpc_timeout() || route.has_grpc_timeout_offset() ||
+      route.has_max_stream_duration()) {
+    return std::make_unique<OptionalTimeouts>(route);
+  }
+  return nullptr;
+}
+
 PathRewriterSharedPtr
 RouteEntryImplBase::buildPathRewriter(envoy::config::route::v3::Route route,
                                       ProtobufMessage::ValidationVisitor& validator) const {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -547,6 +547,60 @@ private:
 };
 using DefaultInternalRedirectPolicy = ConstSingleton<InternalRedirectPolicyImpl>;
 
+// Manages various optional route timeouts. We pack them in a separate data structure for memory
+// efficiency:
+// - Sharing one bool avoids the overhead of `absl::optional`, saving 8 bytes per timeout
+// - If none of the timeouts are configured, we avoid tracking any of the `std::duration` values,
+// saving another 8 bytes per timeout
+class OptionalTimeouts {
+public:
+  OptionalTimeouts(const envoy::config::route::v3::RouteAction& route);
+
+  absl::optional<std::chrono::milliseconds> idleTimeout() const {
+    return has_idle_timeout_ ? absl::optional<std::chrono::milliseconds>(idle_timeout_)
+                             : absl::nullopt;
+  }
+  absl::optional<std::chrono::milliseconds> maxStreamDuration() const {
+    return has_max_stream_duration_
+               ? absl::optional<std::chrono::milliseconds>(max_stream_duration_)
+               : absl::nullopt;
+  }
+  absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const {
+    return has_grpc_timeout_header_max_
+               ? absl::optional<std::chrono::milliseconds>(grpc_timeout_header_max_)
+               : absl::nullopt;
+  }
+  absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const {
+    return has_grpc_timeout_header_offset_
+               ? absl::optional<std::chrono::milliseconds>(grpc_timeout_header_offset_)
+               : absl::nullopt;
+  }
+  absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const {
+    return has_max_grpc_timeout_ ? absl::optional<std::chrono::milliseconds>(max_grpc_timeout_)
+                                 : absl::nullopt;
+  }
+  absl::optional<std::chrono::milliseconds> grpcTimeoutOffset() const {
+    return has_grpc_timeout_offset_
+               ? absl::optional<std::chrono::milliseconds>(grpc_timeout_offset_)
+               : absl::nullopt;
+  }
+
+private:
+  std::chrono::milliseconds idle_timeout_;
+  std::chrono::milliseconds max_stream_duration_;
+  std::chrono::milliseconds grpc_timeout_header_max_;
+  std::chrono::milliseconds grpc_timeout_header_offset_;
+  std::chrono::milliseconds max_grpc_timeout_;
+  std::chrono::milliseconds grpc_timeout_offset_;
+  // Keep small members at the end of class, to reduce alignment overhead.
+  bool has_idle_timeout_ : 1;
+  bool has_max_stream_duration_ : 1;
+  bool has_grpc_timeout_header_max_ : 1;
+  bool has_grpc_timeout_header_offset_ : 1;
+  bool has_max_grpc_timeout_ : 1;
+  bool has_grpc_timeout_offset_ : 1;
+};
+
 /**
  * Base implementation for all route entries.q
  */
@@ -657,22 +711,26 @@ public:
     return vhost_.virtualClusterFromEntries(headers);
   }
   std::chrono::milliseconds timeout() const override { return timeout_; }
-  absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
+  absl::optional<std::chrono::milliseconds> idleTimeout() const override {
+    return optional_timeouts_ != nullptr ? optional_timeouts_->idleTimeout() : absl::nullopt;
+  }
   bool usingNewTimeouts() const override { return using_new_timeouts_; }
   absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
-    return max_stream_duration_;
+    return optional_timeouts_ != nullptr ? optional_timeouts_->maxStreamDuration() : absl::nullopt;
   }
   absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const override {
-    return grpc_timeout_header_max_;
+    return optional_timeouts_ != nullptr ? optional_timeouts_->grpcTimeoutHeaderMax()
+                                         : absl::nullopt;
   }
   absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const override {
-    return grpc_timeout_header_offset_;
+    return optional_timeouts_ != nullptr ? optional_timeouts_->grpcTimeoutHeaderOffset()
+                                         : absl::nullopt;
   }
   absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override {
-    return max_grpc_timeout_;
+    return optional_timeouts_ != nullptr ? optional_timeouts_->maxGrpcTimeout() : absl::nullopt;
   }
   absl::optional<std::chrono::milliseconds> grpcTimeoutOffset() const override {
-    return grpc_timeout_offset_;
+    return optional_timeouts_ != nullptr ? optional_timeouts_->grpcTimeoutOffset() : absl::nullopt;
   }
   const VirtualHost& virtualHost() const override { return vhost_; }
   bool autoHostRewrite() const override { return auto_host_rewrite_; }
@@ -1048,6 +1106,9 @@ private:
                               ProtobufMessage::ValidationVisitor& validator,
                               absl::string_view current_route_name) const;
 
+  std::unique_ptr<OptionalTimeouts>
+  buildOptionalTimeouts(const envoy::config::route::v3::RouteAction& route) const;
+
   PathMatcherSharedPtr buildPathMatcher(envoy::config::route::v3::Route route,
                                         ProtobufMessage::ValidationVisitor& validator) const;
 
@@ -1076,12 +1137,7 @@ private:
   const Http::LowerCaseString cluster_header_name_;
   ClusterSpecifierPluginSharedPtr cluster_specifier_plugin_;
   const std::chrono::milliseconds timeout_;
-  const absl::optional<std::chrono::milliseconds> idle_timeout_;
-  const absl::optional<std::chrono::milliseconds> max_stream_duration_;
-  const absl::optional<std::chrono::milliseconds> grpc_timeout_header_max_;
-  const absl::optional<std::chrono::milliseconds> grpc_timeout_header_offset_;
-  const absl::optional<std::chrono::milliseconds> max_grpc_timeout_;
-  const absl::optional<std::chrono::milliseconds> grpc_timeout_offset_;
+  std::unique_ptr<const OptionalTimeouts> optional_timeouts_;
   Runtime::Loader& loader_;
   std::unique_ptr<const RuntimeData> runtime_;
   const std::string scheme_redirect_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -550,7 +550,7 @@ using DefaultInternalRedirectPolicy = ConstSingleton<InternalRedirectPolicyImpl>
 // Manages various optional route timeouts. We pack them in a separate data structure for memory
 // efficiency:
 // - Sharing one bool avoids the overhead of `absl::optional`, saving 8 bytes per timeout
-// - If none of the timeouts are configured, we avoid tracking any of the `std::duration` values,
+// - If none of the timeouts are configured, we avoid allocating any of the `std::duration` values,
 // saving another 8 bytes per timeout
 class OptionalTimeouts {
 public:


### PR DESCRIPTION
Reduce Route memory utilization by avoiding `absl::optional` overhead for optional timeouts.

`std::duration` values wrapped in an absl::optional take twice as much memory as the durations themseves -- 16 bytes for each optional milliseconds value.

This PR removes the optional overhead by
1. Packing all timeouts into a separate data structure, sharing a single bool to track which timeout is set. This saves 8 bytes per timeout.
2. Not creating the data structure at all, if none of the optional timeouts are present. This saves another 8 bytes per timeout, for routes that don't configure them.

There are 6 optional timeouts, so this saves either 40 or 90 bytes per route.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
