### PR TITLE
test: Add explicit static casting to size_t in the string ctor

### DIFF
--- a/test/test_common/file_system_for_test.cc
+++ b/test/test_common/file_system_for_test.cc
@@ -36,7 +36,8 @@ Api::IoCallSizeResult MemfileImpl::pwrite(const void* buf, uint64_t count, uint6
   std::string after = (offset + count > info_->data_.size())
                           ? ""
                           : info_->data_.substr(info_->data_.size() - offset - count);
-  info_->data_ = before + std::string{static_cast<const char*>(buf), count} + after;
+  info_->data_ =
+      before + std::string{static_cast<const char*>(buf), static_cast<size_t>(count)} + after;
   return resultSuccess<ssize_t>(count);
 }
 


### PR DESCRIPTION
Non-64-bit ARM builds fail to compile without the static cast from uint64_t to size_t when calling the std::string constructor.

Signed-off-by: Ali Beyad <abeyad@google.com>