### PR TITLE
mobile: retry starting iOS Simulator up to 3 times for iOS tests

### DIFF
--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -19,6 +19,13 @@ jobs:
     - name: 'Install dependencies'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     - name: 'Run swift library tests'
       if: steps.should_run.outputs.run_ci_job == 'true'
       env:
@@ -44,6 +51,13 @@ jobs:
     - name: 'Install dependencies'
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./ci/mac_ci_setup.sh
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Start simulator'
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        command: ./mobile/ci/start_ios_simulator.sh
     - name: 'Run Objective-C library tests'
       if: steps.should_run.outputs.run_ci_job == 'true'
       env:


### PR DESCRIPTION
Like https://github.com/envoyproxy/envoy/pull/24936 but applied to the CI jobs in the `ios_tests` workflow.

Appears to have worked in this run: https://github.com/envoyproxy/envoy/actions/runs/4000834933/jobs/6866438706

Signed-off-by: JP Simard <jp@jpsim.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: Low, CI only
Testing: CI
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
