### PR TITLE
ci: run all mobile CI jobs on `main`

### DIFF
--- a/mobile/tools/should_run_ci.sh
+++ b/mobile/tools/should_run_ci.sh
@@ -22,13 +22,12 @@ function failure() {
   echo "run_ci_job=false" >> "$GITHUB_OUTPUT"
 }
 
-# TODO(jpsim): Consider enabling this if the load on EngFlow is ok
-# if [[ $branch_name == "main" ]]; then
-#   # Run all mobile CI jobs on `main`
-#   echo "Running $job because current branch is main"
-#   echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
-#   exit 0
-# fi
+if [[ $branch_name == "main" ]]; then
+  # Run all mobile CI jobs on `main`
+  echo "Running $job because current branch is main"
+  echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
 
 base_commit="$(git merge-base origin/main HEAD)"
 changed_files="$(git diff "$base_commit" --name-only)"


### PR DESCRIPTION
Commit Message: ci: run all mobile CI jobs on `main`
Additional Description: This will give us more visibility when changes that break Envoy Mobile land in Envoy. Slack discussion: https://envoyproxy.slack.com/archives/C02QMNG92A3/p1673288665957089
Risk Level: Moderate on CI stability, low on the Envoy libraries themselves
Testing: CI, these jobs have already been running for nearly two months on PRs with mobile/deps changes
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]