### PR TITLE
Reduce Route memory utilization by avoiding weighed clusters config overhead when no such clusters are configured

### DIFF
--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -963,9 +963,14 @@ public:
   // We keep them in a separate data structure to avoid memory overhead for the routes that do not
   // use weightless clusters.
   struct WeightedClustersConfig {
-    std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
-    uint64_t total_cluster_weight_;
-    std::string random_value_header_name_;
+    WeightedClustersConfig(const std::vector<WeightedClusterEntrySharedPtr>& weighted_clusters,
+                           uint64_t total_cluster_weight,
+                           const std::string& random_value_header_name)
+        : weighted_clusters_(weighted_clusters), total_cluster_weight_(total_cluster_weight),
+          random_value_header_name_(random_value_header_name) {}
+    const std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+    const uint64_t total_cluster_weight_;
+    const std::string random_value_header_name_;
   };
 
 protected:

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -961,7 +961,7 @@ public:
   using WeightedClusterEntrySharedPtr = std::shared_ptr<WeightedClusterEntry>;
   // Container for route config elements that pertain to a weightless clusters.
   // We keep them in a separate data structure to avoid memory overhead for the routes that do not
-  // use weighless clusters.
+  // use weightless clusters.
   struct WeightedClustersConfig {
     std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
     uint64_t total_cluster_weight_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1109,7 +1109,7 @@ private:
   std::vector<ShadowPolicyPtr> shadow_policies_;
   std::vector<Http::HeaderUtility::HeaderDataPtr> config_headers_;
   std::vector<ConfigUtility::QueryParameterMatcherPtr> config_query_parameters_;
-  std::unique_ptr<WeightedClustersConfig> weighted_clusters_config_;
+  std::unique_ptr<const WeightedClustersConfig> weighted_clusters_config_;
 
   UpgradeMap upgrade_map_;
   std::unique_ptr<const Http::HashPolicyImpl> hash_policy_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -959,9 +959,9 @@ public:
   };
 
   using WeightedClusterEntrySharedPtr = std::shared_ptr<WeightedClusterEntry>;
-  // Container for route config elements that pertain to a weightless clusters.
+  // Container for route config elements that pertain to weighted clusters.
   // We keep them in a separate data structure to avoid memory overhead for the routes that do not
-  // use weightless clusters.
+  // use weighted clusters.
   struct WeightedClustersConfig {
     WeightedClustersConfig(const std::vector<WeightedClusterEntrySharedPtr>& weighted_clusters,
                            uint64_t total_cluster_weight,

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -959,6 +959,14 @@ public:
   };
 
   using WeightedClusterEntrySharedPtr = std::shared_ptr<WeightedClusterEntry>;
+  // Container for route config elements that pertain to a weightless clusters.
+  // We keep them in a separate data structure to avoid memory overhead for the routes that do not
+  // use weighless clusters.
+  struct WeightedClustersConfig {
+    std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+    uint64_t total_cluster_weight_;
+    std::string random_value_header_name_;
+  };
 
 protected:
   const std::string prefix_rewrite_;
@@ -1096,10 +1104,9 @@ private:
   std::vector<ShadowPolicyPtr> shadow_policies_;
   std::vector<Http::HeaderUtility::HeaderDataPtr> config_headers_;
   std::vector<ConfigUtility::QueryParameterMatcherPtr> config_query_parameters_;
-  std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+  std::unique_ptr<WeightedClustersConfig> weighted_clusters_config_;
 
   UpgradeMap upgrade_map_;
-  uint64_t total_cluster_weight_;
   std::unique_ptr<const Http::HashPolicyImpl> hash_policy_;
   MetadataMatchCriteriaConstPtr metadata_match_criteria_;
   TlsContextMatchCriteriaConstPtr tls_context_match_criteria_;
@@ -1118,7 +1125,6 @@ private:
   PerFilterConfigs per_filter_configs_;
   const std::string route_name_;
   TimeSource& time_source_;
-  const std::string random_value_header_name_;
   EarlyDataPolicyPtr early_data_policy_;
 
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.


### PR DESCRIPTION
Reduce Route memory utilization by avoiding weighted clusters config overhead when no such clusters are configured

Currently each Route instance contains 3 member variables that are representing weighted clusters config, whether the route has such clusters or not. For routes without weighted clusters that's 56 bytes overhead (empty vector, empty string, int64).

This PR packs all weighted cluster related config into a separate data structure and only creates an instance of it when the route has such clusters. This is saving 50 bytes for any route that does not have weighted clusters.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
