### PR TITLE
core: add missing extension registration

### DIFF
--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
         "@envoy//source/extensions/filters/http/router:config",
         "@envoy//source/extensions/filters/network/http_connection_manager:config",
         "@envoy//source/extensions/http/header_formatters/preserve_case:config",
+        "@envoy//source/extensions/listener_managers/listener_manager:connection_handler_lib",
         "@envoy//source/extensions/network/dns_resolver/getaddrinfo:config",
         "@envoy//source/extensions/request_id/uuid:config",
         "@envoy//source/extensions/stat_sinks/metrics_service:config",

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -16,6 +16,7 @@
 #include "source/extensions/filters/network/http_connection_manager/config.h"
 #include "source/extensions/http/header_formatters/preserve_case/config.h"
 #include "source/extensions/http/original_ip_detection/xff/config.h"
+#include "source/extensions/listener_managers/listener_manager/connection_handler_impl.h"
 #include "source/extensions/listener_managers/listener_manager/listener_manager_impl.h"
 #include "source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.h"
 #include "source/extensions/request_id/uuid/config.h"
@@ -85,6 +86,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::RequestId::forceRegisterUUIDRequestIDExtensionFactory();
   Envoy::Server::forceRegisterDefaultListenerManagerFactoryImpl();
   Envoy::Server::forceRegisterApiListenerManagerFactoryImpl();
+  Envoy::Server::forceRegisterConnectionHandlerFactoryImpl();
 
 #ifdef ENVOY_ENABLE_QUIC
   Quic::forceRegisterQuicServerTransportSocketConfigFactory();

--- a/mobile/envoy_build_config/extensions_build_config.bzl
+++ b/mobile/envoy_build_config/extensions_build_config.bzl
@@ -28,6 +28,7 @@ EXTENSIONS = {
     "envoy.transport_sockets.raw_buffer":                  "//source/extensions/transport_sockets/raw_buffer:config",
     "envoy.transport_sockets.tls":                         "//source/extensions/transport_sockets/tls:config",
     "envoy.http.stateful_header_formatters.preserve_case": "//source/extensions/http/header_formatters/preserve_case:config",
+    "envoy.connection_handler.default":                    "//source/extensions/listener_managers/listener_manager:connection_handler_lib",
     "envoy_mobile.cert_validator.platform_bridge_cert_validator": "@envoy_mobile//library/common/extensions/cert_validator/platform_bridge:config",
     "envoy.listener_manager_impl.api":                     "@envoy_mobile//library/common/extensions/listener_managers/api_listener_manager:api_listener_manager_lib",
 


### PR DESCRIPTION
Commit Message: A follow up fixes to https://github.com/envoyproxy/envoy/pull/24495. Without these fixes application crashes after `addDirectResponse` call on `TestEngineBuilder` (iOS only api) as the `handler_` in https://github.com/envoyproxy/envoy/blob/93ea91f42ef749a4560a4596174402a5aad8ee65/source/server/worker_impl.cc#L61 is `nullptr`.
Additional Description: The question is whether without the added registration calls application may crash even without the `addDirectResponse` call. cc @alyssawilk. Asking since Lyft has pushed https://github.com/envoyproxy/envoy/pull/24495 to prod pipeline already and the question is whether we need to cherry-pick the fix from this PR now.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

