### PR TITLE
lua: new option of http call to skip sending xff

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -66,5 +66,8 @@ new_features:
 - area: router
   change: |
     support route info in upstream access log.
+- area: lua
+  change: |
+    added an new option to the options of lua ``httpCall``. This allows to skip adding ``x-forwarded-for`` by setting ``{["send_xff"] = false}`` as the ``options``.
 
 deprecated:

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -423,6 +423,8 @@ the supported keys are:
   If the *return_duplicate_headers* is set to false (default), the returned *headers* is table with value type of string.
   If the *return_duplicate_headers* is set to true, the returned *headers* is table with value type of string or value type
   of table.
+- *send_xff* is a boolean flag that decides whether the *x-forwarded-for* header is sent to target server.
+  The default value is true.
 
   For example, the following upstream response headers have repeated headers.
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -62,6 +62,12 @@ const OptionHandlers& optionHandlers() {
                                 // = <boolean>} entry.
                                 options.return_duplicate_headers_ = lua_toboolean(state, -1);
                               }},
+                             {"send_xff",
+                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
+                                // Handle the case when the table has: {["send_xff"] =
+                                // <boolean>} entry.
+                                options.request_options_.setSendXff(lua_toboolean(state, -1));
+                              }},
                          });
 }
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1594,7 +1594,7 @@ TEST_F(LuaHttpFilterTest, HttpCallInvalidCluster) {
   EXPECT_EQ(1, stats_store_.counter("test.lua.errors").value());
 }
 
-// HTTP request flow with timeout and sampled flag in options.
+// HTTP request flow with timeout, sampled and send_xff flag in options.
 TEST_F(LuaHttpFilterTest, HttpCallWithTimeoutAndSampledInOptions) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_request(request_handle)
@@ -1609,6 +1609,7 @@ TEST_F(LuaHttpFilterTest, HttpCallWithTimeoutAndSampledInOptions) {
         {
           ["timeout_ms"] = 5000,
           ["trace_sampled"] = false,
+          ["send_xff"] = false,
         })
     end
   )EOF"};
@@ -1627,6 +1628,7 @@ TEST_F(LuaHttpFilterTest, HttpCallWithTimeoutAndSampledInOptions) {
               const Http::AsyncClient::RequestOptions& options) -> Http::AsyncClient::Request* {
             EXPECT_EQ(options.timeout->count(), 5000);
             EXPECT_EQ(options.sampled_.value(), false);
+            EXPECT_EQ(options.send_xff, false);
             callbacks = &cb;
             return &request;
           }));


### PR DESCRIPTION


Commit Message: lua: new option of http call to skip sending xff
Additional Description:

To close #25190

Risk Level: low.
Testing: unit.
Docs Changes: added.
Release Notes: added.
Platform Specific Features: n/a.