### PR TITLE
mobile: remove unnecessary macOS CI dependencies

### DIFF
--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -45,7 +45,7 @@ if ! retry brew update; then
   echo "Failed to update homebrew"
 fi
 
-DEPS="automake cmake coreutils libtool wget ninja"
+DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"
@@ -53,7 +53,6 @@ done
 
 ./bazelw version
 
-pip3 install slackclient
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
 sudo xcode-select --switch /Applications/Xcode_14.1.app
 


### PR DESCRIPTION
These don't appear to be used in macOS CI and take time to install on every CI job.

Commit Message:
Additional Description:
Risk Level: Low in general, moderate on Envoy Mobile CI if something is actually using these and I missed them
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]