### PR TITLE
tls: Use a generic lambda for BoringSSL comparison functions

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -104,8 +104,10 @@ SPIFFEValidator::SPIFFEValidator(const Envoy::Ssl::CertificateValidationContextC
 }
 
 void SPIFFEValidator::addClientValidationContext(SSL_CTX* ctx, bool) {
-  bssl::UniquePtr<STACK_OF(X509_NAME)> list(sk_X509_NAME_new(
-      [](const X509_NAME** a, const X509_NAME** b) -> int { return X509_NAME_cmp(*a, *b); }));
+  // Use a generic lambda to be compatible with BoringSSL before and after
+  // https://boringssl-review.googlesource.com/c/boringssl/+/56190
+  bssl::UniquePtr<STACK_OF(X509_NAME)> list(
+      sk_X509_NAME_new([](auto* a, auto* b) -> int { return X509_NAME_cmp(*a, *b); }));
 
   for (auto& ca : ca_certs_) {
     X509_NAME* name = X509_get_subject_name(ca.get());


### PR DESCRIPTION
Commit Message:
`STACK_OF(T)`'s comparison functions take a double pointer (the double pointer is silly, but it dates to C `qsort`). Both pointers are supposed to be const, but we incorrectly only marked one as const in BoringSSL. I.e. our type is `const T **`. In OpenSSL, the type is `const T *const *` https://www.openssl.org/docs/man1.1.1/man3/DEFINE_SPECIAL_STACK_OF.html

We plan on switching BoringSSL to match OpenSSL in https://boringssl-review.googlesource.com/c/boringssl/+/56190, making it both more const-correct and to remove an unnecessary OpenSSL/BoringSSL API divergence.

To avoid Envoy breaking, this patch switches the call sites to C++14 generic lambdas. This will keep Envoy compatible both before and after that PR. Once your minimum BoringSSL revision moves past that CL, you can switch back to explicit types, if you like.

Signed-off-by: David Benjamin <davidben@google.com>

Additional Description:
Risk Level: low (no behavior change)
Testing: compiles
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
