### PR TITLE
Clean up: Remove obsolete TODO

### DIFF
--- a/source/extensions/filters/http/gcp_authn/token_cache.h
+++ b/source/extensions/filters/http/gcp_authn/token_cache.h
@@ -93,7 +93,6 @@ TokenType* TokenCacheImpl<TokenType>::validateTokenAndReturn(const std::string& 
     // Note: verifyTimeConstraint() interface is correct for the token consumer. However, as the
     // token producer here, we should instead include the clock skew as the part of the `now` time
     // up front to account for the clock skew on the consumer side where the token will be consumed.
-    // TODO(tyxia) Add test for token verification. It currently relies on the tests in jwt library.
     if (found_token->verifyTimeConstraint(
             DateUtil::nowToSeconds(time_source_) + ::google::jwt_verify::kClockSkewInSecond,
             /*clock_skew=*/0) == ::google::jwt_verify::Status::JwtExpired) {


### PR DESCRIPTION
This TODO has already been addressed in PR #23366 (i.e., token_cache_test.cc tests token_cache)

Signed-off-by: tyxia <tyxia@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

