### PR TITLE
common: refactor exponential backoff calculation

### DIFF
--- a/source/common/common/backoff_strategy.cc
+++ b/source/common/common/backoff_strategy.cc
@@ -14,12 +14,8 @@ uint64_t JitteredExponentialBackOffStrategy::nextBackOffMs() {
   const uint64_t backoff = next_interval_;
   ASSERT(backoff > 0);
   // Set next_interval_ to max_interval_ if doubling the interval would exceed the max or overflow.
-  if (next_interval_ < max_interval_ / 2) {
-    next_interval_ *= 2;
-  } else {
-    next_interval_ = max_interval_;
-  }
-  return std::min(random_.random() % backoff, max_interval_);
+  next_interval_ = (next_interval_ < doubling_limit_) ? (next_interval_ * 2u) : max_interval_;
+  return (random_.random() % backoff);
 }
 
 void JitteredExponentialBackOffStrategy::reset() { next_interval_ = base_interval_; }

--- a/source/common/common/backoff_strategy.h
+++ b/source/common/common/backoff_strategy.h
@@ -37,6 +37,7 @@ public:
 private:
   uint64_t base_interval_;
   const uint64_t max_interval_{};
+  const uint64_t doubling_limit_{max_interval_ / 2u};
   uint64_t next_interval_;
   Random::RandomGenerator& random_;
 };


### PR DESCRIPTION
Hi,
this is my first time contributing to this project.
I noticed that the `std::min()` call in the exponential backoff interval calculation wasn't needed since `backoff <= max_interval` is already guaranteed, so I removed the call.
Additionally, since `max_interval` is const,  I added a const member for the "halfway point" when checking whether we can double again or clamp to max. Trying this in godbolt it seemed to get rid of the div/shift. Hope this is okay, tested it locally and UTs where green.

Best, 
Frank

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Risk Level: Low
Testing: Unit Test (backoff_strategy_test)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
