### PR TITLE
[Envoy-mobile]add enums in Cronvoy to match Cronet interface

### DIFF
--- a/mobile/library/java/org/chromium/net/EffectiveConnectionType.java
+++ b/mobile/library/java/org/chromium/net/EffectiveConnectionType.java
@@ -1,0 +1,39 @@
+package org.chromium.net;
+
+import androidx.annotation.IntDef;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IntDef({
+  EffectiveConnectionType.TYPE_UNKNOWN, EffectiveConnectionType.TYPE_OFFLINE,
+  EffectiveConnectionType.TYPE_SLOW_2G, EffectiveConnectionType.TYPE_2G,
+  EffectiveConnectionType.TYPE_3G, EffectiveConnectionType.TYPE_4G,
+  EffectiveConnectionType.TYPE_LAST
+})
+@Retention(RetentionPolicy.SOURCE)
+public @interface EffectiveConnectionType {
+  /** Effective connection type reported when the network quality is unknown. */
+  int TYPE_UNKNOWN = 0;
+  /**
+   * Effective connection type reported when the Internet is unreachable because the device does not
+   * have a connection (as reported by underlying platform APIs). Note that due to rare but
+   * potential bugs in the platform APIs, it is possible that effective connection type is reported
+   * as TYPE_OFFLINE. Callers must use caution when using acting on this.
+   */
+  int TYPE_OFFLINE = 1;
+  /**
+   * Effective connection type reported when the network has the quality of a poor 2G connection.
+   */
+  int TYPE_SLOW_2G = 2;
+  /**
+   * Effective connection type reported when the network has the quality of a faster 2G connection.
+   */
+  int TYPE_2G = 3;
+  /** Effective connection type reported when the network has the quality of a 3G connection. */
+  int TYPE_3G = 4;
+  /** Effective connection type reported when the network has the quality of a 4G connection. */
+  int TYPE_4G = 5;
+  /** Last value of the effective connection type. This value is unused. */
+  int TYPE_LAST = 6;
+}
+

--- a/mobile/library/java/org/chromium/net/EffectiveConnectionType.java
+++ b/mobile/library/java/org/chromium/net/EffectiveConnectionType.java
@@ -4,12 +4,10 @@ import androidx.annotation.IntDef;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-@IntDef({
-  EffectiveConnectionType.TYPE_UNKNOWN, EffectiveConnectionType.TYPE_OFFLINE,
-  EffectiveConnectionType.TYPE_SLOW_2G, EffectiveConnectionType.TYPE_2G,
-  EffectiveConnectionType.TYPE_3G, EffectiveConnectionType.TYPE_4G,
-  EffectiveConnectionType.TYPE_LAST
-})
+@IntDef({EffectiveConnectionType.TYPE_UNKNOWN, EffectiveConnectionType.TYPE_OFFLINE,
+         EffectiveConnectionType.TYPE_SLOW_2G, EffectiveConnectionType.TYPE_2G,
+         EffectiveConnectionType.TYPE_3G, EffectiveConnectionType.TYPE_4G,
+         EffectiveConnectionType.TYPE_LAST})
 @Retention(RetentionPolicy.SOURCE)
 public @interface EffectiveConnectionType {
   /** Effective connection type reported when the network quality is unknown. */
@@ -36,4 +34,3 @@ public @interface EffectiveConnectionType {
   /** Last value of the effective connection type. This value is unused. */
   int TYPE_LAST = 6;
 }
-

--- a/mobile/library/java/org/chromium/net/NetworkQualityObservationSource.java
+++ b/mobile/library/java/org/chromium/net/NetworkQualityObservationSource.java
@@ -4,18 +4,13 @@ import androidx.annotation.IntDef;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-@IntDef({
-  NetworkQualityObservationSource.HTTP,
-  NetworkQualityObservationSource.TCP,
-  NetworkQualityObservationSource.QUIC,
-  NetworkQualityObservationSource.HTTP_CACHED_ESTIMATE,
-  NetworkQualityObservationSource.DEFAULT_HTTP_FROM_PLATFORM,
-  NetworkQualityObservationSource.DEPRECATED_HTTP_EXTERNAL_ESTIMATE,
-  NetworkQualityObservationSource.TRANSPORT_CACHED_ESTIMATE,
-  NetworkQualityObservationSource.DEFAULT_TRANSPORT_FROM_PLATFORM,
-  NetworkQualityObservationSource.H2_PINGS,
-  NetworkQualityObservationSource.MAX
-})
+@IntDef({NetworkQualityObservationSource.HTTP, NetworkQualityObservationSource.TCP,
+         NetworkQualityObservationSource.QUIC, NetworkQualityObservationSource.HTTP_CACHED_ESTIMATE,
+         NetworkQualityObservationSource.DEFAULT_HTTP_FROM_PLATFORM,
+         NetworkQualityObservationSource.DEPRECATED_HTTP_EXTERNAL_ESTIMATE,
+         NetworkQualityObservationSource.TRANSPORT_CACHED_ESTIMATE,
+         NetworkQualityObservationSource.DEFAULT_TRANSPORT_FROM_PLATFORM,
+         NetworkQualityObservationSource.H2_PINGS, NetworkQualityObservationSource.MAX})
 @Retention(RetentionPolicy.SOURCE)
 public @interface NetworkQualityObservationSource {
   /**
@@ -59,4 +54,3 @@ public @interface NetworkQualityObservationSource {
 
   int MAX = 9;
 }
-

--- a/mobile/library/java/org/chromium/net/NetworkQualityObservationSource.java
+++ b/mobile/library/java/org/chromium/net/NetworkQualityObservationSource.java
@@ -1,0 +1,62 @@
+package org.chromium.net;
+
+import androidx.annotation.IntDef;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IntDef({
+  NetworkQualityObservationSource.HTTP,
+  NetworkQualityObservationSource.TCP,
+  NetworkQualityObservationSource.QUIC,
+  NetworkQualityObservationSource.HTTP_CACHED_ESTIMATE,
+  NetworkQualityObservationSource.DEFAULT_HTTP_FROM_PLATFORM,
+  NetworkQualityObservationSource.DEPRECATED_HTTP_EXTERNAL_ESTIMATE,
+  NetworkQualityObservationSource.TRANSPORT_CACHED_ESTIMATE,
+  NetworkQualityObservationSource.DEFAULT_TRANSPORT_FROM_PLATFORM,
+  NetworkQualityObservationSource.H2_PINGS,
+  NetworkQualityObservationSource.MAX
+})
+@Retention(RetentionPolicy.SOURCE)
+public @interface NetworkQualityObservationSource {
+  /**
+   * The observation was taken at the request layer, e.g., a round trip time is recorded as the time
+   * between the request being sent and the first byte being received.
+   */
+  int HTTP = 0;
+  /** The observation is taken from TCP statistics maintained by the kernel. */
+  int TCP = 1;
+  /** The observation is taken at the QUIC layer. */
+  int QUIC = 2;
+  /**
+   * The observation is a previously cached estimate of the metric. The metric was computed at the
+   * HTTP layer.
+   */
+  int HTTP_CACHED_ESTIMATE = 3;
+  /**
+   * The observation is derived from network connection information provided by the platform. For
+   * example, typical RTT and throughput values are used for a given type of network connection. The
+   * metric was provided for use at the HTTP layer.
+   */
+  int DEFAULT_HTTP_FROM_PLATFORM = 4;
+  /**
+   * The observation came from a Chromium-external source. The metric was computed by the external
+   * source at the HTTP layer. Deprecated since external estimate provider is not currently queried.
+   */
+  int DEPRECATED_HTTP_EXTERNAL_ESTIMATE = 5;
+  /**
+   * The observation is a previously cached estimate of the metric. The metric was computed at the
+   * transport layer.
+   */
+  int TRANSPORT_CACHED_ESTIMATE = 6;
+  /**
+   * The observation is derived from the network connection information provided by the platform.
+   * For example, typical RTT and throughput values are used for a given type of network connection.
+   * The metric was provided for use at the transport layer.
+   */
+  int DEFAULT_TRANSPORT_FROM_PLATFORM = 7;
+  /** Round trip ping latency reported by H2 connections. */
+  int H2_PINGS = 8;
+
+  int MAX = 9;
+}
+


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@google.com>

Commit Message: add enums in Cronvoy to match Cronet interface
Additional Description: In Cronet, those java enums are generated from the native code as such: https://source.chromium.org/chromium/chromium/src/+/main:net/BUILD.gn;l=1724. In Cronvoy, we don't have such native code. Thus we need to manually create the enum classes so that Cronvoy customers get the full API.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Android only
