### PR TITLE
examples: Add (optional) image cleanup (rmi)

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -190,6 +190,7 @@ function run_ci_verify () {
   sudo apt-get update -y
   sudo apt-get install -y -qq --no-install-recommends expect redis-tools
   export DOCKER_NO_PULL=1
+  export DOCKER_RMI_CLEANUP=1
   umask 027
   chmod -R o-rwx examples/
   "${ENVOY_SRCDIR}"/ci/verify_examples.sh "${@}" || exit

--- a/examples/shared/build/build-entrypoint.sh
+++ b/examples/shared/build/build-entrypoint.sh
@@ -7,4 +7,7 @@ if [[ $(id -u envoybuild) != "${BUILD_UID}" ]]; then
     chown envoybuild /home/envoybuild
 fi
 
+chown envoybuild /output
+chmod 1777 /tmp
+
 exec gosu envoybuild "$@"

--- a/examples/verify-common.sh
+++ b/examples/verify-common.sh
@@ -61,7 +61,7 @@ cleanup_stack () {
 }
 
 cleanup () {
-    local path paths
+    local path paths image rmi
     read -ra paths <<< "$(echo "$PATHS" | tr ',' ' ')"
     for path in "${paths[@]}"; do
         pushd "$path" > /dev/null || return 1
@@ -71,6 +71,16 @@ cleanup () {
         }
         popd > /dev/null
     done
+
+    read -ra rmi <<< "$(echo "$RMI" | tr ',' ' ')"
+
+    if [[ -n "$DOCKER_RMI_CLEANUP" ]]; then
+        for image in "${rmi[@]}"; do
+            docker rmi -f "$image"
+        done
+        docker image prune -f
+    fi
+
 }
 
 _curl () {

--- a/examples/wasm-cc/docker-compose-wasm.yaml
+++ b/examples/wasm-cc/docker-compose-wasm.yaml
@@ -11,7 +11,7 @@ services:
     entrypoint: /source/examples/shared/build/build-entrypoint.sh
     environment:
     - BUILD_UID=${UID:-1000}
-    - TEST_TMPDIR=${ENVOY_TEST_TMPDIR:-/tmp}
+    - TEST_TMPDIR=/tmp
     working_dir: /source
     volumes:
     - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/tmp

--- a/examples/wasm-cc/verify.sh
+++ b/examples/wasm-cc/verify.sh
@@ -2,6 +2,8 @@
 
 export NAME=wasm-cc
 export UID
+export RMI="wasm-cc_wasm_compile_update:latest"
+
 
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"


### PR DESCRIPTION
if the env var `DOCKER_RMI_CLEANUP` is set, this will remove any images listed for the `RMI` variable in an example's verify.sh.

also:

- fixes some permissions in the build entrypoint
- adds some cleanups for the `wasm-cc` example

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
