### PR TITLE
Propose a boolean field in ClientStatusRequest to indicate whether xds server should exclude detailed config(xds_config filed in GenericXdsConfig) in response. 

### DIFF
--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -86,6 +86,11 @@ message ClientStatusRequest {
 
   // The node making the csds request.
   config.core.v3.Node node = 2;
+
+  // The flag to indicate whether xDS server needs to propagate the detailed
+  // per_xds_config.
+  // [#not-implemented-hide:]
+  bool exclude_detailed_config = 3;
 }
 
 // Detailed config (per xDS) with status.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: 
Propose a boolean field in ClientStatusRequest to indicate whether xds server should exclude detailed config(xds_config filed in GenericXdsConfig) but keep the rest of fields in response.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
