### PR TITLE
mobile: cleaning up runWithTemplate APIs

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -33,9 +33,14 @@ public class AndroidEngineImpl implements EnvoyEngine {
     return envoyEngine.startStream(callbacks, explicitFlowControl);
   }
 
-  public int runWithTemplate(String configurationYAML, EnvoyConfiguration envoyConfiguration,
-                             String logLevel) {
-    return envoyEngine.runWithTemplate(configurationYAML, envoyConfiguration, logLevel);
+  @Override
+  public void performRegistration(EnvoyConfiguration envoyConfiguration) {
+    envoyEngine.performRegistration(envoyConfiguration);
+  }
+
+  @Override
+  public int runWithYaml(String configurationYAML, String logLevel) {
+    return envoyEngine.runWithYaml(configurationYAML, logLevel);
   }
 
   @Override

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 import io.envoyproxy.envoymobile.engine.types.EnvoyKeyValueStore;
+import io.envoyproxy.envoymobile.engine.JniLibrary;
 
 /* Typed configuration that may be used for starting Envoy. */
 public class EnvoyConfiguration {
@@ -133,6 +134,7 @@ public class EnvoyConfiguration {
       Map<String, EnvoyStringAccessor> stringAccessors,
       Map<String, EnvoyKeyValueStore> keyValueStores, List<String> statSinks,
       Boolean enableSkipDNSLookupForProxiedRequests, boolean enablePlatformCertificatesValidation) {
+    JniLibrary.load();
     this.adminInterfaceEnabled = adminInterfaceEnabled;
     this.grpcStatsDomain = grpcStatsDomain;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
@@ -169,30 +171,20 @@ public class EnvoyConfiguration {
     this.enablePlatformCertificatesValidation = enablePlatformCertificatesValidation;
     this.enableSkipDNSLookupForProxiedRequests = enableSkipDNSLookupForProxiedRequests;
   }
-
   /**
-   * Resolves the provided configuration template using properties on this
-   * configuration.
+   * Creates configuration YAML based on the configuration of the class
    *
-   * @param configTemplate the template configuration to resolve.
-   * @param platformFilterTemplate helper template to build platform http filters.
-   * @param nativeFilterTemplate helper template to build native http filters.
-   * @param altProtocolCacheFilterInsert helper insert to include the alt protocol cache filter.
-   * @param gzipFilterInsert helper to include to enable gzip compression.
-   * @param brotliFilterInsert helper to include to enable brotli compression.
-   * @param socketTagFilterInsert helper to include to enable socket tagging.
-   * @param persistentDNSCacheConfigInsert helper to include to enable DNS cache.
-   * @param certValidationTemplate helper template to enable cert validation.
-   * @return String, the resolved template.
-   * @throws ConfigurationException, when the template provided is not fully
+   * @return String, the resolved yaml.
+   * @throws ConfigurationException, when the yaml provided is not fully
    *                                 resolved.
    */
-  String resolveTemplate(final String configTemplate, final String platformFilterTemplate,
-                         final String nativeFilterTemplate,
-                         final String altProtocolCacheFilterInsert, final String gzipFilterInsert,
-                         final String brotliFilterInsert, final String socketTagFilterInsert,
-                         final String persistentDNSCacheConfigInsert,
-                         final String certValidationTemplate) {
+  String createYaml() {
+    final String configTemplate = JniLibrary.configTemplate();
+    final String certValidationTemplate =
+        JniLibrary.certValidationTemplate(enablePlatformCertificatesValidation);
+    final String platformFilterTemplate = JniLibrary.platformFilterTemplate();
+    final String nativeFilterTemplate = JniLibrary.nativeFilterTemplate();
+
     final StringBuilder customFiltersBuilder = new StringBuilder();
 
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {
@@ -208,17 +200,21 @@ public class EnvoyConfiguration {
     }
 
     if (enableHttp3) {
+      final String altProtocolCacheFilterInsert = JniLibrary.altProtocolCacheFilterInsert();
       customFiltersBuilder.append(altProtocolCacheFilterInsert);
     }
 
     if (enableGzip) {
+      final String gzipFilterInsert = JniLibrary.gzipConfigInsert();
       customFiltersBuilder.append(gzipFilterInsert);
     }
 
     if (enableBrotli) {
+      final String brotliFilterInsert = JniLibrary.brotliConfigInsert();
       customFiltersBuilder.append(brotliFilterInsert);
     }
     if (enableSocketTagging) {
+      final String socketTagFilterInsert = JniLibrary.socketTagConfigInsert();
       customFiltersBuilder.append(socketTagFilterInsert);
     }
 
@@ -257,6 +253,7 @@ public class EnvoyConfiguration {
         .append("\n");
 
     if (enableDNSCache) {
+      final String persistentDNSCacheConfigInsert = JniLibrary.persistentDNSCacheConfigInsert();
       configBuilder.append(
           String.format("- &persistent_dns_cache_config %s\n", persistentDNSCacheConfigInsert));
     }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -23,20 +23,29 @@ public interface EnvoyEngine {
   void terminate();
 
   /**
+   * Performs any registrations necessary before running Envoy.
+   *
+   * The envoyConfiguration is used to determined what to register.
+   *
+   * @param envoyConfiguration The EnvoyConfiguration used to start Envoy.
+   */
+  void performRegistration(EnvoyConfiguration envoyConfiguration);
+
+  /**
    * Run the Envoy engine with the provided yaml string and log level.
    *
-   * The envoyConfiguration is used to resolve the configurationYAML.
+   * This does not perform registration, and performRegistration may need to be called first.
    *
    * @param configurationYAML The configuration yaml with which to start Envoy.
-   * @param envoyConfiguration The EnvoyConfiguration used to start Envoy.
    * @param logLevel          The log level to use when starting Envoy.
    * @return A status indicating if the action was successful.
    */
-  int runWithTemplate(String configurationYAML, EnvoyConfiguration envoyConfiguration,
-                      String logLevel);
+  int runWithYaml(String configurationYAML, String logLevel);
 
   /**
    * Run the Envoy engine with the provided EnvoyConfiguration and log level.
+   *
+   * This automatically performs any necessary registrations.
    *
    * @param envoyConfiguration The EnvoyConfiguration used to start Envoy.
    * @param logLevel           The log level to use when starting Envoy.

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -34,7 +34,7 @@ public interface EnvoyEngine {
   /**
    * Run the Envoy engine with the provided yaml string and log level.
    *
-   * This does not perform registration, and performRegistration may need to be called first.
+   * This does not perform registration, and performRegistration() may need to be called first.
    *
    * @param configurationYAML The configuration yaml with which to start Envoy.
    * @param logLevel          The log level to use when starting Envoy.

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -67,9 +67,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   /**
    * Performs various JNI registration prior to engine running.
    *
-   * @param configurationYAML The configuration yaml with which to start Envoy.
    * @param envoyConfiguration The EnvoyConfiguration used to start Envoy.
-   * @param logLevel          The log level to use when starting Envoy.
    */
   @Override
   public void performRegistration(EnvoyConfiguration envoyConfiguration) {
@@ -99,6 +97,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    * @param configurationYAML The configuration yaml with which to start Envoy.
    * @param logLevel          The log level to use when starting Envoy.
    * @return A status indicating if the action was successful.
+   * TODO(alyssawilk) change all the status returns to EnvoyStatus.
    */
   @Override
   public int runWithYaml(String configurationYAML, String logLevel) {

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -65,18 +65,14 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   }
 
   /**
-   * Run the Envoy engine with the provided yaml string and log level.
-   *
-   * The envoyConfiguration is used to resolve the configurationYAML.
+   * Performs various JNI registration prior to engine running.
    *
    * @param configurationYAML The configuration yaml with which to start Envoy.
    * @param envoyConfiguration The EnvoyConfiguration used to start Envoy.
    * @param logLevel          The log level to use when starting Envoy.
-   * @return A status indicating if the action was successful.
    */
   @Override
-  public int runWithTemplate(String configurationYAML, EnvoyConfiguration envoyConfiguration,
-                             String logLevel) {
+  public void performRegistration(EnvoyConfiguration envoyConfiguration) {
     for (EnvoyHTTPFilterFactory filterFactory : envoyConfiguration.httpPlatformFilterFactories) {
       JniLibrary.registerFilterFactory(filterFactory.getFilterName(),
                                        new JvmFilterFactoryContext(filterFactory));
@@ -93,16 +89,20 @@ public class EnvoyEngineImpl implements EnvoyEngine {
       JniLibrary.registerKeyValueStore(entry.getKey(),
                                        new JvmKeyValueStoreContext(entry.getValue()));
     }
+  }
 
-    return runWithResolvedYAML(
-        envoyConfiguration.resolveTemplate(
-            configurationYAML, JniLibrary.platformFilterTemplate(),
-            JniLibrary.nativeFilterTemplate(), JniLibrary.altProtocolCacheFilterInsert(),
-            JniLibrary.gzipConfigInsert(), JniLibrary.brotliConfigInsert(),
-            JniLibrary.socketTagConfigInsert(), JniLibrary.persistentDNSCacheConfigInsert(),
-            JniLibrary.certValidationTemplate(
-                envoyConfiguration.enablePlatformCertificatesValidation)),
-        logLevel);
+  /**
+   * Run the Envoy engine with the provided yaml string and log level.
+   *
+   * This does not perform registration, and performRegistration may need to be called first.
+   *
+   * @param configurationYAML The configuration yaml with which to start Envoy.
+   * @param logLevel          The log level to use when starting Envoy.
+   * @return A status indicating if the action was successful.
+   */
+  @Override
+  public int runWithYaml(String configurationYAML, String logLevel) {
+    return runWithResolvedYAML(configurationYAML, logLevel);
   }
 
   /**
@@ -114,7 +114,9 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    */
   @Override
   public int runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
-    return runWithTemplate(JniLibrary.configTemplate(), envoyConfiguration, logLevel);
+    performRegistration(envoyConfiguration);
+
+    return runWithResolvedYAML(envoyConfiguration.createYaml(), logLevel);
   }
 
   private int runWithResolvedYAML(String configurationYAML, String logLevel) {

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineImpl.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineImpl.kt
@@ -26,7 +26,8 @@ class EngineImpl constructor(
     streamClient = StreamClientImpl(envoyEngine)
     pulseClient = PulseClientImpl(envoyEngine)
     if (configurationYAML != null) {
-      envoyEngine.runWithTemplate(configurationYAML, envoyConfiguration, logLevel.level)
+      envoyEngine.performRegistration(envoyConfiguration)
+      envoyEngine.runWithYaml(configurationYAML, logLevel.level)
     } else {
       envoyEngine.runWithConfig(envoyConfiguration, logLevel.level)
     }

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -13,9 +13,10 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor
 internal class MockEnvoyEngine : EnvoyEngine {
   override fun runWithConfig(envoyConfiguration: EnvoyConfiguration?, logLevel: String?): Int = 0
 
-  override fun runWithTemplate(
+  override fun performRegistration(envoyConfiguration: EnvoyConfiguration) = Unit
+
+  override fun runWithYaml(
     configurationYAML: String,
-    envoyConfiguration: EnvoyConfiguration,
     logLevel: String
   ): Int = 0
 

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,11 +1,15 @@
-load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test", "envoy_mobile_kt_test")
+load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test", "envoy_mobile_jni_kt_test", "envoy_mobile_kt_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_mobile_kt_test(
+envoy_mobile_jni_kt_test(
     name = "envoy_configuration_test",
     srcs = [
         "EnvoyConfigurationTest.kt",
+    ],
+    native_deps = [
+        "//test/common/jni:libenvoy_jni_with_test_extensions.so",
+        "//test/common/jni:libenvoy_jni_with_test_extensions_jnilib",
     ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -1,8 +1,8 @@
-load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_kt_test")
+load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_jni_kt_test", "envoy_mobile_kt_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_mobile_kt_test(
+envoy_mobile_jni_kt_test(
     name = "engine_builder_test",
     srcs = [
         "EngineBuilderTest.kt",
@@ -11,6 +11,10 @@ envoy_mobile_kt_test(
         # TODO(lfpino): Remove this once the JVM paths are allow-listed in the sandbox.
         "sandboxAllowed": "False",
     },
+    native_deps = [
+        "//test/common/jni:libenvoy_jni_with_test_extensions.so",
+        "//test/common/jni:libenvoy_jni_with_test_extensions_jnilib",
+    ],
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -4,10 +4,15 @@ import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.mock
+import io.envoyproxy.envoymobile.engine.JniLibrary
 
 class EngineBuilderTest {
   private lateinit var engineBuilder: EngineBuilder
   private var envoyEngine: EnvoyEngine = mock(EnvoyEngine::class.java)
+
+  init {
+    JniLibrary.loadTestLibrary()
+  }
 
   @Test
   fun `adding log level builder uses log level for running Envoy`() {


### PR DESCRIPTION
Changing the java and kotlin APIs to by default, createYaml(), and optionally run with custom registrations and yaml.
This allows Lyft (and OSS CI) to retain the ability to run custom yaml, but changes the default to doing builder-only engines, in preparation for moving Java to use the C++ engine in bootstrap mode.


Risk Level: Medium (though some test tweaks may be necessary for Lyft)
Testing: CI
Docs Changes: n/a (runWithTemplate didn't show up in docs)
Release Notes: n/a (ditto)
https://github.com/envoyproxy/envoy/issues/24976