### PR TITLE
Reduce RDS subscription memory overhead by removing unnecessary `absl:optional`

### DIFF
--- a/source/common/rds/rds_route_config_provider_impl.cc
+++ b/source/common/rds/rds_route_config_provider_impl.cc
@@ -16,12 +16,12 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   });
   // It should be 1:1 mapping due to shared rds config.
   ASSERT(subscription_->routeConfigProvider() == nullptr);
-  subscription_->routeConfigProvider() == this;
+  subscription_->routeConfigProvider() = this;
 }
 
 RdsRouteConfigProviderImpl::~RdsRouteConfigProviderImpl() {
   ASSERT(subscription_->routeConfigProvider() != nullptr);
-  subscription_->routeConfigProvider() == nullptr;
+  subscription_->routeConfigProvider() = nullptr;
 }
 
 const absl::optional<RouteConfigProvider::ConfigInfo>&

--- a/source/common/rds/rds_route_config_provider_impl.cc
+++ b/source/common/rds/rds_route_config_provider_impl.cc
@@ -15,13 +15,13 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
     return std::make_shared<ThreadLocalConfig>(initial_config);
   });
   // It should be 1:1 mapping due to shared rds config.
-  ASSERT(!subscription_->routeConfigProvider().has_value());
-  subscription_->routeConfigProvider().emplace(this);
+  ASSERT(subscription_->routeConfigProvider() == nullptr);
+  subscription_->routeConfigProvider() == this;
 }
 
 RdsRouteConfigProviderImpl::~RdsRouteConfigProviderImpl() {
-  ASSERT(subscription_->routeConfigProvider().has_value());
-  subscription_->routeConfigProvider().reset();
+  ASSERT(subscription_->routeConfigProvider() != nullptr);
+  subscription_->routeConfigProvider() == nullptr;
 }
 
 const absl::optional<RouteConfigProvider::ConfigInfo>&

--- a/source/common/rds/rds_route_config_subscription.h
+++ b/source/common/rds/rds_route_config_subscription.h
@@ -54,7 +54,7 @@ public:
 
   ~RdsRouteConfigSubscription() override;
 
-  absl::optional<RouteConfigProvider*>& routeConfigProvider();
+  RouteConfigProvider*& routeConfigProvider() { return route_config_provider_; }
 
   RouteConfigUpdatePtr& routeConfigUpdate() { return config_update_info_; }
 
@@ -98,7 +98,7 @@ protected:
   RdsStats stats_;
   RouteConfigProviderManager& route_config_provider_manager_;
   const uint64_t manager_identifier_;
-  absl::optional<RouteConfigProvider*> route_config_provider_opt_;
+  RouteConfigProvider* route_config_provider_;
   RouteConfigUpdatePtr config_update_info_;
   Envoy::Config::OpaqueResourceDecoderSharedPtr resource_decoder_;
 };

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -98,8 +98,8 @@ void RdsRouteConfigSubscription::beforeProviderUpdate(
     ASSERT(config_update_info_->configInfo().has_value());
     maybeCreateInitManager(routeConfigUpdate()->configInfo().value().version_, noop_init_manager,
                            resume_rds);
-    vhds_subscription_ = std::make_unique<VhdsSubscription>(
-        config_update_info_, factory_context_, stat_prefix_, route_config_provider_opt_);
+    vhds_subscription_ = std::make_unique<VhdsSubscription>(config_update_info_, factory_context_,
+                                                            stat_prefix_, route_config_provider_);
     vhds_subscription_->registerInitTargetWithInitManager(
         noop_init_manager == nullptr ? local_init_manager_ : *noop_init_manager);
   }
@@ -150,7 +150,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   // The subscription referenced by the 'base_' and by 'this' is the same.
   // In it the provider is already set by the 'base_' so it points to that.
   // Need to set again to point to 'this'.
-  base_.subscription().routeConfigProvider().emplace(this);
+  base_.subscription().routeConfigProvider() = this;
 }
 
 RdsRouteConfigSubscription& RdsRouteConfigProviderImpl::subscription() {

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -20,10 +20,10 @@ namespace Envoy {
 namespace Router {
 
 // Implements callbacks to handle DeltaDiscovery protocol for VirtualHostDiscoveryService
-VhdsSubscription::VhdsSubscription(
-    RouteConfigUpdatePtr& config_update_info,
-    Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
-    absl::optional<Rds::RouteConfigProvider*>& route_config_provider_opt)
+VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
+                                   Server::Configuration::ServerFactoryContext& factory_context,
+                                   const std::string& stat_prefix,
+                                   Rds::RouteConfigProvider* route_config_provider)
     : Envoy::Config::SubscriptionBase<envoy::config::route::v3::VirtualHost>(
           factory_context.messageValidationContext().dynamicValidationVisitor(), "name"),
       config_update_info_(config_update_info),
@@ -36,7 +36,7 @@ VhdsSubscription::VhdsSubscription(
                      subscription_->start(
                          {config_update_info_->protobufConfigurationCast().name()});
                    }),
-      route_config_provider_opt_(route_config_provider_opt) {
+      route_config_provider_(route_config_provider) {
   const auto& config_source = config_update_info_->protobufConfigurationCast()
                                   .vhds()
                                   .config_source()
@@ -90,8 +90,8 @@ void VhdsSubscription::onConfigUpdate(
     ENVOY_LOG(debug, "vhds: loading new configuration: config_name={} hash={}",
               config_update_info_->protobufConfigurationCast().name(),
               config_update_info_->configHash());
-    if (route_config_provider_opt_.has_value()) {
-      route_config_provider_opt_.value()->onConfigUpdate();
+    if (route_config_provider_ != nullptr) {
+      route_config_provider_->onConfigUpdate();
     }
   }
 

--- a/source/common/router/vhds.h
+++ b/source/common/router/vhds.h
@@ -41,8 +41,7 @@ class VhdsSubscription : Envoy::Config::SubscriptionBase<envoy::config::route::v
 public:
   VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
                    Server::Configuration::ServerFactoryContext& factory_context,
-                   const std::string& stat_prefix,
-                   absl::optional<Rds::RouteConfigProvider*>& route_config_providers);
+                   const std::string& stat_prefix, Rds::RouteConfigProvider* route_config_provider);
 
   ~VhdsSubscription() override { init_target_.ready(); }
 
@@ -71,7 +70,7 @@ private:
   VhdsStats stats_;
   Envoy::Config::SubscriptionPtr subscription_;
   Init::TargetImpl init_target_;
-  absl::optional<Rds::RouteConfigProvider*>& route_config_provider_opt_;
+  Rds::RouteConfigProvider* route_config_provider_;
 };
 
 using VhdsSubscriptionPtr = std::unique_ptr<VhdsSubscription>;

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -568,7 +568,7 @@ TEST_F(RdsImplTest, FailureInvalidConfig) {
   // SubscriptionCallbacks, so we has to use reinterpret_cast here.
   RdsRouteConfigSubscription* rds_subscription =
       reinterpret_cast<RdsRouteConfigSubscription*>(rds_callbacks_);
-  auto config_impl_pointer = rds_subscription->routeConfigProvider().value()->config();
+  auto config_impl_pointer = rds_subscription->routeConfigProvider()->config();
   // Now send an invalid config update.
   const std::string invalid_json =
       R"EOF(
@@ -596,7 +596,7 @@ TEST_F(RdsImplTest, FailureInvalidConfig) {
       "INVALID_NAME_FOR_route_config");
 
   // Verify that the config is still the old value.
-  ASSERT_EQ(config_impl_pointer, rds_subscription->routeConfigProvider().value()->config());
+  ASSERT_EQ(config_impl_pointer, rds_subscription->routeConfigProvider()->config());
 }
 
 // rds and vhds configurations change together
@@ -714,7 +714,7 @@ TEST_F(RdsImplTest, RdsRouteConfigProviderImplSubscriptionSetup) {
   EXPECT_CALL(init_watcher_, ready());
   RdsRouteConfigSubscription& subscription =
       dynamic_cast<RdsRouteConfigProviderImpl&>(*rds_).subscription();
-  EXPECT_EQ(rds_.get(), subscription.routeConfigProvider().value());
+  EXPECT_EQ(rds_.get(), subscription.routeConfigProvider());
 }
 
 class RdsRouteConfigSubscriptionTest : public RdsTestBase {

--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -88,7 +88,7 @@ vhds:
   Init::ExpectableWatcherImpl init_watcher_;
   Init::TargetHandlePtr init_target_handle_;
   const std::string context_ = "vhds_test";
-  absl::optional<Envoy::Rds::RouteConfigProvider*> provider_;
+  Envoy::Rds::RouteConfigProvider* provider_ = nullptr;
   Protobuf::util::MessageDifferencer messageDifferencer_;
   std::string default_vhds_config_;
   NiceMock<Envoy::Config::MockSubscriptionFactory> subscription_factory_;


### PR DESCRIPTION
Reduce RDS subscription memory overhead by removing unnecessary `absl:optional`

Wrapping a raw pointer in `absl::optional` does not provide much value, but adds extra 8 bytes of memory overhead. A nullptr conveys the same meaning as "no value".

This PR switches `absl::optional<RouteConfigProvider*>` to just `RouteConfigProvider*` and `has_value` checks with checks against nullptr.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
