### PR TITLE
Release assert `inotify_init1` output

### DIFF
--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -17,16 +17,17 @@ namespace Envoy {
 namespace Filesystem {
 
 WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher, Filesystem::Instance& file_system)
-    : file_system_(file_system), inotify_fd_(inotify_init1(IN_NONBLOCK)),
-      inotify_event_(dispatcher.createFileEvent(
-          inotify_fd_,
-          [this](uint32_t events) -> void {
-            ASSERT(events == Event::FileReadyType::Read);
-            onInotifyEvent();
-          },
-          Event::FileTriggerType::Edge, Event::FileReadyType::Read)) {
+    : file_system_(file_system) {
+  inotify_fd_ = inotify_init1(IN_NONBLOCK);
   RELEASE_ASSERT(inotify_fd_ >= 0,
                  "Consider increasing value of user.max_inotify_watches via sysctl");
+  inotify_event_ = dispatcher.createFileEvent(
+      inotify_fd_,
+      [this](uint32_t events) -> void {
+        ASSERT(events == Event::FileReadyType::Read);
+        onInotifyEvent();
+      },
+      Event::FileTriggerType::Edge, Event::FileReadyType::Read)
 }
 
 WatcherImpl::~WatcherImpl() { close(inotify_fd_); }

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -27,7 +27,7 @@ WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher, Filesystem::Instance& fi
         ASSERT(events == Event::FileReadyType::Read);
         onInotifyEvent();
       },
-      Event::FileTriggerType::Edge, Event::FileReadyType::Read)
+      Event::FileTriggerType::Edge, Event::FileReadyType::Read);
 }
 
 WatcherImpl::~WatcherImpl() { close(inotify_fd_); }


### PR DESCRIPTION
With the order previously if `inotify_init1` failed then Envoy would crash in `createFileEvent` with `SOCKET_VALID(fd)` and the inotify specific assert would never hit.

I recently tried to debug this failure and I had to use `strace` to figure out how things are failing and that release assert could have saved me quite a bit of time.

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>