### PR TITLE
CustomCluster configuration memory optimization

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -968,7 +968,8 @@ public:
   /**
    * @return the type of cluster, only used for custom discovery types.
    */
-  virtual OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> clusterType() const PURE;
+  virtual OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>
+  clusterType() const PURE;
 
   /**
    * @return configuration for round robin load balancing, only used if LB type is round robin.

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -968,7 +968,7 @@ public:
   /**
    * @return the type of cluster, only used for custom discovery types.
    */
-  virtual const absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType>&
+  virtual OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>
   clusterType() const PURE;
 
   /**

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -968,8 +968,7 @@ public:
   /**
    * @return the type of cluster, only used for custom discovery types.
    */
-  virtual OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>
-  clusterType() const PURE;
+  virtual OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> clusterType() const PURE;
 
   /**
    * @return configuration for round robin load balancing, only used if LB type is round robin.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1054,11 +1054,10 @@ ClusterInfoImpl::ClusterInfoImpl(
                   common_lb_config_.ignore_new_hosts_until_first_hc()),
       set_local_interface_name_on_upstream_connections_(
           config.upstream_connection_options().set_local_interface_name_on_upstream_connections()),
-      cluster_type_(
-          config.has_cluster_type()
-              ? std::make_unique<envoy::config::cluster::v3::Cluster::CustomClusterType>(
-                    config.cluster_type())
-              : nullptr),
+      cluster_type_(config.has_cluster_type()
+                        ? std::make_unique<envoy::config::cluster::v3::Cluster::CustomClusterType>(
+                              config.cluster_type())
+                        : nullptr),
       factory_context_(
           std::make_unique<FactoryContextImpl>(*stats_scope_, runtime, factory_context)),
       upstream_context_(server_context, init_manager, *stats_scope_) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1056,9 +1056,9 @@ ClusterInfoImpl::ClusterInfoImpl(
           config.upstream_connection_options().set_local_interface_name_on_upstream_connections()),
       cluster_type_(
           config.has_cluster_type()
-              ? absl::make_optional<envoy::config::cluster::v3::Cluster::CustomClusterType>(
+              ? std::make_unique<envoy::config::cluster::v3::Cluster::CustomClusterType>(
                     config.cluster_type())
-              : absl::nullopt),
+              : nullptr),
       factory_context_(
           std::make_unique<FactoryContextImpl>(*stats_scope_, runtime, factory_context)),
       upstream_context_(server_context, init_manager, *stats_scope_) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -762,7 +762,8 @@ public:
   LoadBalancerType lbType() const override { return lb_type_; }
   envoy::config::cluster::v3::Cluster::DiscoveryType type() const override { return type_; }
 
-  OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> clusterType() const override {
+  OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>
+  clusterType() const override {
     if (cluster_type_ == nullptr) {
       return absl::nullopt;
     }
@@ -975,7 +976,7 @@ private:
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;
   absl::optional<std::string> eds_service_name_;
-  const std::unique_ptr<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   const std::unique_ptr<Server::Configuration::CommonFactoryContext> factory_context_;
   std::vector<Network::FilterFactoryCb> filter_factories_;
   Http::FilterChainUtility::FilterFactoriesList http_filter_factories_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -976,7 +976,7 @@ private:
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;
   absl::optional<std::string> eds_service_name_;
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   const std::unique_ptr<Server::Configuration::CommonFactoryContext> factory_context_;
   std::vector<Network::FilterFactoryCb> filter_factories_;
   Http::FilterChainUtility::FilterFactoriesList http_filter_factories_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -761,9 +761,14 @@ public:
   extensionProtocolOptions(const std::string& name) const override;
   LoadBalancerType lbType() const override { return lb_type_; }
   envoy::config::cluster::v3::Cluster::DiscoveryType type() const override { return type_; }
-  const absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType>&
+
+  OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>
   clusterType() const override {
-    return cluster_type_;
+    if(cluster_type_ == nullptr)
+    {
+      return absl::nullopt;
+    }
+    return *cluster_type_;
   }
   OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
   lbRoundRobinConfig() const override {
@@ -972,7 +977,7 @@ private:
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;
   absl::optional<std::string> eds_service_name_;
-  const absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  const std::unique_ptr<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   const std::unique_ptr<Server::Configuration::CommonFactoryContext> factory_context_;
   std::vector<Network::FilterFactoryCb> filter_factories_;
   Http::FilterChainUtility::FilterFactoriesList http_filter_factories_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -762,10 +762,8 @@ public:
   LoadBalancerType lbType() const override { return lb_type_; }
   envoy::config::cluster::v3::Cluster::DiscoveryType type() const override { return type_; }
 
-  OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>
-  clusterType() const override {
-    if(cluster_type_ == nullptr)
-    {
+  OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> clusterType() const override {
+    if (cluster_type_ == nullptr) {
       return absl::nullopt;
     }
     return *cluster_type_;

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -90,7 +90,7 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
 
   // We only need to do DNS lookups for hosts in dynamic forward proxy clusters,
   // since the other cluster types do their own DNS management.
-  OptRef<CustomClusterType> cluster_type = cluster_info_->clusterType();
+  OptRef<const CustomClusterType> cluster_type = cluster_info_->clusterType();
   if (!cluster_type.has_value()) {
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -90,8 +90,8 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
 
   // We only need to do DNS lookups for hosts in dynamic forward proxy clusters,
   // since the other cluster types do their own DNS management.
-  const absl::optional<CustomClusterType>& cluster_type = cluster_info_->clusterType();
-  if (!cluster_type) {
+  OptRef<CustomClusterType> cluster_type = cluster_info_->clusterType();
+  if (!cluster_type.has_value()) {
     return Http::FilterHeadersStatus::Continue;
   }
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -156,7 +156,7 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
   // its members. This is done once to minimize overhead in the data path, makeRequest() in
   // particular.
   Upstream::ClusterInfoConstSharedPtr info = cluster_->info();
-  const auto& cluster_type = info->clusterType();
+  OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type = info->clusterType();
   is_redis_cluster_ = info->lbType() == Upstream::LoadBalancerType::ClusterProvided &&
                       cluster_type.has_value() && cluster_type->name() == "envoy.clusters.redis";
 }

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -156,7 +156,8 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
   // its members. This is done once to minimize overhead in the data path, makeRequest() in
   // particular.
   Upstream::ClusterInfoConstSharedPtr info = cluster_->info();
-  OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type = info->clusterType();
+  OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type =
+      info->clusterType();
   is_redis_cluster_ = info->lbType() == Upstream::LoadBalancerType::ClusterProvided &&
                       cluster_type.has_value() && cluster_type->name() == "envoy.clusters.redis";
 }

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -65,7 +65,9 @@ public:
     // kind we need to do DNS entries for.
     CustomClusterType cluster_type;
     cluster_type.set_name("envoy.clusters.dynamic_forward_proxy");
-    cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = cluster_type;
+    cm_.thread_local_cluster_.cluster_.info_->cluster_type_ =
+        std::make_unique<const envoy::config::cluster::v3::Cluster::CustomClusterType>(
+            cluster_type);
 
     // Configure max pending to 1 so we can test circuit breaking.
     cm_.thread_local_cluster_.cluster_.info_->resetResourceManager(0, 1, 0, 0, 0, 100);
@@ -284,7 +286,7 @@ TEST_F(ProxyFilterTest, NoCluster) {
 
 // No cluster type leads to skipping DNS lookups.
 TEST_F(ProxyFilterTest, NoClusterType) {
-  cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = absl::nullopt;
+  cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = nullptr;
 
   InSequence s;
 
@@ -297,7 +299,8 @@ TEST_F(ProxyFilterTest, NoClusterType) {
 TEST_F(ProxyFilterTest, NonDynamicForwardProxy) {
   CustomClusterType cluster_type;
   cluster_type.set_name("envoy.cluster.static");
-  cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = cluster_type;
+  cm_.thread_local_cluster_.cluster_.info_->cluster_type_ =
+      std::make_unique<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type);
 
   InSequence s;
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -1032,13 +1032,12 @@ TEST_F(RedisConnPoolImplTest, HostsAddedAndEndWithClusterRemoval) {
 
 TEST_F(RedisConnPoolImplTest, MakeRequestToRedisCluster) {
 
-  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type_;
-  cluster_type_.set_name("envoy.clusters.redis");
+  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type;
+  cluster_type.set_name("envoy.clusters.redis");
 
-  OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type =
-      makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type_);
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
-      .WillOnce(Return(cluster_type));
+      .WillOnce(Return(
+          makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type)));
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, lbType())
       .WillOnce(Return(Upstream::LoadBalancerType::ClusterProvided));
 
@@ -1054,13 +1053,12 @@ TEST_F(RedisConnPoolImplTest, MakeRequestToRedisCluster) {
 
 TEST_F(RedisConnPoolImplTest, MakeRequestToRedisClusterHashtag) {
 
-  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type_;
-  cluster_type_.set_name("envoy.clusters.redis");
+  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type;
+  cluster_type.set_name("envoy.clusters.redis");
 
-  OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type =
-      makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type_);
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
-      .WillOnce(Return(cluster_type));
+      .WillOnce(Return(
+          makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type)));
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, lbType())
       .WillOnce(Return(Upstream::LoadBalancerType::ClusterProvided));
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -1032,11 +1032,13 @@ TEST_F(RedisConnPoolImplTest, HostsAddedAndEndWithClusterRemoval) {
 
 TEST_F(RedisConnPoolImplTest, MakeRequestToRedisCluster) {
 
-  absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type;
-  cluster_type.emplace();
-  cluster_type->set_name("envoy.clusters.redis");
+  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type_;
+  cluster_type_.set_name("envoy.clusters.redis");
+
+  OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type =
+      makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type_);
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
-      .WillOnce(ReturnRef(cluster_type));
+      .WillOnce(Return(cluster_type));
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, lbType())
       .WillOnce(Return(Upstream::LoadBalancerType::ClusterProvided));
 
@@ -1052,11 +1054,13 @@ TEST_F(RedisConnPoolImplTest, MakeRequestToRedisCluster) {
 
 TEST_F(RedisConnPoolImplTest, MakeRequestToRedisClusterHashtag) {
 
-  absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type;
-  cluster_type.emplace();
-  cluster_type->set_name("envoy.clusters.redis");
+  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type_;
+  cluster_type_.set_name("envoy.clusters.redis");
+
+  OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type =
+      makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type_);
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
-      .WillOnce(ReturnRef(cluster_type));
+      .WillOnce(Return(cluster_type));
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, lbType())
       .WillOnce(Return(Upstream::LoadBalancerType::ClusterProvided));
 

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -171,10 +171,10 @@ MockClusterInfo::MockClusterInfo()
       }));
   ON_CALL(*this, clusterType())
       .WillByDefault(
-        Invoke([this]() -> OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> {
-          return makeOptRefFromPtr<envoy::config::cluster::v3::Cluster::CustomClusterType>(
-              cluster_type_.get());
-        }));
+          Invoke([this]() -> OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> {
+            return makeOptRefFromPtr<envoy::config::cluster::v3::Cluster::CustomClusterType>(
+                cluster_type_.get());
+          }));
   ON_CALL(*this, upstreamHttpProtocol(_))
       .WillByDefault(Return(std::vector<Http::Protocol>{Http::Protocol::Http11}));
   ON_CALL(*this, createFilterChain(_, _))

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -169,7 +169,12 @@ MockClusterInfo::MockClusterInfo()
         }
         return *typed_metadata_;
       }));
-  ON_CALL(*this, clusterType()).WillByDefault(ReturnRef(cluster_type_));
+  ON_CALL(*this, clusterType())
+      .WillByDefault(
+        Invoke([this]() -> OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> {
+          return makeOptRefFromPtr<envoy::config::cluster::v3::Cluster::CustomClusterType>(
+              cluster_type_.get());
+        }));
   ON_CALL(*this, upstreamHttpProtocol(_))
       .WillByDefault(Return(std::vector<Http::Protocol>{Http::Protocol::Http11}));
   ON_CALL(*this, createFilterChain(_, _))

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -171,8 +171,8 @@ MockClusterInfo::MockClusterInfo()
       }));
   ON_CALL(*this, clusterType())
       .WillByDefault(
-          Invoke([this]() -> OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType> {
-            return makeOptRefFromPtr<envoy::config::cluster::v3::Cluster::CustomClusterType>(
+          Invoke([this]() -> OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType> {
+            return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::CustomClusterType>(
                 cluster_type_.get());
           }));
   ON_CALL(*this, upstreamHttpProtocol(_))

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -229,7 +229,7 @@ public:
   LoadBalancerType lb_type_{LoadBalancerType::RoundRobin};
   envoy::config::cluster::v3::Cluster::DiscoveryType type_{
       envoy::config::cluster::v3::Cluster::STRICT_DNS};
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
   absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -131,8 +131,8 @@ public:
   MOCK_METHOD(const envoy::config::cluster::v3::Cluster::CommonLbConfig&, lbConfig, (), (const));
   MOCK_METHOD(LoadBalancerType, lbType, (), (const));
   MOCK_METHOD(envoy::config::cluster::v3::Cluster::DiscoveryType, type, (), (const));
-  MOCK_METHOD(OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>,
-              clusterType, (), (const));
+  MOCK_METHOD(OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>, clusterType, (),
+              (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>, lbRingHashConfig,
               (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>, lbMaglevConfig, (),

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -131,7 +131,7 @@ public:
   MOCK_METHOD(const envoy::config::cluster::v3::Cluster::CommonLbConfig&, lbConfig, (), (const));
   MOCK_METHOD(LoadBalancerType, lbType, (), (const));
   MOCK_METHOD(envoy::config::cluster::v3::Cluster::DiscoveryType, type, (), (const));
-  MOCK_METHOD(OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>, clusterType, (),
+  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>, clusterType, (),
               (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>, lbRingHashConfig,
               (), (const));
@@ -229,7 +229,7 @@ public:
   LoadBalancerType lb_type_{LoadBalancerType::RoundRobin};
   envoy::config::cluster::v3::Cluster::DiscoveryType type_{
       envoy::config::cluster::v3::Cluster::STRICT_DNS};
-  std::unique_ptr<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
   absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -131,7 +131,7 @@ public:
   MOCK_METHOD(const envoy::config::cluster::v3::Cluster::CommonLbConfig&, lbConfig, (), (const));
   MOCK_METHOD(LoadBalancerType, lbType, (), (const));
   MOCK_METHOD(envoy::config::cluster::v3::Cluster::DiscoveryType, type, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType>&,
+  MOCK_METHOD(OptRef<envoy::config::cluster::v3::Cluster::CustomClusterType>,
               clusterType, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>, lbRingHashConfig,
               (), (const));
@@ -229,7 +229,7 @@ public:
   LoadBalancerType lb_type_{LoadBalancerType::RoundRobin};
   envoy::config::cluster::v3::Cluster::DiscoveryType type_{
       envoy::config::cluster::v3::Cluster::STRICT_DNS};
-  absl::optional<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
+  std::unique_ptr<envoy::config::cluster::v3::Cluster::CustomClusterType> cluster_type_;
   NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
   absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;


### PR DESCRIPTION
Commit Message: Saves memory in cluster info
Additional Description: In cases where CustomClusterType is not used, the unique_ptr will be null and save memory
Risk Level: Low
Testing: Changed mock for new typing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
