### PR TITLE
[backport/1.25] ci: Only run mobile jobs in the Envoy repo

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   androidbuild:
+    if: github.repository == 'envoyproxy/envoy'
     name: android_build
     runs-on: macos-12
     timeout-minutes: 90
@@ -37,6 +38,7 @@ jobs:
           --fat_apk_cpu=x86_64 \
           //:android_dist
   javahelloworld:
+    if: github.repository == 'envoyproxy/envoy'
     name: java_helloworld
     needs: androidbuild
     runs-on: macos-12
@@ -82,6 +84,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 200" -m 1
   kotlinhelloworld:
+    if: github.repository == 'envoyproxy/envoy'
     name: kotlin_helloworld
     needs: androidbuild
     runs-on: macos-12
@@ -127,6 +130,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 200" -m 1
   kotlinbaselineapp:
+    if: github.repository == 'envoyproxy/envoy'
     name: kotlin_baseline_app
     needs: androidbuild
     runs-on: macos-12
@@ -172,6 +176,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: adb logcat -e "received headers with status 301" -m 1
   kotlinexperimentalapp:
+    if: github.repository == 'envoyproxy/envoy'
     name: kotlin_experimental_app
     needs: androidbuild
     runs-on: macos-12

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   kotlintestsmac:
+    if: github.repository == 'envoyproxy/envoy'
     # revert to //test/kotlin/... once fixed
     # https://github.com/envoyproxy/envoy-mobile/issues/1932
     name: kotlin_tests_mac
@@ -41,6 +42,7 @@ jobs:
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/kotlin/io/...
   javatestsmac:
+    if: github.repository == 'envoyproxy/envoy'
     name: java_tests_mac
     runs-on: macos-12
     timeout-minutes: 120
@@ -74,6 +76,7 @@ jobs:
             --define=signal_trace=disabled \
             //test/java/...
   kotlintestslinux:
+    if: github.repository == 'envoyproxy/envoy'
     # Only kotlin tests are executed since with linux:
     # https://github.com/envoyproxy/envoy-mobile/issues/1418.
     name: kotlin_tests_linux

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   asan:
+    if: github.repository == 'envoyproxy/envoy'
     name: asan
     runs-on: ubuntu-20.04
     timeout-minutes: 180

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   cctests:
+    if: github.repository == 'envoyproxy/envoy'
     name: cc_tests
     runs-on: ubuntu-20.04
     timeout-minutes: 120

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   retest:
+    if: github.repository == 'envoyproxy/envoy'
     name: Retest
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   unittests:
+    if: github.repository == 'envoyproxy/envoy'
     name: unit_tests
     runs-on: macos-12
     timeout-minutes: 120

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   coverage:
+    if: github.repository == 'envoyproxy/envoy'
     name: coverage
     runs-on: ubuntu-20.04
     timeout-minutes: 120

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   docs:
+    if: github.repository == 'envoyproxy/envoy'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     container:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   formatall:
+    if: github.repository == 'envoyproxy/envoy'
     name: format_all
     runs-on: ubuntu-20.04
     timeout-minutes: 45
@@ -29,6 +30,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && ./tools/check_format.sh
   precommit:
+    if: github.repository == 'envoyproxy/envoy'
     name: precommit
     runs-on: macos-12
     timeout-minutes: 45
@@ -44,6 +46,7 @@ jobs:
       if: steps.should_run.outputs.run_ci_job == 'true'
       run: cd mobile && find mobile/* | pre-commit run --files
   swiftlint:
+    if: github.repository == 'envoyproxy/envoy'
     name: swift_lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -55,6 +58,7 @@ jobs:
       run: swiftlint lint --strict
       working-directory: mobile
   drstring:
+    if: github.repository == 'envoyproxy/envoy'
     name: drstring
     runs-on: macos-12
     timeout-minutes: 10
@@ -69,6 +73,7 @@ jobs:
         DEVELOPER_DIR: /Applications/Xcode_14.1.app
       run: cd mobile && ./bazelw run @DrString//:drstring check
   kotlinlint:
+    if: github.repository == 'envoyproxy/envoy'
     name: kotlin_lint
     runs-on: macos-12
     timeout-minutes: 45

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   iosbuild:
+    if: github.repository == 'envoyproxy/envoy'
     name: ios_build
     runs-on: macos-12
     timeout-minutes: 120
@@ -31,6 +32,7 @@ jobs:
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //library/swift:ios_framework
   swifthelloworld:
+    if: github.repository == 'envoyproxy/envoy'
     name: swift_helloworld
     needs: iosbuild
     runs-on: macos-12
@@ -78,6 +80,7 @@ jobs:
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftbaselineapp:
+    if: github.repository == 'envoyproxy/envoy'
     name: swift_baseline_app
     needs: iosbuild
     runs-on: macos-12
@@ -125,6 +128,7 @@ jobs:
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftexperimentalapp:
+    if: github.repository == 'envoyproxy/envoy'
     name: swift_experimental_app
     needs: iosbuild
     runs-on: macos-12
@@ -172,6 +176,7 @@ jobs:
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   swiftasyncawait:
+    if: github.repository == 'envoyproxy/envoy'
     name: swift_async_await
     needs: iosbuild
     runs-on: macos-12
@@ -219,6 +224,7 @@ jobs:
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
   objchelloworld:
+    if: github.repository == 'envoyproxy/envoy'
     name: objc_helloworld
     needs: iosbuild
     runs-on: macos-12

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   swifttests:
+    if: github.repository == 'envoyproxy/envoy'
     name: swift_tests
     runs-on: macos-12
     timeout-minutes: 120
@@ -33,6 +34,7 @@ jobs:
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/...
   objctests:
+    if: github.repository == 'envoyproxy/envoy'
     name: c_and_objc_tests
     runs-on: macos-12
     timeout-minutes: 120

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sizecurrent:
+    if: github.repository == 'envoyproxy/envoy'
     name: size_current
     runs-on: ubuntu-20.04
     timeout-minutes: 120
@@ -34,6 +35,7 @@ jobs:
         name: sizecurrent
         path: mobile/bazel-bin/test/performance/test_binary_size
   sizemain:
+    if: github.repository == 'envoyproxy/envoy'
     name: size_main
     runs-on: ubuntu-20.04
     timeout-minutes: 90
@@ -62,6 +64,7 @@ jobs:
         name: sizemain
         path: mobile/bazel-bin/test/performance/test_binary_size
   sizecompare:
+    if: github.repository == 'envoyproxy/envoy'
     name: size_compare
     needs: [sizecurrent, sizemain]
     runs-on: ubuntu-20.04

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   pythontests:
+    if: github.repository == 'envoyproxy/envoy'
     name: python_tests
     runs-on: ubuntu-20.04
     timeout-minutes: 90

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   validate_swiftpm_example:
+    if: github.repository == 'envoyproxy/envoy'
     name: validate_swiftpm_example
     runs-on: macos-12
     timeout-minutes: 120

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   tsan:
+    if: github.repository == 'envoyproxy/envoy'
     name: tsan
     runs-on: ubuntu-20.04
     timeout-minutes: 90


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
