### PR TITLE
mobile: re-enable RBE for `mobile_perf` CI jobs

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,6 +32,7 @@ jobs:
         cd mobile && ./bazelw build \
             --config=sizeopt \
             --config=release-common \
+            --config=remote-ci-linux-clang \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/performance:test_binary_size
     - uses: actions/upload-artifact@v3
@@ -61,6 +62,7 @@ jobs:
           cd mobile && ./bazelw build \
             --config=sizeopt \
             --config=release-common \
+            --config=remote-ci-linux-clang \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/performance:test_binary_size
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This was accidentally disabled in https://github.com/envoyproxy/envoy/pull/25189, causing the CI job to be extremely slow.