### PR TITLE
docs: fix the name of a response code detail

### DIFF
--- a/docs/root/configuration/http/http_conn_man/response_code_details.rst
+++ b/docs/root/configuration/http/http_conn_man/response_code_details.rst
@@ -38,7 +38,7 @@ Below are the list of reasons the HttpConnectionManager or Router filter may sen
    missing_path_rejected, The request was rejected due to a missing Path or :path header field.
    no_healthy_upstream, The request was rejected by the router filter because there was no healthy upstream found.
    overload, The request was rejected due to the Overload Manager reaching configured resource limits.
-   original_ip_detection_failed, The request was rejected because the original IP couldn't be detected.
+   rejecting_because_detection_failed, The request was rejected because the original IP couldn't be detected.
    path_normalization_failed, "The request was rejected because path normalization was configured on and failed, probably due to an invalid path."
    request_headers_failed_strict_check, The request was rejected due to x-envoy-* headers failing strict header validation.
    request_overall_timeout, The per-stream total request timeout was exceeded.


### PR DESCRIPTION
"original_ip_detection_failed" does not exist, use the correct value "rejecting_because_detection_failed" instead.

Fixes #25147

Signed-off-by: Michael Kaufmann <michael.kaufmann@ergon.ch>


Risk Level: Low
Docs Changes: replaced "original_ip_detection_failed" with "rejecting_because_detection_failed"