### PR TITLE
[backport/1.22] build(deps): bump distroless/base-nossl-debian11 from `6f20a31` to `3…

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -41,7 +41,7 @@ CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
 
 # STAGE: envoy-distroless
 # gcr.io/distroless/base-nossl-debian11:nonroot
-FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:50562a71d0dfad3a374ec33ab577fc7aab16dfcf37bf95889af6cc58a108dbc1 AS envoy-distroless
+FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:3ee458a5858e11666ad3773e974e0e78d3530953745780bdf681dfcd4216c94b AS envoy-distroless
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /usr/local/bin/su-exec /usr/local/bin/


### PR DESCRIPTION
…ee458a` in /ci (#24830)

build(deps): bump distroless/base-nossl-debian11 in /ci

Bumps distroless/base-nossl-debian11 from `6f20a31` to `3ee458a`.

---
updated-dependencies:
- dependency-name: distroless/base-nossl-debian11 dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Signed-off-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
