### PR TITLE
upstream: lb policy configuration memory optimization

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "envoy/common/callback.h"
+#include "envoy/common/optref.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/core/v3/protocol.pb.h"
@@ -973,25 +974,25 @@ public:
   /**
    * @return configuration for round robin load balancing, only used if LB type is round robin.
    */
-  virtual const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>&
+  virtual OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
   lbRoundRobinConfig() const PURE;
 
   /**
    * @return configuration for least request load balancing, only used if LB type is least request.
    */
-  virtual const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>&
+  virtual OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const PURE;
 
   /**
    * @return configuration for ring hash load balancing, only used if type is set to ring_hash_lb.
    */
-  virtual const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>&
+  virtual OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
   lbRingHashConfig() const PURE;
 
   /**
    * @return configuration for maglev load balancing, only used if type is set to maglev_lb.
    */
-  virtual const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>&
+  virtual OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
   lbMaglevConfig() const PURE;
 
   /**
@@ -999,7 +1000,7 @@ public:
    * configuration for the Original Destination load balancing policy, only used if type is set to
    *         ORIGINAL_DST_LB.
    */
-  virtual const absl::optional<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>&
+  virtual OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
   lbOriginalDstConfig() const PURE;
 
   /**

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -533,17 +533,15 @@ public:
       const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
       Runtime::Loader& runtime, Random::RandomGenerator& random,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
-      const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
-          round_robin_config,
+      OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> round_robin_config,
       TimeSource& time_source)
       : EdfLoadBalancerBase(
-            priority_set, local_priority_set, stats, runtime, random,
-            PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(common_config, healthy_panic_threshold,
+            priority_set, local_priority_set, stats, runtime, random, PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(common_config, healthy_panic_threshold,
                                                            100, 50),
             LoadBalancerConfigHelper::localityLbConfigFromCommonLbConfig(common_config),
             round_robin_config.has_value()
                 ? LoadBalancerConfigHelper::slowStartConfigFromLegacyProto(
-                      round_robin_config.value())
+                      round_robin_config.ref())
                 : absl::nullopt,
             time_source) {
     initialize();
@@ -627,8 +625,7 @@ public:
       const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
       Runtime::Loader& runtime, Random::RandomGenerator& random,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
-      const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
-          least_request_config,
+      OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig> least_request_config,
       TimeSource& time_source)
       : EdfLoadBalancerBase(
             priority_set, local_priority_set, stats, runtime, random,
@@ -637,12 +634,12 @@ public:
             LoadBalancerConfigHelper::localityLbConfigFromCommonLbConfig(common_config),
             least_request_config.has_value()
                 ? LoadBalancerConfigHelper::slowStartConfigFromLegacyProto(
-                      least_request_config.value())
+                      least_request_config.ref())
                 : absl::nullopt,
             time_source),
         choice_count_(
             least_request_config.has_value()
-                ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(least_request_config.value(), choice_count, 2)
+                ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(least_request_config.ref(), choice_count, 2)
                 : 2),
         active_request_bias_runtime_(
             least_request_config.has_value() && least_request_config->has_active_request_bias()

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -536,12 +536,12 @@ public:
       OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> round_robin_config,
       TimeSource& time_source)
       : EdfLoadBalancerBase(
-            priority_set, local_priority_set, stats, runtime, random, PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(common_config, healthy_panic_threshold,
+            priority_set, local_priority_set, stats, runtime, random,
+            PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(common_config, healthy_panic_threshold,
                                                            100, 50),
             LoadBalancerConfigHelper::localityLbConfigFromCommonLbConfig(common_config),
             round_robin_config.has_value()
-                ? LoadBalancerConfigHelper::slowStartConfigFromLegacyProto(
-                      round_robin_config.ref())
+                ? LoadBalancerConfigHelper::slowStartConfigFromLegacyProto(round_robin_config.ref())
                 : absl::nullopt,
             time_source) {
     initialize();

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -95,11 +95,11 @@ uint64_t MaglevTable::permutation(const TableBuildEntry& entry) {
 MaglevLoadBalancer::MaglevLoadBalancer(
     const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
     Runtime::Loader& runtime, Random::RandomGenerator& random,
-    const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>& config,
+    OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> config,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
     : ThreadAwareLoadBalancerBase(priority_set, stats, runtime, random, common_config),
       scope_(scope.createScope("maglev_lb.")), stats_(generateStats(*scope_)),
-      table_size_(config ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.value(), table_size,
+      table_size_(config ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.ref(), table_size,
                                                            MaglevTable::DefaultTableSize)
                          : MaglevTable::DefaultTableSize),
       use_hostname_for_hashing_(

--- a/source/common/upstream/maglev_lb.h
+++ b/source/common/upstream/maglev_lb.h
@@ -71,11 +71,10 @@ private:
 class MaglevLoadBalancer : public ThreadAwareLoadBalancerBase,
                            Logger::Loggable<Logger::Id::upstream> {
 public:
-  MaglevLoadBalancer(
-      const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-      Runtime::Loader& runtime, Random::RandomGenerator& random,
-      const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>& config,
-      const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
+  MaglevLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
+                     Runtime::Loader& runtime, Random::RandomGenerator& random,
+                     OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> config,
+                     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
 
   const MaglevLoadBalancerStats& stats() const { return stats_; }
   uint64_t tableSize() const { return table_size_; }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -19,18 +19,19 @@ namespace Upstream {
 RingHashLoadBalancer::RingHashLoadBalancer(
     const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
     Runtime::Loader& runtime, Random::RandomGenerator& random,
-    const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>& config,
+    OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> config,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
     : ThreadAwareLoadBalancerBase(priority_set, stats, runtime, random, common_config),
       scope_(scope.createScope("ring_hash_lb.")), stats_(generateStats(*scope_)),
-      min_ring_size_(config ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.value(), minimum_ring_size,
-                                                              DefaultMinRingSize)
-                            : DefaultMinRingSize),
-      max_ring_size_(config ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.value(), maximum_ring_size,
-                                                              DefaultMaxRingSize)
-                            : DefaultMaxRingSize),
-      hash_function_(config ? config.value().hash_function()
-                            : HashFunction::Cluster_RingHashLbConfig_HashFunction_XX_HASH),
+      min_ring_size_(config.has_value() ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+                                              config.ref(), minimum_ring_size, DefaultMinRingSize)
+                                        : DefaultMinRingSize),
+      max_ring_size_(config.has_value() ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+                                              config.ref(), maximum_ring_size, DefaultMaxRingSize)
+                                        : DefaultMaxRingSize),
+      hash_function_(config.has_value()
+                         ? config->hash_function()
+                         : HashFunction::Cluster_RingHashLbConfig_HashFunction_XX_HASH),
       use_hostname_for_hashing_(
           common_config.has_consistent_hashing_lb_config()
               ? common_config.consistent_hashing_lb_config().use_hostname_for_hashing()

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -40,11 +40,10 @@ struct RingHashLoadBalancerStats {
 class RingHashLoadBalancer : public ThreadAwareLoadBalancerBase,
                              Logger::Loggable<Logger::Id::upstream> {
 public:
-  RingHashLoadBalancer(
-      const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-      Runtime::Loader& runtime, Random::RandomGenerator& random,
-      const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>& config,
-      const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
+  RingHashLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
+                       Runtime::Loader& runtime, Random::RandomGenerator& random,
+                       OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> config,
+                       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
 
   const RingHashLoadBalancerStats& stats() const { return stats_; }
 

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -36,22 +36,22 @@ SubsetLoadBalancer::SubsetLoadBalancer(
       lb_ring_hash_config_(
           lb_ring_hash_config.has_value()
               ? std::make_unique<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
-                    lb_ring_hash_config.value())
+                    lb_ring_hash_config.ref())
               : nullptr),
       lb_maglev_config_(
           lb_maglev_config.has_value()
               ? std::make_unique<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
-                    lb_maglev_config.value())
+                    lb_maglev_config.ref())
               : nullptr),
       round_robin_config_(
           round_robin_config.has_value()
               ? std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
-                    round_robin_config.value())
+                    round_robin_config.ref())
               : nullptr),
       least_request_config_(
           least_request_config.has_value()
               ? std::make_unique<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
-                    least_request_config.value())
+                    least_request_config.ref())
               : nullptr),
       common_config_(common_config), stats_(stats), scope_(scope), runtime_(runtime),
       random_(random), fallback_policy_(subsets.fallbackPolicy()),

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "envoy/common/optref.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/runtime/runtime.h"
@@ -25,19 +26,35 @@ SubsetLoadBalancer::SubsetLoadBalancer(
     LoadBalancerType lb_type, PrioritySet& priority_set, const PrioritySet* local_priority_set,
     ClusterLbStats& stats, Stats::Scope& scope, Runtime::Loader& runtime,
     Random::RandomGenerator& random, const LoadBalancerSubsetInfo& subsets,
-    const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>&
-        lb_ring_hash_config,
-    const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>& lb_maglev_config,
-    const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>&
-        round_robin_config,
-    const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>&
-        least_request_config,
+    OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config,
+    OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config,
+    OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> round_robin_config,
+    OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig> least_request_config,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
     TimeSource& time_source)
-    : lb_type_(lb_type), lb_ring_hash_config_(lb_ring_hash_config),
-      lb_maglev_config_(lb_maglev_config), round_robin_config_(round_robin_config),
-      least_request_config_(least_request_config), common_config_(common_config), stats_(stats),
-      scope_(scope), runtime_(runtime), random_(random), fallback_policy_(subsets.fallbackPolicy()),
+    : lb_type_(lb_type),
+      lb_ring_hash_config_(
+          lb_ring_hash_config.has_value()
+              ? std::make_unique<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+                    lb_ring_hash_config.value())
+              : nullptr),
+      lb_maglev_config_(
+          lb_maglev_config.has_value()
+              ? std::make_unique<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
+                    lb_maglev_config.value())
+              : nullptr),
+      round_robin_config_(
+          round_robin_config.has_value()
+              ? std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+                    round_robin_config.value())
+              : nullptr),
+      least_request_config_(
+          least_request_config.has_value()
+              ? std::make_unique<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
+                    least_request_config.value())
+              : nullptr),
+      common_config_(common_config), stats_(stats), scope_(scope), runtime_(runtime),
+      random_(random), fallback_policy_(subsets.fallbackPolicy()),
       metadata_fallback_policy_(subsets.metadataFallbackPolicy()),
       default_subset_metadata_(subsets.defaultSubset().fields().begin(),
                                subsets.defaultSubset().fields().end()),
@@ -685,7 +702,7 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
   case LoadBalancerType::LeastRequest:
     lb_ = std::make_unique<LeastRequestLoadBalancer>(
         *this, subset_lb.original_local_priority_set_, subset_lb.stats_, subset_lb.runtime_,
-        subset_lb.random_, subset_lb.common_config_, subset_lb.least_request_config_,
+        subset_lb.random_, subset_lb.common_config_, subset_lb.lbLeastRequestConfig(),
         subset_lb.time_source_);
     break;
 
@@ -698,7 +715,7 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
   case LoadBalancerType::RoundRobin:
     lb_ = std::make_unique<RoundRobinLoadBalancer>(
         *this, subset_lb.original_local_priority_set_, subset_lb.stats_, subset_lb.runtime_,
-        subset_lb.random_, subset_lb.common_config_, subset_lb.round_robin_config_,
+        subset_lb.random_, subset_lb.common_config_, subset_lb.lbRoundRobinConfig(),
         subset_lb.time_source_);
     break;
 
@@ -708,7 +725,7 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
     // can also use a thread aware sub-LB properly. The following works fine but is not optimal.
     thread_aware_lb_ = std::make_unique<RingHashLoadBalancer>(
         *this, subset_lb.stats_, subset_lb.scope_, subset_lb.runtime_, subset_lb.random_,
-        subset_lb.lb_ring_hash_config_, subset_lb.common_config_);
+        subset_lb.lbRingHashConfig(), subset_lb.common_config_);
     thread_aware_lb_->initialize();
     lb_ = thread_aware_lb_->factory()->create();
     break;
@@ -719,7 +736,7 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
     // can also use a thread aware sub-LB properly. The following works fine but is not optimal.
     thread_aware_lb_ = std::make_unique<MaglevLoadBalancer>(
         *this, subset_lb.stats_, subset_lb.scope_, subset_lb.runtime_, subset_lb.random_,
-        subset_lb.lb_maglev_config_, subset_lb.common_config_);
+        subset_lb.lbMaglevConfig(), subset_lb.common_config_);
     thread_aware_lb_->initialize();
     lb_ = thread_aware_lb_->factory()->create();
     break;

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/common/optref.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/scope.h"
@@ -32,13 +33,10 @@ public:
       LoadBalancerType lb_type, PrioritySet& priority_set, const PrioritySet* local_priority_set,
       ClusterLbStats& stats, Stats::Scope& scope, Runtime::Loader& runtime,
       Random::RandomGenerator& random, const LoadBalancerSubsetInfo& subsets,
-      const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>&
-          lb_ring_hash_config,
-      const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>& lb_maglev_config,
-      const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>&
-          round_robin_config,
-      const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>&
-          least_request_config,
+      OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config,
+      OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config,
+      OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> round_robin_config,
+      OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig> least_request_config,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
       TimeSource& time_source);
   ~SubsetLoadBalancer() override;
@@ -358,11 +356,47 @@ private:
   const ProtobufWkt::Value* getMetadataFallbackList(LoadBalancerContext* context) const;
   LoadBalancerContextWrapper removeMetadataFallbackList(LoadBalancerContext* context);
 
+  OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
+    if (round_robin_config_ != nullptr) {
+      return *round_robin_config_;
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
+  lbLeastRequestConfig() const {
+    if (round_robin_config_ != nullptr) {
+      return *least_request_config_;
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lbMaglevConfig() const {
+    if (lb_maglev_config_ != nullptr) {
+      return *lb_maglev_config_;
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lbRingHashConfig() const {
+    if (lb_ring_hash_config_ != nullptr) {
+      return *lb_ring_hash_config_;
+    } else {
+      return absl::nullopt;
+    }
+  }
+
   const LoadBalancerType lb_type_;
-  const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config_;
-  const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config_;
-  const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> round_robin_config_;
-  const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
+      lb_ring_hash_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
+      lb_maglev_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
+      round_robin_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
       least_request_config_;
   const envoy::config::cluster::v3::Cluster::CommonLbConfig common_config_;
   ClusterLbStats& stats_;

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -359,34 +359,30 @@ private:
   OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
     if (round_robin_config_ != nullptr) {
       return *round_robin_config_;
-    } else {
-      return absl::nullopt;
     }
+    return absl::nullopt;
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const {
     if (round_robin_config_ != nullptr) {
       return *least_request_config_;
-    } else {
-      return absl::nullopt;
     }
+    return absl::nullopt;
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lbMaglevConfig() const {
     if (lb_maglev_config_ != nullptr) {
       return *lb_maglev_config_;
-    } else {
-      return absl::nullopt;
     }
+    return absl::nullopt;
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lbRingHashConfig() const {
     if (lb_ring_hash_config_ != nullptr) {
       return *lb_ring_hash_config_;
-    } else {
-      return absl::nullopt;
     }
+    return absl::nullopt;
   }
 
   const LoadBalancerType lb_type_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1015,11 +1015,30 @@ ClusterInfoImpl::ClusterInfoImpl(
       maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),
       upstream_local_address_selector_(
           std::make_shared<UpstreamLocalAddressSelectorImpl>(config, bind_config)),
-      lb_round_robin_config_(config.round_robin_lb_config()),
-      lb_least_request_config_(config.least_request_lb_config()),
-      lb_ring_hash_config_(config.ring_hash_lb_config()),
-      lb_maglev_config_(config.maglev_lb_config()),
-      lb_original_dst_config_(config.original_dst_lb_config()),
+      lb_round_robin_config_(
+          config.has_round_robin_lb_config()
+              ? std::make_unique<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+                    config.round_robin_lb_config())
+              : nullptr),
+      lb_least_request_config_(
+          config.has_least_request_lb_config()
+              ? std::make_unique<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
+                    config.least_request_lb_config())
+              : nullptr),
+      lb_ring_hash_config_(
+          config.has_ring_hash_lb_config()
+              ? std::make_unique<envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+                    config.ring_hash_lb_config())
+              : nullptr),
+      lb_maglev_config_(config.has_maglev_lb_config()
+                            ? std::make_unique<envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
+                                  config.maglev_lb_config())
+                            : nullptr),
+      lb_original_dst_config_(
+          config.has_original_dst_lb_config()
+              ? std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
+                    config.original_dst_lb_config())
+              : nullptr),
       upstream_config_(config.has_upstream_config()
                            ? absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>(
                                  config.upstream_config())

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "envoy/common/callback.h"
+#include "envoy/common/optref.h"
 #include "envoy/common/time.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/address.pb.h"
@@ -764,25 +765,45 @@ public:
   clusterType() const override {
     return cluster_type_;
   }
-  const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>&
+  OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
   lbRoundRobinConfig() const override {
-    return lb_round_robin_config_;
+    if (lb_round_robin_config_ == nullptr) {
+      return absl::nullopt;
+    } else {
+      return *lb_round_robin_config_;
+    }
   }
-  const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>&
+  OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const override {
-    return lb_least_request_config_;
+    if (lb_least_request_config_ == nullptr) {
+      return absl::nullopt;
+    } else {
+      return *lb_least_request_config_;
+    }
   }
-  const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>&
+  OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
   lbRingHashConfig() const override {
-    return lb_ring_hash_config_;
+    if (lb_ring_hash_config_ == nullptr) {
+      return absl::nullopt;
+    } else {
+      return *lb_ring_hash_config_;
+    }
   }
-  const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>&
+  OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
   lbMaglevConfig() const override {
-    return lb_maglev_config_;
+    if (lb_maglev_config_ == nullptr) {
+      return absl::nullopt;
+    } else {
+      return *lb_maglev_config_;
+    }
   }
-  const absl::optional<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>&
+  OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
   lbOriginalDstConfig() const override {
-    return lb_original_dst_config_;
+    if (lb_original_dst_config_ == nullptr) {
+      return absl::nullopt;
+    } else {
+      return *lb_original_dst_config_;
+    }
   }
   const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
   upstreamConfig() const override {
@@ -931,12 +952,16 @@ private:
   const std::string maintenance_mode_runtime_key_;
   std::shared_ptr<UpstreamLocalAddressSelector> upstream_local_address_selector_;
   LoadBalancerType lb_type_;
-  absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lb_round_robin_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
+      lb_round_robin_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
       lb_least_request_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig> lb_original_dst_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
+      lb_ring_hash_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
+      lb_maglev_config_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
+      lb_original_dst_config_;
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
   const bool added_via_api_;
   LoadBalancerSubsetInfoImpl lb_subset_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -769,41 +769,36 @@ public:
   lbRoundRobinConfig() const override {
     if (lb_round_robin_config_ == nullptr) {
       return absl::nullopt;
-    } else {
-      return *lb_round_robin_config_;
     }
+    return *lb_round_robin_config_;
   }
   OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const override {
     if (lb_least_request_config_ == nullptr) {
       return absl::nullopt;
-    } else {
-      return *lb_least_request_config_;
     }
+    return *lb_least_request_config_;
   }
   OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
   lbRingHashConfig() const override {
     if (lb_ring_hash_config_ == nullptr) {
       return absl::nullopt;
-    } else {
-      return *lb_ring_hash_config_;
     }
+    return *lb_ring_hash_config_;
   }
   OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
   lbMaglevConfig() const override {
     if (lb_maglev_config_ == nullptr) {
       return absl::nullopt;
-    } else {
-      return *lb_maglev_config_;
     }
+    return *lb_maglev_config_;
   }
   OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
   lbOriginalDstConfig() const override {
     if (lb_original_dst_config_ == nullptr) {
       return absl::nullopt;
-    } else {
-      return *lb_original_dst_config_;
     }
+    return *lb_original_dst_config_;
   }
   const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
   upstreamConfig() const override {

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -155,11 +155,6 @@ public:
   RingHashTester(uint64_t num_hosts, uint64_t min_ring_size) : BaseTester(num_hosts) {
     config_ = envoy::config::cluster::v3::Cluster::RingHashLbConfig();
     config_.value().mutable_minimum_ring_size()->set_value(min_ring_size);
-<<<<<<< HEAD
-    ring_hash_lb_ =
-        std::make_unique<RingHashLoadBalancer>(priority_set_, stats_, *stats_store_.rootScope(),
-                                               runtime_, random_, config_, common_config_);
-=======
     ring_hash_lb_ = std::make_unique<RingHashLoadBalancer>(
         priority_set_, stats_, stats_store_, runtime_, random_,
         config_.has_value()
@@ -167,7 +162,6 @@ public:
                   config_.value())
             : absl::nullopt,
         common_config_);
->>>>>>> 1dca85fa14 (Change LBConfig types to save memory)
   }
 
   absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> config_;
@@ -178,18 +172,12 @@ class MaglevTester : public BaseTester {
 public:
   MaglevTester(uint64_t num_hosts, uint32_t weighted_subset_percent = 0, uint32_t weight = 0)
       : BaseTester(num_hosts, weighted_subset_percent, weight) {
-<<<<<<< HEAD
-    maglev_lb_ =
-        std::make_unique<MaglevLoadBalancer>(priority_set_, stats_, *stats_store_.rootScope(),
-                                             runtime_, random_, config_, common_config_);
-=======
     maglev_lb_ = std::make_unique<MaglevLoadBalancer>(
         priority_set_, stats_, stats_store_, runtime_, random_,
         config_.has_value()
             ? makeOptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(config_.value())
             : absl::nullopt,
         common_config_);
->>>>>>> 1dca85fa14 (Change LBConfig types to save memory)
   }
 
   absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig> config_;

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -16,6 +16,7 @@
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/simulated_time_system.h"
 
+#include "absl/types/optional.h"
 #include "benchmark/benchmark.h"
 
 namespace Envoy {
@@ -154,9 +155,19 @@ public:
   RingHashTester(uint64_t num_hosts, uint64_t min_ring_size) : BaseTester(num_hosts) {
     config_ = envoy::config::cluster::v3::Cluster::RingHashLbConfig();
     config_.value().mutable_minimum_ring_size()->set_value(min_ring_size);
+<<<<<<< HEAD
     ring_hash_lb_ =
         std::make_unique<RingHashLoadBalancer>(priority_set_, stats_, *stats_store_.rootScope(),
                                                runtime_, random_, config_, common_config_);
+=======
+    ring_hash_lb_ = std::make_unique<RingHashLoadBalancer>(
+        priority_set_, stats_, stats_store_, runtime_, random_,
+        config_.has_value()
+            ? makeOptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+                  config_.value())
+            : absl::nullopt,
+        common_config_);
+>>>>>>> 1dca85fa14 (Change LBConfig types to save memory)
   }
 
   absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> config_;
@@ -167,9 +178,18 @@ class MaglevTester : public BaseTester {
 public:
   MaglevTester(uint64_t num_hosts, uint32_t weighted_subset_percent = 0, uint32_t weight = 0)
       : BaseTester(num_hosts, weighted_subset_percent, weight) {
+<<<<<<< HEAD
     maglev_lb_ =
         std::make_unique<MaglevLoadBalancer>(priority_set_, stats_, *stats_store_.rootScope(),
                                              runtime_, random_, config_, common_config_);
+=======
+    maglev_lb_ = std::make_unique<MaglevLoadBalancer>(
+        priority_set_, stats_, stats_store_, runtime_, random_,
+        config_.has_value()
+            ? makeOptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(config_.value())
+            : absl::nullopt,
+        common_config_);
+>>>>>>> 1dca85fa14 (Change LBConfig types to save memory)
   }
 
   absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig> config_;

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -13,6 +13,8 @@
 #include "test/mocks/upstream/priority_set.h"
 #include "test/test_common/simulated_time_system.h"
 
+#include "absl/types/optional.h"
+
 namespace Envoy {
 namespace Upstream {
 namespace {
@@ -48,8 +50,12 @@ public:
       : stat_names_(stats_store_.symbolTable()), stats_(stat_names_, *stats_store_.rootScope()) {}
 
   void createLb() {
-    lb_ = std::make_unique<MaglevLoadBalancer>(priority_set_, stats_, *stats_store_.rootScope(),
-                                               runtime_, random_, config_, common_config_);
+    lb_ = std::make_unique<MaglevLoadBalancer>(
+        priority_set_, stats_, *stats_store_.rootScope(), runtime_, random_,
+        config_.has_value()
+            ? makeOptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(config_.value())
+            : absl::nullopt,
+        common_config_);
   }
 
   void init(uint64_t table_size) {

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -21,6 +21,7 @@
 #include "test/test_common/simulated_time_system.h"
 
 #include "absl/container/node_hash_map.h"
+#include "absl/types/optional.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -61,8 +62,13 @@ public:
       : stat_names_(stats_store_.symbolTable()), stats_(stat_names_, *stats_store_.rootScope()) {}
 
   void init() {
-    lb_ = std::make_unique<RingHashLoadBalancer>(priority_set_, stats_, *stats_store_.rootScope(),
-                                                 runtime_, random_, config_, common_config_);
+    lb_ = std::make_unique<RingHashLoadBalancer>(
+        priority_set_, stats_, *stats_store_.rootScope(), runtime_, random_,
+        config_.has_value()
+            ? makeOptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+                  config_.value())
+            : absl::nullopt,
+        common_config_);
     lb_->initialize();
   }
 

--- a/test/common/upstream/round_robin_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/round_robin_load_balancer_fuzz_test.cc
@@ -1,5 +1,7 @@
 #include <memory>
 
+#include "envoy/common/optref.h"
+
 #include "test/common/upstream/round_robin_load_balancer_fuzz.pb.validate.h"
 #include "test/common/upstream/zone_aware_load_balancer_fuzz_base.h"
 #include "test/fuzz/fuzz_runner.h"
@@ -32,7 +34,9 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::RoundRobinLoadBalancerTestCase
         zone_aware_load_balancer_fuzz.stats_, zone_aware_load_balancer_fuzz.runtime_,
         zone_aware_load_balancer_fuzz.random_,
         zone_aware_load_balancer_test_case.load_balancer_test_case().common_lb_config(),
-        input.round_robin_lb_config(), zone_aware_load_balancer_fuzz.simTime());
+        makeOptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+            input.round_robin_lb_config()),
+        zone_aware_load_balancer_fuzz.simTime());
   } catch (EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException; {}", e.what());
     return;

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -2,9 +2,8 @@
 
 #include <limits>
 
-#include "envoy/config/cluster/v3/cluster.pb.h"
-
 #include "envoy/common/optref.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/upstream/host_description.h"
 #include "envoy/upstream/upstream.h"
 

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -4,7 +4,6 @@
 
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
-//#include "envoy/config/cluster/v3/cluster.proto.h"
 #include "envoy/common/optref.h"
 #include "envoy/upstream/host_description.h"
 #include "envoy/upstream/upstream.h"

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -3,6 +3,9 @@
 #include <limits>
 
 #include "envoy/config/cluster/v3/cluster.pb.h"
+
+//#include "envoy/config/cluster/v3/cluster.proto.h"
+#include "envoy/common/optref.h"
 #include "envoy/upstream/host_description.h"
 #include "envoy/upstream/upstream.h"
 
@@ -127,10 +130,31 @@ MockClusterInfo::MockClusterInfo()
           [this](ResourcePriority) -> Upstream::ResourceManager& { return *resource_manager_; }));
   ON_CALL(*this, lbType()).WillByDefault(ReturnPointee(&lb_type_));
   ON_CALL(*this, lbSubsetInfo()).WillByDefault(ReturnRef(lb_subset_));
-  ON_CALL(*this, lbRoundRobinConfig()).WillByDefault(ReturnRef(lb_round_robin_config_));
-  ON_CALL(*this, lbRingHashConfig()).WillByDefault(ReturnRef(lb_ring_hash_config_));
-  ON_CALL(*this, lbMaglevConfig()).WillByDefault(ReturnRef(lb_maglev_config_));
-  ON_CALL(*this, lbOriginalDstConfig()).WillByDefault(ReturnRef(lb_original_dst_config_));
+  ON_CALL(*this, lbRoundRobinConfig())
+      .WillByDefault(
+          Invoke([this]() -> OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> {
+            return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+                lb_round_robin_config_.get());
+          }));
+  ON_CALL(*this, lbRingHashConfig())
+      .WillByDefault(
+          Invoke([this]() -> OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> {
+            return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+                lb_ring_hash_config_.get());
+          }));
+  ON_CALL(*this, lbMaglevConfig())
+      .WillByDefault(
+          Invoke([this]() -> OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> {
+            return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
+                lb_maglev_config_.get());
+          }));
+  ON_CALL(*this, lbOriginalDstConfig())
+      .WillByDefault(Invoke(
+          [this]() -> OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig> {
+            return makeOptRefFromPtr<
+                const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
+                lb_original_dst_config_.get());
+          }));
   ON_CALL(*this, upstreamConfig()).WillByDefault(ReturnRef(upstream_config_));
   ON_CALL(*this, lbConfig()).WillByDefault(ReturnRef(lb_config_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -133,15 +133,15 @@ public:
   MOCK_METHOD(envoy::config::cluster::v3::Cluster::DiscoveryType, type, (), (const));
   MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType>&,
               clusterType, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig>&,
-              lbRingHashConfig, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig>&,
-              lbMaglevConfig, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>&,
+  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>, lbRingHashConfig,
+              (), (const));
+  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>, lbMaglevConfig, (),
+              (const));
+  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>,
               lbRoundRobinConfig, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>&,
+  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>,
               lbLeastRequestConfig, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>&,
+  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>,
               lbOriginalDstConfig, (), (const));
   MOCK_METHOD(const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&, upstreamConfig,
               (), (const));
@@ -235,10 +235,12 @@ public:
       upstream_http_protocol_options_;
   absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>
       alternate_protocols_cache_options_;
-  absl::optional<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lb_round_robin_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config_;
-  absl::optional<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig> lb_original_dst_config_;
+  std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
+      lb_round_robin_config_;
+  std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lb_ring_hash_config_;
+  std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config_;
+  std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
+      lb_original_dst_config_;
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
   Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
   envoy::config::cluster::v3::Cluster::CommonLbConfig lb_config_;


### PR DESCRIPTION
Commit Message: Changes how LB policies are stored to save memory
Additional Description:
Changed how some of these configs are stored to be unique_ptr instead of optionals. This will help save memory in cases where some of these policies are not set or used.

This will save a percentage of memory used by ClusterInfo and Subset_Lb

sizeof() test results:
Without these changes:
ClusterInfoImpl: 2896
Subset_LB: 536

With these changes:
ClusterInfoImpl: 2704
Subset_Lb: 384

Risk Level: Low
Testing: Updated existing load balancing tests to ensure success with new types
Docs Changes: N/A
Release Notes: N/A
