### PR TITLE
remove include_ifaddrs from Envoy Mobile build config

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -57,7 +57,7 @@ build:dbg-common --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 build:ios --define=manual_stamp=manual_stamp
 
 # Default flags for builds targeting Android
-build:android --define=logger=android --define=include_ifaddrs=true
+build:android --define=logger=android
 
 # Default flags for Android debug builds
 build:dbg-android --config=dbg-common
@@ -113,7 +113,6 @@ build:release-ios --compilation_mode=opt
 
 # Flags for release builds targeting Android or the JVM
 # Release does not use the option --define=logger=android
-build:release-android --define=include_ifaddrs=true
 build:release-android --config=release-common
 build:release-android --compilation_mode=opt
 

--- a/mobile/bazel/BUILD
+++ b/mobile/bazel/BUILD
@@ -18,11 +18,6 @@ kt_jvm_library(
 )
 
 config_setting(
-    name = "include_ifaddrs",
-    values = {"define": "include_ifaddrs=true"},
-)
-
-config_setting(
     name = "exclude_certificates",
     values = {"define": "exclude_certificates=true"},
 )

--- a/mobile/library/common/network/BUILD
+++ b/mobile/library/common/network/BUILD
@@ -10,7 +10,7 @@ envoy_cc_library(
         "connectivity_manager.cc",
         "android.cc",
     ] + select({
-        "//bazel:include_ifaddrs": [
+        "@envoy//bazel:android": [
             "//third_party:android/ifaddrs-android.h",
             "//third_party:android/LocalArray.h",
             "//third_party:android/ScopedFd.h",
@@ -22,10 +22,6 @@ envoy_cc_library(
         "connectivity_manager.h",
         "proxy_settings.h",
     ],
-    copts = select({
-        "//bazel:include_ifaddrs": ["-DINCLUDE_IFADDRS"],
-        "//conditions:default": [],
-    }),
     repository = "@envoy",
     deps = [
         "//library/common/network:src_addr_socket_option_lib",

--- a/mobile/library/common/network/android.cc
+++ b/mobile/library/common/network/android.cc
@@ -29,7 +29,7 @@ namespace {
 #endif
 
 void setAlternateGetifaddrs() {
-#if defined(__ANDROID_API__)
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
   ENVOY_BUG(!os_syscalls.supportsGetifaddrs(),
             "setAlternateGetifaddrs should only be called when supportsGetifaddrs is false");

--- a/mobile/library/common/network/android.cc
+++ b/mobile/library/common/network/android.cc
@@ -19,7 +19,7 @@ namespace Network {
 namespace Android {
 namespace Utility {
 
-#if defined(INCLUDE_IFADDRS)
+#if defined(__ANDROID_API__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
 namespace {
@@ -29,7 +29,7 @@ namespace {
 #endif
 
 void setAlternateGetifaddrs() {
-#if defined(INCLUDE_IFADDRS)
+#if defined(__ANDROID_API__)
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
   ENVOY_BUG(!os_syscalls.supportsGetifaddrs(),
             "setAlternateGetifaddrs should only be called when supportsGetifaddrs is false");


### PR DESCRIPTION
Remove include_ifaddrs from Envoy Mobile build config
The code which uses INCUDE_IFADDRS is android specific so we can just key off of Android instead of adding a layer of indirection which must be true on Android and false elsewhere.

Signed-off-by: Ryan Hamilton <rch@google.com>