### PR TITLE
[backport/1.23] ci: Bump Ubuntu images

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -30,7 +30,7 @@ stages:
   - job: format
     dependsOn: []
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: Cache@2
       inputs:
@@ -58,7 +58,7 @@ stages:
   - job: proto_format
     dependsOn: []
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: Cache@2
       inputs:
@@ -87,7 +87,7 @@ stages:
     dependsOn: []  # this removes the implicit dependency on previous stage and causes this to run in parallel.
     condition: ne(variables['PostSubmit'], true)
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: Cache@2
       inputs:
@@ -118,7 +118,7 @@ stages:
   - job: dependencies
     dependsOn: []  # this removes the implicit dependency on previous stage and causes this to run in parallel.
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: Cache@2
       inputs:
@@ -145,7 +145,7 @@ stages:
   - job: filter_example
     dependsOn: []
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: InstallSSHKey@0
       inputs:
@@ -163,7 +163,7 @@ stages:
   - job: data_plane_api
     dependsOn: []
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: InstallSSHKey@0
       inputs:
@@ -181,7 +181,7 @@ stages:
   - job: go_control_plane
     dependsOn: []
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: InstallSSHKey@0
       inputs:
@@ -210,7 +210,7 @@ stages:
   - job: release
     timeoutInMinutes: 120
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - template: bazel.yml
       parameters:
@@ -240,7 +240,7 @@ stages:
     dependsOn: []
     timeoutInMinutes: 120
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - template: bazel.yml
       parameters:
@@ -261,7 +261,7 @@ stages:
     dependsOn: ["package_x64"]
     timeoutInMinutes: 120
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: DownloadBuildArtifacts@0
       inputs:
@@ -329,7 +329,7 @@ stages:
           CI_TARGET: "bazel.compile_time_options"
     timeoutInMinutes: 120
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - template: bazel.yml
       parameters:
@@ -371,7 +371,7 @@ stages:
     displayName: "linux multiarch"
     timeoutInMinutes: 120
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - bash: |
         echo "disk space at beginning of build:"
@@ -441,7 +441,7 @@ stages:
   jobs:
   - job: docs
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: Cache@2
       inputs:
@@ -578,7 +578,7 @@ stages:
   jobs:
   - job: examples
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - task: DownloadBuildArtifacts@0
       inputs:


### PR DESCRIPTION
This makes the 1.23 branch work with the newer ubuntu images and prevents failure during github brownouts (or after apr 1st when the deprecation period ends)

Signed-off-by: Ryan Northey <ryan@synca.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
