### PR TITLE
Remove entry for old sr extension maintainer from OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -69,8 +69,6 @@ without further review.
 
 * Michael Warres ([mpwarres] (https://github.com/mpwarres)) (mpw@google.com)
   * Wasm
-* Raúl Gutiérrez Segalés ([rgs1](https://github.com/rgs1)) (rgs@pinterest.com)
-  * Thrift
 
 # Envoy security team
 


### PR DESCRIPTION
Remove entry for old sr extension maintainer from OWNERS.md

Signed-off-by: Ryan Hamilton <rch@google.com>
