### PR TITLE
ci: wait up to 5 minutes for Android emulator to start

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -59,7 +59,6 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
-      timeout-minutes: 5
     # Return to using:
     #   cd mobile && ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
@@ -101,7 +100,6 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
-      timeout-minutes: 5
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
@@ -143,7 +141,6 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
-      timeout-minutes: 5
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
@@ -185,7 +182,6 @@ jobs:
     - name: 'Start simulator'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_start_emulator.sh
-      timeout-minutes: 5
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
     # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.

--- a/mobile/ci/mac_start_emulator.sh
+++ b/mobile/ci/mac_start_emulator.sh
@@ -8,5 +8,5 @@ ls "${ANDROID_HOME}/tools/bin/"
 
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
     # shellcheck disable=SC2016
-    "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
+    timeout 300 "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82' || true
 }


### PR DESCRIPTION
And if 5 minutes elapses, assume the emulator booted successfully and we missed the `sys.boot_completed` event.

Remove the `timeout-minutes` setting on the GitHub Actions job definitions so we only consider booting the emulator in the timeout and not installing the SDK or creating the emulator.

Bug: #24841

Risk Level: Low - CI only
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A