### PR TITLE
Add default filter state to MockListenerFilterCallbacks

### DIFF
--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -113,7 +113,9 @@ MockDrainDecision::~MockDrainDecision() = default;
 
 MockListenerFilter::~MockListenerFilter() { destroy_(); }
 
-MockListenerFilterCallbacks::MockListenerFilterCallbacks() {
+MockListenerFilterCallbacks::MockListenerFilterCallbacks()
+    : filter_state_(StreamInfo::FilterStateImpl(StreamInfo::FilterState::LifeSpan::FilterChain)) {
+  ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));
 }
 MockListenerFilterCallbacks::~MockListenerFilterCallbacks() = default;

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -23,6 +23,7 @@
 #include "source/common/network/socket_interface.h"
 #include "source/common/network/socket_interface_impl.h"
 #include "source/common/stats/isolated_store_impl.h"
+#include "source/common/stream_info/filter_state_impl.h"
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/network/connection.h"
@@ -384,6 +385,7 @@ public:
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, dynamicMetadata, (), (const));
   MOCK_METHOD(StreamInfo::FilterState&, filterState, (), ());
 
+  StreamInfo::FilterStateImpl filter_state_;
   NiceMock<MockConnectionSocket> socket_;
 };
 


### PR DESCRIPTION
Adding default filter state implementation to MockListenerFilterCallbacks for listener filters that make use of the filter state.