### PR TITLE
mobile ci: cancel ongoing mobile CI jobs when new SHA pushed to PR

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   androidbuild:
     name: android_build

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   kotlintestsmac:
     # revert to //test/kotlin/... once fixed

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   asan:
     name: asan

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cctests:
     name: cc_tests

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -3,7 +3,7 @@ on:
   - cron: '0 12 * * 4'
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -2,6 +2,10 @@ on:
   schedule:
   - cron: '0 12 * * 4'
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -8,6 +8,10 @@ on:
     - 'dependabot/**'
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unittests:
     name: unit_tests

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -2,7 +2,7 @@ name: 'Dependency Review'
 on: [pull_request]
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,6 +1,10 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   formatall:
     name: format_all

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   iosbuild:
     name: ios_build

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   swifttests:
     name: swift_tests

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   sizecurrent:
     name: size_current

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pythontests:
     name: python_tests

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   validate_swiftpm_example:
     name: validate_swiftpm_example

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -6,6 +6,10 @@ on:
     - main
   pull_request:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tsan:
     name: tsan


### PR DESCRIPTION
Signed-off-by: glokta1 <rafeyahmad@protonmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: [mobile ci: cancel ongoing mobile CI jobs when new SHA pushed to PR](https://github.com/glokta1/envoy/commit/ff707a607086cb32cd82ecde3d3d8d03bd0a5a9a)

Additional Description:  Added the `concurrency` key to all workflows which had a `pull_request` event attached. Some workflows are also additionally triggered on push to main, so added a fallback variable `github.run_id` to avoid syntax errors.

I was a little confused on whether to cancel the workflows that are run by cronjobs like  `codeql-daily.yml` but still include a `pull_request` event in some step. I have set it to cancel but let me know if this needs to be changed.

Fixes #24982 