### PR TITLE
[backport/1.22] build(deps): bump distroless/base-nossl-debian11 to `bf61596`

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -41,7 +41,7 @@ CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
 
 # STAGE: envoy-distroless
 # gcr.io/distroless/base-nossl-debian11:nonroot
-FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:cd7fe70a797fe1bda4407d2d047d395b42ea4eb4f600f806187a63ea7f579443 AS envoy-distroless
+FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:bf6159657aa6ac2c0d52e78a616991ac523adafd0718d17c6a013958a6770e1d AS envoy-distroless
 
 COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 COPY --from=binary /usr/local/bin/su-exec /usr/local/bin/


### PR DESCRIPTION
in /ci (#25291)

build(deps): bump distroless/base-nossl-debian11 in /ci

Bumps distroless/base-nossl-debian11 from `cd7fe70` to `bf61596`.

---
updated-dependencies:
- dependency-name: distroless/base-nossl-debian11 dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
