### PR TITLE
bazel: fix missing framework on macOS

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -54,7 +54,12 @@ def envoy_cc_binary(
 # Compute the final linkopts based on various options.
 def _envoy_linkopts():
     return select({
-        "@envoy//bazel:apple": [],
+        "@envoy//bazel:apple": [
+            # https://github.com/envoyproxy/envoy/issues/24782
+            "-Wl,-framework,CoreFoundation",
+            # https://github.com/bazelbuild/bazel/pull/16414
+            "-Wl,-undefined,error",
+        ],
         "@envoy//bazel:windows_opt_build": [
             "-DEFAULTLIB:ws2_32.lib",
             "-DEFAULTLIB:iphlpapi.lib",


### PR DESCRIPTION
When using only the command line tools (not a full Xcode installation) on macOS, bazel does not pass `-fobjc-link-runtime` and therefore does not link to the CoreFoundation framework, which is required by absl. This adds the required framework, and makes this a linker error instead of a runtime error for the future.

Fixes https://github.com/envoyproxy/envoy/issues/24782

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>