### PR TITLE
Remove scope id from ipv6 address in getLocalAddress

### DIFF
--- a/envoy/network/address.h
+++ b/envoy/network/address.h
@@ -64,6 +64,12 @@ public:
    * if the Ipv6 address isn't Ipv4 mapped.
    */
   virtual InstanceConstSharedPtr v4CompatibleAddress() const PURE;
+
+  /**
+   * @return Ipv6 address that has no scope/zone identifier. Return `nullptr`
+   * if the conversion failed.
+   */
+  virtual InstanceConstSharedPtr addressWithoutScopeId() const PURE;
 };
 
 enum class IpVersion { v4, v6 }; // NOLINT(readability-identifier-naming)

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -268,6 +268,13 @@ InstanceConstSharedPtr Ipv6Instance::Ipv6Helper::v4CompatibleAddress() const {
   return nullptr;
 }
 
+InstanceConstSharedPtr Ipv6Instance::Ipv6Helper::addressWithoutScopeId() const {
+  struct sockaddr_in6 ret_addr = address_;
+  ret_addr.sin6_scope_id = 0;
+  auto addr = Address::InstanceFactory::createInstancePtr<Address::Ipv6Instance>(ret_addr, v6only_);
+  return addr.ok() ? addr.value() : nullptr;
+}
+
 Ipv6Instance::Ipv6Instance(const sockaddr_in6& address, bool v6only,
                            const SocketInterface* sock_interface)
     : InstanceBase(Type::Ip, sockInterfaceOrDefault(sock_interface)) {

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -243,6 +243,7 @@ private:
     uint32_t scopeId() const override;
     uint32_t port() const;
     InstanceConstSharedPtr v4CompatibleAddress() const override;
+    InstanceConstSharedPtr addressWithoutScopeId() const override;
 
     std::string makeFriendlyAddress() const;
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -236,6 +236,9 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
       if (!isLoopbackAddress(*interface_address.interface_addr_) &&
           interface_address.interface_addr_->ip()->version() == version) {
         ret = interface_address.interface_addr_;
+        if (ret->ip()->version() == Address::IpVersion::v6) {
+          ret = ret->ip()->ipv6()->addressWithoutScopeId();
+        }
         break;
       }
     }

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -279,6 +279,24 @@ TEST(Ipv6InstanceTest, AddressAndPort) {
   EXPECT_TRUE(address.ip()->isUnicastAddress());
 }
 
+TEST(Ipv6InstanceTest, ScopeIdStripping) {
+  sockaddr_in6 addr6;
+  memset(&addr6, 0, sizeof(addr6));
+  addr6.sin6_family = AF_INET6;
+  EXPECT_EQ(1, inet_pton(AF_INET6, "fe80::f8f3:11ff:fef4:25a8", &addr6.sin6_addr));
+  addr6.sin6_port = htons(80);
+  addr6.sin6_scope_id = 20u;
+
+  Ipv6Instance address(addr6);
+  EXPECT_EQ("[fe80::f8f3:11ff:fef4:25a8%20]:80", address.asString());
+  EXPECT_EQ(IpVersion::v6, address.ip()->version());
+  EXPECT_EQ(20U, address.ip()->ipv6()->scopeId());
+  auto no_scope_address = address.ip()->ipv6()->addressWithoutScopeId();
+  EXPECT_EQ("[fe80::f8f3:11ff:fef4:25a8]:80", no_scope_address->asString());
+  EXPECT_EQ(IpVersion::v6, no_scope_address->ip()->version());
+  EXPECT_EQ(0U, no_scope_address->ip()->ipv6()->scopeId());
+}
+
 TEST(Ipv6InstanceTest, PortOnly) {
   Ipv6Instance address(443);
   EXPECT_EQ("[::]:443", address.asString());

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -318,6 +318,9 @@ TEST_P(NetworkUtilityGetLocalAddress, GetLocalAddress) {
   auto local_address = Utility::getLocalAddress(ip_version);
   EXPECT_NE(nullptr, local_address);
   EXPECT_EQ(ip_version, local_address->ip()->version());
+  if (ip_version == Address::IpVersion::v6) {
+    EXPECT_EQ(0u, local_address->ip()->ipv6()->scopeId());
+  }
 }
 
 TEST(NetworkUtility, GetOriginalDst) {


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@google.com>

Commit Message: Remove scope id from ipv6 address in getLocalAddress
Additional Description: This fixes the issue where Envoy-mobile fails to send out any packet on ipv6.
Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #25326
