### PR TITLE
http2: migrates metadata_encoder_decoder_test.cc to the new HTTP/2 codec API

### DIFF
--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -135,6 +135,7 @@ envoy_cc_test(
     srcs = ["metadata_encoder_decoder_test.cc"],
     external_deps = [
         "nghttp2",
+        "quiche_http2_adapter",
     ],
     deps = [
         "//source/common/buffer:buffer_lib",

--- a/test/common/http/http2/metadata_encoder_decoder_test.cc
+++ b/test/common/http/http2/metadata_encoder_decoder_test.cc
@@ -46,8 +46,9 @@ struct UserData {
 };
 
 // Nghttp2 callback function for receiving extension frame.
-static int on_extension_chunk_recv_callback(nghttp2_session* /*session*/, const nghttp2_frame_hd* hd,
-                                            const uint8_t* data, size_t len, void* user_data) {
+static int on_extension_chunk_recv_callback(nghttp2_session* /*session*/,
+                                            const nghttp2_frame_hd* hd, const uint8_t* data,
+                                            size_t len, void* user_data) {
   EXPECT_GE(hd->length, len);
 
   MetadataDecoder* decoder = reinterpret_cast<UserData*>(user_data)->decoder;
@@ -67,8 +68,8 @@ static int unpack_extension_callback(nghttp2_session* /*session*/, void** payloa
 }
 
 // Nghttp2 callback function for sending data to peer.
-static ssize_t send_callback(nghttp2_session* /*session*/, const uint8_t* buf, size_t len, int flags,
-                             void* user_data) {
+static ssize_t send_callback(nghttp2_session* /*session*/, const uint8_t* buf, size_t len,
+                             int flags, void* user_data) {
   EXPECT_LE(0, flags);
 
   TestBuffer* buffer = (reinterpret_cast<UserData*>(user_data))->output_buffer;
@@ -255,8 +256,8 @@ TEST_F(MetadataEncoderDecoderTest, EncodeMetadataMapVectorSmall) {
   // Verifies flag and payload are encoded correctly.
   const uint64_t consume_size = random_generator_.random() % output_buffer_.length;
   session_->ProcessBytes(toStringView(output_buffer_.buf, consume_size));
-  session_->ProcessBytes(toStringView(output_buffer_.buf + consume_size,
-                                      output_buffer_.length - consume_size));
+  session_->ProcessBytes(
+      toStringView(output_buffer_.buf + consume_size, output_buffer_.length - consume_size));
 
   cleanUp();
 }
@@ -280,8 +281,8 @@ TEST_F(MetadataEncoderDecoderTest, EncodeMetadataMapVectorLarge) {
   // Verifies flag and payload are encoded correctly.
   const uint64_t consume_size = random_generator_.random() % output_buffer_.length;
   session_->ProcessBytes(toStringView(output_buffer_.buf, consume_size));
-  session_->ProcessBytes(toStringView(output_buffer_.buf + consume_size,
-                                      output_buffer_.length - consume_size));
+  session_->ProcessBytes(
+      toStringView(output_buffer_.buf + consume_size, output_buffer_.length - consume_size));
   cleanUp();
 }
 


### PR DESCRIPTION
This also obsoletes the old MetadataEncoder implementation. This is part of addressing https://github.com/envoyproxy/envoy/issues/23596.

Signed-off-by: Biren Roy <birenroy@google.com>

Commit Message: Migrates metadata_encoder_decoder_test.cc to the new HTTP/2 codec API.
Additional Description:
Risk Level: low
Testing: ran unit tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
