### PR TITLE
[http] fix http1.0 drain cause delay close.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1460,6 +1460,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
   // See if we want to drain/close the connection. Send the go away frame prior to encoding the
   // header block.
   if (connection_manager_.drain_state_ == DrainState::NotDraining &&
+      connection_manager_.codec_->protocol() == Protocol::Http11 &&
       (connection_manager_.drain_close_.drainClose() || drain_connection_due_to_overload)) {
 
     // This doesn't really do anything for HTTP/1.1 other then give the connection another boost

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1460,7 +1460,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
   // See if we want to drain/close the connection. Send the go away frame prior to encoding the
   // header block.
   if (connection_manager_.drain_state_ == DrainState::NotDraining &&
-      connection_manager_.codec_->protocol() == Protocol::Http11 &&
+      connection_manager_.codec_->protocol() != Protocol::Http10 &&
       (connection_manager_.drain_close_.drainClose() || drain_connection_due_to_overload)) {
 
     // This doesn't really do anything for HTTP/1.1 other then give the connection another boost


### PR DESCRIPTION
When we have the following situation:
 A --http1.0 request--> envoy --http1.1 request--> B
 A <--http1.0 response-- envoy <-- http1.1 response chunked-- B

Envoy response to A will not have content-length, the response will be framed by connection close.
When listener are draining, the drain timeout will cause connection delay close,and A will stop receiving response until connection close.
Since http1.0 is short-lived connections,maybe we don't need drain when use http10?
Signed-off-by: GuangYang <pyrl247@gmail.com>

Risk Level: Low
Testing:
Docs Changes: n/a
Release Notes: n/a
