### PR TITLE
repokitteh: Add `/milestone` command

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -57,3 +57,8 @@ def _backport():
   github.issue_label('backport/review')
 
 handlers.command(name='backport', func=_backport)
+
+def _milestone():
+  github.issue_label('milestone/review')
+
+handlers.command(name='milestone', func=_milestone)


### PR DESCRIPTION
Commit Message:
Add `/milestone` command

Additional Description:
As discussed with @phlax , as the first step, this will add the `milestone/review` label, for maintainers to review easier.

Usage: `/milestone 48`
that means suggest adding this issue/pr to [milestone 48](https://github.com/envoyproxy/envoy/milestone/48), but it will not be applied automatically -  instead - adding the `milestone/review` label - waiting for maintainers to review.

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
