### PR TITLE
docs: Fix the invalid end of table

### DIFF
--- a/docs/root/configuration/listeners/stats.rst
+++ b/docs/root/configuration/listeners/stats.rst
@@ -83,7 +83,7 @@ on either accepted or active connections.
    downstream_cx_total, Counter, Total connections on this handler.
    downstream_cx_active, Gauge, Total active connections on this handler.
 
-   .. _config_listener_manager_stats:
+.. _config_listener_manager_stats:
 
 Listener manager
 ----------------


### PR DESCRIPTION
Commit Message:

This patch fixes a tiny format issue in [Per-handler Listener Stats](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/stats#per-handler-listener-stats).
The table has two empty rows (please find the rows under `downstream_cx_active`) due to invalid table end line.

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a