### PR TITLE
Lua: describe the get result when multiple headers have the same key

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -631,7 +631,8 @@ get()
   headers:get(key)
 
 Gets a header. *key* is a string that supplies the header key. Returns a string that is the header
-value or nil if there is no such header.
+value or nil if there is no such header. If there are multiple headers in the same case-insensitive
+key, their values will be combined with a *,* separator and returned as a string.
 
 getAtIndex()
 ^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: RRobot-lm <RRobot-lm@users.noreply.github.com>

Commit Message: Lua: describe the get result when multiple headers have the same key
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: Done
Release Notes:
Platform Specific Features:
Fixes #24718
