### PR TITLE
[file_system_http_cache] Rename stat with tags

### DIFF
--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -18,29 +18,33 @@ IsolatedStoreImpl::IsolatedStoreImpl(std::unique_ptr<SymbolTable>&& symbol_table
   symbol_table_storage_ = std::move(symbol_table);
 }
 
+static StatNameTagVector tagVectorFromOpt(StatNameTagVectorOptConstRef tags) {
+  return tags ? tags->get() : StatNameTagVector{};
+}
+
 IsolatedStoreImpl::IsolatedStoreImpl(SymbolTable& symbol_table)
     : alloc_(symbol_table),
       counters_([this](const TagUtility::TagStatNameJoiner& joiner,
                        StatNameTagVectorOptConstRef tags) -> CounterSharedPtr {
         return alloc_.makeCounter(joiner.nameWithTags(), joiner.tagExtractedName(),
-                                  tags ? tags->get() : StatNameTagVector{});
+                                  tagVectorFromOpt(tags));
       }),
       gauges_([this](const TagUtility::TagStatNameJoiner& joiner, StatNameTagVectorOptConstRef tags,
                      Gauge::ImportMode import_mode) -> GaugeSharedPtr {
         return alloc_.makeGauge(joiner.nameWithTags(), joiner.tagExtractedName(),
-                                tags ? tags->get() : StatNameTagVector{}, import_mode);
+                                tagVectorFromOpt(tags), import_mode);
       }),
       histograms_([this](const TagUtility::TagStatNameJoiner& joiner,
                          StatNameTagVectorOptConstRef tags,
                          Histogram::Unit unit) -> HistogramSharedPtr {
         return {new HistogramImpl(joiner.nameWithTags(), unit, *this, joiner.tagExtractedName(),
-                                  tags ? tags->get() : StatNameTagVector{})};
+                                  tagVectorFromOpt(tags))};
       }),
       text_readouts_([this](const TagUtility::TagStatNameJoiner& joiner,
                             StatNameTagVectorOptConstRef tags,
                             TextReadout::Type) -> TextReadoutSharedPtr {
         return alloc_.makeTextReadout(joiner.nameWithTags(), joiner.tagExtractedName(),
-                                      tags ? tags->get() : StatNameTagVector{});
+                                      tagVectorFromOpt(tags));
       }),
       null_counter_(new NullCounterImpl(symbol_table)),
       null_gauge_(new NullGaugeImpl(symbol_table)) {}

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -26,10 +26,17 @@ namespace Stats {
  */
 template <class Base> class IsolatedStatsCache {
 public:
-  using CounterAllocator = std::function<RefcountPtr<Base>(StatName name)>;
-  using GaugeAllocator = std::function<RefcountPtr<Base>(StatName, Gauge::ImportMode)>;
-  using HistogramAllocator = std::function<RefcountPtr<Base>(StatName, Histogram::Unit)>;
-  using TextReadoutAllocator = std::function<RefcountPtr<Base>(StatName name, TextReadout::Type)>;
+  using CounterAllocator = std::function<RefcountPtr<Base>(
+      const TagUtility::TagStatNameJoiner& joiner, StatNameTagVectorOptConstRef tags)>;
+  using GaugeAllocator =
+      std::function<RefcountPtr<Base>(const TagUtility::TagStatNameJoiner& joiner,
+                                      StatNameTagVectorOptConstRef tags, Gauge::ImportMode)>;
+  using HistogramAllocator =
+      std::function<RefcountPtr<Base>(const TagUtility::TagStatNameJoiner& joiner,
+                                      StatNameTagVectorOptConstRef tags, Histogram::Unit)>;
+  using TextReadoutAllocator =
+      std::function<RefcountPtr<Base>(const TagUtility::TagStatNameJoiner& joiner,
+                                      StatNameTagVectorOptConstRef tags, TextReadout::Type)>;
   using BaseOptConstRef = absl::optional<std::reference_wrapper<const Base>>;
 
   IsolatedStatsCache(CounterAllocator alloc) : counter_alloc_(alloc) {}
@@ -37,46 +44,58 @@ public:
   IsolatedStatsCache(HistogramAllocator alloc) : histogram_alloc_(alloc) {}
   IsolatedStatsCache(TextReadoutAllocator alloc) : text_readout_alloc_(alloc) {}
 
-  Base& get(StatName name) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = counter_alloc_(name);
+    RefcountPtr<Base> new_stat = counter_alloc_(joiner, tags);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
 
-  Base& get(StatName name, Gauge::ImportMode import_mode) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table, Gauge::ImportMode import_mode) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = gauge_alloc_(name, import_mode);
+    RefcountPtr<Base> new_stat = gauge_alloc_(joiner, tags, import_mode);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
 
-  Base& get(StatName name, Histogram::Unit unit) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table, Histogram::Unit unit) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = histogram_alloc_(name, unit);
+    RefcountPtr<Base> new_stat = histogram_alloc_(joiner, tags, unit);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
 
-  Base& get(StatName name, TextReadout::Type type) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table, TextReadout::Type type) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = text_readout_alloc_(name, type);
+    RefcountPtr<Base> new_stat = text_readout_alloc_(joiner, tags, type);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
@@ -270,31 +289,24 @@ public:
   const SymbolTable& constSymbolTable() const override { return store_.symbolTable(); }
   Counter& counterFromStatNameWithTags(const StatName& name,
                                        StatNameTagVectorOptConstRef tags) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    Counter& counter = store_.counters_.get(joiner.nameWithTags());
-    return counter;
+    return store_.counters_.get(prefix(), name, tags, symbolTable());
   }
   ScopeSharedPtr createScope(const std::string& name) override;
   ScopeSharedPtr scopeFromStatName(StatName name) override;
   Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    Gauge& gauge = store_.gauges_.get(joiner.nameWithTags(), import_mode);
+    Gauge& gauge = store_.gauges_.get(prefix(), name, tags, symbolTable(), import_mode);
     gauge.mergeImportMode(import_mode);
     return gauge;
   }
   Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    Histogram& histogram = store_.histograms_.get(joiner.nameWithTags(), unit);
-    return histogram;
+    return store_.histograms_.get(prefix(), name, tags, symbolTable(), unit);
   }
   TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
                                                StatNameTagVectorOptConstRef tags) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    TextReadout& text_readout =
-        store_.text_readouts_.get(joiner.nameWithTags(), TextReadout::Type::Default);
-    return text_readout;
+    return store_.text_readouts_.get(prefix(), name, tags, symbolTable(),
+                                     TextReadout::Type::Default);
   }
   CounterOptConstRef findCounter(StatName name) const override {
     return store_.counters_.find(name);

--- a/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.cc
+++ b/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.cc
@@ -87,7 +87,8 @@ FileSystemHttpCache::FileSystemHttpCache(
 }
 
 CacheShared::CacheShared(ConfigProto config, Stats::Scope& stats_scope)
-    : config_(config), stats_(generateStats(stats_scope, cachePath())) {}
+    : config_(config), stat_names_(stats_scope.symbolTable()),
+      stats_(generateStats(stat_names_, stats_scope, cachePath())) {}
 
 FileSystemHttpCache::~FileSystemHttpCache() { cache_eviction_thread_.removeCache(shared_); }
 

--- a/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.h
+++ b/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.h
@@ -233,6 +233,7 @@ private:
 struct CacheShared {
   CacheShared(ConfigProto config, Stats::Scope& stats_scope);
   const ConfigProto config_;
+  CacheStatNames stat_names_;
   CacheStats stats_;
   // These are part of stats, but we have to track them separately because there is
   // potential to go "less than zero" due to not having sole control of the file cache;

--- a/source/extensions/http/cache/file_system_http_cache/stats.cc
+++ b/source/extensions/http/cache/file_system_http_cache/stats.cc
@@ -12,7 +12,7 @@ CacheStats generateStats(CacheStatNames& stat_names, Stats::Scope& scope,
                          absl::string_view cache_path) {
   Stats::StatName cache_path_statname =
       stat_names.pool_.add(absl::StrReplaceAll(cache_path, {{".", "_"}}));
-  return {stat_names, scope, std::move(cache_path_statname)};
+  return {stat_names, scope, cache_path_statname};
 }
 
 } // namespace FileSystemHttpCache

--- a/source/extensions/http/cache/file_system_http_cache/stats.cc
+++ b/source/extensions/http/cache/file_system_http_cache/stats.cc
@@ -1,15 +1,18 @@
 #include "source/extensions/http/cache/file_system_http_cache/stats.h"
 
+#include "absl/strings/str_replace.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 namespace FileSystemHttpCache {
 
-CacheStats generateStats(Stats::Scope& scope, absl::string_view cache_path) {
-  const std::string full_prefix = absl::StrCat("cache_path=", cache_path, ".cache.");
-  return {ALL_CACHE_STATS(POOL_COUNTER_PREFIX(scope, full_prefix),
-                          POOL_GAUGE_PREFIX(scope, full_prefix))};
+CacheStats generateStats(CacheStatNames& stat_names, Stats::Scope& scope,
+                         absl::string_view cache_path) {
+  Stats::StatName cache_path_statname =
+      stat_names.pool_.add(absl::StrReplaceAll(cache_path, {{".", "_"}}));
+  return {stat_names, scope, std::move(cache_path_statname)};
 }
 
 } // namespace FileSystemHttpCache

--- a/source/extensions/http/cache/file_system_http_cache/stats.h
+++ b/source/extensions/http/cache/file_system_http_cache/stats.h
@@ -42,7 +42,7 @@ MAKE_STAT_NAMES_STRUCT(CacheStatNames, ALL_CACHE_STATS);
 
 struct CacheStats {
   CacheStats(const CacheStatNames& stat_names, Envoy::Stats::Scope& scope,
-             Stats::StatName&& cache_path)
+             Stats::StatName cache_path)
       : stat_names_(stat_names), prefix_(stat_names_.cache_), cache_path_(cache_path),
         tags_({{stat_names_.cache_path_, cache_path_}})
             ALL_CACHE_STATS(COUNTER_HELPER_, GAUGE_HELPER_, HISTOGRAM_HELPER_, TEXT_READOUT_HELPER_,

--- a/source/extensions/http/cache/file_system_http_cache/stats.h
+++ b/source/extensions/http/cache/file_system_http_cache/stats.h
@@ -19,19 +19,44 @@ namespace FileSystemHttpCache {
  *
  * Drift will eventually be reconciled at the next pre-cache-purge measurement.
  **/
-#define ALL_CACHE_STATS(COUNTER, GAUGE)                                                            \
+
+#define ALL_CACHE_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)                         \
   COUNTER(eviction_runs)                                                                           \
   GAUGE(size_bytes, NeverImport)                                                                   \
   GAUGE(size_count, NeverImport)                                                                   \
   GAUGE(size_limit_bytes, NeverImport)                                                             \
-  GAUGE(size_limit_count, NeverImport)
+  GAUGE(size_limit_count, NeverImport)                                                             \
+  STATNAME(cache)                                                                                  \
+  STATNAME(cache_path)
 // TODO(ravenblack): Add other stats from DESIGN.md
 
+#define COUNTER_HELPER_(NAME)                                                                      \
+  , NAME##_(                                                                                       \
+        Envoy::Stats::Utility::counterFromStatNames(scope, {prefix_, stat_names.NAME##_}, tags_))
+#define GAUGE_HELPER_(NAME, MODE)                                                                  \
+  , NAME##_(Envoy::Stats::Utility::gaugeFromStatNames(                                             \
+        scope, {prefix_, stat_names.NAME##_}, Envoy::Stats::Gauge::ImportMode::MODE, tags_))
+#define STATNAME_HELPER_(NAME)
+
+MAKE_STAT_NAMES_STRUCT(CacheStatNames, ALL_CACHE_STATS);
+
 struct CacheStats {
-  ALL_CACHE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+  CacheStats(const CacheStatNames& stat_names, Envoy::Stats::Scope& scope,
+             Stats::StatName&& cache_path)
+      : stat_names_(stat_names), prefix_(stat_names_.cache_), cache_path_(cache_path),
+        tags_({{stat_names_.cache_path_, cache_path_}})
+            ALL_CACHE_STATS(COUNTER_HELPER_, GAUGE_HELPER_, HISTOGRAM_HELPER_, TEXT_READOUT_HELPER_,
+                            STATNAME_HELPER_) {}
+  const CacheStatNames& stat_names_;
+  const Stats::StatName prefix_;
+  const Stats::StatName cache_path_;
+  Stats::StatNameTagVector tags_;
+  ALL_CACHE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT,
+                  GENERATE_TEXT_READOUT_STRUCT, GENERATE_STATNAME_STRUCT)
 };
 
-CacheStats generateStats(Stats::Scope& scope, absl::string_view cache_path);
+CacheStats generateStats(CacheStatNames& stat_names, Stats::Scope& scope,
+                         absl::string_view cache_path);
 
 } // namespace FileSystemHttpCache
 } // namespace Cache

--- a/test/common/stats/isolated_store_impl_test.cc
+++ b/test/common/stats/isolated_store_impl_test.cc
@@ -192,37 +192,75 @@ TEST_F(StatsIsolatedStoreImplTest, AllWithSymbolTable) {
 
 TEST_F(StatsIsolatedStoreImplTest, CounterWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
-  Counter& c1 = scope_->counterFromStatNameWithTags(makeStatName("c1"), tags);
-  EXPECT_EQ("c1.tag1.tag1Value", c1.name());
-  EXPECT_EQ("c1", c1.tagExtractedName());
+  StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
+  StatName base = makeStatName("counter");
+  Counter& c1 = scope_->counterFromStatNameWithTags(base, tags);
+  Counter& c2 = scope_->counterFromStatNameWithTags(base, tags2);
+  EXPECT_EQ("counter.tag1.tag1Value", c1.name());
+  EXPECT_EQ("counter", c1.tagExtractedName());
   EXPECT_THAT(c1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
+  EXPECT_EQ("counter.tag1.tag1Value2", c2.name());
+  EXPECT_EQ("counter", c2.tagExtractedName());
+  EXPECT_THAT(c2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
+  // Verify that counterFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(&c1, &scope_->counterFromStatNameWithTags(base, tags));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, GaugeWithTags) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")},
                          {makeStatName("tag2"), makeStatName("tag2Value")}};
-  Gauge& g1 =
-      scope_->gaugeFromStatNameWithTags(makeStatName("g1"), tags, Gauge::ImportMode::Accumulate);
-  EXPECT_EQ("g1.tag1.tag1Value.tag2.tag2Value", g1.name());
-  EXPECT_EQ("g1", g1.tagExtractedName());
+  // tags2 being a subset of tags to ensure no collision in that case.
+  StatNameTagVector tags2{{makeStatName("tag2"), makeStatName("tag2Value")}};
+  StatName base = makeStatName("gauge");
+  Gauge& g1 = scope_->gaugeFromStatNameWithTags(base, tags, Gauge::ImportMode::Accumulate);
+  Gauge& g2 = scope_->gaugeFromStatNameWithTags(base, tags2, Gauge::ImportMode::Accumulate);
+  EXPECT_EQ("gauge.tag1.tag1Value.tag2.tag2Value", g1.name());
+  EXPECT_EQ("gauge", g1.tagExtractedName());
   EXPECT_THAT(g1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}, Tag{"tag2", "tag2Value"}));
+  EXPECT_EQ("gauge.tag2.tag2Value", g2.name());
+  EXPECT_EQ("gauge", g2.tagExtractedName());
+  EXPECT_THAT(g2.tags(), testing::ElementsAre(Tag{"tag2", "tag2Value"}));
+  // Verify that gaugeFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(&g1, &scope_->gaugeFromStatNameWithTags(base, tags, Gauge::ImportMode::Accumulate));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, TextReadoutWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
-  TextReadout& b1 = scope_->textReadoutFromStatNameWithTags(makeStatName("b1"), tags);
-  EXPECT_EQ("b1.tag1.tag1Value", b1.name());
-  EXPECT_EQ("b1", b1.tagExtractedName());
+  StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
+  StatName base = makeStatName("textreadout");
+  TextReadout& b1 = scope_->textReadoutFromStatNameWithTags(base, tags);
+  TextReadout& b2 = scope_->textReadoutFromStatNameWithTags(base, tags2);
+  EXPECT_EQ("textreadout.tag1.tag1Value", b1.name());
+  EXPECT_EQ("textreadout", b1.tagExtractedName());
   EXPECT_THAT(b1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
+  EXPECT_EQ("textreadout.tag1.tag1Value2", b2.name());
+  EXPECT_EQ("textreadout", b2.tagExtractedName());
+  EXPECT_THAT(b2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
+  // Verify that textReadoutFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(&b1, &scope_->textReadoutFromStatNameWithTags(base, tags));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, HistogramWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
-  Histogram& h1 = scope_->histogramFromStatNameWithTags(makeStatName("h1"), tags,
-                                                        Stats::Histogram::Unit::Unspecified);
-  EXPECT_EQ("h1.tag1.tag1Value", h1.name());
-  EXPECT_EQ("h1", h1.tagExtractedName());
+  StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
+  StatName base = makeStatName("histogram");
+  Histogram& h1 =
+      scope_->histogramFromStatNameWithTags(base, tags, Stats::Histogram::Unit::Unspecified);
+  Histogram& h2 =
+      scope_->histogramFromStatNameWithTags(base, tags2, Stats::Histogram::Unit::Unspecified);
+  EXPECT_EQ("histogram.tag1.tag1Value", h1.name());
+  EXPECT_EQ("histogram", h1.tagExtractedName());
   EXPECT_THAT(h1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
+  EXPECT_EQ("histogram.tag1.tag1Value2", h2.name());
+  EXPECT_EQ("histogram", h2.tagExtractedName());
+  EXPECT_THAT(h2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
+  // Verify that histogramFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(
+      &h1, &scope_->histogramFromStatNameWithTags(base, tags, Stats::Histogram::Unit::Unspecified));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, ConstSymtabAccessor) {

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -192,14 +192,27 @@ class FileSystemHttpCacheTest : public FileSystemCacheTestContext, public ::test
   void SetUp() override { initCache(); }
 };
 
+MATCHER_P2(IsStatTag, name, value, "") {
+  if (!ExplainMatchResult(name, arg.name_, result_listener) ||
+      !ExplainMatchResult(value, arg.value_, result_listener)) {
+    *result_listener << "\nexpected {name: \"" << name << "\", value: \"" << value
+                     << "\"},\n but got {name: \"" << arg.name_ << "\", value: \"" << arg.value_
+                     << "\"}\n";
+    return false;
+  }
+  return true;
+}
+
 TEST_F(FileSystemHttpCacheTest, StatsAreConstructedCorrectly) {
-  Stats::Tag cache_path_tag{"cache_path", cache_path_};
+  std::string cache_path_no_periods = absl::StrReplaceAll(cache_path_, {{".", "_"}});
   // Validate that a gauge has appropriate name and tags.
   EXPECT_EQ(cache_->stats().size_bytes_.tagExtractedName(), "cache.size_bytes");
-  EXPECT_THAT(cache_->stats().size_bytes_.tags(), ::testing::ElementsAre(cache_path_tag));
+  EXPECT_THAT(cache_->stats().size_bytes_.tags(),
+              ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
   // Validate that a counter has appropriate name and tags.
   EXPECT_EQ(cache_->stats().eviction_runs_.tagExtractedName(), "cache.eviction_runs");
-  EXPECT_THAT(cache_->stats().eviction_runs_.tags(), ::testing::ElementsAre(cache_path_tag));
+  EXPECT_THAT(cache_->stats().eviction_runs_.tags(),
+              ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
 }
 
 TEST_F(FileSystemHttpCacheTest, TrackFileRemovedClampsAtZero) {

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -192,6 +192,16 @@ class FileSystemHttpCacheTest : public FileSystemCacheTestContext, public ::test
   void SetUp() override { initCache(); }
 };
 
+TEST_F(FileSystemHttpCacheTest, StatsAreConstructedCorrectly) {
+  Stats::Tag cache_path_tag{"cache_path", cache_path_};
+  // Validate that a gauge has appropriate name and tags.
+  EXPECT_EQ(cache_->stats().size_bytes_.tagExtractedName(), "cache.size_bytes");
+  EXPECT_THAT(cache_->stats().size_bytes_.tags(), ::testing::ElementsAre(cache_path_tag));
+  // Validate that a counter has appropriate name and tags.
+  EXPECT_EQ(cache_->stats().eviction_runs_.tagExtractedName(), "cache.eviction_runs");
+  EXPECT_THAT(cache_->stats().eviction_runs_.tags(), ::testing::ElementsAre(cache_path_tag));
+}
+
 TEST_F(FileSystemHttpCacheTest, TrackFileRemovedClampsAtZero) {
   cache_->trackFileAdded(1);
   EXPECT_EQ(cache_->stats().size_bytes_.value(), 1);


### PR DESCRIPTION
Commit Message: [file_system_http_cache] Rename stat with tags
Additional Description: Discovered in testing that a stat named `a.b.c` is not the same as a stat that prints out as `a.b.c`, if `b.c` is derived from tags. This changes the stats for `file_system_http_cache` from having the cache path in the stat-name to having the cache path as a tag value.
Risk Level: Very low, extension is WIP.
Testing: Coverage is there; stat-names could be tested better, but right now the fake metrics don't support it correctly. It would make more sense to test stat name generation while creating and migrating to a stats-common method to make tagged stats anyway.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
