### PR TITLE
Reduce VirtualHost memory utilization by avoiding Stats scope for virtual clusters when no virtual clusters are present

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1716,9 +1716,6 @@ VirtualHostImpl::VirtualHostImpl(
     ProtobufMessage::ValidationVisitor& validator,
     const absl::optional<Upstream::ClusterManager::ClusterInfoMaps>& validation_clusters)
     : stat_name_storage_(virtual_host.name(), factory_context.scope().symbolTable()),
-      vcluster_scope_(Stats::Utility::scopeFromStatNames(
-          scope, {stat_name_storage_.statName(),
-                  factory_context.routerContext().virtualClusterStatNames().vcluster_})),
       global_route_config_(global_route_config),
       per_filter_configs_(virtual_host.typed_per_filter_config(), optional_http_filters,
                           factory_context, validator),
@@ -1799,6 +1796,9 @@ VirtualHostImpl::VirtualHostImpl(
   }
 
   if (!virtual_host.virtual_clusters().empty()) {
+    vcluster_scope_ = Stats::Utility::scopeFromStatNames(
+        scope, {stat_name_storage_.statName(),
+                factory_context.routerContext().virtualClusterStatNames().vcluster_});
     virtual_cluster_catch_all_ = std::make_unique<CatchAllVirtualCluster>(
         *vcluster_scope_, factory_context.routerContext().virtualClusterStatNames());
     for (const auto& virtual_cluster : virtual_host.virtual_clusters()) {


### PR DESCRIPTION
Reduce VirtualHost memory utilization by avoiding Stats scope for virtual clusters when no virtual clusters are present.

Currently every virtual host always creates a stats scope for virtual clusters, but that scope is only used when there are actual virtual clusters present. If no such clusters exist, the scope is just memory overhead.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
