### PR TITLE
build: removing optional extensions from stripped_main_base

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -67,7 +67,7 @@ envoy_cc_library(
     srcs = ["stripped_main_base.cc"],
     hdrs = ["stripped_main_base.h"],
     deps = [
-        ":envoy_common_lib",
+        ":envoy_common_with_core_extensions_lib",
         ":platform_impl_lib",
         ":process_wide_lib",
         "//source/common/thread_local:thread_local_lib",


### PR DESCRIPTION
This sets up the stripped main library to not pull in all extensions (which in monorepo, pulls in all upstream Envoy extensions).

Risk Level: Low for Envoy, Medium for Envoy Mobile (worst case explicitly link your extensions)
Testing: CI
Docs Changes: n/a
Release Notes: n/a