### PR TITLE
mobile: update rules_xcodeproj to 1.1.0

### DIFF
--- a/mobile/bazel/envoy_mobile_repositories.bzl
+++ b/mobile/bazel/envoy_mobile_repositories.bzl
@@ -79,8 +79,8 @@ def swift_repos():
 
     http_archive(
         name = "com_github_buildbuddy_io_rules_xcodeproj",
-        sha256 = "9c86784491854f205b075e5c4d8a838612d433d9454a226d270ad1a17ad8d634",
-        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.12.2/release.tar.gz",
+        sha256 = "1e2f40eaee520093343528ac9a4a9180b0500cdd83b1e5e2a95abc8c541686e2",
+        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/1.1.0/release.tar.gz",
     )
 
 def kotlin_repos():


### PR DESCRIPTION
There have been lots of fixes, features and optimizations since the last time we updated.

In particular, the releases now include prebuilt optimized binaries.

https://github.com/buildbuddy-io/rules_xcodeproj/releases/tag/1.1.0

Read the release blog post to learn more about the state of the project: https://www.buildbuddy.io/blog/introducing-rules_xcodeproj-1-0/

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]