### PR TITLE
Added rules_rust toolchain for s390x

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -5,7 +5,8 @@ load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependenci
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
+load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
 load("@base_pip3//:requirements.bzl", pip_dependencies = "install_deps")
 load("@dev_pip3//:requirements.bzl", pip_dev_dependencies = "install_deps")
@@ -33,6 +34,15 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     pip_dev_dependencies()
     pip_fuzzing_dependencies()
     rules_pkg_dependencies()
+    rust_repository_set(
+        name = "rust_linux_s390x",
+        exec_triple = "s390x-unknown-linux-gnu",
+        extra_target_triples = [
+            "wasm32-unknown-unknown",
+            "wasm32-wasi",
+        ],
+        versions = [rust_common.default_version],
+    )
     rules_rust_dependencies()
     rust_register_toolchains(
         extra_target_triples = [


### PR DESCRIPTION
rules_rust does not include s390x platform by default, added it manually.
Fixes https://github.com/envoyproxy/envoy/issues/25340