### PR TITLE
Change mobile binary size comparison workflow to use release build

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         cd mobile && ./bazelw build \
             --config=sizeopt \
-            --config=remote-ci-linux-clang \
+            --config=release-common \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/performance:test_binary_size
     - uses: actions/upload-artifact@v3
@@ -54,7 +54,7 @@ jobs:
         git checkout main && git pull origin main
           cd mobile && ./bazelw build \
             --config=sizeopt \
-            --config=remote-ci-linux-clang \
+            --config=release-common \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/performance:test_binary_size
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -86,4 +86,4 @@ jobs:
         zip -9 dist/main.zip dist/main.stripped
         zip -9 dist/current.zip dist/current.stripped
     - name: 'Test size regression'
-      run: cd mobile && ./ci/test_size_regression.sh dist/main.zip dist/current.zip
+      run: cd mobile && ./ci/test_size_regression.sh ../dist/main.zip ../dist/current.zip


### PR DESCRIPTION
Was debugging a binary size increase in https://github.com/envoyproxy/envoy/actions/runs/4008291380/workflow and noticed that the comparison is based on --config=remote-ci-linux-clang.  Talked with JP and it seems more appropriate to compare a release build instead.

Test plan: Look at CI