### PR TITLE
mobile: retry starting iOS Simulator up to 3 times

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -75,7 +75,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
+      # if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftbaselineapp:
     name: swift_baseline_app
@@ -122,7 +122,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
+      # if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftexperimentalapp:
     name: swift_experimental_app
@@ -169,7 +169,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
+      # if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftasyncawait:
     name: swift_async_await
@@ -216,7 +216,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check upload succeeded'
     - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
+      # if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   objchelloworld:
     name: objc_helloworld
@@ -263,5 +263,5 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      if: ${{ failure() || cancelled() }}
+      # if: ${{ failure() || cancelled() }}
       name: 'Log app run'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -53,6 +53,12 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/hello_world:app
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
     - name: 'Run app'
       if: steps.should_run.outputs.run_ci_job == 'true'
@@ -93,6 +99,12 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/baseline:app
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
     - name: 'Run app'
       if: steps.should_run.outputs.run_ci_job == 'true'
@@ -133,6 +145,12 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/experimental:app
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
     - name: 'Run app'
       if: steps.should_run.outputs.run_ci_job == 'true'
@@ -173,6 +191,12 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/async_await:app
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
     - name: 'Run app'
       if: steps.should_run.outputs.run_ci_job == 'true'
@@ -213,6 +237,12 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
     - name: 'Run app'
       if: steps.should_run.outputs.run_ci_job == 'true'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -75,7 +75,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      # if: ${{ failure() || cancelled() }}
+      if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftbaselineapp:
     name: swift_baseline_app
@@ -122,7 +122,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      # if: ${{ failure() || cancelled() }}
+      if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftexperimentalapp:
     name: swift_experimental_app
@@ -169,7 +169,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      # if: ${{ failure() || cancelled() }}
+      if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftasyncawait:
     name: swift_async_await
@@ -216,7 +216,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check upload succeeded'
     - run: cat /tmp/envoy.log
-      # if: ${{ failure() || cancelled() }}
+      if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   objchelloworld:
     name: objc_helloworld
@@ -263,5 +263,5 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
-      # if: ${{ failure() || cancelled() }}
+      if: ${{ failure() || cancelled() }}
       name: 'Log app run'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -57,6 +57,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Start simulator'
       with:
+        timeout_minutes: 5
         max_attempts: 3
         command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
@@ -103,6 +104,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Start simulator'
       with:
+        timeout_minutes: 5
         max_attempts: 3
         command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
@@ -149,6 +151,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Start simulator'
       with:
+        timeout_minutes: 5
         max_attempts: 3
         command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
@@ -195,6 +198,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Start simulator'
       with:
+        timeout_minutes: 5
         max_attempts: 3
         command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.
@@ -241,6 +245,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Start simulator'
       with:
+        timeout_minutes: 5
         max_attempts: 3
         command: ./mobile/ci/start_ios_simulator.sh
     # Run the app in the background and redirect logs.

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -33,7 +33,7 @@ jobs:
     - run: unzip mobile/bazel-bin/library/swift/Envoy.xcframework.zip -d mobile/examples/swift/swiftpm/Packages || true
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Unzip xcframework'
-    - run: xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 13 Pro Max,OS=16.1"
+    - run: xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 14 Pro Max,OS=16.1"
       if: steps.should_run.outputs.run_ci_job == 'true'
       name: 'Build app'
     # TODO(jpsim): Run app and inspect logs to validate

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -16,7 +16,6 @@ build --features=swift.debug_prefix_map
 build --host_force_python=PY3
 build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
-build --ios_simulator_device="iPhone 14 Pro Max"
 build --ios_simulator_version=16.1
 build --verbose_failures
 build --workspace_status_command=../bazel/get_workspace_status

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -16,7 +16,7 @@ build --features=swift.debug_prefix_map
 build --host_force_python=PY3
 build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
-build --ios_simulator_device="iPhone 13"
+build --ios_simulator_device="iPhone 14 Pro Max"
 build --ios_simulator_version=16.1
 build --verbose_failures
 build --workspace_status_command=../bazel/get_workspace_status

--- a/mobile/ci/start_ios_simulator.sh
+++ b/mobile/ci/start_ios_simulator.sh
@@ -13,6 +13,7 @@ attempt=0
 max=5
 delay=5
 while true; do
+  # shellcheck disable=SC2015
   (xcrun simctl list | grep "($simulator_uuid) (Booted)") && break || {
     if [[ $attempt -lt $max ]]; then
       ((attempt++))

--- a/mobile/ci/start_ios_simulator.sh
+++ b/mobile/ci/start_ios_simulator.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+simulator_name="iPhone 14 Pro Max"
+simulator_uuid="$(xcrun simctl list | sed -nr "s/.*$simulator_name \(([A-Z0-9\-]{36})\).*/\1/p" | head -n1)"
+
+echo "Booting simulator named '$simulator_name' with uuid '$simulator_uuid'"
+
+open -a "$(xcode-select -p)/Applications/Simulator.app" --args -CurrentDeviceUDID "$simulator_uuid"
+
+attempt=0
+max=5
+delay=5
+while true; do
+  (xcrun simctl list | grep "($simulator_uuid) (Booted)") && break || {
+    if [[ $attempt -lt $max ]]; then
+      ((attempt++))
+      echo "Simulator not yet booted. Attempt $attempt/$max. Waiting $delay seconds."
+      sleep $delay;
+    else
+      echo "The simulator did not boot after $attempt attempts."
+      exit 1
+    fi
+  }
+done
+
+echo "Simulator booted successfully"


### PR DESCRIPTION
Similar to https://github.com/envoyproxy/envoy/pull/24919 but this time for iOS.

Instead of relying on `bazel run` to launch the simulator, we do this ahead of time so we can retry that step if it fails.

Slack discussion: https://envoyproxy.slack.com/archives/C02F93EEJCE/p1673618671587659

Commit Message:
Additional Description:
Risk Level: Low, CI only
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]