### PR TITLE
Wait at most 5 minutes for the emulator to start

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -59,6 +59,7 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
+      timeout-minutes: 5
     # Return to using:
     #   cd mobile && ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
@@ -100,6 +101,7 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
+      timeout-minutes: 5
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
@@ -141,6 +143,7 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
+      timeout-minutes: 5
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
@@ -182,6 +185,7 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
+      timeout-minutes: 5
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.

--- a/mobile/ci/mac_start_emulator.sh
+++ b/mobile/ci/mac_start_emulator.sh
@@ -8,5 +8,6 @@ ls "${ANDROID_HOME}/tools/bin/"
 
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
     # shellcheck disable=SC2016
-    "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
+    # Wait at most 5 minutes (300 seconds) for the emulator to start.
+    "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'i=0; while [[ $i -lt 300 && -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; ((i++)); done; input keyevent 82'
 }

--- a/mobile/ci/mac_start_emulator.sh
+++ b/mobile/ci/mac_start_emulator.sh
@@ -8,6 +8,5 @@ ls "${ANDROID_HOME}/tools/bin/"
 
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
     # shellcheck disable=SC2016
-    # Wait at most 5 minutes (300 seconds) for the emulator to start.
-    "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'i=0; while [[ $i -lt 300 && -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; ((i++)); done; input keyevent 82'
+    "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
 }


### PR DESCRIPTION
Wait at most 5 minutes for the emulator to start.  A more correct solution would be to find a better way to determine if the emulator is actually booted, but hopefully this fails faster, at least.

Bug: #24841

Risk Level: Low - CI only
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A