### PR TITLE
Use route name suffix to specify header only decoding.

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -288,4 +288,17 @@ message GrpcJsonTranscoder {
   //
   // If unset, the current stream buffer size is used.
   google.protobuf.UInt32Value max_response_body_size = 16 [(validate.rules).uint32 = {gt: 0}];
+
+  // If true, the transcoder will honor route naming conventions for the below
+  // suffix applied to the route.
+  //
+  // "_skip_transcoding": the transcoder will skip transcoding for the route.
+  // "_header_only_decoding": the transcoder will only decode at headers
+  //   and will ignore body, trailer and all encoding paths.
+  //
+  // This is a workaround when per_filter_config isn't available for the route
+  // config. For example, istio control plane.
+  // TODO: remove this feature after istio supports per filter config in their
+  // first-class route APIs.
+  bool use_route_naming_conventions = 17;
 }

--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
         "api_httpbody_protos",
     ],
     deps = [
+        ":decode_data_filter_state_lib",
         ":http_body_utils_lib",
         ":transcoder_input_stream_lib",
         "//envoy/http:filter_interface",
@@ -33,6 +34,16 @@ envoy_cc_library(
         "//source/common/runtime:runtime_features_lib",
         "@com_google_googleapis//google/api:http_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "decode_data_filter_state_lib",
+    srcs = ["decode_data_filter_state.cc"],
+    hdrs = ["decode_data_filter_state.h"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/stream_info:filter_state_lib",
     ],
 )
 

--- a/source/extensions/filters/http/grpc_json_transcoder/decode_data_filter_state.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/decode_data_filter_state.cc
@@ -1,0 +1,15 @@
+#include "source/extensions/filters/http/grpc_json_transcoder/decode_data_filter_state.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+HttpBackendDataFilterState::HttpBackendDataFilterState(Envoy::Buffer::Instance& buffer) {
+  data.move(buffer);
+}
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/grpc_json_transcoder/decode_data_filter_state.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/decode_data_filter_state.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "source/common/stream_info/filter_state_impl.h"
+#include "source/common/buffer/buffer_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace GrpcJsonTranscoder {
+
+constexpr absl::string_view kHeaderOnlyDecodeDataKey =
+    "envoy.extensions.httpfilters.GrpcJsonTranscoder."
+    "HeaderOnlyDecodeDataKey";
+
+struct HttpBackendDataFilterState
+    : public Envoy::StreamInfo::FilterState::Object {
+ public:
+  explicit HttpBackendDataFilterState(Envoy::Buffer::Instance& buffer);
+
+  Envoy::Buffer::OwnedImpl data;
+};
+
+} // namespace GrpcJsonTranscoder
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -112,6 +112,7 @@ public:
   absl::optional<uint32_t> max_response_body_size_;
 
   void addBuiltinSymbolDescriptor(const std::string& symbol_name);
+  bool use_route_naming_conventions() const {return use_route_naming_conventions_;}
 
 private:
   /**
@@ -138,6 +139,7 @@ private:
   bool ignore_unknown_query_parameters_{false};
   bool convert_grpc_status_{false};
   bool case_insensitive_enum_parsing_{false};
+  bool use_route_naming_conventions_{false};
 
   bool disabled_;
 };
@@ -180,6 +182,8 @@ public:
     return !error_ && transcoder_ && per_route_config_ && !per_route_config_->disabled();
   }
 
+  bool isHeaderOnlyDecoding();
+
 private:
   bool checkAndRejectIfRequestTranscoderFailed(const std::string& details);
   bool checkAndRejectIfResponseTranscoderFailed();
@@ -207,6 +211,9 @@ private:
    */
   void maybeExpandBufferLimits();
 
+  void translateToBuffer(Buffer::Instance& buffer);
+  void checkRouteNameHeaderOnlyDecoding();
+
   const JsonTranscoderConfig& config_;
   const JsonTranscoderConfig* per_route_config_{};
   std::unique_ptr<google::grpc::transcoding::Transcoder> transcoder_;
@@ -227,6 +234,7 @@ private:
   bool error_{false};
   bool has_body_{false};
   bool http_body_response_headers_set_{false};
+  bool is_header_only_decoding_{false};
 
   // Don't buffer unary response data in the `FilterManager` buffer.
   Buffer::OwnedImpl response_out_;


### PR DESCRIPTION
Context: we have a requirement to support http backends. But we still need to wave the information in the header (path & query params) to proto message in order to develop the features on top of proto message, for example, resource extraction for IAM authz; field scrubbing for audit logging.

Therefore we came up with this idea to perform "header-only" decoding so we can offer the above features without touching bodies or any response data.

We have a subsequent filter which will read the decoded header data in the filter state and will process accordingly.

This is an early draft to seek feedback. Let us know how you think about it. Thank you.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
