### PR TITLE
Clarify that on-demand CDS does not support SotW xDS

### DIFF
--- a/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
+++ b/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
@@ -19,6 +19,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: On Demand Discovery]
 // On Demand Discovery :ref:`configuration overview <config_http_filters_on_demand>`.
 // [#extension: envoy.filters.http.on_demand]
+//
+// .. warning::
+//
+//    On-demand CDS does not support SotW streams. Currently it only supports incremental xDS.
+//
 
 // Configuration of on-demand CDS.
 message OnDemandCds {

--- a/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
+++ b/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // .. warning::
 //
-//    On-demand CDS does not support SotW streams. Currently it only supports incremental xDS.
+//    Envoy currently only supports On-demand CDS when using Incremental-xDS and not State-of-the-World.
 //
 
 // Configuration of on-demand CDS.


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

Commit Message: Clarify that on-demand CDS does not support SotW xDS
Additional Description:
Risk Level: n/a
Testing: n/a
Docs Changes: It's a doc change.
Release Notes: n/a
Platform Specific Features: n/a

I was trying to configure on-demand CDS in an Istio ingress-gateway, but the process failed with the following error:
```
2023-01-04T13:38:10.587354Z     critical        envoy assert    panic: not supported
2023-01-04T13:38:10.587411Z     critical        envoy backtrace Caught Aborted, suspect faulting address 0x5390000001e
2023-01-04T13:38:10.587416Z     critical        envoy backtrace Backtrace (use tools/stack_decode.py to get line numbers):
2023-01-04T13:38:10.587418Z     critical        envoy backtrace Envoy version: 383b3bdbec79392badac7cbf3525f09d1f0f18f8/1.24.1-dev/Clean/RELEASE/BoringSSL
2023-01-04T13:38:10.587694Z     critical        envoy backtrace #0: [0x7fcd2f3e4520]
...
2023-01-04T13:38:11.139240Z     info    ads     ADS: "@" istio-ingressgateway-5d68845c68-hqp4t.istio-system-2 terminated
2023-01-04T13:38:11.139360Z     info    ads     ADS: "@" istio-ingressgateway-5d68845c68-hqp4t.istio-system-1 terminated
2023-01-04T13:38:11.140610Z     error   Envoy exited with error: signal: aborted (core dumped)
```
I had to dive into the code base to figure out why it fails and I found this method:
```
void OdCdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& resources,
  ...
  // On-demand cluster updates are only supported for delta, not sotw.
  PANIC("not supported");
}
```
so I think it's worth to mention about this limitation in the docs.

Could I also add more details to that panic message or is it intentionally so general? I noticed that most panic messages are very general, so I wonder if this is a convention...?

**Question:**
Btw. is it an intended limitation or could it be implemented? I'm considering on-demand CDS as a workaround for the problem described in #18958, so if there are no obstacles to make it work with SotW ADS, I would be interested in implementing this feature.