### PR TITLE
clarify stateful formatter docs

### DIFF
--- a/docs/root/configuration/http/http_conn_man/header_casing.rst
+++ b/docs/root/configuration/http/http_conn_man/header_casing.rst
@@ -43,5 +43,9 @@ configured via the :ref:`stateful_formatter
 <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.HeaderKeyFormat.stateful_formatter>` field.
 The following is an example configuration which will preserve HTTP/1 header case across the proxy.
 
+.. note::
+
+   When Stateful formatters are used, headers added by Envoy and in other filters like Lua will still be lowercased.
+
 .. literalinclude:: _include/preserve-case.yaml
     :language: yaml

--- a/docs/root/configuration/http/http_conn_man/header_casing.rst
+++ b/docs/root/configuration/http/http_conn_man/header_casing.rst
@@ -45,7 +45,7 @@ The following is an example configuration which will preserve HTTP/1 header case
 
 .. note::
 
-   When Stateful formatters are used, headers added by Envoy and in other filters like Lua will still be lowercased.
+   When Stateful formatters are used, headers added internally by Envoy or by filters (e.g. the Lua filter) will still be lowercased.
 
 .. literalinclude:: _include/preserve-case.yaml
     :language: yaml


### PR DESCRIPTION
Commit Message: clarify stateful formatter docs
Additional Description: clarify stateful formatter docs to indicate headers added by envoy and other filters will still be lowercased.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
