### PR TITLE
[balsa] Set error code to 431 for too large headers.

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -693,6 +693,7 @@ Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t 
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_use_balsa_parser")) {
       if (parser_->errorMessage() == "headers size exceeds limit" ||
           parser_->errorMessage() == "trailers size exceeds limit") {
+        error_code_ = Http::Code::RequestHeaderFieldsTooLarge;
         error = Http1ResponseCodeDetails::get().HeadersTooLarge;
       } else if (parser_->errorMessage() == "header value contains invalid chars") {
         error = Http1ResponseCodeDetails::get().InvalidCharacters;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -298,7 +298,8 @@ void Http1ServerConnectionImplTest::testTrailersExceedLimit(std::string trailer_
   EXPECT_TRUE(status.ok());
   buffer = Buffer::OwnedImpl(trailer_string);
   if (enable_trailers) {
-    EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+    EXPECT_CALL(decoder, sendLocalReply(Http::Code::RequestHeaderFieldsTooLarge,
+                                        "Request Header Fields Too Large", _, _, _));
     status = codec_->dispatch(buffer);
     EXPECT_TRUE(isCodecProtocolError(status));
     EXPECT_EQ(status.message(), error_message);

--- a/test/extensions/filters/http/health_check/health_check_integration_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_integration_test.cc
@@ -147,11 +147,6 @@ TEST_P(HealthCheckIntegrationTest, HealthCheck) {
 TEST_P(HealthCheckIntegrationTest, HealthCheckWithoutServerStats) {
   DISABLE_IF_ADMIN_DISABLED;
 
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   envoy::config::metrics::v3::StatsMatcher stats_matcher;
   stats_matcher.mutable_exclusion_list()->add_patterns()->set_prefix("server.");
   config_helper_.addConfigModifier(

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -73,14 +73,7 @@ TEST_P(DrainCloseIntegrationTest, DrainCloseImmediate) {
   }
 }
 
-TEST_P(DrainCloseIntegrationTest, AdminDrain) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
-  testAdminDrain(downstreamProtocol());
-}
+TEST_P(DrainCloseIntegrationTest, AdminDrain) { testAdminDrain(downstreamProtocol()); }
 
 TEST_P(DrainCloseIntegrationTest, AdminGracefulDrain) {
   drain_strategy_ = Server::DrainStrategy::Immediate;

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -986,11 +986,6 @@ TEST_P(IntegrationTest, TestClientAllowChunkedLength) {
 }
 
 TEST_P(IntegrationTest, BadFirstline) {
-  if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "hello", &response);
@@ -1560,13 +1555,7 @@ TEST_P(IntegrationTest, Connect) {
 }
 
 // Test that Envoy returns HTTP code 502 on upstream protocol error.
-TEST_P(IntegrationTest, UpstreamProtocolError) {
-  if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-  testRouterUpstreamProtocolError("502", "UPE");
-}
+TEST_P(IntegrationTest, UpstreamProtocolError) { testRouterUpstreamProtocolError("502", "UPE"); }
 
 TEST_P(IntegrationTest, TestHead) {
   initialize();

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2090,11 +2090,6 @@ name: local-reply-during-encode-data
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestUrlRejected) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   // Send one 95 kB URL with limit 60 kB headers.
   testLargeRequestUrl(95, 60);
 }
@@ -2105,21 +2100,11 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestUrlAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   // Send one 95 kB header with limit 60 kB and 100 headers.
   testLargeRequestHeaders(95, 1, 60, 100);
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, VeryLargeRequestHeadersRejected) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   // Send one very large 600 kB header with limit 500 kB and 100 headers.
   // The limit and the header size are set in such a way to accommodate for flow control limits.
   // If the headers are too large and the flow control blocks the response is truncated and the test
@@ -2219,11 +2204,6 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersRejected) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   testLargeRequestTrailers(66, 60);
 }
@@ -3999,11 +3979,6 @@ TEST_P(ProtocolIntegrationTest, LocalInterfaceNameForUpstreamConnection) {
 #endif
 
 TEST_P(DownstreamProtocolIntegrationTest, InvalidRequestHeaderName) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -4028,10 +4003,6 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidRequestHeaderName) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, InvalidResponseHeaderName) {
-  if (GetParam().http1_implementation == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));


### PR DESCRIPTION
This makes the following integration tests pass with BalsaParser:

DownstreamProtocolIntegrationTest.LargeRequestHeadersRejected DownstreamProtocolIntegrationTest.LargeRequestTrailersRejected DownstreamProtocolIntegrationTest.LargeRequestUrlRejected DownstreamProtocolIntegrationTest.VeryLargeRequestHeadersRejected

The following tests, also re-enabled here for BalsaParser, were already passing without the change in ConnectionImpl::dispatchSlice():

DownstreamProtocolIntegrationTest.InvalidRequestHeaderName DownstreamProtocolIntegrationTest.InvalidResponseHeaderName DrainCloseIntegrationTest.AdminDrain
HealthCheckIntegrationTest.HealthCheckWithoutServerStats IntegrationTest.BadFirstline
IntegrationTest.UpstreamProtocolError

Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Set error code to 431 for too large headers.
Additional Description: see above
Risk Level: low, changed code protected by existing default-false runtime flag.
Testing: //test/integration:drain_close_integration_test //test/integration:integration_test //test/integration:protocol_integration_test //test/extensions/filters/http/health_check:health_check_integration_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser