### PR TITLE
mongo proxy bson: fix OOB read in removeString

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -98,6 +98,9 @@ std::string BufferHelper::removeString(Buffer::Instance& data) {
   }
 
   char* start = reinterpret_cast<char*>(data.linearize(length));
+  // The BSON spec encodes both strings and cstrings with an additional null
+  // byte, however strings may contain embedded null bytes, therefore the
+  // constructor needs to be given the length of the string explicitly.
   std::string ret(start, length > 0 ? length - 1 : 0);
   data.drain(length);
   return ret;

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -98,8 +98,8 @@ std::string BufferHelper::removeString(Buffer::Instance& data) {
   }
 
   char* start = reinterpret_cast<char*>(data.linearize(length));
-  // The BSON spec encodes both strings and cstrings with an additional null
-  // byte, however strings may contain embedded null bytes, therefore the
+  // The BSON spec encodes both strings and C style strings with an additional
+  // null byte, however strings may contain embedded null bytes, therefore the
   // constructor needs to be given the length of the string explicitly.
   std::string ret(start, length > 0 ? length - 1 : 0);
   data.drain(length);

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -98,7 +98,7 @@ std::string BufferHelper::removeString(Buffer::Instance& data) {
   }
 
   char* start = reinterpret_cast<char*>(data.linearize(length));
-  std::string ret(start, length);
+  std::string ret(start, length > 0 ? length - 1 : 0);
   data.drain(length);
   return ret;
 }

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -98,7 +98,7 @@ std::string BufferHelper::removeString(Buffer::Instance& data) {
   }
 
   char* start = reinterpret_cast<char*>(data.linearize(length));
-  std::string ret(start);
+  std::string ret(start, length);
   data.drain(length);
   return ret;
 }

--- a/test/extensions/filters/network/mongo_proxy/bson_impl_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/bson_impl_test.cc
@@ -84,6 +84,23 @@ TEST(BufferHelperTest, InvalidSize) {
   }
 }
 
+TEST(BsonImplTest, StringContainsNullBytes) {
+  std::string s("hello\0world", 11);
+  Buffer::OwnedImpl buffer;
+  BufferHelper::writeString(buffer, s);
+  EXPECT_TRUE(BufferHelper::removeString(buffer) == s);
+}
+
+TEST(BsonImplTest, StringSizeObserved) {
+  char s[] = "helloworld";
+  Buffer::OwnedImpl buffer;
+
+  std::string hello("hello");
+  BufferHelper::writeInt32(buffer, hello.size() + 1);
+  buffer.add(s, sizeof(s));
+  EXPECT_TRUE(BufferHelper::removeString(buffer) == hello);
+}
+
 } // namespace Bson
 } // namespace MongoProxy
 } // namespace NetworkFilters


### PR DESCRIPTION
Fixes a possible OOB read in removeString of the bson parser. The std::string constructor relies on finding a null-byte, but should rely on the bounds-checked length given by the line format.

Signed-off-by: Robert Femmer <robert.femmer@x41-dsec.de>
