### PR TITLE
docs: Use PR commit sha

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -195,6 +195,7 @@ stages:
         ENVOY_RBE: "true"
         BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
         AZP_BRANCH: $(Build.SourceBranch)
+        AZP_COMMIT_SHA: $(system.pullRequest.sourceCommitId)
         ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
         BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
         BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -90,6 +90,7 @@ docker run --rm \
        "${ENVOY_DOCKER_OPTIONS[@]}" \
        "${VOLUMES[@]}" \
        -e AZP_BRANCH \
+       -e AZP_COMMIT_SHA \
        -e HTTP_PROXY \
        -e HTTPS_PROXY \
        -e NO_PROXY \

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -234,7 +234,7 @@ genrule(
     . $(location //bazel:volatile_env) \
     && $(location //tools/docs:sphinx_runner) \
          $${SPHINX_RUNNER_ARGS:-} \
-         --build_sha="$${BUILD_SCM_REVISION:-}" \
+         --build_sha="$${BUILD_DOCS_SHA:-$${BUILD_SCM_REVISION}}" \
          --docs_tag="$${BUILD_DOCS_TAG:-}" \
          --version_file=$(location //:VERSION.txt) \
          --descriptor_path=$(location @envoy_api//:v3_proto_set) \\

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -5,6 +5,7 @@
 
 set -e
 
+
 if [[ ! $(command -v bazel) ]]; then
     # shellcheck disable=SC2016
     echo 'ERROR: bazel must be installed and available in "$PATH" to build docs' >&2
@@ -28,6 +29,13 @@ if [[ "${AZP_BRANCH}" =~ ^refs/tags/v.* ]]; then
     export BUILD_DOCS_TAG="${AZP_BRANCH/refs\/tags\//}"
     echo "BUILD AZP RELEASE BRANCH ${BUILD_DOCS_TAG}"
     BAZEL_BUILD_OPTIONS+=("--action_env=BUILD_DOCS_TAG")
+elif [[ "${AZP_BRANCH}" =~ ^refs/pull ]]; then
+    # For PRs use the unmerged PR commit in the version string.
+    #
+    # Staged/built docs still use the merged sha in the URL to distinguish builds
+    #
+    export BUILD_DOCS_SHA="${AZP_COMMIT_SHA}"
+    BAZEL_BUILD_OPTIONS+=("--action_env=BUILD_DOCS_SHA")
 fi
 
 if [[ -n "${AZP_BRANCH}" ]] || [[ -n "${SPHINX_QUIET}" ]]; then


### PR DESCRIPTION
This uses the commit sha from the PR HEAD in the staged docs version string, which should make it easier to associate with a pushed PR version

The staged docs are still published to a URL using the merged commit sha - so individual builds (from the same pr commit) are still distinct

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
