### PR TITLE
RequestDecoder list of access loggers returns const reference

### DIFF
--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -257,7 +257,7 @@ public:
   /**
    * @return List of shared pointers to access loggers for this stream.
    */
-  virtual std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() PURE;
+  virtual const std::list<AccessLog::InstanceSharedPtr>& accessLogHandlers() PURE;
 };
 
 /**

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -201,7 +201,7 @@ private:
                         absl::string_view details) override {
       return filter_manager_.sendLocalReply(code, body, modify_headers, grpc_status, details);
     }
-    std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() override {
+    const std::list<AccessLog::InstanceSharedPtr>& accessLogHandlers() override {
       return filter_manager_.accessLogHandlers();
     }
     // Hand off headers/trailers and stream info to the codec's response encoder, for logging later

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -673,7 +673,9 @@ public:
     }
   }
 
-  std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() { return access_log_handlers_; }
+  const std::list<AccessLog::InstanceSharedPtr>& accessLogHandlers() {
+    return access_log_handlers_;
+  }
 
   void onStreamComplete() {
     for (auto& filter : decoder_filters_) {

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -30,7 +30,7 @@ public:
   // Log this stream using available stream info and access loggers.
   void maybeDoDeferredLog(bool record_ack_timing = true);
   // Set list of pointers to access loggers.
-  void setAccessLogHandlers(std::list<AccessLog::InstanceSharedPtr> handlers) {
+  void setAccessLogHandlers(const std::list<AccessLog::InstanceSharedPtr>& handlers) {
     access_log_handlers_ = handlers;
   }
   // Set headers, trailers, and stream info used for deferred logging.

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -225,7 +225,7 @@ public:
     RELEASE_ASSERT(false, "initialize if this is needed");
     return *stream_info_;
   }
-  std::list<AccessLog::InstanceSharedPtr> accessLogHandlers() override {
+  const std::list<AccessLog::InstanceSharedPtr>& accessLogHandlers() override {
     return access_log_handlers_;
   }
 

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -31,7 +31,7 @@ public:
   // Http::RequestDecoder
   MOCK_METHOD(void, decodeHeaders_, (RequestHeaderMapSharedPtr & headers, bool end_stream));
   MOCK_METHOD(void, decodeTrailers_, (RequestTrailerMapPtr & trailers));
-  MOCK_METHOD(std::list<AccessLog::InstanceSharedPtr>, accessLogHandlers, ());
+  MOCK_METHOD(const std::list<AccessLog::InstanceSharedPtr>&, accessLogHandlers, ());
 };
 
 class MockResponseDecoder : public ResponseDecoder {


### PR DESCRIPTION
Commit Message: RequestDecoder list of access loggers returns const reference
Additional Description: Purely to reduce unnecessary copies.
Risk Level: Low, no functional change
Testing: No new tests
