### PR TITLE
Filter state dynamic forward proxy

### DIFF
--- a/api/versioning/BUILD
+++ b/api/versioning/BUILD
@@ -147,6 +147,7 @@ proto_library(
         "//envoy/extensions/filters/network/dubbo_proxy/v3:pkg",
         "//envoy/extensions/filters/network/echo/v3:pkg",
         "//envoy/extensions/filters/network/ext_authz/v3:pkg",
+        "//envoy/extensions/filters/network/filter_state_dynamic_forward_proxy/v3:pkg",
         "//envoy/extensions/filters/network/http_connection_manager/v3:pkg",
         "//envoy/extensions/filters/network/local_ratelimit/v3:pkg",
         "//envoy/extensions/filters/network/mongo_proxy/v3:pkg",


### PR DESCRIPTION
This is an initial implementation for the "Filter State dynamic forward proxy", which allows filters to set a filter state value for dynamic forward proxy cluster to read from and resolve the host from it.

The implementation for the network filter is copied from "sni_dynamic_forward_proxy" filter, only changed to retrieve host from the filter state instead of the SNI field.

Please read following issue for an example use case:
Resolves #25093

This PR is missing the following:
- Tests
- Docs
- Extracting common code from this filter and SNI dynamic forward proxy to a base class

Although there's missing work I am creating this PR to get prior feedback.