### PR TITLE
ci: increase flaky test's timeout value

### DIFF
--- a/mobile/test/swift/integration/ReceiveDataTest.swift
+++ b/mobile/test/swift/integration/ReceiveDataTest.swift
@@ -82,7 +82,7 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [headersExpectation, dataExpectation], timeout: 1,
+    XCTAssertEqual(XCTWaiter.wait(for: [headersExpectation, dataExpectation], timeout: 10,
                                   enforceOrder: true),
                    .completed)
 


### PR DESCRIPTION
Commit Message: Test seems to be occasionally failing due to a timeout issue. Increasing the timeout to 10s which is the value used by the corresponding Android test.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
