### PR TITLE
http2: updates method signatures to remove nghttp2-specific names and types.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -979,8 +979,8 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
     dispatching_ = true;
     ssize_t rc;
     rc = adapter_->ProcessBytes(absl::string_view(static_cast<char*>(slice.mem_), slice.len_));
-    if (!nghttp2_callback_status_.ok()) {
-      return nghttp2_callback_status_;
+    if (!codec_callback_status_.ok()) {
+      return codec_callback_status_;
     }
     // This error is returned when nghttp2 library detected a frame flood by one of its
     // internal mechanisms. Most flood protection is done by Envoy's codec and this error
@@ -1063,18 +1063,19 @@ Status ConnectionImpl::protocolErrorForTest() {
   return sendPendingFrames();
 }
 
-Status ConnectionImpl::onBeforeFrameReceived(const nghttp2_frame_hd* hd) {
+Status ConnectionImpl::onBeforeFrameReceived(int32_t stream_id, size_t length, uint8_t type,
+                                             uint8_t flags) {
   ENVOY_CONN_LOG(trace, "about to recv frame type={}, flags={}, stream_id={}", connection_,
-                 static_cast<uint64_t>(hd->type), static_cast<uint64_t>(hd->flags), hd->stream_id);
+                 static_cast<uint64_t>(type), static_cast<uint64_t>(flags), stream_id);
   ASSERT(connection_.state() == Network::Connection::State::Open);
 
-  current_stream_id_ = hd->stream_id;
+  current_stream_id_ = stream_id;
   // Track all the frames without padding here, since this is the only callback we receive
   // for some of them (e.g. CONTINUATION frame, frames sent on closed streams, etc.).
   // HEADERS frame is tracked in onBeginHeaders(), DATA frame is tracked in onFrameReceived().
   auto status = okStatus();
-  if (hd->type != NGHTTP2_HEADERS && hd->type != NGHTTP2_DATA) {
-    status = trackInboundFrames(hd, 0);
+  if (type != NGHTTP2_HEADERS && type != NGHTTP2_DATA) {
+    status = trackInboundFrames(stream_id, length, type, flags, 0);
   }
 
   return status;
@@ -1122,7 +1123,8 @@ Status ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
   }
 
   if (frame->hd.type == NGHTTP2_DATA) {
-    RETURN_IF_ERROR(trackInboundFrames(&frame->hd, frame->data.padlen));
+    RETURN_IF_ERROR(trackInboundFrames(frame->hd.stream_id, frame->hd.length, frame->hd.type,
+                                       frame->hd.flags, frame->data.padlen));
   }
 
   // Only raise GOAWAY once, since we don't currently expose stream information. Shutdown
@@ -1598,15 +1600,15 @@ void ConnectionImpl::sendSettings(
   }
 }
 
-int ConnectionImpl::setAndCheckNghttp2CallbackStatus(Status&& status) {
+int ConnectionImpl::setAndCheckCodecCallbackStatus(Status&& status) {
   // Keep the error status that caused the original failure. Subsequent
   // error statuses are silently discarded.
-  nghttp2_callback_status_.Update(std::move(status));
-  if (nghttp2_callback_status_.ok() && connection_.state() != Network::Connection::State::Open) {
-    nghttp2_callback_status_ = codecProtocolError("Connection was closed while dispatching frames");
+  codec_callback_status_.Update(std::move(status));
+  if (codec_callback_status_.ok() && connection_.state() != Network::Connection::State::Open) {
+    codec_callback_status_ = codecProtocolError("Connection was closed while dispatching frames");
   }
 
-  return nghttp2_callback_status_.ok() ? 0 : NGHTTP2_ERR_CALLBACK_FAILURE;
+  return codec_callback_status_.ok() ? 0 : NGHTTP2_ERR_CALLBACK_FAILURE;
 }
 
 void ConnectionImpl::scheduleProtocolConstraintViolationCallback() {
@@ -1656,7 +1658,7 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
   nghttp2_session_callbacks_set_on_begin_headers_callback(
       callbacks_, [](nghttp2_session*, const nghttp2_frame* frame, void* user_data) -> int {
         auto status = static_cast<ConnectionImpl*>(user_data)->onBeginHeaders(frame);
-        return static_cast<ConnectionImpl*>(user_data)->setAndCheckNghttp2CallbackStatus(
+        return static_cast<ConnectionImpl*>(user_data)->setAndCheckCodecCallbackStatus(
             std::move(status));
       });
 
@@ -1682,15 +1684,16 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
 
   nghttp2_session_callbacks_set_on_begin_frame_callback(
       callbacks_, [](nghttp2_session*, const nghttp2_frame_hd* hd, void* user_data) -> int {
-        auto status = static_cast<ConnectionImpl*>(user_data)->onBeforeFrameReceived(hd);
-        return static_cast<ConnectionImpl*>(user_data)->setAndCheckNghttp2CallbackStatus(
+        auto status = static_cast<ConnectionImpl*>(user_data)->onBeforeFrameReceived(
+            hd->stream_id, hd->length, hd->type, hd->flags);
+        return static_cast<ConnectionImpl*>(user_data)->setAndCheckCodecCallbackStatus(
             std::move(status));
       });
 
   nghttp2_session_callbacks_set_on_frame_recv_callback(
       callbacks_, [](nghttp2_session*, const nghttp2_frame* frame, void* user_data) -> int {
         auto status = static_cast<ConnectionImpl*>(user_data)->onFrameReceived(frame);
-        return static_cast<ConnectionImpl*>(user_data)->setAndCheckNghttp2CallbackStatus(
+        return static_cast<ConnectionImpl*>(user_data)->setAndCheckCodecCallbackStatus(
             std::move(status));
       });
 
@@ -1698,7 +1701,7 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
       callbacks_,
       [](nghttp2_session*, int32_t stream_id, uint32_t error_code, void* user_data) -> int {
         auto status = static_cast<ConnectionImpl*>(user_data)->onStreamClose(stream_id, error_code);
-        return static_cast<ConnectionImpl*>(user_data)->setAndCheckNghttp2CallbackStatus(
+        return static_cast<ConnectionImpl*>(user_data)->setAndCheckCodecCallbackStatus(
             std::move(status));
       });
 
@@ -1980,7 +1983,8 @@ Status ClientConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   RELEASE_ASSERT(frame->headers.cat == NGHTTP2_HCAT_RESPONSE ||
                      frame->headers.cat == NGHTTP2_HCAT_HEADERS,
                  "");
-  RETURN_IF_ERROR(trackInboundFrames(&frame->hd, frame->headers.padlen));
+  RETURN_IF_ERROR(trackInboundFrames(frame->hd.stream_id, frame->hd.length, frame->hd.type,
+                                     frame->hd.flags, frame->headers.padlen));
   if (frame->headers.cat == NGHTTP2_HCAT_HEADERS) {
     StreamImpl* stream = getStream(frame->hd.stream_id);
     stream->allocTrailers();
@@ -1999,19 +2003,19 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 }
 
 // TODO(yanavlasov): move to the base class once the runtime flag is removed.
-Status ClientConnectionImpl::trackInboundFrames(const nghttp2_frame_hd* hd,
-                                                uint32_t padding_length) {
+Status ClientConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length, uint8_t type,
+                                                uint8_t flags, uint32_t padding_length) {
   Status result;
   ENVOY_CONN_LOG(trace, "track inbound frame type={} flags={} length={} padding_length={}",
-                 connection_, static_cast<uint64_t>(hd->type), static_cast<uint64_t>(hd->flags),
-                 static_cast<uint64_t>(hd->length), padding_length);
+                 connection_, static_cast<uint64_t>(type), static_cast<uint64_t>(flags),
+                 static_cast<uint64_t>(length), padding_length);
 
-  result = protocol_constraints_.trackInboundFrames(hd, padding_length);
+  result = protocol_constraints_.trackInboundFrames(length, type, flags, padding_length);
   if (!result.ok()) {
     ENVOY_CONN_LOG(trace, "error reading frame: {} received in this HTTP/2 session.", connection_,
                    result.message());
     if (isInboundFramesWithEmptyPayloadError(result)) {
-      ConnectionImpl::StreamImpl* stream = getStream(hd->stream_id);
+      ConnectionImpl::StreamImpl* stream = getStream(stream_id);
       if (stream) {
         stream->setDetails(Http2ResponseCodeDetails::get().inbound_empty_frame_flood);
       }
@@ -2061,7 +2065,8 @@ Status ServerConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   // For a server connection, we should never get push promise frames.
   ASSERT(frame->hd.type == NGHTTP2_HEADERS);
   ASSERT(connection_.state() == Network::Connection::State::Open);
-  RETURN_IF_ERROR(trackInboundFrames(&frame->hd, frame->headers.padlen));
+  RETURN_IF_ERROR(trackInboundFrames(frame->hd.stream_id, frame->hd.length, frame->hd.type,
+                                     frame->hd.flags, frame->headers.padlen));
 
   if (frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
     stats_.trailers_.inc();
@@ -2092,18 +2097,18 @@ int ServerConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
   return saveHeader(frame, std::move(name), std::move(value));
 }
 
-Status ServerConnectionImpl::trackInboundFrames(const nghttp2_frame_hd* hd,
-                                                uint32_t padding_length) {
+Status ServerConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length, uint8_t type,
+                                                uint8_t flags, uint32_t padding_length) {
   ENVOY_CONN_LOG(trace, "track inbound frame type={} flags={} length={} padding_length={}",
-                 connection_, static_cast<uint64_t>(hd->type), static_cast<uint64_t>(hd->flags),
-                 static_cast<uint64_t>(hd->length), padding_length);
+                 connection_, static_cast<uint64_t>(type), static_cast<uint64_t>(flags),
+                 static_cast<uint64_t>(length), padding_length);
 
-  auto result = protocol_constraints_.trackInboundFrames(hd, padding_length);
+  auto result = protocol_constraints_.trackInboundFrames(length, type, flags, padding_length);
   if (!result.ok()) {
     ENVOY_CONN_LOG(trace, "error reading frame: {} received in this HTTP/2 session.", connection_,
                    result.message());
     if (isInboundFramesWithEmptyPayloadError(result)) {
-      ConnectionImpl::StreamImpl* stream = getStream(hd->stream_id);
+      ConnectionImpl::StreamImpl* stream = getStream(stream_id);
       if (stream) {
         stream->setDetails(Http2ResponseCodeDetails::get().inbound_empty_frame_flood);
       }

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -570,10 +570,10 @@ protected:
   }
 
   /**
-   * Save `status` into nghttp2_callback_status_.
-   * Return nghttp2 callback return code corresponding to `status`.
+   * Save `status` into codec_callback_status_.
+   * Return codec callback return code corresponding to `status`.
    */
-  int setAndCheckNghttp2CallbackStatus(Status&& status);
+  int setAndCheckCodecCallbackStatus(Status&& status);
 
   /**
    * Callback for terminating connection when protocol constrain has been violated
@@ -608,9 +608,9 @@ protected:
 
   // Status for any errors encountered by the nghttp2 callbacks.
   // nghttp2 library uses single return code to indicate callback failure and
-  // `nghttp2_callback_status_` is used to save right error information returned by a callback. The
-  // `nghttp2_callback_status_` is valid iff nghttp call returned NGHTTP2_ERR_CALLBACK_FAILURE.
-  Status nghttp2_callback_status_;
+  // `codec_callback_status_` is used to save right error information returned by a callback. The
+  // `codec_callback_status_` is valid iff nghttp call returned NGHTTP2_ERR_CALLBACK_FAILURE.
+  Status codec_callback_status_;
 
   // Set if the type of frame that is about to be sent is PING or SETTINGS with the ACK flag set, or
   // RST_STREAM.
@@ -646,7 +646,7 @@ private:
   virtual ConnectionCallbacks& callbacks() PURE;
   virtual Status onBeginHeaders(const nghttp2_frame* frame) PURE;
   int onData(int32_t stream_id, const uint8_t* data, size_t len);
-  Status onBeforeFrameReceived(const nghttp2_frame_hd* hd);
+  Status onBeforeFrameReceived(int32_t stream_id, size_t length, uint8_t type, uint8_t flags);
   Status onFrameReceived(const nghttp2_frame* frame);
   int onBeforeFrameSend(const nghttp2_frame* frame);
   int onFrameSend(const nghttp2_frame* frame);
@@ -663,7 +663,8 @@ private:
 
   // Adds buffer fragment for a new outbound frame to the supplied Buffer::OwnedImpl.
   void addOutboundFrameFragment(Buffer::OwnedImpl& output, const uint8_t* data, size_t length);
-  virtual Status trackInboundFrames(const nghttp2_frame_hd* hd, uint32_t padding_length) PURE;
+  virtual Status trackInboundFrames(int32_t stream_id, size_t length, uint8_t type, uint8_t flags,
+                                    uint32_t padding_length) PURE;
   void onKeepaliveResponse();
   void onKeepaliveResponseTimeout();
   bool slowContainsStreamId(int32_t stream_id) const;
@@ -710,7 +711,8 @@ private:
   ConnectionCallbacks& callbacks() override { return callbacks_; }
   Status onBeginHeaders(const nghttp2_frame* frame) override;
   int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) override;
-  Status trackInboundFrames(const nghttp2_frame_hd*, uint32_t) override;
+  Status trackInboundFrames(int32_t stream_id, size_t length, uint8_t type, uint8_t flags,
+                            uint32_t) override;
   void dumpStreams(std::ostream& os, int indent_level) const override;
   StreamResetReason getMessagingErrorResetReason() const override;
   Http::ConnectionCallbacks& callbacks_;
@@ -735,7 +737,8 @@ private:
   ConnectionCallbacks& callbacks() override { return callbacks_; }
   Status onBeginHeaders(const nghttp2_frame* frame) override;
   int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) override;
-  Status trackInboundFrames(const nghttp2_frame_hd* hd, uint32_t padding_length) override;
+  Status trackInboundFrames(int32_t stream_id, size_t length, uint8_t type, uint8_t flags,
+                            uint32_t padding_length) override;
   absl::optional<int> checkHeaderNameForUnderscores(absl::string_view header_name) override;
   StreamResetReason getMessagingErrorResetReason() const override {
     return StreamResetReason::LocalReset;

--- a/source/common/http/http2/protocol_constraints.cc
+++ b/source/common/http/http2/protocol_constraints.cc
@@ -58,14 +58,14 @@ Status ProtocolConstraints::checkOutboundFrameLimits() {
   return okStatus();
 }
 
-Status ProtocolConstraints::trackInboundFrames(const nghttp2_frame_hd* hd,
+Status ProtocolConstraints::trackInboundFrames(size_t length, uint8_t type, uint8_t flags,
                                                uint32_t padding_length) {
-  switch (hd->type) {
+  switch (type) {
   case NGHTTP2_HEADERS:
   case NGHTTP2_CONTINUATION:
   case NGHTTP2_DATA:
     // Track frames with an empty payload and no end stream flag.
-    if (hd->length - padding_length == 0 && !(hd->flags & NGHTTP2_FLAG_END_STREAM)) {
+    if (length - padding_length == 0 && !(flags & NGHTTP2_FLAG_END_STREAM)) {
       consecutive_inbound_frames_with_empty_payload_++;
     } else {
       consecutive_inbound_frames_with_empty_payload_ = 0;

--- a/source/common/http/http2/protocol_constraints.h
+++ b/source/common/http/http2/protocol_constraints.h
@@ -47,7 +47,7 @@ public:
 
   // Track received frames of various types.
   // Return an error status if inbound frame constraints were violated.
-  Status trackInboundFrames(const nghttp2_frame_hd* hd, uint32_t padding_length);
+  Status trackInboundFrames(size_t length, uint8_t type, uint8_t flags, uint32_t padding_length);
   // Increment the number of DATA frames sent to the peer.
   void incrementOutboundDataFrameCount() { ++outbound_data_frames_; }
   void incrementOpenedStreamCount() { ++opened_streams_; }

--- a/test/common/http/http2/protocol_constraints_test.cc
+++ b/test/common/http/http2/protocol_constraints_test.cc
@@ -86,13 +86,13 @@ TEST_F(ProtocolConstraintsTest, OutboundFrameFloodStatusIsIdempotent) {
 TEST_F(ProtocolConstraintsTest, InboundZeroLenData) {
   options_.mutable_max_consecutive_inbound_frames_with_empty_payload()->set_value(2);
   ProtocolConstraints constraints(http2CodecStats(), options_);
-  nghttp2_frame_hd frame;
-  frame.type = NGHTTP2_DATA;
-  frame.length = 0;
-  frame.flags = 0;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(&frame, 0)));
+  uint8_t type = NGHTTP2_DATA;
+  size_t length = 0;
+  uint8_t flags = 0;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(
+      isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(length, type, flags, 0)));
   EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.status()));
   EXPECT_EQ(1, stats_store_.counter("http2.inbound_empty_frames_flood").value());
 }
@@ -105,13 +105,13 @@ TEST_F(ProtocolConstraintsTest, OutboundAndInboundFrameFloodStatusIsIdempotent) 
   options_.mutable_max_consecutive_inbound_frames_with_empty_payload()->set_value(2);
   ProtocolConstraints constraints(http2CodecStats(), options_);
   // First trigger inbound frame flood
-  nghttp2_frame_hd frame;
-  frame.type = NGHTTP2_DATA;
-  frame.length = 0;
-  frame.flags = 0;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(&frame, 0)));
+  uint8_t type = NGHTTP2_DATA;
+  size_t length = 0;
+  uint8_t flags = 0;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(
+      isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(length, type, flags, 0)));
 
   // Then trigger outbound control flood
   constraints.incrementOutboundFrameCount(true);
@@ -125,13 +125,13 @@ TEST_F(ProtocolConstraintsTest, OutboundAndInboundFrameFloodStatusIsIdempotent) 
 TEST_F(ProtocolConstraintsTest, InboundZeroLenDataWithPadding) {
   options_.mutable_max_consecutive_inbound_frames_with_empty_payload()->set_value(2);
   ProtocolConstraints constraints(http2CodecStats(), options_);
-  nghttp2_frame_hd frame;
-  frame.type = NGHTTP2_DATA;
-  frame.length = 8;
-  frame.flags = 0;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 8).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 8).ok());
-  EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(&frame, 8)));
+  uint8_t type = NGHTTP2_DATA;
+  size_t length = 8;
+  uint8_t flags = 0;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 8).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 8).ok());
+  EXPECT_TRUE(
+      isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(length, type, flags, 8)));
   EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.status()));
   EXPECT_EQ(1, stats_store_.counter("http2.inbound_empty_frames_flood").value());
 }
@@ -139,18 +139,18 @@ TEST_F(ProtocolConstraintsTest, InboundZeroLenDataWithPadding) {
 TEST_F(ProtocolConstraintsTest, InboundZeroLenDataEndStreamResetCounter) {
   options_.mutable_max_consecutive_inbound_frames_with_empty_payload()->set_value(2);
   ProtocolConstraints constraints(http2CodecStats(), options_);
-  nghttp2_frame_hd frame;
-  frame.type = NGHTTP2_DATA;
-  frame.length = 0;
-  frame.flags = 0;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  frame.flags = NGHTTP2_FLAG_END_STREAM;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  frame.flags = 0;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(&frame, 0)));
+  uint8_t type = NGHTTP2_DATA;
+  size_t length = 0;
+  uint8_t flags = 0;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  flags = NGHTTP2_FLAG_END_STREAM;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  flags = 0;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(
+      isInboundFramesWithEmptyPayloadError(constraints.trackInboundFrames(length, type, flags, 0)));
   EXPECT_TRUE(isInboundFramesWithEmptyPayloadError(constraints.status()));
   EXPECT_EQ(1, stats_store_.counter("http2.inbound_empty_frames_flood").value());
 }
@@ -161,13 +161,14 @@ TEST_F(ProtocolConstraintsTest, Priority) {
   // Create one stream
   constraints.incrementOpenedStreamCount();
 
-  nghttp2_frame_hd frame;
-  frame.type = NGHTTP2_PRIORITY;
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
-  EXPECT_TRUE(isBufferFloodError(constraints.trackInboundFrames(&frame, 0)));
+  size_t length = 5;
+  uint8_t type = NGHTTP2_PRIORITY;
+  uint8_t flags = 0;
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
+  EXPECT_TRUE(isBufferFloodError(constraints.trackInboundFrames(length, type, flags, 0)));
   EXPECT_TRUE(isBufferFloodError(constraints.status()));
   EXPECT_EQ("Too many PRIORITY frames", constraints.status().message());
   EXPECT_EQ(1, stats_store_.counter("http2.inbound_priority_frames_flood").value());
@@ -186,12 +187,13 @@ TEST_F(ProtocolConstraintsTest, WindowUpdate) {
   // max_inbound_window_update_frames_per_data_frame_sent_ * outbound_data_frames_`
   // formula 5 + 2 * (1 + 2 * 2) = 15 WINDOW_UPDATE frames should NOT fail constraint
   // check, but 16th should.
-  nghttp2_frame_hd frame;
-  frame.type = NGHTTP2_WINDOW_UPDATE;
+  size_t length = 4;
+  uint8_t type = NGHTTP2_WINDOW_UPDATE;
+  uint8_t flags = 0;
   for (uint32_t i = 0; i < 15; ++i) {
-    EXPECT_TRUE(constraints.trackInboundFrames(&frame, 0).ok());
+    EXPECT_TRUE(constraints.trackInboundFrames(length, type, flags, 0).ok());
   }
-  EXPECT_TRUE(isBufferFloodError(constraints.trackInboundFrames(&frame, 0)));
+  EXPECT_TRUE(isBufferFloodError(constraints.trackInboundFrames(length, type, flags, 0)));
   EXPECT_TRUE(isBufferFloodError(constraints.status()));
   EXPECT_EQ("Too many WINDOW_UPDATE frames", constraints.status().message());
   EXPECT_EQ(1, stats_store_.counter("http2.inbound_window_update_frames_flood").value());


### PR DESCRIPTION
Signed-off-by: Biren Roy <birenroy@google.com>

Commit Message: Removes nghttp2-specific names and types from CodecImpl. Cleanup related to https://github.com/envoyproxy/envoy/issues/23596.
Additional Description:
Risk Level: low
Testing: ran http and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
