### PR TITLE
mobile linker: add 'ldl' linker option

### DIFF
--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -107,7 +107,9 @@ cc_library(
 # Library which contains all the JNI related targets.
 cc_library(
     name = "envoy_jni_lib",
-    linkopts = select({
+    linkopts = [
+        "-ldl",
+    ] + select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
         "//conditions:default": [],
     }),
@@ -133,7 +135,10 @@ config_setting(
 # Main dynamic library for the Envoy Mobile aar
 cc_binary(
     name = "libenvoy_jni.so",
-    linkopts = select({
+    linkopts = [
+        "-lm",
+    ] +
+     select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
         "//conditions:default": [],
     }),

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -134,6 +134,8 @@ config_setting(
 cc_binary(
     name = "libenvoy_jni.so",
     linkopts = [
+        # Without this option the app crashes when launched 
+        # on arm64 emulator which is not covered by CI.
         "-ldl",
     ] + select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -107,9 +107,7 @@ cc_library(
 # Library which contains all the JNI related targets.
 cc_library(
     name = "envoy_jni_lib",
-    linkopts = [
-        "-ldl",
-    ] + select({
+    linkopts = select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
         "//conditions:default": [],
     }),
@@ -136,9 +134,8 @@ config_setting(
 cc_binary(
     name = "libenvoy_jni.so",
     linkopts = [
-        "-lm",
-    ] +
-     select({
+        "-ldl",
+    ] + select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
         "//conditions:default": [],
     }),

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -134,7 +134,7 @@ config_setting(
 cc_binary(
     name = "libenvoy_jni.so",
     linkopts = [
-        # Without this option the app crashes when launched 
+        # Without this option the app crashes when launched
         # on arm64 emulator which is not covered by CI.
         "-ldl",
     ] + select({


### PR DESCRIPTION
Commit Message: Without this option the app crashes when attempted to being launched on arm64 emulator. The `ldl` flag was removed in https://github.com/envoyproxy/envoy/pull/24806.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
