### PR TITLE
kotlin: more test clean up

### DIFF
--- a/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -1,6 +1,6 @@
 package test.kotlin.integration
 
-import io.envoyproxy.envoymobile.Custom
+import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -27,38 +27,6 @@ private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.
 private const val localErrorFilterType =
   "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
 private const val filterName = "error_validation_filter"
-private const val config =
-"""
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
-    api_listener:
-      api_listener:
-        "@type": $hcmType
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-            - name: api
-              domains: ["*"]
-              routes:
-              - match: { prefix: "/" }
-                direct_response: { status: 503 }
-          http_filters:
-          - name: envoy.filters.http.platform_bridge
-            typed_config:
-              "@type": $pbfType
-              platform_filter_name: $filterName
-          - name: envoy.filters.http.local_error
-            typed_config:
-              "@type": $localErrorFilterType
-          - name: envoy.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-"""
 
 class GRPCReceiveErrorTest {
   init {
@@ -114,11 +82,12 @@ class GRPCReceiveErrorTest {
       path = "/pb.api.v1.Foo/GetBar"
     ).build()
 
-    val engine = EngineBuilder(Custom(config))
+    val engine = EngineBuilder(Standard())
       .addPlatformFilter(
         name = filterName,
         factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }
       )
+      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $pbfType, platform_filter_name: $filterName}")
       .setOnEngineRunning {}
       .build()
 

--- a/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
+++ b/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
@@ -1,6 +1,6 @@
 package test.kotlin.integration
 
-import io.envoyproxy.envoymobile.Custom
+import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -13,48 +13,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
+private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 private val apiListenerType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
 private val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-private val config =
-"""
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": $apiListenerType
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": $assertionFilterType
-                match_config:
-                  http_request_headers_match:
-                    headers:
-                      - name: ":authority"
-                        exact_match: example.com
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-"""
 
+// This test doesn't do what it advertises (https://github.com/envoyproxy/envoy/issues/25180)
 class ResetConnectivityStateTest {
 
   init {
@@ -65,7 +28,9 @@ class ResetConnectivityStateTest {
   fun `successful request after connection drain`() {
     val headersExpectation = CountDownLatch(2)
 
-    val engine = EngineBuilder(Custom(config)).build()
+    val engine = EngineBuilder(Standard())
+      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+      .build()
     val client = engine.streamClient()
 
     val requestHeaders = RequestHeadersBuilder(
@@ -85,6 +50,9 @@ class ResetConnectivityStateTest {
         resultEndStream1 = endStream
         headersExpectation.countDown()
       }
+      .setOnResponseData { _, endStream, _ ->
+        resultEndStream1 = endStream
+      }
       .setOnError { _, _ -> fail("Unexpected error") }
       .start()
       .sendHeaders(requestHeaders, true)
@@ -100,6 +68,9 @@ class ResetConnectivityStateTest {
         resultHeaders2 = responseHeaders
         resultEndStream2 = endStream
         headersExpectation.countDown()
+      }
+      .setOnResponseData { _, endStream, _ ->
+        resultEndStream2 = endStream
       }
       .setOnError { _, _ -> fail("Unexpected error") }
       .start()


### PR DESCRIPTION
Akin to https://github.com/envoyproxy/envoy/pull/25159 moving the rest of the non-proxy Kotlin tests to use the builder APIs

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
part of https://github.com/envoyproxy/envoy/issues/24976
