### PR TITLE
[backport/1.21] docker: Use distroless-nossl

### DIFF
--- a/ci/Dockerfile-envoy-distroless
+++ b/ci/Dockerfile-envoy-distroless
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-debian11:nonroot@sha256:4b22ca3c68018333c56f8dddcf1f8b55f32889f2dd12d28ab60856eba1130d04
+FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:50562a71d0dfad3a374ec33ab577fc7aab16dfcf37bf95889af6cc58a108dbc1
 
 ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
