### PR TITLE
Fix flaky QUIC test for deferred logging

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1194,7 +1194,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLogging) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   sendRequestAndWaitForResponse(default_request_headers_, /*request_size=*/0,
                                 default_response_headers_,
-                                /*response_size=*/0,
+                                /*response_size=*/1024 * 1024,
                                 /*upstream_index=*/0, TestUtility::DefaultTimeout);
   codec_client_->close();
 
@@ -1203,7 +1203,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLogging) {
   std::vector<std::string> metrics = absl::StrSplit(log, ",");
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
-  EXPECT_GE(/* ROUNDTRIP_DURATION */ std::stoi(metrics.at(1)), 0);
+  EXPECT_GT(/* ROUNDTRIP_DURATION */ std::stoi(metrics.at(1)), 0);
   EXPECT_GE(/* REQUEST_DURATION */ std::stoi(metrics.at(2)), 0);
   EXPECT_GE(/* RESPONSE_DURATION */ std::stoi(metrics.at(3)), 0);
   EXPECT_EQ(/* RESPONSE_CODE */ metrics.at(4), "200");

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1191,11 +1191,16 @@ TEST_P(QuicHttpIntegrationTest, DeferredLogging) {
       "METADATA("
       "udp.proxy.session:bytes_sent)%,%REQ(:path)%,%STREAM_INFO_REQ(:path)%");
   initialize();
+
+  // Make a header-only request and delay the response by 1ms to ensure that the ROUNDTRIP_DURATION
+  // metric is > 0 if exists.
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  sendRequestAndWaitForResponse(default_request_headers_, /*request_size=*/0,
-                                default_response_headers_,
-                                /*response_size=*/1024 * 1024,
-                                /*upstream_index=*/0, TestUtility::DefaultTimeout);
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  absl::SleepFor(absl::Milliseconds(1));
+  waitForNextUpstreamRequest(0, TestUtility::DefaultTimeout);
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  RELEASE_ASSERT(response->waitForEndStream(TestUtility::DefaultTimeout), "unexpected timeout");
   codec_client_->close();
 
   std::string log = waitForAccessLog(access_log_name_);

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1203,7 +1203,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLogging) {
   std::vector<std::string> metrics = absl::StrSplit(log, ",");
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
-  EXPECT_GT(/* ROUNDTRIP_DURATION */ std::stoi(metrics.at(1)), 0);
+  EXPECT_GE(/* ROUNDTRIP_DURATION */ std::stoi(metrics.at(1)), 0);
   EXPECT_GE(/* REQUEST_DURATION */ std::stoi(metrics.at(2)), 0);
   EXPECT_GE(/* RESPONSE_DURATION */ std::stoi(metrics.at(3)), 0);
   EXPECT_EQ(/* RESPONSE_CODE */ metrics.at(4), "200");


### PR DESCRIPTION
Commit Message: Fix flaky QUIC test for deferred logging
Risk Level: N/A, test-only

Fixes https://github.com/envoyproxy/envoy/issues/25264