### PR TITLE
[balsa] Add Http1ProtocolOptions field to override HTTP/1 parser.

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -259,7 +259,7 @@ message HttpProtocolOptions {
   google.protobuf.UInt32Value max_requests_per_connection = 6;
 }
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message Http1ProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.Http1ProtocolOptions";
@@ -350,6 +350,11 @@ message Http1ProtocolOptions {
   // (inferred if not present), host (from the host/:authority header) and path
   // (from first line or :path header).
   bool send_fully_qualified_url = 8;
+
+  // If set, force HTTP/1 parser: BalsaParser if true, http-parser if false.
+  // If unset, HTTP/1 parser is selected based on
+  // envoy.reloadable_features.http1_use_balsa_parser.
+  optional bool use_balsa_parser = 9;
 }
 
 message KeepaliveSettings {

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -492,6 +492,10 @@ struct Http1Settings {
 
   // If true, Envoy will send a fully qualified URL in the firstline of the request.
   bool send_fully_qualified_url_{false};
+
+  // If true, BalsaParser is used for HTTP/1 parsing; if false, http-parser is
+  // used.
+  bool use_balsa_parser_{false};
 };
 
 /**

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -513,7 +513,7 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
       processing_trailers_(false), handling_upgrade_(false), reset_stream_called_(false),
       deferred_end_stream_headers_(false), dispatching_(false), max_headers_kb_(max_headers_kb),
       max_headers_count_(max_headers_count) {
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_use_balsa_parser")) {
+  if (codec_settings_.use_balsa_parser_) {
     parser_ = std::make_unique<BalsaParser>(type, this, max_headers_kb_ * 1024, enableTrailers());
   } else {
     parser_ = std::make_unique<LegacyHttpParserImpl>(type, this);
@@ -692,7 +692,7 @@ Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t 
   const ParserStatus status = parser_->getStatus();
   if (status != ParserStatus::Ok && status != ParserStatus::Paused) {
     absl::string_view error = Http1ResponseCodeDetails::get().HttpCodecError;
-    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_use_balsa_parser")) {
+    if (codec_settings_.use_balsa_parser_) {
       if (parser_->errorMessage() == "headers size exceeds limit" ||
           parser_->errorMessage() == "trailers size exceeds limit") {
         error_code_ = Http::Code::RequestHeaderFieldsTooLarge;

--- a/source/common/http/http1/settings.cc
+++ b/source/common/http/http1/settings.cc
@@ -3,6 +3,7 @@
 #include "envoy/http/header_formatter.h"
 
 #include "source/common/config/utility.h"
+#include "source/common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Http {
@@ -29,6 +30,13 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
         factory);
     ret.header_key_format_ = Http1Settings::HeaderKeyFormat::StatefulFormatter;
     ret.stateful_header_key_formatter_ = factory.createFromProto(*header_formatter_config);
+  }
+
+  if (config.has_use_balsa_parser()) {
+    ret.use_balsa_parser_ = config.use_balsa_parser();
+  } else {
+    ret.use_balsa_parser_ =
+        Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_use_balsa_parser");
   }
 
   return ret;


### PR DESCRIPTION
If present, force http-parser (if value is false) or BalsaParser (if value is true).  If not present, parser is selected based on envoy.reloadable_features.http1_use_balsa_parser.

Tracking issue: https://github.com/envoyproxy/envoy/issues/21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Add Http1ProtocolOptions field to override HTTP/1 parser.
Additional Description:
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a