### PR TITLE
mobile: adding dns config knobs to C++ builder

### DIFF
--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -67,6 +67,7 @@ public:
   EngineBuilder& enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on);
   EngineBuilder& enforceTrustChainVerification(bool trust_chain_verification_on);
   EngineBuilder& enablePlatformCertificatesValidation(bool platform_certificates_validation_on);
+  EngineBuilder& enableDnsCache(bool dns_cache_on);
 
   // These functions are not compatible with boostrap mode, see class definition for details.
   EngineBuilder& addStatsSinks(const std::vector<std::string>& stat_sinks);
@@ -133,6 +134,7 @@ private:
   bool brotli_filter_ = false;
   bool socket_tagging_filter_ = false;
   bool platform_certificates_validation_on_ = false;
+  bool dns_cache_on_ = false;
 
   absl::flat_hash_map<std::string, KeyValueStoreSharedPtr> key_value_stores_{};
 

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -52,6 +52,7 @@ TEST(TestConfig, BootstrapCompatibleConfigIsApplied) {
                                            "- &h2_connection_keepalive_idle_interval 0.222s",
                                            "- &h2_connection_keepalive_timeout 333s",
                                            "- &stats_flush_interval 654s",
+                                           "  key: dns_persistent_cache",
                                            ("- &metadata { device_os: probably-ubuntu-on-CI, "
                                             "app_version: 1.2.3, app_id: 1234-1234-1234 }"),
                                            R"(- &validation_context

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -38,6 +38,7 @@ TEST(TestConfig, BootstrapCompatibleConfigIsApplied) {
       .addStatsFlushSeconds(654)
       .setAppVersion("1.2.3")
       .setAppId("1234-1234-1234")
+      .enableDnsCache(true)
       .setDeviceOs("probably-ubuntu-on-CI");
   std::string config_str = engine_builder.generateConfigStr();
 


### PR DESCRIPTION
Brings the C++ parity to the Java builder for DNS

Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a