### PR TITLE
mobile: fix producing comma-separated lists in Java/Kotlin builders

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -253,15 +253,18 @@ public class EnvoyConfiguration {
     String maybeComma = "";
     StringBuilder virtualClustersBuilder = new StringBuilder("[");
     for (String cluster : virtualClusters) {
-      virtualClustersBuilder.append(cluster);
       virtualClustersBuilder.append(maybeComma);
+      virtualClustersBuilder.append(cluster);
       maybeComma = ",";
     }
     virtualClustersBuilder.append("]");
 
+    maybeComma = "";
     StringBuilder dnsBuilder = new StringBuilder("[");
     for (String dns : dnsPreresolveHostnames) {
+      dnsBuilder.append(maybeComma);
       dnsBuilder.append("{address: " + dns + ", port_value: 443}");
+      maybeComma = ",";
     }
     dnsBuilder.append("]");
 

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -73,7 +73,7 @@ class EnvoyConfigurationTest {
     dnsFailureRefreshSecondsMax: Int = 456,
     dnsQueryTimeoutSeconds: Int = 321,
     dnsMinRefreshSeconds: Int = 12,
-    dnsPreresolveHostnames: MutableList<String> = mutableListOf("hostname"),
+    dnsPreresolveHostnames: MutableList<String> = mutableListOf("hostname1", "hostname2"),
     enableDNSCache: Boolean = false,
     dnsCacheSaveIntervalSeconds: Int = 101,
     enableDrainPostDnsRefresh: Boolean = false,
@@ -94,7 +94,7 @@ class EnvoyConfigurationTest {
     appVersion: String = "v1.2.3",
     appId: String = "com.example.myapp",
     trustChainVerification: TrustChainVerification = TrustChainVerification.VERIFY_TRUST_CHAIN,
-    virtualClusters: MutableList<String> = mutableListOf("{name: test}"),
+    virtualClusters: MutableList<String> = mutableListOf("{name: test1}", "{name: test2}"),
     filterChain: MutableList<EnvoyNativeFilterConfig> = mutableListOf(EnvoyNativeFilterConfig("buffer_filter_1", "{'@type': 'type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer'}"), EnvoyNativeFilterConfig("buffer_filter_2", "{'@type': 'type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer'}")),
     platformFilterFactories: MutableList<EnvoyHTTPFilterFactory> = mutableListOf(TestEnvoyHTTPFilterFactory("name1"), TestEnvoyHTTPFilterFactory("name2")),
     enableSkipDNSLookupForProxiedRequests: Boolean = false,
@@ -159,7 +159,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_query_timeout 321s")
     assertThat(resolvedTemplate).contains("&dns_lookup_family V4_PREFERRED")
     assertThat(resolvedTemplate).contains("&dns_min_refresh_rate 12s")
-    assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [{address: hostname, port_value: 443}]")
+    assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [{address: hostname1, port_value: 443},{address: hostname2, port_value: 443}]")
     assertThat(resolvedTemplate).contains("&enable_drain_post_dns_refresh false")
 
     // Interface Binding
@@ -190,7 +190,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("app_version: v1.2.3")
     assertThat(resolvedTemplate).contains("app_id: com.example.myapp")
 
-    assertThat(resolvedTemplate).contains("virtual_clusters [{name: test}]")
+    assertThat(resolvedTemplate).contains("virtual_clusters [{name: test1},{name: test2}]")
 
     // Stats
     assertThat(resolvedTemplate).contains("&stats_domain stats.example.com")


### PR DESCRIPTION
* The virtual clusters builder was omitting the first comma and adding an extra trailing comma
* The DNS preresolved host names builder wasn't adding any commas at all

Commit Message: mobile: fix producing comma-separated lists in Java/Kotlin builders
Additional Description:
Risk Level: Low
Testing: Added regression tests
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]