### PR TITLE
mobile: skip Envoy Mobile CI jobs on PRs targeting release branches

### DIFF
--- a/mobile/tools/should_run_ci.sh
+++ b/mobile/tools/should_run_ci.sh
@@ -29,6 +29,13 @@ if [[ $branch_name == "main" ]]; then
   exit 0
 fi
 
+if [[ $GITHUB_BASE_REF == release/* ]]; then
+  # Skip mobile CI jobs on PRs targeting release branches
+  echo "Skipping $job because the PR is targeting a release branch"
+  echo "run_ci_job=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
 base_commit="$(git merge-base origin/main HEAD)"
 changed_files="$(git diff "$base_commit" --name-only)"
 


### PR DESCRIPTION
Environment variable reference docs: https://docs.github.com/en/enterprise-server@3.7/actions/learn-github-actions/variables

> `GITHUB_BASE_REF`
> The name of the base ref or target branch of the pull request in a workflow run. This is only set when the event that triggers a workflow run is either `pull_request` or `pull_request_target`. For example, `main`.

Commit Message: mobile: skip Envoy Mobile CI jobs on PRs targeting release branches
Additional Description:
Risk Level:
Testing: Local
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes https://github.com/envoyproxy/envoy/issues/25205
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]