### PR TITLE
runtime: removing envoy.reloadable_features.dns_multiple_addresses

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,6 +21,9 @@ bug_fixes:
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+- area: dns
+  change: |
+    removed ``envoy.reloadable_features.dns_multiple_addresses`` runtime flag and legacy code paths.
 - area: router
   change: |
     removed ``envoy.reloadable_features.get_route_config_factory_by_type`` runtime flag. The flag is no longer needed as the behavior is now the default.

--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -87,8 +87,7 @@ Happy Eyeballs Support
 ----------------------
 
 Envoy supports Happy Eyeballs, `RFC6555 <https://tools.ietf.org/html/rfc6555>`_,
-for upstream TCP connections. This behavior is now on by default but can be disabled by the runtime flag
-``envoy.reloadable_features.allow_multiple_dns_addresses``. For clusters which use
+for upstream TCP connections.  For clusters which use
 :ref:`LOGICAL_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.LOGICAL_DNS>`,
 this behavior is configured by setting the DNS IP address resolution policy in
 :ref:`config.cluster.v3.Cluster.DnsLookupFamily <envoy_v3_api_enum_config.cluster.v3.Cluster.DnsLookupFamily>`

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -213,7 +213,6 @@ std::string EngineBuilder::generateConfigStr() const {
         {"dns_fail_max_interval", fmt::format("{}s", dns_failure_refresh_seconds_max_)},
         {"dns_lookup_family", enable_happy_eyeballs_ ? "ALL" : "V4_PREFERRED"},
         {"dns_min_refresh_rate", fmt::format("{}s", dns_min_refresh_seconds_)},
-        {"dns_multiple_addresses", enable_happy_eyeballs_ ? "true" : "false"},
         {"dns_preresolve_hostnames", dns_preresolve_hostnames_},
         {"dns_refresh_rate", fmt::format("{}s", dns_refresh_seconds_)},
         {"dns_query_timeout", fmt::format("{}s", dns_query_timeout_seconds_)},

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -117,7 +117,6 @@ const std::string config_header = R"(
 - &dns_fail_max_interval 10s
 - &dns_lookup_family ALL
 - &dns_min_refresh_rate 60s
-- &dns_multiple_addresses true
 - &dns_preresolve_hostnames []
 - &dns_query_timeout 25s
 - &dns_refresh_rate 60s
@@ -531,7 +530,6 @@ layered_runtime:
           # Global stats do not play well with engines with limited lifetimes
           disallow_global_stats: true
           reloadable_features:
-            allow_multiple_dns_addresses: *dns_multiple_addresses
             always_use_v6: *force_ipv6
             skip_dns_lookup_for_proxied_requests: *skip_dns_lookup_for_proxied_requests
 )"

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -234,8 +234,6 @@ public class EnvoyConfiguration {
         .append(String.format("- &dns_preresolve_hostnames %s\n", dnsPreresolveHostnames))
         .append(String.format("- &dns_lookup_family %s\n",
                               enableHappyEyeballs ? "ALL" : "V4_PREFERRED"))
-        .append(
-            String.format("- &dns_multiple_addresses %s\n", enableHappyEyeballs ? "true" : "false"))
         .append(String.format("- &dns_refresh_rate %ss\n", dnsRefreshSeconds))
         .append(String.format("- &enable_drain_post_dns_refresh %s\n",
                               enableDrainPostDnsRefresh ? "true" : "false"))

--- a/mobile/library/objective-c/EnvoyConfiguration.m
+++ b/mobile/library/objective-c/EnvoyConfiguration.m
@@ -167,8 +167,6 @@
   [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", self.dnsPreresolveHostnames];
   [definitions appendFormat:@"- &dns_lookup_family %@\n",
                             self.enableHappyEyeballs ? @"ALL" : @"V4_PREFERRED"];
-  [definitions appendFormat:@"- &dns_multiple_addresses %@\n",
-                            self.enableHappyEyeballs ? @"true" : @"false"];
   [definitions appendFormat:@"- &dns_refresh_rate %lus\n", (unsigned long)self.dnsRefreshSeconds];
   [definitions appendFormat:@"- &enable_drain_post_dns_refresh %@\n",
                             self.enableDrainPostDnsRefresh ? @"true" : @"false"];

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -214,8 +214,6 @@ TEST(TestConfig, EnableHappyEyeballs) {
   config_str = absl::StrCat(config_header, engine_builder.generateConfigStr());
   ASSERT_THAT(config_str, Not(HasSubstr("&dns_lookup_family V4_PREFERRED")));
   ASSERT_THAT(config_str, HasSubstr("&dns_lookup_family ALL"));
-  ASSERT_THAT(config_str, Not(HasSubstr("&dns_multiple_addresses false")));
-  ASSERT_THAT(config_str, HasSubstr("&dns_multiple_addresses true"));
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 
@@ -223,8 +221,6 @@ TEST(TestConfig, EnableHappyEyeballs) {
   config_str = engine_builder.generateConfigStr();
   ASSERT_THAT(config_str, HasSubstr("&dns_lookup_family V4_PREFERRED"));
   ASSERT_THAT(config_str, Not(HasSubstr("&dns_lookup_family ALL")));
-  ASSERT_THAT(config_str, HasSubstr("&dns_multiple_addresses false"));
-  ASSERT_THAT(config_str, Not(HasSubstr("&dns_multiple_addresses true")));
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 }
 

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -144,7 +144,6 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_fail_max_interval 456s")
     assertThat(resolvedTemplate).contains("&dns_query_timeout 321s")
     assertThat(resolvedTemplate).contains("&dns_lookup_family V4_PREFERRED")
-    assertThat(resolvedTemplate).contains("&dns_multiple_addresses false")
     assertThat(resolvedTemplate).contains("&dns_min_refresh_rate 12s")
     assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [hostname]")
     assertThat(resolvedTemplate).contains("&enable_drain_post_dns_refresh false")
@@ -222,7 +221,6 @@ CERT_VALIDATION_TEMPLATE
 
     // DNS
     assertThat(resolvedTemplate).contains("&dns_lookup_family ALL")
-    assertThat(resolvedTemplate).contains("&dns_multiple_addresses true")
     assertThat(resolvedTemplate).contains("&enable_drain_post_dns_refresh true")
     assertThat(resolvedTemplate).contains("config: persistent_dns_cache")
 

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -491,7 +491,6 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_min_refresh_rate 100s"))
     XCTAssertTrue(resolvedYAML.contains("&dns_preresolve_hostnames [test]"))
     XCTAssertTrue(resolvedYAML.contains("&dns_lookup_family ALL"))
-    XCTAssertTrue(resolvedYAML.contains("&dns_multiple_addresses true"))
     XCTAssertFalse(resolvedYAML.contains("&persistent_dns_cache_config"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding true"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification ACCEPT_UNTRUSTED"))
@@ -594,7 +593,6 @@ final class EngineBuilderTests: XCTestCase {
 """
     ))
 // swiftlint:enable line_length
-    XCTAssertTrue(resolvedYAML.contains("&dns_multiple_addresses false"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding false"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification VERIFY_TRUST_CHAIN"))
     XCTAssertTrue(resolvedYAML.contains(

--- a/source/common/common/dns_utils.cc
+++ b/source/common/common/dns_utils.cc
@@ -34,9 +34,6 @@ getDnsLookupFamilyFromEnum(envoy::config::cluster::v3::Cluster::DnsLookupFamily 
 std::vector<Network::Address::InstanceConstSharedPtr>
 generateAddressList(const std::list<Network::DnsResponse>& responses, uint32_t port) {
   std::vector<Network::Address::InstanceConstSharedPtr> addresses;
-  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_multiple_dns_addresses")) {
-    return addresses;
-  }
   for (const auto& response : responses) {
     auto address = Network::Utility::getAddressWithPort(*(response.addrInfo().address_), port);
     if (address) {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -30,7 +30,6 @@
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_admin_stats_filter_use_re2);
-RUNTIME_GUARD(envoy_reloadable_features_allow_multiple_dns_addresses);
 RUNTIME_GUARD(envoy_reloadable_features_allow_upstream_filters);
 RUNTIME_GUARD(envoy_reloadable_features_append_query_parameters_path_rewriter);
 RUNTIME_GUARD(envoy_reloadable_features_cares_accept_nodata);

--- a/test/common/common/dns_utils_test.cc
+++ b/test/common/common/dns_utils_test.cc
@@ -9,21 +9,7 @@
 namespace Envoy {
 namespace {
 
-TEST(DnsUtils, LegacyGenerateTest) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.allow_multiple_dns_addresses", "false"}});
-
-  std::list<Network::DnsResponse> responses =
-      TestUtility::makeDnsResponse({"10.0.0.1", "10.0.0.2"});
-  std::vector<Network::Address::InstanceConstSharedPtr> addresses =
-      DnsUtils::generateAddressList(responses, 2);
-  EXPECT_EQ(0, addresses.size());
-}
-
 TEST(DnsUtils, MultipleGenerateTest) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.allow_multiple_dns_addresses", "true"}});
-
   std::list<Network::DnsResponse> responses =
       TestUtility::makeDnsResponse({"10.0.0.1", "10.0.0.2"});
   std::vector<Network::Address::InstanceConstSharedPtr> addresses =
@@ -34,9 +20,6 @@ TEST(DnsUtils, MultipleGenerateTest) {
 }
 
 TEST(DnsUtils, ListChanged) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.allow_multiple_dns_addresses", "true"}});
-
   Network::Address::InstanceConstSharedPtr address1 =
       Network::Utility::parseInternetAddress("10.0.0.1");
   Network::Address::InstanceConstSharedPtr address1_dup =

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -1278,8 +1278,7 @@ TEST(UtilityTest, PrepareDnsRefreshStrategy) {
 
 TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.allow_multiple_dns_addresses", "true"},
-                              {"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
 
   auto* time_source = new NiceMock<MockTimeSystem>();
   context_.dispatcher_.time_system_.reset(time_source);
@@ -1407,8 +1406,7 @@ TEST_F(DnsCacheImplTest, ResolveSuccessWithCaching) {
 
 TEST_F(DnsCacheImplTest, CacheLoad) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.allow_multiple_dns_addresses", "true"},
-                              {"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.no_extension_lookup_by_name", "false"}});
 
   auto* time_source = new NiceMock<MockTimeSystem>();
   context_.dispatcher_.time_system_.reset(time_source);


### PR DESCRIPTION
(Not removing the moble APIs as they still control the DNS lookup type and so are still functional)

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes https://github.com/envoyproxy/envoy/issues/25008