### PR TITLE
adding bytes received/sent to cluster TCP stats

### DIFF
--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -13,7 +13,7 @@
    cx_rx_data_segments, Counter, Total TCP segments with a non-zero data length received
    cx_tx_retransmitted_segments, Counter, Total TCP segments retransmitted
    cx_rx_bytes_received, Counter, Total payload bytes received for which TCP acknowledgments have been sent.
-   cx_tx_bytes_sent, Counter, Total payload bytes transmitted, including retransmitted bytes.
+   cx_tx_bytes_sent, Counter, Total payload bytes transmitted (including retransmitted bytes).
    cx_tx_unsent_bytes, Gauge, Bytes which Envoy has sent to the operating system which have not yet been sent
    cx_tx_unacked_segments, Gauge, Segments which have been transmitted that have not yet been acknowledged
    cx_tx_percent_retransmitted_segments, Histogram, Percent of segments on a connection which were retransmistted

--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -12,8 +12,8 @@
    cx_tx_data_segments, Counter, Total TCP segments with a non-zero data length transmitted
    cx_rx_data_segments, Counter, Total TCP segments with a non-zero data length received
    cx_tx_retransmitted_segments, Counter, Total TCP segments retransmitted
-   cx_rx_bytes_received, Counter, Bytes received from clients which TCP acknowledgments have been generated.
-   cx_tx_bytes_sent, Counter, Bytes transmitted from clients which TCP acknowledgments have been generated.
+   cx_rx_bytes_received, Counter, Total payload bytes received for which TCP acknowledgments have been sent.
+   cx_tx_bytes_sent, Counter, Total payload bytes transmitted, including retransmitted bytes.
    cx_tx_unsent_bytes, Gauge, Bytes which Envoy has sent to the operating system which have not yet been sent
    cx_tx_unacked_segments, Gauge, Segments which have been transmitted that have not yet been acknowledged
    cx_tx_percent_retransmitted_segments, Histogram, Percent of segments on a connection which were retransmistted

--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -12,6 +12,8 @@
    cx_tx_data_segments, Counter, Total TCP segments with a non-zero data length transmitted
    cx_rx_data_segments, Counter, Total TCP segments with a non-zero data length received
    cx_tx_retransmitted_segments, Counter, Total TCP segments retransmitted
+   cx_rx_bytes_received, Counter, Bytes received from clients which TCP acknowledgments have been generated.
+   cx_tx_bytes_sent, Counter, Bytes transmitted from clients which TCP acknowledgments have been generated.
    cx_tx_unsent_bytes, Gauge, Bytes which Envoy has sent to the operating system which have not yet been sent
    cx_tx_unacked_segments, Gauge, Segments which have been transmitted that have not yet been acknowledged
    cx_tx_percent_retransmitted_segments, Histogram, Percent of segments on a connection which were retransmistted

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -141,6 +141,10 @@ void TcpStatsSocket::recordStats() {
                  tcp_info->tcpi_data_segs_in);
   update_counter(config_->stats_.cx_tx_retransmitted_segments_, last_cx_tx_retransmitted_segments_,
                  tcp_info->tcpi_total_retrans);
+  update_counter(config_->stats_.cx_rx_bytes_received_, last_cx_rx_bytes_received_,
+                 tcp_info->tcpi_bytes_received);
+  update_counter(config_->stats_.cx_tx_bytes_sent_, last_cx_tx_bytes_sent_,
+                 tcp_info->tcpi_bytes_sent);
 
   update_gauge(config_->stats_.cx_tx_unsent_bytes_, last_cx_tx_unsent_bytes_,
                tcp_info->tcpi_notsent_bytes);

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -26,6 +26,8 @@ namespace TcpStats {
   COUNTER(cx_tx_data_segments)                                                                     \
   COUNTER(cx_rx_data_segments)                                                                     \
   COUNTER(cx_tx_retransmitted_segments)                                                            \
+  COUNTER(cx_rx_bytes_received)                                                                    \
+  COUNTER(cx_tx_bytes_sent)                                                                        \
   GAUGE(cx_tx_unsent_bytes, Accumulate)                                                            \
   GAUGE(cx_tx_unacked_segments, Accumulate)                                                        \
   HISTOGRAM(cx_tx_percent_retransmitted_segments, Percent)                                         \
@@ -73,6 +75,8 @@ private:
   uint32_t last_cx_tx_data_segments_{};
   uint32_t last_cx_rx_data_segments_{};
   uint32_t last_cx_tx_retransmitted_segments_{};
+  uint32_t last_cx_rx_bytes_received_{};
+  uint32_t last_cx_tx_bytes_sent_{};
   uint32_t last_cx_tx_unsent_bytes_{};
   uint32_t last_cx_tx_unacked_segments_{};
 };


### PR DESCRIPTION
Commit Message: adding bytes received/sent to cluster TCP stats
Additional Description: Adding more tcp stats taken from tcpi_bytes_received and tcpi_bytes_sent data
Risk Level: Low
Testing: Compiled and tested with tcpdump for comparison
Docs Changes: No docs changed.
Release Notes: None
Platform Specific Features: None

