### PR TITLE
Fix clang-tidy `performance-inefficient-vector-operation` warning

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -317,7 +317,7 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::config::route::v3::RetryPolicy& re
 
 std::vector<Upstream::RetryHostPredicateSharedPtr> RetryPolicyImpl::retryHostPredicates() const {
   std::vector<Upstream::RetryHostPredicateSharedPtr> predicates;
-
+  predicates.reserve(retry_host_predicate_configs_.size());
   for (const auto& config : retry_host_predicate_configs_) {
     predicates.emplace_back(config.first.createHostPredicate(*config.second, num_retries_));
   }
@@ -353,6 +353,7 @@ InternalRedirectPolicyImpl::InternalRedirectPolicyImpl(
 
 std::vector<InternalRedirectPredicateSharedPtr> InternalRedirectPolicyImpl::predicates() const {
   std::vector<InternalRedirectPredicateSharedPtr> predicates;
+  predicates.reserve(predicate_factories_.size());
   for (const auto& predicate_factory : predicate_factories_) {
     predicates.emplace_back(predicate_factory.first->createInternalRedirectPredicate(
         *predicate_factory.second, current_route_name_));


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/performance/inefficient-vector-operation.html

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
