### PR TITLE
go filter extension: check the filter state while invoking C api from Go

### DIFF
--- a/contrib/golang/filters/http/source/cgo.cc
+++ b/contrib/golang/filters/http/source/cgo.cc
@@ -22,105 +22,105 @@ absl::string_view copyGoString(void* str) {
 
 extern "C" {
 
-void envoyGoFilterHandlerWrapper(void* r, std::function<void(std::shared_ptr<Filter>&)> f) {
+int envoyGoFilterHandlerWrapper(void* r, std::function<int(std::shared_ptr<Filter>&)> f) {
   auto req = reinterpret_cast<httpRequestInternal*>(r);
   auto weakFilter = req->weakFilter();
   if (auto filter = weakFilter.lock()) {
-    f(filter);
+    return f(filter);
   }
+  return CAPIFilterIsGone;
 }
 
-void envoyGoFilterHttpContinue(void* r, int status) {
-  envoyGoFilterHandlerWrapper(r, [status](std::shared_ptr<Filter>& filter) {
-    filter->continueStatus(static_cast<GolangStatus>(status));
+int envoyGoFilterHttpContinue(void* r, int status) {
+  return envoyGoFilterHandlerWrapper(r, [status](std::shared_ptr<Filter>& filter) -> int {
+    return filter->continueStatus(static_cast<GolangStatus>(status));
   });
 }
 
-void envoyGoFilterHttpSendLocalReply(void* r, int response_code, void* body_text, void* headers,
-                                     long long int grpc_status, void* details) {
-  envoyGoFilterHandlerWrapper(r, [response_code, body_text, headers, grpc_status,
-                                  details](std::shared_ptr<Filter>& filter) {
-    UNREFERENCED_PARAMETER(headers);
-    auto grpcStatus = static_cast<Grpc::Status::GrpcStatus>(grpc_status);
-    filter->sendLocalReply(static_cast<Http::Code>(response_code), copyGoString(body_text), nullptr,
-                           grpcStatus, copyGoString(details));
-  });
-}
-
-// unsafe API, without copy memory from c to go.
-void envoyGoFilterHttpGetHeader(void* r, void* key, void* value) {
-  envoyGoFilterHandlerWrapper(r, [key, value](std::shared_ptr<Filter>& filter) {
-    auto keyStr = copyGoString(key);
-    auto v = filter->getHeader(keyStr);
-    if (v.has_value()) {
-      auto goValue = reinterpret_cast<GoString*>(value);
-      goValue->p = v.value().data();
-      goValue->n = v.value().length();
-    }
-  });
-}
-
-void envoyGoFilterHttpCopyHeaders(void* r, void* strs, void* buf) {
-  envoyGoFilterHandlerWrapper(r, [strs, buf](std::shared_ptr<Filter>& filter) {
-    auto goStrs = reinterpret_cast<GoString*>(strs);
-    auto goBuf = reinterpret_cast<char*>(buf);
-    filter->copyHeaders(goStrs, goBuf);
-  });
-}
-
-void envoyGoFilterHttpSetHeader(void* r, void* key, void* value) {
-  envoyGoFilterHandlerWrapper(r, [key, value](std::shared_ptr<Filter>& filter) {
-    auto keyStr = copyGoString(key);
-    auto valueStr = copyGoString(value);
-    filter->setHeader(keyStr, valueStr);
-  });
-}
-
-void envoyGoFilterHttpRemoveHeader(void* r, void* key) {
-  envoyGoFilterHandlerWrapper(r, [key](std::shared_ptr<Filter>& filter) {
-    // TODO: it's safe to skip copy
-    auto keyStr = copyGoString(key);
-    filter->removeHeader(keyStr);
-  });
-}
-
-void envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer_ptr, void* data) {
-  envoyGoFilterHandlerWrapper(r, [buffer_ptr, data](std::shared_ptr<Filter>& filter) {
-    auto buffer = reinterpret_cast<Buffer::Instance*>(buffer_ptr);
-    filter->copyBuffer(buffer, reinterpret_cast<char*>(data));
-  });
-}
-
-void envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer_ptr, void* data,
-                                      int length, bufferAction action) {
-  envoyGoFilterHandlerWrapper(
-      r, [buffer_ptr, data, length, action](std::shared_ptr<Filter>& filter) {
-        auto buffer = reinterpret_cast<Buffer::Instance*>(buffer_ptr);
-        auto value = absl::string_view(reinterpret_cast<const char*>(data), length);
-        filter->setBufferHelper(buffer, value, action);
+int envoyGoFilterHttpSendLocalReply(void* r, int response_code, void* body_text, void* headers,
+                                    long long int grpc_status, void* details) {
+  return envoyGoFilterHandlerWrapper(
+      r,
+      [response_code, body_text, headers, grpc_status,
+       details](std::shared_ptr<Filter>& filter) -> int {
+        UNREFERENCED_PARAMETER(headers);
+        auto grpcStatus = static_cast<Grpc::Status::GrpcStatus>(grpc_status);
+        return filter->sendLocalReply(static_cast<Http::Code>(response_code),
+                                      copyGoString(body_text), nullptr, grpcStatus,
+                                      copyGoString(details));
       });
 }
 
-void envoyGoFilterHttpCopyTrailers(void* r, void* strs, void* buf) {
-  envoyGoFilterHandlerWrapper(r, [strs, buf](std::shared_ptr<Filter>& filter) {
+// unsafe API, without copy memory from c to go.
+int envoyGoFilterHttpGetHeader(void* r, void* key, void* value) {
+  return envoyGoFilterHandlerWrapper(r, [key, value](std::shared_ptr<Filter>& filter) -> int {
+    auto keyStr = copyGoString(key);
+    auto goValue = reinterpret_cast<GoString*>(value);
+    return filter->getHeader(keyStr, goValue);
+  });
+}
+
+int envoyGoFilterHttpCopyHeaders(void* r, void* strs, void* buf) {
+  return envoyGoFilterHandlerWrapper(r, [strs, buf](std::shared_ptr<Filter>& filter) -> int {
     auto goStrs = reinterpret_cast<GoString*>(strs);
     auto goBuf = reinterpret_cast<char*>(buf);
-    filter->copyTrailers(goStrs, goBuf);
+    return filter->copyHeaders(goStrs, goBuf);
   });
 }
 
-void envoyGoFilterHttpSetTrailer(void* r, void* key, void* value) {
-  envoyGoFilterHandlerWrapper(r, [key, value](std::shared_ptr<Filter>& filter) {
+int envoyGoFilterHttpSetHeader(void* r, void* key, void* value) {
+  return envoyGoFilterHandlerWrapper(r, [key, value](std::shared_ptr<Filter>& filter) -> int {
     auto keyStr = copyGoString(key);
     auto valueStr = copyGoString(value);
-    filter->setTrailer(keyStr, valueStr);
+    return filter->setHeader(keyStr, valueStr);
   });
 }
 
-void envoyGoFilterHttpGetStringValue(void* r, int id, void* value) {
-  envoyGoFilterHandlerWrapper(r, [id, value](std::shared_ptr<Filter>& filter) {
+int envoyGoFilterHttpRemoveHeader(void* r, void* key) {
+  return envoyGoFilterHandlerWrapper(r, [key](std::shared_ptr<Filter>& filter) -> int {
+    // TODO: it's safe to skip copy
+    auto keyStr = copyGoString(key);
+    return filter->removeHeader(keyStr);
+  });
+}
+
+int envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer_ptr, void* data) {
+  return envoyGoFilterHandlerWrapper(r, [buffer_ptr, data](std::shared_ptr<Filter>& filter) -> int {
+    auto buffer = reinterpret_cast<Buffer::Instance*>(buffer_ptr);
+    return filter->copyBuffer(buffer, reinterpret_cast<char*>(data));
+  });
+}
+
+int envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer_ptr, void* data,
+                                     int length, bufferAction action) {
+  return envoyGoFilterHandlerWrapper(
+      r, [buffer_ptr, data, length, action](std::shared_ptr<Filter>& filter) -> int {
+        auto buffer = reinterpret_cast<Buffer::Instance*>(buffer_ptr);
+        auto value = absl::string_view(reinterpret_cast<const char*>(data), length);
+        return filter->setBufferHelper(buffer, value, action);
+      });
+}
+
+int envoyGoFilterHttpCopyTrailers(void* r, void* strs, void* buf) {
+  return envoyGoFilterHandlerWrapper(r, [strs, buf](std::shared_ptr<Filter>& filter) -> int {
+    auto goStrs = reinterpret_cast<GoString*>(strs);
+    auto goBuf = reinterpret_cast<char*>(buf);
+    return filter->copyTrailers(goStrs, goBuf);
+  });
+}
+
+int envoyGoFilterHttpSetTrailer(void* r, void* key, void* value) {
+  return envoyGoFilterHandlerWrapper(r, [key, value](std::shared_ptr<Filter>& filter) -> int {
+    auto keyStr = copyGoString(key);
+    auto valueStr = copyGoString(value);
+    return filter->setTrailer(keyStr, valueStr);
+  });
+}
+
+int envoyGoFilterHttpGetStringValue(void* r, int id, void* value) {
+  return envoyGoFilterHandlerWrapper(r, [id, value](std::shared_ptr<Filter>& filter) -> int {
     auto valueStr = reinterpret_cast<GoString*>(value);
-    filter->getStringValue(id, valueStr);
+    return filter->getStringValue(id, valueStr);
   });
 }
 

--- a/contrib/golang/filters/http/source/go/pkg/api/api.h
+++ b/contrib/golang/filters/http/source/go/pkg/api/api.h
@@ -6,6 +6,13 @@
 extern "C" {
 #endif
 
+// This describes the return value of a C Api from Go.
+#define CAPIOK 0
+#define CAPIFilterIsGone -1
+#define CAPIFilterIsDestroy -2
+#define CAPINotInGo -3
+#define CAPIInvalidPhase -4
+
 typedef struct { // NOLINT(modernize-use-using)
   const char* data;
   unsigned long long int len;
@@ -23,23 +30,23 @@ typedef enum { // NOLINT(modernize-use-using)
   Prepend,
 } bufferAction;
 
-void envoyGoFilterHttpContinue(void* r, int status);
-void envoyGoFilterHttpSendLocalReply(void* r, int response_code, void* body_text, void* headers,
-                                     long long int grpc_status, void* details);
+int envoyGoFilterHttpContinue(void* r, int status);
+int envoyGoFilterHttpSendLocalReply(void* r, int response_code, void* body_text, void* headers,
+                                    long long int grpc_status, void* details);
 
-void envoyGoFilterHttpGetHeader(void* r, void* key, void* value);
-void envoyGoFilterHttpCopyHeaders(void* r, void* strs, void* buf);
-void envoyGoFilterHttpSetHeader(void* r, void* key, void* value);
-void envoyGoFilterHttpRemoveHeader(void* r, void* key);
+int envoyGoFilterHttpGetHeader(void* r, void* key, void* value);
+int envoyGoFilterHttpCopyHeaders(void* r, void* strs, void* buf);
+int envoyGoFilterHttpSetHeader(void* r, void* key, void* value);
+int envoyGoFilterHttpRemoveHeader(void* r, void* key);
 
-void envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer, void* value);
-void envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer, void* data,
-                                      int length, bufferAction action);
+int envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer, void* value);
+int envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer, void* data, int length,
+                                     bufferAction action);
 
-void envoyGoFilterHttpCopyTrailers(void* r, void* strs, void* buf);
-void envoyGoFilterHttpSetTrailer(void* r, void* key, void* value);
+int envoyGoFilterHttpCopyTrailers(void* r, void* strs, void* buf);
+int envoyGoFilterHttpSetTrailer(void* r, void* key, void* value);
 
-void envoyGoFilterHttpGetStringValue(void* r, int id, void* value);
+int envoyGoFilterHttpGetStringValue(void* r, int id, void* value);
 
 void envoyGoFilterHttpFinalize(void* r, int reason);
 

--- a/contrib/golang/filters/http/source/go/pkg/api/api.h
+++ b/contrib/golang/filters/http/source/go/pkg/api/api.h
@@ -6,13 +6,6 @@
 extern "C" {
 #endif
 
-// This describes the return value of a C Api from Go.
-#define CAPIOK 0
-#define CAPIFilterIsGone -1
-#define CAPIFilterIsDestroy -2
-#define CAPINotInGo -3
-#define CAPIInvalidPhase -4
-
 typedef struct { // NOLINT(modernize-use-using)
   const char* data;
   unsigned long long int len;
@@ -30,23 +23,32 @@ typedef enum { // NOLINT(modernize-use-using)
   Prepend,
 } bufferAction;
 
-int envoyGoFilterHttpContinue(void* r, int status);
-int envoyGoFilterHttpSendLocalReply(void* r, int response_code, void* body_text, void* headers,
-                                    long long int grpc_status, void* details);
+// The return value of C Api that invoking from Go.
+typedef enum { // NOLINT(modernize-use-using)
+  CAPIOK = 0,
+  CAPIFilterIsGone = -1,
+  CAPIFilterIsDestroy = -2,
+  CAPINotInGo = -3,
+  CAPIInvalidPhase = -4,
+} CAPIStatus;
 
-int envoyGoFilterHttpGetHeader(void* r, void* key, void* value);
-int envoyGoFilterHttpCopyHeaders(void* r, void* strs, void* buf);
-int envoyGoFilterHttpSetHeader(void* r, void* key, void* value);
-int envoyGoFilterHttpRemoveHeader(void* r, void* key);
+CAPIStatus envoyGoFilterHttpContinue(void* r, int status);
+CAPIStatus envoyGoFilterHttpSendLocalReply(void* r, int response_code, void* body_text,
+                                           void* headers, long long int grpc_status, void* details);
 
-int envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer, void* value);
-int envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer, void* data, int length,
-                                     bufferAction action);
+CAPIStatus envoyGoFilterHttpGetHeader(void* r, void* key, void* value);
+CAPIStatus envoyGoFilterHttpCopyHeaders(void* r, void* strs, void* buf);
+CAPIStatus envoyGoFilterHttpSetHeader(void* r, void* key, void* value);
+CAPIStatus envoyGoFilterHttpRemoveHeader(void* r, void* key);
 
-int envoyGoFilterHttpCopyTrailers(void* r, void* strs, void* buf);
-int envoyGoFilterHttpSetTrailer(void* r, void* key, void* value);
+CAPIStatus envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer, void* value);
+CAPIStatus envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer, void* data,
+                                            int length, bufferAction action);
 
-int envoyGoFilterHttpGetStringValue(void* r, int id, void* value);
+CAPIStatus envoyGoFilterHttpCopyTrailers(void* r, void* strs, void* buf);
+CAPIStatus envoyGoFilterHttpSetTrailer(void* r, void* key, void* value);
+
+CAPIStatus envoyGoFilterHttpGetStringValue(void* r, int id, void* value);
 
 void envoyGoFilterHttpFinalize(void* r, int reason);
 

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -46,8 +46,26 @@ const (
 
 type httpCApiImpl struct{}
 
+// Only CAPIOK is expected, otherwise, it means unexpected stage when invoke C API,
+// panic here and it will be recover in the Go entry function (TODO).
+func handleCApiStatus(status C.int) {
+	switch status {
+	case C.CAPIOK:
+		return
+	case C.CAPIFilterIsGone:
+		panic("request has been finished")
+	case C.CAPIFilterIsDestroy:
+		panic("golang filter has been destroyed")
+	case C.CAPINotInGo:
+		panic("not proccessing Go")
+	case C.CAPIInvalidPhase:
+		panic("invalid phase, maybe headers/buffer already continued")
+	}
+}
+
 func (c *httpCApiImpl) HttpContinue(r unsafe.Pointer, status uint64) {
-	C.envoyGoFilterHttpContinue(r, C.int(status))
+	res := C.envoyGoFilterHttpContinue(r, C.int(status))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpSendLocalReply(r unsafe.Pointer, response_code int, body_text string, headers map[string]string, grpc_status int64, details string) {
@@ -56,11 +74,13 @@ func (c *httpCApiImpl) HttpSendLocalReply(r unsafe.Pointer, response_code int, b
 	for k, v := range headers {
 		strs = append(strs, k, v)
 	}
-	C.envoyGoFilterHttpSendLocalReply(r, C.int(response_code), unsafe.Pointer(&body_text), unsafe.Pointer(&strs), C.longlong(grpc_status), unsafe.Pointer(&details))
+	res := C.envoyGoFilterHttpSendLocalReply(r, C.int(response_code), unsafe.Pointer(&body_text), unsafe.Pointer(&strs), C.longlong(grpc_status), unsafe.Pointer(&details))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpGetHeader(r unsafe.Pointer, key *string, value *string) {
-	C.envoyGoFilterHttpGetHeader(r, unsafe.Pointer(key), unsafe.Pointer(value))
+	res := C.envoyGoFilterHttpGetHeader(r, unsafe.Pointer(key), unsafe.Pointer(value))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpCopyHeaders(r unsafe.Pointer, num uint64, bytes uint64) map[string]string {
@@ -75,7 +95,8 @@ func (c *httpCApiImpl) HttpCopyHeaders(r unsafe.Pointer, num uint64, bytes uint6
 	sHeader := (*reflect.SliceHeader)(unsafe.Pointer(&strs))
 	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
 
-	C.envoyGoFilterHttpCopyHeaders(r, unsafe.Pointer(sHeader.Data), unsafe.Pointer(bHeader.Data))
+	res := C.envoyGoFilterHttpCopyHeaders(r, unsafe.Pointer(sHeader.Data), unsafe.Pointer(bHeader.Data))
+	handleCApiStatus(res)
 
 	m := make(map[string]string, num)
 	for i := uint64(0); i < num*2; i += 2 {
@@ -88,11 +109,13 @@ func (c *httpCApiImpl) HttpCopyHeaders(r unsafe.Pointer, num uint64, bytes uint6
 }
 
 func (c *httpCApiImpl) HttpSetHeader(r unsafe.Pointer, key *string, value *string) {
-	C.envoyGoFilterHttpSetHeader(r, unsafe.Pointer(key), unsafe.Pointer(value))
+	res := C.envoyGoFilterHttpSetHeader(r, unsafe.Pointer(key), unsafe.Pointer(value))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpRemoveHeader(r unsafe.Pointer, key *string) {
-	C.envoyGoFilterHttpRemoveHeader(r, unsafe.Pointer(key))
+	res := C.envoyGoFilterHttpRemoveHeader(r, unsafe.Pointer(key))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpGetBuffer(r unsafe.Pointer, bufferPtr uint64, value *string, length uint64) {
@@ -101,7 +124,8 @@ func (c *httpCApiImpl) HttpGetBuffer(r unsafe.Pointer, bufferPtr uint64, value *
 	sHeader := (*reflect.StringHeader)(unsafe.Pointer(value))
 	sHeader.Data = bHeader.Data
 	sHeader.Len = int(length)
-	C.envoyGoFilterHttpGetBuffer(r, C.ulonglong(bufferPtr), unsafe.Pointer(bHeader.Data))
+	res := C.envoyGoFilterHttpGetBuffer(r, C.ulonglong(bufferPtr), unsafe.Pointer(bHeader.Data))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpSetBufferHelper(r unsafe.Pointer, bufferPtr uint64, value string, action api.BufferAction) {
@@ -115,7 +139,8 @@ func (c *httpCApiImpl) HttpSetBufferHelper(r unsafe.Pointer, bufferPtr uint64, v
 	case api.PrependBuffer:
 		act = C.Prepend
 	}
-	C.envoyGoFilterHttpSetBufferHelper(r, C.ulonglong(bufferPtr), unsafe.Pointer(sHeader.Data), C.int(sHeader.Len), act)
+	res := C.envoyGoFilterHttpSetBufferHelper(r, C.ulonglong(bufferPtr), unsafe.Pointer(sHeader.Data), C.int(sHeader.Len), act)
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpCopyTrailers(r unsafe.Pointer, num uint64, bytes uint64) map[string]string {
@@ -128,7 +153,8 @@ func (c *httpCApiImpl) HttpCopyTrailers(r unsafe.Pointer, num uint64, bytes uint
 	sHeader := (*reflect.SliceHeader)(unsafe.Pointer(&strs))
 	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
 
-	C.envoyGoFilterHttpCopyTrailers(r, unsafe.Pointer(sHeader.Data), unsafe.Pointer(bHeader.Data))
+	res := C.envoyGoFilterHttpCopyTrailers(r, unsafe.Pointer(sHeader.Data), unsafe.Pointer(bHeader.Data))
+	handleCApiStatus(res)
 
 	m := make(map[string]string, num)
 	for i := uint64(0); i < num*2; i += 2 {
@@ -140,12 +166,14 @@ func (c *httpCApiImpl) HttpCopyTrailers(r unsafe.Pointer, num uint64, bytes uint
 }
 
 func (c *httpCApiImpl) HttpSetTrailer(r unsafe.Pointer, key *string, value *string) {
-	C.envoyGoFilterHttpSetTrailer(r, unsafe.Pointer(key), unsafe.Pointer(value))
+	res := C.envoyGoFilterHttpSetTrailer(r, unsafe.Pointer(key), unsafe.Pointer(value))
+	handleCApiStatus(res)
 }
 
 func (c *httpCApiImpl) HttpGetRouteName(r unsafe.Pointer) string {
 	var value string
-	C.envoyGoFilterHttpGetStringValue(r, ValueRouteName, unsafe.Pointer(&value))
+	res := C.envoyGoFilterHttpGetStringValue(r, ValueRouteName, unsafe.Pointer(&value))
+	handleCApiStatus(res)
 	// copy the memory from c to Go.
 	return strings.Clone(value)
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -48,7 +48,7 @@ type httpCApiImpl struct{}
 
 // Only CAPIOK is expected, otherwise, it means unexpected stage when invoke C API,
 // panic here and it will be recover in the Go entry function (TODO).
-func handleCApiStatus(status C.int) {
+func handleCApiStatus(status C.CAPIStatus) {
 	switch status {
 	case C.CAPIOK:
 		return

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -565,6 +565,7 @@ CAPIStatus Filter::getHeader(absl::string_view key, GoString* goValue) {
   }
   auto m = state.isProcessingHeader() ? headers_ : trailers_;
   if (m == nullptr) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   auto result = m->get(Http::LowerCaseString(key));
@@ -616,6 +617,7 @@ CAPIStatus Filter::copyHeaders(GoString* go_strs, char* go_buf) {
     return CAPIStatus::CAPINotInGo;
   }
   if (headers_ == nullptr) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   copyHeaderMapToGo(*headers_, go_strs, go_buf);
@@ -634,6 +636,7 @@ CAPIStatus Filter::setHeader(absl::string_view key, absl::string_view value) {
     return CAPIStatus::CAPINotInGo;
   }
   if (headers_ == nullptr) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   headers_->setCopy(Http::LowerCaseString(key), value);
@@ -653,6 +656,7 @@ CAPIStatus Filter::removeHeader(absl::string_view key) {
     return CAPIStatus::CAPINotInGo;
   }
   if (headers_ == nullptr) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   headers_->remove(Http::LowerCaseString(key));
@@ -672,6 +676,7 @@ CAPIStatus Filter::copyBuffer(Buffer::Instance* buffer, char* data) {
     return CAPIStatus::CAPINotInGo;
   }
   if (!state.doDataList.checkExisting(buffer)) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   for (const Buffer::RawSlice& slice : buffer->getRawSlices()) {
@@ -696,6 +701,7 @@ CAPIStatus Filter::setBufferHelper(Buffer::Instance* buffer, absl::string_view& 
     return CAPIStatus::CAPINotInGo;
   }
   if (!state.doDataList.checkExisting(buffer)) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   if (action == bufferAction::Set) {
@@ -721,6 +727,7 @@ CAPIStatus Filter::copyTrailers(GoString* go_strs, char* go_buf) {
     return CAPIStatus::CAPINotInGo;
   }
   if (trailers_ == nullptr) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   copyHeaderMapToGo(*trailers_, go_strs, go_buf);
@@ -739,6 +746,7 @@ CAPIStatus Filter::setTrailer(absl::string_view key, absl::string_view value) {
     return CAPIStatus::CAPINotInGo;
   }
   if (trailers_ == nullptr) {
+    ENVOY_LOG(debug, "invoking cgo api at invalid phase: {}", __func__);
     return CAPIStatus::CAPIInvalidPhase;
   }
   trailers_->setCopy(Http::LowerCaseString(key), value);

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -140,24 +140,27 @@ public:
 
   void onStreamComplete() override {}
 
-  void continueStatus(GolangStatus status);
+  int continueStatus(GolangStatus status);
 
-  void sendLocalReply(Http::Code response_code, absl::string_view body_text,
-                      std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
-                      Grpc::Status::GrpcStatus grpc_status, absl::string_view details);
+  int sendLocalReply(Http::Code response_code, absl::string_view body_text,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                     Grpc::Status::GrpcStatus grpc_status, absl::string_view details);
 
-  absl::optional<absl::string_view> getHeader(absl::string_view key);
-  void copyHeaders(GoString* go_strs, char* go_buf);
-  void setHeader(absl::string_view key, absl::string_view value);
-  void removeHeader(absl::string_view key);
-  void copyBuffer(Buffer::Instance* buffer, char* data);
-  void setBufferHelper(Buffer::Instance* buffer, absl::string_view& value, bufferAction action);
-  void copyTrailers(GoString* go_strs, char* go_buf);
-  void setTrailer(absl::string_view key, absl::string_view value);
-  void getStringValue(int id, GoString* value_str);
+  int getHeader(absl::string_view key, GoString* goValue);
+  int copyHeaders(GoString* go_strs, char* go_buf);
+  int setHeader(absl::string_view key, absl::string_view value);
+  int removeHeader(absl::string_view key);
+  int copyBuffer(Buffer::Instance* buffer, char* data);
+  int setBufferHelper(Buffer::Instance* buffer, absl::string_view& value, bufferAction action);
+  int copyTrailers(GoString* go_strs, char* go_buf);
+  int setTrailer(absl::string_view key, absl::string_view value);
+  int getStringValue(int id, GoString* value_str);
 
 private:
   ProcessorState& getProcessorState();
+
+  // check the filter state when invoking C API from Go.
+  int checkApiState();
 
   bool doHeaders(ProcessorState& state, Http::RequestOrResponseHeaderMap& headers, bool end_stream);
   GolangStatus doHeadersGo(ProcessorState& state, Http::RequestOrResponseHeaderMap& headers,

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -159,9 +159,6 @@ public:
 private:
   ProcessorState& getProcessorState();
 
-  // check the filter state when invoking C API from Go.
-  int checkApiState();
-
   bool doHeaders(ProcessorState& state, Http::RequestOrResponseHeaderMap& headers, bool end_stream);
   GolangStatus doHeadersGo(ProcessorState& state, Http::RequestOrResponseHeaderMap& headers,
                            bool end_stream);

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -140,21 +140,22 @@ public:
 
   void onStreamComplete() override {}
 
-  int continueStatus(GolangStatus status);
+  CAPIStatus continueStatus(GolangStatus status);
 
-  int sendLocalReply(Http::Code response_code, absl::string_view body_text,
-                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
-                     Grpc::Status::GrpcStatus grpc_status, absl::string_view details);
+  CAPIStatus sendLocalReply(Http::Code response_code, absl::string_view body_text,
+                            std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                            Grpc::Status::GrpcStatus grpc_status, absl::string_view details);
 
-  int getHeader(absl::string_view key, GoString* goValue);
-  int copyHeaders(GoString* go_strs, char* go_buf);
-  int setHeader(absl::string_view key, absl::string_view value);
-  int removeHeader(absl::string_view key);
-  int copyBuffer(Buffer::Instance* buffer, char* data);
-  int setBufferHelper(Buffer::Instance* buffer, absl::string_view& value, bufferAction action);
-  int copyTrailers(GoString* go_strs, char* go_buf);
-  int setTrailer(absl::string_view key, absl::string_view value);
-  int getStringValue(int id, GoString* value_str);
+  CAPIStatus getHeader(absl::string_view key, GoString* goValue);
+  CAPIStatus copyHeaders(GoString* go_strs, char* go_buf);
+  CAPIStatus setHeader(absl::string_view key, absl::string_view value);
+  CAPIStatus removeHeader(absl::string_view key);
+  CAPIStatus copyBuffer(Buffer::Instance* buffer, char* data);
+  CAPIStatus setBufferHelper(Buffer::Instance* buffer, absl::string_view& value,
+                             bufferAction action);
+  CAPIStatus copyTrailers(GoString* go_strs, char* go_buf);
+  CAPIStatus setTrailer(absl::string_view key, absl::string_view value);
+  CAPIStatus getStringValue(int id, GoString* value_str);
 
 private:
   ProcessorState& getProcessorState();

--- a/contrib/golang/filters/http/source/processor_state.cc
+++ b/contrib/golang/filters/http/source/processor_state.cc
@@ -38,7 +38,7 @@ void BufferList::clearAll() {
 };
 
 bool BufferList::checkExisting(Buffer::Instance* data) {
-  for (auto it = queue_.begin(); it != queue_.end(); it = queue_.erase(it)) {
+  for (auto it = queue_.begin(); it != queue_.end(); ++it) {
     if ((*it).get() == data) {
       return true;
     };

--- a/contrib/golang/filters/http/source/processor_state.cc
+++ b/contrib/golang/filters/http/source/processor_state.cc
@@ -37,6 +37,15 @@ void BufferList::clearAll() {
   queue_.clear();
 };
 
+bool BufferList::checkExisting(Buffer::Instance* data) {
+  for (auto it = queue_.begin(); it != queue_.end(); it = queue_.erase(it)) {
+    if ((*it).get() == data) {
+      return true;
+    };
+  }
+  return false;
+};
+
 // headers_ should set to nullptr when return true.
 bool ProcessorState::handleHeaderGolangStatus(const GolangStatus status) {
   ENVOY_LOG(debug, "golang filter handle header status, state: {}, phase: {}, status: {}",

--- a/contrib/golang/filters/http/source/processor_state.h
+++ b/contrib/golang/filters/http/source/processor_state.h
@@ -34,6 +34,8 @@ public:
   void clearLatest();
   // clear all.
   void clearAll();
+  // check the buffer instance if existing
+  bool checkExisting(Buffer::Instance* data);
 
 private:
   std::deque<Buffer::InstancePtr> queue_;

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -39,6 +39,9 @@ namespace {
 class TestFilter : public Filter {
 public:
   using Filter::Filter;
+  void onDestroy() override {
+    // do nothing
+  }
 };
 
 class GolangHttpFilterTest : public testing::Test {
@@ -159,6 +162,14 @@ TEST_F(GolangHttpFilterTest, ScriptHeadersOnlyRequestHeadersOnly) {
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
   EXPECT_EQ(0, stats_store_.counter("test.golang.errors").value());
+}
+
+// setHeader at wrong stage
+TEST_F(GolangHttpFilterTest, SetHeaderAtWrongStage) {
+  InSequence s;
+  setup(PASSTHROUGH, genSoPath(PASSTHROUGH), PASSTHROUGH);
+
+  EXPECT_EQ(CAPINotInGo, filter_->setHeader("foo", "bar"));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message:

To make the APIs robust, users could call the Go exposed API safely.

Additional Description:

Now, just panic while invoking C API in an unexpected stage,  will add go recover in the Goroutine entry function, in another PR.

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
