### PR TITLE
mobile: update `rules_apple` to latest commit and use new xctest runner

### DIFF
--- a/mobile/bazel/apple_test.bzl
+++ b/mobile/bazel/apple_test.bzl
@@ -2,6 +2,8 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
+TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
+
 # Macro providing a way to easily/consistently define Swift unit test targets.
 #
 # - Prevents consumers from having to define both swift_library and ios_unit_test targets
@@ -35,6 +37,7 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], reposit
     ios_unit_test(
         name = name,
         data = data,
+        runner = TEST_RUNNER,
         deps = [test_lib_name],
         minimum_os_version = MINIMUM_IOS_VERSION,
         tags = tags,
@@ -55,6 +58,7 @@ def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = [], visibili
     ios_unit_test(
         name = name,
         data = data,
+        runner = TEST_RUNNER,
         deps = [test_lib_name],
         minimum_os_version = MINIMUM_IOS_VERSION,
         tags = tags,

--- a/mobile/bazel/envoy_mobile_repositories.bzl
+++ b/mobile/bazel/envoy_mobile_repositories.bzl
@@ -50,9 +50,9 @@ def upstream_envoy_overrides():
 def swift_repos():
     http_archive(
         name = "build_bazel_rules_apple",
-        sha256 = "687644bf48ccf91286f31c4ec26cf6591800b39bee8a630438626fc9bb4042de",
-        strip_prefix = "rules_apple-a0f8748ce89698a599149d984999eaefd834c004",
-        url = "https://github.com/bazelbuild/rules_apple/archive/a0f8748ce89698a599149d984999eaefd834c004.tar.gz",
+        sha256 = "ebd3becc3967f02eb25cc60937d49e62d48b6500b6c520d4b1fe0ce11584a21e",
+        strip_prefix = "rules_apple-5b8217613aa1ef4d889477d036590979858dbf4e",
+        url = "https://github.com/bazelbuild/rules_apple/archive/5b8217613aa1ef4d889477d036590979858dbf4e.tar.gz",
     )
 
     # https://github.com/bazelbuild/rules_swift/pull/922


### PR DESCRIPTION
We've been having reliability issues with the iOS tests in the last few weeks, so hopefully switching to this newer test runner helps.

Introduced in https://github.com/bazelbuild/rules_apple/pull/1612.

Commit Message: mobile: update `rules_apple` to latest commit and use new xctest runner
Additional Description: We've been having reliability issues with the iOS tests in the last few weeks, so hopefully switching to this newer test runner helps. Introduced in https://github.com/bazelbuild/rules_apple/pull/1612.
Risk Level: Moderate to CI
Testing: `./bazelw test //test/swift:test` locally
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]