### PR TITLE
Fix nullptr constructor in grpc_access_log_utils

### DIFF
--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
@@ -172,7 +172,7 @@ void Utility::extractCommonAccessLogProperties(
         *stream_info.downstreamAddressProvider().localAddress(),
         *common_access_log.mutable_downstream_local_address());
   }
-  if (stream_info.downstreamAddressProvider().requestedServerName() != nullptr) {
+  if (!stream_info.downstreamAddressProvider().requestedServerName().empty()) {
     common_access_log.mutable_tls_properties()->set_tls_sni_hostname(
         std::string(stream_info.downstreamAddressProvider().requestedServerName()));
   }


### PR DESCRIPTION
Commit Message: Fix nullptr constructor in grpc_access_log_utils
Additional Description: This is effectively a no-op change for google-impl of absl::string_view, which constructs an empty string_view from nullptr and then compares, to see if the comparator string_view is empty. For std::string_view implementation, however, constructing from nullptr is a problem.
Risk Level: None; intended behavior is preserved.
Testing: Passes existing tests, also tested 'live' in the environment where the old version has a problem.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
