### PR TITLE
mobile: update ObjC/Swift APIs to take arrays instead of strings

### DIFF
--- a/mobile/docs/root/api/starting_envoy.rst
+++ b/mobile/docs/root/api/starting_envoy.rst
@@ -101,21 +101,13 @@ Specify the interval at which Envoy should timeout a DNS query.
 ``addDNSPreresolveHostnames``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attention::
-
-  This API is non-ideal as it exposes lower-level internals of Envoy than desired by this
-  project.
-
 Add a list of hostnames to preresolve on Engine startup.
-For Swift, the configuration is expected as a JSON list.
-:issue:`#1581 <1581>` tracks enhancing this API.
-For Kotlin, the configuration is expected as a list of hostnames
 
   // Kotlin
-  builder.addDNSPreresolveHostnames("{"lyft.com", "google.com"}")
+  builder.addDNSPreresolveHostnames(listOf("lyft.com", "google.com"))
 
   // Swift
-  builder.addDNSPreresolveHostnames("[{\"address\": \"foo.com", \"port_value\": 443}]")
+  builder.addDNSPreresolveHostnames(["lyft.com", "google.com"])
 
 ~~~~~~~~~~~~~~~
 ``addLogLevel``
@@ -233,12 +225,12 @@ This information is sent as metadata when flushing stats.
   // Swift
   builder.addAppId("com.mydomain.myapp)
 
-~~~~~~~~~~~~~~~~~~~~~~
-``addVirtualClusters``
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
+``addVirtualCluster``
+~~~~~~~~~~~~~~~~~~~~~
 
-Specify the virtual clusters config for Envoy Mobile's configuration.
-The configuration is expected as a JSON list.
+Add a virtual cluster config for Envoy Mobile's configuration.
+The configuration is expected as a JSON object.
 This functionality is used for stat segmentation.
 
 .. attention::

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -15,8 +15,8 @@ Breaking changes:
 - swift/kotlin: add `cancel` method to `GRPCStream`` type (:issue:`#24780 <24780>`).
 - all: enable HTTP/3 by default in Engine builders.
 - api: remove ``extendKeepaliveTimeout`` method from engine builders.
-- api: move Java and C++ addVirtualClusters taking concatenated cluster YAML to addVirtualCluster with one cluster config at a time (:issue: `#25297 <25297>`, :issue: `#25259 <25259>`)
-- api: move Java and C++ dnsPreresolveHostnames from taking concatenated cluster YAML to taking a list of String hostnames (:issue: `#25297 <25297>`, :issue: `#25259 <25259>`)
+- api: move ``addVirtualClusters`` APIs taking concatenated cluster YAML to ``addVirtualCluster`` with one cluster config at a time (:issue: `#25297 <25297>`, :issue: `#25259 <25259>`, :issue: `#25457 <25457>`)
+- api: move ``dnsPreresolveHostnames`` APIs from taking concatenated cluster YAML to taking a list of String hostnames (:issue: `#25297 <25297>`, :issue: `#25259 <25259>`, :issue: `#25457 <25457>`)
 
 Bugfixes:
 

--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
 @property (nonatomic, assign) UInt32 dnsQueryTimeoutSeconds;
 @property (nonatomic, assign) UInt32 dnsMinRefreshSeconds;
-@property (nonatomic, strong) NSString *dnsPreresolveHostnames;
+@property (nonatomic, strong) NSArray<NSString *> *dnsPreresolveHostnames;
 @property (nonatomic, assign) UInt32 dnsRefreshSeconds;
 @property (nonatomic, assign) BOOL enableDNSCache;
 @property (nonatomic, assign) UInt32 dnsCacheSaveIntervalSeconds;
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
 @property (nonatomic, strong) NSString *appVersion;
 @property (nonatomic, strong) NSString *appId;
-@property (nonatomic, strong) NSString *virtualClusters;
+@property (nonatomic, strong) NSArray<NSString *> *virtualClusters;
 @property (nonatomic, strong) NSString *directResponseMatchers;
 @property (nonatomic, strong) NSString *directResponses;
 @property (nonatomic, strong) NSArray<EnvoyNativeFilterConfig *> *nativeFilterChain;
@@ -53,14 +53,14 @@ NS_ASSUME_NONNULL_BEGIN
  Create a new instance of the configuration.
  */
 - (instancetype)initWithAdminInterfaceEnabled:(BOOL)adminInterfaceEnabled
-                                  GrpcStatsDomain:(nullable NSString *)grpcStatsDomain
+                                  grpcStatsDomain:(nullable NSString *)grpcStatsDomain
                             connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
                                 dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
                      dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
                       dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                            dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
                              dnsMinRefreshSeconds:(UInt32)dnsMinRefreshSeconds
-                           dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
+                           dnsPreresolveHostnames:(NSArray<NSString *> *)dnsPreresolveHostnames
                                    enableDNSCache:(BOOL)enableDNSCache
                       dnsCacheSaveIntervalSeconds:(UInt32)dnsCacheSaveIntervalSeconds
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
                                        appVersion:(NSString *)appVersion
                                             appId:(NSString *)appId
-                                  virtualClusters:(NSString *)virtualClusters
+                                  virtualClusters:(NSArray<NSString *> *)virtualClusters
                            directResponseMatchers:(NSString *)directResponseMatchers
                                   directResponses:(NSString *)directResponses
                                 nativeFilterChain:

--- a/mobile/library/objective-c/EnvoyConfiguration.m
+++ b/mobile/library/objective-c/EnvoyConfiguration.m
@@ -5,14 +5,14 @@
 @implementation EnvoyConfiguration
 
 - (instancetype)initWithAdminInterfaceEnabled:(BOOL)adminInterfaceEnabled
-                                  GrpcStatsDomain:(nullable NSString *)grpcStatsDomain
+                                  grpcStatsDomain:(nullable NSString *)grpcStatsDomain
                             connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
                                 dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
                      dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
                       dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                            dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
                              dnsMinRefreshSeconds:(UInt32)dnsMinRefreshSeconds
-                           dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
+                           dnsPreresolveHostnames:(NSArray<NSString *> *)dnsPreresolveHostnames
                                    enableDNSCache:(BOOL)enableDNSCache
                       dnsCacheSaveIntervalSeconds:(UInt32)dnsCacheSaveIntervalSeconds
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
@@ -35,7 +35,7 @@
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
                                        appVersion:(NSString *)appVersion
                                             appId:(NSString *)appId
-                                  virtualClusters:(NSString *)virtualClusters
+                                  virtualClusters:(NSArray<NSString *> *)virtualClusters
                            directResponseMatchers:(NSString *)directResponseMatchers
                                   directResponses:(NSString *)directResponses
                                 nativeFilterChain:
@@ -197,7 +197,17 @@
       appendFormat:@"- &dns_query_timeout %lus\n", (unsigned long)self.dnsQueryTimeoutSeconds];
   [definitions
       appendFormat:@"- &dns_min_refresh_rate %lus\n", (unsigned long)self.dnsMinRefreshSeconds];
-  [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", self.dnsPreresolveHostnames];
+  if (self.dnsPreresolveHostnames.count > 0) {
+    NSMutableString *hostnamesYAML = [[NSMutableString alloc] initWithString:@"["];
+    NSString *maybeComma = @"";
+    for (NSString *hostname in self.dnsPreresolveHostnames) {
+      [hostnamesYAML appendString:maybeComma];
+      [hostnamesYAML appendFormat:@"{\"address\": \"%@\", \"port_value\": 443}", hostname];
+      maybeComma = @",";
+    }
+    [hostnamesYAML appendString:@"]"];
+    [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", hostnamesYAML];
+  }
   [definitions appendFormat:@"- &dns_lookup_family %@\n",
                             self.enableHappyEyeballs ? @"ALL" : @"V4_PREFERRED"];
   [definitions appendFormat:@"- &dns_refresh_rate %lus\n", (unsigned long)self.dnsRefreshSeconds];
@@ -221,7 +231,8 @@
       appendFormat:@"- &per_try_idle_timeout %lus\n", (unsigned long)self.perTryIdleTimeoutSeconds];
   [definitions appendFormat:@"- &metadata { device_os: %@, app_version: %@, app_id: %@ }\n", @"iOS",
                             self.appVersion, self.appId];
-  [definitions appendFormat:@"- &virtual_clusters %@\n", self.virtualClusters];
+  [definitions appendFormat:@"- &virtual_clusters [%@]\n",
+                            [self.virtualClusters componentsJoinedByString:@","]];
 
   [definitions
       appendFormat:@"- &stats_flush_interval %lus\n", (unsigned long)self.statsFlushSeconds];

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -21,7 +21,7 @@ open class EngineBuilder: NSObject {
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var dnsQueryTimeoutSeconds: UInt32 = 25
   private var dnsMinRefreshSeconds: UInt32 = 60
-  private var dnsPreresolveHostnames: String = "[]"
+  private var dnsPreresolveHostnames: [String] = []
   private var dnsRefreshSeconds: UInt32 = 60
   private var enableDNSCache: Bool = false
   private var dnsCacheSaveIntervalSeconds: UInt32 = 1
@@ -48,7 +48,7 @@ open class EngineBuilder: NSObject {
   private var perTryIdleTimeoutSeconds: UInt32 = 15
   private var appVersion: String = "unspecified"
   private var appId: String = "unspecified"
-  private var virtualClusters: String = "[]"
+  private var virtualClusters: [String] = []
   private var onEngineRunning: (() -> Void)?
   private var logger: ((String) -> Void)?
   private var eventTracker: (([String: String]) -> Void)?
@@ -165,7 +165,7 @@ open class EngineBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addDNSPreresolveHostnames(dnsPreresolveHostnames: String) -> Self {
+  public func addDNSPreresolveHostnames(dnsPreresolveHostnames: [String]) -> Self {
     self.dnsPreresolveHostnames = dnsPreresolveHostnames
     return self
   }
@@ -541,12 +541,23 @@ open class EngineBuilder: NSObject {
 
   /// Add virtual cluster configuration.
   ///
-  /// - parameter virtualClusters: The JSON configuration string for virtual clusters.
+  /// - parameter virtualCluster: The JSON configuration string for a virtual cluster.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addVirtualClusters(_ virtualClusters: String) -> Self {
-    self.virtualClusters = virtualClusters
+  public func addVirtualCluster(_ virtualCluster: String) -> Self {
+    self.virtualClusters.append(virtualCluster)
+    return self
+  }
+
+  /// Add virtual cluster configurations.
+  ///
+  /// - parameter virtualClusters: The JSON configuration strings for virtual clusters.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addVirtualClusters(_ virtualClusters: [String]) -> Self {
+    self.virtualClusters.append(contentsOf: virtualClusters)
     return self
   }
 

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -367,13 +367,13 @@ final class EngineBuilderTests: XCTestCase {
   func testAddingVirtualClustersAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual("[test]", config.virtualClusters)
+      XCTAssertEqual(["test"], config.virtualClusters)
       expectation.fulfill()
     }
 
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addVirtualClusters("[test]")
+      .addVirtualClusters(["test"])
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
@@ -458,7 +458,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsMinRefreshSeconds: 100,
-      dnsPreresolveHostnames: "[test]",
+      dnsPreresolveHostnames: ["host1", "host2"],
       enableDNSCache: false,
       dnsCacheSaveIntervalSeconds: 0,
       enableHappyEyeballs: true,
@@ -480,7 +480,7 @@ final class EngineBuilderTests: XCTestCase {
       perTryIdleTimeoutSeconds: 777,
       appVersion: "v1.2.3",
       appId: "com.envoymobile.ios",
-      virtualClusters: "[test]",
+      virtualClusters: ["test"],
       directResponseMatchers: "",
       directResponses: "",
       nativeFilterChain: [
@@ -500,7 +500,14 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_fail_max_interval 500s"))
     XCTAssertTrue(resolvedYAML.contains("&dns_query_timeout 800s"))
     XCTAssertTrue(resolvedYAML.contains("&dns_min_refresh_rate 100s"))
-    XCTAssertTrue(resolvedYAML.contains("&dns_preresolve_hostnames [test]"))
+    XCTAssertTrue(
+      resolvedYAML.contains(
+#"""
+&dns_preresolve_hostnames [{"address": "host1", "port_value": 443},\#
+{"address": "host2", "port_value": 443}]
+"""#
+      )
+    )
     XCTAssertTrue(resolvedYAML.contains("&dns_lookup_family ALL"))
     XCTAssertFalse(resolvedYAML.contains("&persistent_dns_cache_config"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding true"))
@@ -557,7 +564,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsMinRefreshSeconds: 100,
-      dnsPreresolveHostnames: "[test]",
+      dnsPreresolveHostnames: ["test"],
       enableDNSCache: true,
       dnsCacheSaveIntervalSeconds: 10,
       enableHappyEyeballs: false,
@@ -579,7 +586,7 @@ final class EngineBuilderTests: XCTestCase {
       perTryIdleTimeoutSeconds: 777,
       appVersion: "v1.2.3",
       appId: "com.envoymobile.ios",
-      virtualClusters: "[test]",
+      virtualClusters: ["test"],
       directResponseMatchers: "",
       directResponses: "",
       nativeFilterChain: [
@@ -638,7 +645,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsMinRefreshSeconds: 100,
-      dnsPreresolveHostnames: "[test]",
+      dnsPreresolveHostnames: ["test"],
       enableDNSCache: false,
       dnsCacheSaveIntervalSeconds: 0,
       enableHappyEyeballs: false,
@@ -660,7 +667,7 @@ final class EngineBuilderTests: XCTestCase {
       perTryIdleTimeoutSeconds: 700,
       appVersion: "v1.2.3",
       appId: "com.envoymobile.ios",
-      virtualClusters: "[test]",
+      virtualClusters: ["test"],
       directResponseMatchers: "",
       directResponses: "",
       nativeFilterChain: [],


### PR DESCRIPTION
This mirrors what was done to builders for other languages in #25297 and #25259.

Commit Message:
Additional Description:
Risk Level: Low
Testing: Unit tests & Lyft apps
Docs Changes: Updated
Release Notes: Updated
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
