### PR TITLE
stats: remove use and definition of deprecated functions

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -28,14 +28,6 @@ using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextR
 using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
 
-// TODO(#20911): Until 2022, scopes were generally captured by the creator as
-// unique_ptr<Scope>. This has changed to std::shared_ptr<Scope>, and to make
-// this transition work we made ScopePtr an alias for ScopeSharedPtr. All
-// references in the Envoy repo are now removed, but there remain references in
-// external repositories, so we'll leave this alias until we have some
-// confidence that external repositories are cleaned up.
-using ScopePtr ABSL_DEPRECATED("Use ScopeSharedPtr() instead.") = ScopeSharedPtr;
-
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 
 /**

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -152,10 +152,6 @@ public:
   virtual bool iterate(const IterateFn<Histogram>& fn) const PURE;
   virtual bool iterate(const IterateFn<TextReadout>& fn) const PURE;
 
-  // TODO(#24007): Remove this operator overload: it is not needed anymore. Once
-  // #24567, #24843, and #24861 have landed we can remove this API.
-  operator Scope&() { return *rootScope(); }
-
   // Delegate some methods to the root scope; these are exposed to make it more
   // convenient to use stats_macros.h. We may consider dropping them if desired,
   // when we resolve #24007 or in the next follow-up.

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -67,8 +67,9 @@ public:
   PrioritySetImpl priority_set_;
   PrioritySetImpl local_priority_set_;
   Stats::IsolatedStoreImpl stats_store_;
+  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   ClusterLbStatNames stat_names_{stats_store_.symbolTable()};
-  ClusterLbStats stats_{stat_names_, *stats_store_.rootScope()};
+  ClusterLbStats stats_{stat_names_, stats_scope_};
   NiceMock<Runtime::MockLoader> runtime_;
   Random::RandomGeneratorImpl random_;
   envoy::config::cluster::v3::Cluster::CommonLbConfig common_config_;
@@ -156,7 +157,7 @@ public:
     config_ = envoy::config::cluster::v3::Cluster::RingHashLbConfig();
     config_.value().mutable_minimum_ring_size()->set_value(min_ring_size);
     ring_hash_lb_ = std::make_unique<RingHashLoadBalancer>(
-        priority_set_, stats_, stats_store_, runtime_, random_,
+        priority_set_, stats_, stats_scope_, runtime_, random_,
         config_.has_value()
             ? makeOptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
                   config_.value())
@@ -173,7 +174,7 @@ public:
   MaglevTester(uint64_t num_hosts, uint32_t weighted_subset_percent = 0, uint32_t weight = 0)
       : BaseTester(num_hosts, weighted_subset_percent, weight) {
     maglev_lb_ = std::make_unique<MaglevLoadBalancer>(
-        priority_set_, stats_, stats_store_, runtime_, random_,
+        priority_set_, stats_, stats_scope_, runtime_, random_,
         config_.has_value()
             ? makeOptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(config_.value())
             : absl::nullopt,
@@ -554,9 +555,9 @@ public:
 
     subset_info_ = std::make_unique<LoadBalancerSubsetInfoImpl>(subset_config);
     lb_ = std::make_unique<SubsetLoadBalancer>(
-        LoadBalancerType::Random, priority_set_, &local_priority_set_, stats_,
-        *stats_store_.rootScope(), runtime_, random_, *subset_info_, absl::nullopt, absl::nullopt,
-        absl::nullopt, absl::nullopt, common_config_, simTime());
+        LoadBalancerType::Random, priority_set_, &local_priority_set_, stats_, stats_scope_,
+        runtime_, random_, *subset_info_, absl::nullopt, absl::nullopt, absl::nullopt,
+        absl::nullopt, common_config_, simTime());
 
     const HostVector& hosts = priority_set_.getOrCreateHostSet(0).hosts();
     ASSERT(hosts.size() == num_hosts);


### PR DESCRIPTION
Commit Message: Removes Stats::ScopePtr definition as well as the cast operator from Stats::Store to Stats::Scope.
Additional Description:
Risk Level: medium -- other PRs may be adding use of this; but the cleanup should be easy if necessary. There may also be out-of-repo deps which I mostly tried to clean up where I could find them.
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes: #20911
Fixes: #24007 
