### PR TITLE
mobile: reducing the number of enabled Envoy stats

### DIFF
--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -496,12 +496,17 @@ stats_config:
   stats_matcher:
     inclusion_list:
       patterns:
-        - prefix: cluster.base.
-        - prefix: cluster.base_h2.
-        - prefix: cluster.stats.
-        - prefix: http.client.
-        - prefix: http.dispatcher.
-        - prefix: http.hcm.
+        - prefix: cluster.base.upstream_rq_
+        - prefix: cluster.base_h2.upstream_rq_
+        - prefix: cluster.stats.upstream_rq_
+        - prefix: cluster.base.upstream_cx_
+        - prefix: cluster.base_h2.upstream_cx_
+        - prefix: cluster.stats.upstream_cx_
+        - exact:  cluster.base.http2.keepalive_timeout
+        - exact:  cluster.base_h2.http2.keepalive_timeout
+        - exact:  cluster.stats.http2.keepalive_timeout
+        - prefix: http.hcm.downstream_rq_
+        - prefix: http.hcm.decompressor.
         - prefix: pbf_filter.
         - prefix: pulse.
         - safe_regex:

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -507,7 +507,6 @@ stats_config:
         - exact:  cluster.stats.http2.keepalive_timeout
         - prefix: http.hcm.downstream_rq_
         - prefix: http.hcm.decompressor.
-        - prefix: pbf_filter.
         - prefix: pulse.
         - safe_regex:
             regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry|total)'

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -502,9 +502,9 @@ stats_config:
         - prefix: cluster.base.upstream_cx_
         - prefix: cluster.base_h2.upstream_cx_
         - prefix: cluster.stats.upstream_cx_
-        - exact:  cluster.base.http2.keepalive_timeout
-        - exact:  cluster.base_h2.http2.keepalive_timeout
-        - exact:  cluster.stats.http2.keepalive_timeout
+        - exact: cluster.base.http2.keepalive_timeout
+        - exact: cluster.base_h2.http2.keepalive_timeout
+        - exact: cluster.stats.http2.keepalive_timeout
         - prefix: http.hcm.downstream_rq_
         - prefix: http.hcm.decompressor.
         - prefix: pulse.


### PR DESCRIPTION
Commit Message: As a result of changes from https://github.com/envoyproxy/envoy/pull/24733 we ended up increasing the number of enabled stats from 317 to 462. We did not really want to increase the number of enabled stats but doing this was required if we wanted our stats inclusion list to use as many `prefix`es that end up with a dot "." character as possible. That kind of `prefix`es are optimized in a special way that we hoped would help us to improve envoy mobile launch times. Since then, we learnt that as they are now upload of Envoy Mobile stats consumes a lot of bandwidth and we are working on balancing the app launch time with the use of network bandwidth - for this reason, we decided to disable some of the stats enabled in https://github.com/envoyproxy/envoy/pull/24733. We are not going back to using regexes - instead we use prefixes.
Additional Description:
Risk Level: Low, less of enabled stats at a cost of slightly longer Envoy launch time.
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
