### PR TITLE
extensions: split extension registration macro

### DIFF
--- a/contrib/client_ssl_auth/filters/network/source/config.cc
+++ b/contrib/client_ssl_auth/filters/network/source/config.cc
@@ -29,8 +29,9 @@ Network::FilterFactoryCb ClientSslAuthConfigFactory::createFilterFactoryFromProt
 /**
  * Static registration for the client SSL auth filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(ClientSslAuthConfigFactory,
-                   Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.client_ssl_auth");
+LEGACY_REGISTER_FACTORY(ClientSslAuthConfigFactory,
+                        Server::Configuration::NamedNetworkFilterConfigFactory,
+                        "envoy.client_ssl_auth");
 
 } // namespace ClientSslAuth
 } // namespace NetworkFilters

--- a/contrib/client_ssl_auth/filters/network/source/config.cc
+++ b/contrib/client_ssl_auth/filters/network/source/config.cc
@@ -29,8 +29,8 @@ Network::FilterFactoryCb ClientSslAuthConfigFactory::createFilterFactoryFromProt
 /**
  * Static registration for the client SSL auth filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(ClientSslAuthConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.client_ssl_auth"};
+REGISTER_FACTORY_D(ClientSslAuthConfigFactory,
+                   Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.client_ssl_auth");
 
 } // namespace ClientSslAuth
 } // namespace NetworkFilters

--- a/contrib/dynamo/filters/http/source/config.cc
+++ b/contrib/dynamo/filters/http/source/config.cc
@@ -26,8 +26,8 @@ Http::FilterFactoryCb DynamoFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the http dynamodb filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(DynamoFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.http_dynamo_filter");
+LEGACY_REGISTER_FACTORY(DynamoFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.http_dynamo_filter");
 
 } // namespace Dynamo
 } // namespace HttpFilters

--- a/contrib/dynamo/filters/http/source/config.cc
+++ b/contrib/dynamo/filters/http/source/config.cc
@@ -26,8 +26,8 @@ Http::FilterFactoryCb DynamoFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the http dynamodb filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(DynamoFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.http_dynamo_filter"};
+REGISTER_FACTORY_D(DynamoFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.http_dynamo_filter");
 
 } // namespace Dynamo
 } // namespace HttpFilters

--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -48,8 +48,8 @@ GolangFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the golang extensions filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(GolangFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.golang"};
+REGISTER_FACTORY_D(GolangFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.golang");
 
 } // namespace Golang
 } // namespace HttpFilters

--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -48,8 +48,8 @@ GolangFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the golang extensions filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(GolangFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.golang");
+LEGACY_REGISTER_FACTORY(GolangFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.golang");
 
 } // namespace Golang
 } // namespace HttpFilters

--- a/contrib/squash/filters/http/source/config.cc
+++ b/contrib/squash/filters/http/source/config.cc
@@ -30,8 +30,8 @@ Http::FilterFactoryCb SquashFilterConfigFactory::createFilterFactoryFromProtoTyp
 /**
  * Static registration for the squash filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(SquashFilterConfigFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.squash"};
+REGISTER_FACTORY_D(SquashFilterConfigFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.squash");
 
 } // namespace Squash
 } // namespace HttpFilters

--- a/contrib/squash/filters/http/source/config.cc
+++ b/contrib/squash/filters/http/source/config.cc
@@ -30,8 +30,8 @@ Http::FilterFactoryCb SquashFilterConfigFactory::createFilterFactoryFromProtoTyp
 /**
  * Static registration for the squash filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(SquashFilterConfigFactory, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.squash");
+LEGACY_REGISTER_FACTORY(SquashFilterConfigFactory,
+                        Server::Configuration::NamedHttpFilterConfigFactory, "envoy.squash");
 
 } // namespace Squash
 } // namespace HttpFilters

--- a/envoy/registry/registry.h
+++ b/envoy/registry/registry.h
@@ -497,7 +497,7 @@ private:
  * unit. For an example of a typical use case, @see NamedNetworkFilterConfigFactory.
  *
  * Example registration: REGISTER_FACTORY(SpecificFactory, BaseFactory);
- *                       REGISTER_FACTORY(SpecificFactory, BaseFactory){"deprecated_name"};
+ *                       REGISTER_FACTORY_D(SpecificFactory, BaseFactory, "deprecated_name");
  */
 template <class T, class Base> class RegisterFactory {
 public:
@@ -618,6 +618,16 @@ private:
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \
       FACTORY##_registered
+/**
+ * Macro used for static registration with deprecated name.
+ */
+#define REGISTER_FACTORY_D(FACTORY, BASE, DEPRECATED_NAME)                                         \
+  ABSL_ATTRIBUTE_UNUSED void forceRegister##FACTORY() {}                                           \
+  static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
+                                          FACTORY, BASE>                                           \
+      FACTORY##_registered {                                                                       \
+    DEPRECATED_NAME                                                                                \
+  }
 
 #define FACTORY_VERSION(major, minor, patch, ...) major, minor, patch, __VA_ARGS__
 

--- a/envoy/registry/registry.h
+++ b/envoy/registry/registry.h
@@ -497,7 +497,7 @@ private:
  * unit. For an example of a typical use case, @see NamedNetworkFilterConfigFactory.
  *
  * Example registration: REGISTER_FACTORY(SpecificFactory, BaseFactory);
- *                       REGISTER_FACTORY_D(SpecificFactory, BaseFactory, "deprecated_name");
+ *                       LEGACY_REGISTER_FACTORY(SpecificFactory, BaseFactory, "deprecated_name");
  */
 template <class T, class Base> class RegisterFactory {
 public:
@@ -621,7 +621,7 @@ private:
 /**
  * Macro used for static registration with deprecated name.
  */
-#define REGISTER_FACTORY_D(FACTORY, BASE, DEPRECATED_NAME)                                         \
+#define LEGACY_REGISTER_FACTORY(FACTORY, BASE, DEPRECATED_NAME)                                    \
   ABSL_ATTRIBUTE_UNUSED void forceRegister##FACTORY() {}                                           \
   static Envoy::Registry::RegisterFactory</* NOLINT(fuchsia-statically-constructed-objects) */     \
                                           FACTORY, BASE>                                           \

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -81,8 +81,8 @@ std::string FileAccessLogFactory::name() const { return "envoy.access_loggers.fi
 /**
  * Static registration for the file access log. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(FileAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
-                   "envoy.file_access_log");
+LEGACY_REGISTER_FACTORY(FileAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                        "envoy.file_access_log");
 
 } // namespace File
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -81,8 +81,8 @@ std::string FileAccessLogFactory::name() const { return "envoy.access_loggers.fi
 /**
  * Static registration for the file access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(FileAccessLogFactory,
-                 Server::Configuration::AccessLogInstanceFactory){"envoy.file_access_log"};
+REGISTER_FACTORY_D(FileAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                   "envoy.file_access_log");
 
 } // namespace File
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -49,8 +49,8 @@ std::string HttpGrpcAccessLogFactory::name() const { return "envoy.access_logger
 /**
  * Static registration for the HTTP gRPC access log. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(HttpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
-                   "envoy.http_grpc_access_log");
+LEGACY_REGISTER_FACTORY(HttpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                        "envoy.http_grpc_access_log");
 
 } // namespace HttpGrpc
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -49,8 +49,8 @@ std::string HttpGrpcAccessLogFactory::name() const { return "envoy.access_logger
 /**
  * Static registration for the HTTP gRPC access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(HttpGrpcAccessLogFactory,
-                 Server::Configuration::AccessLogInstanceFactory){"envoy.http_grpc_access_log"};
+REGISTER_FACTORY_D(HttpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                   "envoy.http_grpc_access_log");
 
 } // namespace HttpGrpc
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -48,8 +48,8 @@ std::string TcpGrpcAccessLogFactory::name() const { return "envoy.access_loggers
 /**
  * Static registration for the TCP gRPC access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(TcpGrpcAccessLogFactory,
-                 Server::Configuration::AccessLogInstanceFactory){"envoy.tcp_grpc_access_log"};
+REGISTER_FACTORY_D(TcpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                   "envoy.tcp_grpc_access_log");
 
 } // namespace TcpGrpc
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -48,8 +48,8 @@ std::string TcpGrpcAccessLogFactory::name() const { return "envoy.access_loggers
 /**
  * Static registration for the TCP gRPC access log. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(TcpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
-                   "envoy.tcp_grpc_access_log");
+LEGACY_REGISTER_FACTORY(TcpGrpcAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                        "envoy.tcp_grpc_access_log");
 
 } // namespace TcpGrpc
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -46,8 +46,8 @@ std::string StdoutAccessLogFactory::name() const { return "envoy.access_loggers.
 /**
  * Static registration for the file access log. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(StdoutAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
-                   "envoy.stdout_access_log");
+LEGACY_REGISTER_FACTORY(StdoutAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                        "envoy.stdout_access_log");
 
 AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
@@ -75,8 +75,8 @@ std::string StderrAccessLogFactory::name() const { return "envoy.access_loggers.
 /**
  * Static registration for the `stderr` access log. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(StderrAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
-                   "envoy.stderr_access_log");
+LEGACY_REGISTER_FACTORY(StderrAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                        "envoy.stderr_access_log");
 
 } // namespace File
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -46,8 +46,8 @@ std::string StdoutAccessLogFactory::name() const { return "envoy.access_loggers.
 /**
  * Static registration for the file access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(StdoutAccessLogFactory,
-                 Server::Configuration::AccessLogInstanceFactory){"envoy.stdout_access_log"};
+REGISTER_FACTORY_D(StdoutAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                   "envoy.stdout_access_log");
 
 AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
@@ -75,8 +75,8 @@ std::string StderrAccessLogFactory::name() const { return "envoy.access_loggers.
 /**
  * Static registration for the `stderr` access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(StderrAccessLogFactory,
-                 Server::Configuration::AccessLogInstanceFactory){"envoy.stderr_access_log"};
+REGISTER_FACTORY_D(StderrAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                   "envoy.stderr_access_log");
 
 } // namespace File
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -71,8 +71,8 @@ std::string WasmAccessLogFactory::name() const { return "envoy.access_loggers.wa
 /**
  * Static registration for the wasm access log. @see RegisterFactory.
  */
-REGISTER_FACTORY(WasmAccessLogFactory,
-                 Server::Configuration::AccessLogInstanceFactory){"envoy.wasm_access_log"};
+REGISTER_FACTORY_D(WasmAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                   "envoy.wasm_access_log");
 
 } // namespace Wasm
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -71,8 +71,8 @@ std::string WasmAccessLogFactory::name() const { return "envoy.access_loggers.wa
 /**
  * Static registration for the wasm access log. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(WasmAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
-                   "envoy.wasm_access_log");
+LEGACY_REGISTER_FACTORY(WasmAccessLogFactory, Server::Configuration::AccessLogInstanceFactory,
+                        "envoy.wasm_access_log");
 
 } // namespace Wasm
 } // namespace AccessLoggers

--- a/source/extensions/config/validators/minimum_clusters/config.cc
+++ b/source/extensions/config/validators/minimum_clusters/config.cc
@@ -36,8 +36,8 @@ std::string MinimumClustersValidatorFactory::typeUrl() const {
 /**
  * Static registration for this config validator factory. @see RegisterFactory.
  */
-REGISTER_FACTORY(MinimumClustersValidatorFactory,
-                 Envoy::Config::ConfigValidatorFactory){"envoy.config.validators.minimum_clusters"};
+REGISTER_FACTORY_D(MinimumClustersValidatorFactory, Envoy::Config::ConfigValidatorFactory,
+                   "envoy.config.validators.minimum_clusters");
 
 } // namespace Validators
 } // namespace Config

--- a/source/extensions/config/validators/minimum_clusters/config.cc
+++ b/source/extensions/config/validators/minimum_clusters/config.cc
@@ -36,8 +36,8 @@ std::string MinimumClustersValidatorFactory::typeUrl() const {
 /**
  * Static registration for this config validator factory. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(MinimumClustersValidatorFactory, Envoy::Config::ConfigValidatorFactory,
-                   "envoy.config.validators.minimum_clusters");
+LEGACY_REGISTER_FACTORY(MinimumClustersValidatorFactory, Envoy::Config::ConfigValidatorFactory,
+                        "envoy.config.validators.minimum_clusters");
 
 } // namespace Validators
 } // namespace Config

--- a/source/extensions/filters/http/bandwidth_limit/config.cc
+++ b/source/extensions/filters/http/bandwidth_limit/config.cc
@@ -33,8 +33,8 @@ BandwidthLimitFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the bandwidth limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(BandwidthLimitFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.bandwidth_limit"};
+REGISTER_FACTORY_D(BandwidthLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.bandwidth_limit");
 
 } // namespace BandwidthLimitFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/bandwidth_limit/config.cc
+++ b/source/extensions/filters/http/bandwidth_limit/config.cc
@@ -33,8 +33,9 @@ BandwidthLimitFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the bandwidth limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(BandwidthLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.bandwidth_limit");
+LEGACY_REGISTER_FACTORY(BandwidthLimitFilterConfig,
+                        Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.bandwidth_limit");
 
 } // namespace BandwidthLimitFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -36,10 +36,10 @@ BufferFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the buffer filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(BufferFilterFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.buffer"};
-REGISTER_FACTORY(UpstreamBufferFilterFactory,
-                 Server::Configuration::UpstreamHttpFilterConfigFactory){"envoy.buffer"};
+REGISTER_FACTORY_D(BufferFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.buffer");
+REGISTER_FACTORY_D(UpstreamBufferFilterFactory,
+                   Server::Configuration::UpstreamHttpFilterConfigFactory, "envoy.buffer");
 
 } // namespace BufferFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -36,10 +36,10 @@ BufferFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the buffer filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(BufferFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.buffer");
-REGISTER_FACTORY_D(UpstreamBufferFilterFactory,
-                   Server::Configuration::UpstreamHttpFilterConfigFactory, "envoy.buffer");
+LEGACY_REGISTER_FACTORY(BufferFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.buffer");
+LEGACY_REGISTER_FACTORY(UpstreamBufferFilterFactory,
+                        Server::Configuration::UpstreamHttpFilterConfigFactory, "envoy.buffer");
 
 } // namespace BufferFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -37,8 +37,8 @@ CorsFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the cors filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(CorsFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.cors");
+LEGACY_REGISTER_FACTORY(CorsFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.cors");
 
 } // namespace Cors
 } // namespace HttpFilters

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -37,8 +37,8 @@ CorsFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the cors filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(CorsFilterFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.cors"};
+REGISTER_FACTORY_D(CorsFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.cors");
 
 } // namespace Cors
 } // namespace HttpFilters

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -31,8 +31,8 @@ CsrfFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the CSRF filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(CsrfFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.csrf");
+LEGACY_REGISTER_FACTORY(CsrfFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.csrf");
 
 } // namespace Csrf
 } // namespace HttpFilters

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -31,8 +31,8 @@ CsrfFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the CSRF filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(CsrfFilterFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.csrf"};
+REGISTER_FACTORY_D(CsrfFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.csrf");
 
 } // namespace Csrf
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -85,8 +85,8 @@ ExtAuthzFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the external authorization filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(ExtAuthzFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.ext_authz"};
+REGISTER_FACTORY_D(ExtAuthzFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.ext_authz");
 
 } // namespace ExtAuthz
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -85,8 +85,8 @@ ExtAuthzFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the external authorization filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(ExtAuthzFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.ext_authz");
+LEGACY_REGISTER_FACTORY(ExtAuthzFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.ext_authz");
 
 } // namespace ExtAuthz
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -33,8 +33,8 @@ ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
   return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 
-REGISTER_FACTORY_D(ExternalProcessingFilterConfig,
-                   Server::Configuration::NamedHttpFilterConfigFactory, "envoy.ext_proc");
+LEGACY_REGISTER_FACTORY(ExternalProcessingFilterConfig,
+                        Server::Configuration::NamedHttpFilterConfigFactory, "envoy.ext_proc");
 
 } // namespace ExternalProcessing
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -33,8 +33,8 @@ ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
   return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 
-REGISTER_FACTORY(ExternalProcessingFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.ext_proc"};
+REGISTER_FACTORY_D(ExternalProcessingFilterConfig,
+                   Server::Configuration::NamedHttpFilterConfigFactory, "envoy.ext_proc");
 
 } // namespace ExternalProcessing
 } // namespace HttpFilters

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -31,8 +31,8 @@ FaultFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the fault filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(FaultFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.fault");
+LEGACY_REGISTER_FACTORY(FaultFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.fault");
 
 } // namespace Fault
 } // namespace HttpFilters

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -31,8 +31,8 @@ FaultFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the fault filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(FaultFilterFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.fault"};
+REGISTER_FACTORY_D(FaultFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.fault");
 
 } // namespace Fault
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -21,8 +21,8 @@ Http::FilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoT
 /**
  * Static registration for the grpc HTTP1 bridge filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(GrpcHttp1BridgeFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.grpc_http1_bridge"};
+REGISTER_FACTORY_D(GrpcHttp1BridgeFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.grpc_http1_bridge");
 
 } // namespace GrpcHttp1Bridge
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -21,8 +21,9 @@ Http::FilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoT
 /**
  * Static registration for the grpc HTTP1 bridge filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(GrpcHttp1BridgeFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.grpc_http1_bridge");
+LEGACY_REGISTER_FACTORY(GrpcHttp1BridgeFilterConfig,
+                        Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.grpc_http1_bridge");
 
 } // namespace GrpcHttp1Bridge
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -35,8 +35,9 @@ GrpcJsonTranscoderFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the grpc transcoding filter. @see RegisterNamedHttpFilterConfigFactory.
  */
-REGISTER_FACTORY(GrpcJsonTranscoderFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.grpc_json_transcoder"};
+REGISTER_FACTORY_D(GrpcJsonTranscoderFilterConfig,
+                   Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.grpc_json_transcoder");
 
 } // namespace GrpcJsonTranscoder
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -35,9 +35,9 @@ GrpcJsonTranscoderFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the grpc transcoding filter. @see RegisterNamedHttpFilterConfigFactory.
  */
-REGISTER_FACTORY_D(GrpcJsonTranscoderFilterConfig,
-                   Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.grpc_json_transcoder");
+LEGACY_REGISTER_FACTORY(GrpcJsonTranscoderFilterConfig,
+                        Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.grpc_json_transcoder");
 
 } // namespace GrpcJsonTranscoder
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_web/config.cc
+++ b/source/extensions/filters/http/grpc_web/config.cc
@@ -20,8 +20,8 @@ Http::FilterFactoryCb GrpcWebFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the gRPC-Web filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(GrpcWebFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.grpc_web"};
+REGISTER_FACTORY_D(GrpcWebFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.grpc_web");
 
 } // namespace GrpcWeb
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_web/config.cc
+++ b/source/extensions/filters/http/grpc_web/config.cc
@@ -20,8 +20,8 @@ Http::FilterFactoryCb GrpcWebFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the gRPC-Web filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(GrpcWebFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.grpc_web");
+LEGACY_REGISTER_FACTORY(GrpcWebFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.grpc_web");
 
 } // namespace GrpcWeb
 } // namespace HttpFilters

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -56,8 +56,8 @@ Http::FilterFactoryCb HealthCheckFilterConfig::createFilterFactoryFromProtoTyped
 /**
  * Static registration for the health check filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(HealthCheckFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.health_check"};
+REGISTER_FACTORY_D(HealthCheckFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.health_check");
 
 } // namespace HealthCheck
 } // namespace HttpFilters

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -56,8 +56,8 @@ Http::FilterFactoryCb HealthCheckFilterConfig::createFilterFactoryFromProtoTyped
 /**
  * Static registration for the health check filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(HealthCheckFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.health_check");
+LEGACY_REGISTER_FACTORY(HealthCheckFilterConfig,
+                        Server::Configuration::NamedHttpFilterConfigFactory, "envoy.health_check");
 
 } // namespace HealthCheck
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ip_tagging/config.cc
+++ b/source/extensions/filters/http/ip_tagging/config.cc
@@ -27,8 +27,8 @@ Http::FilterFactoryCb IpTaggingFilterFactory::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the ip tagging filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(IpTaggingFilterFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.ip_tagging"};
+REGISTER_FACTORY_D(IpTaggingFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.ip_tagging");
 
 } // namespace IpTagging
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ip_tagging/config.cc
+++ b/source/extensions/filters/http/ip_tagging/config.cc
@@ -27,8 +27,8 @@ Http::FilterFactoryCb IpTaggingFilterFactory::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the ip tagging filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(IpTaggingFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.ip_tagging");
+LEGACY_REGISTER_FACTORY(IpTaggingFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.ip_tagging");
 
 } // namespace IpTagging
 } // namespace HttpFilters

--- a/source/extensions/filters/http/local_ratelimit/config.cc
+++ b/source/extensions/filters/http/local_ratelimit/config.cc
@@ -35,8 +35,8 @@ LocalRateLimitFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(LocalRateLimitFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.local_rate_limit"};
+REGISTER_FACTORY_D(LocalRateLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.local_rate_limit");
 
 } // namespace LocalRateLimitFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/local_ratelimit/config.cc
+++ b/source/extensions/filters/http/local_ratelimit/config.cc
@@ -35,8 +35,9 @@ LocalRateLimitFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(LocalRateLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.local_rate_limit");
+LEGACY_REGISTER_FACTORY(LocalRateLimitFilterConfig,
+                        Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.local_rate_limit");
 
 } // namespace LocalRateLimitFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -33,7 +33,8 @@ LuaFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the Lua filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(LuaFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory){"envoy.lua"};
+REGISTER_FACTORY_D(LuaFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.lua");
 
 } // namespace Lua
 } // namespace HttpFilters

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -33,8 +33,8 @@ LuaFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the Lua filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(LuaFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.lua");
+LEGACY_REGISTER_FACTORY(LuaFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.lua");
 
 } // namespace Lua
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -46,8 +46,8 @@ RateLimitFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(RateLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.rate_limit");
+LEGACY_REGISTER_FACTORY(RateLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.rate_limit");
 
 } // namespace RateLimitFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -46,8 +46,8 @@ RateLimitFilterConfig::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(RateLimitFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.rate_limit"};
+REGISTER_FACTORY_D(RateLimitFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.rate_limit");
 
 } // namespace RateLimitFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/router/config.cc
+++ b/source/extensions/filters/http/router/config.cc
@@ -28,8 +28,8 @@ Http::FilterFactoryCb RouterFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the router filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(RouterFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
-                   "envoy.router");
+LEGACY_REGISTER_FACTORY(RouterFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.router");
 
 } // namespace RouterFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/router/config.cc
+++ b/source/extensions/filters/http/router/config.cc
@@ -28,8 +28,8 @@ Http::FilterFactoryCb RouterFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the router filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(RouterFilterConfig,
-                 Server::Configuration::NamedHttpFilterConfigFactory){"envoy.router"};
+REGISTER_FACTORY_D(RouterFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
+                   "envoy.router");
 
 } // namespace RouterFilter
 } // namespace HttpFilters

--- a/source/extensions/filters/network/echo/config.cc
+++ b/source/extensions/filters/network/echo/config.cc
@@ -38,8 +38,8 @@ private:
 /**
  * Static registration for the echo filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(EchoConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
-                   "envoy.echo");
+LEGACY_REGISTER_FACTORY(EchoConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
+                        "envoy.echo");
 
 } // namespace Echo
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/echo/config.cc
+++ b/source/extensions/filters/network/echo/config.cc
@@ -38,8 +38,8 @@ private:
 /**
  * Static registration for the echo filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(EchoConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.echo"};
+REGISTER_FACTORY_D(EchoConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
+                   "envoy.echo");
 
 } // namespace Echo
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -45,8 +45,8 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
 /**
  * Static registration for the external authorization filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(ExtAuthzConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
-                   "envoy.ext_authz");
+LEGACY_REGISTER_FACTORY(ExtAuthzConfigFactory,
+                        Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.ext_authz");
 
 } // namespace ExtAuthz
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -45,8 +45,8 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
 /**
  * Static registration for the external authorization filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(ExtAuthzConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.ext_authz"};
+REGISTER_FACTORY_D(ExtAuthzConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
+                   "envoy.ext_authz");
 
 } // namespace ExtAuthz
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -292,9 +292,9 @@ MobileHttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoType
 /**
  * Static registration for the HTTP connection manager filter.
  */
-REGISTER_FACTORY(HttpConnectionManagerFilterConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){
-    "envoy.http_connection_manager"};
+REGISTER_FACTORY_D(HttpConnectionManagerFilterConfigFactory,
+                   Server::Configuration::NamedNetworkFilterConfigFactory,
+                   "envoy.http_connection_manager");
 
 InternalAddressConfig::InternalAddressConfig(
     const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -292,9 +292,9 @@ MobileHttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoType
 /**
  * Static registration for the HTTP connection manager filter.
  */
-REGISTER_FACTORY_D(HttpConnectionManagerFilterConfigFactory,
-                   Server::Configuration::NamedNetworkFilterConfigFactory,
-                   "envoy.http_connection_manager");
+LEGACY_REGISTER_FACTORY(HttpConnectionManagerFilterConfigFactory,
+                        Server::Configuration::NamedNetworkFilterConfigFactory,
+                        "envoy.http_connection_manager");
 
 InternalAddressConfig::InternalAddressConfig(
     const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -53,8 +53,9 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
 /**
  * Static registration for the mongo filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(MongoProxyFilterConfigFactory,
-                   Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.mongo_proxy");
+LEGACY_REGISTER_FACTORY(MongoProxyFilterConfigFactory,
+                        Server::Configuration::NamedNetworkFilterConfigFactory,
+                        "envoy.mongo_proxy");
 
 } // namespace MongoProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -53,8 +53,8 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
 /**
  * Static registration for the mongo filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(MongoProxyFilterConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.mongo_proxy"};
+REGISTER_FACTORY_D(MongoProxyFilterConfigFactory,
+                   Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.mongo_proxy");
 
 } // namespace MongoProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -40,8 +40,8 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(RateLimitConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.ratelimit"};
+REGISTER_FACTORY_D(RateLimitConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
+                   "envoy.ratelimit");
 
 } // namespace RateLimitFilter
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -40,8 +40,8 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
 /**
  * Static registration for the rate limit filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(RateLimitConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
-                   "envoy.ratelimit");
+LEGACY_REGISTER_FACTORY(RateLimitConfigFactory,
+                        Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.ratelimit");
 
 } // namespace RateLimitFilter
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -98,8 +98,8 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
 /**
  * Static registration for the redis filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(RedisProxyFilterConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.redis_proxy"};
+REGISTER_FACTORY_D(RedisProxyFilterConfigFactory,
+                   Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.redis_proxy");
 
 } // namespace RedisProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -98,8 +98,9 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
 /**
  * Static registration for the redis filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(RedisProxyFilterConfigFactory,
-                   Server::Configuration::NamedNetworkFilterConfigFactory, "envoy.redis_proxy");
+LEGACY_REGISTER_FACTORY(RedisProxyFilterConfigFactory,
+                        Server::Configuration::NamedNetworkFilterConfigFactory,
+                        "envoy.redis_proxy");
 
 } // namespace RedisProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/tcp_proxy/config.cc
+++ b/source/extensions/filters/network/tcp_proxy/config.cc
@@ -27,8 +27,8 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the tcp_proxy filter. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(ConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
-                   "envoy.tcp_proxy");
+LEGACY_REGISTER_FACTORY(ConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
+                        "envoy.tcp_proxy");
 
 } // namespace TcpProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/tcp_proxy/config.cc
+++ b/source/extensions/filters/network/tcp_proxy/config.cc
@@ -27,8 +27,8 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the tcp_proxy filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(ConfigFactory,
-                 Server::Configuration::NamedNetworkFilterConfigFactory){"envoy.tcp_proxy"};
+REGISTER_FACTORY_D(ConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory,
+                   "envoy.tcp_proxy");
 
 } // namespace TcpProxy
 } // namespace NetworkFilters

--- a/source/extensions/http/header_formatters/preserve_case/config.cc
+++ b/source/extensions/http/header_formatters/preserve_case/config.cc
@@ -22,8 +22,8 @@ PreserveCaseFormatterFactoryConfig::createFromProto(const Protobuf::Message& mes
                                                         config.formatter_type_on_envoy_headers());
 }
 
-REGISTER_FACTORY_D(PreserveCaseFormatterFactoryConfig,
-                   Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig, "preserve_case");
+LEGACY_REGISTER_FACTORY(PreserveCaseFormatterFactoryConfig,
+                        Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig, "preserve_case");
 
 } // namespace PreserveCase
 } // namespace HeaderFormatters

--- a/source/extensions/http/header_formatters/preserve_case/config.cc
+++ b/source/extensions/http/header_formatters/preserve_case/config.cc
@@ -22,8 +22,8 @@ PreserveCaseFormatterFactoryConfig::createFromProto(const Protobuf::Message& mes
                                                         config.formatter_type_on_envoy_headers());
 }
 
-REGISTER_FACTORY(PreserveCaseFormatterFactoryConfig,
-                 Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig){"preserve_case"};
+REGISTER_FACTORY_D(PreserveCaseFormatterFactoryConfig,
+                   Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig, "preserve_case");
 
 } // namespace PreserveCase
 } // namespace HeaderFormatters

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -42,7 +42,8 @@ std::string DogStatsdSinkFactory::name() const { return DogStatsdName; }
 /**
  * Static registration for the this sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY(DogStatsdSinkFactory, Server::Configuration::StatsSinkFactory){"envoy.dog_statsd"};
+REGISTER_FACTORY_D(DogStatsdSinkFactory, Server::Configuration::StatsSinkFactory,
+                   "envoy.dog_statsd");
 
 } // namespace DogStatsd
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -42,8 +42,8 @@ std::string DogStatsdSinkFactory::name() const { return DogStatsdName; }
 /**
  * Static registration for the this sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(DogStatsdSinkFactory, Server::Configuration::StatsSinkFactory,
-                   "envoy.dog_statsd");
+LEGACY_REGISTER_FACTORY(DogStatsdSinkFactory, Server::Configuration::StatsSinkFactory,
+                        "envoy.dog_statsd");
 
 } // namespace DogStatsd
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/graphite_statsd/config.cc
+++ b/source/extensions/stat_sinks/graphite_statsd/config.cc
@@ -52,8 +52,8 @@ std::string GraphiteStatsdSinkFactory::name() const { return "envoy.stat_sinks.g
 /**
  * Static registration for the statsd sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY(GraphiteStatsdSinkFactory,
-                 Server::Configuration::StatsSinkFactory){"envoy.graphite_statsd"};
+REGISTER_FACTORY_D(GraphiteStatsdSinkFactory, Server::Configuration::StatsSinkFactory,
+                   "envoy.graphite_statsd");
 
 } // namespace GraphiteStatsd
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/graphite_statsd/config.cc
+++ b/source/extensions/stat_sinks/graphite_statsd/config.cc
@@ -52,8 +52,8 @@ std::string GraphiteStatsdSinkFactory::name() const { return "envoy.stat_sinks.g
 /**
  * Static registration for the statsd sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(GraphiteStatsdSinkFactory, Server::Configuration::StatsSinkFactory,
-                   "envoy.graphite_statsd");
+LEGACY_REGISTER_FACTORY(GraphiteStatsdSinkFactory, Server::Configuration::StatsSinkFactory,
+                        "envoy.graphite_statsd");
 
 } // namespace GraphiteStatsd
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -52,8 +52,8 @@ std::string MetricsServiceSinkFactory::name() const { return MetricsServiceName;
 /**
  * Static registration for the this sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(MetricsServiceSinkFactory, Server::Configuration::StatsSinkFactory,
-                   "envoy.metrics_service");
+LEGACY_REGISTER_FACTORY(MetricsServiceSinkFactory, Server::Configuration::StatsSinkFactory,
+                        "envoy.metrics_service");
 
 } // namespace MetricsService
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -52,8 +52,8 @@ std::string MetricsServiceSinkFactory::name() const { return MetricsServiceName;
 /**
  * Static registration for the this sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY(MetricsServiceSinkFactory,
-                 Server::Configuration::StatsSinkFactory){"envoy.metrics_service"};
+REGISTER_FACTORY_D(MetricsServiceSinkFactory, Server::Configuration::StatsSinkFactory,
+                   "envoy.metrics_service");
 
 } // namespace MetricsService
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -49,7 +49,7 @@ std::string StatsdSinkFactory::name() const { return StatsdName; }
 /**
  * Static registration for the statsd sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY(StatsdSinkFactory, Server::Configuration::StatsSinkFactory){"envoy.statsd"};
+REGISTER_FACTORY_D(StatsdSinkFactory, Server::Configuration::StatsSinkFactory, "envoy.statsd");
 
 } // namespace Statsd
 } // namespace StatSinks

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -49,7 +49,7 @@ std::string StatsdSinkFactory::name() const { return StatsdName; }
 /**
  * Static registration for the statsd sink factory. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(StatsdSinkFactory, Server::Configuration::StatsSinkFactory, "envoy.statsd");
+LEGACY_REGISTER_FACTORY(StatsdSinkFactory, Server::Configuration::StatsSinkFactory, "envoy.statsd");
 
 } // namespace Statsd
 } // namespace StatSinks

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -28,8 +28,8 @@ Tracing::DriverSharedPtr DynamicOpenTracingTracerFactory::createTracerDriverType
 /**
  * Static registration for the dynamic opentracing tracer. @see RegisterFactory.
  */
-REGISTER_FACTORY(DynamicOpenTracingTracerFactory,
-                 Server::Configuration::TracerFactory){"envoy.dynamic.ot"};
+REGISTER_FACTORY_D(DynamicOpenTracingTracerFactory, Server::Configuration::TracerFactory,
+                   "envoy.dynamic.ot");
 
 } // namespace DynamicOt
 } // namespace Tracers

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -28,8 +28,8 @@ Tracing::DriverSharedPtr DynamicOpenTracingTracerFactory::createTracerDriverType
 /**
  * Static registration for the dynamic opentracing tracer. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(DynamicOpenTracingTracerFactory, Server::Configuration::TracerFactory,
-                   "envoy.dynamic.ot");
+LEGACY_REGISTER_FACTORY(DynamicOpenTracingTracerFactory, Server::Configuration::TracerFactory,
+                        "envoy.dynamic.ot");
 
 } // namespace DynamicOt
 } // namespace Tracers

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -28,7 +28,7 @@ Tracing::DriverSharedPtr ZipkinTracerFactory::createTracerDriverTyped(
 /**
  * Static registration for the Zipkin tracer. @see RegisterFactory.
  */
-REGISTER_FACTORY_D(ZipkinTracerFactory, Server::Configuration::TracerFactory, "envoy.zipkin");
+LEGACY_REGISTER_FACTORY(ZipkinTracerFactory, Server::Configuration::TracerFactory, "envoy.zipkin");
 
 } // namespace Zipkin
 } // namespace Tracers

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -28,7 +28,7 @@ Tracing::DriverSharedPtr ZipkinTracerFactory::createTracerDriverTyped(
 /**
  * Static registration for the Zipkin tracer. @see RegisterFactory.
  */
-REGISTER_FACTORY(ZipkinTracerFactory, Server::Configuration::TracerFactory){"envoy.zipkin"};
+REGISTER_FACTORY_D(ZipkinTracerFactory, Server::Configuration::TracerFactory, "envoy.zipkin");
 
 } // namespace Zipkin
 } // namespace Tracers

--- a/source/extensions/transport_sockets/raw_buffer/config.cc
+++ b/source/extensions/transport_sockets/raw_buffer/config.cc
@@ -29,11 +29,12 @@ ProtobufTypes::MessagePtr RawBufferSocketFactory::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer>();
 }
 
-REGISTER_FACTORY_D(UpstreamRawBufferSocketFactory,
-                   Server::Configuration::UpstreamTransportSocketConfigFactory, "raw_buffer");
+LEGACY_REGISTER_FACTORY(UpstreamRawBufferSocketFactory,
+                        Server::Configuration::UpstreamTransportSocketConfigFactory, "raw_buffer");
 
-REGISTER_FACTORY_D(DownstreamRawBufferSocketFactory,
-                   Server::Configuration::DownstreamTransportSocketConfigFactory, "raw_buffer");
+LEGACY_REGISTER_FACTORY(DownstreamRawBufferSocketFactory,
+                        Server::Configuration::DownstreamTransportSocketConfigFactory,
+                        "raw_buffer");
 
 } // namespace RawBuffer
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/raw_buffer/config.cc
+++ b/source/extensions/transport_sockets/raw_buffer/config.cc
@@ -29,11 +29,11 @@ ProtobufTypes::MessagePtr RawBufferSocketFactory::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer>();
 }
 
-REGISTER_FACTORY(UpstreamRawBufferSocketFactory,
-                 Server::Configuration::UpstreamTransportSocketConfigFactory){"raw_buffer"};
+REGISTER_FACTORY_D(UpstreamRawBufferSocketFactory,
+                   Server::Configuration::UpstreamTransportSocketConfigFactory, "raw_buffer");
 
-REGISTER_FACTORY(DownstreamRawBufferSocketFactory,
-                 Server::Configuration::DownstreamTransportSocketConfigFactory){"raw_buffer"};
+REGISTER_FACTORY_D(DownstreamRawBufferSocketFactory,
+                   Server::Configuration::DownstreamTransportSocketConfigFactory, "raw_buffer");
 
 } // namespace RawBuffer
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/starttls/config.cc
+++ b/source/extensions/transport_sockets/starttls/config.cc
@@ -53,11 +53,11 @@ UpstreamStartTlsSocketFactory::createTransportSocketFactory(
                                                  std::move(tls_socket_factory));
 }
 
-REGISTER_FACTORY(DownstreamStartTlsSocketFactory,
-                 Server::Configuration::DownstreamTransportSocketConfigFactory){"starttls"};
+REGISTER_FACTORY_D(DownstreamStartTlsSocketFactory,
+                   Server::Configuration::DownstreamTransportSocketConfigFactory, "starttls");
 
-REGISTER_FACTORY(UpstreamStartTlsSocketFactory,
-                 Server::Configuration::UpstreamTransportSocketConfigFactory){"starttls"};
+REGISTER_FACTORY_D(UpstreamStartTlsSocketFactory,
+                   Server::Configuration::UpstreamTransportSocketConfigFactory, "starttls");
 
 } // namespace StartTls
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/starttls/config.cc
+++ b/source/extensions/transport_sockets/starttls/config.cc
@@ -53,11 +53,11 @@ UpstreamStartTlsSocketFactory::createTransportSocketFactory(
                                                  std::move(tls_socket_factory));
 }
 
-REGISTER_FACTORY_D(DownstreamStartTlsSocketFactory,
-                   Server::Configuration::DownstreamTransportSocketConfigFactory, "starttls");
+LEGACY_REGISTER_FACTORY(DownstreamStartTlsSocketFactory,
+                        Server::Configuration::DownstreamTransportSocketConfigFactory, "starttls");
 
-REGISTER_FACTORY_D(UpstreamStartTlsSocketFactory,
-                   Server::Configuration::UpstreamTransportSocketConfigFactory, "starttls");
+LEGACY_REGISTER_FACTORY(UpstreamStartTlsSocketFactory,
+                        Server::Configuration::UpstreamTransportSocketConfigFactory, "starttls");
 
 } // namespace StartTls
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/tls/config.cc
+++ b/source/extensions/transport_sockets/tls/config.cc
@@ -28,8 +28,8 @@ ProtobufTypes::MessagePtr UpstreamSslSocketFactory::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext>();
 }
 
-REGISTER_FACTORY(UpstreamSslSocketFactory,
-                 Server::Configuration::UpstreamTransportSocketConfigFactory){"tls"};
+REGISTER_FACTORY_D(UpstreamSslSocketFactory,
+                   Server::Configuration::UpstreamTransportSocketConfigFactory, "tls");
 
 Network::DownstreamTransportSocketFactoryPtr
 DownstreamSslSocketFactory::createTransportSocketFactory(
@@ -48,8 +48,8 @@ ProtobufTypes::MessagePtr DownstreamSslSocketFactory::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext>();
 }
 
-REGISTER_FACTORY(DownstreamSslSocketFactory,
-                 Server::Configuration::DownstreamTransportSocketConfigFactory){"tls"};
+REGISTER_FACTORY_D(DownstreamSslSocketFactory,
+                   Server::Configuration::DownstreamTransportSocketConfigFactory, "tls");
 
 Ssl::ContextManagerPtr SslContextManagerFactory::createContextManager(TimeSource& time_source) {
   return std::make_unique<ContextManagerImpl>(time_source);

--- a/source/extensions/transport_sockets/tls/config.cc
+++ b/source/extensions/transport_sockets/tls/config.cc
@@ -28,8 +28,8 @@ ProtobufTypes::MessagePtr UpstreamSslSocketFactory::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext>();
 }
 
-REGISTER_FACTORY_D(UpstreamSslSocketFactory,
-                   Server::Configuration::UpstreamTransportSocketConfigFactory, "tls");
+LEGACY_REGISTER_FACTORY(UpstreamSslSocketFactory,
+                        Server::Configuration::UpstreamTransportSocketConfigFactory, "tls");
 
 Network::DownstreamTransportSocketFactoryPtr
 DownstreamSslSocketFactory::createTransportSocketFactory(
@@ -48,8 +48,8 @@ ProtobufTypes::MessagePtr DownstreamSslSocketFactory::createEmptyConfigProto() {
   return std::make_unique<envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext>();
 }
 
-REGISTER_FACTORY_D(DownstreamSslSocketFactory,
-                   Server::Configuration::DownstreamTransportSocketConfigFactory, "tls");
+LEGACY_REGISTER_FACTORY(DownstreamSslSocketFactory,
+                        Server::Configuration::DownstreamTransportSocketConfigFactory, "tls");
 
 Ssl::ContextManagerPtr SslContextManagerFactory::createContextManager(TimeSource& time_source) {
   return std::make_unique<ContextManagerImpl>(time_source);

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -149,8 +149,8 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
       upstream_http_protocol_options_(upstream_options),
       use_downstream_protocol_(use_downstream_protocol), use_http2_(use_http2) {}
 
-REGISTER_FACTORY_D(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory,
-                   "envoy.upstreams.http.http_protocol_options");
+LEGACY_REGISTER_FACTORY(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory,
+                        "envoy.upstreams.http.http_protocol_options");
 } // namespace Http
 } // namespace Upstreams
 } // namespace Extensions

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -149,8 +149,8 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
       upstream_http_protocol_options_(upstream_options),
       use_downstream_protocol_(use_downstream_protocol), use_http2_(use_http2) {}
 
-REGISTER_FACTORY(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory){
-    "envoy.upstreams.http.http_protocol_options"};
+REGISTER_FACTORY_D(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory,
+                   "envoy.upstreams.http.http_protocol_options");
 } // namespace Http
 } // namespace Upstreams
 } // namespace Extensions

--- a/source/extensions/upstreams/tcp/config.cc
+++ b/source/extensions/upstreams/tcp/config.cc
@@ -21,8 +21,8 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
   }
 }
 
-REGISTER_FACTORY(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory){
-    "envoy.upstreams.tcp.tcp_protocol_options"};
+REGISTER_FACTORY_D(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory,
+                   "envoy.upstreams.tcp.tcp_protocol_options");
 } // namespace Tcp
 } // namespace Upstreams
 } // namespace Extensions

--- a/source/extensions/upstreams/tcp/config.cc
+++ b/source/extensions/upstreams/tcp/config.cc
@@ -21,8 +21,8 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
   }
 }
 
-REGISTER_FACTORY_D(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory,
-                   "envoy.upstreams.tcp.tcp_protocol_options");
+LEGACY_REGISTER_FACTORY(ProtocolOptionsConfigFactory, Server::Configuration::ProtocolOptionsFactory,
+                        "envoy.upstreams.tcp.tcp_protocol_options");
 } // namespace Tcp
 } // namespace Upstreams
 } // namespace Extensions


### PR DESCRIPTION
In preparation for disabling static extension factory registration in https://github.com/envoyproxy/envoy/pull/24844, split the `REGISTER_FACTORY` macro into two, one that doesn't take a deprecated name and one that does, called `LEGACY_REGISTER_FACTORY`.

This is done because the previous approach of appending a `{deprecated_name}` suffix at the usage site is incompatible with the approach taken by https://github.com/envoyproxy/envoy/pull/24844 to not statically register the extension factories.

Commit Message: extensions: split extension registration macro
Risk Level: Low
Testing: Existing unit tests
Docs Changes: None
Release Notes: Inline comments
Platform Specific Features: N/A