### PR TITLE
mobile: run iOS tests locally

### DIFF
--- a/mobile/test/objective-c/BUILD
+++ b/mobile/test/objective-c/BUILD
@@ -12,6 +12,7 @@ envoy_mobile_objc_test(
     deps = [
         "//library/objective-c:envoy_objc_bridge_lib",
     ],
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )
 
 envoy_mobile_objc_test(
@@ -25,4 +26,5 @@ envoy_mobile_objc_test(
         "//library/objective-c:envoy_key_value_store_bridge_impl_lib",
         "//library/objective-c:envoy_objc_bridge_lib",
     ],
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )

--- a/mobile/test/objective-c/BUILD
+++ b/mobile/test/objective-c/BUILD
@@ -8,11 +8,11 @@ envoy_mobile_objc_test(
         "EnvoyBridgeUtilityTest.m",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_objc_bridge_lib",
     ],
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )
 
 envoy_mobile_objc_test(
@@ -21,10 +21,10 @@ envoy_mobile_objc_test(
         "EnvoyKeyValueStoreBridgeImplTest.m",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_key_value_store_bridge_impl_lib",
         "//library/objective-c:envoy_objc_bridge_lib",
     ],
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )

--- a/mobile/test/swift/BUILD
+++ b/mobile/test/swift/BUILD
@@ -21,4 +21,5 @@ envoy_mobile_swift_test(
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )

--- a/mobile/test/swift/BUILD
+++ b/mobile/test/swift/BUILD
@@ -17,9 +17,9 @@ envoy_mobile_swift_test(
         "RetryPolicyTests.swift",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )

--- a/mobile/test/swift/stats/BUILD
+++ b/mobile/test/swift/stats/BUILD
@@ -10,9 +10,9 @@ envoy_mobile_swift_test(
         "TagsBuilderTests.swift",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )

--- a/mobile/test/swift/stats/BUILD
+++ b/mobile/test/swift/stats/BUILD
@@ -14,4 +14,5 @@ envoy_mobile_swift_test(
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],
+    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
 )


### PR DESCRIPTION
By setting `tags = ["no-remote-exec"]`. It appears that the EngFlow RBE machines are having trouble connecting to the `testmanagerd` socket due to permission errors. Perhaps a sandboxing issue.

See https://envoyproxy.slack.com/archives/C02QMNG92A3/p1674766800532359 for discussion.

Commit Message:
Additional Description:
Risk Level: Moderate to Envoy Mobile iOS CI jobs
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]