### PR TITLE
Make ProtocolOptionsConfigImpl const correct

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1167,7 +1167,7 @@ public:
   /**
    * @return alternate protocols cache options for upstream connections.
    */
-  virtual const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
+  virtual const absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>&
   alternateProtocolsCacheOptions() const PURE;
 
   /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -841,7 +841,7 @@ public:
     return http_protocol_options_->upstream_http_protocol_options_;
   }
 
-  const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
+  const absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>&
   alternateProtocolsCacheOptions() const override {
     return http_protocol_options_->alternate_protocol_cache_options_;
   }

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -54,6 +54,45 @@ getHttp3Options(const envoy::extensions::upstreams::http::v3::HttpProtocolOption
   return options.explicit_http_config().http3_protocol_options();
 }
 
+bool useHttp2(const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options) {
+  if (options.has_explicit_http_config() &&
+      options.explicit_http_config().has_http2_protocol_options()) {
+    return true;
+  } else if (options.has_use_downstream_protocol_config() &&
+             options.use_downstream_protocol_config().has_http2_protocol_options()) {
+    return true;
+  } else if (options.has_auto_config()) {
+    return true;
+  }
+  return false;
+}
+
+bool useHttp3(const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options) {
+  if (options.has_explicit_http_config() &&
+      options.explicit_http_config().has_http3_protocol_options()) {
+    return true;
+  } else if (options.has_use_downstream_protocol_config() &&
+             options.use_downstream_protocol_config().has_http3_protocol_options()) {
+    return true;
+  } else if (options.has_auto_config() && options.auto_config().has_http3_protocol_options()) {
+    return true;
+  }
+  return false;
+}
+
+absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>
+getAlternateProtocolsCacheOptions(
+    const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options) {
+  if (options.has_auto_config() && options.auto_config().has_http3_protocol_options()) {
+    if (!options.auto_config().has_alternate_protocols_cache_options()) {
+      throw EnvoyException(fmt::format("alternate protocols cache must be configured when HTTP/3 "
+                                       "is enabled with auto_config"));
+    }
+    return options.auto_config().alternate_protocols_cache_options();
+  }
+  return absl::nullopt;
+}
+
 } // namespace
 
 uint64_t ProtocolOptionsConfigImpl::parseFeatures(const envoy::config::cluster::v3::Cluster& config,
@@ -90,37 +129,12 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
           options.has_upstream_http_protocol_options()
               ? absl::make_optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>(
                     options.upstream_http_protocol_options())
-              : absl::nullopt) {
-  if (options.has_explicit_http_config()) {
-    if (options.explicit_http_config().has_http3_protocol_options()) {
-      use_http3_ = true;
-    } else if (options.explicit_http_config().has_http2_protocol_options()) {
-      use_http2_ = true;
-    }
-  }
-  if (options.has_use_downstream_protocol_config()) {
-    if (options.use_downstream_protocol_config().has_http3_protocol_options()) {
-      use_http3_ = true;
-    }
-    if (options.use_downstream_protocol_config().has_http2_protocol_options()) {
-      use_http2_ = true;
-    }
-    use_downstream_protocol_ = true;
-  }
-  http_filters_ = options.http_filters();
-  if (options.has_auto_config()) {
-    use_http2_ = true;
-    use_alpn_ = true;
-    use_http3_ = options.auto_config().has_http3_protocol_options();
-    if (use_http3_) {
-      if (!options.auto_config().has_alternate_protocols_cache_options()) {
-        throw EnvoyException(fmt::format("alternate protocols cache must be configured when HTTP/3 "
-                                         "is enabled with auto_config"));
-      }
-      alternate_protocol_cache_options_ = options.auto_config().alternate_protocols_cache_options();
-    }
-  }
-}
+              : absl::nullopt),
+      http_filters_(options.http_filters()),
+      alternate_protocol_cache_options_(getAlternateProtocolsCacheOptions(options)),
+      use_downstream_protocol_(options.has_use_downstream_protocol_config()),
+      use_http2_(useHttp2(options)), use_http3_(useHttp3(options)),
+      use_alpn_(options.has_auto_config()) {}
 
 ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
     const envoy::config::core::v3::Http1ProtocolOptions& http1_settings,

--- a/source/extensions/upstreams/http/config.h
+++ b/source/extensions/upstreams/http/config.h
@@ -49,15 +49,15 @@ public:
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;
 
-  bool use_downstream_protocol_{};
-  bool use_http2_{};
-  bool use_http3_{};
-  bool use_alpn_{};
   using FiltersList = Protobuf::RepeatedPtrField<
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>;
-  FiltersList http_filters_;
-  absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>
+  const FiltersList http_filters_;
+  const absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>
       alternate_protocol_cache_options_;
+  const bool use_downstream_protocol_{};
+  const bool use_http2_{};
+  const bool use_http3_{};
+  const bool use_alpn_{};
 };
 
 class ProtocolOptionsConfigFactory : public Server::Configuration::ProtocolOptionsFactory {

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -171,7 +171,7 @@ public:
   MOCK_METHOD(bool, setLocalInterfaceNameOnUpstreamConnections, (), (const));
   MOCK_METHOD(const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>&,
               upstreamHttpProtocolOptions, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&,
+  MOCK_METHOD(const absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>&,
               alternateProtocolsCacheOptions, (), (const));
   MOCK_METHOD(absl::optional<std::string>, edsServiceName, (), (const));
   MOCK_METHOD(void, createNetworkFilterChain, (Network::Connection&), (const));
@@ -233,7 +233,7 @@ public:
   NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
   absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;
-  absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>
+  absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>
       alternate_protocols_cache_options_;
   absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lb_round_robin_config_;
   absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config_;


### PR DESCRIPTION
Commit Message:
this makes it easier to reason about immutability of shared config objects
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
