### PR TITLE
Move the copt for ABSL_FLAGS_STRIP_NAMES from the .bazelrc to the appropriate BUILD file

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -34,9 +34,6 @@ build --define cxxopts=-std=c++17
 build --features=-per_object_debug_info
 # Suppress deprecated declaration warnings due to extensive transitive noise from protobuf.
 build --copt -Wno-deprecated-declarations
-# Abseil Flag literals are compiled out by default on mobile platforms. These flags are needed for
-# Envoy's runtime system. This option prevents them from being compiled out.
-build --copt -DABSL_FLAGS_STRIP_NAMES=0
 
 build:rules_xcodeproj --config=ios
 build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -17,6 +17,18 @@ envoy_cc_library(
     hdrs = [
         "runtime_features.h",
     ],
+    # ABSL_FLAGS_STRIP_NAMES controls the behavior of the ABSL_FLAG
+    # macro. By default, it is defined on mobile platforms and false elsewhere.
+    # When defined, it causes flags to be registered in the global flag registry,
+    # which is required for Envoy runtime flags to work. By forcing this to be
+    # defined in source/common/runtime:runtime_features_lib, we ensure that
+    # even on mobile, runtime features work correctly since the ABSL_FLAGS
+    # which control them live in that target. This does NOT cause ABSL_FLAGS
+    # defined in other targets to be added to the registry, but that does not
+    # affect Envoy's usage.
+    copts = [
+        "-DABSL_FLAGS_STRIP_NAMES=0",
+    ],
     deps = [
         # AVOID ADDING TO THESE DEPENDENCIES IF POSSIBLE
         # Any code using runtime guards depends on this library, and the more dependencies there are,


### PR DESCRIPTION
Move the copt for ABSL_FLAGS_STRIP_NAMES from the .bazelrc to the appropriate BUILD file

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A