### PR TITLE
mobile: fix types in `compareYaml` JNI function

### DIFF
--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -1185,18 +1185,20 @@ javaObjectArrayToStringPairVector(JNIEnv* env, jobjectArray entries) {
 
 extern "C" JNIEXPORT jstring JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_compareYaml(
     JNIEnv* env, jclass, jstring yaml, jstring grpc_stats_domain, jboolean admin_interface_enabled,
-    jint connect_timeout_seconds, jint dns_refresh_seconds, jint dns_failure_refresh_seconds_base,
-    jint dns_failure_refresh_seconds_max, jint dns_query_timeout_seconds,
-    jint dns_min_refresh_seconds, jobjectArray dns_preresolve_hostnames, jboolean enable_dns_cache,
-    jint dns_cache_drain_interval_seconds, jboolean drain_post_dns_refresh_on, jboolean http3_on,
-    jboolean gzip_on, jboolean brotli_on, jboolean socket_tagging_on, jboolean happy_eyeballs_on,
-    jboolean interface_binding_on, jint h2_connection_keepalive_idle_interval_milliseconds,
-    jint h2_connection_keepalive_timeout_seconds, jint max_connections_per_host,
-    jint stats_flush_seconds, jint stream_idle_timeout_seconds, jint per_try_idle_timeout_seconds,
-    jstring app_version, jstring app_id, jboolean enforce_trust_chain_verification,
-    jobjectArray native_clusters, jobjectArray native_filters, jobjectArray native_stats_sinks,
-    jboolean platform_certificates_validation_on,
-    jboolean skip_dns_lLookup_for_proxied_requests_on) {
+    jlong connect_timeout_seconds, jlong dns_refresh_seconds,
+    jlong dns_failure_refresh_seconds_base, jlong dns_failure_refresh_seconds_max,
+    jlong dns_query_timeout_seconds, jlong dns_min_refresh_seconds,
+    jobjectArray dns_preresolve_hostnames, jboolean enable_dns_cache,
+    jlong dns_cache_save_interval_seconds, jboolean enable_drain_post_dns_refresh,
+    jboolean enable_http3, jboolean enable_gzip, jboolean enable_brotli,
+    jboolean enable_socket_tagging, jboolean enable_happy_eyeballs,
+    jboolean enable_interface_binding, jlong h2_connection_keepalive_idle_interval_milliseconds,
+    jlong h2_connection_keepalive_timeout_seconds, jlong max_connections_per_host,
+    jlong stats_flush_seconds, jlong stream_idle_timeout_seconds,
+    jlong per_try_idle_timeout_seconds, jstring app_version, jstring app_id,
+    jboolean trust_chain_verification, jobjectArray virtual_clusters, jobjectArray filter_chain,
+    jobjectArray stat_sinks, jboolean enable_platform_certificates_validation,
+    jboolean enable_skip_dns_lookup_for_proxied_requests) {
   Envoy::Platform::EngineBuilder builder;
 
   setString(env, grpc_stats_domain, &builder, &EngineBuilder::addGrpcStatsDomain);
@@ -1206,7 +1208,7 @@ extern "C" JNIEXPORT jstring JNICALL Java_io_envoyproxy_envoymobile_engine_JniLi
                                       (dns_failure_refresh_seconds_max));
   builder.addDnsQueryTimeoutSeconds((dns_query_timeout_seconds));
   builder.addDnsMinRefreshSeconds((dns_min_refresh_seconds));
-  builder.enableDnsCache(enable_dns_cache == JNI_TRUE, dns_cache_drain_interval_seconds);
+  builder.enableDnsCache(enable_dns_cache == JNI_TRUE, dns_cache_save_interval_seconds);
   builder.addMaxConnectionsPerHost((max_connections_per_host));
   builder.addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       (h2_connection_keepalive_idle_interval_milliseconds));
@@ -1221,29 +1223,30 @@ extern "C" JNIEXPORT jstring JNICALL Java_io_envoyproxy_envoymobile_engine_JniLi
   builder.setStreamIdleTimeoutSeconds((stream_idle_timeout_seconds));
   builder.setPerTryIdleTimeoutSeconds((per_try_idle_timeout_seconds));
   builder.enableAdminInterface(admin_interface_enabled == JNI_TRUE);
-  builder.enableGzip(gzip_on == JNI_TRUE);
-  builder.enableBrotli(brotli_on == JNI_TRUE);
-  builder.enableSocketTagging(socket_tagging_on == JNI_TRUE);
-  builder.enableHappyEyeballs(happy_eyeballs_on == JNI_TRUE);
-  builder.enableHttp3(http3_on == JNI_TRUE);
-  builder.enableInterfaceBinding(interface_binding_on == JNI_TRUE);
-  builder.enableDrainPostDnsRefresh(drain_post_dns_refresh_on == JNI_TRUE);
-  builder.enforceTrustChainVerification(enforce_trust_chain_verification == JNI_TRUE);
-  builder.enablePlatformCertificatesValidation(platform_certificates_validation_on == JNI_TRUE);
+  builder.enableGzip(enable_gzip == JNI_TRUE);
+  builder.enableBrotli(enable_brotli == JNI_TRUE);
+  builder.enableSocketTagging(enable_socket_tagging == JNI_TRUE);
+  builder.enableHappyEyeballs(enable_happy_eyeballs == JNI_TRUE);
+  builder.enableHttp3(enable_http3 == JNI_TRUE);
+  builder.enableInterfaceBinding(enable_interface_binding == JNI_TRUE);
+  builder.enableDrainPostDnsRefresh(enable_drain_post_dns_refresh == JNI_TRUE);
+  builder.enforceTrustChainVerification(trust_chain_verification == JNI_TRUE);
+  builder.enablePlatformCertificatesValidation(enable_platform_certificates_validation == JNI_TRUE);
   builder.setForceAlwaysUsev6(true);
-  builder.setSkipDnsLookupForProxiedRequests(skip_dns_lLookup_for_proxied_requests_on == JNI_TRUE);
+  builder.setSkipDnsLookupForProxiedRequests(enable_skip_dns_lookup_for_proxied_requests ==
+                                             JNI_TRUE);
 
   const char* native_yaml = env->GetStringUTFChars(yaml, nullptr);
 
-  auto filters = javaObjectArrayToStringPairVector(env, native_filters);
+  auto filters = javaObjectArrayToStringPairVector(env, filter_chain);
   for (std::pair<std::string, std::string>& filter : filters) {
     builder.addNativeFilter(filter.first, filter.second);
   }
-  std::vector<std::string> clusters = javaObjectArrayToStringVector(env, native_clusters);
+  std::vector<std::string> clusters = javaObjectArrayToStringVector(env, virtual_clusters);
   for (std::string& cluster : clusters) {
     builder.addVirtualCluster(cluster);
   }
-  std::vector<std::string> sinks = javaObjectArrayToStringVector(env, native_stats_sinks);
+  std::vector<std::string> sinks = javaObjectArrayToStringVector(env, stat_sinks);
   builder.addStatsSinks(std::move(sinks));
 
   std::vector<std::string> hostnames = javaObjectArrayToStringVector(env, dns_preresolve_hostnames);


### PR DESCRIPTION
Fixes the following crash:

```
FATAL ERROR in native method: Bad global or local ref passed to JNI
  at io.envoyproxy.envoymobile.engine.JniLibrary.compareYaml(Native Method)
```

By mapping Java's `long` type to `jlong` in JNI instead of `jint`.

The process I took was taking the function definition from `JniLibrary.java`, converting the parameter names from CamelCase to snake_case, and mapping the following types:

* `String` -> `jstring`
* `long` -> `jlong`
* `boolean` -> `jboolean`
* `byte[][]` -> `jobjectArray`

Because of this, I changed the parameter names in the JNI function to match the Java function definition, which I believe will make repeating this process easier and less error prone moving forward.

Commit Message:
Additional Description:
Risk Level:
Testing: `./bazelw test //test/java/io/envoyproxy/envoymobile/engine:envoy_configuration_test`
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
