### PR TITLE
[balsa] Use ProcessHeaders() instead of OnHeader().

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -244,23 +244,14 @@ void BalsaParser::OnBodyChunkInput(absl::string_view input) {
 
 void BalsaParser::OnHeaderInput(absl::string_view /*input*/) {}
 void BalsaParser::OnTrailerInput(absl::string_view /*input*/) {}
+void BalsaParser::OnHeader(absl::string_view /*key*/, absl::string_view /*value*/) {}
 
-void BalsaParser::OnHeader(absl::string_view key, absl::string_view value) {
-  if (status_ == ParserStatus::Error) {
-    return;
-  }
-
-  status_ = convertResult(connection_->onHeaderField(key.data(), key.length()));
-
-  if (status_ == ParserStatus::Error) {
-    return;
-  }
-
-  status_ = convertResult(connection_->onHeaderValue(value.data(), value.length()));
+void BalsaParser::ProcessHeaders(const BalsaHeaders& headers) {
+  ProcessHeadersOrTrailersImpl(headers);
 }
-
-void BalsaParser::ProcessHeaders(const BalsaHeaders& /*headers*/) {}
-void BalsaParser::ProcessTrailers(const BalsaHeaders& /*trailer*/) {}
+void BalsaParser::ProcessTrailers(const BalsaHeaders& trailer) {
+  ProcessHeadersOrTrailersImpl(trailer);
+}
 
 void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
                                           absl::string_view method_input,
@@ -366,6 +357,24 @@ void BalsaParser::HandleError(BalsaFrameEnums::ErrorCode error_code) {
 void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode error_code) {
   if (error_code == BalsaFrameEnums::TRAILER_MISSING_COLON) {
     HandleError(error_code);
+  }
+}
+
+void BalsaParser::ProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers) {
+  for (const std::pair<absl::string_view, absl::string_view>& key_value : headers.lines()) {
+    if (status_ == ParserStatus::Error) {
+      return;
+    }
+
+    absl::string_view key = key_value.first;
+    status_ = convertResult(connection_->onHeaderField(key.data(), key.length()));
+
+    if (status_ == ParserStatus::Error) {
+      return;
+    }
+
+    absl::string_view value = key_value.second;
+    status_ = convertResult(connection_->onHeaderValue(value.data(), value.length()));
   }
 }
 

--- a/source/common/http/http1/balsa_parser.h
+++ b/source/common/http/http1/balsa_parser.h
@@ -57,6 +57,9 @@ private:
   void HandleError(quiche::BalsaFrameEnums::ErrorCode error_code) override;
   void HandleWarning(quiche::BalsaFrameEnums::ErrorCode error_code) override;
 
+  // Shared implementation for ProcessHeaders() and ProcessTrailers().
+  void ProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers);
+
   // Return ParserStatus::Error if `result` is CallbackResult::Error.
   // Return current value of `status_` otherwise.
   // Typical use would be `status_ = convertResult(result);`


### PR DESCRIPTION
BalsaVisitorInterface provides two ways of processing headers: OnHeader() is called for each header line, and ProcessHeaders() and ProcessTrailers() are called with the entire header/trailer block.  All of these methods are only called after the entire header block or trailer block is parsed, so using OnHeader() does not actually allow early processing of headers.

The major difference is that some header validation happens after OnHeader() is called, for example, check for empty header names (both for headers and trailers), multiple Content-Length headers, multiple Transfer-Encoding headers, and the presence of Content-Length and Transfer-Encoding in the same header block (not for trailers).  (Some of these test can be disabling using HttpValidationPolicy.)  If the headers fail, for example, because of an empty field name or because of multiple Transfer-Encoding headers, ProcessHeaders() or ProcessTrailers() are not called.

One problem with using OnHeader() is that an assertion in ConnectionImpl::completeCurrentHeader() can fail if the header name is empty, see issue #25458.  Another problem is that header names and values are copied immediately, using unnecessary memory in case an error is detected later.  This PR migrates BalsaParser from using OnHeader() to ProcessHeaders() and ProcessTrailers().

This PR also adds two tests.  The first one, the case of empty header name, would cause an assertion failure without the change.  The second one would pass either way, because the error from Balsa is propagated properly to ConnectionImpl.  Note that the error message is slightly different with http-parser, because http-parser does not have a check for Transfer-Encoding, but ConnectionImpl::onHeadersCompleteImpl() signals an error, because the combined value of "chunked,chunked" does not match "chunked".

Relevant issues: #25458, #21245.

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Use ProcessHeaders() instead of OnHeader().
Additional Description:
Risk Level: low, changed code is protected by existing default-false runtime flag.
Testing: //test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser