### PR TITLE
build: Add Android explicitely to the os_sys_calls_lib select

### DIFF
--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
     }) + envoy_select_hot_restart(["posix/os_sys_calls_impl_hot_restart.cc"]),
     hdrs = select({
         "//bazel:linux": [
+
             "posix/os_sys_calls_impl.h",
             "posix/os_sys_calls_impl_linux.h",
         ],

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -30,6 +30,10 @@ envoy_cc_library(
             "posix/os_sys_calls_impl.cc",
             "posix/os_sys_calls_impl_linux.cc",
         ],
+        "//bazel:android": [
+            "posix/os_sys_calls_impl.cc",
+            "posix/os_sys_calls_impl_linux.cc",
+        ],
         "//bazel:windows_x86_64": ["win32/os_sys_calls_impl.cc"],
         "//conditions:default": ["posix/os_sys_calls_impl.cc"],
     }) + envoy_select_hot_restart(["posix/os_sys_calls_impl_hot_restart.cc"]),

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -38,6 +38,10 @@ envoy_cc_library(
             "posix/os_sys_calls_impl.h",
             "posix/os_sys_calls_impl_linux.h",
         ],
+        "//bazel:android": [
+            "posix/os_sys_calls_impl.h",
+            "posix/os_sys_calls_impl_linux.h",
+        ],
         "//bazel:windows_x86_64": ["win32/os_sys_calls_impl.h"],
         "//conditions:default": ["posix/os_sys_calls_impl.h"],
     }) + envoy_select_hot_restart(["posix/os_sys_calls_impl_hot_restart.h"]),

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
     ],
 )
 
+# TODO(abeyad): remove kick start ci
 envoy_cc_library(
     name = "os_sys_calls_lib",
     srcs = select({
@@ -39,7 +40,6 @@ envoy_cc_library(
     }) + envoy_select_hot_restart(["posix/os_sys_calls_impl_hot_restart.cc"]),
     hdrs = select({
         "//bazel:linux": [
-
             "posix/os_sys_calls_impl.h",
             "posix/os_sys_calls_impl_linux.h",
         ],


### PR DESCRIPTION
Without this, building test/common/... on Android fails because "os_sys_calls_impl_linux.h" can not be found when included in api/mocks.h.

Signed-off-by: Ali Beyad <abeyad@google.com>