### PR TITLE
ci: increase timeouts in swift integration tests

### DIFF
--- a/mobile/test/swift/integration/CancelGRPCStreamTest.swift
+++ b/mobile/test/swift/integration/CancelGRPCStreamTest.swift
@@ -111,7 +111,7 @@ static_resources:
       .cancel()
 
     let expectations = [onCancelCallbackExpectation, filterExpectation]
-    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 3), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/CancelStreamTest.swift
+++ b/mobile/test/swift/integration/CancelStreamTest.swift
@@ -113,7 +113,8 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: false)
       .cancel()
 
-    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 10), .completed)
+    let expectations = [filterExpectation, runExpectation]
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/CancelStreamTest.swift
+++ b/mobile/test/swift/integration/CancelStreamTest.swift
@@ -113,7 +113,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: false)
       .cancel()
 
-    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 3), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/FilterResetIdleTest.swift
+++ b/mobile/test/swift/integration/FilterResetIdleTest.swift
@@ -217,7 +217,7 @@ static_resources:
     )
 
     XCTAssertEqual(
-      XCTWaiter.wait(for: [cancelExpectation], timeout: 1),
+      XCTWaiter.wait(for: [cancelExpectation], timeout: 2),
       .completed
     )
 

--- a/mobile/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/mobile/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -124,7 +124,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: false)
       .sendMessage(message)
 
-    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/IdleTimeoutTest.swift
+++ b/mobile/test/swift/integration/IdleTimeoutTest.swift
@@ -169,7 +169,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: true)
 
     XCTAssertEqual(
-      XCTWaiter.wait(for: [filterExpectation, callbackExpectation], timeout: 2),
+      XCTWaiter.wait(for: [filterExpectation, callbackExpectation], timeout: 10),
       .completed
     )
 

--- a/mobile/test/swift/integration/ReceiveErrorTest.swift
+++ b/mobile/test/swift/integration/ReceiveErrorTest.swift
@@ -124,7 +124,7 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/ResetConnectivityStateTest.swift
+++ b/mobile/test/swift/integration/ResetConnectivityStateTest.swift
@@ -95,7 +95,7 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation2], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation2], timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/SendDataTest.swift
+++ b/mobile/test/swift/integration/SendDataTest.swift
@@ -79,7 +79,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: false)
       .close(data: body)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/SendHeadersTest.swift
+++ b/mobile/test/swift/integration/SendHeadersTest.swift
@@ -72,7 +72,7 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/SendTrailersTest.swift
+++ b/mobile/test/swift/integration/SendTrailersTest.swift
@@ -84,7 +84,7 @@ static_resources:
       .sendData(body)
       .close(trailers: requestTrailers)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
 
     engine.terminate()
   }

--- a/mobile/test/swift/integration/SetLoggerTest.swift
+++ b/mobile/test/swift/integration/SetLoggerTest.swift
@@ -91,7 +91,7 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [logEventExpectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [logEventExpectation], timeout: 10), .completed)
 
     engine.terminate()
   }


### PR DESCRIPTION
Commit Message: Saw another timeout in Swift `ResetConnectivityStateTest` ([link](https://github.com/envoyproxy/envoy/actions/runs/3897119069/jobs/6654451915)). Decided to go through Swift integration tests and bump timeout values used in them so that they match their Android counterparts. This should help to remove some of the flakiness from our tests.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
