### PR TITLE
UHV: Remove StreamInfo parameter from UHV factory

### DIFF
--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -240,8 +240,7 @@ envoy_cc_library(
         "//envoy/config:typed_config_interface",
         "//envoy/http:header_map_interface",
         "//envoy/http:protocol_interface",
-        "//envoy/server:factory_context_interface",
-        "//envoy/stream_info:stream_info_interface",
+        "//envoy/protobuf:message_validator_interface",
     ],
 )
 

--- a/envoy/http/header_validator.h
+++ b/envoy/http/header_validator.h
@@ -6,8 +6,7 @@
 #include "envoy/config/typed_config.h"
 #include "envoy/http/header_map.h"
 #include "envoy/http/protocol.h"
-#include "envoy/server/factory_context.h"
-#include "envoy/stream_info/stream_info.h"
+#include "envoy/protobuf/message_validator.h"
 
 namespace Envoy {
 namespace Http {
@@ -120,8 +119,7 @@ public:
   /**
    * Create a new header validator for the specified protocol.
    */
-  virtual HeaderValidatorPtr create(Protocol protocol, StreamInfo::StreamInfo& stream_info,
-                                    HeaderValidatorStats& stats) PURE;
+  virtual HeaderValidatorPtr create(Protocol protocol, HeaderValidatorStats& stats) PURE;
 };
 
 using HeaderValidatorFactoryPtr = std::unique_ptr<HeaderValidatorFactory>;
@@ -133,7 +131,7 @@ class HeaderValidatorFactoryConfig : public Config::TypedFactory {
 public:
   virtual HeaderValidatorFactoryPtr
   createFromProto(const Protobuf::Message& config,
-                  Server::Configuration::FactoryContext& context) PURE;
+                  ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
 
   std::string category() const override { return "envoy.http.header_validators"; }
 };

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -514,12 +514,10 @@ public:
    * Creates new header validator. This method always returns nullptr unless the `ENVOY_ENABLE_UHV`
    * pre-processor variable is defined.
    * @param protocol HTTP protocol version that is to be validated.
-   * @param stream_info stream info object for storing validation error details.
    * @return pointer to the header validator.
    *         If nullptr, header validation will not be done.
    */
-  virtual HeaderValidatorPtr makeHeaderValidator(Protocol protocol,
-                                                 StreamInfo::StreamInfo& stream_info) PURE;
+  virtual HeaderValidatorPtr makeHeaderValidator(Protocol protocol) PURE;
 
   /**
    * @return whether to append the x-forwarded-port header.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -681,8 +681,8 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
                       StreamInfo::FilterState::LifeSpan::Connection),
       request_response_timespan_(new Stats::HistogramCompletableTimespanImpl(
           connection_manager_.stats_.named_.downstream_rq_time_, connection_manager_.timeSource())),
-      header_validator_(connection_manager.config_.makeHeaderValidator(
-          connection_manager.codec_->protocol(), filter_manager_.streamInfo())) {
+      header_validator_(
+          connection_manager.config_.makeHeaderValidator(connection_manager.codec_->protocol())) {
   ASSERT(!connection_manager.config_.isRoutable() ||
              ((connection_manager.config_.routeConfigProvider() == nullptr &&
                connection_manager.config_.scopedRouteConfigProvider() != nullptr) ||

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -125,10 +125,10 @@ envoy::extensions::filters::network::http_connection_manager::v3::HttpConnection
       KEEP_UNCHANGED;
 }
 
-Http::HeaderValidatorFactoryPtr
-createHeaderValidatorFactory([[maybe_unused]] const envoy::extensions::filters::network::
-                                 http_connection_manager::v3::HttpConnectionManager& config,
-                             [[maybe_unused]] Server::Configuration::FactoryContext& context) {
+Http::HeaderValidatorFactoryPtr createHeaderValidatorFactory(
+    [[maybe_unused]] const envoy::extensions::filters::network::http_connection_manager::v3::
+        HttpConnectionManager& config,
+    [[maybe_unused]] ProtobufMessage::ValidationVisitor& validation_visitor) {
 
   Http::HeaderValidatorFactoryPtr header_validator_factory;
 #ifdef ENVOY_ENABLE_UHV
@@ -170,7 +170,7 @@ createHeaderValidatorFactory([[maybe_unused]] const envoy::extensions::filters::
   }
 
   header_validator_factory =
-      factory->createFromProto(header_validator_config.typed_config(), context);
+      factory->createFromProto(header_validator_config.typed_config(), validation_visitor);
   if (!header_validator_factory) {
     throw EnvoyException(fmt::format("Header validator extension could not be created: '{}'",
                                      header_validator_config.name()));
@@ -382,7 +382,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
                                ? std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>(
                                      config.proxy_status_config())
                                : nullptr),
-      header_validator_factory_(createHeaderValidatorFactory(config, context)),
+      header_validator_factory_(
+          createHeaderValidatorFactory(config, context.messageValidationVisitor())),
       append_x_forwarded_port_(config.append_x_forwarded_port()) {
   if (!idle_timeout_) {
     idle_timeout_ = std::chrono::hours(1);

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -239,13 +239,11 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  Http::HeaderValidatorPtr
-  makeHeaderValidator([[maybe_unused]] Http::Protocol protocol,
-                      [[maybe_unused]] StreamInfo::StreamInfo& stream_info) override {
+  Http::HeaderValidatorPtr makeHeaderValidator([[maybe_unused]] Http::Protocol protocol) override {
 #ifdef ENVOY_ENABLE_UHV
-    return header_validator_factory_ ? header_validator_factory_->create(
-                                           protocol, stream_info, getHeaderValidatorStats(protocol))
-                                     : nullptr;
+    return header_validator_factory_
+               ? header_validator_factory_->create(protocol, getHeaderValidatorStats(protocol))
+               : nullptr;
 #else
     return nullptr;
 #endif

--- a/source/extensions/http/header_validators/envoy_default/config.cc
+++ b/source/extensions/http/header_validators/envoy_default/config.cc
@@ -12,15 +12,14 @@ namespace Http {
 namespace HeaderValidators {
 namespace EnvoyDefault {
 
-::Envoy::Http::HeaderValidatorFactoryPtr
-HeaderValidatorFactoryConfig::createFromProto(const Protobuf::Message& message,
-                                              Server::Configuration::FactoryContext& context) {
+::Envoy::Http::HeaderValidatorFactoryPtr HeaderValidatorFactoryConfig::createFromProto(
+    const Protobuf::Message& message, ProtobufMessage::ValidationVisitor& validation_visitor) {
   auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const ProtobufWkt::Any&>(message), context.messageValidationVisitor(), *this);
+      dynamic_cast<const ProtobufWkt::Any&>(message), validation_visitor, *this);
   const auto& proto_config =
       MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::
                                            envoy_default::v3::HeaderValidatorConfig&>(
-          *mptr, context.messageValidationVisitor());
+          *mptr, validation_visitor);
   return std::make_unique<HeaderValidatorFactory>(proto_config);
 }
 

--- a/source/extensions/http/header_validators/envoy_default/config.h
+++ b/source/extensions/http/header_validators/envoy_default/config.h
@@ -19,7 +19,7 @@ class HeaderValidatorFactoryConfig : public ::Envoy::Http::HeaderValidatorFactor
 public:
   ::Envoy::Http::HeaderValidatorFactoryPtr
   createFromProto(const Protobuf::Message& config,
-                  Server::Configuration::FactoryContext& context) override;
+                  ProtobufMessage::ValidationVisitor& validation_visitor) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -7,6 +7,7 @@
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
 
 #include "absl/container/node_hash_set.h"
+#include "absl/strings/match.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -20,10 +21,9 @@ using ::Envoy::Http::Protocol;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 HeaderValidator::HeaderValidator(const HeaderValidatorConfig& config, Protocol protocol,
-                                 StreamInfo::StreamInfo& stream_info,
                                  ::Envoy::Http::HeaderValidatorStats& stats)
-    : config_(config), protocol_(protocol), stream_info_(stream_info),
-      header_values_(::Envoy::Http::Headers::get()), stats_(stats), path_normalizer_(config) {}
+    : config_(config), protocol_(protocol), header_values_(::Envoy::Http::Headers::get()),
+      stats_(stats), path_normalizer_(config) {}
 
 HeaderValidator::HeaderValueValidationResult
 HeaderValidator::validateMethodHeader(const HeaderString& value) {

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -21,8 +21,7 @@ public:
   HeaderValidator(
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&
           config,
-      ::Envoy::Http::Protocol protocol, StreamInfo::StreamInfo& stream_info,
-      ::Envoy::Http::HeaderValidatorStats& stats);
+      ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
   using HeaderValueValidationResult = RejectResult;
   /*
@@ -135,7 +134,6 @@ protected:
   const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       config_;
   ::Envoy::Http::Protocol protocol_;
-  StreamInfo::StreamInfo& stream_info_;
   const ::Envoy::Http::HeaderValues& header_values_;
   ::Envoy::Http::HeaderValidatorStats& stats_;
   const PathNormalizer path_normalizer_;

--- a/source/extensions/http/header_validators/envoy_default/header_validator_factory.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator_factory.cc
@@ -16,15 +16,14 @@ HeaderValidatorFactory::HeaderValidatorFactory(const HeaderValidatorConfig& conf
     : config_(config) {}
 
 ::Envoy::Http::HeaderValidatorPtr
-HeaderValidatorFactory::create(Protocol protocol, StreamInfo::StreamInfo& stream_info,
-                               ::Envoy::Http::HeaderValidatorStats& stats) {
+HeaderValidatorFactory::create(Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats) {
   switch (protocol) {
   case Protocol::Http3:
   case Protocol::Http2:
-    return std::make_unique<Http2HeaderValidator>(config_, protocol, stream_info, stats);
+    return std::make_unique<Http2HeaderValidator>(config_, protocol, stats);
   case Protocol::Http11:
   case Protocol::Http10:
-    return std::make_unique<Http1HeaderValidator>(config_, protocol, stream_info, stats);
+    return std::make_unique<Http1HeaderValidator>(config_, protocol, stats);
   }
 
   RELEASE_ASSERT(false, fmt::format("Unexpected protocol: {}", static_cast<int>(protocol)));

--- a/source/extensions/http/header_validators/envoy_default/header_validator_factory.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator_factory.h
@@ -16,7 +16,6 @@ public:
           config);
 
   ::Envoy::Http::HeaderValidatorPtr create(::Envoy::Http::Protocol protocol,
-                                           StreamInfo::StreamInfo& stream_info,
                                            ::Envoy::Http::HeaderValidatorStats& stats) override;
 
 private:

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -42,9 +42,8 @@ using Http1ResponseCodeDetail = ConstSingleton<Http1ResponseCodeDetailValues>;
  *
  */
 Http1HeaderValidator::Http1HeaderValidator(const HeaderValidatorConfig& config, Protocol protocol,
-                                           StreamInfo::StreamInfo& stream_info,
                                            ::Envoy::Http::HeaderValidatorStats& stats)
-    : HeaderValidator(config, protocol, stream_info, stats) {}
+    : HeaderValidator(config, protocol, stats) {}
 
 ::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
 Http1HeaderValidator::validateRequestHeaderEntry(const HeaderString& key,

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.h
@@ -13,8 +13,7 @@ public:
   Http1HeaderValidator(
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&
           config,
-      ::Envoy::Http::Protocol protocol, StreamInfo::StreamInfo& stream_info,
-      ::Envoy::Http::HeaderValidatorStats& stats);
+      ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
   HeaderEntryValidationResult
   validateRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -6,6 +6,7 @@
 
 #include "absl/container/node_hash_map.h"
 #include "absl/container/node_hash_set.h"
+#include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -40,9 +41,8 @@ using Http2ResponseCodeDetail = ConstSingleton<Http2ResponseCodeDetailValues>;
  *
  */
 Http2HeaderValidator::Http2HeaderValidator(const HeaderValidatorConfig& config, Protocol protocol,
-                                           StreamInfo::StreamInfo& stream_info,
                                            ::Envoy::Http::HeaderValidatorStats& stats)
-    : HeaderValidator(config, protocol, stream_info, stats) {}
+    : HeaderValidator(config, protocol, stats) {}
 
 ::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
 Http2HeaderValidator::validateRequestHeaderEntry(const HeaderString& key,

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.h
@@ -13,8 +13,7 @@ public:
   Http2HeaderValidator(
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&
           config,
-      ::Envoy::Http::Protocol protocol, StreamInfo::StreamInfo& stream_info,
-      ::Envoy::Http::HeaderValidatorStats& stats);
+      ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
   HeaderEntryValidationResult
   validateRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,

--- a/source/extensions/http/header_validators/envoy_default/path_normalizer.cc
+++ b/source/extensions/http/header_validators/envoy_default/path_normalizer.cc
@@ -5,6 +5,8 @@
 #include "source/common/http/headers.h"
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Http {

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -213,7 +213,7 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  Http::HeaderValidatorPtr makeHeaderValidator(Http::Protocol, StreamInfo::StreamInfo&) override {
+  Http::HeaderValidatorPtr makeHeaderValidator(Http::Protocol) override {
     // TODO(yanavlasov): admin interface should use the default validator
     return nullptr;
   }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -218,7 +218,7 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  Http::HeaderValidatorPtr makeHeaderValidator(Protocol, StreamInfo::StreamInfo&) override {
+  Http::HeaderValidatorPtr makeHeaderValidator(Protocol) override {
     // TODO(yanavlasov): fuzz test interface should use the default validator, although this could
     // be changed too
     return nullptr;

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -3159,7 +3159,7 @@ TEST_F(HttpConnectionManagerImplTest, DirectLocalReplyCausesDisconnect) {
 // Header validator rejects header map for HTTP/1.x protocols
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp1) {
   setup(false, "");
-  EXPECT_CALL(header_validator_factory_, create(Protocol::Http11, _, _))
+  EXPECT_CALL(header_validator_factory_, create(Protocol::Http11, _))
       .WillOnce(InvokeWithoutArgs([]() {
         auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
         EXPECT_CALL(*header_validator, validateRequestHeaderMap(_))
@@ -3213,7 +3213,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp1) {
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp2) {
   codec_->protocol_ = Protocol::Http2;
   setup(false, "");
-  EXPECT_CALL(header_validator_factory_, create(Protocol::Http2, _, _))
+  EXPECT_CALL(header_validator_factory_, create(Protocol::Http2, _))
       .WillOnce(InvokeWithoutArgs([]() {
         auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
         EXPECT_CALL(*header_validator, validateRequestHeaderMap(_))
@@ -3250,7 +3250,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp2) {
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectGrpcRequest) {
   codec_->protocol_ = Protocol::Http2;
   setup(false, "");
-  EXPECT_CALL(header_validator_factory_, create(_, _, _)).WillOnce(InvokeWithoutArgs([]() {
+  EXPECT_CALL(header_validator_factory_, create(_, _)).WillOnce(InvokeWithoutArgs([]() {
     auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
     EXPECT_CALL(*header_validator, validateRequestHeaderMap(_)).WillOnce(InvokeWithoutArgs([]() {
       return HeaderValidator::RequestHeaderMapValidationResult(
@@ -3285,7 +3285,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectGrpcRequest) {
 // Header validator redirects
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRedirect) {
   setup(false, "");
-  EXPECT_CALL(header_validator_factory_, create(_, _, _)).WillOnce(InvokeWithoutArgs([]() {
+  EXPECT_CALL(header_validator_factory_, create(_, _)).WillOnce(InvokeWithoutArgs([]() {
     auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
     EXPECT_CALL(*header_validator, validateRequestHeaderMap(_))
         .WillOnce(Invoke([](RequestHeaderMap& header_map) {
@@ -3321,7 +3321,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRedirect) {
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRedirectGrpcRequest) {
   codec_->protocol_ = Protocol::Http2;
   setup(false, "");
-  EXPECT_CALL(header_validator_factory_, create(_, _, _)).WillOnce(InvokeWithoutArgs([]() {
+  EXPECT_CALL(header_validator_factory_, create(_, _)).WillOnce(InvokeWithoutArgs([]() {
     auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
     EXPECT_CALL(*header_validator, validateRequestHeaderMap(_))
         .WillOnce(Invoke([](RequestHeaderMap& header_map) {
@@ -3359,7 +3359,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRedirectGrpcRequest) {
 // Request completes normally if header validator accepts it
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorAccept) {
   setup(false, "");
-  EXPECT_CALL(header_validator_factory_, create(_, _, _)).WillOnce(InvokeWithoutArgs([]() {
+  EXPECT_CALL(header_validator_factory_, create(_, _)).WillOnce(InvokeWithoutArgs([]() {
     auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
     EXPECT_CALL(*header_validator, validateRequestHeaderMap(_)).WillOnce(InvokeWithoutArgs([]() {
       return HeaderValidator::RequestHeaderMapValidationResult::success();

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -152,9 +152,8 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  HeaderValidatorPtr makeHeaderValidator(Protocol protocol,
-                                         StreamInfo::StreamInfo& stream_info) override {
-    return header_validator_factory_.create(protocol, stream_info, header_validator_stats_);
+  HeaderValidatorPtr makeHeaderValidator(Protocol protocol) override {
+    return header_validator_factory_.create(protocol, header_validator_stats_);
   }
   bool appendXForwardedPort() const override { return false; }
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -168,7 +168,7 @@ public:
             headers_with_underscores_action_));
     header_validator_ =
         std::make_unique<Extensions::Http::HeaderValidators::EnvoyDefault::Http1HeaderValidator>(
-            header_validator_config_, Protocol::Http11, stream_info_, http1CodecStats());
+            header_validator_config_, Protocol::Http11, http1CodecStats());
   }
 
 protected:
@@ -178,7 +178,6 @@ protected:
       headers_with_underscores_action_{envoy::config::core::v3::HttpProtocolOptions::ALLOW};
   envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       header_validator_config_;
-  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
   HeaderValidatorPtr header_validator_;
 };
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -343,7 +343,7 @@ public:
             headers_with_underscores_action_));
     header_validator_ =
         std::make_unique<Extensions::Http::HeaderValidators::EnvoyDefault::Http2HeaderValidator>(
-            header_validator_config_, Protocol::Http2, stream_info_, server_->http2CodecStats());
+            header_validator_config_, Protocol::Http2, server_->http2CodecStats());
   }
 
   TestScopedRuntime scoped_runtime_;
@@ -391,7 +391,6 @@ public:
       headers_with_underscores_action_{envoy::config::core::v3::HttpProtocolOptions::ALLOW};
   envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       header_validator_config_;
-  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
   HeaderValidatorPtr header_validator_;
 };
 

--- a/test/extensions/http/header_validators/envoy_default/BUILD
+++ b/test/extensions/http/header_validators/envoy_default/BUILD
@@ -26,6 +26,7 @@ envoy_extension_cc_test(
         "//source/common/network:utility_lib",
         "//source/extensions/http/header_validators/envoy_default:character_tables",
         "//source/extensions/http/header_validators/envoy_default:header_validator_common",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -39,6 +40,7 @@ envoy_extension_cc_test(
         ":header_validator_test_lib",
         "//envoy/http:header_validator_errors",
         "//source/extensions/http/header_validators/envoy_default:http1_header_validator",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -53,6 +55,7 @@ envoy_extension_cc_test(
         "//envoy/http:header_validator_errors",
         "//source/extensions/http/header_validators/envoy_default:character_tables",
         "//source/extensions/http/header_validators/envoy_default:http2_header_validator",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -65,7 +68,6 @@ envoy_extension_cc_test_library(
     deps = [
         "//source/extensions/http/header_validators/envoy_default:config",
         "//test/mocks/http:header_validator_mocks",
-        "//test/mocks/stream_info:stream_info_mocks",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],
 )
@@ -80,7 +82,7 @@ envoy_extension_cc_test(
         "//source/common/network:utility_lib",
         "//source/extensions/http/header_validators/envoy_default:config",
         "//test/mocks/http:header_validator_mocks",
-        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/protobuf:protobuf_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],
@@ -105,8 +107,7 @@ envoy_extension_cc_test(
     deps = [
         "//envoy/registry",
         "//source/extensions/http/header_validators/envoy_default:config",
-        "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/mocks/protobuf:protobuf_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],
@@ -129,6 +130,5 @@ envoy_cc_fuzz_test(
         "//source/extensions/http/header_validators/envoy_default:http1_header_validator",
         "//source/extensions/http/header_validators/envoy_default:path_normalizer",
         "//test/mocks/http:header_validator_mocks",
-        "//test/mocks/stream_info:stream_info_mocks",
     ],
 )

--- a/test/extensions/http/header_validators/envoy_default/config_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/config_test.cc
@@ -3,7 +3,7 @@
 
 #include "source/extensions/http/header_validators/envoy_default/config.h"
 
-#include "test/mocks/server/factory_context.h"
+#include "test/mocks/protobuf/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -29,8 +29,8 @@ TEST(EnvoyDefaultUhvFactoryTest, Basic) {
 )EOF";
   TestUtility::loadFromYaml(yaml, typed_config);
 
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_NE(factory->createFromProto(typed_config.typed_config(), context), nullptr);
+  ::testing::NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
+  EXPECT_NE(factory->createFromProto(typed_config.typed_config(), validation_visitor), nullptr);
 }
 
 } // namespace EnvoyDefault

--- a/test/extensions/http/header_validators/envoy_default/header_validator_factory_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_factory_test.cc
@@ -6,8 +6,7 @@
 #include "source/extensions/http/header_validators/envoy_default/http2_header_validator.h"
 
 #include "test/mocks/http/header_validator.h"
-#include "test/mocks/server/factory_context.h"
-#include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/protobuf/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -20,6 +19,7 @@ namespace EnvoyDefault {
 namespace {
 
 using ::Envoy::Http::Protocol;
+using ::testing::NiceMock;
 
 class HeaderValidatorFactoryTest : public testing::Test {
 protected:
@@ -32,13 +32,12 @@ protected:
     envoy::config::core::v3::TypedExtensionConfig typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);
 
-    uhv_factory_ = factory->createFromProto(typed_config.typed_config(), context_);
-    return uhv_factory_->create(protocol, stream_info_, stats_);
+    uhv_factory_ = factory->createFromProto(typed_config.typed_config(), validation_visitor_);
+    return uhv_factory_->create(protocol, stats_);
   }
 
-  NiceMock<Server::Configuration::MockFactoryContext> context_;
+  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
   ::Envoy::Http::HeaderValidatorFactoryPtr uhv_factory_;
-  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
   NiceMock<Envoy::Http::MockHeaderValidatorStats> stats_;
 
   static constexpr absl::string_view empty_config = R"EOF(

--- a/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
@@ -5,6 +5,8 @@
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
 #include "source/extensions/http/header_validators/envoy_default/header_validator.h"
 
+#include "test/test_common/utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Http {
@@ -23,8 +25,8 @@ public:
   BaseHttpHeaderValidator(
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&
           config,
-      Protocol protocol, StreamInfo::StreamInfo& stream_info, HeaderValidatorStats& stats)
-      : HeaderValidator(config, protocol, stream_info, stats) {}
+      Protocol protocol, HeaderValidatorStats& stats)
+      : HeaderValidator(config, protocol, stats) {}
 
   HeaderEntryValidationResult validateRequestHeaderEntry(const HeaderString&,
                                                          const HeaderString&) override {
@@ -54,8 +56,7 @@ protected:
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);
 
-    return std::make_unique<BaseHttpHeaderValidator>(typed_config, Protocol::Http11, stream_info_,
-                                                     stats_);
+    return std::make_unique<BaseHttpHeaderValidator>(typed_config, Protocol::Http11, stats_);
   }
 };
 

--- a/test/extensions/http/header_validators/envoy_default/header_validator_test.h
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_test.h
@@ -1,7 +1,6 @@
 #include "envoy/extensions/http/header_validators/envoy_default/v3/header_validator.pb.h"
 
 #include "test/mocks/http/header_validator.h"
-#include "test/mocks/stream_info/mocks.h"
 
 #include "gtest/gtest.h"
 
@@ -29,8 +28,7 @@ protected:
     header_string.setCopyUnvalidatedForTestOnly(value);
   }
 
-  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
-  NiceMock<Envoy::Http::MockHeaderValidatorStats> stats_;
+  ::testing::NiceMock<Envoy::Http::MockHeaderValidatorStats> stats_;
 
   static constexpr absl::string_view empty_config = "{}";
 

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -3,6 +3,7 @@
 #include "source/extensions/http/header_validators/envoy_default/http1_header_validator.h"
 
 #include "test/extensions/http/header_validators/envoy_default/header_validator_test.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -22,8 +23,7 @@ protected:
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);
 
-    return std::make_unique<Http1HeaderValidator>(typed_config, Protocol::Http11, stream_info_,
-                                                  stats_);
+    return std::make_unique<Http1HeaderValidator>(typed_config, Protocol::Http11, stats_);
   }
 };
 

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -4,6 +4,7 @@
 #include "source/extensions/http/header_validators/envoy_default/http2_header_validator.h"
 
 #include "test/extensions/http/header_validators/envoy_default/header_validator_test.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -24,8 +25,7 @@ protected:
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);
 
-    return std::make_unique<Http2HeaderValidator>(typed_config, Protocol::Http2, stream_info_,
-                                                  stats_);
+    return std::make_unique<Http2HeaderValidator>(typed_config, Protocol::Http2, stats_);
   }
 };
 

--- a/test/extensions/http/header_validators/envoy_default/path_normalizer_fuzz_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/path_normalizer_fuzz_test.cc
@@ -4,7 +4,6 @@
 #include "test/extensions/http/header_validators/envoy_default/path_normalizer_fuzz.pb.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/mocks/http/header_validator.h"
-#include "test/mocks/stream_info/mocks.h"
 
 namespace Envoy {
 
@@ -20,10 +19,9 @@ DEFINE_PROTO_FUZZER(
 
   ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig config;
   *config.mutable_uri_path_normalization_options() = input.options();
-  NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  NiceMock<Http::MockHeaderValidatorStats> stats_fake;
+  ::testing::NiceMock<Http::MockHeaderValidatorStats> stats_fake;
   Extensions::Http::HeaderValidators::EnvoyDefault::Http1HeaderValidator validator(
-      config, Http::Protocol::Http11, stream_info, stats_fake);
+      config, Http::Protocol::Http11, stats_fake);
   // The character set of the :path and :method headers is validated before normalization.
   // Here we will just not run the test with invalid values
   if (!validator.validateMethodHeader(method) ||

--- a/test/mocks/http/header_validator.h
+++ b/test/mocks/http/header_validator.h
@@ -28,9 +28,7 @@ public:
 
 class MockHeaderValidatorFactory : public HeaderValidatorFactory {
 public:
-  MOCK_METHOD(HeaderValidatorPtr, create,
-              (Protocol protocol, StreamInfo::StreamInfo& stream_info,
-               HeaderValidatorStats& stats));
+  MOCK_METHOD(HeaderValidatorPtr, create, (Protocol protocol, HeaderValidatorStats& stats));
 };
 
 } // namespace Http

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -634,8 +634,7 @@ public:
   }
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
   MOCK_METHOD(const HttpConnectionManagerProto::ProxyStatusConfig*, proxyStatusConfig, (), (const));
-  MOCK_METHOD(HeaderValidatorPtr, makeHeaderValidator,
-              (Protocol protocol, StreamInfo::StreamInfo& stream_info));
+  MOCK_METHOD(HeaderValidatorPtr, makeHeaderValidator, (Protocol protocol));
   MOCK_METHOD(bool, appendXForwardedPort, (), (const));
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =


### PR DESCRIPTION
Additional Description:
This is large but safe change that removes unused StreamInfo& parameter from UHV factory and adjusts all call sites accordingly.

In addition the factory context parameter is replaced with the proto validator, which is what the factory actually needs. This change allows using UHV for validating upstream responses, as the FactoryContext is not available when header validator is created for upstream connections.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
