### PR TITLE
Upstream config memory optimization

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1007,7 +1007,7 @@ public:
    * @return const absl::optional<envoy::config::core::v3::TypedExtensionConfig>& the configuration
    *         for the upstream, if a custom upstream is configured.
    */
-  virtual const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
+  virtual OptRef<envoy::config::core::v3::TypedExtensionConfig>
   upstreamConfig() const PURE;
 
   /**

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1007,8 +1007,7 @@ public:
    * @return const absl::optional<envoy::config::core::v3::TypedExtensionConfig>& the configuration
    *         for the upstream, if a custom upstream is configured.
    */
-  virtual OptRef<envoy::config::core::v3::TypedExtensionConfig>
-  upstreamConfig() const PURE;
+  virtual OptRef<envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const PURE;
 
   /**
    * @return Whether the cluster is currently in maintenance mode and should not be routed to.

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1007,7 +1007,7 @@ public:
    * @return const absl::optional<envoy::config::core::v3::TypedExtensionConfig>& the configuration
    *         for the upstream, if a custom upstream is configured.
    */
-  virtual OptRef<envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const PURE;
+  virtual OptRef<const envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const PURE;
 
   /**
    * @return Whether the cluster is currently in maintenance mode and should not be routed to.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -710,10 +710,10 @@ Filter::createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster) {
   GenericConnPoolFactory* factory = nullptr;
   if (cluster_->upstreamConfig().has_value()) {
     factory = Envoy::Config::Utility::getFactory<GenericConnPoolFactory>(
-        cluster_->upstreamConfig().value());
+        cluster_->upstreamConfig().ref());
     ENVOY_BUG(factory != nullptr,
               fmt::format("invalid factory type '{}', failing over to default upstream",
-                          cluster_->upstreamConfig().value().DebugString()));
+                          cluster_->upstreamConfig().ref().DebugString()));
   }
   if (!factory) {
     factory = &config_.router_context_.genericConnPoolFactory();

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -471,7 +471,7 @@ bool Filter::maybeTunnel(Upstream::ThreadLocalCluster& cluster) {
   GenericConnPoolFactory* factory = nullptr;
   if (cluster.info()->upstreamConfig().has_value()) {
     factory = Envoy::Config::Utility::getFactory<GenericConnPoolFactory>(
-        cluster.info()->upstreamConfig().value());
+        cluster.info()->upstreamConfig().ref());
   } else {
     factory = Envoy::Config::Utility::getFactoryByName<GenericConnPoolFactory>(
         "envoy.filters.connection_pools.tcp.generic");

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1040,9 +1040,9 @@ ClusterInfoImpl::ClusterInfoImpl(
                     config.original_dst_lb_config())
               : nullptr),
       upstream_config_(config.has_upstream_config()
-                           ? absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>(
+                           ? std::make_unique<envoy::config::core::v3::TypedExtensionConfig>(
                                  config.upstream_config())
-                           : absl::nullopt),
+                           : nullptr),
       added_via_api_(added_via_api),
       lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())),
       metadata_(config.metadata()), typed_metadata_(config.metadata()),

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -800,9 +800,12 @@ public:
     }
     return *lb_original_dst_config_;
   }
-  const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&
+  OptRef<envoy::config::core::v3::TypedExtensionConfig>
   upstreamConfig() const override {
-    return upstream_config_;
+    if(upstream_config_ == nullptr) {
+      return absl::nullopt;
+    }
+    return *upstream_config_;
   }
   bool maintenanceMode() const override;
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
@@ -957,7 +960,7 @@ private:
       lb_maglev_config_;
   const std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
       lb_original_dst_config_;
-  absl::optional<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
+  std::unique_ptr<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
   const bool added_via_api_;
   LoadBalancerSubsetInfoImpl lb_subset_;
   const envoy::config::core::v3::Metadata metadata_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -800,9 +800,8 @@ public:
     }
     return *lb_original_dst_config_;
   }
-  OptRef<envoy::config::core::v3::TypedExtensionConfig>
-  upstreamConfig() const override {
-    if(upstream_config_ == nullptr) {
+  OptRef<envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const override {
+    if (upstream_config_ == nullptr) {
       return absl::nullopt;
     }
     return *upstream_config_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -800,7 +800,7 @@ public:
     }
     return *lb_original_dst_config_;
   }
-  OptRef<envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const override {
+  OptRef<const envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const override {
     if (upstream_config_ == nullptr) {
       return absl::nullopt;
     }

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -107,9 +107,8 @@ public:
     cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
         std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
     envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-    cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
-        mutable_typed_config()
-        ->PackFrom(generic_config);
+    cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()->PackFrom(
+        generic_config);
     callbacks_.route_->route_entry_.connect_config_ =
         absl::make_optional<RouteEntry::ConnectConfig>();
 
@@ -5848,9 +5847,8 @@ TEST_F(RouterTest, InvalidUpstream) {
       std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   // Configure a TCP upstream rather than an HTTP upstream.
   envoy::extensions::upstreams::tcp::generic::v3::GenericConnectionPoolProto generic_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
-      mutable_typed_config()
-      ->PackFrom(generic_config);
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()->PackFrom(
+      generic_config);
 
   NiceMock<Http::MockRequestEncoder> encoder;
   Http::ResponseDecoder* response_decoder = nullptr;
@@ -5879,8 +5877,8 @@ TEST_F(RouterTest, ConnectPauseNoResume) {
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
       std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::http::v3::HttpConnectionPoolProto http_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()
-      ->PackFrom(http_config);
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()->PackFrom(
+      http_config);
 
   NiceMock<Http::MockRequestEncoder> encoder;
   Http::ResponseDecoder* response_decoder = nullptr;
@@ -5912,9 +5910,8 @@ TEST_F(RouterTest, ConnectExplicitTcpUpstream) {
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
       std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::tcp::v3::TcpConnectionPoolProto tcp_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
-      mutable_typed_config()
-      ->PackFrom(tcp_config);
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()->PackFrom(
+      tcp_config);
   callbacks_.route_->route_entry_.connect_config_ =
       absl::make_optional<RouteEntry::ConnectConfig>();
 
@@ -5934,9 +5931,8 @@ TEST_F(RouterTest, PostExplicitTcpUpstream) {
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
       std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
-      mutable_typed_config()
-      ->PackFrom(generic_config);
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()->PackFrom(
+      generic_config);
   callbacks_.route_->route_entry_.connect_config_ =
       absl::make_optional<RouteEntry::ConnectConfig>();
   callbacks_.route_->route_entry_.connect_config_.value().set_allow_post(true);
@@ -5956,9 +5952,8 @@ TEST_F(RouterTest, PostHttpUpstream) {
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
       std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
-      mutable_typed_config()
-      ->PackFrom(generic_config);
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()->PackFrom(
+      generic_config);
   callbacks_.route_->route_entry_.connect_config_ =
       absl::make_optional<RouteEntry::ConnectConfig>();
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -105,10 +105,10 @@ public:
             }));
 
     cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
-        absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+        std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
     envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-    cm_.thread_local_cluster_.cluster_.info_->upstream_config_.value()
-        .mutable_typed_config()
+    cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
+        mutable_typed_config()
         ->PackFrom(generic_config);
     callbacks_.route_->route_entry_.connect_config_ =
         absl::make_optional<RouteEntry::ConnectConfig>();
@@ -5845,11 +5845,11 @@ TEST_F(RouterTest, ConnectPauseAndResume) {
 TEST_F(RouterTest, InvalidUpstream) {
   // Explicitly configure an HTTP upstream, to test factory creation.
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
-      absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+      std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   // Configure a TCP upstream rather than an HTTP upstream.
   envoy::extensions::upstreams::tcp::generic::v3::GenericConnectionPoolProto generic_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_.value()
-      .mutable_typed_config()
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
+      mutable_typed_config()
       ->PackFrom(generic_config);
 
   NiceMock<Http::MockRequestEncoder> encoder;
@@ -5877,10 +5877,9 @@ TEST_F(RouterTest, InvalidUpstream) {
 TEST_F(RouterTest, ConnectPauseNoResume) {
   // Explicitly configure an HTTP upstream, to test factory creation.
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
-      absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+      std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::http::v3::HttpConnectionPoolProto http_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_.value()
-      .mutable_typed_config()
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->mutable_typed_config()
       ->PackFrom(http_config);
 
   NiceMock<Http::MockRequestEncoder> encoder;
@@ -5911,10 +5910,10 @@ TEST_F(RouterTest, ConnectPauseNoResume) {
 TEST_F(RouterTest, ConnectExplicitTcpUpstream) {
   // Explicitly configure a TCP upstream, to test factory creation.
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
-      absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+      std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::tcp::v3::TcpConnectionPoolProto tcp_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_.value()
-      .mutable_typed_config()
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
+      mutable_typed_config()
       ->PackFrom(tcp_config);
   callbacks_.route_->route_entry_.connect_config_ =
       absl::make_optional<RouteEntry::ConnectConfig>();
@@ -5933,10 +5932,10 @@ TEST_F(RouterTest, ConnectExplicitTcpUpstream) {
 TEST_F(RouterTest, PostExplicitTcpUpstream) {
   // Explicitly configure a generic upstream, to test factory creation.
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
-      absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+      std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_.value()
-      .mutable_typed_config()
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
+      mutable_typed_config()
       ->PackFrom(generic_config);
   callbacks_.route_->route_entry_.connect_config_ =
       absl::make_optional<RouteEntry::ConnectConfig>();
@@ -5955,10 +5954,10 @@ TEST_F(RouterTest, PostExplicitTcpUpstream) {
 TEST_F(RouterTest, PostHttpUpstream) {
   // Explicitly configure a generic upstream, to test factory creation.
   cm_.thread_local_cluster_.cluster_.info_->upstream_config_ =
-      absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+      std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-  cm_.thread_local_cluster_.cluster_.info_->upstream_config_.value()
-      .mutable_typed_config()
+  cm_.thread_local_cluster_.cluster_.info_->upstream_config_->
+      mutable_typed_config()
       ->PackFrom(generic_config);
   callbacks_.route_->route_entry_.connect_config_ =
       absl::make_optional<RouteEntry::ConnectConfig>();

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -194,9 +194,9 @@ TEST_F(TcpProxyTest, HalfCloseProxy) {
 TEST_F(TcpProxyTest, ExplicitFactory) {
   // Explicitly configure an HTTP upstream, to test factory creation.
   auto& info = factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_;
-  info->upstream_config_ = absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+  info->upstream_config_ = std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   envoy::extensions::upstreams::tcp::generic::v3::GenericConnectionPoolProto generic_config;
-  info->upstream_config_.value().mutable_typed_config()->PackFrom(generic_config);
+  info->upstream_config_->mutable_typed_config()->PackFrom(generic_config);
   setup(1);
 
   raiseEventUpstreamConnected(0);
@@ -216,10 +216,10 @@ TEST_F(TcpProxyTest, ExplicitFactory) {
 // Test nothing bad happens if an invalid factory is configured.
 TEST_F(TcpProxyTest, BadFactory) {
   auto& info = factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_;
-  info->upstream_config_ = absl::make_optional<envoy::config::core::v3::TypedExtensionConfig>();
+  info->upstream_config_ = std::make_unique<envoy::config::core::v3::TypedExtensionConfig>();
   // The HTTP Generic connection pool is not a valid type for TCP upstreams.
   envoy::extensions::upstreams::http::generic::v3::GenericConnectionPoolProto generic_config;
-  info->upstream_config_.value().mutable_typed_config()->PackFrom(generic_config);
+  info->upstream_config_->mutable_typed_config()->PackFrom(generic_config);
 
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
 

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -153,7 +153,15 @@ MockClusterInfo::MockClusterInfo()
                 const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
                 lb_original_dst_config_.get());
           }));
-  ON_CALL(*this, upstreamConfig()).WillByDefault(ReturnRef(upstream_config_));
+  ON_CALL(*this, upstreamConfig())
+      .WillByDefault(Invoke(
+          [this]() -> OptRef<envoy::config::core::v3::TypedExtensionConfig> {
+            return makeOptRefFromPtr<
+            envoy::config::core::v3::TypedExtensionConfig>(
+              upstream_config_.get());
+          }));
+
+
   ON_CALL(*this, lbConfig()).WillByDefault(ReturnRef(lb_config_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, upstreamHttpProtocolOptions())

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -154,10 +154,11 @@ MockClusterInfo::MockClusterInfo()
                 lb_original_dst_config_.get());
           }));
   ON_CALL(*this, upstreamConfig())
-      .WillByDefault(Invoke([this]() -> OptRef<envoy::config::core::v3::TypedExtensionConfig> {
-        return makeOptRefFromPtr<envoy::config::core::v3::TypedExtensionConfig>(
-            upstream_config_.get());
-      }));
+      .WillByDefault(
+          Invoke([this]() -> OptRef<const envoy::config::core::v3::TypedExtensionConfig> {
+            return makeOptRefFromPtr<const envoy::config::core::v3::TypedExtensionConfig>(
+                upstream_config_.get());
+          }));
 
   ON_CALL(*this, lbConfig()).WillByDefault(ReturnRef(lb_config_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -154,13 +154,10 @@ MockClusterInfo::MockClusterInfo()
                 lb_original_dst_config_.get());
           }));
   ON_CALL(*this, upstreamConfig())
-      .WillByDefault(Invoke(
-          [this]() -> OptRef<envoy::config::core::v3::TypedExtensionConfig> {
-            return makeOptRefFromPtr<
-            envoy::config::core::v3::TypedExtensionConfig>(
-              upstream_config_.get());
-          }));
-
+      .WillByDefault(Invoke([this]() -> OptRef<envoy::config::core::v3::TypedExtensionConfig> {
+        return makeOptRefFromPtr<envoy::config::core::v3::TypedExtensionConfig>(
+            upstream_config_.get());
+      }));
 
   ON_CALL(*this, lbConfig()).WillByDefault(ReturnRef(lb_config_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -143,7 +143,8 @@ public:
               lbLeastRequestConfig, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>,
               lbOriginalDstConfig, (), (const));
-  MOCK_METHOD(OptRef<envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig, (), (const));
+  MOCK_METHOD(OptRef<const envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig, (),
+              (const));
   MOCK_METHOD(bool, maintenanceMode, (), (const));
   MOCK_METHOD(uint32_t, maxResponseHeadersCount, (), (const));
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -143,8 +143,7 @@ public:
               lbLeastRequestConfig, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>,
               lbOriginalDstConfig, (), (const));
-  MOCK_METHOD(OptRef<envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig,
-              (), (const));
+  MOCK_METHOD(OptRef<envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig, (), (const));
   MOCK_METHOD(bool, maintenanceMode, (), (const));
   MOCK_METHOD(uint32_t, maxResponseHeadersCount, (), (const));
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -143,7 +143,7 @@ public:
               lbLeastRequestConfig, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>,
               lbOriginalDstConfig, (), (const));
-  MOCK_METHOD(const absl::optional<envoy::config::core::v3::TypedExtensionConfig>&, upstreamConfig,
+  MOCK_METHOD(OptRef<envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig,
               (), (const));
   MOCK_METHOD(bool, maintenanceMode, (), (const));
   MOCK_METHOD(uint32_t, maxResponseHeadersCount, (), (const));
@@ -241,7 +241,7 @@ public:
   std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lb_maglev_config_;
   std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
       lb_original_dst_config_;
-  absl::optional<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
+  std::unique_ptr<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
   Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
   envoy::config::cluster::v3::Cluster::CommonLbConfig lb_config_;
   envoy::config::core::v3::Metadata metadata_;


### PR DESCRIPTION
Commit Message: Reduce memory usage if cluster does not contain an upstream config
Additional Description: In cases where a cluster does not have a set upstream config, this will save memory using unique pointers
Risk Level: Low
Testing: Changed mocks as needed
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
