### PR TITLE
mobile: allow overriding dns cache key value save interval

### DIFF
--- a/mobile/docs/root/api/starting_envoy.rst
+++ b/mobile/docs/root/api/starting_envoy.rst
@@ -491,6 +491,27 @@ Available on Android only.
     builder.enableProxying(true)
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enableDNSCache``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify whether to enable DNS cache. Note that DNS cache requires an addition of
+a key value store named 'reserved.platform_store'.
+
+The interval at which results are saved to the key value store defaults to 1s
+but can also be set explicitly.
+
+A maximum of 100 entries will be stored.
+
+**Example**::
+
+  // Kotlin
+  builder.enableDNSCache(true, saveInterval: 60)
+
+  // Swift
+  builder.enableDNSCache(true, saveInterval: 60)
+
+
 ----------------------
 Advanced configuration
 ----------------------

--- a/mobile/docs/root/api/starting_envoy.rst
+++ b/mobile/docs/root/api/starting_envoy.rst
@@ -368,61 +368,33 @@ Specify whether to use Happy Eyeballs when multiple IP stacks may be supported. 
   // Swift
   builder.enableHappyEyeballs(true)
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enableGzipDecompression``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
+``enableGzip``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Specify whether to enable transparent response Gzip decompression. Defaults to true.
 
 **Example**::
 
   // Kotlin
-  builder.enableGzipDecompression(false)
+  builder.enableGzip(false)
 
   // Swift
-  builder.enableGzipDecompression(false)
+  builder.enableGzip(false)
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enableGzipCompression``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Specify whether to enable transparent request Gzip compression. Defaults to false.
-
-**Example**::
-
-  // Kotlin
-  builder.enableGzipCompression(true)
-
-  // Swift
-  builder.enableGzipCompression(true)
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enableBrotliDecompression``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
+``enableBrotli``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Specify whether to enable transparent response Brotli decompression. Defaults to false.
 
 **Example**::
 
   // Kotlin
-  builder.enableBrotliDecompression(true)
+  builder.enableBrotli(true)
 
   // Swift
-  builder.enableBrotliDecompression(true)
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enableBrotliCompression``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Specify whether to enable transparent request Brotli compression. Defaults to false.
-
-**Example**::
-
-  // Kotlin
-  builder.enableBrotliCompression(true)
-
-  // Swift
-  builder.enableBrotliCompression(true)
+  builder.enableBrotli(true)
 
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``enableSocketTagging``

--- a/mobile/docs/root/api/starting_envoy.rst
+++ b/mobile/docs/root/api/starting_envoy.rst
@@ -368,33 +368,61 @@ Specify whether to use Happy Eyeballs when multiple IP stacks may be supported. 
   // Swift
   builder.enableHappyEyeballs(true)
 
-~~~~~~~~~~~~~~~~~~~~~~~
-``enableGzip``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enableGzipDecompression``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Specify whether to enable transparent response Gzip decompression. Defaults to true.
 
 **Example**::
 
   // Kotlin
-  builder.enableGzip(false)
+  builder.enableGzipDecompression(false)
 
   // Swift
-  builder.enableGzip(false)
+  builder.enableGzipDecompression(false)
 
-~~~~~~~~~~~~~~~~~~~~~~~
-``enableBrotli``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enableGzipCompression``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify whether to enable transparent request Gzip compression. Defaults to false.
+
+**Example**::
+
+  // Kotlin
+  builder.enableGzipCompression(true)
+
+  // Swift
+  builder.enableGzipCompression(true)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enableBrotliDecompression``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Specify whether to enable transparent response Brotli decompression. Defaults to false.
 
 **Example**::
 
   // Kotlin
-  builder.enableBrotli(true)
+  builder.enableBrotliDecompression(true)
 
   // Swift
-  builder.enableBrotli(true)
+  builder.enableBrotliDecompression(true)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enableBrotliCompression``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify whether to enable transparent request Brotli compression. Defaults to false.
+
+**Example**::
+
+  // Kotlin
+  builder.enableBrotliCompression(true)
+
+  // Swift
+  builder.enableBrotliCompression(true)
 
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``enableSocketTagging``

--- a/mobile/examples/objective-c/hello_world/ViewController.m
+++ b/mobile/examples/objective-c/hello_world/ViewController.m
@@ -39,7 +39,7 @@ NSString *_REQUEST_SCHEME = @"https";
   NSLog(@"starting Envoy...");
   EngineBuilder *builder = [[EngineBuilder alloc] init];
   [builder addLogLevel:LogLevelDebug];
-  [builder enableDNSCache:YES];
+  [builder enableDNSCache:YES saveInterval:1];
   [builder addKeyValueStoreWithName:@"reserved.platform_store"
                       keyValueStore:NSUserDefaults.standardUserDefaults];
   [builder setOnEngineRunningWithClosure:^{

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -356,9 +356,9 @@ std::string EngineBuilder::generateConfigStr() const {
     replacements.push_back({"stats_domain", stats_domain_});
   }
   if (dns_cache_on_) {
-    replacements.push_back({"persistent_dns_cache_config", persistent_dns_cache_config_insert});
     replacements.push_back({"persistent_dns_cache_save_interval",
                             fmt::format("{}", dns_cache_save_interval_seconds_)});
+    replacements.push_back({"persistent_dns_cache_config", persistent_dns_cache_config_insert});
   }
 
   // NOTE: this does not include support for custom filters

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -591,7 +591,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   if (dns_cache_on_) {
     envoymobile::extensions::key_value::platform::PlatformKeyValueStoreConfig kv_config;
     kv_config.set_key("dns_persistent_cache");
-    kv_config.mutable_save_interval()->set_seconds(0);
+    kv_config.mutable_save_interval()->set_seconds(1);
     kv_config.set_max_entries(100);
     dns_cache_config->mutable_key_value_config()->mutable_config()->set_name(
         "envoy.key_value.platform");

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -69,7 +69,7 @@ public:
   // Adds an ADS layer.
   EngineBuilder& setAggregatedDiscoveryService(const std::string& api_type,
                                                const std::string& address, const int port);
-  EngineBuilder& enableDnsCache(bool dns_cache_on);
+  EngineBuilder& enableDnsCache(bool dns_cache_on, int save_interval_seconds = 1);
   EngineBuilder& setForceAlwaysUsev6(bool value);
   EngineBuilder& setSkipDnsLookupForProxiedRequests(bool value);
   EngineBuilder& addDnsPreresolveHostnames(const std::vector<std::string>& hostnames);
@@ -140,6 +140,7 @@ private:
   std::string ads_address_ = "";
   int ads_port_;
   bool dns_cache_on_ = false;
+  bool dns_cache_save_interval_seconds_ = 1;
 
   absl::flat_hash_map<std::string, KeyValueStoreSharedPtr> key_value_stores_{};
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -140,7 +140,7 @@ private:
   std::string ads_address_ = "";
   int ads_port_;
   bool dns_cache_on_ = false;
-  bool dns_cache_save_interval_seconds_ = 1;
+  int dns_cache_save_interval_seconds_ = 1;
 
   absl::flat_hash_map<std::string, KeyValueStoreSharedPtr> key_value_stores_{};
 

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -105,7 +105,7 @@ const char* persistent_dns_cache_config_insert = R"(
       "@type": type.googleapis.com/envoymobile.extensions.key_value.platform.PlatformKeyValueStoreConfig
       key: dns_persistent_cache
       save_interval:
-        seconds: 0
+        seconds: *persistent_dns_cache_save_interval
       max_entries: 100
 )";
 
@@ -121,6 +121,7 @@ const std::string config_header = R"(
 - &dns_query_timeout 25s
 - &dns_refresh_rate 60s
 - &persistent_dns_cache_config NULL
+- &persistent_dns_cache_save_interval 1
 - &force_ipv6 false
 )"
 #if defined(__APPLE__)

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -257,11 +257,11 @@ public class EnvoyConfiguration {
         .append("\n");
 
     if (enableDNSCache) {
+      configBuilder.append(
+          String.format("- &persistent_dns_cache_save_interval %s\n", dnsCacheSaveIntervalSeconds));
       final String persistentDNSCacheConfigInsert = JniLibrary.persistentDNSCacheConfigInsert();
       configBuilder.append(
           String.format("- &persistent_dns_cache_config %s\n", persistentDNSCacheConfigInsert));
-      configBuilder.append(
-          String.format("- &persistent_dns_cache_save_interval %s\n", dnsCacheSaveIntervalSeconds));
     }
 
     configBuilder.append(String.format("- &stats_flush_interval %ss\n", statsFlushSeconds));

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -261,8 +261,8 @@ public class EnvoyConfiguration {
       configBuilder.append(
           String.format("- &persistent_dns_cache_config %s\n", persistentDNSCacheConfigInsert));
       // TODO: Wire this through
-      configBuilder.append(String.format("- &persistent_dns_cache_save_interval %s\n",
-                                         dnsCacheSaveIntervalSeconds))
+      configBuilder.append(
+          String.format("- &persistent_dns_cache_save_interval %s\n", dnsCacheSaveIntervalSeconds))
     }
 
     configBuilder.append(String.format("- &stats_flush_interval %ss\n", statsFlushSeconds));

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -36,6 +36,7 @@ public class EnvoyConfiguration {
   public final Integer dnsMinRefreshSeconds;
   public final String dnsPreresolveHostnames;
   public final Boolean enableDNSCache;
+  public final Integer dnsCacheSaveIntervalSeconds;
   public final Boolean enableDrainPostDnsRefresh;
   public final Boolean enableHttp3;
   public final Boolean enableGzip;
@@ -84,6 +85,8 @@ public class EnvoyConfiguration {
    * @param dnsPreresolveHostnames                        hostnames to preresolve on Envoy Client
    *     construction.
    * @param enableDNSCache                                whether to enable DNS cache.
+   * @param dnsCacheSaveIntervalSeconds                   the interval at which to save results to
+   *     the configured key value store.
    * @param enableDrainPostDnsRefresh                     whether to drain connections after soft
    *     DNS refresh.
    * @param enableHttp3                                   whether to enable experimental support for
@@ -122,8 +125,8 @@ public class EnvoyConfiguration {
       boolean adminInterfaceEnabled, String grpcStatsDomain, int connectTimeoutSeconds,
       int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
       int dnsQueryTimeoutSeconds, int dnsMinRefreshSeconds, String dnsPreresolveHostnames,
-      boolean enableDNSCache, boolean enableDrainPostDnsRefresh, boolean enableHttp3,
-      boolean enableGzip, boolean enableBrotli, boolean enableSocketTagging,
+      boolean enableDNSCache, int dnsCacheSaveIntervalSeconds, boolean enableDrainPostDnsRefresh,
+      boolean enableHttp3, boolean enableGzip, boolean enableBrotli, boolean enableSocketTagging,
       boolean enableHappyEyeballs, boolean enableInterfaceBinding,
       int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
       int maxConnectionsPerHost, int statsFlushSeconds, int streamIdleTimeoutSeconds,
@@ -145,6 +148,7 @@ public class EnvoyConfiguration {
     this.dnsMinRefreshSeconds = dnsMinRefreshSeconds;
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
     this.enableDNSCache = enableDNSCache;
+    this.dnsCacheSaveIntervalSeconds = dnsCacheSaveIntervalSeconds;
     this.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh;
     this.enableHttp3 = enableHttp3;
     this.enableGzip = enableGzip;
@@ -256,6 +260,9 @@ public class EnvoyConfiguration {
       final String persistentDNSCacheConfigInsert = JniLibrary.persistentDNSCacheConfigInsert();
       configBuilder.append(
           String.format("- &persistent_dns_cache_config %s\n", persistentDNSCacheConfigInsert));
+      // TODO: Wire this through
+      configBuilder.append(String.format("- &persistent_dns_cache_save_interval %s\n",
+                                         dnsCacheSaveIntervalSeconds))
     }
 
     configBuilder.append(String.format("- &stats_flush_interval %ss\n", statsFlushSeconds));

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -260,9 +260,8 @@ public class EnvoyConfiguration {
       final String persistentDNSCacheConfigInsert = JniLibrary.persistentDNSCacheConfigInsert();
       configBuilder.append(
           String.format("- &persistent_dns_cache_config %s\n", persistentDNSCacheConfigInsert));
-      // TODO: Wire this through
       configBuilder.append(
-          String.format("- &persistent_dns_cache_save_interval %s\n", dnsCacheSaveIntervalSeconds))
+          String.format("- &persistent_dns_cache_save_interval %s\n", dnsCacheSaveIntervalSeconds));
     }
 
     configBuilder.append(String.format("- &stats_flush_interval %ss\n", statsFlushSeconds));

--- a/mobile/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -43,6 +43,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private int mDnsMinRefreshSeconds = 60;
   private String mDnsPreresolveHostnames = "[]";
   private boolean mEnableDNSCache = false;
+  private int mDnsCacheSaveIntervalSeconds = 1;
   private List<String> mDnsFallbackNameservers = Collections.emptyList();
   private boolean mEnableDnsFilterUnroutableFamilies = true;
   private boolean mDnsUseSystemResolver = true;
@@ -122,7 +123,8 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
     return new EnvoyConfiguration(
         mAdminInterfaceEnabled, mGrpcStatsDomain, mConnectTimeoutSeconds, mDnsRefreshSeconds,
         mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax, mDnsQueryTimeoutSeconds,
-        mDnsMinRefreshSeconds, mDnsPreresolveHostnames, mEnableDNSCache, mEnableDrainPostDnsRefresh,
+        mDnsMinRefreshSeconds, mDnsPreresolveHostnames, mEnableDNSCache, mDnsCacheSaveIntervalSeconds,
+        mEnableDrainPostDnsRefresh,
         quicEnabled(), mEnableGzip, brotliEnabled(), mEnableSocketTag, mEnableHappyEyeballs,
         mEnableInterfaceBinding, mH2ConnectionKeepaliveIdleIntervalMilliseconds,
         mH2ConnectionKeepaliveTimeoutSeconds, mMaxConnectionsPerHost, mStatsFlushSeconds,

--- a/mobile/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -123,14 +123,13 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
     return new EnvoyConfiguration(
         mAdminInterfaceEnabled, mGrpcStatsDomain, mConnectTimeoutSeconds, mDnsRefreshSeconds,
         mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax, mDnsQueryTimeoutSeconds,
-        mDnsMinRefreshSeconds, mDnsPreresolveHostnames, mEnableDNSCache, mDnsCacheSaveIntervalSeconds,
-        mEnableDrainPostDnsRefresh,
-        quicEnabled(), mEnableGzip, brotliEnabled(), mEnableSocketTag, mEnableHappyEyeballs,
-        mEnableInterfaceBinding, mH2ConnectionKeepaliveIdleIntervalMilliseconds,
-        mH2ConnectionKeepaliveTimeoutSeconds, mMaxConnectionsPerHost, mStatsFlushSeconds,
-        mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion, mAppId,
-        mTrustChainVerification, mVirtualClusters, nativeFilterChain, platformFilterChain,
-        stringAccessors, keyValueStores, statSinks, mEnableSkipDNSLookupForProxiedRequests,
-        mEnablePlatformCertificatesValidation);
+        mDnsMinRefreshSeconds, mDnsPreresolveHostnames, mEnableDNSCache,
+        mDnsCacheSaveIntervalSeconds, mEnableDrainPostDnsRefresh, quicEnabled(), mEnableGzip,
+        brotliEnabled(), mEnableSocketTag, mEnableHappyEyeballs, mEnableInterfaceBinding,
+        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
+        mMaxConnectionsPerHost, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
+        mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters,
+        nativeFilterChain, platformFilterChain, stringAccessors, keyValueStores, statSinks,
+        mEnableSkipDNSLookupForProxiedRequests, mEnablePlatformCertificatesValidation);
   }
 }

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -52,6 +52,7 @@ open class EngineBuilder(
   private var dnsMinRefreshSeconds = 60
   private var dnsPreresolveHostnames = "[]"
   private var enableDNSCache = false
+  private var dnsCacheSaveIntervalSeconds = 1
   private var enableDrainPostDnsRefresh = false
   private var enableHttp3 = true
   private var enableHappyEyeballs = true
@@ -215,11 +216,13 @@ open class EngineBuilder(
    * 'reserved.platform_store'.
    *
    * @param enableDNSCache whether to enable DNS cache. Disabled by default.
+   * @param saveInterval   the interval at which to save results to the configured key value store.
    *
    * @return This builder.
    */
-  fun enableDNSCache(enableDNSCache: Boolean): EngineBuilder {
+  fun enableDNSCache(enableDNSCache: Boolean, saveInterval: Int = 1): EngineBuilder {
     this.enableDNSCache = enableDNSCache
+    this.dnsCacheSaveIntervalSeconds = saveInterval
     return this
   }
 
@@ -591,6 +594,7 @@ open class EngineBuilder(
       dnsMinRefreshSeconds,
       dnsPreresolveHostnames,
       enableDNSCache,
+      dnsCacheSaveIntervalSeconds,
       enableDrainPostDnsRefresh,
       enableHttp3,
       enableGzip,

--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *dnsPreresolveHostnames;
 @property (nonatomic, assign) UInt32 dnsRefreshSeconds;
 @property (nonatomic, assign) BOOL enableDNSCache;
+@property (nonatomic, assign) UInt32 dnsCacheSaveIntervalSeconds;
 @property (nonatomic, assign) BOOL enableHappyEyeballs;
 @property (nonatomic, assign) BOOL enableHttp3;
 @property (nonatomic, assign) BOOL enableGzip;
@@ -59,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
                              dnsMinRefreshSeconds:(UInt32)dnsMinRefreshSeconds
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
                                    enableDNSCache:(BOOL)enableDNSCache
+                      dnsCacheSaveIntervalSeconds:(UInt32)dnsCacheSaveIntervalSeconds
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
                                       enableHttp3:(BOOL)enableHttp3
                                        enableGzip:(BOOL)enableGzip

--- a/mobile/library/objective-c/EnvoyConfiguration.m
+++ b/mobile/library/objective-c/EnvoyConfiguration.m
@@ -14,6 +14,7 @@
                              dnsMinRefreshSeconds:(UInt32)dnsMinRefreshSeconds
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
                                    enableDNSCache:(BOOL)enableDNSCache
+                      dnsCacheSaveIntervalSeconds:(UInt32)dnsCacheSaveIntervalSeconds
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
                                       enableHttp3:(BOOL)enableHttp3
                                        enableGzip:(BOOL)enableGzip
@@ -61,6 +62,7 @@
   self.dnsMinRefreshSeconds = dnsMinRefreshSeconds;
   self.dnsPreresolveHostnames = dnsPreresolveHostnames;
   self.enableDNSCache = enableDNSCache;
+  self.dnsCacheSaveIntervalSeconds = dnsCacheSaveIntervalSeconds;
   self.enableHappyEyeballs = enableHappyEyeballs;
   self.enableHttp3 = enableHttp3;
   self.enableGzip = enableGzip;
@@ -202,6 +204,8 @@
   if (self.enableDNSCache) {
     NSString *persistent_dns_cache_config = @(persistent_dns_cache_config_insert);
     [definitions appendFormat:@"- &persistent_dns_cache_config %@\n", persistent_dns_cache_config];
+    [definitions appendFormat:@"- &persistent_dns_cache_save_interval %lu\n",
+                              (unsigned long)self.dnsCacheSaveIntervalSeconds];
   }
 
   NSMutableArray *stat_sinks_config = [self.statsSinks mutableCopy];

--- a/mobile/library/objective-c/EnvoyConfiguration.m
+++ b/mobile/library/objective-c/EnvoyConfiguration.m
@@ -202,10 +202,10 @@
   [definitions appendFormat:@"%@\n", cert_validator_template];
 
   if (self.enableDNSCache) {
-    NSString *persistent_dns_cache_config = @(persistent_dns_cache_config_insert);
-    [definitions appendFormat:@"- &persistent_dns_cache_config %@\n", persistent_dns_cache_config];
     [definitions appendFormat:@"- &persistent_dns_cache_save_interval %lu\n",
                               (unsigned long)self.dnsCacheSaveIntervalSeconds];
+    NSString *persistent_dns_cache_config = @(persistent_dns_cache_config_insert);
+    [definitions appendFormat:@"- &persistent_dns_cache_config %@\n", persistent_dns_cache_config];
   }
 
   NSMutableArray *stat_sinks_config = [self.statsSinks mutableCopy];

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -24,6 +24,7 @@ open class EngineBuilder: NSObject {
   private var dnsPreresolveHostnames: String = "[]"
   private var dnsRefreshSeconds: UInt32 = 60
   private var enableDNSCache: Bool = false
+  private var dnsCacheSaveIntervalSeconds: UInt32 = 1
   private var enableHappyEyeballs: Bool = true
   private var enableGzip: Bool = true
   private var enableBrotli: Bool = false
@@ -180,11 +181,14 @@ open class EngineBuilder: NSObject {
   /// 'reserved.platform_store'.
   ///
   /// - parameter enableDNSCache: whether to enable DNS cache. Disabled by default.
+  /// - parameter saveInterval:   the interval at which to save results to the configured
+  ///                             key value store.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func enableDNSCache(_ enableDNSCache: Bool) -> Self {
+  public func enableDNSCache(_ enableDNSCache: Bool, saveInterval: UInt32 = 1) -> Self {
     self.enableDNSCache = enableDNSCache
+    self.dnsCacheSaveIntervalSeconds = saveInterval
     return self
   }
 
@@ -546,6 +550,7 @@ open class EngineBuilder: NSObject {
       dnsMinRefreshSeconds: self.dnsMinRefreshSeconds,
       dnsPreresolveHostnames: self.dnsPreresolveHostnames,
       enableDNSCache: self.enableDNSCache,
+      dnsCacheSaveIntervalSeconds: self.dnsCacheSaveIntervalSeconds,
       enableHappyEyeballs: self.enableHappyEyeballs,
       enableHttp3: self.enableHttp3,
       enableGzip: self.enableGzip,

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -38,7 +38,7 @@ TEST(TestConfig, ConfigIsApplied) {
       .addStatsFlushSeconds(654)
       .setAppVersion("1.2.3")
       .setAppId("1234-1234-1234")
-      .enableDnsCache(true)
+      .enableDnsCache(true, /* save_interval_seconds */ 1)
       .addDnsPreresolveHostnames({"lyft.com", "google.com"})
       .enableAdminInterface(true)
       .setForceAlwaysUsev6(true)
@@ -57,6 +57,7 @@ TEST(TestConfig, ConfigIsApplied) {
                                            "- &stats_flush_interval 654s",
                                            "  key: dns_persistent_cache",
                                            "- &force_ipv6 true",
+                                           "- &persistent_dns_cache_save_interval 1",
                                            ("- &metadata { device_os: probably-ubuntu-on-CI, "
                                             "app_version: 1.2.3, app_id: 1234-1234-1234 }"),
                                            R"(- &validation_context

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -38,7 +38,7 @@ TEST(TestConfig, ConfigIsApplied) {
       .addStatsFlushSeconds(654)
       .setAppVersion("1.2.3")
       .setAppId("1234-1234-1234")
-      .enableDnsCache(true, /* save_interval_seconds */ 1)
+      .enableDnsCache(true, /* save_interval_seconds */ 101)
       .addDnsPreresolveHostnames({"lyft.com", "google.com"})
       .enableAdminInterface(true)
       .setForceAlwaysUsev6(true)
@@ -57,7 +57,7 @@ TEST(TestConfig, ConfigIsApplied) {
                                            "- &stats_flush_interval 654s",
                                            "  key: dns_persistent_cache",
                                            "- &force_ipv6 true",
-                                           "- &persistent_dns_cache_save_interval 1",
+                                           "- &persistent_dns_cache_save_interval 101",
                                            ("- &metadata { device_os: probably-ubuntu-on-CI, "
                                             "app_version: 1.2.3, app_id: 1234-1234-1234 }"),
                                            R"(- &validation_context

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -74,6 +74,7 @@ class EnvoyConfigurationTest {
     dnsMinRefreshSeconds: Int = 12,
     dnsPreresolveHostnames: String = "[{address: hostname, port_value: 443}]",
     enableDNSCache: Boolean = false,
+    dnsCacheSaveIntervalSeconds: Int = 101,
     enableDrainPostDnsRefresh: Boolean = false,
     enableHttp3: Boolean = true,
     enableGzip: Boolean = true,
@@ -108,6 +109,7 @@ class EnvoyConfigurationTest {
       dnsMinRefreshSeconds,
       dnsPreresolveHostnames,
       enableDNSCache,
+      dnsCacheSaveIntervalSeconds,
       enableDrainPostDnsRefresh,
       enableHttp3,
       enableGzip,
@@ -219,6 +221,7 @@ class EnvoyConfigurationTest {
       grpcStatsDomain = "",
       enableDrainPostDnsRefresh = true,
       enableDNSCache = true,
+      dnsCacheSaveIntervalSeconds = 101,
       enableHappyEyeballs = true,
       enableHttp3 = false,
       enableGzip = false,
@@ -243,6 +246,8 @@ class EnvoyConfigurationTest {
 
     // enableDNSCache = true
     assertThat(resolvedTemplate).contains("key: dns_persistent_cache")
+    // dnsCacheSaveIntervalSeconds = 101
+    assertThat(resolvedTemplate).contains("&persistent_dns_cache_save_interval 101")
 
     // enableHappyEyeballs = true
     assertThat(resolvedTemplate).contains("&dns_lookup_family ALL")

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -452,6 +452,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsMinRefreshSeconds: 100,
       dnsPreresolveHostnames: "[test]",
       enableDNSCache: false,
+      dnsCacheSaveIntervalSeconds: 0,
       enableHappyEyeballs: true,
       enableHttp3: true,
       enableGzip: true,
@@ -546,6 +547,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsMinRefreshSeconds: 100,
       dnsPreresolveHostnames: "[test]",
       enableDNSCache: true,
+      dnsCacheSaveIntervalSeconds: 10,
       enableHappyEyeballs: false,
       enableHttp3: false,
       enableGzip: false,
@@ -588,10 +590,11 @@ final class EngineBuilderTests: XCTestCase {
       "@type": type.googleapis.com/envoymobile.extensions.key_value.platform.PlatformKeyValueStoreConfig
       key: dns_persistent_cache
       save_interval:
-        seconds: 0
+        seconds: *persistent_dns_cache_save_interval
       max_entries: 100
 """
     ))
+    XCTAssertTrue(resolvedYAML.contains("&persistent_dns_cache_save_interval 10"))
 // swiftlint:enable line_length
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding false"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification VERIFY_TRUST_CHAIN"))
@@ -621,6 +624,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsMinRefreshSeconds: 100,
       dnsPreresolveHostnames: "[test]",
       enableDNSCache: false,
+      dnsCacheSaveIntervalSeconds: 0,
       enableHappyEyeballs: false,
       enableHttp3: false,
       enableGzip: false,


### PR DESCRIPTION
In Lyft's usage, we have up to 14 calls per second to save DNS results to the key value store. Buffering these to save at most once per second should be sufficient.

Commit Message: mobile: set dns cache key value save interval to 1s
Additional Description: In Lyft's usage, we have up to 14 calls per second to save DNS results to the key value store. Buffering these to save at most once per second should be sufficient.
Risk Level: Low
Testing: In Lyft's apps
Docs Changes: Added
Release Notes: Added
Platform Specific Features: N/A