### PR TITLE
Fixing a CEP filter test failure due to using private mutable_type_url() methods of any.proto

### DIFF
--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -578,13 +578,12 @@ TEST_P(CustomResponseIntegrationTest, ModifyRequestHeaders) {
   // Add modify_request_headers_action to the config. This will enable
   // TestModifyRequestHeadersAction to add "x-envoy-cer-backend" header to the
   // request before being redirected.
-  modifyPolicy<RedirectPolicyProto>(custom_response_filter_config_, "520_action",
-                                    [](RedirectPolicyProto& policy) {
-                                      auto action = policy.mutable_modify_request_headers_action();
-                                      action->set_name("modify-request-headers-action");
-                                      action->mutable_typed_config()->set_type_url(
-                                          "type.googleapis.com/google.protobuf.Struct");
-                                    });
+  modifyPolicy<RedirectPolicyProto>(
+      custom_response_filter_config_, "520_action", [](RedirectPolicyProto& policy) {
+        auto action = policy.mutable_modify_request_headers_action();
+        action->set_name("modify-request-headers-action");
+        action->mutable_typed_config()->set_type_url("type.googleapis.com/google.protobuf.Struct");
+      });
 
   // Add TestModifyRequestHeaders extension that will add the
   // "x-envoy-cer-backend" header to the redirected request, which is required

--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -582,7 +582,7 @@ TEST_P(CustomResponseIntegrationTest, ModifyRequestHeaders) {
                                     [](RedirectPolicyProto& policy) {
                                       auto action = policy.mutable_modify_request_headers_action();
                                       action->set_name("modify-request-headers-action");
-                                      action->mutable_typed_config()->mutable_type_url()->assign(
+                                      action->mutable_typed_config()->set_type_url(
                                           "type.googleapis.com/google.protobuf.Struct");
                                     });
 


### PR DESCRIPTION
mutable_type_url() methods of any.proto is a private method in some systems.
Using mutable_type_url()->assign() in those systems cause build failure. Replacing it with set_type_url() which is a public method.

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
