### PR TITLE
Fix divide by zero fuzz issue

### DIFF
--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1000,6 +1000,49 @@ double EdfLoadBalancerBase::applySlowStartFactor(double host_weight, const Host&
   }
 }
 
+double LeastRequestLoadBalancer::hostWeight(const Host& host) {
+  // This method is called to calculate the dynamic weight as following when all load balancing
+  // weights are not equal:
+  //
+  // `weight = load_balancing_weight / (active_requests + 1)^active_request_bias`
+  //
+  // `active_request_bias` can be configured via runtime and its value is cached in
+  // `active_request_bias_` to avoid having to do a runtime lookup each time a host weight is
+  // calculated.
+  //
+  // When `active_request_bias == 0.0` we behave like `RoundRobinLoadBalancer` and return the
+  // host weight without considering the number of active requests at the time we do the pick.
+  //
+  // When `active_request_bias > 0.0` we scale the host weight by the number of active
+  // requests at the time we do the pick. We always add 1 to avoid division by 0.
+  //
+  // It might be possible to do better by picking two hosts off of the schedule, and selecting the
+  // one with fewer active requests at the time of selection.
+
+  double host_weight = static_cast<double>(host.weight());
+
+  // If the value of active requests is the max value, adding +1 will overflow
+  // it and cause a divide by zero. This won't happen in normal cases but stops
+  // failing fuzz tests
+  const uint64_t active_request_value =
+      host.stats().rq_active_.value() != std::numeric_limits<uint64_t>::max()
+          ? host.stats().rq_active_.value() + 1
+          : host.stats().rq_active_.value();
+
+  if (active_request_bias_ == 1.0) {
+    host_weight = static_cast<double>(host.weight()) / active_request_value;
+  } else if (active_request_bias_ != 0.0) {
+    host_weight =
+        static_cast<double>(host.weight()) / std::pow(active_request_value, active_request_bias_);
+  }
+
+  if (!noHostsAreInSlowStart()) {
+    return applySlowStartFactor(host_weight, host);
+  } else {
+    return host_weight;
+  }
+}
+
 HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPeek(const HostVector&,
                                                                 const HostsSource&) {
   // LeastRequestLoadBalancer can not do deterministic preconnecting, because

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -686,48 +686,7 @@ protected:
 
 private:
   void refreshHostSource(const HostsSource&) override {}
-  double hostWeight(const Host& host) override {
-    // This method is called to calculate the dynamic weight as following when all load balancing
-    // weights are not equal:
-    //
-    // `weight = load_balancing_weight / (active_requests + 1)^active_request_bias`
-    //
-    // `active_request_bias` can be configured via runtime and its value is cached in
-    // `active_request_bias_` to avoid having to do a runtime lookup each time a host weight is
-    // calculated.
-    //
-    // When `active_request_bias == 0.0` we behave like `RoundRobinLoadBalancer` and return the
-    // host weight without considering the number of active requests at the time we do the pick.
-    //
-    // When `active_request_bias > 0.0` we scale the host weight by the number of active
-    // requests at the time we do the pick. We always add 1 to avoid division by 0.
-    //
-    // It might be possible to do better by picking two hosts off of the schedule, and selecting the
-    // one with fewer active requests at the time of selection.
-
-    double host_weight = static_cast<double>(host.weight());
-
-    // If the value of active requests is the max value, adding +1 will overflow
-    // it and cause a divide by zero. This won't happen in normal cases but stops
-    // failing fuzz tests
-    auto active_request_value =
-        host.stats().rq_active_.value() != std::numeric_limits<uint64_t>::max()
-            ? host.stats().rq_active_.value() + 1
-            : host.stats().rq_active_.value();
-
-    if (active_request_bias_ == 1.0) {
-      host_weight = static_cast<double>(host.weight()) / active_request_value;
-    } else if (active_request_bias_ != 0.0) {
-      host_weight =
-          static_cast<double>(host.weight()) / std::pow(active_request_value, active_request_bias_);
-    }
-
-    if (!noHostsAreInSlowStart()) {
-      return applySlowStartFactor(host_weight, host);
-    } else {
-      return host_weight;
-    }
-  }
+  double hostWeight(const Host& host) override;
   HostConstSharedPtr unweightedHostPeek(const HostVector& hosts_to_use,
                                         const HostsSource& source) override;
   HostConstSharedPtr unweightedHostPick(const HostVector& hosts_to_use,

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -707,11 +707,19 @@ private:
 
     double host_weight = static_cast<double>(host.weight());
 
+    // If the value of active requests is the max value, adding +1 will overflow
+    // it and cause a divide by zero. This won't happen in normal cases but stops
+    // failing fuzz tests
+    auto active_request_value =
+        host.stats().rq_active_.value() != std::numeric_limits<uint64_t>::max()
+            ? host.stats().rq_active_.value() + 1
+            : host.stats().rq_active_.value();
+
     if (active_request_bias_ == 1.0) {
-      host_weight = static_cast<double>(host.weight()) / (host.stats().rq_active_.value() + 1);
+      host_weight = static_cast<double>(host.weight()) / active_request_value;
     } else if (active_request_bias_ != 0.0) {
-      host_weight = static_cast<double>(host.weight()) /
-                    std::pow(host.stats().rq_active_.value() + 1, active_request_bias_);
+      host_weight =
+          static_cast<double>(host.weight()) / std::pow(active_request_value, active_request_bias_);
     }
 
     if (!noHostsAreInSlowStart()) {

--- a/test/common/upstream/least_request_load_balancer_corpus/least_request-max-request-value
+++ b/test/common/upstream/least_request_load_balancer_corpus/least_request-max-request-value
@@ -1,0 +1,24 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 96
+      random_bytestring: 5
+    }
+    seed_for_prng: 7
+  }
+  random_bytestring_for_weights: "K"
+}
+least_request_lb_config {
+  slow_start_config {
+    slow_start_window {
+      nanos: 1048576
+    }
+    aggression {
+      default_value: 2
+      runtime_key: "("
+    }
+  }
+}
+random_bytestring_for_requests: "\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201\201h"


### PR DESCRIPTION
Signed-off-by: AlanDiaz <diazalan@google.com>

Commit Message: Fix for divide by zero bug
Additional Description: If the number of active requests meets the max value of uint64, the + 1 will overflow the value to zero and cause a divide by zero error. This is unlikely to happen in normal cases but stops a fuzz test from failing.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
