### PR TITLE
mobile: add CI jobs to build Envoy Mobile with custom compile time flags

### DIFF
--- a/.github/workflows/compile_time_options.yml
+++ b/.github/workflows/compile_time_options.yml
@@ -1,0 +1,96 @@
+name: mobile_compile_time_options
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.head_ref-github.workflow || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  cc_build:
+    if: github.repository == 'envoyproxy/envoy'
+    name: cc_build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+    container:
+      image: envoyproxy/envoy-build-ubuntu:b0ff77ae3f25b0bf595f9b8bba46b489723ab446
+    steps:
+    - uses: actions/checkout@v1
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy/envoy
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
+    - name: 'Build C++ library'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd mobile && ./bazelw build \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            --define=admin_html=enabled \
+            --@envoy//bazel:http3=False \
+            //library/cc/...
+  swift_build:
+    if: github.repository == 'envoyproxy/envoy'
+    name: swift_build
+    runs-on: macos-12
+    timeout-minutes: 120
+    steps:
+    - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
+    - run: cd mobile && ./ci/mac_ci_setup.sh
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      name: 'Install dependencies'
+    - name: 'Build Swift library'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd mobile && ./bazelw shutdown
+          ./bazelw build \
+            --config=ios \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            --define=admin_html=enabled \
+            --@envoy//bazel:http3=False \
+            //library/swift:ios_framework
+  kotlin_build:
+    if: github.repository == 'envoyproxy/envoy'
+    name: kotlin_build
+    runs-on: macos-12
+    timeout-minutes: 90
+    steps:
+    - uses: actions/checkout@v1
+    - id: should_run
+      name: 'Check whether to run'
+      run: ./mobile/tools/should_run_ci.sh
+    - uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      with:
+        java-version: '8'
+        java-package: jdk
+        architecture: x64
+        distribution: zulu
+    - name: 'Install dependencies'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      run: cd mobile && ./ci/mac_ci_setup.sh --android
+    - name: 'Build Kotlin library'
+      if: steps.should_run.outputs.run_ci_job == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd mobile && ./bazelw build \
+        $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          --fat_apk_cpu=x86_64 \
+          --define=admin_html=enabled \
+          --@envoy//bazel:http3=False \
+          //:android_dist


### PR DESCRIPTION
These will give us some level of additional coverage to ensure that builds don't break with custom compile time options. 

For stronger coverage we'd also run the tests but I'm concerned about the additional CI load for that, so prefer starting with just builds.

Commit Message:
Additional Description:
Risk Level:
Testing: CI :)
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes: https://github.com/envoyproxy/envoy/issues/25379
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]