### PR TITLE
ZK filter: add RelativeZxid support for SetWatches requests

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -422,6 +422,8 @@ void DecoderImpl::parseReconfigRequest(Buffer::Instance& data, uint64_t& offset,
 void DecoderImpl::parseSetWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len) {
   ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + (3 * INT_LENGTH));
 
+  // Ignore relative Zxid.
+  helper_.peekInt64(data, offset);
   // Data watches.
   skipStrings(data, offset);
   // Exist watches.

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -365,6 +365,7 @@ public:
     buffer.writeBEInt<int32_t>(8 + watches_buffer.length());
     buffer.writeBEInt<int32_t>(xid);
     buffer.writeBEInt<int32_t>(enumToSignedInt(OpCodes::SetWatches));
+    buffer.writeBEInt<int64_t>(3000);
     buffer.add(watches_buffer);
 
     return buffer;
@@ -877,8 +878,8 @@ TEST_F(ZooKeeperFilterTest, SetWatchesRequestControlXid) {
   Buffer::OwnedImpl data =
       encodeSetWatchesRequest(dataw, existw, childw, enumToSignedInt(XidCodes::SetWatchesXid));
 
-  testRequest(data, {{{"opname", "setwatches"}}, {{"bytes", "76"}}},
-              config_->stats().setwatches_rq_, 76);
+  testRequest(data, {{{"opname", "setwatches"}}, {{"bytes", "84"}}},
+              config_->stats().setwatches_rq_, 84);
   testResponse(
       {{{"opname", "setwatches_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
       config_->stats().setwatches_resp_, enumToSignedInt(XidCodes::SetWatchesXid));
@@ -893,8 +894,8 @@ TEST_F(ZooKeeperFilterTest, SetWatchesRequest) {
 
   Buffer::OwnedImpl data = encodeSetWatchesRequest(dataw, existw, childw);
 
-  testRequest(data, {{{"opname", "setwatches"}}, {{"bytes", "76"}}},
-              config_->stats().setwatches_rq_, 76);
+  testRequest(data, {{{"opname", "setwatches"}}, {{"bytes", "84"}}},
+              config_->stats().setwatches_rq_, 84);
   testResponse(
       {{{"opname", "setwatches_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
       config_->stats().setwatches_resp_);


### PR DESCRIPTION
Signed-off-by: Zhewei Hu <zhu@pinterest.com>

Commit Message: ZK filter: add RelativeZxid support for SetWatches requests
Additional Description: When parsing the SetWatches requests, we noticed some decoder errors. After looking into the requests bytes, we found that the [RelativeZxid](https://github.com/apache/zookeeper/blob/master/zookeeper-jute/src/main/resources/zookeeper.jute#L78) was not skipped during the decoding. This diff try to skip RelativeZxid then the filter could parse later watches data correctly without raising the "read beyond the max length" or "packet is too big" errors.
Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A