### PR TITLE
mobile grpc: expose cancel method on a stream

### DIFF
--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -11,6 +11,7 @@ Breaking changes:
 - kotlin: always use ``getaddrinfo`` DNS resolver. Remove ``addDNSFallbackNameservers``, ``enableDNSFilterUnroutableFamilies``, and ``enableDNSUseSystemResolver`` methods from the Kotlin engine builder. (:issue:`#2618 <2618>`)
 - Envoy Mobile's release builds compile without admin support by default. (``--define=admin_functionality=disabled``) (:issue`#2693 <2693>`)
 - swift/kotlin: remove `gauge`, `timer`, and `distribution` methods from the PulseClient.
+- swift/kotlin: add `cancel` method to `GRPCStream`` type (:issue:`#24780 <24780>`).
 
 Bugfixes:
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
@@ -51,14 +51,17 @@ class GRPCStream(
   }
 
   /**
-   * Close this connection.
+   * Close the stream, wait for the peer to finish before actually closing the stream.
    */
   fun close() {
+    // The gRPC protocol requires the client stream to close with a DATA frame.
+    // More information here:
+    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     underlyingStream.close(ByteBuffer.allocate(0))
   }
 
   /**
-   * Cancel this connection.
+   * Cancel the stream forcefully regardless of whether the peer has more data to send.
    */
   fun cancel() {
     underlyingStream.cancel()

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
@@ -56,4 +56,11 @@ class GRPCStream(
   fun close() {
     underlyingStream.close(ByteBuffer.allocate(0))
   }
+
+  /**
+   * Cancel this connection.
+   */
+  fun cancel() {
+    underlyingStream.cancel()
+  }
 }

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
@@ -51,11 +51,11 @@ class GRPCStream(
   }
 
   /**
-   * Close stream by sending the "end stream" signal to the peer and 
+   * Close stream by sending the "end stream" signal to the peer and
    * then waiting for the peer to finish before actually closing the stream.
    */
   fun close() {
-    // TODO(Augustyniak): Remove the method once `cancel` method is proved 
+    // TODO(Augustyniak): Remove the method once `cancel` method is proved
     // to work fine.
 
     // The gRPC protocol requires the client stream to close with a DATA frame.

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
@@ -51,9 +51,13 @@ class GRPCStream(
   }
 
   /**
-   * Close the stream, wait for the peer to finish before actually closing the stream.
+   * Close stream by sending the "end stream" signal to the peer and 
+   * then waiting for the peer to finish before actually closing the stream.
    */
   fun close() {
+    // TODO(Augustyniak): Remove the method once `cancel` method is proved 
+    // to work fine.
+
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here:
     // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests

--- a/mobile/library/swift/grpc/GRPCStream.swift
+++ b/mobile/library/swift/grpc/GRPCStream.swift
@@ -61,7 +61,7 @@ public final class GRPCStream: NSObject {
     return self
   }
 
-  /// Close this connection.
+  /// Close the stream, wait for the peer to finish before actually closing the stream.
   public func close() {
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here:
@@ -69,7 +69,7 @@ public final class GRPCStream: NSObject {
     self.underlyingStream.close(data: Data())
   }
 
-  /// Cancel this connection.
+  /// Cancel the stream forcefully regardless of whether the peer has more data to send.
   public func cancel() {
     self.underlying.cancel()
   }

--- a/mobile/library/swift/grpc/GRPCStream.swift
+++ b/mobile/library/swift/grpc/GRPCStream.swift
@@ -68,4 +68,9 @@ public final class GRPCStream: NSObject {
     // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     self.underlyingStream.close(data: Data())
   }
+
+  /// Cancel this connection.
+  public func cancel() {
+    self.underlying.cancel()
+  }
 }

--- a/mobile/library/swift/grpc/GRPCStream.swift
+++ b/mobile/library/swift/grpc/GRPCStream.swift
@@ -64,6 +64,9 @@ public final class GRPCStream: NSObject {
   /// Close stream by sending the "end stream" signal to the peer and 
   /// then waiting for the peer to finish before actually closing the stream.
   public func close() {
+    // TODO(Augustyniak): Remove the method once `cancel` method is proved 
+    // to work fine.
+
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here:
     // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
@@ -72,6 +75,6 @@ public final class GRPCStream: NSObject {
 
   /// Cancel the stream forcefully regardless of whether the peer has more data to send.
   public func cancel() {
-    self.underlying.cancel()
+    self.underlyingStream.cancel()
   }
 }

--- a/mobile/library/swift/grpc/GRPCStream.swift
+++ b/mobile/library/swift/grpc/GRPCStream.swift
@@ -61,7 +61,8 @@ public final class GRPCStream: NSObject {
     return self
   }
 
-  /// Close the stream, wait for the peer to finish before actually closing the stream.
+  /// Close stream by sending the "end stream" signal to the peer and 
+  /// then waiting for the peer to finish before actually closing the stream.
   public func close() {
     // The gRPC protocol requires the client stream to close with a DATA frame.
     // More information here:

--- a/mobile/library/swift/grpc/GRPCStream.swift
+++ b/mobile/library/swift/grpc/GRPCStream.swift
@@ -61,10 +61,10 @@ public final class GRPCStream: NSObject {
     return self
   }
 
-  /// Close stream by sending the "end stream" signal to the peer and 
+  /// Close stream by sending the "end stream" signal to the peer and
   /// then waiting for the peer to finish before actually closing the stream.
   public func close() {
-    // TODO(Augustyniak): Remove the method once `cancel` method is proved 
+    // TODO(Augustyniak): Remove the method once `cancel` method is proved
     // to work fine.
 
     // The gRPC protocol requires the client stream to close with a DATA frame.

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -101,6 +101,20 @@ envoy_mobile_jni_kt_test(
 )
 
 envoy_mobile_jni_kt_test(
+    name = "cancel_grpc_stream_test",
+    srcs = [
+        "CancelGRPCStreamTest.kt",
+    ],
+    native_deps = [
+        "//library/common/jni:libjava_jni_lib.so",
+        "//library/common/jni:java_jni_lib.jnilib",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
+)
+
+envoy_mobile_jni_kt_test(
     name = "reset_connectivity_state_test",
     srcs = [
         "ResetConnectivityStateTest.kt",

--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -1,0 +1,155 @@
+package test.kotlin.integration
+
+import io.envoyproxy.envoymobile.Custom
+import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.EnvoyError
+import io.envoyproxy.envoymobile.FilterDataStatus
+import io.envoyproxy.envoymobile.FilterHeadersStatus
+import io.envoyproxy.envoymobile.FilterTrailersStatus
+import io.envoyproxy.envoymobile.FinalStreamIntel
+import io.envoyproxy.envoymobile.GRPCClient
+import io.envoyproxy.envoymobile.GRPCRequestHeadersBuilder
+import io.envoyproxy.envoymobile.RequestMethod
+import io.envoyproxy.envoymobile.ResponseFilter
+import io.envoyproxy.envoymobile.ResponseHeaders
+import io.envoyproxy.envoymobile.ResponseTrailers
+import io.envoyproxy.envoymobile.StreamIntel
+import io.envoyproxy.envoymobile.engine.JniLibrary
+import java.nio.ByteBuffer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+private const val emhcmType =
+  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
+private const val lefType =
+  "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+private const val filterName = "cancel_validation_filter"
+private val remotePort = (10001..11000).random()
+private val config =
+"""
+static_resources:
+  listeners:
+  - name: base_api_listener
+    address:
+      socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
+    api_listener:
+      api_listener:
+        "@type": $emhcmType
+        config:
+          stat_prefix: api_hcm
+          route_config:
+            name: api_router
+            virtual_hosts:
+            - name: api
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: fake_remote }
+          http_filters:
+          - name: envoy.filters.http.local_error
+            typed_config:
+              "@type": $lefType
+          - name: envoy.filters.http.platform_bridge
+            typed_config:
+              "@type": $pbfType
+              platform_filter_name: $filterName
+          - name: envoy.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: fake_remote
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: fake_remote
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address: { address: 127.0.0.1, port_value: $remotePort }
+"""
+
+class CancelStreamTest {
+
+  init {
+    JniLibrary.loadTestLibrary()
+  }
+
+  private val filterExpectation = CountDownLatch(1)
+  private val runExpectation = CountDownLatch(1)
+
+  class CancelValidationFilter(
+    private val latch: CountDownLatch
+  ) : ResponseFilter {
+    override fun onResponseHeaders(
+      headers: ResponseHeaders,
+      endStream: Boolean,
+      streamIntel: StreamIntel
+    ): FilterHeadersStatus<ResponseHeaders> {
+      return FilterHeadersStatus.Continue(headers)
+    }
+
+    override fun onResponseData(
+      body: ByteBuffer,
+      endStream: Boolean,
+      streamIntel: StreamIntel
+    ): FilterDataStatus<ResponseHeaders> {
+      return FilterDataStatus.Continue(body)
+    }
+
+    override fun onResponseTrailers(
+      trailers: ResponseTrailers,
+      streamIntel: StreamIntel
+    ): FilterTrailersStatus<ResponseHeaders, ResponseTrailers> {
+      return FilterTrailersStatus.Continue(trailers)
+    }
+
+    override fun onError(error: EnvoyError, finalStreamIntel: FinalStreamIntel) {}
+    override fun onComplete(finalStreamIntel: FinalStreamIntel) {}
+
+    override fun onCancel(finalStreamIntel: FinalStreamIntel) {
+      latch.countDown()
+    }
+  }
+
+  @Test
+  fun `cancel grpc stream calls onCancel callback`() {
+    val engine = EngineBuilder(Custom(config))
+      .addPlatformFilter(
+        name = "cancel_validation_filter",
+        factory = { CancelValidationFilter(filterExpectation) }
+      )
+      .setOnEngineRunning {}
+      .build()
+
+    val client = GRPCClient(engine.streamClient())
+
+    val requestHeaders = GRPCRequestHeadersBuilder(
+      scheme = "https",
+      authority = "example.com",
+      path = "/test"
+    )
+      .build()
+
+    client.newGRPCStreamPrototype()
+      .setOnCancel { _ ->
+        runExpectation.countDown()
+      }
+      .start(Executors.newSingleThreadExecutor())
+      .sendHeaders(requestHeaders, false)
+      .cancel()
+
+    filterExpectation.await(10, TimeUnit.SECONDS)
+    runExpectation.await(10, TimeUnit.SECONDS)
+
+    engine.terminate()
+
+    assertThat(filterExpectation.count).isEqualTo(0)
+    assertThat(runExpectation.count).isEqualTo(0)
+  }
+}

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
@@ -97,7 +97,7 @@ class GRPCStreamTest {
   fun `cancel calls a stream callback`() {
     val countDownLatch = CountDownLatch(1)
     val streamClient = MockStreamClient { stream ->
-      stream.onCancel = { 
+      stream.onCancel = {
         countDownLatch.countDown()
       }
     }

--- a/mobile/test/swift/GRPCStreamTests.swift
+++ b/mobile/test/swift/GRPCStreamTests.swift
@@ -83,6 +83,20 @@ final class GRPCStreamTests: XCTestCase {
     XCTAssertEqual(Data(), closedData)
   }
 
+  func testCancelCallsStreamCallback() {
+    let expectation = self.expectation(description: "onCancel callback is called")
+    let streamClient = MockStreamClient { stream in
+      stream.onCancel = expectation.fulfill
+    }
+
+    GRPCClient(streamClient: streamClient)
+      .newGRPCStreamPrototype()
+      .start()
+      .cancel()
+
+    self.waitForExpectations(timeout: 0.1)
+  }
+
   // MARK: - Response tests
 
   func testHeadersCallbackPassesHeaders() {

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -42,6 +42,21 @@ envoy_mobile_swift_test(
     ],
 )
 
+envoy_mobile_swift_test(
+    name = "cancel_grpc_stream_test",
+    srcs = [
+        "CancelGRPCStreamTest.swift",
+    ],
+    # TODO(jpsim): Fix remote execution for these tests
+    tags = [
+        "no-remote-exec",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
+    ],
+)
+
 envoy_cc_library(
     name = "test_extensions_cc",
     srcs = [

--- a/mobile/test/swift/integration/CancelGRPCStreamTest.swift
+++ b/mobile/test/swift/integration/CancelGRPCStreamTest.swift
@@ -110,7 +110,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: false)
       .cancel()
 
-    let expectations = [filterExpectation, onCancelCallbackExpectation]
+    let expectations = [onCancelCallbackExpectation, filterExpectation]
     XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 3, enforceOrder: true), .completed)
 
     engine.terminate()

--- a/mobile/test/swift/integration/CancelGRPCStreamTest.swift
+++ b/mobile/test/swift/integration/CancelGRPCStreamTest.swift
@@ -1,0 +1,115 @@
+import Envoy
+import EnvoyEngine
+import Foundation
+import XCTest
+
+final class CancelGRPCStreamTests: XCTestCase {
+
+  func testCancelGRPCStream() {
+    let filterName = "cancel_validation_filter"
+    let config =
+"""
+static_resources:
+  listeners:
+  - name: base_api_listener
+    address:
+      socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
+    api_listener:
+      api_listener:
+        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager
+        config:
+          stat_prefix: api_hcm
+          route_config:
+            name: api_router
+            virtual_hosts:
+            - name: api
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: fake_remote }
+          http_filters:
+          - name: envoy.filters.http.local_error
+            typed_config:
+              "@type": type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError
+          - name: envoy.filters.http.platform_bridge
+            typed_config:
+              "@type": type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge
+              platform_filter_name: \(filterName)
+          - name: envoy.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: fake_remote
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: fake_remote
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address: { address: 127.0.0.1, port_value: \(Int.random(in: 10001...11000)) }
+"""
+
+    struct CancelValidationFilter: ResponseFilter {
+      let expectation: XCTestExpectation
+
+      func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool, streamIntel: StreamIntel)
+        -> FilterHeadersStatus<ResponseHeaders>
+      {
+        return .continue(headers: headers)
+      }
+
+      func onResponseData(_ body: Data, endStream: Bool, streamIntel: StreamIntel)
+        -> FilterDataStatus<ResponseHeaders>
+      {
+        return .continue(data: body)
+      }
+
+      func onResponseTrailers(_ trailers: ResponseTrailers, streamIntel: StreamIntel)
+          -> FilterTrailersStatus<ResponseHeaders, ResponseTrailers> {
+        return .continue(trailers: trailers)
+      }
+
+      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
+
+      func onCancel(streamIntel: FinalStreamIntel) {
+        self.expectation.fulfill()
+      }
+
+      func onComplete(streamIntel: FinalStreamIntel) {}
+    }
+
+    let onCancelCallbackExpectation = self.expectation(description: "onCancel callback called")
+    let filterExpectation = self.expectation(description: "Filter called with cancellation")
+
+    let engine = EngineBuilder(yaml: config)
+      .addLogLevel(.trace)
+      .addPlatformFilter(
+        name: filterName,
+        factory: { CancelValidationFilter(expectation: filterExpectation) }
+      )
+      .build()
+
+    let client = GRPCClient(streamClient: engine.streamClient())
+
+    let requestHeaders = GRPCRequestHeadersBuilder(
+        scheme: "https",
+        authority: "example.com", path: "/test")
+      .build()
+
+    client
+      .newGRPCStreamPrototype()
+      .setOnCancel { _ in
+         onCancelCallbackExpectation.fulfill()
+      }
+      .start()
+      .sendHeaders(requestHeaders, endStream: false)
+      .cancel()
+
+    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, onCancelCallbackExpectation], timeout: 3), .completed)
+
+    engine.terminate()
+  }
+}

--- a/mobile/test/swift/integration/CancelGRPCStreamTest.swift
+++ b/mobile/test/swift/integration/CancelGRPCStreamTest.swift
@@ -4,9 +4,10 @@ import Foundation
 import XCTest
 
 final class CancelGRPCStreamTests: XCTestCase {
-
   func testCancelGRPCStream() {
     let filterName = "cancel_validation_filter"
+
+// swiftlint:disable line_length
     let config =
 """
 static_resources:
@@ -51,6 +52,7 @@ static_resources:
             address:
               socket_address: { address: 127.0.0.1, port_value: \(Int.random(in: 10001...11000)) }
 """
+// swiftlint:enable line_length
 
     struct CancelValidationFilter: ResponseFilter {
       let expectation: XCTestExpectation
@@ -108,7 +110,8 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: false)
       .cancel()
 
-    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, onCancelCallbackExpectation], timeout: 3), .completed)
+    let expectations = [filterExpectation, onCancelCallbackExpectation]
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 3, enforceOrder: true), .completed)
 
     engine.terminate()
   }


### PR DESCRIPTION
Commit Message: Expose `cancel` method on a gRPC stream.
Additional Description:
Risk Level: Low, new API
Testing: Unit/integration tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
