### PR TITLE
Make isolated_stats_cache support tags correctly

### DIFF
--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -18,29 +18,33 @@ IsolatedStoreImpl::IsolatedStoreImpl(std::unique_ptr<SymbolTable>&& symbol_table
   symbol_table_storage_ = std::move(symbol_table);
 }
 
+static StatNameTagVector tagVectorFromOpt(StatNameTagVectorOptConstRef tags) {
+  return tags ? tags->get() : StatNameTagVector{};
+}
+
 IsolatedStoreImpl::IsolatedStoreImpl(SymbolTable& symbol_table)
     : alloc_(symbol_table),
       counters_([this](const TagUtility::TagStatNameJoiner& joiner,
                        StatNameTagVectorOptConstRef tags) -> CounterSharedPtr {
         return alloc_.makeCounter(joiner.nameWithTags(), joiner.tagExtractedName(),
-                                  tags ? tags->get() : StatNameTagVector{});
+                                  tagVectorFromOpt(tags));
       }),
       gauges_([this](const TagUtility::TagStatNameJoiner& joiner, StatNameTagVectorOptConstRef tags,
                      Gauge::ImportMode import_mode) -> GaugeSharedPtr {
         return alloc_.makeGauge(joiner.nameWithTags(), joiner.tagExtractedName(),
-                                tags ? tags->get() : StatNameTagVector{}, import_mode);
+                                tagVectorFromOpt(tags), import_mode);
       }),
       histograms_([this](const TagUtility::TagStatNameJoiner& joiner,
                          StatNameTagVectorOptConstRef tags,
                          Histogram::Unit unit) -> HistogramSharedPtr {
         return {new HistogramImpl(joiner.nameWithTags(), unit, *this, joiner.tagExtractedName(),
-                                  tags ? tags->get() : StatNameTagVector{})};
+                                  tagVectorFromOpt(tags))};
       }),
       text_readouts_([this](const TagUtility::TagStatNameJoiner& joiner,
                             StatNameTagVectorOptConstRef tags,
                             TextReadout::Type) -> TextReadoutSharedPtr {
         return alloc_.makeTextReadout(joiner.nameWithTags(), joiner.tagExtractedName(),
-                                      tags ? tags->get() : StatNameTagVector{});
+                                      tagVectorFromOpt(tags));
       }),
       null_counter_(new NullCounterImpl(symbol_table)),
       null_gauge_(new NullGaugeImpl(symbol_table)) {}

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -26,10 +26,17 @@ namespace Stats {
  */
 template <class Base> class IsolatedStatsCache {
 public:
-  using CounterAllocator = std::function<RefcountPtr<Base>(StatName name)>;
-  using GaugeAllocator = std::function<RefcountPtr<Base>(StatName, Gauge::ImportMode)>;
-  using HistogramAllocator = std::function<RefcountPtr<Base>(StatName, Histogram::Unit)>;
-  using TextReadoutAllocator = std::function<RefcountPtr<Base>(StatName name, TextReadout::Type)>;
+  using CounterAllocator = std::function<RefcountPtr<Base>(
+      const TagUtility::TagStatNameJoiner& joiner, StatNameTagVectorOptConstRef tags)>;
+  using GaugeAllocator =
+      std::function<RefcountPtr<Base>(const TagUtility::TagStatNameJoiner& joiner,
+                                      StatNameTagVectorOptConstRef tags, Gauge::ImportMode)>;
+  using HistogramAllocator =
+      std::function<RefcountPtr<Base>(const TagUtility::TagStatNameJoiner& joiner,
+                                      StatNameTagVectorOptConstRef tags, Histogram::Unit)>;
+  using TextReadoutAllocator =
+      std::function<RefcountPtr<Base>(const TagUtility::TagStatNameJoiner& joiner,
+                                      StatNameTagVectorOptConstRef tags, TextReadout::Type)>;
   using BaseOptConstRef = absl::optional<std::reference_wrapper<const Base>>;
 
   IsolatedStatsCache(CounterAllocator alloc) : counter_alloc_(alloc) {}
@@ -37,46 +44,58 @@ public:
   IsolatedStatsCache(HistogramAllocator alloc) : histogram_alloc_(alloc) {}
   IsolatedStatsCache(TextReadoutAllocator alloc) : text_readout_alloc_(alloc) {}
 
-  Base& get(StatName name) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = counter_alloc_(name);
+    RefcountPtr<Base> new_stat = counter_alloc_(joiner, tags);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
 
-  Base& get(StatName name, Gauge::ImportMode import_mode) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table, Gauge::ImportMode import_mode) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = gauge_alloc_(name, import_mode);
+    RefcountPtr<Base> new_stat = gauge_alloc_(joiner, tags, import_mode);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
 
-  Base& get(StatName name, Histogram::Unit unit) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table, Histogram::Unit unit) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = histogram_alloc_(name, unit);
+    RefcountPtr<Base> new_stat = histogram_alloc_(joiner, tags, unit);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
 
-  Base& get(StatName name, TextReadout::Type type) {
+  Base& get(StatName prefix, StatName basename, StatNameTagVectorOptConstRef tags,
+            SymbolTable& symbol_table, TextReadout::Type type) {
+    TagUtility::TagStatNameJoiner joiner(prefix, basename, tags, symbol_table);
+    StatName name = joiner.nameWithTags();
     auto stat = stats_.find(name);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
-    RefcountPtr<Base> new_stat = text_readout_alloc_(name, type);
+    RefcountPtr<Base> new_stat = text_readout_alloc_(joiner, tags, type);
     stats_.emplace(new_stat->statName(), new_stat);
     return *new_stat;
   }
@@ -270,31 +289,24 @@ public:
   const SymbolTable& constSymbolTable() const override { return store_.symbolTable(); }
   Counter& counterFromStatNameWithTags(const StatName& name,
                                        StatNameTagVectorOptConstRef tags) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    Counter& counter = store_.counters_.get(joiner.nameWithTags());
-    return counter;
+    return store_.counters_.get(prefix(), name, tags, symbolTable());
   }
   ScopeSharedPtr createScope(const std::string& name) override;
   ScopeSharedPtr scopeFromStatName(StatName name) override;
   Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    Gauge& gauge = store_.gauges_.get(joiner.nameWithTags(), import_mode);
+    Gauge& gauge = store_.gauges_.get(prefix(), name, tags, symbolTable(), import_mode);
     gauge.mergeImportMode(import_mode);
     return gauge;
   }
   Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    Histogram& histogram = store_.histograms_.get(joiner.nameWithTags(), unit);
-    return histogram;
+    return store_.histograms_.get(prefix(), name, tags, symbolTable(), unit);
   }
   TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
                                                StatNameTagVectorOptConstRef tags) override {
-    TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
-    TextReadout& text_readout =
-        store_.text_readouts_.get(joiner.nameWithTags(), TextReadout::Type::Default);
-    return text_readout;
+    return store_.text_readouts_.get(prefix(), name, tags, symbolTable(),
+                                     TextReadout::Type::Default);
   }
   CounterOptConstRef findCounter(StatName name) const override {
     return store_.counters_.find(name);

--- a/test/common/stats/isolated_store_impl_test.cc
+++ b/test/common/stats/isolated_store_impl_test.cc
@@ -192,37 +192,75 @@ TEST_F(StatsIsolatedStoreImplTest, AllWithSymbolTable) {
 
 TEST_F(StatsIsolatedStoreImplTest, CounterWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
-  Counter& c1 = scope_->counterFromStatNameWithTags(makeStatName("c1"), tags);
-  EXPECT_EQ("c1.tag1.tag1Value", c1.name());
-  EXPECT_EQ("c1", c1.tagExtractedName());
+  StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
+  StatName base = makeStatName("counter");
+  Counter& c1 = scope_->counterFromStatNameWithTags(base, tags);
+  Counter& c2 = scope_->counterFromStatNameWithTags(base, tags2);
+  EXPECT_EQ("counter.tag1.tag1Value", c1.name());
+  EXPECT_EQ("counter", c1.tagExtractedName());
   EXPECT_THAT(c1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
+  EXPECT_EQ("counter.tag1.tag1Value2", c2.name());
+  EXPECT_EQ("counter", c2.tagExtractedName());
+  EXPECT_THAT(c2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
+  // Verify that counterFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(&c1, &scope_->counterFromStatNameWithTags(base, tags));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, GaugeWithTags) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")},
                          {makeStatName("tag2"), makeStatName("tag2Value")}};
-  Gauge& g1 =
-      scope_->gaugeFromStatNameWithTags(makeStatName("g1"), tags, Gauge::ImportMode::Accumulate);
-  EXPECT_EQ("g1.tag1.tag1Value.tag2.tag2Value", g1.name());
-  EXPECT_EQ("g1", g1.tagExtractedName());
+  // tags2 being a subset of tags to ensure no collision in that case.
+  StatNameTagVector tags2{{makeStatName("tag2"), makeStatName("tag2Value")}};
+  StatName base = makeStatName("gauge");
+  Gauge& g1 = scope_->gaugeFromStatNameWithTags(base, tags, Gauge::ImportMode::Accumulate);
+  Gauge& g2 = scope_->gaugeFromStatNameWithTags(base, tags2, Gauge::ImportMode::Accumulate);
+  EXPECT_EQ("gauge.tag1.tag1Value.tag2.tag2Value", g1.name());
+  EXPECT_EQ("gauge", g1.tagExtractedName());
   EXPECT_THAT(g1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}, Tag{"tag2", "tag2Value"}));
+  EXPECT_EQ("gauge.tag2.tag2Value", g2.name());
+  EXPECT_EQ("gauge", g2.tagExtractedName());
+  EXPECT_THAT(g2.tags(), testing::ElementsAre(Tag{"tag2", "tag2Value"}));
+  // Verify that gaugeFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(&g1, &scope_->gaugeFromStatNameWithTags(base, tags, Gauge::ImportMode::Accumulate));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, TextReadoutWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
-  TextReadout& b1 = scope_->textReadoutFromStatNameWithTags(makeStatName("b1"), tags);
-  EXPECT_EQ("b1.tag1.tag1Value", b1.name());
-  EXPECT_EQ("b1", b1.tagExtractedName());
+  StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
+  StatName base = makeStatName("textreadout");
+  TextReadout& b1 = scope_->textReadoutFromStatNameWithTags(base, tags);
+  TextReadout& b2 = scope_->textReadoutFromStatNameWithTags(base, tags2);
+  EXPECT_EQ("textreadout.tag1.tag1Value", b1.name());
+  EXPECT_EQ("textreadout", b1.tagExtractedName());
   EXPECT_THAT(b1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
+  EXPECT_EQ("textreadout.tag1.tag1Value2", b2.name());
+  EXPECT_EQ("textreadout", b2.tagExtractedName());
+  EXPECT_THAT(b2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
+  // Verify that textReadoutFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(&b1, &scope_->textReadoutFromStatNameWithTags(base, tags));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, HistogramWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
-  Histogram& h1 = scope_->histogramFromStatNameWithTags(makeStatName("h1"), tags,
-                                                        Stats::Histogram::Unit::Unspecified);
-  EXPECT_EQ("h1.tag1.tag1Value", h1.name());
-  EXPECT_EQ("h1", h1.tagExtractedName());
+  StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
+  StatName base = makeStatName("histogram");
+  Histogram& h1 =
+      scope_->histogramFromStatNameWithTags(base, tags, Stats::Histogram::Unit::Unspecified);
+  Histogram& h2 =
+      scope_->histogramFromStatNameWithTags(base, tags2, Stats::Histogram::Unit::Unspecified);
+  EXPECT_EQ("histogram.tag1.tag1Value", h1.name());
+  EXPECT_EQ("histogram", h1.tagExtractedName());
   EXPECT_THAT(h1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
+  EXPECT_EQ("histogram.tag1.tag1Value2", h2.name());
+  EXPECT_EQ("histogram", h2.tagExtractedName());
+  EXPECT_THAT(h2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
+  // Verify that histogramFromStatNameWithTags with the same params returns
+  // the existing stat object.
+  EXPECT_EQ(
+      &h1, &scope_->histogramFromStatNameWithTags(base, tags, Stats::Histogram::Unit::Unspecified));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, ConstSymtabAccessor) {


### PR DESCRIPTION
Commit Message: Make isolated_stats_cache support tags correctly
Additional Description: Attempting to test stat names and tags when a metric is created with populated tags results in failure, as isolated_stats_cache converts `a.b` with tags `{c:d}` into `a.b.c.d` in both stat_name_ and tags_extracted_stat_name_, along with an empty tags member. This fix should make it behave the same as other stat stores.
Risk Level: Unknown. It appears `IsolatedStoreImpl` is used in some core server features, so care may need to be taken.
Testing: Passes existing tests; added tests for the behavior with tags.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
