### PR TITLE
ci: Remove deprecated `proto_format` check warning

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1066,13 +1066,6 @@ if __name__ == "__main__":
     if format_checker.check_error_messages(ct_error_messages):
         sys.exit(1)
 
-    if not os.environ.get("CI"):
-        # TODO(phlax): Remove this after a month or so
-        logger.warning(
-            "Please note: `tools/code_format/check_format.py` no longer checks API `.proto` files, "
-            "please use `tools/proto_format/proto_format.sh` if you are making changes to the API files"
-        )
-
     def check_visibility(error_messages):
         command = (
             "git diff $(tools/git/last_github_commit.sh) -- source/extensions/* %s |grep '+.*visibility ='"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
