### PR TITLE
stats: Stats remove operator scope hack phase 2 (see #24567)

### DIFF
--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -160,7 +160,7 @@ public:
   // accessing the rootScope() to call these methods. The first in the series is
   // https://github.com/envoyproxy/envoy/pull/24567 which just takes care of
   // test/common/...
-  // operator Scope&() { return *rootScope(); }
+  operator Scope&() { return *rootScope(); }
 
   // Delegate some methods to the root scope; these are exposed to make it more
   // convenient to use stats_macros.h. We may consider dropping them if desired,

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -160,7 +160,7 @@ public:
   // accessing the rootScope() to call these methods. The first in the series is
   // https://github.com/envoyproxy/envoy/pull/24567 which just takes care of
   // test/common/...
-  operator Scope&() { return *rootScope(); }
+  // operator Scope&() { return *rootScope(); }
 
   // Delegate some methods to the root scope; these are exposed to make it more
   // convenient to use stats_macros.h. We may consider dropping them if desired,

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -98,7 +98,7 @@ void ValidationInstance::initialize(const Options& options,
       options.serviceZone(), options.serviceClusterName(), options.serviceNodeName());
 
   overload_manager_ = std::make_unique<OverloadManagerImpl>(
-      dispatcher(), stats(), threadLocal(), bootstrap_.overload_manager(),
+      dispatcher(), *stats().rootScope(), threadLocal(), bootstrap_.overload_manager(),
       messageValidationContext().staticValidationVisitor(), *api_, options_);
   Configuration::InitialImpl initial_config(bootstrap_);
   initial_config.initAdminAccessLog(bootstrap_, *this);

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -146,7 +146,7 @@ public:
                            const xds::core::v3::ResourceLocator* lds_resources_locator) override {
       return std::make_unique<LdsApiImpl>(
           lds_config, lds_resources_locator, parent_.clusterManager(), parent_.initManager(),
-          parent_.stats(), parent_.listenerManager(),
+          *parent_.stats().rootScope(), parent_.listenerManager(),
           parent_.messageValidationContext().dynamicValidationVisitor());
     }
     std::vector<Network::FilterFactoryCb> createNetworkFilterFactoryList(

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -106,7 +106,7 @@ void HotRestartingChild::mergeParentStats(Stats::Store& stats_store,
                                           const HotRestartMessage::Reply::Stats& stats_proto) {
   if (!stat_merger_) {
     stat_merger_ = std::make_unique<Stats::StatMerger>(stats_store);
-    hot_restart_generation_stat_name_ = hotRestartGeneration(stats_store).statName();
+    hot_restart_generation_stat_name_ = hotRestartGeneration(*stats_store.rootScope()).statName();
   }
 
   // Convert the protobuf for serialized dynamic spans into the structure

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -85,7 +85,7 @@ void HotRestartingParent::onSocketEvent() {
 void HotRestartingParent::shutdown() { socket_event_.reset(); }
 
 HotRestartingParent::Internal::Internal(Server::Instance* server) : server_(server) {
-  Stats::Gauge& hot_restart_generation = hotRestartGeneration(server->stats());
+  Stats::Gauge& hot_restart_generation = hotRestartGeneration(*server->stats().rootScope());
   hot_restart_generation.inc();
 }
 

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -120,7 +120,7 @@ public:
         std::chrono::duration_cast<std::chrono::nanoseconds>(buffer_flush_interval_msec).count());
 
     logger_ = std::make_unique<MockGrpcAccessLoggerImpl>(
-        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, stats_store_,
+        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, *stats_store_.rootScope(),
         "mock_access_log_prefix.", mockMethodDescriptor(), true);
   }
 
@@ -354,7 +354,7 @@ public:
         std::chrono::duration_cast<std::chrono::nanoseconds>(buffer_flush_interval_msec).count());
 
     logger_ = std::make_unique<MockGrpcAccessLoggerImpl>(
-        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, stats_store_,
+        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, *stats_store_.rootScope(),
         "mock_access_log_prefix.", mockMethodDescriptor(), false);
   }
 
@@ -494,7 +494,7 @@ private:
 
 class GrpcAccessLoggerCacheTest : public testing::Test {
 public:
-  GrpcAccessLoggerCacheTest() : logger_cache_(async_client_manager_, scope_, tls_) {}
+  GrpcAccessLoggerCacheTest() : logger_cache_(async_client_manager_, *scope_.rootScope(), tls_) {}
 
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -75,8 +75,9 @@ public:
     config_.mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
     config_.mutable_buffer_flush_interval()->set_nanos(
         std::chrono::duration_cast<std::chrono::nanoseconds>(FlushInterval).count());
-    logger_ = std::make_unique<GrpcAccessLoggerImpl>(
-        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, local_info_, stats_store_);
+    logger_ =
+        std::make_unique<GrpcAccessLoggerImpl>(Grpc::RawAsyncClientPtr{async_client_}, config_,
+                                               dispatcher_, local_info_, *stats_store_.rootScope());
   }
 
   Grpc::MockAsyncClient* async_client_;
@@ -145,7 +146,8 @@ public:
   Grpc::MockAsyncClient* async_client_;
   Grpc::MockAsyncClientFactory* factory_;
   Grpc::MockAsyncClientManager async_client_manager_;
-  NiceMock<Stats::MockIsolatedStatsStore> scope_;
+  NiceMock<Stats::MockIsolatedStatsStore> store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   NiceMock<ThreadLocal::MockInstance> tls_;
   LocalInfo::MockLocalInfo local_info_;
   GrpcAccessLoggerCacheImpl logger_cache_;

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -76,8 +76,9 @@ public:
     config_.mutable_common_config()->mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
     config_.mutable_common_config()->mutable_buffer_flush_interval()->set_nanos(
         std::chrono::duration_cast<std::chrono::nanoseconds>(FlushInterval).count());
-    logger_ = std::make_unique<GrpcAccessLoggerImpl>(
-        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, local_info_, stats_store_);
+    logger_ =
+        std::make_unique<GrpcAccessLoggerImpl>(Grpc::RawAsyncClientPtr{async_client_}, config_,
+                                               dispatcher_, local_info_, *stats_store_.rootScope());
   }
 
   Grpc::MockAsyncClient* async_client_;
@@ -137,7 +138,8 @@ public:
   Grpc::MockAsyncClientFactory* factory_;
   Grpc::MockAsyncClientManager async_client_manager_;
   LocalInfo::MockLocalInfo local_info_;
-  NiceMock<Stats::MockIsolatedStatsStore> scope_;
+  NiceMock<Stats::MockIsolatedStatsStore> store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   NiceMock<ThreadLocal::MockInstance> tls_;
   GrpcAccessLoggerCacheImpl logger_cache_;
   GrpcAccessLoggerImplTestHelper grpc_access_logger_impl_test_helper_;

--- a/test/extensions/access_loggers/wasm/config_test.cc
+++ b/test/extensions/access_loggers/wasm/config_test.cc
@@ -31,7 +31,7 @@ class WasmAccessLogConfigTest
 protected:
   WasmAccessLogConfigTest() : api_(Api::createApiForTest(stats_store_)) {
     ON_CALL(context_, api()).WillByDefault(ReturnRef(*api_));
-    ON_CALL(context_, scope()).WillByDefault(ReturnRef(stats_store_));
+    ON_CALL(context_, scope()).WillByDefault(ReturnRef(scope_));
     ON_CALL(context_, listenerMetadata()).WillByDefault(ReturnRef(listener_metadata_));
     ON_CALL(context_, initManager()).WillByDefault(ReturnRef(init_manager_));
     ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
@@ -51,6 +51,7 @@ protected:
 
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   Stats::IsolatedStoreImpl stats_store_;
+  Stats::Scope& scope_{*stats_store_.rootScope()};
   Api::ApiPtr api_;
   envoy::config::core::v3::Metadata listener_metadata_;
   Init::ManagerImpl init_manager_{"init_manager"};

--- a/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
+++ b/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
@@ -307,7 +307,7 @@ public:
     bool continueOnListenerFiltersTimeout() const override {
       return continue_on_listener_filters_timeout_;
     }
-    Stats::Scope& listenerScope() override { return parent_.stats_store_; }
+    Stats::Scope& listenerScope() override { return *parent_.stats_store_.rootScope(); }
     uint64_t listenerTag() const override { return tag_; }
     const std::string& name() const override { return name_; }
     Network::UdpListenerConfigOptRef udpListenerConfig() override { return {}; }

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -33,7 +33,7 @@ class AggregateClusterTest : public Event::TestUsingSimulatedTime, public testin
 public:
   AggregateClusterTest()
       : stat_names_(stats_store_.symbolTable()),
-        stats_(Upstream::ClusterInfoImpl::generateStats(stats_store_, stat_names_)) {
+        stats_(Upstream::ClusterInfoImpl::generateStats(*stats_store_.rootScope(), stat_names_)) {
     ON_CALL(*primary_info_, name()).WillByDefault(ReturnRef(primary_name));
     ON_CALL(*secondary_info_, name()).WillByDefault(ReturnRef(secondary_name));
   }

--- a/test/extensions/clusters/eds/eds_speed_test.cc
+++ b/test/extensions/clusters/eds/eds_speed_test.cc
@@ -46,7 +46,7 @@ public:
   EdsSpeedTest(State& state, bool use_unified_mux)
       : state_(state), use_unified_mux_(use_unified_mux),
         type_url_("type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"),
-        subscription_stats_(Config::Utility::generateStats(stats_)),
+        subscription_stats_(Config::Utility::generateStats(scope_)),
         async_client_(new Grpc::MockAsyncClient()),
         config_validators_(std::make_unique<NiceMock<Config::MockCustomConfigValidators>>()) {
     if (use_unified_mux_) {
@@ -54,7 +54,7 @@ public:
           std::unique_ptr<Grpc::MockAsyncClient>(async_client_), server_context_.dispatcher_,
           *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
               "envoy.service.endpoint.v3.EndpointDiscoveryService.StreamEndpoints"),
-          random_, stats_, {}, local_info_, true, std::move(config_validators_),
+          random_, scope_, {}, local_info_, true, std::move(config_validators_),
           /*xds_config_tracker=*/Config::XdsConfigTrackerOptRef()));
     } else {
       grpc_mux_.reset(new Config::GrpcMuxImpl(
@@ -62,7 +62,7 @@ public:
           server_context_.dispatcher_,
           *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
               "envoy.service.endpoint.v3.EndpointDiscoveryService.StreamEndpoints"),
-          random_, stats_, {}, true, std::move(config_validators_),
+          random_, scope_, {}, true, std::move(config_validators_),
           /*xds_config_tracker=*/Config::XdsConfigTrackerOptRef(),
           /*xds_resources_delegate=*/Config::XdsResourcesDelegateOptRef(),
           /*target_xds_authority=*/""));
@@ -90,11 +90,11 @@ public:
   void resetCluster(const std::string& yaml_config, Cluster::InitializePhase initialize_phase) {
     local_info_.node_.mutable_locality()->set_zone("us-east-1a");
     eds_cluster_ = parseClusterFromV3Yaml(yaml_config);
-    Envoy::Stats::ScopeSharedPtr scope = stats_.createScope(fmt::format(
+    Envoy::Stats::ScopeSharedPtr scope = stats_.rootScope()->createScope(fmt::format(
         "cluster.{}.",
         eds_cluster_.alt_stat_name().empty() ? eds_cluster_.name() : eds_cluster_.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-        server_context_, ssl_context_manager_, *scope, server_context_.cluster_manager_, stats_,
+        server_context_, ssl_context_manager_, scope_, server_context_.cluster_manager_, stats_,
         validation_visitor_);
     cluster_ = std::make_shared<EdsClusterImpl>(server_context_, eds_cluster_, runtime_,
                                                 factory_context, std::move(scope), false);
@@ -167,6 +167,7 @@ public:
   uint64_t version_{};
   bool initialized_{};
   Stats::TestUtil::TestStore stats_;
+  Stats::Scope& scope_{*stats_.rootScope()};
   Config::SubscriptionStats subscription_stats_;
   Ssl::MockContextManager ssl_context_manager_;
   envoy::config::cluster::v3::Cluster eds_cluster_;

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager_test.cc
@@ -26,8 +26,8 @@ public:
     envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheCircuitBreakers cb_config;
     TestUtility::loadFromYaml(config_yaml, cb_config);
 
-    resource_manager_ =
-        std::make_unique<DnsCacheResourceManagerImpl>(store_, loader_, "dummy", cb_config);
+    resource_manager_ = std::make_unique<DnsCacheResourceManagerImpl>(*store_.rootScope(), loader_,
+                                                                      "dummy", cb_config);
   }
 
   void cleanup() {

--- a/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
+++ b/test/extensions/common/proxy_protocol/proxy_protocol_regression_test.cc
@@ -75,7 +75,7 @@ public:
   uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override { return {}; }
   bool continueOnListenerFiltersTimeout() const override { return false; }
-  Stats::Scope& listenerScope() override { return stats_store_; }
+  Stats::Scope& listenerScope() override { return *stats_store_.rootScope(); }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }
   Network::UdpListenerConfigOptRef udpListenerConfig() override {

--- a/test/extensions/compression/brotli/compressor/brotli_compressor_impl_test.cc
+++ b/test/extensions/compression/brotli/compressor/brotli_compressor_impl_test.cc
@@ -38,8 +38,8 @@ protected:
     drainBuffer(buffer);
 
     Stats::IsolatedStoreImpl stats_store{};
-    Compression::Brotli::Decompressor::BrotliDecompressorImpl decompressor{stats_store, "test.",
-                                                                           4096, false};
+    Compression::Brotli::Decompressor::BrotliDecompressorImpl decompressor{*stats_store.rootScope(),
+                                                                           "test.", 4096, false};
 
     decompressor.decompress(accumulation_buffer, buffer);
     std::string decompressed_text{buffer.toString()};

--- a/test/extensions/compression/brotli/decompressor/brotli_decompressor_impl_test.cc
+++ b/test/extensions/compression/brotli/decompressor/brotli_decompressor_impl_test.cc
@@ -46,7 +46,7 @@ TEST_F(BrotliDecompressorImplTest, DetectExcessiveCompressionRatio) {
 
   Buffer::OwnedImpl output_buffer;
   Stats::IsolatedStoreImpl stats_store{};
-  BrotliDecompressorImpl decompressor{stats_store, "test.", 16, false};
+  BrotliDecompressorImpl decompressor{*stats_store.rootScope(), "test.", 16, false};
   decompressor.decompress(buffer, output_buffer);
   EXPECT_EQ(1, stats_store.counterFromString("test.brotli_error").value());
 }
@@ -139,7 +139,7 @@ TEST_F(BrotliDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   ASSERT_EQ(0, buffer.length());
 
   Stats::IsolatedStoreImpl stats_store{};
-  BrotliDecompressorImpl decompressor{stats_store, "test.", 16, false};
+  BrotliDecompressorImpl decompressor{*stats_store.rootScope(), "test.", 16, false};
 
   decompressor.decompress(accumulation_buffer, buffer);
   std::string decompressed_text{buffer.toString()};
@@ -158,7 +158,7 @@ TEST_F(BrotliDecompressorImplTest, WrongInput) {
       zeros, 20, [](const void*, size_t, const Buffer::BufferFragmentImpl* frag) { delete frag; });
   buffer.addBufferFragment(*frag);
   Stats::IsolatedStoreImpl stats_store{};
-  BrotliDecompressorImpl decompressor{stats_store, "test.", 16, false};
+  BrotliDecompressorImpl decompressor{*stats_store.rootScope(), "test.", 16, false};
   decompressor.decompress(buffer, output_buffer);
   EXPECT_EQ(1, stats_store.counterFromString("test.brotli_error").value());
 }
@@ -193,7 +193,7 @@ TEST_F(BrotliDecompressorImplTest, CompressDecompressOfMultipleSlices) {
   accumulation_buffer.add(buffer);
 
   Stats::IsolatedStoreImpl stats_store{};
-  BrotliDecompressorImpl decompressor{stats_store, "test.", 16, false};
+  BrotliDecompressorImpl decompressor{*stats_store.rootScope(), "test.", 16, false};
 
   drainBuffer(buffer);
   ASSERT_EQ(0, buffer.length());
@@ -238,7 +238,7 @@ protected:
     ASSERT_EQ(0, buffer.length());
 
     Stats::IsolatedStoreImpl stats_store{};
-    BrotliDecompressorImpl decompressor{stats_store, "test.", 4096,
+    BrotliDecompressorImpl decompressor{*stats_store.rootScope(), "test.", 4096,
                                         disable_ring_buffer_reallocation};
 
     decompressor.decompress(accumulation_buffer, buffer);

--- a/test/extensions/compression/gzip/compressor_fuzz_test.cc
+++ b/test/extensions/compression/gzip/compressor_fuzz_test.cc
@@ -23,7 +23,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   FuzzedDataProvider provider(buf, len);
   ZlibCompressorImpl compressor;
   Stats::IsolatedStoreImpl stats_store;
-  Decompressor::ZlibDecompressorImpl decompressor{stats_store, "test", 4096, 100};
+  Decompressor::ZlibDecompressorImpl decompressor{*stats_store.rootScope(), "test", 4096, 100};
 
   // Select target compression level. We can't use ConsumeEnum() since the range
   // is non-contiguous.

--- a/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/extensions/compression/gzip/decompressor/zlib_decompressor_impl_test.cc
@@ -45,8 +45,7 @@ protected:
     drainBuffer(buffer);
     ASSERT_EQ(0, buffer.length());
 
-    Stats::IsolatedStoreImpl stats_store{};
-    ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+    ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
     decompressor.init(window_bits);
 
     decompressor.decompress(accumulation_buffer, buffer);
@@ -61,25 +60,26 @@ protected:
   static constexpr int64_t gzip_window_bits{31};
   static constexpr int64_t memory_level{8};
   static constexpr uint64_t default_input_size{796};
+
+  Stats::IsolatedStoreImpl stats_store_{};
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
 };
 
 class ZlibDecompressorImplFailureTest : public ZlibDecompressorImplTest {
 protected:
-  static void decompressorBadInitTestHelper(int64_t window_bits) {
-    Stats::IsolatedStoreImpl stats_store{};
-    ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+  void decompressorBadInitTestHelper(int64_t window_bits) {
+    ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
     decompressor.init(window_bits);
   }
 
-  static void uninitializedDecompressorTestHelper() {
+  void uninitializedDecompressorTestHelper() {
     Buffer::OwnedImpl input_buffer;
     Buffer::OwnedImpl output_buffer;
-    Stats::IsolatedStoreImpl stats_store{};
-    ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+    ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
     TestUtility::feedBufferWithRandomCharacters(input_buffer, 100);
     decompressor.decompress(input_buffer, output_buffer);
     ASSERT_TRUE(decompressor.decompression_error_ < 0);
-    ASSERT_EQ(stats_store.counterFromString("test.zlib_stream_error").value(), 1);
+    ASSERT_EQ(stats_store_.counterFromString("test.zlib_stream_error").value(), 1);
   }
 };
 
@@ -108,8 +108,7 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   compressor.compress(compressor_buffer, Envoy::Compression::Compressor::State::Flush);
   ASSERT_TRUE(compressor.checksum() > 0);
 
-  Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+  ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
   EXPECT_EQ(0, decompressor.checksum());
 
@@ -140,11 +139,10 @@ TEST_F(ZlibDecompressorImplTest, DetectExcessiveCompressionRatio) {
   compressor.compress(buffer, Envoy::Compression::Compressor::State::Finish);
 
   Buffer::OwnedImpl output_buffer;
-  Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+  ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
   decompressor.decompress(buffer, output_buffer);
-  ASSERT_EQ(stats_store.counterFromString("test.zlib_data_error").value(), 1);
+  ASSERT_EQ(stats_store_.counterFromString("test.zlib_data_error").value(), 1);
 }
 
 // Exercises compression and decompression by compressing some data, decompressing it and then
@@ -179,8 +177,7 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   drainBuffer(buffer);
   ASSERT_EQ(0, buffer.length());
 
-  Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+  ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
@@ -210,14 +207,13 @@ TEST_F(ZlibDecompressorImplTest, FailedDecompression) {
     accumulation_buffer.add(buffer);
     drainBuffer(buffer);
   }
-  Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+  ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
 
   ASSERT_TRUE(decompressor.decompression_error_ < 0);
-  ASSERT_EQ(stats_store.counterFromString("test.zlib_data_error").value(), 17);
+  ASSERT_EQ(stats_store_.counterFromString("test.zlib_data_error").value(), 17);
 }
 
 // Exercises decompression with a very small output buffer.
@@ -250,8 +246,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   drainBuffer(buffer);
   ASSERT_EQ(0, buffer.length());
 
-  Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 16, 100};
+  ZlibDecompressorImpl decompressor{stats_scope_, "test.", 16, 100};
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
@@ -317,8 +312,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressOfMultipleSlices) {
   compressor.compress(buffer, Envoy::Compression::Compressor::State::Flush);
   accumulation_buffer.add(buffer);
 
-  Stats::IsolatedStoreImpl stats_store{};
-  ZlibDecompressorImpl decompressor{stats_store, "test.", 4096, 100};
+  ZlibDecompressorImpl decompressor{stats_scope_, "test.", 4096, 100};
   decompressor.init(gzip_window_bits);
 
   drainBuffer(buffer);
@@ -337,7 +331,8 @@ protected:
   void chargeErrorStats(const int result) { decompressor_.chargeErrorStats(result); }
 
   Stats::IsolatedStoreImpl stats_store_{};
-  ZlibDecompressorImpl decompressor_{stats_store_, "test.", 4096, 100};
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
+  ZlibDecompressorImpl decompressor_{stats_scope_, "test.", 4096, 100};
 };
 
 TEST_F(ZlibDecompressorStatsTest, ChargeErrorStats) {

--- a/test/extensions/compression/zstd/compressor/zstd_compressor_impl_test.cc
+++ b/test/extensions/compression/zstd/compressor/zstd_compressor_impl_test.cc
@@ -40,7 +40,7 @@ protected:
     drainBuffer(buffer);
 
     Stats::IsolatedStoreImpl stats_store{};
-    Zstd::Decompressor::ZstdDecompressorImpl decompressor{stats_store, "test.",
+    Zstd::Decompressor::ZstdDecompressorImpl decompressor{*stats_store.rootScope(), "test.",
                                                           default_ddict_manager_, 4096};
 
     decompressor.decompress(accumulation_buffer, buffer);

--- a/test/extensions/compression/zstd/decompressor/zstd_decompressor_impl_test.cc
+++ b/test/extensions/compression/zstd/decompressor/zstd_decompressor_impl_test.cc
@@ -53,7 +53,7 @@ TEST_F(ZstdDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   drainBuffer(buffer);
 
   Stats::IsolatedStoreImpl stats_store{};
-  ZstdDecompressorImpl decompressor{stats_store, "test.", default_ddict_manager_, 16};
+  ZstdDecompressorImpl decompressor{*stats_store.rootScope(), "test.", default_ddict_manager_, 16};
 
   decompressor.decompress(accumulation_buffer, buffer);
   std::string decompressed_text{buffer.toString()};
@@ -72,7 +72,7 @@ TEST_F(ZstdDecompressorImplTest, WrongInput) {
       zeros, 20, [](const void*, size_t, const Buffer::BufferFragmentImpl* frag) { delete frag; });
   buffer.addBufferFragment(*frag);
   Stats::IsolatedStoreImpl stats_store{};
-  ZstdDecompressorImpl decompressor{stats_store, "test.", default_ddict_manager_, 16};
+  ZstdDecompressorImpl decompressor{*stats_store.rootScope(), "test.", default_ddict_manager_, 16};
   decompressor.decompress(buffer, output_buffer);
   EXPECT_EQ(1, stats_store.counterFromString("test.zstd_generic_error").value());
 }
@@ -108,7 +108,7 @@ TEST_F(ZstdDecompressorImplTest, CompressDecompressOfMultipleSlices) {
   drainBuffer(buffer);
 
   Stats::IsolatedStoreImpl stats_store{};
-  ZstdDecompressorImpl decompressor{stats_store, "test.", default_ddict_manager_, 16};
+  ZstdDecompressorImpl decompressor{*stats_store.rootScope(), "test.", default_ddict_manager_, 16};
 
   decompressor.decompress(accumulation_buffer, buffer);
   std::string decompressed_text{buffer.toString()};
@@ -165,7 +165,7 @@ TEST_F(ZstdDecompressorImplTest, DetectExcessiveCompressionRatio) {
 
   Buffer::OwnedImpl output_buffer;
   Stats::IsolatedStoreImpl stats_store{};
-  ZstdDecompressorImpl decompressor{stats_store, "test.", default_ddict_manager_, 16};
+  ZstdDecompressorImpl decompressor{*stats_store.rootScope(), "test.", default_ddict_manager_, 16};
   decompressor.decompress(buffer, output_buffer);
   ASSERT_EQ(stats_store.counterFromString("test.zstd_generic_error").value(), 1);
 }
@@ -183,7 +183,7 @@ protected:
 
   Stats::IsolatedStoreImpl stats_store_{};
   ZstdDDictManagerPtr ddict_manager_{nullptr};
-  ZstdDecompressorImpl decompressor_{stats_store_, "test.", ddict_manager_, 16};
+  ZstdDecompressorImpl decompressor_{*stats_store_.rootScope(), "test.", ddict_manager_, 16};
 };
 
 TEST_F(ZstdDecompressorStatsTest, ChargeErrorStats) {

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_test.cc
@@ -58,7 +58,8 @@ public:
   }
 
   Event::SimulatedTimeSystem time_system_;
-  Stats::IsolatedStoreImpl stats_;
+  Stats::IsolatedStoreImpl stats_store_;
+  Stats::Scope& stats_{*stats_store_.rootScope()};
   NiceMock<Runtime::MockLoader> runtime_;
   std::shared_ptr<MockConcurrencyController> controller_{new MockConcurrencyController()};
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -52,9 +52,9 @@ public:
         dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   GradientControllerSharedPtr makeController(const std::string& yaml_config) {
-    const auto config = std::make_shared<GradientController>(makeConfig(yaml_config, runtime_),
-                                                             *dispatcher_, runtime_, "test_prefix.",
-                                                             stats_, random_, time_system_);
+    const auto config = std::make_shared<GradientController>(
+        makeConfig(yaml_config, runtime_), *dispatcher_, runtime_, "test_prefix.",
+        *stats_.rootScope(), random_, time_system_);
 
     // Advance time so that the latency sample calculations don't underflow if monotonic time is 0.
     time_system_.advanceTimeAndRun(std::chrono::hours(42), *dispatcher_,
@@ -667,9 +667,9 @@ min_rtt_calc_params:
       .WillOnce(Return(rtt_timer))
       .WillOnce(Return(sample_timer));
   EXPECT_CALL(*sample_timer, enableTimer(std::chrono::milliseconds(123), _));
-  auto controller =
-      std::make_shared<GradientController>(makeConfig(yaml, runtime_), fake_dispatcher, runtime_,
-                                           "test_prefix.", stats_, random_, time_system_);
+  auto controller = std::make_shared<GradientController>(
+      makeConfig(yaml, runtime_), fake_dispatcher, runtime_, "test_prefix.", *stats_.rootScope(),
+      random_, time_system_);
 
   // Set the minRTT- this will trigger the timer for the next minRTT calculation.
 
@@ -712,9 +712,9 @@ min_rtt_calc_params:
       .WillOnce(Return(rtt_timer))
       .WillOnce(Return(sample_timer));
   EXPECT_CALL(*sample_timer, enableTimer(std::chrono::milliseconds(123), _));
-  auto controller =
-      std::make_shared<GradientController>(makeConfig(yaml, runtime_), fake_dispatcher, runtime_,
-                                           "test_prefix.", stats_, random_, time_system_);
+  auto controller = std::make_shared<GradientController>(
+      makeConfig(yaml, runtime_), fake_dispatcher, runtime_, "test_prefix.", *stats_.rootScope(),
+      random_, time_system_);
 
   // Set the minRTT- this will trigger the timer for the next minRTT calculation.
   EXPECT_CALL(*rtt_timer, enableTimer(std::chrono::milliseconds(45000), _));

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -44,7 +44,8 @@ protected:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   AdmissionControlFilterFactory::DualInfo dual_info_{context_};
-  Stats::IsolatedStoreImpl scope_;
+  Stats::IsolatedStoreImpl store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   NiceMock<Random::MockRandomGenerator> random_;
 };
 

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -55,7 +55,7 @@ public:
   envoy::config::core::v3::Metadata metadata_;
   Arn arn_;
   Stats::IsolatedStoreImpl stats_store_;
-  FilterStats stats_ = generateStats("test", stats_store_);
+  FilterStats stats_ = generateStats("test", *stats_store_.rootScope());
   const std::string metadata_yaml_ = "egress_gateway: true";
 };
 
@@ -162,7 +162,7 @@ TEST_F(AwsLambdaFilterTest, DecodeDataRecordsPayloadSize) {
 
   setupClusterMetadata();
 
-  FilterStats stats(generateStats("test", store));
+  FilterStats stats(generateStats("test", *store.rootScope()));
   signer_ = std::make_shared<NiceMock<MockSigner>>();
   filter_ = std::make_unique<Filter>(settings, stats, signer_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
@@ -32,7 +32,7 @@ public:
 
   std::shared_ptr<Common::Aws::MockSigner> signer_;
   Stats::IsolatedStoreImpl stats_store_;
-  FilterStats stats_{Filter::generateStats("test", stats_store_)};
+  FilterStats stats_{Filter::generateStats("test", *stats_store_.rootScope())};
   std::string host_rewrite_;
   bool use_unsigned_payload_;
 };
@@ -189,7 +189,7 @@ TEST_F(AwsRequestSigningFilterTest, FilterConfigImplGetters) {
   Stats::IsolatedStoreImpl stats;
   auto signer = std::make_unique<Common::Aws::MockSigner>();
   const auto* signer_ptr = signer.get();
-  FilterConfigImpl config(std::move(signer), "prefix", stats, "foo", true);
+  FilterConfigImpl config(std::move(signer), "prefix", *stats.rootScope(), "foo", true);
 
   EXPECT_EQ(signer_ptr, &config.signer());
   EXPECT_EQ(0UL, config.stats().signing_added_.value());

--- a/test/extensions/filters/http/bandwidth_limit/filter_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/filter_test.cc
@@ -25,7 +25,8 @@ public:
   void setup(const std::string& yaml) {
     envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit config;
     TestUtility::loadFromYaml(yaml, config);
-    config_ = std::make_shared<FilterConfig>(config, stats_, runtime_, time_system_, true);
+    config_ =
+        std::make_shared<FilterConfig>(config, *stats_.rootScope(), runtime_, time_system_, true);
     filter_ = std::make_shared<BandwidthLimiter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_filter_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_filter_callbacks_);

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -151,7 +151,7 @@ public:
 
   Stats::IsolatedStoreImpl stats_store_;
   Extensions::Compression::Gzip::Decompressor::ZlibDecompressorImpl decompressor_{
-      stats_store_, "test", 4096, 100};
+      *stats_store_.rootScope(), "test", 4096, 100};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, CompressorIntegrationTest,

--- a/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_speed_test.cc
@@ -121,7 +121,7 @@ CompressorFilterConfigSharedPtr makeGzipConfig(Stats::IsolatedStoreImpl& stats,
   Envoy::Compression::Compressor::CompressorFactoryPtr compressor_factory =
       std::make_unique<MockGzipCompressorFactory>(level, strategy, window_bits, memory_level);
   CompressorFilterConfigSharedPtr config = std::make_shared<CompressorFilterConfig>(
-      compressor, "test.", stats, runtime, std::move(compressor_factory));
+      compressor, "test.", *stats.rootScope(), runtime, std::move(compressor_factory));
 
   return config;
 }
@@ -137,7 +137,7 @@ CompressorFilterConfigSharedPtr makeZstdConfig(Stats::IsolatedStoreImpl& stats,
   Envoy::Compression::Compressor::CompressorFactoryPtr compressor_factory =
       std::make_unique<MockZstdCompressorFactory>(level, strategy);
   CompressorFilterConfigSharedPtr config = std::make_shared<CompressorFilterConfig>(
-      compressor, "test.", stats, runtime, std::move(compressor_factory));
+      compressor, "test.", *stats.rootScope(), runtime, std::move(compressor_factory));
 
   return config;
 }
@@ -152,7 +152,7 @@ CompressorFilterConfigSharedPtr makeBrotliConfig(Stats::IsolatedStoreImpl& stats
   Envoy::Compression::Compressor::CompressorFactoryPtr compressor_factory =
       std::make_unique<MockBrotliCompressorFactory>(quality);
   CompressorFilterConfigSharedPtr config = std::make_shared<CompressorFilterConfig>(
-      compressor, "test.", stats, runtime, std::move(compressor_factory));
+      compressor, "test.", *stats.rootScope(), runtime, std::move(compressor_factory));
 
   return config;
 }

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -65,8 +65,8 @@ public:
     TestUtility::loadFromJson(json, compressor);
     auto compressor_factory = std::make_unique<TestCompressorFactory>("test");
     compressor_factory_ = compressor_factory.get();
-    config_ = std::make_shared<CompressorFilterConfig>(compressor, "test.", stats_, runtime_,
-                                                       std::move(compressor_factory));
+    config_ = std::make_shared<CompressorFilterConfig>(compressor, "test.", *stats_.rootScope(),
+                                                       runtime_, std::move(compressor_factory));
     filter_ = std::make_unique<CompressorFilter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
@@ -763,8 +763,8 @@ protected:
                               compressor);
     auto compressor_factory1 = std::make_unique<TestCompressorFactory>("test1");
     compressor_factory1->setExpectedCompressCalls(0);
-    auto config1 = std::make_shared<CompressorFilterConfig>(compressor, "test1.", stats1_, runtime_,
-                                                            std::move(compressor_factory1));
+    auto config1 = std::make_shared<CompressorFilterConfig>(
+        compressor, "test1.", *stats1_.rootScope(), runtime_, std::move(compressor_factory1));
     filter1_ = std::make_unique<CompressorFilter>(config1);
 
     TestUtility::loadFromJson(R"EOF(
@@ -780,8 +780,8 @@ protected:
                               compressor);
     auto compressor_factory2 = std::make_unique<TestCompressorFactory>("test2");
     compressor_factory2->setExpectedCompressCalls(0);
-    auto config2 = std::make_shared<CompressorFilterConfig>(compressor, "test2.", stats2_, runtime_,
-                                                            std::move(compressor_factory2));
+    auto config2 = std::make_shared<CompressorFilterConfig>(
+        compressor, "test2.", *stats2_.rootScope(), runtime_, std::move(compressor_factory2));
     filter2_ = std::make_unique<CompressorFilter>(config2);
   }
 
@@ -886,8 +886,8 @@ protected:
                                           choose_first1),
                               compressor);
     auto compressor_factory1 = std::make_unique<TestCompressorFactory>("test1");
-    auto config1 = std::make_shared<CompressorFilterConfig>(compressor, "test1.", stats1_, runtime_,
-                                                            std::move(compressor_factory1));
+    auto config1 = std::make_shared<CompressorFilterConfig>(
+        compressor, "test1.", *stats1_.rootScope(), runtime_, std::move(compressor_factory1));
     filter1_ = std::make_unique<CompressorFilter>(config1);
 
     TestUtility::loadFromJson(fmt::format(R"EOF(
@@ -904,8 +904,8 @@ protected:
                                           choose_first2),
                               compressor);
     auto compressor_factory2 = std::make_unique<TestCompressorFactory>("test2");
-    auto config2 = std::make_shared<CompressorFilterConfig>(compressor, "test2.", stats2_, runtime_,
-                                                            std::move(compressor_factory2));
+    auto config2 = std::make_shared<CompressorFilterConfig>(
+        compressor, "test2.", *stats2_.rootScope(), runtime_, std::move(compressor_factory2));
     filter2_ = std::make_unique<CompressorFilter>(config2);
   }
 
@@ -1012,7 +1012,7 @@ TEST(CompressorFilterConfigTests, MakeCompressorTest) {
   EXPECT_CALL(*compressor_factory, createCompressor());
   EXPECT_CALL(*compressor_factory, statsPrefix());
   EXPECT_CALL(*compressor_factory, contentEncoding());
-  CompressorFilterConfig config(compressor_cfg, "test.compressor.", stats, runtime,
+  CompressorFilterConfig config(compressor_cfg, "test.compressor.", *stats.rootScope(), runtime,
                                 std::move(compressor_factory));
   Envoy::Compression::Compressor::CompressorPtr compressor = config.makeCompressor();
 }

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -40,7 +40,7 @@ Matchers::StringMatcherPtr makeStdRegexStringMatcher(const std::string& regex) {
 
 class CorsFilterTest : public testing::Test {
 public:
-  CorsFilterTest() : config_(new CorsFilterConfig("test.", stats_)), filter_(config_) {
+  CorsFilterTest() : config_(new CorsFilterConfig("test.", *stats_.rootScope())), filter_(config_) {
     cors_policy_ = std::make_unique<Router::TestCorsPolicy>();
     cors_policy_->enabled_ = true;
     cors_policy_->shadow_enabled_ = false;

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -43,7 +43,7 @@ public:
     const auto& add_regex_origin = policy.mutable_additional_origins()->Add();
     add_regex_origin->MergeFrom(TestUtility::createRegexMatcher(R"(www\-[0-9]\.allow\.com)"));
 
-    return std::make_shared<CsrfFilterConfig>(policy, "test", stats_, runtime_);
+    return std::make_shared<CsrfFilterConfig>(policy, "test", *stats_.rootScope(), runtime_);
   }
 
   CsrfFilterTest() : config_(setupConfig()), filter_(config_) {}

--- a/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
+++ b/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
@@ -41,8 +41,8 @@ decompressor_library:
     auto decompressor_factory =
         std::make_unique<NiceMock<Compression::Decompressor::MockDecompressorFactory>>();
     decompressor_factory_ = decompressor_factory.get();
-    config_ = std::make_shared<DecompressorFilterConfig>(decompressor, "test.", stats_, runtime_,
-                                                         std::move(decompressor_factory));
+    config_ = std::make_shared<DecompressorFilterConfig>(decompressor, "test.", *stats_.rootScope(),
+                                                         runtime_, std::move(decompressor_factory));
     filter_ = std::make_unique<DecompressorFilter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
@@ -90,8 +90,8 @@ DEFINE_PROTO_FUZZER(const envoy::extensions::filters::http::ext_authz::ExtAuthzT
   FilterConfigSharedPtr config;
 
   try {
-    config = std::make_shared<FilterConfig>(proto_config, stats_store, mocks.runtime_, http_context,
-                                            "ext_authz_prefix", bootstrap);
+    config = std::make_shared<FilterConfig>(proto_config, *stats_store.rootScope(), mocks.runtime_,
+                                            http_context, "ext_authz_prefix", bootstrap);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException during filter config validation: {}", e.what());
     return;

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -58,7 +58,7 @@ public:
     if (!yaml.empty()) {
       TestUtility::loadFromYaml(yaml, proto_config);
     }
-    config_.reset(new FilterConfig(proto_config, stats_store_, runtime_, http_context_,
+    config_.reset(new FilterConfig(proto_config, *stats_store_.rootScope(), runtime_, http_context_,
                                    "ext_authz_prefix", bootstrap_));
     client_ = new Filters::Common::ExtAuthz::MockClient();
     filter_ = std::make_unique<Filter>(config_, Filters::Common::ExtAuthz::ClientPtr{client_});
@@ -118,6 +118,7 @@ public:
   }
 
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   FilterConfigSharedPtr config_;
   Filters::Common::ExtAuthz::MockClient* client_;

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -34,7 +34,8 @@ protected:
     EXPECT_CALL(client_manager_, getOrCreateRawAsyncClient(_, _, _))
         .WillOnce(Invoke(this, &ExtProcStreamTest::doFactory));
 
-    client_ = std::make_unique<ExternalProcessorClientImpl>(client_manager_, stats_store_);
+    client_ =
+        std::make_unique<ExternalProcessorClientImpl>(client_manager_, *stats_store_.rootScope());
   }
 
   Grpc::RawAsyncClientSharedPtr doFactory(Unused, Unused, Unused) {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -85,7 +85,7 @@ protected:
     if (!yaml.empty()) {
       TestUtility::loadFromYaml(yaml, proto_config);
     }
-    config_.reset(new FilterConfig(proto_config, 200ms, stats_store_, ""));
+    config_.reset(new FilterConfig(proto_config, 200ms, *stats_store_.rootScope(), ""));
     filter_ = std::make_unique<Filter>(config_, std::move(client_), grpc_service_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
     EXPECT_CALL(encoder_callbacks_, encoderBufferLimit()).WillRepeatedly(Return(BufferSize));

--- a/test/extensions/filters/http/ext_proc/ordering_test.cc
+++ b/test/extensions/filters/http/ext_proc/ordering_test.cc
@@ -69,7 +69,7 @@ protected:
     if (cb) {
       (*cb)(proto_config);
     }
-    config_.reset(new FilterConfig(proto_config, kMessageTimeout, stats_store_, ""));
+    config_.reset(new FilterConfig(proto_config, kMessageTimeout, *stats_store_.rootScope(), ""));
     filter_ = std::make_unique<Filter>(config_, std::move(client_), proto_config.grpc_service());
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -131,7 +131,8 @@ public:
   const std::string v2_empty_fault_config_yaml = "{}";
 
   void setUpTest(const envoy::extensions::filters::http::fault::v3::HTTPFault fault) {
-    config_ = std::make_shared<FaultFilterConfig>(fault, runtime_, "prefix.", stats_, time_system_);
+    config_ = std::make_shared<FaultFilterConfig>(fault, runtime_, "prefix.", *stats_.rootScope(),
+                                                  time_system_);
     filter_ = std::make_unique<FaultFilter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_filter_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_filter_callbacks_);

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -36,7 +36,7 @@ protected:
     ON_CALL(decoder_callbacks_, streamInfo()).WillByDefault(testing::ReturnRef(stream_info_));
 
     ON_CALL(*decoder_callbacks_.cluster_info_, statsScope())
-        .WillByDefault(testing::ReturnRef(stats_store_));
+        .WillByDefault(testing::ReturnRef(scope_));
 
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   }
@@ -67,6 +67,7 @@ protected:
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  Stats::Scope& scope_{*stats_store_.rootScope()};
 };
 
 TEST_F(GrpcStatsFilterConfigTest, StatsHttp2HeaderOnlyResponse) {

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -43,7 +43,8 @@ ip_tags:
   void initializeFilter(const std::string& yaml) {
     envoy::extensions::filters::http::ip_tagging::v3::IPTagging config;
     TestUtility::loadFromYaml(yaml, config);
-    config_ = std::make_shared<IpTaggingFilterConfig>(config, "prefix.", stats_, runtime_);
+    config_ =
+        std::make_shared<IpTaggingFilterConfig>(config, "prefix.", *stats_.rootScope(), runtime_);
     filter_ = std::make_unique<IpTaggingFilter>(config_);
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
   }

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -32,7 +32,7 @@ JwtAuthnFilterStats generateMockStats(Stats::Scope& scope) {
 
 class MockFilterConfig : public FilterConfig {
 public:
-  MockFilterConfig() : stats_(generateMockStats(stats_store_)) {
+  MockFilterConfig() : stats_(generateMockStats(*stats_store_.rootScope())) {
     ON_CALL(*this, bypassCorsPreflightRequest()).WillByDefault(Return(true));
     ON_CALL(*this, findVerifier(_, _)).WillByDefault(Return(nullptr));
     ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -91,7 +91,7 @@ public:
 
 class MockJwksCache : public JwksCache {
 public:
-  MockJwksCache() : stats_(generateMockStats(stats_store_)) {
+  MockJwksCache() : stats_(generateMockStats(*stats_store_.rootScope())) {
     ON_CALL(*this, findByIssuer(_)).WillByDefault(::testing::Return(&jwks_data_));
     ON_CALL(*this, findByProvider(_)).WillByDefault(::testing::Return(&jwks_data_));
     ON_CALL(*this, stats()).WillByDefault(::testing::ReturnRef(stats_));

--- a/test/extensions/filters/http/local_ratelimit/filter_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/filter_test.cc
@@ -73,8 +73,8 @@ public:
 
     envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit config;
     TestUtility::loadFromYaml(yaml, config);
-    config_ = std::make_shared<FilterConfig>(config, local_info_, dispatcher_, stats_, runtime_,
-                                             per_route);
+    config_ = std::make_shared<FilterConfig>(config, local_info_, dispatcher_, *stats_.rootScope(),
+                                             runtime_, per_route);
     filter_ = std::make_shared<Filter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -94,7 +94,7 @@ public:
                    envoy::extensions::filters::http::lua::v3::LuaPerRoute& per_route_proto_config) {
     // Setup filter config for Lua filter.
     config_ = std::make_shared<FilterConfig>(proto_config, tls_, cluster_manager_, api_,
-                                             stats_store_, "test.");
+                                             *stats_store_.rootScope(), "test.");
     // Setup per route config for Lua filter.
     per_route_config_ =
         std::make_shared<FilterConfigPerRoute>(per_route_proto_config, server_factory_context_);
@@ -246,7 +246,7 @@ TEST(LuaHttpFilterConfigTest, BadCode) {
   proto_config.mutable_default_source_code()->set_inline_string(SCRIPT);
 
   EXPECT_THROW_WITH_MESSAGE(
-      FilterConfig(proto_config, tls, cluster_manager, api, stats_store, "lua"),
+      FilterConfig(proto_config, tls, cluster_manager, api, *stats_store.rootScope(), "lua"),
       Filters::Common::Lua::LuaException,
       "script load error: [string \"...\"]:3: '=' expected near '<eof>'");
 }

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -192,7 +192,8 @@ public:
   FilterConfigSharedPtr config_;
   Http::MockAsyncClientRequest request_;
   std::deque<Http::AsyncClient::Callbacks*> callbacks_;
-  Stats::IsolatedStoreImpl scope_;
+  Stats::IsolatedStoreImpl store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   Event::SimulatedTimeSystem test_time_;
 };
 

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -53,8 +53,8 @@ public:
     envoy::extensions::filters::http::ratelimit::v3::RateLimit proto_config{};
     TestUtility::loadFromYaml(yaml, proto_config);
 
-    config_ = std::make_shared<FilterConfig>(proto_config, local_info_, stats_store_, runtime_,
-                                             http_context_);
+    config_ = std::make_shared<FilterConfig>(proto_config, local_info_, *stats_store_.rootScope(),
+                                             runtime_, http_context_);
 
     client_ = new Filters::Common::RateLimit::MockClient();
     filter_ = std::make_unique<Filter>(config_, Filters::Common::RateLimit::ClientPtr{client_});

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -94,13 +94,15 @@ matcher_tree:
   Stats::IsolatedStoreImpl store;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_THROW(std::make_shared<RoleBasedAccessControlFilterConfig>(
-                   config, "test", store, context, ProtobufMessage::getStrictValidationVisitor()),
+                   config, "test", *store.rootScope(), context,
+                   ProtobufMessage::getStrictValidationVisitor()),
                Envoy::EnvoyException);
 
   config.clear_matcher();
   *config.mutable_shadow_matcher() = matcher_proto;
   EXPECT_THROW(std::make_shared<RoleBasedAccessControlFilterConfig>(
-                   config, "test", store, context, ProtobufMessage::getStrictValidationVisitor()),
+                   config, "test", *store.rootScope(), context,
+                   ProtobufMessage::getStrictValidationVisitor()),
                Envoy::EnvoyException);
 }
 

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -57,7 +57,8 @@ public:
     config.set_shadow_rules_stat_prefix("prefix_");
 
     setupConfig(std::make_shared<RoleBasedAccessControlFilterConfig>(
-        config, "test", store_, context_, ProtobufMessage::getStrictValidationVisitor()));
+        config, "test", *store_.rootScope(), context_,
+        ProtobufMessage::getStrictValidationVisitor()));
   }
 
   void setupMatcher(std::string action, std::string on_no_match_action) {
@@ -157,7 +158,8 @@ on_no_match:
     config.set_shadow_rules_stat_prefix("prefix_");
 
     setupConfig(std::make_shared<RoleBasedAccessControlFilterConfig>(
-        config, "test", store_, context_, ProtobufMessage::getStrictValidationVisitor()));
+        config, "test", *store_.rootScope(), context_,
+        ProtobufMessage::getStrictValidationVisitor()));
   }
 
   void setupConfig(RoleBasedAccessControlFilterConfigSharedPtr config) {
@@ -619,7 +621,8 @@ public:
     (*config.mutable_rules()->mutable_policies())["foo"] = policy;
 
     auto config_ptr = std::make_shared<RoleBasedAccessControlFilterConfig>(
-        config, "test", store_, context_, ProtobufMessage::getStrictValidationVisitor());
+        config, "test", *store_.rootScope(), context_,
+        ProtobufMessage::getStrictValidationVisitor());
 
     // Setup test with the policy config.
     setupConfig(config_ptr);

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -64,7 +64,8 @@ public:
 
     static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
+        std::vector<std::string>{});
   }
 };
 

--- a/test/extensions/filters/http/tap/tap_filter_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_test.cc
@@ -25,7 +25,7 @@ public:
   FilterStats& stats() override { return stats_; }
 
   Stats::IsolatedStoreImpl stats_store_;
-  FilterStats stats_{Filter::generateStats("foo", stats_store_)};
+  FilterStats stats_{Filter::generateStats("foo", *stats_store_.rootScope())};
 };
 
 class MockHttpPerRequestTapper : public HttpPerRequestTapper {

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -35,7 +35,7 @@ class WasmFilterConfigTest : public Event::TestUsingSimulatedTime,
 protected:
   WasmFilterConfigTest() : api_(Api::createApiForTest(stats_store_)) {
     ON_CALL(context_, api()).WillByDefault(ReturnRef(*api_));
-    ON_CALL(context_, scope()).WillByDefault(ReturnRef(stats_store_));
+    ON_CALL(context_, scope()).WillByDefault(ReturnRef(stats_scope_));
     ON_CALL(context_, listenerMetadata()).WillByDefault(ReturnRef(listener_metadata_));
     EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager_));
     ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
@@ -55,6 +55,7 @@ protected:
 
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   Stats::IsolatedStoreImpl stats_store_;
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   Api::ApiPtr api_;
   envoy::config::core::v3::Metadata listener_metadata_;
   Init::ManagerImpl init_manager_{"init_manager"};

--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fuzzer.h
@@ -56,7 +56,7 @@ public:
   uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override { return {}; }
   bool continueOnListenerFiltersTimeout() const override { return false; }
-  Stats::Scope& listenerScope() override { return stats_store_; }
+  Stats::Scope& listenerScope() override { return *stats_store_.rootScope(); }
   uint64_t listenerTag() const override { return 1; }
   ResourceLimit& openConnections() override { return open_connections_; }
   const std::string& name() const override { return name_; }

--- a/test/extensions/filters/listener/http_inspector/http_inspector_fuzz_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_fuzz_test.cc
@@ -18,7 +18,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::listener::FilterFuzzWithDat
   }
 
   Stats::IsolatedStoreImpl store;
-  ConfigSharedPtr cfg = std::make_shared<Config>(store);
+  ConfigSharedPtr cfg = std::make_shared<Config>(*store.rootScope());
   auto filter = std::make_unique<Filter>(cfg);
 
   ListenerFilterWithDataFuzzer fuzzer;

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -30,7 +30,7 @@ namespace {
 class HttpInspectorTest : public testing::Test {
 public:
   HttpInspectorTest()
-      : cfg_(std::make_shared<Config>(store_)),
+      : cfg_(std::make_shared<Config>(*store_.rootScope())),
         io_handle_(
             Network::SocketInterfaceImpl::makePlatformSpecificSocket(42, false, absl::nullopt)) {}
   ~HttpInspectorTest() override { io_handle_->close(); }

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_fuzz_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_fuzz_test.cc
@@ -19,7 +19,7 @@ DEFINE_PROTO_FUZZER(
   }
 
   Stats::IsolatedStoreImpl store;
-  ConfigSharedPtr cfg = std::make_shared<Config>(store, input.config());
+  ConfigSharedPtr cfg = std::make_shared<Config>(*store.rootScope(), input.config());
   auto filter = std::make_unique<Filter>(std::move(cfg));
 
   ListenerFilterWithDataFuzzer fuzzer;

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -92,7 +92,7 @@ public:
   uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override { return {}; }
   bool continueOnListenerFiltersTimeout() const override { return false; }
-  Stats::Scope& listenerScope() override { return stats_store_; }
+  Stats::Scope& listenerScope() override { return *stats_store_.rootScope(); }
   uint64_t listenerTag() const override { return 1; }
   ResourceLimit& openConnections() override { return open_connections_; }
   const std::string& name() const override { return name_; }
@@ -1796,7 +1796,7 @@ public:
   std::chrono::milliseconds listenerFiltersTimeout() const override { return {}; }
   ResourceLimit& openConnections() override { return open_connections_; }
   bool continueOnListenerFiltersTimeout() const override { return false; }
-  Stats::Scope& listenerScope() override { return stats_store_; }
+  Stats::Scope& listenerScope() override { return *stats_store_.rootScope(); }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }
   Network::UdpListenerConfigOptRef udpListenerConfig() override {

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -72,7 +72,7 @@ static void BM_TlsInspector(benchmark::State& state) {
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls};
   NiceMock<Stats::MockStore> store;
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
-  ConfigSharedPtr cfg(std::make_shared<Config>(store, proto_config));
+  ConfigSharedPtr cfg(std::make_shared<Config>(*store.rootScope(), proto_config));
   Network::IoHandlePtr io_handle = std::make_unique<Network::IoSocketHandleImpl>();
   Network::ConnectionSocketImpl socket(std::move(io_handle), nullptr, nullptr);
   NiceMock<FastMockDispatcher> dispatcher;

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_fuzz_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_fuzz_test.cc
@@ -23,9 +23,9 @@ DEFINE_PROTO_FUZZER(
 
   if (input.max_size() == 0) {
     // If max_size not set, use default constructor
-    cfg = std::make_shared<Config>(store, input.config());
+    cfg = std::make_shared<Config>(*store.rootScope(), input.config());
   } else {
-    cfg = std::make_shared<Config>(store, input.config(), input.max_size());
+    cfg = std::make_shared<Config>(*store.rootScope(), input.config(), input.max_size());
   }
 
   auto filter = std::make_unique<Filter>(std::move(cfg));

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -80,7 +80,7 @@ public:
         Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
-                                 *config_, redis_command_stats_, stats_, false);
+                                 *config_, redis_command_stats_, *stats_.rootScope(), false);
     EXPECT_EQ(1UL, host_->cluster_.traffic_stats_->upstream_cx_total_.value());
     EXPECT_EQ(1UL, host_->stats_.cx_total_.value());
     EXPECT_EQ(false, client_->active());
@@ -1213,8 +1213,8 @@ TEST(RedisClientFactoryImplTest, Basic) {
       Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
   const std::string auth_username;
   const std::string auth_password;
-  ClientPtr client = factory.create(host, dispatcher, config, redis_command_stats, stats_,
-                                    auth_username, auth_password, false);
+  ClientPtr client = factory.create(host, dispatcher, config, redis_command_stats,
+                                    *stats_.rootScope(), auth_username, auth_password, false);
   client->close();
 }
 } // namespace Client

--- a/test/extensions/filters/network/connection_limit/connection_limit_test.cc
+++ b/test/extensions/filters/network/connection_limit/connection_limit_test.cc
@@ -26,7 +26,7 @@ public:
   void initialize(const std::string& filter_yaml) {
     envoy::extensions::filters::network::connection_limit::v3::ConnectionLimit proto_config;
     TestUtility::loadFromYamlAndValidate(filter_yaml, proto_config);
-    config_ = std::make_shared<Config>(proto_config, stats_store_, runtime_);
+    config_ = std::make_shared<Config>(proto_config, *stats_store_.rootScope(), runtime_);
   }
 
   Thread::ThreadSynchronizer& synchronizer() { return config_->synchronizer_; }

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -118,7 +118,7 @@ public:
 class ConnectionManagerTest : public testing::Test {
 public:
   ConnectionManagerTest()
-      : stats_(DubboFilterStats::generateStats("test.", store_)),
+      : stats_(DubboFilterStats::generateStats("test.", *store_.rootScope())),
         engine_(std::make_unique<Regex::GoogleReEngine>()) {
 
     route_config_provider_manager_ =

--- a/test/extensions/filters/network/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_fuzz_test.cc
@@ -65,7 +65,8 @@ DEFINE_PROTO_FUZZER(const envoy::extensions::filters::network::ext_authz::ExtAut
   envoy::extensions::filters::network::ext_authz::v3::ExtAuthz proto_config = input.config();
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
 
-  ConfigSharedPtr config = std::make_shared<Config>(proto_config, stats_store, bootstrap);
+  ConfigSharedPtr config =
+      std::make_shared<Config>(proto_config, *stats_store.rootScope(), bootstrap);
   std::unique_ptr<Filter> filter =
       std::make_unique<Filter>(config, Filters::Common::ExtAuthz::ClientPtr{client});
 

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -40,7 +40,7 @@ public:
   void initialize(std::string yaml) {
     envoy::extensions::filters::network::ext_authz::v3::ExtAuthz proto_config{};
     TestUtility::loadFromYaml(yaml, proto_config);
-    config_ = std::make_shared<Config>(proto_config, stats_store_, bootstrap_);
+    config_ = std::make_shared<Config>(proto_config, *stats_store_.rootScope(), bootstrap_);
     client_ = new Filters::Common::ExtAuthz::MockClient();
     filter_ = std::make_unique<Filter>(config_, Filters::Common::ExtAuthz::ClientPtr{client_});
     filter_->initializeReadFilterCallbacks(filter_callbacks_);

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_fuzz_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_fuzz_test.cc
@@ -71,8 +71,8 @@ DEFINE_PROTO_FUZZER(
       input.config();
   ConfigSharedPtr config = nullptr;
   try {
-    config =
-        std::make_shared<Config>(proto_config, dispatcher, stats_store, runtime, singleton_manager);
+    config = std::make_shared<Config>(proto_config, dispatcher, *stats_store.rootScope(), runtime,
+                                      singleton_manager);
   } catch (EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException in config's constructor: {}", e.what());
     return;

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
@@ -34,8 +34,8 @@ public:
       EXPECT_CALL(*fill_timer_, enableTimer(_, nullptr));
       EXPECT_CALL(*fill_timer_, disableTimer());
     }
-    config_ = std::make_shared<Config>(proto_config, dispatcher_, stats_store_, runtime_,
-                                       singleton_manager_);
+    config_ = std::make_shared<Config>(proto_config, dispatcher_, *stats_store_.rootScope(),
+                                       runtime_, singleton_manager_);
     return proto_config.token_bucket().max_tokens();
   }
 
@@ -149,8 +149,8 @@ public:
       EXPECT_CALL(*timer, enableTimer(_, nullptr));
       EXPECT_CALL(*timer, disableTimer());
     }
-    config2_ = std::make_shared<Config>(proto_config, dispatcher_, stats_store_, runtime_,
-                                        singleton_manager_);
+    config2_ = std::make_shared<Config>(proto_config, dispatcher_, *stats_store_.rootScope(),
+                                        runtime_, singleton_manager_);
 
     // This test just uses the initial tokens without ever refilling.
     if (expect_sharing) {
@@ -241,8 +241,8 @@ token_bucket:
     std::string yaml = fmt::format(yaml_template, i);
     envoy::extensions::filters::network::local_ratelimit::v3::LocalRateLimit proto_config;
     TestUtility::loadFromYamlAndValidate(yaml, proto_config);
-    configs.push_back(std::make_unique<Config>(proto_config, dispatcher_, stats_store_, runtime_,
-                                               singleton_manager_));
+    configs.push_back(std::make_unique<Config>(proto_config, dispatcher_, *stats_store_.rootScope(),
+                                               runtime_, singleton_manager_));
   }
 
   configs.clear();

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -60,7 +60,7 @@ public:
 class MongoProxyFilterTest : public testing::Test {
 public:
   MongoProxyFilterTest()
-      : mongo_stats_(std::make_shared<MongoStats>(store_, "test",
+      : mongo_stats_(std::make_shared<MongoStats>(*store_.rootScope(), "test",
                                                   std::vector<std::string>{"insert", "count"})),
         stream_info_(time_source_) {
     setup();
@@ -85,7 +85,7 @@ public:
 
   void initializeFilter(bool emit_dynamic_metadata = false) {
     filter_ = std::make_unique<TestProxyFilter>(
-        "test.", store_, runtime_, access_log_, fault_config_, drain_decision_,
+        "test.", *store_.rootScope(), runtime_, access_log_, fault_config_, drain_decision_,
         dispatcher_.timeSource(), emit_dynamic_metadata, mongo_stats_);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -47,7 +47,7 @@ public:
 
     envoy::extensions::filters::network::ratelimit::v3::RateLimit proto_config{};
     TestUtility::loadFromYaml(yaml, proto_config);
-    config_ = std::make_shared<Config>(proto_config, stats_store_, runtime_);
+    config_ = std::make_shared<Config>(proto_config, *stats_store_.rootScope(), runtime_);
     client_ = new Filters::Common::RateLimit::MockClient();
     filter_ = std::make_unique<Filter>(config_, Filters::Common::RateLimit::ClientPtr{client_});
 

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -68,15 +68,17 @@ private:
 
     Stats::IsolatedStoreImpl store;
     NiceMock<Server::Configuration::MockServerFactoryContext> context;
-    EXPECT_THROW(std::make_shared<RoleBasedAccessControlFilterConfig>(
-                     config, store, context, ProtobufMessage::getStrictValidationVisitor()),
-                 Envoy::EnvoyException);
+    EXPECT_THROW(
+        std::make_shared<RoleBasedAccessControlFilterConfig>(
+            config, *store.rootScope(), context, ProtobufMessage::getStrictValidationVisitor()),
+        Envoy::EnvoyException);
 
     config.clear_matcher();
     *config.mutable_shadow_matcher() = matcher_proto;
-    EXPECT_THROW(std::make_shared<RoleBasedAccessControlFilterConfig>(
-                     config, store, context, ProtobufMessage::getStrictValidationVisitor()),
-                 Envoy::EnvoyException);
+    EXPECT_THROW(
+        std::make_shared<RoleBasedAccessControlFilterConfig>(
+            config, *store.rootScope(), context, ProtobufMessage::getStrictValidationVisitor()),
+        Envoy::EnvoyException);
   }
 };
 

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -58,7 +58,7 @@ public:
     }
 
     config_ = std::make_shared<RoleBasedAccessControlFilterConfig>(
-        config, store_, context_, ProtobufMessage::getStrictValidationVisitor());
+        config, *store_.rootScope(), context_, ProtobufMessage::getStrictValidationVisitor());
 
     filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
     filter_->initializeReadFilterCallbacks(callbacks_);
@@ -161,7 +161,7 @@ on_no_match:
     }
 
     config_ = std::make_shared<RoleBasedAccessControlFilterConfig>(
-        config, store_, context_, ProtobufMessage::getStrictValidationVisitor());
+        config, *store_.rootScope(), context_, ProtobufMessage::getStrictValidationVisitor());
 
     filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
     filter_->initializeReadFilterCallbacks(callbacks_);

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -78,8 +78,12 @@ public:
   NiceMock<MockFaultManager> fault_manager_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   CommandSplitter::InstanceImpl splitter_{
-      RouterPtr{router_}, store_, "redis.foo.",
-      time_system_,       false,  std::make_unique<NiceMock<MockFaultManager>>(fault_manager_)};
+      RouterPtr{router_},
+      *store_.rootScope(),
+      "redis.foo.",
+      time_system_,
+      false,
+      std::make_unique<NiceMock<MockFaultManager>>(fault_manager_)};
   NoOpSplitCallbacks callbacks_;
   CommandSplitter::SplitRequestPtr handle_;
 };

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -73,7 +73,7 @@ public:
 
   Event::SimulatedTimeSystem time_system_;
   InstanceImpl splitter_{std::make_unique<NiceMock<MockRouter>>(route_),
-                         store_,
+                         *store_.rootScope(),
                          "redis.foo.",
                          time_system_,
                          latency_in_micros_,

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -69,7 +69,8 @@ TEST_F(RedisProxyFilterConfigTest, Normal) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ("redis.foo.", config.stat_prefix_);
   EXPECT_TRUE(config.downstream_auth_username_.empty());
   EXPECT_TRUE(config.downstream_auth_passwords_.empty());
@@ -98,7 +99,8 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthPasswordSet) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ(config.downstream_auth_passwords_.size(), 1);
   EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
 }
@@ -120,7 +122,8 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamMultipleAuthPasswordsSet) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ(config.downstream_auth_passwords_.size(), 3);
   EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
   EXPECT_EQ(config.downstream_auth_passwords_[1], "newpassword1");
@@ -142,7 +145,8 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamOnlyExraAuthPasswordsSet) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ(config.downstream_auth_passwords_.size(), 2);
   EXPECT_EQ(config.downstream_auth_passwords_[0], "newpassword1");
   EXPECT_EQ(config.downstream_auth_passwords_[1], "newpassword2");
@@ -164,7 +168,8 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSet) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ(config.downstream_auth_username_, "someusername");
   EXPECT_EQ(config.downstream_auth_passwords_.size(), 1);
   EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
@@ -189,7 +194,8 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSetWithMultiplePasswords) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ(config.downstream_auth_username_, "someusername");
   EXPECT_EQ(config.downstream_auth_passwords_.size(), 3);
   EXPECT_EQ(config.downstream_auth_passwords_[0], "somepassword");
@@ -214,7 +220,8 @@ TEST_F(RedisProxyFilterConfigTest, DownstreamAuthAclSetWithOnlyExtraPasswords) {
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
       parseProtoFromYaml(yaml_string);
-  ProxyFilterConfig config(proto_config, store_, drain_decision_, runtime_, api_, *this);
+  ProxyFilterConfig config(proto_config, *store_.rootScope(), drain_decision_, runtime_, api_,
+                           *this);
   EXPECT_EQ(config.downstream_auth_username_, "someusername");
   EXPECT_EQ(config.downstream_auth_passwords_.size(), 2);
   EXPECT_EQ(config.downstream_auth_passwords_[0], "newpassword1");
@@ -245,8 +252,8 @@ public:
   RedisProxyFilterTest(const std::string& yaml_string) {
     envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config =
         parseProtoFromYaml(yaml_string);
-    config_ = std::make_shared<ProxyFilterConfig>(proto_config, store_, drain_decision_, runtime_,
-                                                  api_, *this);
+    config_ = std::make_shared<ProxyFilterConfig>(proto_config, *store_.rootScope(),
+                                                  drain_decision_, runtime_, api_, *this);
     filter_ = std::make_unique<ProxyFilter>(*this, Common::Redis::EncoderPtr{encoder_}, splitter_,
                                             config_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -88,7 +88,8 @@ public:
 
 class ThriftConnectionManagerTest : public testing::Test {
 public:
-  ThriftConnectionManagerTest() : stats_(ThriftFilterStats::generateStats("test.", store_)) {
+  ThriftConnectionManagerTest()
+      : stats_(ThriftFilterStats::generateStats("test.", *store_.rootScope())) {
     route_config_provider_manager_ =
         std::make_unique<Router::RouteConfigProviderManagerImpl>(context_.admin_);
     ON_CALL(*context_.access_log_manager_.file_, write(_))

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -55,7 +55,8 @@ public:
         proto_config{};
     TestUtility::loadFromYaml(yaml, proto_config);
 
-    config_ = std::make_shared<Config>(proto_config, local_info_, stats_store_, runtime_, cm_);
+    config_ = std::make_shared<Config>(proto_config, local_info_, *stats_store_.rootScope(),
+                                       runtime_, cm_);
 
     request_metadata_ = std::make_shared<ThriftProxy::MessageMetadata>();
 

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -590,27 +590,28 @@ public:
     router_.reset();
   }
 
-  void expectStatCalls(Stats::MockStore& cluster_scope) {
+  void expectStatCalls(Stats::MockStore& cluster_store) {
+    Stats::MockScope& cluster_scope = cluster_store.mockScope();
     ON_CALL(*context_.cluster_manager_.thread_local_cluster_.cluster_.info_, statsScope())
         .WillByDefault(ReturnRef(cluster_scope));
 
-    EXPECT_CALL(cluster_scope, counter("thrift.upstream_rq_call")).Times(AtLeast(1));
-    EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_reply")).Times(AtLeast(1));
-    EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_success")).Times(AtLeast(1));
+    EXPECT_CALL(cluster_store, counter("thrift.upstream_rq_call")).Times(AtLeast(1));
+    EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_reply")).Times(AtLeast(1));
+    EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_success")).Times(AtLeast(1));
 
-    EXPECT_CALL(cluster_scope,
+    EXPECT_CALL(cluster_store,
                 histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds));
-    EXPECT_CALL(cluster_scope,
+    EXPECT_CALL(cluster_store,
                 deliverHistogramToSinks(
                     testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), _));
 
-    EXPECT_CALL(cluster_scope, histogram("thrift.upstream_rq_size", Stats::Histogram::Unit::Bytes));
-    EXPECT_CALL(cluster_scope,
+    EXPECT_CALL(cluster_store, histogram("thrift.upstream_rq_size", Stats::Histogram::Unit::Bytes));
+    EXPECT_CALL(cluster_store,
                 deliverHistogramToSinks(
                     testing::Property(&Stats::Metric::name, "thrift.upstream_rq_size"), _));
-    EXPECT_CALL(cluster_scope,
+    EXPECT_CALL(cluster_store,
                 histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
-    EXPECT_CALL(cluster_scope,
+    EXPECT_CALL(cluster_store,
                 deliverHistogramToSinks(
                     testing::Property(&Stats::Metric::name, "thrift.upstream_resp_size"), _));
   }
@@ -1109,13 +1110,14 @@ TEST_F(ThriftRouterTest, UnexpectedRouterDestroy) {
 }
 
 TEST_F(ThriftRouterTest, ProtocolUpgrade) {
-  Stats::MockStore cluster_scope;
+  Stats::MockStore cluster_store;
+  Stats::MockScope& cluster_scope{cluster_store.mockScope()};
   ON_CALL(*context_.cluster_manager_.thread_local_cluster_.cluster_.info_, statsScope())
       .WillByDefault(ReturnRef(cluster_scope));
 
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_rq_call"));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_reply"));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_success"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_rq_call"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_reply"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_success"));
 
   initializeRouter();
   startRequest(MessageType::Call);
@@ -1137,18 +1139,18 @@ TEST_F(ThriftRouterTest, ProtocolUpgrade) {
 
   EXPECT_CALL(*protocol_, supportsUpgrade()).WillOnce(Return(true));
 
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), _));
 
-  EXPECT_CALL(cluster_scope, histogram("thrift.upstream_rq_size", Stats::Histogram::Unit::Bytes));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store, histogram("thrift.upstream_rq_size", Stats::Histogram::Unit::Bytes));
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_rq_size"), _));
-  EXPECT_CALL(cluster_scope, histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store, histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_resp_size"), _));
 
@@ -1326,20 +1328,21 @@ TEST_F(ThriftRouterTest, ProtocolUpgradeSkippedOnExistingConnection) {
 TEST_F(ThriftRouterTest, PoolTimeoutUpstreamTimeMeasurement) {
   initializeRouter();
 
-  Stats::MockStore cluster_scope;
+  Stats::MockStore cluster_store;
+  Stats::MockScope& cluster_scope{cluster_store.mockScope()};
   ON_CALL(*context_.cluster_manager_.thread_local_cluster_.cluster_.info_, statsScope())
       .WillByDefault(ReturnRef(cluster_scope));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_rq_call"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_rq_call"));
 
   startRequest(MessageType::Call);
 
   dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(500));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_exception"));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_exception_local"));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception_local"));
+  EXPECT_CALL(cluster_store,
               histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds))
       .Times(0);
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), 500))
       .Times(0);
@@ -1412,19 +1415,20 @@ TEST_P(ThriftRouterFieldTypeTest, CallWithUpstreamRqTime) {
 
   initializeRouter();
 
-  Stats::MockStore cluster_scope;
+  Stats::MockStore cluster_store;
+  Stats::MockScope& cluster_scope{cluster_store.mockScope()};
   ON_CALL(*context_.cluster_manager_.thread_local_cluster_.cluster_.info_, statsScope())
       .WillByDefault(ReturnRef(cluster_scope));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_rq_call"));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_reply"));
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_resp_success"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_rq_call"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_reply"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_success"));
 
-  EXPECT_CALL(cluster_scope, histogram("thrift.upstream_rq_size", Stats::Histogram::Unit::Bytes));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store, histogram("thrift.upstream_rq_size", Stats::Histogram::Unit::Bytes));
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_rq_size"), _));
-  EXPECT_CALL(cluster_scope, histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store, histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_resp_size"), _));
 
@@ -1434,9 +1438,9 @@ TEST_P(ThriftRouterFieldTypeTest, CallWithUpstreamRqTime) {
   completeRequest();
 
   dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(500));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), 500));
   returnResponse();
@@ -1725,8 +1729,8 @@ TEST_P(ThriftRouterPassthroughTest, PassthroughEnable) {
 TEST_F(ThriftRouterTest, RequestResponseSize) {
   initializeRouter();
 
-  Stats::MockStore cluster_scope;
-  expectStatCalls(cluster_scope);
+  Stats::MockStore cluster_store;
+  expectStatCalls(cluster_store);
 
   startRequestWithExistingConnection(MessageType::Call);
   sendTrivialStruct(FieldType::I32);
@@ -1740,9 +1744,9 @@ TEST_F(ThriftRouterTest, UpstreamDraining) {
 
   initializeRouter();
 
-  Stats::MockStore cluster_scope;
-  expectStatCalls(cluster_scope);
-  EXPECT_CALL(cluster_scope, counter("thrift.upstream_cx_drain_close")).Times(AtLeast(1));
+  Stats::MockStore cluster_store;
+  expectStatCalls(cluster_store);
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_cx_drain_close")).Times(AtLeast(1));
   // Keep the downstream connection.
   EXPECT_CALL(callbacks_, resetDownstreamConnection()).Times(0);
   startRequestWithExistingConnection(MessageType::Call);
@@ -1899,7 +1903,8 @@ TEST_F(ThriftRouterTest, UpstreamZoneCallException) {
 }
 
 TEST_F(ThriftRouterTest, UpstreamZoneCallWithRqTime) {
-  NiceMock<Stats::MockStore> cluster_scope;
+  NiceMock<Stats::MockStore> cluster_store;
+  Stats::MockScope& cluster_scope{cluster_store.mockScope()};
   ON_CALL(*context_.cluster_manager_.thread_local_cluster_.cluster_.info_, statsScope())
       .WillByDefault(ReturnRef(cluster_scope));
 
@@ -1911,20 +1916,20 @@ TEST_F(ThriftRouterTest, UpstreamZoneCallWithRqTime) {
   completeRequest();
 
   dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(500));
-  EXPECT_CALL(cluster_scope, histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store, histogram("thrift.upstream_resp_size", Stats::Histogram::Unit::Bytes));
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_resp_size"), _));
 
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), _));
 
-  EXPECT_CALL(cluster_scope, histogram("zone.zone_name.other_zone_name.thrift.upstream_rq_time",
+  EXPECT_CALL(cluster_store, histogram("zone.zone_name.other_zone_name.thrift.upstream_rq_time",
                                        Stats::Histogram::Unit::Milliseconds));
-  EXPECT_CALL(cluster_scope,
+  EXPECT_CALL(cluster_store,
               deliverHistogramToSinks(
                   testing::Property(&Stats::Metric::name,
                                     "zone.zone_name.other_zone_name.thrift.upstream_rq_time"),

--- a/test/extensions/filters/network/wasm/config_test.cc
+++ b/test/extensions/filters/network/wasm/config_test.cc
@@ -28,7 +28,7 @@ class WasmNetworkFilterConfigTest
 protected:
   WasmNetworkFilterConfigTest() : api_(Api::createApiForTest(stats_store_)) {
     ON_CALL(context_, api()).WillByDefault(ReturnRef(*api_));
-    ON_CALL(context_, scope()).WillByDefault(ReturnRef(stats_store_));
+    ON_CALL(context_, scope()).WillByDefault(ReturnRef(stats_scope_));
     ON_CALL(context_, listenerMetadata()).WillByDefault(ReturnRef(listener_metadata_));
     ON_CALL(context_, initManager()).WillByDefault(ReturnRef(init_manager_));
     ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
@@ -48,6 +48,7 @@ protected:
 
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   Stats::IsolatedStoreImpl stats_store_;
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   Api::ApiPtr api_;
   envoy::config::core::v3::Metadata listener_metadata_;
   Init::ManagerImpl init_manager_{"init_manager"};

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -495,10 +495,11 @@ public:
   }
 
   Stats::HistogramOptConstRef findHistogram(const std::string& name) {
-    return scope_.findHistogramByString(name);
+    return store_.findHistogramByString(name);
   }
 
-  Stats::TestUtil::TestStore scope_;
+  Stats::TestUtil::TestStore store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   ZooKeeperFilterConfigSharedPtr config_;
   std::unique_ptr<ZooKeeperFilter> filter_;
   std::string stat_prefix_{"test.zookeeper"};
@@ -611,7 +612,7 @@ TEST_F(ZooKeeperFilterTest, AuthRequest) {
   Buffer::OwnedImpl data = encodeAuth("digest");
 
   testRequest(data, {{{"opname", "auth"}}, {{"bytes", "36"}}},
-              scope_.counter("test.zookeeper.auth.digest_rq"), 36);
+              store_.counter("test.zookeeper.auth.digest_rq"), 36);
   testResponse({{{"opname", "auth_response"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
                config_->stats().auth_resp_, enumToSignedInt(XidCodes::AuthXid));
 }

--- a/test/extensions/listener_managers/listener_manager/lds_api_test.cc
+++ b/test/extensions/listener_managers/listener_manager/lds_api_test.cc
@@ -39,8 +39,9 @@ public:
   void setup() {
     envoy::config::core::v3::ConfigSource lds_config;
     EXPECT_CALL(init_manager_, add(_));
-    lds_ = std::make_unique<LdsApiImpl>(lds_config, nullptr, cluster_manager_, init_manager_,
-                                        store_, listener_manager_, validation_visitor_);
+    lds_ =
+        std::make_unique<LdsApiImpl>(lds_config, nullptr, cluster_manager_, init_manager_,
+                                     *store_.rootScope(), listener_manager_, validation_visitor_);
     EXPECT_CALL(*cluster_manager_.subscription_factory_.subscription_, start(_));
     init_target_handle_->initialize(init_watcher_);
     lds_callbacks_ = cluster_manager_.subscription_factory_.callbacks_;

--- a/test/extensions/matching/input_matchers/ip/matcher_test.cc
+++ b/test/extensions/matching/input_matchers/ip/matcher_test.cc
@@ -19,7 +19,8 @@ public:
     m_ = std::make_unique<Matcher>(std::move(ranges), stat_prefix_, scope_);
   }
 
-  Stats::TestUtil::TestStore scope_;
+  Stats::TestUtil::TestStore store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   std::string stat_prefix_{"ipmatcher.test"};
   std::unique_ptr<Matcher> m_;
 };

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -1453,7 +1453,7 @@ TEST_P(DnsImplTest, PendingTimerEnable) {
   Event::MockDispatcher dispatcher;
   Event::MockTimer* timer = new NiceMock<Event::MockTimer>();
   EXPECT_CALL(dispatcher, createTimer_(_)).WillOnce(Return(timer));
-  resolver_ = std::make_shared<DnsResolverImpl>(config, dispatcher, vec, stats_store_);
+  resolver_ = std::make_shared<DnsResolverImpl>(config, dispatcher, vec, *stats_store_.rootScope());
   Event::FileEvent* file_event = new NiceMock<Event::MockFileEvent>();
   EXPECT_CALL(dispatcher, createFileEvent_(_, _, _, _)).WillOnce(Return(file_event));
   EXPECT_CALL(*timer, enableTimer(_, _));

--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -39,7 +39,7 @@ public:
     cluster_manager_.initializeThreadLocalClusters({"fake_cluster"});
     sink_ = std::make_unique<TcpStatsdSink>(
         local_info_, "fake_cluster", tls_, cluster_manager_,
-        cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_);
+        *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()));
   }
 
   void expectCreateConnection() {
@@ -178,7 +178,8 @@ TEST_F(TcpStatsdSinkTest, NoHost) {
 TEST_F(TcpStatsdSinkTest, WithCustomPrefix) {
   sink_ = std::make_unique<TcpStatsdSink>(
       local_info_, "fake_cluster", tls_, cluster_manager_,
-      cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_, "test_prefix");
+      *(cluster_manager_.active_clusters_["fake_cluster"]->info_->stats_store_.rootScope()),
+      "test_prefix");
 
   NiceMock<Stats::MockCounter> counter;
   counter.name_ = "test_counter";

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -44,7 +44,7 @@ public:
 
     // Set gauge value.
     membership_total_gauge_.name_ = "membership_total";
-    ON_CALL(cluster_stats_scope_, gauge("membership_total", Stats::Gauge::ImportMode::NeverImport))
+    ON_CALL(cluster_stats_store_, gauge("membership_total", Stats::Gauge::ImportMode::NeverImport))
         .WillByDefault(ReturnRef(membership_total_gauge_));
     ON_CALL(membership_total_gauge_, value()).WillByDefault(Return(5));
 
@@ -60,7 +60,7 @@ public:
   // Attach the counter to cluster_stat_scope and set default value.
   void setCounterForTest(NiceMock<Stats::MockCounter>& counter, std::string counter_name) {
     counter.name_ = counter_name;
-    ON_CALL(cluster_stats_scope_, counter(counter_name)).WillByDefault(ReturnRef(counter));
+    ON_CALL(cluster_stats_store_, counter(counter_name)).WillByDefault(ReturnRef(counter));
   }
 
   void setCountersToZero() {
@@ -92,7 +92,8 @@ public:
   Upstream::ClusterInfoConstSharedPtr cluster_info_ptr_{cluster_info_};
 
   NiceMock<Stats::MockStore> stats_store_;
-  NiceMock<Stats::MockStore> cluster_stats_scope_;
+  NiceMock<Stats::MockStore> cluster_stats_store_;
+  Stats::MockScope& cluster_stats_scope_{cluster_stats_store_.mockScope()};
   const std::string cluster_name_;
 
   NiceMock<Stats::MockGauge> membership_total_gauge_;

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -51,7 +51,8 @@ public:
   setupValidDriver(OpenTracingDriver::PropagationMode propagation_mode =
                        OpenTracingDriver::PropagationMode::SingleHeader,
                    const opentracing::mocktracer::PropagationOptions& propagation_options = {}) {
-    driver_ = std::make_unique<TestDriver>(propagation_mode, propagation_options, stats_);
+    driver_ =
+        std::make_unique<TestDriver>(propagation_mode, propagation_options, *stats_.rootScope());
   }
 
   const std::string operation_name_{"test"};

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -55,7 +55,7 @@ public:
       EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(900), _));
     }
 
-    driver_ = std::make_unique<Driver>(datadog_config, cm_, stats_, tls_, runtime_);
+    driver_ = std::make_unique<Driver>(datadog_config, cm_, *stats_.rootScope(), tls_, runtime_);
   }
 
   void setupValidDriver() {

--- a/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
@@ -21,7 +21,8 @@ namespace {
 class DynamicOpenTracingDriverTest : public testing::Test {
 public:
   void setup(const std::string& library, const std::string& tracer_config) {
-    driver_ = std::make_unique<DynamicOpenTracingDriver>(stats_, library, tracer_config);
+    driver_ =
+        std::make_unique<DynamicOpenTracingDriver>(*stats_.rootScope(), library, tracer_config);
   }
 
   void setupValidDriver() { setup(library_path_, tracer_config_); }

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -41,7 +41,7 @@ public:
     ON_CALL(factory_context, runtime()).WillByDefault(ReturnRef(runtime_));
     ON_CALL(factory_context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
         .WillByDefault(Return(ByMove(std::move(mock_client_factory))));
-    ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(stats_));
+    ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(scope_));
 
     driver_ = std::make_unique<Driver>(opentelemetry_config, context_);
   }
@@ -70,6 +70,7 @@ protected:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Event::MockTimer>* timer_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_;
+  Stats::Scope& scope_{*stats_.rootScope()};
 };
 
 TEST_F(OpenTelemetryDriverTest, InitializeDriverValidConfig) {

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -56,8 +56,8 @@ public:
       EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5000), _));
     }
 
-    driver_ = std::make_unique<Driver>(zipkin_config, cm_, stats_, tls_, runtime_, local_info_,
-                                       random_, time_source_);
+    driver_ = std::make_unique<Driver>(zipkin_config, cm_, *stats_.rootScope(), tls_, runtime_,
+                                       local_info_, random_, time_source_);
   }
 
   void setupValidDriverWithHostname(const std::string& version, const std::string& hostname) {

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
@@ -127,7 +127,9 @@ public:
   }
 
 protected:
-  void initialize() { config_ = std::make_unique<Config>(config_proto_, stats_store_); }
+  void initialize() {
+    config_ = std::make_unique<Config>(config_proto_, *stats_store_.rootScope());
+  }
   envoy::extensions::transport_sockets::internal_upstream::v3::InternalUpstreamTransport
       config_proto_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -275,7 +275,7 @@ void StartTlsIntegrationTest::initialize() {
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   tls_context_ = Network::DownstreamTransportSocketFactoryPtr{
       new Extensions::TransportSockets::Tls::ServerSslSocketFactory(
-          std::move(cfg), *tls_context_manager_, *client_stats_store, {})};
+          std::move(cfg), *tls_context_manager_, *client_stats_store->rootScope(), {})};
 
   BaseIntegrationTest::initialize();
 }

--- a/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
+++ b/test/extensions/transport_sockets/tcp_stats/tcp_stats_test.cc
@@ -35,7 +35,7 @@ public:
       proto_config.mutable_update_period()->MergeFrom(
           ProtobufUtil::TimeUtil::MillisecondsToDuration(1000));
     }
-    config_ = std::make_shared<Config>(proto_config, store_);
+    config_ = std::make_shared<Config>(proto_config, *store_.rootScope());
     ON_CALL(transport_callbacks_, ioHandle()).WillByDefault(ReturnRef(io_handle_));
     ON_CALL(io_handle_, getOption(IPPROTO_TCP, TCP_INFO, _, _))
         .WillByDefault(Invoke([this](int, int, void* optval, socklen_t* optlen) {

--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -135,7 +135,7 @@ TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameNotMatched) {
 
 TEST(DefaultCertValidatorTest, TestCertificateVerificationWithSANMatcher) {
   Stats::TestUtil::TestStore test_store;
-  SslStats stats = generateSslStats(test_store);
+  SslStats stats = generateSslStats(*test_store.rootScope());
   // Create the default validator object.
   auto default_validator =
       std::make_unique<Extensions::TransportSockets::Tls::DefaultCertValidator>(
@@ -168,7 +168,7 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithSANMatcher) {
 
 TEST(DefaultCertValidatorTest, TestCertificateVerificationWithNoValidationContext) {
   Stats::TestUtil::TestStore test_store;
-  SslStats stats = generateSslStats(test_store);
+  SslStats stats = generateSslStats(*test_store.rootScope());
   // Create the default validator object.
   auto default_validator =
       std::make_unique<Extensions::TransportSockets::Tls::DefaultCertValidator>(
@@ -198,7 +198,7 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithNoValidationContex
 
 TEST(DefaultCertValidatorTest, TestCertificateVerificationWithEmptyCertChain) {
   Stats::TestUtil::TestStore test_store;
-  SslStats stats = generateSslStats(test_store);
+  SslStats stats = generateSslStats(*test_store.rootScope());
   // Create the default validator object.
   auto default_validator =
       std::make_unique<Extensions::TransportSockets::Tls::DefaultCertValidator>(
@@ -229,7 +229,7 @@ TEST(DefaultCertValidatorTest, NoSanInCert) {
 TEST(DefaultCertValidatorTest, WithVerifyDepth) {
 
   Stats::TestUtil::TestStore test_store;
-  SslStats stats = generateSslStats(test_store);
+  SslStats stats = generateSslStats(*test_store.rootScope());
   envoy::config::core::v3::TypedExtensionConfig typed_conf;
   std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher> san_matchers{};
 
@@ -332,7 +332,7 @@ TEST(DefaultCertValidatorTest, TestUnexpectedSanMatcherType) {
   auto matchers =
       std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher>();
   Stats::TestUtil::TestStore store;
-  auto ssl_stats = generateSslStats(store);
+  auto ssl_stats = generateSslStats(*store.rootScope());
   auto validator = std::make_unique<DefaultCertValidator>(mock_context_config.get(), ssl_stats,
                                                           Event::GlobalTimeSystem().timeSystem());
   auto ctx = std::vector<SSL_CTX*>();

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
@@ -38,7 +38,7 @@ using SSLContextPtr = CSmartPtr<SSL_CTX, SSL_CTX_free>;
 
 class TestSPIFFEValidator : public ::testing::Test, public testing::WithParamInterface<bool> {
 public:
-  TestSPIFFEValidator() : stats_(generateSslStats(store_)) {
+  TestSPIFFEValidator() : stats_(generateSslStats(*store_.rootScope())) {
     Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.tls_async_cert_validation",
                                   GetParam());
   }

--- a/test/extensions/transport_sockets/tls/handshaker_factory_test.cc
+++ b/test/extensions/transport_sockets/tls/handshaker_factory_test.cc
@@ -136,7 +136,7 @@ TEST_F(HandshakerFactoryTest, SetMockFunctionCb) {
       /*config=*/
       std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
           tls_context_, "", mock_factory_ctx),
-      *context_manager_, stats_store_);
+      *context_manager_, *stats_store_.rootScope());
 
   std::unique_ptr<Network::TransportSocket> socket =
       socket_factory.createTransportSocket(nullptr, nullptr);
@@ -162,7 +162,7 @@ TEST_F(HandshakerFactoryTest, SetSpecificSslCtxOption) {
       /*config=*/
       std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
           tls_context_, "", mock_factory_ctx),
-      *context_manager_, stats_store_);
+      *context_manager_, *stats_store_.rootScope());
 
   std::unique_ptr<Network::TransportSocket> socket =
       socket_factory.createTransportSocket(nullptr, nullptr);
@@ -199,7 +199,7 @@ TEST_F(HandshakerFactoryTest, HandshakerContextProvidesObjectsFromParentContext)
       /*config=*/
       std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
           tls_context_, "", mock_factory_ctx),
-      *context_manager_, stats_store_);
+      *context_manager_, *stats_store_.rootScope());
 
   std::unique_ptr<Network::TransportSocket> socket =
       socket_factory.createTransportSocket(nullptr, nullptr);
@@ -295,8 +295,8 @@ TEST_F(HandshakerFactoryDownstreamTest, ServerHandshakerProvidesCertificates) {
   Extensions::TransportSockets::Tls::ServerContextConfigImpl server_context_config(
       tls_context_, mock_factory_ctx);
   EXPECT_TRUE(server_context_config.isReady());
-  EXPECT_NO_THROW(context_manager_->createSslServerContext(stats_store_, server_context_config,
-                                                           std::vector<std::string>{}));
+  EXPECT_NO_THROW(context_manager_->createSslServerContext(
+      *stats_store_.rootScope(), server_context_config, std::vector<std::string>{}));
 }
 
 } // namespace

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -353,8 +353,8 @@ void testUtil(const TestUtilOptions& options) {
       std::make_unique<ServerContextConfigImpl>(server_tls_context, server_factory_context);
   ContextManagerImpl manager(*time_system);
   Event::DispatcherPtr dispatcher = server_api->allocateDispatcher("test_thread");
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(options.version()));
@@ -375,7 +375,7 @@ void testUtil(const TestUtilOptions& options) {
   auto client_cfg =
       std::make_unique<ClientContextConfigImpl>(client_tls_context, client_factory_context);
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
-                                                   client_stats_store);
+                                                   *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -695,7 +695,7 @@ void testUtilV2(const TestUtilOptionsV2& options) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, server_factory_context);
 
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, server_names);
+                                                   *server_stats_store.rootScope(), server_names);
 
   Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
@@ -713,7 +713,7 @@ void testUtilV2(const TestUtilOptionsV2& options) {
   auto client_cfg =
       std::make_unique<ClientContextConfigImpl>(options.clientCtxProto(), client_factory_context);
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
-                                                   client_stats_store);
+                                                   *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(options.transportSocketOptions(), nullptr),
@@ -974,8 +974,8 @@ TEST_P(SslSocketTest, ServerTransportSocketOptions) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(server_ctx_yaml), tls_context);
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
   auto ssl_socket = server_ssl_socket_factory.createDownstreamTransportSocket();
   auto ssl_handshaker = dynamic_cast<const SslHandshakerImpl*>(ssl_socket->ssl().get());
   auto shared_ptr_ptr = static_cast<const Network::TransportSocketOptionsConstSharedPtr*>(
@@ -3006,8 +3006,8 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -3062,8 +3062,8 @@ TEST_P(SslSocketTest, HalfClose) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(server_tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -3082,7 +3082,7 @@ TEST_P(SslSocketTest, HalfClose) {
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context_);
   Stats::TestUtil::TestStore client_stats_store;
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
-                                                   client_stats_store);
+                                                   *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -3144,8 +3144,8 @@ TEST_P(SslSocketTest, ShutdownWithCloseNotify) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(server_tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -3164,7 +3164,7 @@ TEST_P(SslSocketTest, ShutdownWithCloseNotify) {
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context_);
   Stats::TestUtil::TestStore client_stats_store;
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
-                                                   client_stats_store);
+                                                   *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -3232,8 +3232,8 @@ TEST_P(SslSocketTest, ShutdownWithoutCloseNotify) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(server_tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -3252,7 +3252,7 @@ TEST_P(SslSocketTest, ShutdownWithoutCloseNotify) {
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context_);
   Stats::TestUtil::TestStore client_stats_store;
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
-                                                   client_stats_store);
+                                                   *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -3336,8 +3336,8 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(server_tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -3358,7 +3358,8 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml), tls_context);
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context_);
   Stats::TestUtil::TestStore client_stats_store;
-  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager,
+                                            *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -3431,9 +3432,9 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   auto server_cfg2 =
       std::make_unique<ServerContextConfigImpl>(server_tls_context2, server_factory_context);
   ServerSslSocketFactory server_ssl_socket_factory1(std::move(server_cfg1), manager,
-                                                    server_stats_store, server_names1);
+                                                    *server_stats_store.rootScope(), server_names1);
   ServerSslSocketFactory server_ssl_socket_factory2(std::move(server_cfg2), manager,
-                                                    server_stats_store, server_names2);
+                                                    *server_stats_store.rootScope(), server_names2);
 
   auto socket1 = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(ip_version));
@@ -3457,7 +3458,8 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
 
   auto client_cfg =
       std::make_unique<ClientContextConfigImpl>(client_tls_context, client_factory_context);
-  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager,
+                                            *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
       socket1->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -3578,7 +3580,7 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
       std::make_unique<ServerContextConfigImpl>(server_tls_context, server_factory_context);
 
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, {});
+                                                   *server_stats_store.rootScope(), {});
   auto tcp_socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(ip_version));
   NiceMock<Network::MockTcpListenerCallbacks> callbacks;
@@ -3597,7 +3599,8 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
 
   auto client_cfg =
       std::make_unique<ClientContextConfigImpl>(client_tls_context, client_factory_context);
-  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager,
+                                            *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
       tcp_socket->connectionInfoProvider().localAddress(),
       Network::Address::InstanceConstSharedPtr(),
@@ -4174,10 +4177,10 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   auto server2_cfg = std::make_unique<ServerContextConfigImpl>(tls_context2, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
-  ServerSslSocketFactory server2_ssl_socket_factory(std::move(server2_cfg), manager,
-                                                    server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
+  ServerSslSocketFactory server2_ssl_socket_factory(
+      std::move(server2_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -4202,7 +4205,8 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
 
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context_);
   Stats::TestUtil::TestStore client_stats_store;
-  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, client_stats_store);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager,
+                                            *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -4296,8 +4300,8 @@ void SslSocketTest::testClientSessionResumption(const std::string& server_ctx_ya
   TestUtility::loadFromYaml(TestEnvironment::substitute(server_ctx_yaml), server_ctx_proto);
   auto server_cfg =
       std::make_unique<ServerContextConfigImpl>(server_ctx_proto, server_factory_context);
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version));
@@ -4322,7 +4326,7 @@ void SslSocketTest::testClientSessionResumption(const std::string& server_ctx_ya
   auto client_cfg =
       std::make_unique<ClientContextConfigImpl>(client_ctx_proto, client_factory_context);
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
-                                                   client_stats_store);
+                                                   *client_stats_store.rootScope());
   Network::ClientConnectionPtr client_connection = dispatcher->createClientConnection(
       socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(nullptr, nullptr), nullptr, nullptr);
@@ -4558,8 +4562,8 @@ TEST_P(SslSocketTest, SslError) {
   auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, factory_context_);
   ContextManagerImpl manager(time_system_);
   Stats::TestUtil::TestStore server_stats_store;
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
-                                                   server_stats_store, std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *server_stats_store.rootScope(), std::vector<std::string>{});
 
   auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
       Network::Test::getCanonicalLoopbackAddress(version_));
@@ -5562,8 +5566,8 @@ TEST_P(SslSocketTest, DownstreamNotReadySslSocket) {
   EXPECT_FALSE(server_cfg->isReady());
 
   ContextManagerImpl manager(time_system_);
-  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
-                                                   std::vector<std::string>{});
+  ServerSslSocketFactory server_ssl_socket_factory(
+      std::move(server_cfg), manager, *stats_store.rootScope(), std::vector<std::string>{});
   auto transport_socket = server_ssl_socket_factory.createDownstreamTransportSocket();
   EXPECT_FALSE(transport_socket->startSecureTransport());                                  // Noop
   transport_socket->configureInitialCongestionWindow(200, std::chrono::microseconds(223)); // Noop
@@ -5601,7 +5605,8 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
   EXPECT_FALSE(client_cfg->isReady());
 
   ContextManagerImpl manager(time_system_);
-  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
+                                                   *stats_store.rootScope());
   auto transport_socket = client_ssl_socket_factory.createTransportSocket(nullptr, nullptr);
   EXPECT_EQ(EMPTY_STRING, transport_socket->protocol());
   EXPECT_EQ(nullptr, transport_socket->ssl());
@@ -5631,7 +5636,8 @@ TEST_P(SslSocketTest, TestTransportSocketCallback) {
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context);
 
   ContextManagerImpl manager(time_system_);
-  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
+                                                   *stats_store.rootScope());
 
   Network::TransportSocketPtr transport_socket =
       client_ssl_socket_factory.createTransportSocket(nullptr, nullptr);
@@ -5655,7 +5661,8 @@ protected:
         std::make_unique<ServerContextConfigImpl>(downstream_tls_context_, factory_context_);
     manager_ = std::make_unique<ContextManagerImpl>(time_system_);
     server_ssl_socket_factory_ = std::make_unique<ServerSslSocketFactory>(
-        std::move(server_cfg), *manager_, server_stats_store_, std::vector<std::string>{});
+        std::move(server_cfg), *manager_, *server_stats_store_.rootScope(),
+        std::vector<std::string>{});
 
     socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
         Network::Test::getCanonicalLoopbackAddress(version_));
@@ -5666,7 +5673,7 @@ protected:
         std::make_unique<ClientContextConfigImpl>(upstream_tls_context_, factory_context_);
 
     client_ssl_socket_factory_ = std::make_unique<ClientSslSocketFactory>(
-        std::move(client_cfg), *manager_, client_stats_store_);
+        std::move(client_cfg), *manager_, *client_stats_store_.rootScope());
     auto transport_socket = client_ssl_socket_factory_->createTransportSocket(nullptr, nullptr);
     client_transport_socket_ = transport_socket.get();
     client_connection_ = dispatcher_->createClientConnection(

--- a/test/extensions/watchdog/profile_action/config_test.cc
+++ b/test/extensions/watchdog/profile_action/config_test.cc
@@ -46,7 +46,8 @@ TEST(ProfileActionFactoryTest, CanCreateAction) {
   Stats::TestUtil::TestStore stats;
   Event::MockDispatcher dispatcher;
   Api::ApiPtr api = Api::createApiForTest(stats);
-  Server::Configuration::GuardDogActionFactoryContext context{*api, dispatcher, stats, "test"};
+  Server::Configuration::GuardDogActionFactoryContext context{*api, dispatcher, *stats.rootScope(),
+                                                              "test"};
 
   EXPECT_CALL(dispatcher, createTimer_(_));
   EXPECT_NE(factory->createGuardDogActionFromProto(config, context), nullptr);

--- a/test/extensions/watchdog/profile_action/profile_action_test.cc
+++ b/test/extensions/watchdog/profile_action/profile_action_test.cc
@@ -37,7 +37,8 @@ protected:
       : time_system_(std::make_unique<Event::SimulatedTimeSystem>()),
         api_(Api::createApiForTest(stats_, *time_system_)),
         dispatcher_(api_->allocateDispatcher("test")),
-        context_({*api_, *dispatcher_, stats_, "test"}), test_path_(generateTestPath()) {}
+        context_({*api_, *dispatcher_, *stats_.rootScope(), "test"}),
+        test_path_(generateTestPath()) {}
 
   // Generates a unique path for a testcase.
   static std::string generateTestPath() {

--- a/test/integration/alpn_selection_integration_test.cc
+++ b/test/integration/alpn_selection_integration_test.cc
@@ -72,7 +72,8 @@ require_client_certificate: true
         tls_context, factory_context_);
     static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
+        std::vector<std::string>{});
   }
 
   void createUpstreams() override {

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -150,6 +150,7 @@ public:
   Event::TestTimeSystem& timeSystem() { return time_system_; }
 
   Stats::IsolatedStoreImpl stats_store_;
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   Api::ApiPtr api_;
   Api::ApiPtr api_for_server_stat_store_;
   MockBufferFactory* mock_buffer_factory_; // Will point to the dispatcher's factory.

--- a/test/integration/hotrestart_main.cc
+++ b/test/integration/hotrestart_main.cc
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
   return Envoy::MainCommon::main(argc, argv, [](Envoy::Server::Instance& server) {
     // Creates a gauge that will be incremented once and then never touched. This is
     // for testing parent-gauge accumulation in hot_restart_test.sh.
-    Envoy::Stats::Utility::gaugeFromElements(server.stats(),
+    Envoy::Stats::Utility::gaugeFromElements(*server.stats().rootScope(),
                                              {Envoy::Stats::DynamicName("hotrestart_test_gauge")},
                                              Envoy::Stats::Gauge::ImportMode::Accumulate)
         .inc();

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -189,7 +189,8 @@ public:
         // Use smaller window than the default one to have test coverage of client codec buffer
         // exceeding high watermark.
         /*send_buffer_limit=*/2 * Http2::Utility::OptionsLimits::MIN_INITIAL_STREAM_WINDOW_SIZE,
-        persistent_info.crypto_stream_factory_, quic_stat_names_, cache, stats_store_, nullptr);
+        persistent_info.crypto_stream_factory_, quic_stat_names_, cache, *stats_store_.rootScope(),
+        nullptr);
     return session;
   }
 
@@ -260,7 +261,7 @@ public:
     ssl_client_option_.setAlpn(true).setSan(san_to_match_).setSni("lyft.com");
     NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context;
     ON_CALL(context, api()).WillByDefault(testing::ReturnRef(*api_));
-    ON_CALL(context, scope()).WillByDefault(testing::ReturnRef(stats_store_));
+    ON_CALL(context, scope()).WillByDefault(testing::ReturnRef(stats_scope_));
     ON_CALL(context, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager_));
     envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport
         quic_transport_socket_config;

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -604,7 +604,8 @@ public:
         tls_context, factory_context_);
     static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
+        std::vector<std::string>{});
   }
 
   void TearDown() override {

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -99,7 +99,7 @@ common_tls_context:
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   return Network::UpstreamTransportSocketFactoryPtr{
       new Extensions::TransportSockets::Tls::ClientSslSocketFactory(
-          std::move(cfg), *context_manager_, *client_stats_store)};
+          std::move(cfg), *context_manager_, *client_stats_store->rootScope())};
 }
 
 Network::DownstreamTransportSocketFactoryPtr XfccIntegrationTest::createUpstreamSslContext() {
@@ -115,7 +115,8 @@ Network::DownstreamTransportSocketFactoryPtr XfccIntegrationTest::createUpstream
       tls_context, factory_context_);
   static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
   return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-      std::move(cfg), *context_manager_, *upstream_stats_store, std::vector<std::string>{});
+      std::move(cfg), *context_manager_, *(upstream_stats_store->rootScope()),
+      std::vector<std::string>{});
 }
 
 Network::ClientConnectionPtr XfccIntegrationTest::makeTcpClientConnection() {

--- a/test/mocks/server/factory_context.cc
+++ b/test/mocks/server/factory_context.cc
@@ -33,7 +33,7 @@ MockFactoryContext::MockFactoryContext()
   ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(*singleton_manager_));
   ON_CALL(*this, threadLocal()).WillByDefault(ReturnRef(thread_local_));
   ON_CALL(*this, admin()).WillByDefault(Return(OptRef<Server::Admin>{admin_}));
-  ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(*listener_scope_.rootScope()));
+  ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(*listener_store_.rootScope()));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
   ON_CALL(*this, timeSource()).WillByDefault(ReturnRef(time_system_));
   ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));

--- a/test/mocks/server/factory_context.h
+++ b/test/mocks/server/factory_context.h
@@ -73,7 +73,8 @@ public:
   testing::NiceMock<Server::MockOptions> options_;
   Singleton::ManagerPtr singleton_manager_;
   testing::NiceMock<MockAdmin> admin_;
-  Stats::IsolatedStoreImpl listener_scope_;
+  Stats::IsolatedStoreImpl listener_store_;
+  Stats::Scope& listener_scope_{*listener_store_.rootScope()};
   Event::GlobalTimeSystem time_system_;
   testing::NiceMock<ProtobufMessage::MockValidationContext> validation_context_;
   testing::NiceMock<MockOverloadManager> overload_manager_;

--- a/test/server/active_udp_listener_test.cc
+++ b/test/server/active_udp_listener_test.cc
@@ -103,7 +103,8 @@ public:
   Network::Address::InstanceConstSharedPtr local_address_;
   Network::SocketSharedPtr listen_socket_;
   NiceMock<Network::MockListenSocketFactory> socket_factory_;
-  Stats::IsolatedStoreImpl scope_;
+  Stats::IsolatedStoreImpl store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   std::unique_ptr<NiceMock<Network::MockUdpListenerConfig>> udp_listener_config_;
   NiceMock<Network::MockUdpPacketWriterFactory> udp_packet_writer_factory_;
   Network::MockListenerConfig listener_config_;

--- a/test/server/admin/server_info_handler_test.cc
+++ b/test/server/admin/server_info_handler_test.cc
@@ -28,7 +28,7 @@ TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
   Extensions::TransportSockets::Tls::ClientContextConfigImpl cfg(config, factory_context);
   Stats::IsolatedStoreImpl store;
   Envoy::Ssl::ClientContextSharedPtr client_ctx(
-      server_.sslContextManager().createSslClientContext(store, cfg));
+      server_.sslContextManager().createSslClientContext(*store.rootScope(), cfg));
 
   const std::string expected_empty_json = R"EOF({
  "certificates": [

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -142,7 +142,7 @@ public:
     bool continueOnListenerFiltersTimeout() const override {
       return continue_on_listener_filters_timeout_;
     }
-    Stats::Scope& listenerScope() override { return parent_.stats_store_; }
+    Stats::Scope& listenerScope() override { return *parent_.stats_store_.rootScope(); }
     uint64_t listenerTag() const override { return tag_; }
     const std::string& name() const override { return name_; }
     Network::UdpListenerConfigOptRef udpListenerConfig() override { return *udp_listener_config_; }

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -85,8 +85,8 @@ protected:
     return std::make_unique<Event::SimulatedTimeSystem>();
   }
 
-  void initGuardDog(Stats::Scope& stats_scope, const Server::Configuration::Watchdog& config) {
-    guard_dog_ = std::make_unique<GuardDogImpl>(stats_scope, config, *api_, "server",
+  void initGuardDog(Stats::Store& stats_store, const Server::Configuration::Watchdog& config) {
+    guard_dog_ = std::make_unique<GuardDogImpl>(*stats_store.rootScope(), config, *api_, "server",
                                                 std::make_unique<DebugTestInterlock>());
   }
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -227,7 +227,7 @@ protected:
   }
 
   std::unique_ptr<TestOverloadManager> createOverloadManager(const std::string& config) {
-    return std::make_unique<TestOverloadManager>(dispatcher_, stats_, thread_local_,
+    return std::make_unique<TestOverloadManager>(dispatcher_, *stats_.rootScope(), thread_local_,
                                                  parseConfig(config), validation_visitor_, *api_,
                                                  options_);
   }

--- a/test/server/ssl_context_manager_test.cc
+++ b/test/server/ssl_context_manager_test.cc
@@ -15,7 +15,8 @@ namespace {
 
 TEST(SslContextManager, createStub) {
   Event::SimulatedTimeSystem time_system;
-  Stats::MockStore scope;
+  Stats::MockStore store;
+  Stats::Scope& scope(*store.rootScope());
   Ssl::MockClientContextConfig client_config;
   Ssl::MockServerContextConfig server_config;
   std::vector<std::string> server_names;

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -83,7 +83,7 @@ TEST_F(WorkerImplTest, BasicFlow) {
 
   NiceMock<Stats::MockStore> store;
   worker_.start(guard_dog_, emptyCallback);
-  worker_.initializeStats(store);
+  worker_.initializeStats(*store.rootScope());
   ci.waitReady();
 
   // After a worker is started adding/stopping/removing a listener happens on the worker thread.


### PR DESCRIPTION
Commit Message: Second of 3 PRs that will remove dependence on Store::operator Scope&() -- the final PR will remove that operator.

Additional Description: This is a partial fix for https://github.com/envoyproxy/envoy/issues/24007 , a piece of technical debt that was taken in https://github.com/envoyproxy/envoy/pull/23851 and partially resolved in https://github.com/envoyproxy/envoy/pull/24567 in order to solve a structural problem where Stats::Store was a subclass of Stats::Scope, which didn't make OO sense (a Store is not a Scope), but was convenient (you could pass a Store into a function that was expecting a Scope), and the Store worked as a root Scope. That needed to be cleaned up to clarify the ownership model where Store is typically instantiated directly in a production factory or test, and Scope is always held by shared_ptr.

Risk Level: low -- this is a very large PR but it's just trivial one-line changes, getting the root scope explicitly from the store in a 100+ different places. There will be another smaller PR after this one. There are no functional changes or refactors in this PR.

With this PR, //test/... passes with the `operator Scope&` in `Stats::Store` commented out, but there are still dependencies on it remaining in //contrib/..., which will be dealt with in phase 3.
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a