### PR TITLE
Fix clang-tidy `performance-faster-string-find` warning

### DIFF
--- a/mobile/library/cc/headers_builder.cc
+++ b/mobile/library/cc/headers_builder.cc
@@ -37,7 +37,7 @@ HeadersBuilder& HeadersBuilder::internalSet(std::string name, std::vector<std::s
 const RawHeaderMap& HeadersBuilder::allHeaders() const { return this->headers_; }
 
 bool HeadersBuilder::isRestrictedHeader(absl::string_view name) const {
-  return name.find(":") == 0 || name.find("x-envoy-mobile") == 0;
+  return name.find(':') == 0 || name.find("x-envoy-mobile") == 0;
 }
 
 } // namespace Platform

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -28,7 +28,7 @@ namespace Envoy {
 namespace {
 
 absl::string_view filenameFromPath(absl::string_view full_path) {
-  size_t index = full_path.rfind("/");
+  size_t index = full_path.rfind('/');
   if (index == std::string::npos || index == full_path.size()) {
     return full_path;
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -746,7 +746,7 @@ absl::string_view
 RouteEntryImplBase::sanitizePathBeforePathMatching(const absl::string_view path) const {
   absl::string_view ret = path;
   if (vhost_.globalRouteConfig().ignorePathParametersInPathMatching()) {
-    auto pos = ret.find_first_of(";");
+    auto pos = ret.find_first_of(';');
     if (pos != absl::string_view::npos) {
       ret.remove_suffix(ret.length() - pos);
     }

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -271,7 +271,7 @@ Http1HeaderValidator::validateRequestHeaderMap(RequestHeaderMap& header_map) {
     // port value will be validated later on. For a host in reg-name form the delimiter existence
     // check is sufficient. For IPv6, we need to verify that the port delimiter occurs *after* the
     // IPv6 address (following a "]" character).
-    std::size_t port_delim = host.rfind(":");
+    std::size_t port_delim = host.rfind(':');
     if (port_delim == absl::string_view::npos || port_delim == 0) {
       // The uri-host is missing the port
       return {RequestHeaderMapValidationResult::Action::Reject,


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/performance/faster-string-find.html

Signed-off-by: Yury Kats <ykats@google.com>
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
