### PR TITLE
use min_len instead of min_bytes for golang.proto.

### DIFF
--- a/api/contrib/envoy/extensions/filters/http/golang/v3alpha/golang.proto
+++ b/api/contrib/envoy/extensions/filters/http/golang/v3alpha/golang.proto
@@ -51,7 +51,7 @@ message Config {
   // and can be used to associate :ref:`route and virtualHost plugin configuration
   // <envoy_v3_api_field_extensions.filters.http.golang.v3alpha.ConfigsPerRoute.plugins_config>`.
   //
-  string plugin_name = 3 [(validate.rules).string = {min_bytes: 1}];
+  string plugin_name = 3 [(validate.rules).string = {min_len: 1}];
 
   // Configuration for the Go plugin.
   //


### PR DESCRIPTION
Signed-off-by: wangfakang <fakangwang@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: use min_len instead of min_bytes for golang.proto.
Additional Description: use min_len instead of min_bytes for golang.proto.
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #25198
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
