### PR TITLE
formatter: use orError for metadata formatter

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1870,7 +1870,7 @@ MetadataFormatter::formatMetadata(const envoy::config::core::v3::Metadata& metad
   if (value.kind_case() == ProtobufWkt::Value::kStringValue) {
     str = value.string_value();
   } else {
-    str = MessageUtil::getJsonStringFromMessageOrDie(value, false, true);
+    str = MessageUtil::getJsonStringFromMessageOrError(value, false, true);
   }
   truncate(str, max_length_);
   return str;

--- a/test/common/router/header_parser_corpus/upstream_metadata_2
+++ b/test/common/router/header_parser_corpus/upstream_metadata_2
@@ -1,0 +1,22 @@
+headers_to_add {
+  header {
+    key: "d"
+    value: "%START_TIME()%%DYNAMIC_METADATA(|)%"
+  }
+}
+stream_info {
+  dynamic_metadata {
+    filter_metadata {
+      key: "|"
+      value {
+        fields {
+          key: "test"
+          value {
+            number_value: inf
+          }
+        }
+      }
+    }
+  }
+  start_time: 3
+}

--- a/test/common/router/header_parser_corpus/upstream_metadata_2
+++ b/test/common/router/header_parser_corpus/upstream_metadata_2
@@ -10,7 +10,7 @@ stream_info {
       key: "|"
       value {
         fields {
-          key: "test"
+          key: "test_key"
           value {
             number_value: inf
           }


### PR DESCRIPTION
Signed-off-by: Boteng Yao <boteng@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

This is PR is going to avoid crash for potential upgrade of Protobuf. 

The pre-release version of Protobuf includes this change:

`Expect fail when serialize inf and nan for Value.number_value in json format. fixes #11259` 
https://github.com/protocolbuffers/protobuf/commit/ca1cb1ba80ef18f5dccfb5b6ee7fa623ba6caab5

https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value

If we bump the Protobuf version, there will be an exception & crash using `NaN/inf/-inf` in `protobuf.struct` `number_value` when performing the serialization, while there is no check for this behavior right now.

The formatter is used in the header_parser. This is going to use the `orError` method for our metadata value formatter, rather than `orDie` to avoid future crash. 

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
