### PR TITLE
hyperscan: fix missing fat runtime flag

### DIFF
--- a/contrib/hyperscan/matching/input_matchers/source/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/source/BUILD
@@ -27,6 +27,7 @@ envoy_cmake(
         "BUILD_AVX512VBMI": "on",
         "BUILD_EXAMPLES": "off",
         "CMAKE_INSTALL_LIBDIR": "lib",
+        "FAT_RUNTIME": "on",
         "RAGEL": "$EXT_BUILD_DEPS/ragel/bin/ragel",
     },
     env = select({


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: hyperscan: fix missing fat runtime flag
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #25099 
