### PR TITLE
Explicitly set  no_full_scan flag to true for a TLS test case which requires it

### DIFF
--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -1558,6 +1558,12 @@ TEST_P(SslSocketTest, MultiCertPickRSAOnSniMatch) {
 
 // On SNI mismatch, if full scan is disabled, validate that the first cert is used.
 TEST_P(SslSocketTest, MultiCertWithFullScanDisabledOnSniMismatch) {
+  // This test is specific for no full scan case, i.e, below flag is true case.
+  // If the flag is false, the test needs to be skipped.
+  if (!Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.no_full_scan_certs_on_sni_mismatch")) {
+    return;
+  }
   const std::string client_ctx_yaml = absl::StrCat(R"EOF(
     sni: "nomatch.example.com"
     common_tls_context:

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -1559,11 +1559,9 @@ TEST_P(SslSocketTest, MultiCertPickRSAOnSniMatch) {
 // On SNI mismatch, if full scan is disabled, validate that the first cert is used.
 TEST_P(SslSocketTest, MultiCertWithFullScanDisabledOnSniMismatch) {
   // This test is specific for no full scan case, i.e, below flag is true case.
-  // If the flag is false, the test needs to be skipped.
-  if (!Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.no_full_scan_certs_on_sni_mismatch")) {
-    return;
-  }
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.no_full_scan_certs_on_sni_mismatch", "true"}});
   const std::string client_ctx_yaml = absl::StrCat(R"EOF(
     sni: "nomatch.example.com"
     common_tls_context:


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/24483 added below test 
TEST_P(SslSocketTest, MultiCertWithFullScanDisabledOnSniMismatch) {

and a runtime flag: 

RUNTIME_GUARD(envoy_reloadable_features_no_full_scan_certs_on_sni_mismatch);

However, the test is specific to the case when the runtime flag is true.  If the flag is false, this test does not work and crashing.

Explicitly set no_full_scan flag to true for this TLS test case to get test cases pass regardless the default flag setting.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
