### PR TITLE
Fix envoy mobile tests after recent stats change

### DIFF
--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -61,7 +61,7 @@ class PlatformBridgeCertValidatorTest
 protected:
   PlatformBridgeCertValidatorTest()
       : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")),
-        stats_(generateSslStats(test_store_)), ssl_ctx_(SSL_CTX_new(TLS_method())),
+        stats_(generateSslStats(*test_store_.rootScope())), ssl_ctx_(SSL_CTX_new(TLS_method())),
         callback_(std::make_unique<MockValidateResultCallback>()), is_server_(false) {
     mock_validator_ = std::make_unique<MockValidator>();
     main_thread_id_ = std::this_thread::get_id();

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -153,7 +153,7 @@ public:
   NiceMock<Random::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   bool explicit_flow_control_{GetParam()};
-  Client http_client_{api_listener_, dispatcher_, stats_store_, random_};
+  Client http_client_{api_listener_, dispatcher_, *stats_store_.rootScope(), random_};
   envoy_stream_t stream_ = 1;
 };
 

--- a/mobile/test/common/integration/quic_test_server.cc
+++ b/mobile/test/common/integration/quic_test_server.cc
@@ -34,7 +34,7 @@ QuicTestServer::QuicTestServer()
     : api_(Api::createApiForTest(stats_store_, time_system_)),
       version_(Network::Address::IpVersion::v4), upstream_config_(time_system_), port_(0) {
   ON_CALL(factory_context_, api()).WillByDefault(testing::ReturnRef(*api_));
-  ON_CALL(factory_context_, scope()).WillByDefault(testing::ReturnRef(stats_store_));
+  ON_CALL(factory_context_, scope()).WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
   upstream_config_.udp_fake_upstream_ = FakeUpstreamConfig::UdpConfig();
 }
 


### PR DESCRIPTION
This was missed in https://github.com/envoyproxy/envoy/pull/25136 because we don't run Envoy Mobile CI jobs for every PR (yet).

Slack discussion: https://envoyproxy.slack.com/archives/C02F93EEJCE/p1674678980377169

Risk Level: Low, mirrored the changes done in https://github.com/envoyproxy/envoy/pull/25136
Testing: test/common/...
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Ryan Hamilton <rch@google.com>
