### PR TITLE
minor update: move TracerManager registration to common/tracing

### DIFF
--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -90,12 +90,13 @@ envoy_cc_library(
         "tracer_manager_impl.h",
     ],
     deps = [
+        ":tracer_config_lib",
         "//envoy/server:tracer_config_interface",
         "//envoy/singleton:instance_interface",
         "//envoy/tracing:tracer_manager_interface",
         "//source/common/common:minimal_logger_lib",
         "//source/common/config:utility_lib",
-        "//source/common/tracing:http_tracer_lib",
+        "//source/common/tracing:tracer_lib",
     ],
 )
 

--- a/source/common/tracing/tracer_impl.cc
+++ b/source/common/tracing/tracer_impl.cc
@@ -128,6 +128,9 @@ void TracerUtility::finalizeSpan(Span& span, const TraceContext& trace_context,
       it.second->applySpan(span, ctx);
     }
   }
+
+  // Finish the span.
+  span.finishSpan();
 }
 
 TracerImpl::TracerImpl(DriverSharedPtr driver, const LocalInfo::LocalInfo& local_info)

--- a/source/common/tracing/tracer_manager_impl.h
+++ b/source/common/tracing/tracer_manager_impl.h
@@ -5,11 +5,16 @@
 #include "envoy/tracing/tracer_manager.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/tracing/tracer_config_impl.h"
 #include "source/common/tracing/tracer_impl.h"
 
 namespace Envoy {
 namespace Tracing {
 
+/**
+ * TracerManager implementation that manages the tracers. This should be used as a singleton except
+ * in tests.
+ */
 class TracerManagerImpl : public TracerManager,
                           public Singleton::Instance,
                           Logger::Loggable<Logger::Id::tracing> {
@@ -23,6 +28,8 @@ public:
   const absl::flat_hash_map<std::size_t, std::weak_ptr<Tracer>>& peekCachedTracersForTest() const {
     return tracers_;
   }
+
+  static std::shared_ptr<TracerManager> singleton(Server::Configuration::FactoryContext& context);
 
 private:
   void removeExpiredCacheEntries();

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -191,7 +191,6 @@ Http::HeaderValidatorFactoryPtr createHeaderValidatorFactory(
 SINGLETON_MANAGER_REGISTRATION(date_provider);
 SINGLETON_MANAGER_REGISTRATION(route_config_provider_manager);
 SINGLETON_MANAGER_REGISTRATION(scoped_routes_config_provider_manager);
-SINGLETON_MANAGER_REGISTRATION(tracer_manager);
 
 Utility::Singletons Utility::createSingletons(Server::Configuration::FactoryContext& context) {
   std::shared_ptr<Http::TlsCachingDateProviderImpl> date_provider =
@@ -215,12 +214,7 @@ Utility::Singletons Utility::createSingletons(Server::Configuration::FactoryCont
                 context.admin(), *route_config_provider_manager);
           });
 
-  auto tracer_manager = context.singletonManager().getTyped<Tracing::TracerManagerImpl>(
-      SINGLETON_MANAGER_REGISTERED_NAME(tracer_manager), [&context] {
-        return std::make_shared<Tracing::TracerManagerImpl>(
-            std::make_unique<Tracing::TracerFactoryContextImpl>(
-                context.getServerFactoryContext(), context.messageValidationVisitor()));
-      });
+  auto tracer_manager = Tracing::TracerManagerImpl::singleton(context);
 
   std::shared_ptr<Http::DownstreamFilterConfigProviderManager> filter_config_provider_manager =
       Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(


### PR DESCRIPTION
Commit Message: minor update: move TracerManager registration to common/tracing
Additional Description:

Move the tracer manager registration out from HCM. This make other proxy could reuse this tracer manager easily and needn't to register a new tracer manager instance.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.