### PR TITLE
Add // IWYU: export to log_level.h

### DIFF
--- a/mobile/library/cc/log_level.h
+++ b/mobile/library/cc/log_level.h
@@ -7,7 +7,7 @@
 namespace Envoy {
 namespace Platform {
 
-using LogLevel = Envoy::Logger::Logger::Levels;
+using LogLevel = Envoy::Logger::Logger::Levels;  // IWYU: export
 
 std::string logLevelToString(LogLevel method);
 LogLevel logLevelFromString(const std::string& str);

--- a/mobile/library/cc/log_level.h
+++ b/mobile/library/cc/log_level.h
@@ -2,12 +2,12 @@
 
 #include <string>
 
-#include "source/common/common/base_logger.h"
+#include "source/common/common/base_logger.h" // IWYU: export
 
 namespace Envoy {
 namespace Platform {
 
-using LogLevel = Envoy::Logger::Logger::Levels;  // IWYU: export
+using LogLevel = Envoy::Logger::Logger::Levels;
 
 std::string logLevelToString(LogLevel method);
 LogLevel logLevelFromString(const std::string& str);


### PR DESCRIPTION
Add // IWYU: export to log_level.h in order to fix a clang-tidy error which shows up internally.

Signed-off-by: Ryan Hamilton <rch@google.com>