### PR TITLE
subset-lb: fixing a mismatch between checked and returned lb config

### DIFF
--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -365,7 +365,7 @@ private:
 
   OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const {
-    if (round_robin_config_ != nullptr) {
+    if (least_request_config_ != nullptr) {
       return *least_request_config_;
     }
     return absl::nullopt;

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -432,7 +432,7 @@ private:
 
   TimeSource& time_source_;
 
-  friend class SubsetLoadBalancerDescribeMetadataTester;
+  friend class SubsetLoadBalancerInternalStateTester;
 };
 
 } // namespace Upstream


### PR DESCRIPTION

This was approved for a public repo fix because the PR causing the issue was merged 4 days ago.

Commit Message: subset-lb: fixing a mismatch between checked and returned lb config
Additional Description:
PR #24905 optimized the memory used for clusters. However it introduced a subtle bug when Least-Request LB is used, which results in returning the default config for that policy.

Risk Level: Low
Testing: This is a private method that is not easy to validate.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
Fixes commit #24905
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
