### PR TITLE
Add a RequestHeadersBuilder constructor which takes a URL

### DIFF
--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -20,6 +20,7 @@ Bugfixes:
 
 Features:
 
+- api: Add a constructor which takes a URL to C++ RequestEngineBuilder.
 - api: add option to support platform provided certificates validation interfaces on iOS and Android. (:issue `#2144 <2144>`)
 - api: Add a ``setPerTryIdleTimeoutSeconds()`` method to C++ EngineBuilder.
 - swift/kotlin: add an option to enable DNS cache by calling ``enableDNSCache(_:)`` method.

--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -83,6 +83,7 @@ envoy_cc_library(
         "//library/common/api:c_types",
         "//library/common/data:utility_lib",
         "//library/common/extensions/key_value/platform:config",
+	"@envoy//source/common/http:utility_lib",
     ],
 )
 

--- a/mobile/library/cc/request_headers_builder.cc
+++ b/mobile/library/cc/request_headers_builder.cc
@@ -5,28 +5,32 @@ namespace Platform {
 
 RequestHeadersBuilder::RequestHeadersBuilder(RequestMethod request_method, std::string scheme,
                                              std::string authority, std::string path) {
-  this->internalSet(":method", {requestMethodToString(request_method)});
-  this->internalSet(":scheme", {std::move(scheme)});
-  this->internalSet(":authority", {std::move(authority)});
-  this->internalSet(":path", {std::move(path)});
+  internalSet(":method", {requestMethodToString(request_method)});
+  internalSet(":scheme", {std::move(scheme)});
+  internalSet(":authority", {std::move(authority)});
+  internalSet(":path", {std::move(path)});
+}
+
+RequestHeadersBuilder::RequestHeadersBuilder(RequestMethod request_method, Envoy::Http::Utility::Url url)
+  : RequestHeadersBuilder(request_method, std::string(url.scheme()), std::string(url.hostAndPort()), std::string(url.pathAndQueryParams())) {
 }
 
 RequestHeadersBuilder& RequestHeadersBuilder::addRetryPolicy(const RetryPolicy& retry_policy) {
   const RawHeaderMap retry_policy_headers = retry_policy.asRawHeaderMap();
   for (const auto& pair : retry_policy_headers) {
-    this->internalSet(pair.first, pair.second);
+    internalSet(pair.first, pair.second);
   }
   return *this;
 }
 
 RequestHeadersBuilder&
 RequestHeadersBuilder::addUpstreamHttpProtocol(UpstreamHttpProtocol upstream_http_protocol) {
-  this->internalSet("x-envoy-mobile-upstream-protocol",
+  internalSet("x-envoy-mobile-upstream-protocol",
                     std::vector<std::string>{upstreamHttpProtocolToString(upstream_http_protocol)});
   return *this;
 }
 
-RequestHeaders RequestHeadersBuilder::build() const { return RequestHeaders(this->allHeaders()); }
+RequestHeaders RequestHeadersBuilder::build() const { return RequestHeaders(allHeaders()); }
 
 } // namespace Platform
 } // namespace Envoy

--- a/mobile/library/cc/request_headers_builder.h
+++ b/mobile/library/cc/request_headers_builder.h
@@ -8,6 +8,8 @@
 #include "retry_policy.h"
 #include "upstream_http_protocol.h"
 
+#include "source/common/http/utility.h"
+
 namespace Envoy {
 namespace Platform {
 
@@ -18,6 +20,7 @@ class RequestHeadersBuilder : public HeadersBuilder {
 public:
   RequestHeadersBuilder(RequestMethod request_method, std::string scheme, std::string authority,
                         std::string path);
+  RequestHeadersBuilder(RequestMethod request_method, Envoy::Http::Utility::Url url);
 
   RequestHeadersBuilder& addRetryPolicy(const RetryPolicy& retry_policy);
   RequestHeadersBuilder& addUpstreamHttpProtocol(UpstreamHttpProtocol upstream_http_protocol);

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -14,3 +14,13 @@ envoy_cc_test(
         "@envoy_build_config//:extension_registry",
     ],
 )
+
+envoy_cc_test(
+    name = "request_headers_builder_test",
+    srcs = ["request_headers_builder_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "@envoy_build_config//:extension_registry",
+    ],
+)

--- a/mobile/test/cc/unit/request_headers_builder_test.cc
+++ b/mobile/test/cc/unit/request_headers_builder_test.cc
@@ -1,0 +1,31 @@
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "library/cc/request_headers_builder.h"
+
+namespace Envoy {
+namespace Platform {
+namespace {
+
+TEST(RequestHeadersBuilderTest, ConstructsFromPieces) {
+  RequestHeadersBuilder builder(RequestMethod::POST, "https", "www.example.com", "/");
+  RequestHeaders headers = builder.build();
+  EXPECT_EQ("https", headers.scheme());
+  EXPECT_EQ("www.example.com", headers.authority());
+  EXPECT_EQ("/", headers.path());
+}
+
+TEST(RequestHeadersBuilderTest, ConstructsFromUrl) {
+  Envoy::Http::Utility::Url url;
+  ASSERT_TRUE(url.initialize("https://www.example.com/", false));
+  RequestHeadersBuilder builder(RequestMethod::POST, url);
+  RequestHeaders headers = builder.build();
+  EXPECT_EQ("https", headers.scheme());
+  EXPECT_EQ("www.example.com", headers.authority());
+  EXPECT_EQ("/", headers.path());
+}
+
+} // namespace
+} // namespace Platform
+} // namespace Envoy


### PR DESCRIPTION
Add a RequestHeadersBuilder constructor which takes a URL

Fixes: #24893

Risk Level: Low
Testing: New unit test
Docs Changes: None
Release Notes: Updated version_history.rst