### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/mobile/library/cc/retry_policy.cc
+++ b/mobile/library/cc/retry_policy.cc
@@ -44,20 +44,22 @@ RawHeaderMap RetryPolicy::asRawHeaderMap() const {
   }
 
   std::vector<std::string> retry_on;
+  retry_on.reserve(this->retry_on.size());
   for (const auto& retry_rule : this->retry_on) {
     retry_on.push_back(retryRuleToString(retry_rule));
   }
 
-  if (this->retry_status_codes.size() > 0) {
+  if (!this->retry_status_codes.size().empty()) {
     retry_on.push_back("retriable-status-codes");
     std::vector<std::string> retry_status_codes;
+    retry_status_codes.reserve(this->retry_status_codes.size());
     for (const auto& status_code : this->retry_status_codes) {
       retry_status_codes.push_back(std::to_string(status_code));
     }
     outbound_headers["x-envoy-retriable-status-codes"] = retry_status_codes;
   }
 
-  if (retry_on.size() > 0) {
+  if (!retry_on.size().empty()) {
     outbound_headers["x-envoy-retry-on"] = retry_on;
   }
 

--- a/mobile/library/cc/retry_policy.cc
+++ b/mobile/library/cc/retry_policy.cc
@@ -49,7 +49,7 @@ RawHeaderMap RetryPolicy::asRawHeaderMap() const {
     retry_on.push_back(retryRuleToString(retry_rule));
   }
 
-  if (!this->retry_status_codes.size().empty()) {
+  if (!this->retry_status_codes.empty()) {
     retry_on.push_back("retriable-status-codes");
     std::vector<std::string> retry_status_codes;
     retry_status_codes.reserve(this->retry_status_codes.size());
@@ -59,7 +59,7 @@ RawHeaderMap RetryPolicy::asRawHeaderMap() const {
     outbound_headers["x-envoy-retriable-status-codes"] = retry_status_codes;
   }
 
-  if (!retry_on.size().empty()) {
+  if (!retry_on.empty()) {
     outbound_headers["x-envoy-retry-on"] = retry_on;
   }
 


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/performance/inefficient-vector-operation.html and
https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
