### PR TITLE
config/perf: use prefix matchers instead of regexes

### DIFF
--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -496,28 +496,22 @@ stats_config:
   stats_matcher:
     inclusion_list:
       patterns:
-        - safe_regex:
-            regex: '^cluster\.[\w]+?\.upstream_cx_[\w]+'
-        - safe_regex:
-            regex: '^cluster\.[\w]+?\.upstream_rq_[\w]+'
-        - safe_regex:
-            regex: '^cluster\.[\w]+?\.update_(attempt|success|failure)'
-        - safe_regex:
-            regex: '^cluster\.[\w]+?\.http2.keepalive_timeout'
-        - safe_regex:
-            regex: '^dns.apple.*'
-        - safe_regex:
-            regex: '^http.client.*'
-        - safe_regex:
-            regex: '^http.dispatcher.*'
-        - safe_regex:
-            regex: '^http.hcm.decompressor.*'
-        - safe_regex:
-            regex: '^http.hcm.downstream_rq_[\w]+'
-        - safe_regex:
-            regex: '^pbf_filter.*'
-        - safe_regex:
-            regex: '^pulse.*'
+        - prefix: cluster.base.upstream_cx_
+        - prefix: cluster.base_h2.upstream_cx_
+        - prefix: cluster.stats.upstream_cx_
+        - prefix: cluster.base.upstream_rq_
+        - prefix: cluster.base_h2.upstream_rq_
+        - prefix: cluster.stats.upstream_rq_
+        - prefix: cluster.base.http2.keepalive_timeout
+        - prefix: cluster.base_h2.http2.keepalive_timeout
+        - prefix: cluster.stats.http2.keepalive_timeout
+        - prefix: dns.apple.
+        - prefix: http.client.
+        - prefix: http.dispatcher.
+        - prefix: http.hcm.decompressor.
+        - prefix: http.hcm.downstream_rq_
+        - prefix: pbf_filter.
+        - prefix: pulse.
         - safe_regex:
             regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry|total)'
   use_all_default_tags:

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -496,20 +496,12 @@ stats_config:
   stats_matcher:
     inclusion_list:
       patterns:
-        - prefix: cluster.base.upstream_cx_
-        - prefix: cluster.base_h2.upstream_cx_
-        - prefix: cluster.stats.upstream_cx_
-        - prefix: cluster.base.upstream_rq_
-        - prefix: cluster.base_h2.upstream_rq_
-        - prefix: cluster.stats.upstream_rq_
-        - prefix: cluster.base.http2.keepalive_timeout
-        - prefix: cluster.base_h2.http2.keepalive_timeout
-        - prefix: cluster.stats.http2.keepalive_timeout
-        - prefix: dns.apple.
+        - prefix: cluster.base.
+        - prefix: cluster.base_h2.
+        - prefix: cluster.stats.
         - prefix: http.client.
         - prefix: http.dispatcher.
-        - prefix: http.hcm.decompressor.
-        - prefix: http.hcm.downstream_rq_
+        - prefix: http.hcm.
         - prefix: pbf_filter.
         - prefix: pulse.
         - safe_regex:


### PR DESCRIPTION
Commit Message: Converting regex matches to prefix matches as the former are way more costly. This is supposed to help with Envoy Mobile initialization times. The changes increase the number of stats that are enabled with default configuration of Envoy Mobile from 317 to 461. The profiling did not show any significant performance impact of this change but in theory reducing the number of places where we use regex should help.
Additional Description: related PR https://github.com/envoyproxy/envoy/pull/24521
Risk Level: Low
Testing: Manual
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>