### PR TITLE
docs: Fix format issue

### DIFF
--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -34,8 +34,12 @@ sudo-with-permissions (e.g. sudo setcap cap_bpf+ep). If multiple worker threads 
 log a warning on start-up if BPF is unsupported on the platform, or is attempted and fails.
 
 It is recommanded to monitor some UDP listener and QUIC connection stats:
-* :repo:`UDP listener downstream_rx_datagram_dropped </docs/root/configuration/listeners/stats.rst#udp-statistics>`: non-zero means kernel's UDP listen socket's receive buffer isn't large enough. In Linux, it can be configured via listener :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>` by setting prebinding socket option SO_RCVBUF at SOL_SOCKET level.
-* :repo:`QUIC connection error codes and stream reset error codes </docs/root/configuration/http/http_conn_man/stats.rst#http3-per-listener-statistics>`: please refer to `quic_error_codes.h <https://github.com/google/quiche/blob/main/quiche/quic/core/quic_error_codes.h>`_ for the meaning of each error code.
+
+* :repo:`UDP listener downstream_rx_datagram_dropped </docs/root/configuration/listeners/stats.rst#udp-statistics>`: non-zero means kernel's UDP
+  listen socket's receive buffer isn't large enough. In Linux, it can be configured via listener :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>`
+  by setting prebinding socket option SO_RCVBUF at SOL_SOCKET level.
+* :repo:`QUIC connection error codes and stream reset error codes </docs/root/configuration/http/http_conn_man/stats.rst#http3-per-listener-statistics>`: please
+  refer to `quic_error_codes.h <https://github.com/google/quiche/blob/main/quiche/quic/core/quic_error_codes.h>`_ for the meaning of each error code.
 
 HTTP3 upstream
 --------------


### PR DESCRIPTION
Commit Message:

This patch fixes a tiny format issue in [HTTP3 overview](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http3#http3-overview).
The bullet point seems not working due to missing a break line.

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
