### PR TITLE
mobile: minor fixes to C++ engine builder

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -331,8 +331,8 @@ std::string EngineBuilder::generateConfigStr() const {
   std::string preresolve_hostnames = "[";
   std::string maybe_comma = "";
   for (auto& hostname : dns_preresolve_hostnames_) {
-    absl::StrAppend(&preresolve_hostnames, maybe_comma, "{address: ", hostname,
-                    ", port_value: 443}");
+    absl::StrAppend(&preresolve_hostnames, maybe_comma, "{address: \"", hostname,
+                    "\", port_value: 443}");
     maybe_comma = ",";
   }
   absl::StrAppend(&preresolve_hostnames, "]");

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -1231,7 +1231,6 @@ extern "C" JNIEXPORT jstring JNICALL Java_io_envoyproxy_envoymobile_engine_JniLi
 
   setString(env, app_version, &builder, &EngineBuilder::setAppVersion);
   setString(env, app_id, &builder, &EngineBuilder::setAppId);
-  setString(env, app_id, &builder, &EngineBuilder::setAppId);
   builder.setDeviceOs("Android");
 
   builder.setStreamIdleTimeoutSeconds((stream_idle_timeout_seconds));


### PR DESCRIPTION
* Quote `dns_preresolve_hostnames_` values
* Don't set `EngineBuilder::setAppId` twice

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
