### PR TITLE
Remove option java_generic_services from proto files

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.
 option java_outer_classname = "TraProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sip_proxy/tra/v3alpha";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: TRA]

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "CdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.cluster.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "EdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.endpoint.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "LdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.listener.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/rds.proto
+++ b/api/envoy/api/v2/rds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "RdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/api/v2/srds.proto
+++ b/api/envoy/api/v2/srds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.api.v2";
 option java_outer_classname = "SrdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/api/v2;apiv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.route.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/service/accesslog/v2/als.proto
+++ b/api/envoy/service/accesslog/v2/als.proto
@@ -12,7 +12,6 @@ option java_package = "io.envoyproxy.envoy.service.accesslog.v2";
 option java_outer_classname = "AlsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2;accesslogv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: gRPC Access Log Service (ALS)]

--- a/api/envoy/service/accesslog/v3/als.proto
+++ b/api/envoy/service/accesslog/v3/als.proto
@@ -13,7 +13,6 @@ option java_package = "io.envoyproxy.envoy.service.accesslog.v3";
 option java_outer_classname = "AlsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3;accesslogv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: gRPC access log service (ALS)]

--- a/api/envoy/service/auth/v2/external_auth.proto
+++ b/api/envoy/service/auth/v2/external_auth.proto
@@ -15,7 +15,6 @@ option java_package = "io.envoyproxy.envoy.service.auth.v2";
 option java_outer_classname = "ExternalAuthProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2;authv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Authorization Service ]

--- a/api/envoy/service/auth/v2alpha/external_auth.proto
+++ b/api/envoy/service/auth/v2alpha/external_auth.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.service.auth.v2alpha;
 
 option java_multiple_files = true;
-option java_generic_services = true;
 option java_outer_classname = "CertsProto";
 option java_package = "io.envoyproxy.envoy.service.auth.v2alpha";
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2alpha";

--- a/api/envoy/service/auth/v3/external_auth.proto
+++ b/api/envoy/service/auth/v3/external_auth.proto
@@ -17,7 +17,6 @@ option java_package = "io.envoyproxy.envoy.service.auth.v3";
 option java_outer_classname = "ExternalAuthProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3;authv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Authorization service]

--- a/api/envoy/service/cluster/v3/cds.proto
+++ b/api/envoy/service/cluster/v3/cds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.cluster.v3";
 option java_outer_classname = "CdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3;clusterv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: CDS]

--- a/api/envoy/service/discovery/v2/ads.proto
+++ b/api/envoy/service/discovery/v2/ads.proto
@@ -10,7 +10,6 @@ option java_package = "io.envoyproxy.envoy.service.discovery.v2";
 option java_outer_classname = "AdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2;discoveryv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Aggregated Discovery Service (ADS)]

--- a/api/envoy/service/discovery/v2/hds.proto
+++ b/api/envoy/service/discovery/v2/hds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.service.discovery.v2";
 option java_outer_classname = "HdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2;discoveryv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.health.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/service/discovery/v2/rtds.proto
+++ b/api/envoy/service/discovery/v2/rtds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.service.discovery.v2";
 option java_outer_classname = "RtdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2;discoveryv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.runtime.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/service/discovery/v2/sds.proto
+++ b/api/envoy/service/discovery/v2/sds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.discovery.v2";
 option java_outer_classname = "SdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2;discoveryv2";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.secret.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/service/discovery/v3/ads.proto
+++ b/api/envoy/service/discovery/v3/ads.proto
@@ -11,7 +11,6 @@ option java_package = "io.envoyproxy.envoy.service.discovery.v3";
 option java_outer_classname = "AdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3;discoveryv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Aggregated Discovery Service (ADS)]

--- a/api/envoy/service/endpoint/v3/eds.proto
+++ b/api/envoy/service/endpoint/v3/eds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.endpoint.v3";
 option java_outer_classname = "EdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3;endpointv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: EDS]

--- a/api/envoy/service/endpoint/v3/leds.proto
+++ b/api/envoy/service/endpoint/v3/leds.proto
@@ -11,7 +11,6 @@ option java_package = "io.envoyproxy.envoy.service.endpoint.v3";
 option java_outer_classname = "LedsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3;endpointv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#not-implemented-hide:]

--- a/api/envoy/service/event_reporting/v2alpha/event_reporting_service.proto
+++ b/api/envoy/service/event_reporting/v2alpha/event_reporting_service.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.event_reporting.v2alpha";
 option java_outer_classname = "EventReportingServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/event_reporting/v2alpha";
-option java_generic_services = true;
 option (udpa.annotations.file_migrate).move_to_package = "envoy.service.event_reporting.v3";
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 

--- a/api/envoy/service/event_reporting/v3/event_reporting_service.proto
+++ b/api/envoy/service/event_reporting/v3/event_reporting_service.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.event_reporting.v3";
 option java_outer_classname = "EventReportingServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/event_reporting/v3;event_reportingv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: gRPC Event Reporting Service]

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -17,7 +17,6 @@ option java_package = "io.envoyproxy.envoy.service.ext_proc.v3";
 option java_outer_classname = "ExternalProcessorProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3;ext_procv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/envoy/service/extension/v3/config_discovery.proto
+++ b/api/envoy/service/extension/v3/config_discovery.proto
@@ -13,7 +13,6 @@ option java_package = "io.envoyproxy.envoy.service.extension.v3";
 option java_outer_classname = "ConfigDiscoveryProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/extension/v3;extensionv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Extension config discovery service (ECDS)]

--- a/api/envoy/service/health/v3/hds.proto
+++ b/api/envoy/service/health/v3/hds.proto
@@ -19,7 +19,6 @@ option java_package = "io.envoyproxy.envoy.service.health.v3";
 option java_outer_classname = "HdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/health/v3;healthv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Health discovery service (HDS)]

--- a/api/envoy/service/listener/v3/lds.proto
+++ b/api/envoy/service/listener/v3/lds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.listener.v3";
 option java_outer_classname = "LdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3;listenerv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Listener]

--- a/api/envoy/service/load_stats/v2/lrs.proto
+++ b/api/envoy/service/load_stats/v2/lrs.proto
@@ -13,7 +13,6 @@ option java_package = "io.envoyproxy.envoy.service.load_stats.v2";
 option java_outer_classname = "LrsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2;load_statsv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Load reporting service]

--- a/api/envoy/service/load_stats/v3/lrs.proto
+++ b/api/envoy/service/load_stats/v3/lrs.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.load_stats.v3";
 option java_outer_classname = "LrsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3;load_statsv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Load reporting service (LRS)]

--- a/api/envoy/service/metrics/v2/metrics_service.proto
+++ b/api/envoy/service/metrics/v2/metrics_service.proto
@@ -13,7 +13,6 @@ option java_package = "io.envoyproxy.envoy.service.metrics.v2";
 option java_outer_classname = "MetricsServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2;metricsv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Metrics service]

--- a/api/envoy/service/metrics/v3/metrics_service.proto
+++ b/api/envoy/service/metrics/v3/metrics_service.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.metrics.v3";
 option java_outer_classname = "MetricsServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v3;metricsv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Metrics service]

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -15,7 +15,6 @@ option java_package = "io.envoyproxy.envoy.service.rate_limit_quota.v3";
 option java_outer_classname = "RlqsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/rate_limit_quota/v3;rate_limit_quotav3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -12,7 +12,6 @@ option java_package = "io.envoyproxy.envoy.service.ratelimit.v2";
 option java_outer_classname = "RlsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2;ratelimitv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Rate Limit Service (RLS)]

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -17,7 +17,6 @@ option java_package = "io.envoyproxy.envoy.service.ratelimit.v3";
 option java_outer_classname = "RlsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3;ratelimitv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Rate limit service (RLS)]

--- a/api/envoy/service/route/v3/rds.proto
+++ b/api/envoy/service/route/v3/rds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.route.v3";
 option java_outer_classname = "RdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/route/v3;routev3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: RDS]

--- a/api/envoy/service/route/v3/srds.proto
+++ b/api/envoy/service/route/v3/srds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.route.v3";
 option java_outer_classname = "SrdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/route/v3;routev3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: SRDS]

--- a/api/envoy/service/runtime/v3/rtds.proto
+++ b/api/envoy/service/runtime/v3/rtds.proto
@@ -16,7 +16,6 @@ option java_package = "io.envoyproxy.envoy.service.runtime.v3";
 option java_outer_classname = "RtdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3;runtimev3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Runtime discovery service (RTDS)]

--- a/api/envoy/service/secret/v3/sds.proto
+++ b/api/envoy/service/secret/v3/sds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.secret.v3";
 option java_outer_classname = "SdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3;secretv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Secret Discovery Service (SDS)]

--- a/api/envoy/service/status/v2/csds.proto
+++ b/api/envoy/service/status/v2/csds.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.status.v2";
 option java_outer_classname = "CsdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/status/v2;statusv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Client Status Discovery Service (CSDS)]

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -18,7 +18,6 @@ option java_package = "io.envoyproxy.envoy.service.status.v3";
 option java_outer_classname = "CsdsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/status/v3;statusv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Client status discovery service (CSDS)]

--- a/api/envoy/service/tap/v2alpha/tap.proto
+++ b/api/envoy/service/tap/v2alpha/tap.proto
@@ -12,7 +12,6 @@ option java_package = "io.envoyproxy.envoy.service.tap.v2alpha";
 option java_outer_classname = "TapProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/tap/v2alpha";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Tap Sink Service]

--- a/api/envoy/service/tap/v3/tap.proto
+++ b/api/envoy/service/tap/v3/tap.proto
@@ -13,7 +13,6 @@ option java_package = "io.envoyproxy.envoy.service.tap.v3";
 option java_outer_classname = "TapProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/tap/v3;tapv3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Tap sink service]

--- a/api/envoy/service/trace/v2/trace_service.proto
+++ b/api/envoy/service/trace/v2/trace_service.proto
@@ -13,7 +13,6 @@ option java_package = "io.envoyproxy.envoy.service.trace.v2";
 option java_outer_classname = "TraceServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/trace/v2;tracev2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Trace service]

--- a/api/envoy/service/trace/v3/trace_service.proto
+++ b/api/envoy/service/trace/v3/trace_service.proto
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.service.trace.v3";
 option java_outer_classname = "TraceServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/trace/v3;tracev3";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Trace service]

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -241,9 +241,6 @@ def format_header_from_file(
         options.csharp_namespace = '.'.join(names) + 'NS'
         options.ruby_package = '::'.join(names) + 'NS'
 
-    if file_proto.service:
-        options.java_generic_services = True
-
     if file_proto.options.HasExtension(migrate_pb2.file_migrate):
         options.Extensions[migrate_pb2.file_migrate].CopyFrom(
             file_proto.options.Extensions[migrate_pb2.file_migrate])

--- a/tools/testdata/protoxform/envoy/v2/discovery_service.proto.active_or_frozen.gold
+++ b/tools/testdata/protoxform/envoy/v2/discovery_service.proto.active_or_frozen.gold
@@ -14,7 +14,6 @@ option java_package = "io.envoyproxy.envoy.v2";
 option java_outer_classname = "DiscoveryServiceProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/v2;envoyv2";
-option java_generic_services = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 service SomeDiscoveryService {


### PR DESCRIPTION
Commit Message: Remove option java_generic_services from proto files
Additional Description: Generic services are deprecated since protoc version 2.4.0 (2010). Protoc plugins that generates code may require that generic services are disabled, so that they can generate their own classes of the same name.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Optional Fixes #25172

