### PR TITLE
Allow C++ engine builder to use platform cert verification on iOS

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -191,11 +191,6 @@ EngineBuilder& EngineBuilder::enableH2ExtendKeepaliveTimeout(bool h2_extend_keep
 
 EngineBuilder&
 EngineBuilder::enablePlatformCertificatesValidation(bool platform_certificates_validation_on) {
-#if defined(__APPLE__)
-  if (platform_certificates_validation_on) {
-    PANIC("Certificates validation using platform provided APIs is not supported in IOS.");
-  }
-#endif
   platform_certificates_validation_on_ = platform_certificates_validation_on;
   return *this;
 }

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -331,17 +331,12 @@ TEST(TestConfig, EnablePlatformCertificatesValidation) {
               Not(HasSubstr("envoy_mobile.cert_validator.platform_bridge_cert_validator")));
   ASSERT_THAT(bootstrap.DebugString(), HasSubstr("trusted_ca"));
 
-#if not defined(__APPLE__)
   engine_builder.enablePlatformCertificatesValidation(true);
   auto config_str2 = engine_builder.generateConfigStr();
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str2), bootstrap);
   ASSERT_THAT(bootstrap.DebugString(),
               HasSubstr("envoy_mobile.cert_validator.platform_bridge_cert_validator"));
   ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("trusted_ca")));
-#elif GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(engine_builder.enablePlatformCertificatesValidation(true),
-               "Certificates validation using platform provided APIs is not supported in IOS");
-#endif
 }
 
 // Implementation of StringAccessor which tracks the number of times it was used.

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -338,7 +338,7 @@ TEST(TestConfig, EnablePlatformCertificatesValidation) {
   ASSERT_THAT(bootstrap.DebugString(),
               HasSubstr("envoy_mobile.cert_validator.platform_bridge_cert_validator"));
   ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("trusted_ca")));
-#else
+#elif GTEST_HAS_DEATH_TEST
   EXPECT_DEATH(engine_builder.enablePlatformCertificatesValidation(true),
                "Certificates validation using platform provided APIs is not supported in IOS");
 #endif


### PR DESCRIPTION
Allow C++ engine builder to use platform cert verification on iOS.
Remove PANIC from the engine builder since we do actually support platform cert verification on iOS and update test expectations accordingly.