### PR TITLE
Revert "stats: remove use and definition of deprecated functions"

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -28,6 +28,14 @@ using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextR
 using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
 
+// TODO(#20911): Until 2022, scopes were generally captured by the creator as
+// unique_ptr<Scope>. This has changed to std::shared_ptr<Scope>, and to make
+// this transition work we made ScopePtr an alias for ScopeSharedPtr. All
+// references in the Envoy repo are now removed, but there remain references in
+// external repositories, so we'll leave this alias until we have some
+// confidence that external repositories are cleaned up.
+using ScopePtr ABSL_DEPRECATED("Use ScopeSharedPtr() instead.") = ScopeSharedPtr;
+
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 
 /**

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -152,6 +152,10 @@ public:
   virtual bool iterate(const IterateFn<Histogram>& fn) const PURE;
   virtual bool iterate(const IterateFn<TextReadout>& fn) const PURE;
 
+  // TODO(#24007): Remove this operator overload: it is not needed anymore. Once
+  // #24567, #24843, and #24861 have landed we can remove this API.
+  operator Scope&() { return *rootScope(); }
+
   // Delegate some methods to the root scope; these are exposed to make it more
   // convenient to use stats_macros.h. We may consider dropping them if desired,
   // when we resolve #24007 or in the next follow-up.

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -67,9 +67,8 @@ public:
   PrioritySetImpl priority_set_;
   PrioritySetImpl local_priority_set_;
   Stats::IsolatedStoreImpl stats_store_;
-  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   ClusterLbStatNames stat_names_{stats_store_.symbolTable()};
-  ClusterLbStats stats_{stat_names_, stats_scope_};
+  ClusterLbStats stats_{stat_names_, *stats_store_.rootScope()};
   NiceMock<Runtime::MockLoader> runtime_;
   Random::RandomGeneratorImpl random_;
   envoy::config::cluster::v3::Cluster::CommonLbConfig common_config_;
@@ -157,7 +156,7 @@ public:
     config_ = envoy::config::cluster::v3::Cluster::RingHashLbConfig();
     config_.value().mutable_minimum_ring_size()->set_value(min_ring_size);
     ring_hash_lb_ = std::make_unique<RingHashLoadBalancer>(
-        priority_set_, stats_, stats_scope_, runtime_, random_,
+        priority_set_, stats_, stats_store_, runtime_, random_,
         config_.has_value()
             ? makeOptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
                   config_.value())
@@ -174,7 +173,7 @@ public:
   MaglevTester(uint64_t num_hosts, uint32_t weighted_subset_percent = 0, uint32_t weight = 0)
       : BaseTester(num_hosts, weighted_subset_percent, weight) {
     maglev_lb_ = std::make_unique<MaglevLoadBalancer>(
-        priority_set_, stats_, stats_scope_, runtime_, random_,
+        priority_set_, stats_, stats_store_, runtime_, random_,
         config_.has_value()
             ? makeOptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(config_.value())
             : absl::nullopt,
@@ -555,9 +554,9 @@ public:
 
     subset_info_ = std::make_unique<LoadBalancerSubsetInfoImpl>(subset_config);
     lb_ = std::make_unique<SubsetLoadBalancer>(
-        LoadBalancerType::Random, priority_set_, &local_priority_set_, stats_, stats_scope_,
-        runtime_, random_, *subset_info_, absl::nullopt, absl::nullopt, absl::nullopt,
-        absl::nullopt, common_config_, simTime());
+        LoadBalancerType::Random, priority_set_, &local_priority_set_, stats_,
+        *stats_store_.rootScope(), runtime_, random_, *subset_info_, absl::nullopt, absl::nullopt,
+        absl::nullopt, absl::nullopt, common_config_, simTime());
 
     const HostVector& hosts = priority_set_.getOrCreateHostSet(0).hosts();
     ASSERT(hosts.size() == num_hosts);

--- a/test/common/upstream/multiplexed_subscription_factory_test.cc
+++ b/test/common/upstream/multiplexed_subscription_factory_test.cc
@@ -64,7 +64,6 @@ public:
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Config::MockSubscriptionCallbacks> callbacks_;
   Stats::MockIsolatedStatsStore stats_store_;
-  Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   NiceMock<Api::MockApi> api_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   Grpc::MockAsyncClient* async_client_;
@@ -96,10 +95,10 @@ TEST_P(MultiplexedSubscriptionFactoryForGrpcTest, ShouldReturnSameMuxForSameConf
   EXPECT_CALL(dispatcher_, createTimer_(_));
   Config::CustomConfigValidatorsPtr config_validators =
       std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
-  auto first_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_scope_,
+  auto first_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_store_,
                                               config_validators);
   config_validators = std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
-  auto second_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_scope_,
+  auto second_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_store_,
                                                config_validators);
   EXPECT_EQ(first_mux.get(), second_mux.get());
   EXPECT_EQ(1, MultiplexedSubscriptionFactoryPeer::optimizedMuxesSize(factory));
@@ -125,10 +124,10 @@ TEST_P(MultiplexedSubscriptionFactoryForGrpcTest, ShouldReturnSameMuxForSameGrpc
   EXPECT_CALL(dispatcher_, createTimer_(_));
   Config::CustomConfigValidatorsPtr config_validators =
       std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
-  auto first_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_scope_,
+  auto first_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_store_,
                                               config_validators);
   config_validators = std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
-  auto second_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_scope_,
+  auto second_mux = factory.testGetOrCreateMux(config1.api_config_source(), type_url_, stats_store_,
                                                config_validators);
   EXPECT_EQ(first_mux.get(), second_mux.get());
   EXPECT_EQ(1, MultiplexedSubscriptionFactoryPeer::optimizedMuxesSize(factory));
@@ -148,14 +147,14 @@ TEST_P(MultiplexedSubscriptionFactoryForGrpcTest, ShouldReturnDiffMuxesForDiffXd
   Config::CustomConfigValidatorsPtr config_validators =
       std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
   auto first_mux = factory.testGetOrCreateMux(first_config.api_config_source(), type_url_,
-                                              stats_scope_, config_validators);
+                                              stats_store_, config_validators);
   envoy::config::core::v3::ConfigSource second_config;
   config_source = second_config.mutable_api_config_source();
   config_source->set_api_type(GetParam());
   config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("second_cluster");
   config_validators = std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
   auto second_mux = factory.testGetOrCreateMux(second_config.api_config_source(), type_url_,
-                                               stats_scope_, config_validators);
+                                               stats_store_, config_validators);
   EXPECT_NE(first_mux.get(), second_mux.get());
   EXPECT_EQ(2, MultiplexedSubscriptionFactoryPeer::optimizedMuxesSize(factory));
 }
@@ -172,17 +171,17 @@ TEST_P(MultiplexedSubscriptionFactoryForGrpcTest, ShouldReturnDiffMuxesForDiffXd
   EXPECT_CALL(dispatcher_, createTimer_(_)).Times(3);
   Config::CustomConfigValidatorsPtr config_validators =
       std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
-  auto first_mux = factory.testGetOrCreateMux(config.api_config_source(), type_url_, stats_scope_,
+  auto first_mux = factory.testGetOrCreateMux(config.api_config_source(), type_url_, stats_store_,
                                               config_validators);
   config_validators = std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
   auto second_mux = factory.testGetOrCreateMux(
       config.api_config_source(), "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      stats_scope_, config_validators);
+      stats_store_, config_validators);
   EXPECT_NE(first_mux.get(), second_mux.get());
   config_validators = std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
   auto third_mux = factory.testGetOrCreateMux(
       config.api_config_source(), "type.googleapis.com/envoy.config.listener.v3.Listener",
-      stats_scope_, config_validators);
+      stats_store_, config_validators);
   EXPECT_NE(first_mux.get(), third_mux.get());
   EXPECT_NE(second_mux.get(), third_mux.get());
   EXPECT_EQ(3, MultiplexedSubscriptionFactoryPeer::optimizedMuxesSize(factory));
@@ -218,11 +217,11 @@ TEST_P(MultiplexedSubscriptionFactoryForGrpcTest,
   EXPECT_CALL(dispatcher_, createTimer_(_));
   auto subscription =
       factory.subscriptionFromConfigSource(config, Config::TypeUrl::get().ClusterLoadAssignment,
-                                           stats_scope_, callbacks_, resource_decoder_, {});
+                                           stats_store_, callbacks_, resource_decoder_, {});
   Config::CustomConfigValidatorsPtr config_validators =
       std::make_unique<NiceMock<Config::MockCustomConfigValidators>>();
   auto expected_mux = factory.testGetOrCreateMux(config.api_config_source(), type_url_,
-                                                 stats_scope_, config_validators);
+                                                 stats_store_, config_validators);
   EXPECT_EQ(expected_mux.get(),
             (dynamic_cast<Config::GrpcSubscriptionImpl&>(*subscription).grpcMux()).get());
 }
@@ -249,7 +248,7 @@ TEST_P(MultiplexedSubscriptionFactoryForNonGrpcTest,
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
   EXPECT_CALL(dispatcher_, createTimer_(_));
   factory.subscriptionFromConfigSource(config, Config::TypeUrl::get().ClusterLoadAssignment,
-                                       stats_scope_, callbacks_, resource_decoder_, {});
+                                       stats_store_, callbacks_, resource_decoder_, {});
   EXPECT_EQ(0, MultiplexedSubscriptionFactoryPeer::optimizedMuxesSize(factory));
 }
 


### PR DESCRIPTION
Revert "stats: remove use and definition of deprecated functions (#25136)"

Breaks Envoy Mobile builds.

This reverts commit e81612297bc5700a5bbd487ae9fb7bef25dc9240.

Signed-off-by: Ryan Hamilton <rch@google.com>