### PR TITLE
aws: fetch EC2 instance role credentials securely aka IMDSv2

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -166,6 +166,11 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` and legacy code paths.
 
 new_features:
+- area: aws
+  change: |
+    added support to prefer fetching AWS instance role credentials securily
+    (`IMDSv2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>`_)
+    from EC2 instance metadata by getting the token first or fallback to insecure way (IMDSv1) if token fetch fails.
 - area: grpc_json_transcoder
   change: |
     added ``max_request_body_size`` and ``max_response_body_size`` fields, which can either increase or decrease

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -35,6 +35,10 @@ constexpr std::chrono::hours REFRESH_INTERVAL{1};
 constexpr std::chrono::seconds REFRESH_GRACE_PERIOD{5};
 constexpr char EC2_METADATA_HOST[] = "169.254.169.254:80";
 constexpr char CONTAINER_METADATA_HOST[] = "169.254.170.2:80";
+constexpr char EC2_IMDS_TOKEN_RESOURCE[] = "/latest/api/token";
+constexpr char EC2_IMDS_TOKEN_HEADER[] = "X-aws-ec2-metadata-token";
+constexpr char EC2_IMDS_TOKEN_TTL_HEADER[] = "X-aws-ec2-metadata-token-ttl-seconds";
+constexpr char EC2_IMDS_TOKEN_TTL_DEFAULT_VALUE[] = "21600";
 constexpr char SECURITY_CREDENTIALS_PATH[] = "/latest/meta-data/iam/security-credentials";
 
 } // namespace
@@ -70,29 +74,52 @@ bool InstanceProfileCredentialsProvider::needsRefresh() {
 }
 
 void InstanceProfileCredentialsProvider::refresh() {
-  ENVOY_LOG(debug, "Getting AWS credentials from the instance metadata");
+  ENVOY_LOG(debug, "Getting AWS credentials from the EC2MetadataService");
 
-  // First discover the Role of this instance
+  // First request for a session TOKEN so that we can call EC2MetadataService securely.
+  // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+  Http::RequestMessageImpl token_req_message;
+  token_req_message.headers().setMethod(Http::Headers::get().MethodValues.Put);
+  token_req_message.headers().setHost(EC2_METADATA_HOST);
+  token_req_message.headers().setPath(EC2_IMDS_TOKEN_RESOURCE);
+  token_req_message.headers().setCopy(Http::LowerCaseString(EC2_IMDS_TOKEN_TTL_HEADER),
+                                      EC2_IMDS_TOKEN_TTL_DEFAULT_VALUE);
+  const auto token_string = metadata_fetcher_(token_req_message);
+  if (token_string) {
+    ENVOY_LOG(debug, "Obtained token to make secure call to EC2MetadataService");
+    fetchInstanceRole(token_string.value());
+  } else {
+    ENVOY_LOG(warn, "Failed to get token from EC2MetadataService, falling back to less secure way");
+    fetchInstanceRole("");
+  }
+}
+
+void InstanceProfileCredentialsProvider::fetchInstanceRole(const std::string& token_string) {
+  // Discover the Role of this instance.
   Http::RequestMessageImpl message;
   message.headers().setMethod(Http::Headers::get().MethodValues.Get);
   message.headers().setHost(EC2_METADATA_HOST);
   message.headers().setPath(SECURITY_CREDENTIALS_PATH);
+  if (!token_string.empty()) {
+    message.headers().setCopy(Http::LowerCaseString(EC2_IMDS_TOKEN_HEADER),
+                              StringUtil::trim(token_string));
+  }
   const auto instance_role_string = metadata_fetcher_(message);
   if (!instance_role_string) {
-    ENVOY_LOG(error, "Could not retrieve credentials listing from the instance metadata");
+    ENVOY_LOG(error, "Could not retrieve credentials listing from the EC2MetadataService");
     return;
   }
-  fetchCredentialFromInstanceRole(instance_role_string.value());
+  fetchCredentialFromInstanceRole(instance_role_string.value(), token_string);
 }
 
 void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
-    const std::string& instance_role) {
+    const std::string& instance_role, const std::string& token_string) {
   if (instance_role.empty()) {
     return;
   }
   const auto instance_role_list = StringUtil::splitToken(StringUtil::trim(instance_role), "\n");
   if (instance_role_list.empty()) {
-    ENVOY_LOG(error, "No AWS credentials were found in the instance metadata");
+    ENVOY_LOG(error, "No AWS credentials were found in the EC2MetadataService");
     return;
   }
   ENVOY_LOG(debug, "AWS credentials list:\n{}", instance_role);
@@ -109,10 +136,13 @@ void InstanceProfileCredentialsProvider::fetchCredentialFromInstanceRole(
   message.headers().setMethod(Http::Headers::get().MethodValues.Get);
   message.headers().setHost(EC2_METADATA_HOST);
   message.headers().setPath(credential_path);
-
+  if (!token_string.empty()) {
+    message.headers().setCopy(Http::LowerCaseString(EC2_IMDS_TOKEN_HEADER),
+                              StringUtil::trim(token_string));
+  }
   const auto credential_document = metadata_fetcher_(message);
   if (!credential_document) {
-    ENVOY_LOG(error, "Could not load AWS credentials document from the instance metadata");
+    ENVOY_LOG(error, "Could not load AWS credentials document from the EC2MetadataService");
     return;
   }
   extractCredentials(credential_document.value());
@@ -135,7 +165,8 @@ void InstanceProfileCredentialsProvider::extractCredentials(
   const auto secret_access_key = document_json->getString(SECRET_ACCESS_KEY, "");
   const auto session_token = document_json->getString(TOKEN, "");
 
-  ENVOY_LOG(debug, "Found following AWS credentials in the instance metadata: {}={}, {}={}, {}={}",
+  ENVOY_LOG(debug,
+            "Obtained following AWS credentials from the EC2MetadataService: {}={}, {}={}, {}={}",
             AWS_ACCESS_KEY_ID, access_key_id, AWS_SECRET_ACCESS_KEY,
             secret_access_key.empty() ? "" : "*****", AWS_SESSION_TOKEN,
             session_token.empty() ? "" : "*****");

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -68,8 +68,9 @@ public:
 private:
   bool needsRefresh() override;
   void refresh() override;
+  void fetchInstanceRole(const std::string& token);
+  void fetchCredentialFromInstanceRole(const std::string& instance_role, const std::string& token);
   void extractCredentials(const std::string& credential_document_value);
-  void fetchCredentialFromInstanceRole(const std::string& instance_role);
 };
 
 /**

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -235,6 +235,7 @@ absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message
 
   const auto host = message.headers().getHostValue();
   const auto path = message.headers().getPathValue();
+  const auto method = message.headers().getMethodValue();
 
   const std::string url = fmt::format("http://{}{}", host, path);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -257,6 +258,22 @@ absl::optional<std::string> Utility::fetchMetadata(Http::RequestMessage& message
     headers = curl_slist_append(headers, header.c_str());
     return Http::HeaderMap::Iterate::Continue;
   });
+
+  // This function only support doing PUT(UPLOAD) other than GET(_default_) operation.
+  if (Http::Headers::get().MethodValues.Put == method) {
+    // https://curl.se/libcurl/c/CURLOPT_PUT.html is deprecated
+    // so using https://curl.se/libcurl/c/CURLOPT_UPLOAD.html.
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    // To call PUT on HTTP 1.0 we must specify a value for the upload size
+    // since some old EC2's metadata service will be serving on HTTP 1.0.
+    // https://curl.se/libcurl/c/CURLOPT_INFILESIZE.html
+    curl_easy_setopt(curl, CURLOPT_INFILESIZE, 0);
+    // Disabling `Expect: 100-continue` header to get a response
+    // in the first attempt as the put size is zero.
+    // https://everything.curl.dev/http/post/expect100
+    headers = curl_slist_append(headers, "Expect:");
+  }
+
   if (headers != nullptr) {
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   }


### PR DESCRIPTION
Signed-off-by: Sunil Narasimhamurthy <sunnrs@amazon.com>

Commit Message: aws: fetch EC2 instance role credentials securely a.k.a IMDSv2
Additional Description: Use token to fetch the credentials from EC2 Instance Metadata
Risk Level: Low
Testing: Unit testing
Docs Changes: NA
Release Notes: Updated
Platform Specific Features:
Fixes: #24592
