### PR TITLE
delta-xds: fix map name in state tracking

### DIFF
--- a/source/common/config/new_delta_subscription_state.cc
+++ b/source/common/config/new_delta_subscription_state.cc
@@ -172,7 +172,7 @@ bool NewDeltaSubscriptionState::isHeartbeatResponse(
   }
 
   if (const auto itr = ambiguous_resource_state_.find(resource.name());
-      itr != wildcard_resource_state_.end()) {
+      itr != ambiguous_resource_state_.end()) {
     // In theory we should move the ambiguous resource to wildcard, because probably we shouldn't be
     // getting heartbeat responses about resources that we are not interested in, but the server
     // could have sent this heartbeat before it learned about our lack of interest in the resource.


### PR DESCRIPTION
Commit Message: fix map name in state tracking
Additional Description:
Seems that this is a copy-paste error. Fixing var name.

Risk Level: Low
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
