### PR TITLE
rate_limit_quota: Fix typo

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -24,8 +24,8 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
 
   // Second, generate the bucket id for this request based on match action when the request matching
   // succeeds.
-  const RateLimitOnMactchAction* match_action =
-      dynamic_cast<RateLimitOnMactchAction*>(match_result.value().get());
+  const RateLimitOnMatchAction* match_action =
+      dynamic_cast<RateLimitOnMatchAction*>(match_result.value().get());
   auto ret = match_action->generateBucketId(*data_ptr_, factory_context_, visitor_);
   if (!ret.ok()) {
     // When it failed to generate the bucket id for this specific request, the request is ALLOWED by
@@ -40,8 +40,8 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
 }
 
 void RateLimitQuotaFilter::createMatcher() {
-  RateLimitOnMactchActionContext context;
-  Matcher::MatchTreeFactory<Http::HttpMatchingData, RateLimitOnMactchActionContext> factory(
+  RateLimitOnMatchActionContext context;
+  Matcher::MatchTreeFactory<Http::HttpMatchingData, RateLimitOnMatchActionContext> factory(
       context, factory_context_.getServerFactoryContext(), visitor_);
   if (config_->has_bucket_matchers()) {
     matcher_ = factory.create(config_->bucket_matchers())();

--- a/source/extensions/filters/http/rate_limit_quota/matcher.cc
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.cc
@@ -12,7 +12,7 @@ using ValueSpecifierCase = ::envoy::extensions::filters::http::rate_limit_quota:
     RateLimitQuotaBucketSettings_BucketIdBuilder_ValueBuilder::ValueSpecifierCase;
 
 absl::StatusOr<BucketId>
-RateLimitOnMactchAction::generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
+RateLimitOnMatchAction::generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
                                           Server::Configuration::FactoryContext& factory_context,
                                           RateLimitQuotaValidationVisitor& visitor) const {
   BucketId bucket_id;
@@ -66,8 +66,8 @@ RateLimitOnMactchAction::generateBucketId(const Http::Matching::HttpMatchingData
 /**
  * Static registration for the on match action factory.
  */
-REGISTER_FACTORY(RateLimitOnMactchActionFactory,
-                 Matcher::ActionFactory<RateLimitOnMactchActionContext>);
+REGISTER_FACTORY(RateLimitOnMatchActionFactory,
+                 Matcher::ActionFactory<RateLimitOnMatchActionContext>);
 
 } // namespace RateLimitQuota
 } // namespace HttpFilters

--- a/source/extensions/filters/http/rate_limit_quota/matcher.cc
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.cc
@@ -13,8 +13,8 @@ using ValueSpecifierCase = ::envoy::extensions::filters::http::rate_limit_quota:
 
 absl::StatusOr<BucketId>
 RateLimitOnMatchAction::generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
-                                          Server::Configuration::FactoryContext& factory_context,
-                                          RateLimitQuotaValidationVisitor& visitor) const {
+                                         Server::Configuration::FactoryContext& factory_context,
+                                         RateLimitQuotaValidationVisitor& visitor) const {
   BucketId bucket_id;
   std::unique_ptr<Matcher::MatchInputFactory<Http::HttpMatchingData>> input_factory_ptr = nullptr;
   // Generate the `BucketId` based on the bucked id builder from the configuration.

--- a/source/extensions/filters/http/rate_limit_quota/matcher.h
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.h
@@ -32,7 +32,7 @@ struct RateLimitOnMatchActionContext {};
 
 // This class implements the on_match action behavior.
 class RateLimitOnMatchAction : public Matcher::ActionBase<BucketId>,
-                                public Logger::Loggable<Logger::Id::filter> {
+                               public Logger::Loggable<Logger::Id::filter> {
 public:
   explicit RateLimitOnMatchAction(RateLimitQuotaBucketSettings settings)
       : setting_(std::move(settings)) {}
@@ -46,8 +46,7 @@ private:
   RateLimitQuotaBucketSettings setting_;
 };
 
-class RateLimitOnMatchActionFactory
-    : public Matcher::ActionFactory<RateLimitOnMatchActionContext> {
+class RateLimitOnMatchActionFactory : public Matcher::ActionFactory<RateLimitOnMatchActionContext> {
 public:
   std::string name() const override { return "rate_limit_quota"; }
 

--- a/source/extensions/filters/http/rate_limit_quota/matcher.h
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.h
@@ -28,13 +28,13 @@ public:
 
 // Contextual information used to construct the onMatch actions for a match tree.
 // Currently it is empty struct.
-struct RateLimitOnMactchActionContext {};
+struct RateLimitOnMatchActionContext {};
 
 // This class implements the on_match action behavior.
-class RateLimitOnMactchAction : public Matcher::ActionBase<BucketId>,
+class RateLimitOnMatchAction : public Matcher::ActionBase<BucketId>,
                                 public Logger::Loggable<Logger::Id::filter> {
 public:
-  explicit RateLimitOnMactchAction(RateLimitQuotaBucketSettings settings)
+  explicit RateLimitOnMatchAction(RateLimitQuotaBucketSettings settings)
       : setting_(std::move(settings)) {}
 
   absl::StatusOr<BucketId> generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
@@ -46,13 +46,13 @@ private:
   RateLimitQuotaBucketSettings setting_;
 };
 
-class RateLimitOnMactchActionFactory
-    : public Matcher::ActionFactory<RateLimitOnMactchActionContext> {
+class RateLimitOnMatchActionFactory
+    : public Matcher::ActionFactory<RateLimitOnMatchActionContext> {
 public:
   std::string name() const override { return "rate_limit_quota"; }
 
   Matcher::ActionFactoryCb
-  createActionFactoryCb(const Protobuf::Message& config, RateLimitOnMactchActionContext&,
+  createActionFactoryCb(const Protobuf::Message& config, RateLimitOnMatchActionContext&,
                         ProtobufMessage::ValidationVisitor& validation_visitor) override {
     // Validate and then retrieve the bucket settings from config.
     const auto bucket_settings =
@@ -60,7 +60,7 @@ public:
                                              v3::RateLimitQuotaBucketSettings&>(config,
                                                                                 validation_visitor);
     return [bucket_settings = std::move(bucket_settings)]() {
-      return std::make_unique<RateLimitOnMactchAction>(std::move(bucket_settings));
+      return std::make_unique<RateLimitOnMatchAction>(std::move(bucket_settings));
     };
   }
 

--- a/test/extensions/filters/http/rate_limit_quota/filter_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/filter_test.cc
@@ -337,8 +337,8 @@ public:
     // `on_no_match` field is configured.
     ASSERT_TRUE(match_result.ok());
     // Retrieve the matched action.
-    const RateLimitOnMactchAction* match_action =
-        dynamic_cast<RateLimitOnMactchAction*>(match_result.value().get());
+    const RateLimitOnMatchAction* match_action =
+        dynamic_cast<RateLimitOnMatchAction*>(match_result.value().get());
 
     RateLimitQuotaValidationVisitor visitor = {};
     // Generate the bucket ids.
@@ -442,8 +442,8 @@ TEST_F(FilterTest, RequestMatchingWithInvalidOnNoMatch) {
   // `on_no_match` field is configured.
   ASSERT_TRUE(match_result.ok());
   // Retrieve the matched action.
-  const RateLimitOnMactchAction* match_action =
-      dynamic_cast<RateLimitOnMactchAction*>(match_result.value().get());
+  const RateLimitOnMatchAction* match_action =
+      dynamic_cast<RateLimitOnMatchAction*>(match_result.value().get());
 
   RateLimitQuotaValidationVisitor visitor = {};
   // Generate the bucket ids.


### PR DESCRIPTION
Fix typo: `RateLimitOnMactchAction` ---> `RateLimitOnMatchAction`
Signed-off-by: tyxia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
