### PR TITLE
[backport/1.24] Pass correct init manager to the secret manager (#23356)

### DIFF
--- a/contrib/sxg/filters/http/source/config.cc
+++ b/contrib/sxg/filters/http/source/config.cc
@@ -23,10 +23,11 @@ namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
                 Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory) {
+                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Init::Manager& init_manager) {
   if (config.has_sds_config()) {
     return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory);
+                                                            transport_socket_factory, init_manager);
   } else {
     return secret_manager.findStaticGenericSecretProvider(config.name());
   }
@@ -43,12 +44,12 @@ Http::FilterFactoryCb FilterFactory::createFilterFactoryFromProtoTyped(
   auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
   auto& transport_socket_factory = context.getTransportSocketFactoryContext();
   auto secret_provider_certificate =
-      secretsProvider(certificate, secret_manager, transport_socket_factory);
+      secretsProvider(certificate, secret_manager, transport_socket_factory, context.initManager());
   if (secret_provider_certificate == nullptr) {
     throw EnvoyException("invalid certificate secret configuration");
   }
   auto secret_provider_private_key =
-      secretsProvider(private_key, secret_manager, transport_socket_factory);
+      secretsProvider(private_key, secret_manager, transport_socket_factory, context.initManager());
   if (secret_provider_private_key == nullptr) {
     throw EnvoyException("invalid private_key secret configuration");
   }

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -32,7 +32,7 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
   // This returns non-nullptr for certificate and private_key.
   auto& secret_manager = context.cluster_manager_.cluster_manager_factory_.secretManager();
   if (is_sds_config) {
-    ON_CALL(secret_manager, findOrCreateGenericSecretProvider(_, _, _))
+    ON_CALL(secret_manager, findOrCreateGenericSecretProvider(_, _, _, _))
         .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
             envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
   } else {
@@ -45,6 +45,7 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context, timeSource());
   EXPECT_CALL(context, api());
+  EXPECT_CALL(context, initManager()).Times(2);
   EXPECT_CALL(context, getTransportSocketFactoryContext());
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/contrib/sxg/filters/http/test/filter_test.cc
+++ b/contrib/sxg/filters/http/test/filter_test.cc
@@ -367,17 +367,17 @@ TEST_F(FilterTest, SdsDynamicGenericSecret) {
   EXPECT_CALL(secret_context, api()).WillRepeatedly(ReturnRef(*api));
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(init_manager, add(_))
       .WillRepeatedly(Invoke([&init_handle](const Init::Target& target) {
         init_handle = target.createHandle("test");
       }));
 
   auto certificate_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "certificate", secret_context);
+      config_source, "certificate", secret_context, init_manager);
   auto certificate_callback = secret_context.cluster_manager_.subscription_factory_.callbacks_;
   auto private_key_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "private_key", secret_context);
+      config_source, "private_key", secret_context, init_manager);
   auto private_key_callback = secret_context.cluster_manager_.subscription_factory_.callbacks_;
 
   SDSSecretReader secret_reader(certificate_secret_provider, private_key_secret_provider, *api);

--- a/envoy/secret/secret_manager.h
+++ b/envoy/secret/secret_manager.h
@@ -107,7 +107,8 @@ public:
    */
   virtual TlsCertificateConfigProviderSharedPtr findOrCreateTlsCertificateProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) PURE;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) PURE;
 
   /**
    * Finds and returns a dynamic secret provider associated to SDS config. Create
@@ -123,7 +124,8 @@ public:
   virtual CertificateValidationContextConfigProviderSharedPtr
   findOrCreateCertificateValidationContextProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) PURE;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) PURE;
 
   /**
    * Finds and returns a dynamic secret provider associated to SDS config. Create
@@ -139,7 +141,8 @@ public:
   virtual TlsSessionTicketKeysConfigProviderSharedPtr
   findOrCreateTlsSessionTicketKeysContextProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) PURE;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) PURE;
 
   /**
    * Finds and returns a dynamic secret provider associated to SDS config. Create a new one if such
@@ -153,7 +156,8 @@ public:
    */
   virtual GenericSecretConfigProviderSharedPtr findOrCreateGenericSecretProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) PURE;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) PURE;
 };
 
 using SecretManagerPtr = std::unique_ptr<SecretManager>;

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -124,32 +124,36 @@ GenericSecretConfigProviderSharedPtr SecretManagerImpl::createInlineGenericSecre
 
 TlsCertificateConfigProviderSharedPtr SecretManagerImpl::findOrCreateTlsCertificateProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context) {
+    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+    Init::Manager& init_manager) {
   return certificate_providers_.findOrCreate(sds_config_source, config_name,
-                                             secret_provider_context);
+                                             secret_provider_context, init_manager);
 }
 
 CertificateValidationContextConfigProviderSharedPtr
 SecretManagerImpl::findOrCreateCertificateValidationContextProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context) {
+    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+    Init::Manager& init_manager) {
   return validation_context_providers_.findOrCreate(sds_config_source, config_name,
-                                                    secret_provider_context);
+                                                    secret_provider_context, init_manager);
 }
 
 TlsSessionTicketKeysConfigProviderSharedPtr
 SecretManagerImpl::findOrCreateTlsSessionTicketKeysContextProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context) {
+    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+    Init::Manager& init_manager) {
   return session_ticket_keys_providers_.findOrCreate(sds_config_source, config_name,
-                                                     secret_provider_context);
+                                                     secret_provider_context, init_manager);
 }
 
 GenericSecretConfigProviderSharedPtr SecretManagerImpl::findOrCreateGenericSecretProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::TransportSocketFactoryContext& secret_provider_context) {
+    Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+    Init::Manager& init_manager) {
   return generic_secret_providers_.findOrCreate(sds_config_source, config_name,
-                                                secret_provider_context);
+                                                secret_provider_context, init_manager);
 }
 
 ProtobufTypes::MessagePtr

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -52,20 +52,24 @@ public:
 
   TlsCertificateConfigProviderSharedPtr findOrCreateTlsCertificateProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) override;
 
   CertificateValidationContextConfigProviderSharedPtr
   findOrCreateCertificateValidationContextProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) override;
 
   TlsSessionTicketKeysConfigProviderSharedPtr findOrCreateTlsSessionTicketKeysContextProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) override;
 
   GenericSecretConfigProviderSharedPtr findOrCreateGenericSecretProvider(
       const envoy::config::core::v3::ConfigSource& config_source, const std::string& config_name,
-      Server::Configuration::TransportSocketFactoryContext& secret_provider_context) override;
+      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+      Init::Manager& init_manager) override;
 
 private:
   ProtobufTypes::MessagePtr dumpSecretConfigs(const Matchers::StringMatcher& name_matcher);
@@ -77,7 +81,8 @@ private:
     std::shared_ptr<SecretType>
     findOrCreate(const envoy::config::core::v3::ConfigSource& sds_config_source,
                  const std::string& config_name,
-                 Server::Configuration::TransportSocketFactoryContext& secret_provider_context) {
+                 Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+                 Init::Manager& init_manager) {
       const std::string map_key =
           absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name);
 
@@ -95,7 +100,16 @@ private:
       // It is important to add the init target to the manager regardless the secret provider is new
       // or existing. Different clusters / listeners can share same secret so they have to be marked
       // warming correctly.
-      secret_provider_context.initManager().add(*secret_provider->initTarget());
+
+      // Note that we are not using secret_provider_context's init manager because in some cases,
+      // for example oauth2 filter with sds config, it could be server's init manager. In oauth2
+      // filter example, if the filter config is dynamic, it could be received from xds server when
+      // the server's init manager is already in the initialized state. In that situation, adding
+      // init target to the initialized init manager will lead to assertion failure.
+      //
+      // It is expected that correct init manager will be passed to this method by the caller
+      // separately.
+      init_manager.add(*secret_provider->initTarget());
       return secret_provider;
     }
 

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -26,10 +26,11 @@ namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
                 Secret::SecretManager& secret_manager,
-                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory) {
+                Server::Configuration::TransportSocketFactoryContext& transport_socket_factory,
+                Init::Manager& init_manager) {
   if (config.has_sds_config()) {
     return secret_manager.findOrCreateGenericSecretProvider(config.sds_config(), config.name(),
-                                                            transport_socket_factory);
+                                                            transport_socket_factory, init_manager);
   } else {
     return secret_manager.findStaticGenericSecretProvider(config.name());
   }
@@ -52,13 +53,13 @@ Http::FilterFactoryCb OAuth2Config::createFilterFactoryFromProtoTyped(
   auto& cluster_manager = context.clusterManager();
   auto& secret_manager = cluster_manager.clusterManagerFactory().secretManager();
   auto& transport_socket_factory = context.getTransportSocketFactoryContext();
-  auto secret_provider_token_secret =
-      secretsProvider(token_secret, secret_manager, transport_socket_factory);
+  auto secret_provider_token_secret = secretsProvider(
+      token_secret, secret_manager, transport_socket_factory, context.initManager());
   if (secret_provider_token_secret == nullptr) {
     throw EnvoyException("invalid token secret configuration");
   }
   auto secret_provider_hmac_secret =
-      secretsProvider(hmac_secret, secret_manager, transport_socket_factory);
+      secretsProvider(hmac_secret, secret_manager, transport_socket_factory, context.initManager());
   if (secret_provider_hmac_secret == nullptr) {
     throw EnvoyException("invalid HMAC secret configuration");
   }

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -43,7 +43,8 @@ std::vector<Secret::TlsCertificateConfigProviderSharedPtr> getTlsCertificateConf
       if (sds_secret_config.has_sds_config()) {
         // Fetch dynamic secret.
         providers.push_back(factory_context.secretManager().findOrCreateTlsCertificateProvider(
-            sds_secret_config.sds_config(), sds_secret_config.name(), factory_context));
+            sds_secret_config.sds_config(), sds_secret_config.name(), factory_context,
+            factory_context.initManager()));
       } else {
         // Load static secret.
         auto secret_provider = factory_context.secretManager().findStaticTlsCertificateProvider(
@@ -65,7 +66,8 @@ Secret::CertificateValidationContextConfigProviderSharedPtr getProviderFromSds(
   if (sds_secret_config.has_sds_config()) {
     // Fetch dynamic secret.
     return factory_context.secretManager().findOrCreateCertificateValidationContextProvider(
-        sds_secret_config.sds_config(), sds_secret_config.name(), factory_context);
+        sds_secret_config.sds_config(), sds_secret_config.name(), factory_context,
+        factory_context.initManager());
   } else {
     // Load static secret.
     auto secret_provider =
@@ -128,7 +130,8 @@ Secret::TlsSessionTicketKeysConfigProviderSharedPtr getTlsSessionTicketKeysConfi
     if (sds_secret_config.has_sds_config()) {
       // Fetch dynamic secret.
       return factory_context.secretManager().findOrCreateTlsSessionTicketKeysContextProvider(
-          sds_secret_config.sds_config(), sds_secret_config.name(), factory_context);
+          sds_secret_config.sds_config(), sds_secret_config.name(), factory_context,
+          factory_context.initManager());
     } else {
       // Load static secret.
       auto secret_provider =

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -278,7 +278,7 @@ TEST_F(SecretManagerImplTest, DeduplicateDynamicTlsCertificateSecretProvider) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
@@ -305,8 +305,8 @@ api_config_source:
       ->mutable_typed_config()
       ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
                                  "C90b2tlbhILeC10b2tlbi1iaW4="));
-  auto secret_provider1 =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider1 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
 
   // The base64 encoded proto binary is identical to the one above, but in different field order.
   // It is also identical to the YAML below.
@@ -318,8 +318,8 @@ api_config_source:
       ->mutable_typed_config()
       ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
                                  "2VydmljZWFjY291bnQvdG9rZW4="));
-  auto secret_provider2 =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider2 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
 
   API_NO_BOOST(envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig)
   file_based_metadata_config;
@@ -336,8 +336,8 @@ secret_data:
       ->mutable_from_plugin()
       ->mutable_typed_config()
       ->PackFrom(file_based_metadata_config);
-  auto secret_provider3 =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider3 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
 
   EXPECT_EQ(secret_provider1, secret_provider2);
   EXPECT_EQ(secret_provider2, secret_provider3);
@@ -361,13 +361,13 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretUpdateSuccess) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillOnce(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(*dispatcher_));
   EXPECT_CALL(secret_context, localInfo()).WillOnce(ReturnRef(local_info));
   EXPECT_CALL(secret_context, api()).WillRepeatedly(ReturnRef(*api_));
 
-  auto secret_provider =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"
@@ -411,7 +411,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicGenericSecret) {
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(*dispatcher_));
   EXPECT_CALL(secret_context, messageValidationVisitor()).WillOnce(ReturnRef(validation_visitor));
   EXPECT_CALL(secret_context, stats()).WillOnce(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, localInfo()).WillOnce(ReturnRef(local_info));
   EXPECT_CALL(secret_context, api()).WillRepeatedly(ReturnRef(*api_));
   EXPECT_CALL(init_manager, add(_))
@@ -420,7 +420,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicGenericSecret) {
       }));
 
   auto secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "encryption_key", secret_context);
+      config_source, "encryption_key", secret_context, init_manager);
 
   const std::string yaml = R"EOF(
 name: "encryption_key"
@@ -460,12 +460,12 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandler) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
-  auto secret_provider =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"
@@ -516,7 +516,7 @@ dynamic_active_secrets:
   // Add a dynamic tls validation context provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto context_secret_provider = secret_manager->findOrCreateCertificateValidationContextProvider(
-      config_source, "abc.com.validation", secret_context);
+      config_source, "abc.com.validation", secret_context, init_manager);
   const std::string validation_yaml = R"EOF(
 name: "abc.com.validation"
 validation_context:
@@ -568,7 +568,7 @@ dynamic_active_secrets:
   // Add a dynamic tls session ticket encryption keys context provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto stek_secret_provider = secret_manager->findOrCreateTlsSessionTicketKeysContextProvider(
-      config_source, "abc.com.stek", secret_context);
+      config_source, "abc.com.stek", secret_context, init_manager);
   const std::string stek_yaml = R"EOF(
 name: "abc.com.stek"
 session_ticket_keys:
@@ -634,7 +634,7 @@ dynamic_active_secrets:
   // Add a dynamic generic secret provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567900000));
   auto generic_secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "signing_key", secret_context);
+      config_source, "signing_key", secret_context, init_manager);
 
   const std::string generic_secret_yaml = R"EOF(
 name: "signing_key"
@@ -730,12 +730,12 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandlerWarmingSecrets) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
-  auto secret_provider =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
   const std::string expected_secrets_config_dump = R"EOF(
 dynamic_warming_secrets:
 - name: "abc.com"
@@ -754,7 +754,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto context_secret_provider = secret_manager->findOrCreateCertificateValidationContextProvider(
-      config_source, "abc.com.validation", secret_context);
+      config_source, "abc.com.validation", secret_context, init_manager);
   init_target_handle->initialize(init_watcher);
   const std::string updated_config_dump = R"EOF(
 dynamic_warming_secrets:
@@ -781,7 +781,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567899000));
   auto stek_secret_provider = secret_manager->findOrCreateTlsSessionTicketKeysContextProvider(
-      config_source, "abc.com.stek", secret_context);
+      config_source, "abc.com.stek", secret_context, init_manager);
   init_target_handle->initialize(init_watcher);
   const std::string updated_once_more_config_dump = R"EOF(
 dynamic_warming_secrets:
@@ -816,7 +816,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567900000));
   auto generic_secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "signing_key", secret_context);
+      config_source, "signing_key", secret_context, init_manager);
   init_target_handle->initialize(init_watcher);
   const std::string config_dump_with_generic_secret = R"EOF(
 dynamic_warming_secrets:
@@ -878,7 +878,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandlerStaticSecrets) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
@@ -955,7 +955,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandlerStaticValidationContext) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
@@ -1003,7 +1003,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandlerStaticSessionTicketsContext) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
@@ -1084,13 +1084,13 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretPrivateKeyProviderUpdateSuccess) {
         init_target_handle = target.createHandle("test");
       }));
   EXPECT_CALL(secret_context, stats()).WillOnce(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(*dispatcher_));
   EXPECT_CALL(secret_context, localInfo()).WillOnce(ReturnRef(local_info));
   EXPECT_CALL(secret_context, api()).WillRepeatedly(ReturnRef(*api_));
 
-  auto secret_provider =
-      secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
+  auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -126,6 +126,7 @@ config:
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context, timeSource());
   EXPECT_CALL(context, api());
+  EXPECT_CALL(context, initManager()).Times(2);
   EXPECT_CALL(context, getTransportSocketFactoryContext());
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -212,17 +212,17 @@ TEST_F(OAuth2Test, SdsDynamicGenericSecret) {
   EXPECT_CALL(secret_context, api()).WillRepeatedly(ReturnRef(*api));
   EXPECT_CALL(secret_context, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher));
   EXPECT_CALL(secret_context, stats()).WillRepeatedly(ReturnRef(stats));
-  EXPECT_CALL(secret_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(secret_context, initManager()).Times(0);
   EXPECT_CALL(init_manager, add(_))
       .WillRepeatedly(Invoke([&init_handle](const Init::Target& target) {
         init_handle = target.createHandle("test");
       }));
 
-  auto client_secret_provider =
-      secret_manager.findOrCreateGenericSecretProvider(config_source, "client", secret_context);
+  auto client_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
+      config_source, "client", secret_context, init_manager);
   auto client_callback = secret_context.cluster_manager_.subscription_factory_.callbacks_;
-  auto token_secret_provider =
-      secret_manager.findOrCreateGenericSecretProvider(config_source, "token", secret_context);
+  auto token_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
+      config_source, "token", secret_context, init_manager);
   auto token_callback = secret_context.cluster_manager_.subscription_factory_.callbacks_;
 
   SDSSecretReader secret_reader(client_secret_provider, token_secret_provider, *api);

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -16,13 +16,14 @@ namespace HttpFilters {
 namespace Oauth2 {
 namespace {
 
-class OauthIntegrationTest : public testing::Test, public HttpIntegrationTest {
+class OauthIntegrationTest : public HttpIntegrationTest,
+                             public Grpc::GrpcClientIntegrationParamTest {
 public:
   OauthIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP2, Network::Address::IpVersion::v4) {
+    skip_tag_extraction_rule_check_ = true;
     enableHalfClose(true);
   }
-
   envoy::service::discovery::v3::DiscoveryResponse genericSecretResponse(absl::string_view name,
                                                                          absl::string_view value) {
     envoy::extensions::transport_sockets::tls::v3::Secret secret;
@@ -36,8 +37,84 @@ public:
     return response_pb;
   }
 
+  void createLdsStream() {
+    AssertionResult result =
+        fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, lds_connection_);
+    EXPECT_TRUE(result);
+
+    auto result2 = lds_connection_->waitForNewStream(*dispatcher_, lds_stream_);
+    EXPECT_TRUE(result2);
+    lds_stream_->startGrpcStream();
+    ASSERT_NE(nullptr, lds_stream_);
+  }
+
+  void sendLdsResponse(const std::vector<envoy::config::listener::v3::Listener>& listener_configs,
+                       const std::string& version) {
+    envoy::service::discovery::v3::DiscoveryResponse response;
+    response.set_version_info(version);
+    response.set_type_url(Config::TypeUrl::get().Listener);
+    for (const auto& listener_config : listener_configs) {
+      response.add_resources()->PackFrom(listener_config);
+    }
+    ASSERT_NE(nullptr, lds_stream_);
+    lds_stream_->sendGrpcMessage(response);
+  }
+  FakeUpstream& getLdsFakeUpstream() const { return *fake_upstreams_[1]; }
+
+  void sendLdsResponse(const std::vector<std::string>& listener_configs,
+                       const std::string& version) {
+    std::vector<envoy::config::listener::v3::Listener> proto_configs;
+    proto_configs.reserve(listener_configs.size());
+    for (const auto& listener_blob : listener_configs) {
+      proto_configs.emplace_back(
+          TestUtility::parseYaml<envoy::config::listener::v3::Listener>(listener_blob));
+    }
+    sendLdsResponse(proto_configs, version);
+  }
+
+  void setUpGrpcLds() {
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      listener_config_.Swap(bootstrap.mutable_static_resources()->mutable_listeners(0));
+      listener_config_.set_name(listener_name_);
+      bootstrap.mutable_static_resources()->mutable_listeners()->Clear();
+      auto* lds_config_source = bootstrap.mutable_dynamic_resources()->mutable_lds_config();
+      lds_config_source->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+      auto* lds_api_config_source = lds_config_source->mutable_api_config_source();
+      lds_api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+      lds_api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
+      envoy::config::core::v3::GrpcService* grpc_service =
+          lds_api_config_source->add_grpc_services();
+      setGrpcService(*grpc_service, "lds_cluster", getLdsFakeUpstream().localAddress());
+    });
+  }
+
+  void waitForLdsAck() {
+    envoy::service::discovery::v3::DiscoveryRequest sotw_request;
+    EXPECT_TRUE(lds_stream_->waitForGrpcMessage(*dispatcher_, sotw_request));
+    EXPECT_EQ(sotw_request.version_info(), "");
+    EXPECT_TRUE(lds_stream_->waitForGrpcMessage(*dispatcher_, sotw_request));
+    EXPECT_EQ(sotw_request.version_info(), "initial");
+
+    EXPECT_EQ((*test_server_.get()).server().initManager().state(),
+              Init::Manager::State::Initialized);
+  }
+
   void initialize() override {
+    use_lds_ = false; // required for grpc lds
     setUpstreamProtocol(Http::CodecType::HTTP2);
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // Add the static cluster to serve LDS.
+      auto* lds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      lds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      lds_cluster->set_name("lds_cluster");
+      ConfigHelper::setHttp2(*lds_cluster);
+
+      // Add the static cluster to serve RDS.
+      auto* rds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      rds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      rds_cluster->set_name("rds_cluster");
+      ConfigHelper::setHttp2(*rds_cluster);
+    });
 
     TestEnvironment::writeStringToFileForTest("token_secret.yaml", R"EOF(
 resources:
@@ -84,8 +161,18 @@ resources:
     });
 
     setUpstreamCount(2);
-
+    setUpGrpcLds();
     HttpIntegrationTest::initialize();
+    waitForLdsAck();
+    registerTestServerPorts({"http"});
+  }
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+    // Create the LDS upstream (fake_upstreams_[1]).
+    addFakeUpstream(Http::CodecType::HTTP2);
+    // Create the RDS upstream (fake_upstreams_[2]).
+    addFakeUpstream(Http::CodecType::HTTP2);
   }
 
   virtual void setOauthConfig() {
@@ -181,7 +268,7 @@ typed_config:
     request_encoder_ = &encoder_decoder.first;
     auto response = std::move(encoder_decoder.second);
 
-    waitForNextUpstreamRequest(1);
+    waitForNextUpstreamRequest(std::vector<uint64_t>({0, 1, 2, 3}));
 
     ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
 
@@ -211,8 +298,110 @@ typed_config:
   }
 
   const CookieNames default_cookie_names_{"BearerToken", "OauthHMAC", "OauthExpires"};
+  envoy::config::listener::v3::Listener listener_config_;
+  std::string listener_name_{"http"};
+  FakeHttpConnectionPtr lds_connection_;
+  FakeStreamPtr lds_stream_{};
 };
 
+INSTANTIATE_TEST_SUITE_P(IpVersionsAndGrpcTypes, OauthIntegrationTest,
+                         GRPC_CLIENT_INTEGRATION_PARAMS);
+
+// Regular request gets redirected to the login page.
+TEST_P(OauthIntegrationTest, UnauthenticatedFlow) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "initial");
+  };
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/lua/per/route/default"},
+                                         {":scheme", "http"},
+                                         {":authority", "authority"}};
+  auto encoder_decoder = codec_client_->startRequest(headers);
+
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  // We should get an immediate redirect back.
+  response->waitForHeaders();
+  EXPECT_EQ("302", response->headers().getStatusValue());
+}
+
+TEST_P(OauthIntegrationTest, AuthenticationFlow) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "initial");
+  };
+
+  initialize();
+
+  // 1. Do one authentication flow.
+  doAuthenticationFlow("token_secret", "hmac_secret");
+
+  // 2. Reload secrets.
+  EXPECT_EQ(test_server_->counter("sds.token.update_success")->value(), 1);
+  EXPECT_EQ(test_server_->counter("sds.hmac.update_success")->value(), 1);
+  TestEnvironment::renameFile(TestEnvironment::temporaryPath("token_secret_1.yaml"),
+                              TestEnvironment::temporaryPath("token_secret.yaml"));
+  test_server_->waitForCounterEq("sds.token.update_success", 2, std::chrono::milliseconds(5000));
+  TestEnvironment::renameFile(TestEnvironment::temporaryPath("hmac_secret_1.yaml"),
+                              TestEnvironment::temporaryPath("hmac_secret.yaml"));
+  test_server_->waitForCounterEq("sds.hmac.update_success", 2, std::chrono::milliseconds(5000));
+  // 3. Do another one authentication flow.
+  doAuthenticationFlow("token_secret_1", "hmac_secret_1");
+}
+
+// Regression test(issue #22678) where (incorrectly)using server's init manager(initialized state)
+// to add init target by the secret manager led to the assertion failure.
+TEST_P(OauthIntegrationTest, LoadListenerAfterServerIsInitialized) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    envoy::config::listener::v3::Listener listener =
+        TestUtility::parseYaml<envoy::config::listener::v3::Listener>(R"EOF(
+      name: fake_listener
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 0
+      filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              codec_type: HTTP2
+              stat_prefix: config_test
+              route_config:
+                name: route_config_0
+                virtual_hosts:
+                  - name: integration
+                    domains:
+                      - "*"
+                    routes:
+                      - match:
+                          prefix: /
+                        route:
+                          cluster: cluster_0
+              http_filters:
+                - name: envoy.filters.http.router
+        )EOF");
+
+    // dummy listener is being sent so that lds api gets marked as ready, which would
+    // led to server's init manager reach initialized state
+    sendLdsResponse({listener}, "initial");
+  };
+
+  initialize();
+
+  // add listener with oauth2 filter and sds configs
+  sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "delayed");
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 2);
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_warming", 0);
+
+  doAuthenticationFlow("token_secret", "hmac_secret");
+}
 class OauthIntegrationTestWithBasicAuth : public OauthIntegrationTest {
   void setOauthConfig() override {
     config_helper_.prependFilter(TestEnvironment::substitute(R"EOF(
@@ -272,46 +461,15 @@ typed_config:
   }
 };
 
-// Regular request gets redirected to the login page.
-TEST_F(OauthIntegrationTest, UnauthenticatedFlow) {
-  initialize();
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
-                                         {":path", "/lua/per/route/default"},
-                                         {":scheme", "http"},
-                                         {":authority", "authority"}};
-  auto encoder_decoder = codec_client_->startRequest(headers);
-
-  request_encoder_ = &encoder_decoder.first;
-  auto response = std::move(encoder_decoder.second);
-
-  // We should get an immediate redirect back.
-  response->waitForHeaders();
-  EXPECT_EQ("302", response->headers().getStatusValue());
-}
-
-TEST_F(OauthIntegrationTest, AuthenticationFlow) {
-  initialize();
-
-  // 1. Do one authentication flow.
-  doAuthenticationFlow("token_secret", "hmac_secret");
-
-  // 2. Reload secrets.
-  EXPECT_EQ(test_server_->counter("sds.token.update_success")->value(), 1);
-  EXPECT_EQ(test_server_->counter("sds.hmac.update_success")->value(), 1);
-  TestEnvironment::renameFile(TestEnvironment::temporaryPath("token_secret_1.yaml"),
-                              TestEnvironment::temporaryPath("token_secret.yaml"));
-  test_server_->waitForCounterEq("sds.token.update_success", 2, std::chrono::milliseconds(5000));
-  TestEnvironment::renameFile(TestEnvironment::temporaryPath("hmac_secret_1.yaml"),
-                              TestEnvironment::temporaryPath("hmac_secret.yaml"));
-  test_server_->waitForCounterEq("sds.hmac.update_success", 2, std::chrono::milliseconds(5000));
-  // 3. Do another one authentication flow.
-  doAuthenticationFlow("token_secret_1", "hmac_secret_1");
-}
+INSTANTIATE_TEST_SUITE_P(IpVersionsAndGrpcTypes, OauthIntegrationTestWithBasicAuth,
+                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
 // Do OAuth flow with Basic auth header in access token request.
-TEST_F(OauthIntegrationTestWithBasicAuth, AuthenticationFlow) {
+TEST_P(OauthIntegrationTestWithBasicAuth, AuthenticationFlow) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "initial");
+  };
   initialize();
   doAuthenticationFlow("token_secret", "hmac_secret");
 }

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -75,7 +75,8 @@ public:
             .clusterManagerFactory()
             .secretManager()
             .findOrCreateGenericSecretProvider(config_source_, "encryption_key",
-                                               factory_context.getTransportSocketFactoryContext());
+                                               factory_context.getTransportSocketFactoryContext(),
+                                               factory_context.initManager());
     return
         [&factory_context, secret_provider](Http::FilterChainFactoryCallbacks& callbacks) -> void {
           callbacks.addStreamDecoderFilter(std::make_shared<::Envoy::SdsGenericSecretTestFilter>(

--- a/test/mocks/secret/mocks.h
+++ b/test/mocks/secret/mocks.h
@@ -42,19 +42,20 @@ public:
               (const envoy::extensions::transport_sockets::tls::v3::GenericSecret& generic_secret));
   MOCK_METHOD(TlsCertificateConfigProviderSharedPtr, findOrCreateTlsCertificateProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::TransportSocketFactoryContext&));
+               Server::Configuration::TransportSocketFactoryContext&, Init::Manager& init_manager));
   MOCK_METHOD(CertificateValidationContextConfigProviderSharedPtr,
               findOrCreateCertificateValidationContextProvider,
               (const envoy::config::core::v3::ConfigSource& config_source,
                const std::string& config_name,
-               Server::Configuration::TransportSocketFactoryContext& secret_provider_context));
+               Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+               Init::Manager& init_manager));
   MOCK_METHOD(TlsSessionTicketKeysConfigProviderSharedPtr,
               findOrCreateTlsSessionTicketKeysContextProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::TransportSocketFactoryContext&));
+               Server::Configuration::TransportSocketFactoryContext&, Init::Manager& init_manager));
   MOCK_METHOD(GenericSecretConfigProviderSharedPtr, findOrCreateGenericSecretProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::TransportSocketFactoryContext&));
+               Server::Configuration::TransportSocketFactoryContext&, Init::Manager& init_manager));
 };
 
 class MockSecretCallbacks : public SecretCallbacks {


### PR DESCRIPTION
* Pass correct transport_socket_factory to the secret manager

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Fix mocks

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* update tests and add code comment

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Fix sxg http filter as well

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Adjust another test

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Add regression test

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Add integration test

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Revert "Add regression test"

This reverts commit 8a14c3dc328b6e739d91bc34ebf5f84e4812438b.

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* fix format

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

* Fix format and slight improvement in test

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>

Signed-off-by: Vikas Choudhary <choudharyvikas16@gmail.com>
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
