### PR TITLE
weighted-clusters: validate that total sum of weights below max int

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -408,7 +408,8 @@ message WeightedCluster {
     // The weight of the cluster. This value is relative to the other clusters'
     // weights. When a request matches the route, the choice of an upstream cluster
     // is determined by its weight. The sum of weights across all
-    // entries in the clusters array must be greater than 0.
+    // entries in the clusters array must be greater than 0, and must not exceed
+    // uint32_t maximal value (4294967295).
     google.protobuf.UInt32Value weight = 2;
 
     // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -616,6 +616,11 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
           optional_http_filters);
       weighted_clusters.emplace_back(std::move(cluster_entry));
       total_weight += weighted_clusters.back()->clusterWeight();
+      if (total_weight > std::numeric_limits<uint32_t>::max()) {
+        throw EnvoyException(
+            fmt::format("The sum of weights of all weighted clusters of route {} exceeds {}",
+                        route_name_, std::numeric_limits<uint32_t>::max()));
+      }
     }
 
     // Reject the config if the total_weight of all clusters is 0.

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6341,6 +6341,28 @@ virtual_hosts:
       EnvoyException, "Sum of weights in the weighted_cluster must be greater than 0.");
 }
 
+TEST_F(RouteMatcherTest, WeightedClustersSumOfWeightsTooLarge) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+  - name: www2
+    domains: ["www.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        name: lyft_route
+        route:
+          weighted_clusters:
+            clusters:
+              - name: cluster1
+                weight: 2394967295
+              - name: cluster2
+                weight: 2394967295
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(
+      TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
+      "The sum of weights of all weighted clusters of route lyft_route exceeds 4294967295");
+}
+
 TEST_F(RouteMatcherTest, TestWeightedClusterWithMissingWeights) {
   const std::string yaml = R"EOF(
 virtual_hosts:


### PR DESCRIPTION
Commit Message: weighted-clusters: validate that total sum of weights does not exceed max uint32
Additional Description:
Adds additional validation that the sum of weights of weighted clusters in a route does not exceed max uint32.

Risk Level: low - although this is a new validation, previously there was a similar validation when [total_weight](https://github.com/envoyproxy/envoy/blob/93b76c70ae0153452109934818c805b63d8f1221/api/envoy/config/route/v3/route_components.proto#L483) was used.
Testing: Added unit test
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>