### PR TITLE
Fix clang-tidy `misc-uniqueptr-reset-release` warning

### DIFF
--- a/source/server/admin/stats_request.cc
+++ b/source/server/admin/stats_request.cc
@@ -41,7 +41,7 @@ Http::Code StatsRequest::start(Http::ResponseHeaderMap& response_headers) {
     html_render->urlHandler(response_, url_handler_fn_(), params_.query_);
     html_render->tableEnd(response_);
     html_render->startPre(response_);
-    render_.reset(html_render.release());
+    render_ = std::move(html_render);
     break;
   }
 #endif


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/misc/uniqueptr-reset-release.html

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
