### PR TITLE
Make Envoy Mobile's C++ targets public

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
         "engine_builder.h",
     ],
     repository = "@envoy",
+    visibility = ["//visibility:public"],
     deps = [
         ":envoy_engine_cc_lib_no_stamp",
         "@envoy//source/common/common:assert_lib",
@@ -88,6 +89,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_engine_cc_lib",
     repository = "@envoy",
+    visibility = ["//visibility:public"],
     deps = [
         ":engine_builder_lib",
         ":envoy_engine_cc_lib_no_stamp",


### PR DESCRIPTION
envoy_engine_cc_lib_no_stamp is insufficient by itself. engine_builder_lib is required because it's the target that exports the engine_builder.h header. And anyone using a stamped binary needs access to envoy_engine_cc_lib.

Signed-off-by: Michael Bradshaw <mjbshaw@google.com>

Commit Message: Make Envoy Mobile's C++ targets public
Additional Description: envoy_engine_cc_lib_no_stamp is insufficient by itself. engine_builder_lib is required because it's the target that exports the engine_builder.h header. And anyone using a stamped binary needs access to envoy_engine_cc_lib.
Risk Level: Low
Testing: None, honestly.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A