### PR TITLE
mobile: dns cache registration

### DIFF
--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -46,6 +46,7 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/socket_tag:config",
         "@envoy_mobile//library/common/extensions/listener_managers/api_listener_manager:api_listener_manager_lib",
         "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
+        "@envoy_mobile//library/common/extensions/key_value/platform:config",
     ] + envoy_select_enable_http3(
         [
             "@envoy//source/common/quic:quic_transport_socket_factory_lib",

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -44,9 +44,9 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
         "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
         "@envoy_mobile//library/common/extensions/filters/http/socket_tag:config",
+        "@envoy_mobile//library/common/extensions/key_value/platform:config",
         "@envoy_mobile//library/common/extensions/listener_managers/api_listener_manager:api_listener_manager_lib",
         "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
-        "@envoy_mobile//library/common/extensions/key_value/platform:config",
     ] + envoy_select_enable_http3(
         [
             "@envoy//source/common/quic:quic_transport_socket_factory_lib",

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -39,6 +39,7 @@
 #include "library/common/extensions/filters/http/route_cache_reset/config.h"
 #include "library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h"
 #include "library/common/extensions/retry/options/network_configuration/config.h"
+#include "library/common/extensions/key_value/platform/config.h"
 
 namespace Envoy {
 
@@ -83,6 +84,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
   Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
   Envoy::Server::forceRegisterApiListenerManagerFactoryImpl();
+  Envoy::Extensions::KeyValue::forceRegisterPlatformKeyValueStoreFactory();
 
 #ifdef ENVOY_ENABLE_QUIC
   Quic::forceRegisterQuicServerTransportSocketConfigFactory();

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -37,9 +37,9 @@
 #include "library/common/extensions/filters/http/network_configuration/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
 #include "library/common/extensions/filters/http/route_cache_reset/config.h"
+#include "library/common/extensions/key_value/platform/config.h"
 #include "library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h"
 #include "library/common/extensions/retry/options/network_configuration/config.h"
-#include "library/common/extensions/key_value/platform/config.h"
 
 namespace Envoy {
 

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -65,6 +65,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
   Envoy::Extensions::HttpFilters::NetworkConfiguration::
       forceRegisterNetworkConfigurationFilterFactory();
+  Envoy::Extensions::KeyValue::forceRegisterPlatformKeyValueStoreFactory();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::Retry::Options::
@@ -84,7 +85,6 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
   Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
   Envoy::Server::forceRegisterApiListenerManagerFactoryImpl();
-  Envoy::Extensions::KeyValue::forceRegisterPlatformKeyValueStoreFactory();
 
 #ifdef ENVOY_ENABLE_QUIC
   Quic::forceRegisterQuicServerTransportSocketConfigFactory();

--- a/mobile/examples/objective-c/hello_world/ViewController.m
+++ b/mobile/examples/objective-c/hello_world/ViewController.m
@@ -39,7 +39,7 @@ NSString *_REQUEST_SCHEME = @"https";
   NSLog(@"starting Envoy...");
   EngineBuilder *builder = [[EngineBuilder alloc] init];
   [builder addLogLevel:LogLevelDebug];
-  [builder enableDNSCache: YES];
+  [builder enableDNSCache:YES];
   [builder addKeyValueStore:@"reserved.platform_store" keyValueStore: UserDefaults.standard];
   [builder setOnEngineRunningWithClosure:^{
     NSLog(@"Envoy async internal setup completed");

--- a/mobile/examples/objective-c/hello_world/ViewController.m
+++ b/mobile/examples/objective-c/hello_world/ViewController.m
@@ -40,7 +40,8 @@ NSString *_REQUEST_SCHEME = @"https";
   EngineBuilder *builder = [[EngineBuilder alloc] init];
   [builder addLogLevel:LogLevelDebug];
   [builder enableDNSCache:YES];
-  [builder addKeyValueStore:@"reserved.platform_store" keyValueStore: UserDefaults.standard];
+  [builder addKeyValueStoreWithName:@"reserved.platform_store"
+                      keyValueStore:NSUserDefaults.standardUserDefaults];
   [builder setOnEngineRunningWithClosure:^{
     NSLog(@"Envoy async internal setup completed");
   }];

--- a/mobile/examples/objective-c/hello_world/ViewController.m
+++ b/mobile/examples/objective-c/hello_world/ViewController.m
@@ -39,6 +39,8 @@ NSString *_REQUEST_SCHEME = @"https";
   NSLog(@"starting Envoy...");
   EngineBuilder *builder = [[EngineBuilder alloc] init];
   [builder addLogLevel:LogLevelDebug];
+  [builder enableDNSCache: YES];
+  [builder addKeyValueStore:@"reserved.platform_store" keyValueStore: UserDefaults.standard];
   [builder setOnEngineRunningWithClosure:^{
     NSLog(@"Envoy async internal setup completed");
   }];

--- a/mobile/library/common/extensions/key_value/platform/config.cc
+++ b/mobile/library/common/extensions/key_value/platform/config.cc
@@ -2,7 +2,6 @@
 
 #include "envoy/config/common/key_value/v3/config.pb.h"
 #include "envoy/config/common/key_value/v3/config.pb.validate.h"
-#include "envoy/registry/registry.h"
 
 #include "library/common/api/external.h"
 #include "library/common/data/utility.h"

--- a/mobile/library/common/extensions/key_value/platform/config.h
+++ b/mobile/library/common/extensions/key_value/platform/config.h
@@ -1,4 +1,5 @@
 #include "envoy/common/key_value_store.h"
+#include "envoy/registry/registry.h"
 
 #include "source/common/common/key_value_store_base.h"
 
@@ -54,6 +55,8 @@ public:
 
   std::string name() const override { return "envoy.key_value.platform"; }
 };
+
+DECLARE_FACTORY(PlatformKeyValueStoreFactory);
 
 } // namespace KeyValue
 } // namespace Extensions

--- a/mobile/library/swift/KeyValueStore.swift
+++ b/mobile/library/swift/KeyValueStore.swift
@@ -3,7 +3,8 @@ import Foundation
 
 /// `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
 /// key-value store implementation that may be made accessible to native Envoy Mobile code.
-@objc public protocol KeyValueStore {
+@objc
+public protocol KeyValueStore {
   /// Read a value from the key value store implementation.
   ///
   /// - parameter key: The key whose value should be read.

--- a/mobile/library/swift/KeyValueStore.swift
+++ b/mobile/library/swift/KeyValueStore.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
 /// key-value store implementation that may be made accessible to native Envoy Mobile code.
-public protocol KeyValueStore {
+@objc public protocol KeyValueStore {
   /// Read a value from the key value store implementation.
   ///
   /// - parameter key: The key whose value should be read.


### PR DESCRIPTION
Commit Message:
Additional Description: Make `addKeyValueStore...` method on the `EngineBuilder` available to objc code by adding `@objc` attribute to `KeyValueStore` protocol. Fix the crash caused by the the lack of registration of `PlatformKeyValueStoreConfig` type.
Risk Level: Low
Testing: objc hello world app ci job
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
