### PR TITLE
stats: Remove operator Scope hack phase 3/3 (see #24567 and #24843)

### DIFF
--- a/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
+++ b/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
@@ -77,8 +77,8 @@ ip_white_list:
     cm_.initializeClusters({"vpn"}, {});
     cm_.initializeThreadLocalClusters({"vpn"});
     setupRequest();
-    config_ =
-        ClientSslAuthConfig::create(proto_config, tls_, cm_, dispatcher_, stats_store_, random_);
+    config_ = ClientSslAuthConfig::create(proto_config, tls_, cm_, dispatcher_,
+                                          *stats_store_.rootScope(), random_);
 
     createAuthFilter();
   }
@@ -129,9 +129,9 @@ stat_prefix: bad_cluster
   envoy::extensions::filters::network::client_ssl_auth::v3::ClientSSLAuth proto_config{};
   TestUtility::loadFromYaml(yaml, proto_config);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(Upstream::ClusterManager::ClusterInfoMaps()));
-  EXPECT_THROW(
-      ClientSslAuthConfig::create(proto_config, tls_, cm_, dispatcher_, stats_store_, random_),
-      EnvoyException);
+  EXPECT_THROW(ClientSslAuthConfig::create(proto_config, tls_, cm_, dispatcher_,
+                                           *stats_store_.rootScope(), random_),
+               EnvoyException);
 }
 
 TEST_F(ClientSslAuthFilterTest, NoSsl) {

--- a/contrib/cryptomb/private_key_providers/test/ops_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/ops_test.cc
@@ -51,7 +51,7 @@ protected:
       : api_(Api::createApiForTest(store_, time_system_)),
         dispatcher_(api_->allocateDispatcher("test_thread")),
         fakeIpp_(std::make_shared<FakeIppCryptoImpl>(true)),
-        stats_(generateCryptoMbStats("cryptomb", store_)) {}
+        stats_(generateCryptoMbStats("cryptomb", *store_.rootScope())) {}
 
   bssl::UniquePtr<EVP_PKEY> makeRsaKey() {
     std::string file = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(

--- a/contrib/dynamo/filters/http/test/dynamo_filter_test.cc
+++ b/contrib/dynamo/filters/http/test/dynamo_filter_test.cc
@@ -32,7 +32,7 @@ public:
         .WillByDefault(Return(enabled));
     EXPECT_CALL(loader_.snapshot_, featureEnabled("dynamodb.filter_enabled", 100));
 
-    auto stats = std::make_shared<DynamoStats>(stats_, "prefix.");
+    auto stats = std::make_shared<DynamoStats>(*stats_.rootScope(), "prefix.");
     filter_ = std::make_unique<DynamoFilter>(loader_, stats,
                                              decoder_callbacks_.dispatcher().timeSource());
 

--- a/contrib/dynamo/filters/http/test/dynamo_stats_test.cc
+++ b/contrib/dynamo/filters/http/test/dynamo_stats_test.cc
@@ -17,7 +17,7 @@ TEST(DynamoStats, PartitionIdStatString) {
   auto build_partition_string =
       [&store](const std::string& stat_prefix, const std::string& table_name,
                const std::string& operation, const std::string& partition_id) -> std::string {
-    DynamoStats stats(store, stat_prefix);
+    DynamoStats stats(*store.rootScope(), stat_prefix);
     Stats::Counter& counter = stats.buildPartitionStatCounter(table_name, operation, partition_id);
     return counter.name();
   };

--- a/contrib/kafka/filters/network/test/metrics_integration_test.cc
+++ b/contrib/kafka/filters/network/test/metrics_integration_test.cc
@@ -13,7 +13,8 @@ namespace MetricsIntegrationTest {
 
 class MetricsIntegrationTest : public testing::Test {
 protected:
-  Stats::TestUtil::TestStore scope_;
+  Stats::TestUtil::TestStore store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   RichRequestMetricsImpl request_metrics_{scope_, "prefix"};
   RichResponseMetricsImpl response_metrics_{scope_, "prefix"};
 };
@@ -29,7 +30,7 @@ TEST_F(MetricsIntegrationTest, ShouldUpdateRequestMetrics) {
     }
 
     // then
-    Stats::Counter& counter = scope_.counter(MessageUtilities::requestMetric(api_key));
+    Stats::Counter& counter = store_.counter(MessageUtilities::requestMetric(api_key));
     ASSERT_EQ(counter.value(), UPDATE_COUNT);
   };
 }
@@ -42,7 +43,7 @@ TEST_F(MetricsIntegrationTest, ShouldHandleUnparseableRequest) {
   }
 
   // then
-  ASSERT_EQ(scope_.counter("kafka.prefix.request.unknown").value(), UPDATE_COUNT);
+  ASSERT_EQ(store_.counter("kafka.prefix.request.unknown").value(), UPDATE_COUNT);
 }
 
 TEST_F(MetricsIntegrationTest, ShouldUpdateResponseMetrics) {
@@ -54,7 +55,7 @@ TEST_F(MetricsIntegrationTest, ShouldUpdateResponseMetrics) {
     }
 
     // then
-    Stats::Counter& counter = scope_.counter(MessageUtilities::responseMetric(api_key));
+    Stats::Counter& counter = store_.counter(MessageUtilities::responseMetric(api_key));
     ASSERT_EQ(counter.value(), UPDATE_COUNT);
   };
 }
@@ -67,7 +68,7 @@ TEST_F(MetricsIntegrationTest, ShouldHandleUnparseableResponse) {
   }
 
   // then
-  ASSERT_EQ(scope_.counter("kafka.prefix.response.unknown").value(), UPDATE_COUNT);
+  ASSERT_EQ(store_.counter("kafka.prefix.response.unknown").value(), UPDATE_COUNT);
 }
 
 } // namespace MetricsIntegrationTest

--- a/contrib/mysql_proxy/filters/network/test/mysql_filter_test.cc
+++ b/contrib/mysql_proxy/filters/network/test/mysql_filter_test.cc
@@ -30,7 +30,8 @@ public:
 
   MySQLFilterConfigSharedPtr config_;
   std::unique_ptr<MySQLFilter> filter_;
-  Stats::IsolatedStoreImpl scope_;
+  Stats::IsolatedStoreImpl store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   std::string stat_prefix_{"test."};
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
 };

--- a/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
@@ -55,7 +55,8 @@ public:
         }));
   }
 
-  Stats::IsolatedStoreImpl scope_;
+  Stats::IsolatedStoreImpl store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   std::string stat_prefix_{"test."};
   std::unique_ptr<PostgresFilter> filter_;
   PostgresFilterConfigSharedPtr config_;

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -320,7 +320,7 @@ public:
     Network::DownstreamTransportSocketFactoryPtr tls_context =
         Network::DownstreamTransportSocketFactoryPtr{
             new Extensions::TransportSockets::Tls::ServerSslSocketFactory(
-                std::move(cfg), *tls_context_manager, *client_stats_store, {})};
+                std::move(cfg), *tls_context_manager, *(client_stats_store->rootScope()), {})};
 
     Network::TransportSocketPtr ts = tls_context->createDownstreamTransportSocket();
     // Synchronization object used to suspend execution

--- a/contrib/rocketmq_proxy/filters/network/test/active_message_test.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/active_message_test.cc
@@ -22,7 +22,7 @@ namespace RocketmqProxy {
 class ActiveMessageTest : public testing::Test {
 public:
   ActiveMessageTest()
-      : stats_(RocketmqFilterStats::generateStats("test.", store_)),
+      : stats_(RocketmqFilterStats::generateStats("test.", *store_.rootScope())),
         config_(rocketmq_proxy_config_, factory_context_),
         connection_manager_(config_, factory_context_.mainThreadDispatcher().timeSource()) {
     connection_manager_.initializeReadFilterCallbacks(filter_callbacks_);

--- a/contrib/rocketmq_proxy/filters/network/test/conn_manager_test.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/conn_manager_test.cc
@@ -40,7 +40,8 @@ private:
 
 class RocketmqConnectionManagerTest : public Event::TestUsingSimulatedTime, public testing::Test {
 public:
-  RocketmqConnectionManagerTest() : stats_(RocketmqFilterStats::generateStats("test.", store_)) {}
+  RocketmqConnectionManagerTest()
+      : stats_(RocketmqFilterStats::generateStats("test.", *store_.rootScope())) {}
 
   ~RocketmqConnectionManagerTest() override {
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();

--- a/contrib/rocketmq_proxy/filters/network/test/mocks.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/mocks.cc
@@ -29,7 +29,8 @@ MockActiveMessage::MockActiveMessage(ConnectionManager& conn_manager, RemotingCo
 }
 MockActiveMessage::~MockActiveMessage() = default;
 
-MockConfig::MockConfig() : stats_(RocketmqFilterStats::generateStats("test.", store_)) {
+MockConfig::MockConfig()
+    : stats_(RocketmqFilterStats::generateStats("test.", *store_.rootScope())) {
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, createRouter())

--- a/contrib/sip_proxy/filters/network/test/conn_manager_test.cc
+++ b/contrib/sip_proxy/filters/network/test/conn_manager_test.cc
@@ -45,7 +45,7 @@ public:
 class SipConnectionManagerTest : public testing::Test {
 public:
   SipConnectionManagerTest()
-      : stats_(SipFilterStats::generateStats("test.", store_)),
+      : stats_(SipFilterStats::generateStats("test.", *store_.rootScope())),
         transaction_infos_(std::make_shared<Router::TransactionInfos>()) {}
   ~SipConnectionManagerTest() override {
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();

--- a/contrib/sip_proxy/filters/network/test/decoder_test.cc
+++ b/contrib/sip_proxy/filters/network/test/decoder_test.cc
@@ -48,7 +48,7 @@ public:
 class SipDecoderTest : public testing::Test {
 public:
   SipDecoderTest()
-      : stats_(SipFilterStats::generateStats("test.", store_)),
+      : stats_(SipFilterStats::generateStats("test.", *store_.rootScope())),
         transaction_infos_(std::make_shared<Router::TransactionInfos>()) {}
   ~SipDecoderTest() override {
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -48,7 +48,7 @@ MockDecoderFilter::MockDecoderFilter() {
 MockDecoderFilter::~MockDecoderFilter() = default;
 
 MockDecoderFilterCallbacks::MockDecoderFilterCallbacks()
-    : stats_(SipFilterStats::generateStats("test", store_)) {
+    : stats_(SipFilterStats::generateStats("test", *store_.rootScope())) {
 
   ON_CALL(*this, streamId()).WillByDefault(Return(stream_id_));
   ON_CALL(*this, transactionInfos()).WillByDefault(Return(transaction_infos_));

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -40,7 +40,7 @@ class SipRouterTest : public testing::Test {
 public:
   SipRouterTest()
       : router_filter_config_(std::make_shared<NiceMock<MockRouterFilterConfig>>()),
-        router_stats_(RouterFilterConfigImpl::generateStats("test", store_)){};
+        router_stats_(RouterFilterConfigImpl::generateStats("test", *store_.rootScope())){};
   ~SipRouterTest() override { delete (filter_); }
 
   void initializeTrans(const std::string& sip_protocol_options_yaml = "",
@@ -111,7 +111,7 @@ public:
     context_.cluster_manager_.initializeThreadLocalClusters({cluster_name_});
 
     StreamInfo::StreamInfoImpl stream_info{time_source_, nullptr};
-    SipFilterStats stat = SipFilterStats::generateStats("test.", store_);
+    SipFilterStats stat = SipFilterStats::generateStats("test.", *store_.rootScope());
     EXPECT_CALL(config_, stats()).WillRepeatedly(ReturnRef(stat));
 
     filter_ =

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -45,7 +45,7 @@ public:
         envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceConfig>();
     TestUtility::loadFromYaml(tra_yaml, *tra_config);
 
-    SipFilterStats stat = SipFilterStats::generateStats("test.", store_);
+    SipFilterStats stat = SipFilterStats::generateStats("test.", *store_.rootScope());
     auto config = std::make_shared<NiceMock<MockConfig>>();
     EXPECT_CALL(*config, stats()).WillRepeatedly(ReturnRef(stat));
     auto context = std::make_shared<NiceMock<Server::Configuration::MockFactoryContext>>();

--- a/contrib/sxg/filters/http/test/filter_test.cc
+++ b/contrib/sxg/filters/http/test/filter_test.cc
@@ -212,17 +212,17 @@ E9toc6lgrko2JdbV6TyWLVUc/M0Pn+OVSQ==
       EXPECT_FALSE(request_headers.get(x_client_can_accept_sxg_key).empty());
       EXPECT_EQ("true",
                 request_headers.get(x_client_can_accept_sxg_key)[0]->value().getStringView());
-      EXPECT_EQ(1UL, scope_.counter("sxg.total_client_can_accept_sxg").value());
+      EXPECT_EQ(1UL, store_.counter("sxg.total_client_can_accept_sxg").value());
     } else {
       const Envoy::Http::LowerCaseString x_client_can_accept_sxg_key("x-client-can-accept-sxg");
       EXPECT_TRUE(request_headers.get(x_client_can_accept_sxg_key).empty());
-      EXPECT_EQ(0UL, scope_.counter("sxg.total_client_can_accept_sxg").value());
+      EXPECT_EQ(0UL, store_.counter("sxg.total_client_can_accept_sxg").value());
     }
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_should_sign").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_exceeded_max_payload_size").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_signed_attempts").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_signed_succeeded").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_signed_failed").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_should_sign").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_exceeded_max_payload_size").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_signed_attempts").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_signed_succeeded").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_signed_failed").value());
   }
 
   void testFallbackToHtml(Http::TestRequestHeaderMapImpl& request_headers,
@@ -249,13 +249,13 @@ E9toc6lgrko2JdbV6TyWLVUc/M0Pn+OVSQ==
     const Envoy::Http::LowerCaseString x_client_can_accept_sxg_key("x-client-can-accept-sxg");
     EXPECT_FALSE(request_headers.get(x_client_can_accept_sxg_key).empty());
     EXPECT_EQ("true", request_headers.get(x_client_can_accept_sxg_key)[0]->value().getStringView());
-    EXPECT_EQ(1UL, scope_.counter("sxg.total_client_can_accept_sxg").value());
-    EXPECT_EQ(1UL, scope_.counter("sxg.total_should_sign").value());
+    EXPECT_EQ(1UL, store_.counter("sxg.total_client_can_accept_sxg").value());
+    EXPECT_EQ(1UL, store_.counter("sxg.total_should_sign").value());
     EXPECT_EQ(exceeded_max_payload_size ? 1UL : 0UL,
-              scope_.counter("sxg.total_exceeded_max_payload_size").value());
-    EXPECT_EQ(attempted_encode ? 1UL : 0L, scope_.counter("sxg.total_signed_attempts").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_signed_succeeded").value());
-    EXPECT_EQ(attempted_encode ? 1UL : 0UL, scope_.counter("sxg.total_signed_failed").value());
+              store_.counter("sxg.total_exceeded_max_payload_size").value());
+    EXPECT_EQ(attempted_encode ? 1UL : 0L, store_.counter("sxg.total_signed_attempts").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_signed_succeeded").value());
+    EXPECT_EQ(attempted_encode ? 1UL : 0UL, store_.counter("sxg.total_signed_failed").value());
   }
 
   void testEncodeSignedExchange(Http::TestRequestHeaderMapImpl& request_headers,
@@ -331,17 +331,18 @@ E9toc6lgrko2JdbV6TyWLVUc/M0Pn+OVSQ==
     const Envoy::Http::LowerCaseString x_client_can_accept_sxg_key("x-client-can-accept-sxg");
     EXPECT_FALSE(request_headers.get(x_client_can_accept_sxg_key).empty());
     EXPECT_EQ("true", request_headers.get(x_client_can_accept_sxg_key)[0]->value().getStringView());
-    EXPECT_EQ(1UL, scope_.counter("sxg.total_client_can_accept_sxg").value());
-    EXPECT_EQ(1UL, scope_.counter("sxg.total_should_sign").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_exceeded_max_payload_size").value());
-    EXPECT_EQ(1UL, scope_.counter("sxg.total_signed_attempts").value());
-    EXPECT_EQ(1UL, scope_.counter("sxg.total_signed_succeeded").value());
-    EXPECT_EQ(0UL, scope_.counter("sxg.total_signed_failed").value());
+    EXPECT_EQ(1UL, store_.counter("sxg.total_client_can_accept_sxg").value());
+    EXPECT_EQ(1UL, store_.counter("sxg.total_should_sign").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_exceeded_max_payload_size").value());
+    EXPECT_EQ(1UL, store_.counter("sxg.total_signed_attempts").value());
+    EXPECT_EQ(1UL, store_.counter("sxg.total_signed_succeeded").value());
+    EXPECT_EQ(0UL, store_.counter("sxg.total_signed_failed").value());
   }
 
   void callDoSxgAgain() { filter_->doSxg(); }
 
-  Stats::TestUtil::TestStore scope_;
+  Stats::TestUtil::TestStore store_;
+  Stats::Scope& scope_{*store_.rootScope()};
   Event::SimulatedTimeSystem time_system_;
   std::shared_ptr<FilterConfig> config_;
   std::unique_ptr<Encoder> encoder_;

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -152,21 +152,8 @@ public:
   virtual bool iterate(const IterateFn<Histogram>& fn) const PURE;
   virtual bool iterate(const IterateFn<TextReadout>& fn) const PURE;
 
-  // TODO(#24007): The cast operator is available temporarily to bound the size
-  // of https://github.com/envoyproxy/envoy/pull/23851, which detaches the
-  // inheritance of Scope as a parent of Store. There is semantic complexity to
-  // that PR, so it's going to be easier review if it's as small as possible.
-  //
-  // A series of follow-up PRs is required to remove the functions below, which
-  // will require a large number of files to be trivially changed, by explicitly
-  // accessing the rootScope() to call these methods. The first in the series is
-  // https://github.com/envoyproxy/envoy/pull/24567 which just takes care of
-  // test/common/...
-  // operator Scope&() { return *rootScope(); }
-
   // Delegate some methods to the root scope; these are exposed to make it more
-  // convenient to use stats_macros.h. We may consider dropping them if desired,
-  // when we resolve #24007 or in the next follow-up.
+  // convenient to use stats_macros.h. We may consider dropping them if desired.
   Counter& counterFromString(const std::string& name) {
     return rootScope()->counterFromString(name);
   }

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -162,7 +162,7 @@ public:
   // accessing the rootScope() to call these methods. The first in the series is
   // https://github.com/envoyproxy/envoy/pull/24567 which just takes care of
   // test/common/...
-  operator Scope&() { return *rootScope(); }
+  // operator Scope&() { return *rootScope(); }
 
   // Delegate some methods to the root scope; these are exposed to make it more
   // convenient to use stats_macros.h. We may consider dropping them if desired,

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -152,8 +152,13 @@ public:
   virtual bool iterate(const IterateFn<Histogram>& fn) const PURE;
   virtual bool iterate(const IterateFn<TextReadout>& fn) const PURE;
 
+  // TODO(#24007): Remove this operator overload: it is not needed anymore. Once
+  // #24567, #24843, and #24861 have landed we can remove this API.
+  operator Scope&() { return *rootScope(); }
+
   // Delegate some methods to the root scope; these are exposed to make it more
-  // convenient to use stats_macros.h. We may consider dropping them if desired.
+  // convenient to use stats_macros.h. We may consider dropping them if desired,
+  // when we resolve #24007 or in the next follow-up.
   Counter& counterFromString(const std::string& name) {
     return rootScope()->counterFromString(name);
   }

--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -706,7 +706,8 @@ TEST_F(AppleDnsImplFakeApiTest, SynchronousTimeoutInGetAddrInfo) {
 
 TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletionUnroutableFamilies) {
   config_.set_include_unroutable_families(true);
-  resolver_ = std::make_unique<Network::AppleDnsResolverImpl>(config_, dispatcher_, stats_store_);
+  resolver_ = std::make_unique<Network::AppleDnsResolverImpl>(config_, dispatcher_,
+                                                              *stats_store_.rootScope());
 
   const std::string hostname = "foo.com";
   sockaddr_in addr4;

--- a/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/apple/apple_dns_impl_test.cc
@@ -387,7 +387,8 @@ class AppleDnsImplFakeApiTest : public testing::Test {
 public:
   void SetUp() override {
     config_.set_include_unroutable_families(false);
-    resolver_ = std::make_unique<Network::AppleDnsResolverImpl>(config_, dispatcher_, stats_store_);
+    resolver_ = std::make_unique<Network::AppleDnsResolverImpl>(config_, dispatcher_,
+                                                                *stats_store_.rootScope());
   }
 
   void checkErrorStat(DNSServiceErrorType error_code) {


### PR DESCRIPTION
Commit Message: Last of 3 PRs to remove dependencies on Store::operator Scope&().

Additional Description: This fixes technical debt that was taken in https://github.com/envoyproxy/envoy/pull/23851 and partially resolved in https://github.com/envoyproxy/envoy/pull/24567 and https://github.com/envoyproxy/envoy/pull/24843 in order to solve a structural problem where Stats::Store was a subclass of Stats::Scope, which didn't make OO sense (a Store is not a Scope), but was convenient (you could pass a Store into a function that was expecting a Scope), and the Store worked as a root Scope. That needed to be cleaned up to clarify the ownership model where Store is typically instantiated directly in a production factory or test, and Scope is always held by shared_ptr.

We still need one more PR just to remove the operator, once this lands, after which https://github.com/envoyproxy/envoy/issues/24007 can be marked fixed.

Risk Level: low -- this is a large PR but it's just trivial one-line changes, getting the root scope explicitly from the store in a 20+ different places. There are no functional changes or refactors in this PR.
Testing: //test/..., and building //contrib/... which has test-failures independent of this PR.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
