### PR TITLE
only throw when the load_balancing_policy and specific fields of common_lb_config are set

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1189,9 +1189,7 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
                                           Server::Configuration::ServerFactoryContext& context) {
   // Check if load_balancing_policy is set first.
   if (!config.has_load_balancing_policy()) {
-    throw EnvoyException(
-        fmt::format("cluster: load_balancing_policy requires field load_balancing_policy to be set",
-                    envoy::config::cluster::v3::Cluster::LbPolicy_Name(config.lb_policy())));
+    throw EnvoyException("cluster: field load_balancing_policy need to be set");
   }
 
   if (config.has_lb_subset_config()) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1201,7 +1201,7 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
     if (lb_config.has_zone_aware_lb_config() || lb_config.has_locality_weighted_lb_config() ||
         lb_config.has_consistent_hashing_lb_config()) {
       throw EnvoyException(
-          "cluster: load_balancing_policy be combined with partial fields (zone_aware_lb_config, "
+          "cluster: load_balancing_policy cannot be combined with partial fields (zone_aware_lb_config, "
           "locality_weighted_lb_config, consistent_hashing_lb_config) of common_lb_config");
     }
   }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1201,7 +1201,8 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
     if (lb_config.has_zone_aware_lb_config() || lb_config.has_locality_weighted_lb_config() ||
         lb_config.has_consistent_hashing_lb_config()) {
       throw EnvoyException(
-          "cluster: load_balancing_policy cannot be combined with partial fields (zone_aware_lb_config, "
+          "cluster: load_balancing_policy cannot be combined with partial fields "
+          "(zone_aware_lb_config, "
           "locality_weighted_lb_config, consistent_hashing_lb_config) of common_lb_config");
     }
   }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -852,10 +852,8 @@ TEST_P(ClusterManagerSubsetInitializationTest, SubsetLoadBalancerInitialization)
                     envoy::config::cluster::v3::Cluster::LbPolicy_Name(GetParam())));
 
   } else if (GetParam() == envoy::config::cluster::v3::Cluster::LOAD_BALANCING_POLICY_CONFIG) {
-    EXPECT_THROW_WITH_MESSAGE(
-        create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
-        fmt::format("cluster: load_balancing_policy requires field load_balancing_policy to be set",
-                    envoy::config::cluster::v3::Cluster::LbPolicy_Name(GetParam())));
+    EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
+                              "cluster: field load_balancing_policy need to be set");
   } else {
     create(parseBootstrapFromV3Yaml(yaml));
     checkStats(1 /*added*/, 0 /*modified*/, 0 /*removed*/, 1 /*active*/, 0 /*warming*/);

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -845,13 +845,17 @@ TEST_P(ClusterManagerSubsetInitializationTest, SubsetLoadBalancerInitialization)
   }
   const std::string yaml = fmt::format(yamlPattern, cluster_type, policy_name);
 
-  if (GetParam() == envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED ||
-      GetParam() == envoy::config::cluster::v3::Cluster::LOAD_BALANCING_POLICY_CONFIG) {
+  if (GetParam() == envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED) {
     EXPECT_THROW_WITH_MESSAGE(
         create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
         fmt::format("cluster: LB policy {} cannot be combined with lb_subset_config",
                     envoy::config::cluster::v3::Cluster::LbPolicy_Name(GetParam())));
 
+  } else if (GetParam() == envoy::config::cluster::v3::Cluster::LOAD_BALANCING_POLICY_CONFIG) {
+    EXPECT_THROW_WITH_MESSAGE(
+        create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
+        fmt::format("cluster: load_balancing_policy requires field load_balancing_policy to be set",
+                    envoy::config::cluster::v3::Cluster::LbPolicy_Name(GetParam())));
   } else {
     create(parseBootstrapFromV3Yaml(yaml));
     checkStats(1 /*added*/, 0 /*modified*/, 0 /*removed*/, 1 /*active*/, 0 /*warming*/);
@@ -1022,154 +1026,6 @@ TEST_F(ClusterManagerImplTest, ClusterProvidedLbNotConfigured) {
   EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Json(json)), EnvoyException,
                             "cluster manager: cluster provided LB not specified but cluster "
                             "'cluster_0' provided one. Check cluster documentation.");
-}
-
-// Verify that specifying LOAD_BALANCING_POLICY_CONFIG with CommonLbConfig is an error.
-TEST_F(ClusterManagerImplTest, LbPolicyConfigCannotSpecifyCommonLbConfig) {
-  // envoy.load_balancers.custom_lb is registered by linking in
-  // //test/integration/load_balancers:custom_lb_policy.
-  const std::string yaml = fmt::format(R"EOF(
- static_resources:
-  clusters:
-  - name: cluster_1
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: LOAD_BALANCING_POLICY_CONFIG
-    load_balancing_policy:
-      policies:
-      - typed_extension_config:
-          name: envoy.load_balancers.custom_lb
-    common_lb_config:
-      update_merge_window: 3s
-    load_assignment:
-      cluster_name: cluster_1
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8000
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8001
-  )EOF");
-
-  EXPECT_THROW_WITH_MESSAGE(
-      create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
-      "cluster: LB policy LOAD_BALANCING_POLICY_CONFIG cannot be combined with common_lb_config");
-}
-
-// Verify that LOAD_BALANCING_POLICY_CONFIG without specifying load balancing policy is an error.
-TEST_F(ClusterManagerImplTest, LbPolicyConfigMustSpecifyLbPolicy) {
-  const std::string yaml = fmt::format(R"EOF(
- static_resources:
-  clusters:
-  - name: cluster_1
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: LOAD_BALANCING_POLICY_CONFIG
-    load_assignment:
-      cluster_name: cluster_1
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8000
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8001
-  )EOF");
-
-  EXPECT_THROW_WITH_MESSAGE(
-      create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
-      "cluster: LB policy LOAD_BALANCING_POLICY_CONFIG requires load_balancing_policy to be set");
-}
-
-// Verify that multiple load balancing policies can be specified, and Envoy selects the first
-// policy that it has a factory for.
-TEST_F(ClusterManagerImplTest, LbPolicyConfig) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
-
-  // envoy.load_balancers.custom_lb is registered by linking in
-  // //test/integration/load_balancers:custom_lb_policy.
-  const std::string yaml = fmt::format(R"EOF(
- static_resources:
-  clusters:
-  - name: cluster_1
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: LOAD_BALANCING_POLICY_CONFIG
-    load_balancing_policy:
-      policies:
-      - typed_extension_config:
-          name: envoy.load_balancers.unknown_lb
-      - typed_extension_config:
-          name: envoy.load_balancers.custom_lb
-    load_assignment:
-      cluster_name: cluster_1
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8000
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8001
-  )EOF");
-
-  create(parseBootstrapFromV3Yaml(yaml));
-  const auto& cluster = cluster_manager_->clusters().getCluster("cluster_1");
-  EXPECT_NE(cluster, absl::nullopt);
-  EXPECT_NE(cluster->get().info()->loadBalancingPolicy(), nullptr);
-}
-
-// Verify that if Envoy does not have a factory for any of the load balancing policies specified in
-// the load balancing policy config, it is an error.
-TEST_F(ClusterManagerImplTest, LbPolicyConfigThrowsExceptionIfNoLbPoliciesFound) {
-  const std::string yaml = fmt::format(R"EOF(
- static_resources:
-  clusters:
-  - name: cluster_1
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: LOAD_BALANCING_POLICY_CONFIG
-    load_balancing_policy:
-      policies:
-      - typed_extension_config:
-          name: envoy.load_balancers.unknown_lb_1
-      - typed_extension_config:
-          name: envoy.load_balancers.unknown_lb_2
-    load_assignment:
-      cluster_name: cluster_1
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8000
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8001
-  )EOF");
-
-  EXPECT_THROW_WITH_MESSAGE(
-      create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
-      "Didn't find a registered load balancer factory implementation for cluster: 'cluster_1'");
 }
 
 class ClusterManagerImplThreadAwareLbTest : public ClusterManagerImplTest {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2728,6 +2728,7 @@ TEST_F(StaticClusterImplTest, LbPolicyConfig) {
                               std::move(scope), true);
 
     EXPECT_NE(nullptr, cluster.info()->loadBalancingPolicy());
+    EXPECT_NE(nullptr, cluster.info()->loadBalancerFactory());
   });
 }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2496,8 +2496,7 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithoutConfiguration) {
         StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
                                   std::move(scope), true);
       },
-      EnvoyException,
-      "cluster: load_balancing_policy requires field load_balancing_policy to be set");
+      EnvoyException, "cluster: field load_balancing_policy need to be set");
 }
 
 // load_balancing_policy is set and common_lb_config is set.

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2585,7 +2585,8 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithCommonLbConfigAndSpecificFi
                                   std::move(scope), true);
       },
       EnvoyException,
-      "cluster: load_balancing_policy be combined with partial fields (zone_aware_lb_config, "
+      "cluster: load_balancing_policy cannot be combined with partial fields "
+      "(zone_aware_lb_config, "
       "locality_weighted_lb_config, consistent_hashing_lb_config) of common_lb_config");
 }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2680,7 +2680,8 @@ TEST_F(StaticClusterImplTest, LbPolicyConfigThrowsExceptionIfNoLbPoliciesFound) 
       },
       EnvoyException,
       "cluster: didn't find a registered load balancer factory implementation for cluster: "
-      "'cluster_1'");
+      "'cluster_1' with names from [envoy.load_balancers.unknown_lb_1, "
+      "envoy.load_balancers.unknown_lb_2]");
 }
 
 // load_balancing_policy should also be used when lb_policy is set to something else besides

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2455,6 +2455,8 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithLbPolicy) {
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(LoadBalancerType::LoadBalancingPolicyConfig, cluster.info()->lbType());
   EXPECT_TRUE(cluster.info()->addedViaApi());
+  EXPECT_NE(nullptr, cluster.info()->loadBalancingPolicy());
+  EXPECT_NE(nullptr, cluster.info()->loadBalancerFactory());
 }
 
 // lb_policy is set to LOAD_BALANCING_POLICY_CONFIG and has no load_balancing_policy.
@@ -2496,6 +2498,49 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithoutConfiguration) {
       },
       EnvoyException,
       "cluster: load_balancing_policy requires field load_balancing_policy to be set");
+}
+
+// load_balancing_policy is set and common_lb_config is set.
+TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithCommonLbConfig) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
+
+  const std::string yaml = R"EOF(
+    name: staticcluster
+    connect_timeout: 0.25s
+    type: static
+    load_balancing_policy:
+      policies:
+        - typed_extension_config:
+            name: custom_lb
+    common_lb_config:
+      update_merge_window: 1s
+    load_assignment:
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 10.0.0.1
+                  port_value: 11001
+  )EOF";
+
+  NiceMock<MockTypedLoadBalancerFactory> factory;
+  EXPECT_CALL(factory, name()).WillRepeatedly(Return("custom_lb"));
+  Registry::InjectFactory<TypedLoadBalancerFactory> registered_factory(factory);
+
+  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
+  Envoy::Stats::ScopeSharedPtr scope = stats_.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
+  Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
+      server_context_, ssl_context_manager_, *scope, server_context_.cluster_manager_, stats_,
+      validation_visitor_);
+
+  EXPECT_NO_THROW({
+    StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
+                              std::move(scope), true);
+  });
 }
 
 // load_balancing_policy is set and some fields in common_lb_config are set.
@@ -2543,49 +2588,6 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithCommonLbConfigAndSpecificFi
       EnvoyException,
       "cluster: load_balancing_policy be combined with partial fields (zone_aware_lb_config, "
       "locality_weighted_lb_config, consistent_hashing_lb_config) of common_lb_config");
-}
-
-// load_balancing_policy is set and common_lb_config is set.
-TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithCommonLbConfig) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
-
-  const std::string yaml = R"EOF(
-    name: staticcluster
-    connect_timeout: 0.25s
-    type: static
-    load_balancing_policy:
-      policies:
-        - typed_extension_config:
-            name: custom_lb
-    common_lb_config:
-      update_merge_window: 1s
-    load_assignment:
-      endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 10.0.0.1
-                  port_value: 11001
-  )EOF";
-
-  NiceMock<MockTypedLoadBalancerFactory> factory;
-  EXPECT_CALL(factory, name()).WillRepeatedly(Return("custom_lb"));
-  Registry::InjectFactory<TypedLoadBalancerFactory> registered_factory(factory);
-
-  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
-  Envoy::Stats::ScopeSharedPtr scope = stats_.createScope(fmt::format(
-      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
-                                                            : cluster_config.alt_stat_name()));
-  Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-      server_context_, ssl_context_manager_, *scope, server_context_.cluster_manager_, stats_,
-      validation_visitor_);
-
-  EXPECT_NO_THROW({
-    StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
-                              std::move(scope), true);
-  });
 }
 
 // load_balancing_policy is set and lb_subset_config is set.
@@ -2679,57 +2681,6 @@ TEST_F(StaticClusterImplTest, LbPolicyConfigThrowsExceptionIfNoLbPoliciesFound) 
       EnvoyException,
       "cluster: didn't find a registered load balancer factory implementation for cluster: "
       "'cluster_1'");
-}
-
-// Verify that multiple load balancing policies can be specified, and Envoy selects the first
-// policy that it has a factory for.
-TEST_F(StaticClusterImplTest, LbPolicyConfig) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
-
-  // envoy.load_balancers.custom_lb is registered by linking in
-  // //test/integration/load_balancers:custom_lb_policy.
-  const std::string yaml = fmt::format(R"EOF(
-    name: cluster_1
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: LOAD_BALANCING_POLICY_CONFIG
-    load_balancing_policy:
-      policies:
-      - typed_extension_config:
-          name: envoy.load_balancers.unknown_lb
-      - typed_extension_config:
-          name: custom_lb
-    load_assignment:
-      cluster_name: cluster_1
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 8000
-  )EOF");
-
-  NiceMock<MockTypedLoadBalancerFactory> factory;
-  EXPECT_CALL(factory, name()).WillRepeatedly(Return("custom_lb"));
-  Registry::InjectFactory<TypedLoadBalancerFactory> registered_factory(factory);
-
-  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
-  Envoy::Stats::ScopeSharedPtr scope = stats_.createScope(fmt::format(
-      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
-                                                            : cluster_config.alt_stat_name()));
-  Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-      server_context_, ssl_context_manager_, *scope, server_context_.cluster_manager_, stats_,
-      validation_visitor_);
-
-  EXPECT_NO_THROW({
-    StaticClusterImpl cluster(server_context_, cluster_config, runtime_, factory_context,
-                              std::move(scope), true);
-
-    EXPECT_NE(nullptr, cluster.info()->loadBalancingPolicy());
-    EXPECT_NE(nullptr, cluster.info()->loadBalancerFactory());
-  });
 }
 
 // load_balancing_policy should also be used when lb_policy is set to something else besides


### PR DESCRIPTION
Signed-off-by: wbpcode <wangbaiping@corp.netease.com>
Commit Message: only throw when the load_balancing_policy and specific fields of common_lb_config are set
Additional Description:

An exception will be throwed when the common_lb_config and load_balancing_policy are set in the same time in the previous implemention.
But in fact, It should only throw an exception when the specific fields of common_lb_config and load_balancing_policy are set.
This PR correct it to make the behavior more appropriate.

Risk Level: Low.
Testing: Unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
