### PR TITLE
grpc_json_transcoder: to support skip transcoding based on route name.

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -288,4 +288,15 @@ message GrpcJsonTranscoder {
   //
   // If unset, the current stream buffer size is used.
   google.protobuf.UInt32Value max_response_body_size = 16 [(validate.rules).uint32 = {gt: 0}];
+
+  // If true, the transcoder will honor route naming conventions for the below
+  // suffix applied to the route.
+  //
+  // "_skip_transcoding": the transcoder will skip transcoding for the route.
+  //
+  // This is a workaround when per_filter_config isn't available for the route
+  // config. For example, istio control plane.
+  // TODO: remove this feature after istio supports per filter config in their
+  // first-class route APIs.
+  bool use_route_naming_conventions = 17;
 }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -112,6 +112,7 @@ public:
   absl::optional<uint32_t> max_response_body_size_;
 
   void addBuiltinSymbolDescriptor(const std::string& symbol_name);
+  bool use_route_naming_conventions() const { return use_route_naming_conventions_; }
 
 private:
   /**
@@ -138,6 +139,7 @@ private:
   bool ignore_unknown_query_parameters_{false};
   bool convert_grpc_status_{false};
   bool case_insensitive_enum_parsing_{false};
+  bool use_route_naming_conventions_{false};
 
   bool disabled_;
 };
@@ -207,6 +209,9 @@ private:
    */
   void maybeExpandBufferLimits();
 
+  void checkRouteNameIfDisabled();
+  bool isDisabledForTheRoute();
+
   const JsonTranscoderConfig& config_;
   const JsonTranscoderConfig* per_route_config_{};
   std::unique_ptr<google::grpc::transcoding::Transcoder> transcoder_;
@@ -230,6 +235,8 @@ private:
 
   // Don't buffer unary response data in the `FilterManager` buffer.
   Buffer::OwnedImpl response_out_;
+
+  bool disabled_for_the_route_{false};
 };
 
 } // namespace GrpcJsonTranscoder


### PR DESCRIPTION
Additional Description:
grpc_json_transcoder: to support skip transcoding based on route name. We have a requirement to configure istio gateway to skip transcoding for certain routes. However, since istio doesn't support per_filter_config in the route, we cannot use that or other metadata to decorate the route for this feature. Thus we propose to add this naming convention hack until per_filter_config is supported in istio.

Risk Level: Low
Testing: unit test
Docs Changes: N/A
Release Notes: Add an option in grpc_json_transcoder to support skip transcoding based on route naming conventions.
Platform Specific Features: N/A

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
