### PR TITLE
ZK filter: Fix "buffer underflow" error

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -448,6 +448,11 @@ void DecoderImpl::parseXWatchesRequest(Buffer::Instance& data, uint64_t& offset,
 
 void DecoderImpl::skipString(Buffer::Instance& data, uint64_t& offset) {
   const int32_t slen = helper_.peekInt32(data, offset);
+  if (slen < 0) {
+    ENVOY_LOG(trace, "zookeeper_proxy: decoding response with negative string length {} at offset {}", slen,
+              offset);
+    return;
+  }
   helper_.skip(slen, offset);
 }
 

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -449,8 +449,9 @@ void DecoderImpl::parseXWatchesRequest(Buffer::Instance& data, uint64_t& offset,
 void DecoderImpl::skipString(Buffer::Instance& data, uint64_t& offset) {
   const int32_t slen = helper_.peekInt32(data, offset);
   if (slen < 0) {
-    ENVOY_LOG(trace, "zookeeper_proxy: decoding response with negative string length {} at offset {}", slen,
-              offset);
+    ENVOY_LOG(trace,
+              "zookeeper_proxy: decoding response with negative string length {} at offset {}",
+              slen, offset);
     return;
   }
   helper_.skip(slen, offset);

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -274,10 +274,9 @@ public:
     return buffer;
   }
 
-  Buffer::OwnedImpl
-  encodeCreateRequestWithNegativeDataLen(const std::string& path, const CreateFlags flags,
-                      const bool txn = false,
-                      const int32_t opcode = enumToSignedInt(OpCodes::Create)) const {
+  Buffer::OwnedImpl encodeCreateRequestWithNegativeDataLen(
+      const std::string& path, const CreateFlags flags, const bool txn = false,
+      const int32_t opcode = enumToSignedInt(OpCodes::Create)) const {
     Buffer::OwnedImpl buffer;
 
     if (!txn) {
@@ -912,7 +911,8 @@ TEST_F(ZooKeeperFilterTest, MultiRequest) {
 
   Buffer::OwnedImpl create1 = encodeCreateRequest("/foo", "1", CreateFlags::Persistent, true);
   Buffer::OwnedImpl create2 = encodeCreateRequest("/bar", "1", CreateFlags::Persistent, true);
-  Buffer::OwnedImpl create3 = encodeCreateRequestWithNegativeDataLen("/baz", CreateFlags::Persistent, true);
+  Buffer::OwnedImpl create3 =
+      encodeCreateRequestWithNegativeDataLen("/baz", CreateFlags::Persistent, true);
   Buffer::OwnedImpl check1 = encodePathVersion("/foo", 100, enumToSignedInt(OpCodes::Check), true);
   Buffer::OwnedImpl set1 = encodeSetRequest("/bar", "2", -1, true);
 

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -711,9 +711,17 @@ TEST_F(ZooKeeperFilterTest, GetDataRequestEmptyPath) {
                config_->stats().getdata_resp_);
 }
 
-TEST_F(ZooKeeperFilterTest, CreateRequestPersistent) { testCreate(CreateFlags::Persistent); }
+TEST_F(ZooKeeperFilterTest, CreateRequestPersistent) {
+  testCreate(CreateFlags::Persistent);
+  testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
+               config_->stats().create_resp_);
+}
 
-TEST_F(ZooKeeperFilterTest, CreateRequestPersistentWithNegativeDataLen) { testCreateWithNegativeDataLen(CreateFlags::Persistent); }
+TEST_F(ZooKeeperFilterTest, CreateRequestPersistentWithNegativeDataLen) {
+  testCreateWithNegativeDataLen(CreateFlags::Persistent);
+  testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
+               config_->stats().create_resp_);
+}
 
 TEST_F(ZooKeeperFilterTest, CreateRequestPersistentSequential) {
   testCreate(CreateFlags::PersistentSequential);


### PR DESCRIPTION
Commit Message: ZK filter: Fix "buffer underflow" error
Additional Description: When using ZK filter, we noticed some decoder errors. After looking into the issue, we found that some create requests had negative data len without real data and then the ZK filter failed to parse/skip the real data. Negative data len is because the data fetched from buffer is `0xffffffff` in our case, and the type of `len` is `int32_t`. Since the data is beyond the max value of int32, it becomes negative.
Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Zhewei Hu \<zhu@pinterest.com\>