### PR TITLE
[balsa] Re-enable header integration tests for BalsaParser.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -126,6 +126,13 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
     : message_type_(type), connection_(connection) {
   ASSERT(connection_ != nullptr);
 
+  quiche::HttpValidationPolicy http_validation_policy;
+  http_validation_policy.disallow_header_continuation_lines = false;
+  http_validation_policy.require_header_colon = true;
+  http_validation_policy.disallow_multiple_content_length = false;
+  http_validation_policy.disallow_transfer_encoding_with_content_length = false;
+  framer_.set_http_validation_policy(http_validation_policy);
+
   framer_.set_balsa_headers(&headers_);
   if (enable_trailers) {
     framer_.set_balsa_trailer(&trailers_);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1070,11 +1070,7 @@ TEST_P(IntegrationTest, InvalidVersion) {
 
 // Expect that malformed trailers to break the connection
 TEST_P(IntegrationTest, BadTrailer) {
-  if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
+  config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
@@ -1091,11 +1087,6 @@ TEST_P(IntegrationTest, BadTrailer) {
 
 // Expect malformed headers to break the connection
 TEST_P(IntegrationTest, BadHeader) {
-  if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
-    return;
-  }
-
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
@@ -1162,7 +1153,8 @@ TEST_P(IntegrationTest, Http09Enabled) {
 
 TEST_P(IntegrationTest, Http09WithKeepalive) {
   if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
-    // TODO(#21245): Re-enable this test for BalsaParser.
+    // HTTP/0.9 does not allow for headers.
+    // BalsaParser correctly ignores data after "\r\n".
     return;
   }
 


### PR DESCRIPTION
[balsa] Re-enable IntegrationTest.[BadHeader,BadTrailer] for BalsaParser.

Explicitly enable trailers in IntegrationTest.BadTrailer, otherwise BalsaParser does not validate trailers.

Tracking issue: https://github.com/envoyproxy/envoy/issues/21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Re-enable header integration tests for BalsaParser.
Additional Description:
Risk Level: low, test-only change
Testing: //test/integration:integration_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a