### PR TITLE
[build] fix Apple M1 build

### DIFF
--- a/source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc
@@ -109,8 +109,13 @@ void CacheShared::evict() {
     size += entry.size_bytes_.value_or(0);
     struct stat s;
     if (os_sys_calls.stat(absl::StrCat(cachePath(), entry.name_).c_str(), &s).return_value_ != -1) {
+#ifdef _DARWIN_FEATURE_64_BIT_INODE
       Envoy::SystemTime last_touch =
           std::max(timespecToChrono(s.st_atimespec), timespecToChrono(s.st_ctimespec));
+#else
+      Envoy::SystemTime last_touch =
+          std::max(timespecToChrono(s.st_atim), timespecToChrono(s.st_ctim));
+#endif
 
       cache_files.push_back(CacheFile{entry.name_, entry.size_bytes_.value_or(0), last_touch});
     }

--- a/source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc
+++ b/source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc
@@ -110,7 +110,7 @@ void CacheShared::evict() {
     struct stat s;
     if (os_sys_calls.stat(absl::StrCat(cachePath(), entry.name_).c_str(), &s).return_value_ != -1) {
       Envoy::SystemTime last_touch =
-          std::max(timespecToChrono(s.st_atim), timespecToChrono(s.st_ctim));
+          std::max(timespecToChrono(s.st_atimespec), timespecToChrono(s.st_ctimespec));
 
       cache_files.push_back(CacheFile{entry.name_, entry.size_bytes_.value_or(0), last_touch});
     }


### PR DESCRIPTION
Commit Message: [build] fix Apple M1 build
Additional Description:
After https://github.com/envoyproxy/envoy/commit/5991a2053e981038c105a421886af073be9c5941 was merged compiling Envoy on an Apple M1 machine began to fail with:
```
ERROR: /Users/tamal/go/src/github.com/envoyproxy/envoy/source/extensions/http/cache/file_system_http_cache/BUILD:19:19: Compiling source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc failed: (Exit 1): cc_wrapper.sh failed: error executing command (from target //source/extensions/http/cache/file_system_http_cache:config) external/local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics ... (remaining 157 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc:113:39: error: no member named 'st_atim' in 'stat'
          std::max(timespecToChrono(s.st_atim), timespecToChrono(s.st_ctim));
                                    ~ ^
source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.cc:113:68: error: no member named 'st_ctim' in 'stat'
          std::max(timespecToChrono(s.st_atim), timespecToChrono(s.st_ctim));
                                                                 ~ ^
2 errors generated.
Target //source/exe:envoy-static failed to build
```
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: compilation on Apple M1

Signed-off-by: Derek Argueta <deargueta@tesla.com>