### PR TITLE
mobile: fixing a bug for junit config

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -322,12 +322,12 @@ public class EnvoyConfiguration {
 
     for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
       if (element.getClassName().startsWith("org.junit.")) {
-        List<EnvoyNativeFilterConfig> reverseFilterChain = nativeFilterChain;
+        List<EnvoyNativeFilterConfig> reverseFilterChain = new ArrayList<>(nativeFilterChain);
         Collections.reverse(reverseFilterChain);
         Boolean enforceTrustChainVerification =
             trustChainVerification == EnvoyConfiguration.TrustChainVerification.VERIFY_TRUST_CHAIN;
 
-        byte[][] filter_chain = JniBridgeUtility.toJniBytes(nativeFilterChain);
+        byte[][] filter_chain = JniBridgeUtility.toJniBytes(reverseFilterChain);
         byte[][] clusters = JniBridgeUtility.stringsToJniBytes(virtualClusters);
         byte[][] stats_sinks = JniBridgeUtility.stringsToJniBytes(statSinks);
         byte[][] dns_preresolve = JniBridgeUtility.stringsToJniBytes(dnsPreresolveHostnames);


### PR DESCRIPTION
Prior builder PR checked the filter chain didn't change, but in doing so changed the filter chain.  Thankfully only under junit but still buggy.
