### PR TITLE
Add a destructor to Envoy::Platform::Engine which calls terminate()

### DIFF
--- a/mobile/library/cc/engine.cc
+++ b/mobile/library/cc/engine.cc
@@ -8,6 +8,12 @@ namespace Platform {
 
 Engine::Engine(envoy_engine_t engine) : engine_(engine), terminated_(false) {}
 
+Engine::~Engine() {
+  if (!terminated_) {
+    terminate();
+  }
+}
+
 // we lazily construct the stream and pulse clients
 // because they either require or will require a weak ptr
 // which can't be provided from inside of the constructor

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -17,6 +17,8 @@ using StreamClientSharedPtr = std::shared_ptr<StreamClient>;
 
 class Engine : public std::enable_shared_from_this<Engine> {
 public:
+  ~Engine();
+
   StreamClientSharedPtr streamClient();
   PulseClientSharedPtr pulseClient();
 

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -180,7 +180,6 @@ void BaseClientIntegrationTest::threadRoutine(absl::Notification& engine_running
 void BaseClientIntegrationTest::TearDown() {
   test_server_.reset();
   fake_upstreams_.clear();
-  engine_->terminate();
   engine_.reset();
   full_dispatcher_->exit();
   envoy_thread_->join();


### PR DESCRIPTION
Add a destructor to Envoy::Platform::Engine which calls terminate()

Signed-off-by: Ryan Hamilton <rch@google.com>
