### PR TITLE
mobile: perform bounds checks before accessing JNI arrays

### DIFF
--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -22,6 +22,7 @@ Bugfixes:
 
 - android: fix engine startup crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
 - android: respect system security policy when determining whether clear text requests are allowed. (:issue:`#2528 <2528>`)
+- android: fix JNI crashes when responses would have empty headers. (:issue:`#25516 <25516>`)
 
 Features:
 

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -22,7 +22,7 @@ Bugfixes:
 
 - android: fix engine startup crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
 - android: respect system security policy when determining whether clear text requests are allowed. (:issue:`#2528 <2528>`)
-- android: fix JNI crashes when responses would have empty headers. (:issue:`#25516 <25516>`)
+- android: fix JNI crashes when responses would have empty trailers. (:issue:`#25516 <25516>`)
 
 Features:
 

--- a/mobile/library/common/extensions/filters/http/test_remote_response/filter.h
+++ b/mobile/library/common/extensions/filters/http/test_remote_response/filter.h
@@ -25,6 +25,9 @@ public:
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override;
 
   void sendResponse();
+
+private:
+  Http::RequestHeaderMap* headers_{};
 };
 
 } // namespace TestRemoteResponse

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -342,6 +342,12 @@ jvm_http_filter_on_request_headers(envoy_headers input_headers, bool end_stream,
   jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
       "onRequestHeaders", headers, end_stream, stream_intel, const_cast<void*>(context)));
 
+  if (env->GetArrayLength(result) < 2) {
+    env->DeleteLocalRef(result);
+    return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
+                                         /*headers*/ {}};
+  }
+
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
@@ -363,6 +369,12 @@ jvm_http_filter_on_response_headers(envoy_headers input_headers, bool end_stream
   const auto headers = Envoy::Types::ManagedEnvoyHeaders(input_headers);
   jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
       "onResponseHeaders", headers, end_stream, stream_intel, const_cast<void*>(context)));
+
+  if (env->GetArrayLength(result) < 2) {
+    env->DeleteLocalRef(result);
+    return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
+                                         /*headers*/ {}};
+  }
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -413,6 +425,13 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onRequestData", data, end_stream, stream_intel, const_cast<void*>(context)));
 
+  if (env->GetArrayLength(result) < 2) {
+    env->DeleteLocalRef(result);
+    return (envoy_filter_data_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
+                                      /*data*/ {},
+                                      /*pending_headers*/ {}};
+  }
+
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
@@ -442,6 +461,13 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onResponseData", data, end_stream, stream_intel, const_cast<void*>(context)));
+
+  if (env->GetArrayLength(result) < 2) {
+    env->DeleteLocalRef(result);
+    return (envoy_filter_data_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
+                                      /*data*/ {},
+                                      /*pending_headers*/ {}};
+  }
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -510,6 +536,14 @@ jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel s
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onRequestTrailers", trailers, stream_intel, const_cast<void*>(context)));
 
+  if (env->GetArrayLength(result) < 2) {
+    env->DeleteLocalRef(result);
+    return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
+                                          /*trailers*/ {},
+                                          /*pending_headers*/ {},
+                                          /*pending_data*/ {}};
+  }
+
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
 
@@ -545,6 +579,14 @@ jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel 
   JNIEnv* env = get_env();
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onResponseTrailers", trailers, stream_intel, const_cast<void*>(context)));
+
+  if (env->GetArrayLength(result) < 2) {
+    env->DeleteLocalRef(result);
+    return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
+                                          /*trailers*/ {},
+                                          /*pending_headers*/ {},
+                                          /*pending_data*/ {}};
+  }
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -342,7 +342,7 @@ jvm_http_filter_on_request_headers(envoy_headers input_headers, bool end_stream,
   jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
       "onRequestHeaders", headers, end_stream, stream_intel, const_cast<void*>(context)));
 
-  if (env->GetArrayLength(result) < 2) {
+  if (result == NULL || env->GetArrayLength(result) < 2) {
     env->DeleteLocalRef(result);
     return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
                                          /*headers*/ {}};
@@ -370,7 +370,7 @@ jvm_http_filter_on_response_headers(envoy_headers input_headers, bool end_stream
   jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
       "onResponseHeaders", headers, end_stream, stream_intel, const_cast<void*>(context)));
 
-  if (env->GetArrayLength(result) < 2) {
+  if (result == NULL || env->GetArrayLength(result) < 2) {
     env->DeleteLocalRef(result);
     return (envoy_filter_headers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
                                          /*headers*/ {}};
@@ -425,7 +425,7 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onRequestData", data, end_stream, stream_intel, const_cast<void*>(context)));
 
-  if (env->GetArrayLength(result) < 2) {
+  if (result == NULL || env->GetArrayLength(result) < 2) {
     env->DeleteLocalRef(result);
     return (envoy_filter_data_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
                                       /*data*/ {},
@@ -462,7 +462,7 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onResponseData", data, end_stream, stream_intel, const_cast<void*>(context)));
 
-  if (env->GetArrayLength(result) < 2) {
+  if (result == NULL || env->GetArrayLength(result) < 2) {
     env->DeleteLocalRef(result);
     return (envoy_filter_data_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
                                       /*data*/ {},
@@ -536,7 +536,7 @@ jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel s
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onRequestTrailers", trailers, stream_intel, const_cast<void*>(context)));
 
-  if (env->GetArrayLength(result) < 2) {
+  if (result == NULL || env->GetArrayLength(result) < 2) {
     env->DeleteLocalRef(result);
     return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
                                           /*trailers*/ {},
@@ -580,7 +580,7 @@ jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel 
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onResponseTrailers", trailers, stream_intel, const_cast<void*>(context)));
 
-  if (env->GetArrayLength(result) < 2) {
+  if (result == NULL || env->GetArrayLength(result) < 2) {
     env->DeleteLocalRef(result);
     return (envoy_filter_trailers_status){/*status*/ kEnvoyFilterHeadersStatusStopIteration,
                                           /*trailers*/ {},

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -216,6 +216,20 @@ envoy_mobile_jni_kt_test(
     ],
 )
 
+envoy_mobile_jni_kt_test(
+    name = "receive_trailers_test",
+    srcs = [
+        "ReceiveTrailersTest.kt",
+    ],
+    native_deps = [
+        "//test/common/jni:libenvoy_jni_with_test_extensions.so",
+        "//test/common/jni:libenvoy_jni_with_test_extensions_jnilib",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
+)
+
 envoy_mobile_android_test(
     name = "filter_throwing_exception_test",
     srcs = [

--- a/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
@@ -1,0 +1,162 @@
+package test.kotlin.integration
+
+import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.EnvoyError
+import io.envoyproxy.envoymobile.ResponseFilter
+import io.envoyproxy.envoymobile.RequestHeadersBuilder
+import io.envoyproxy.envoymobile.RequestMethod
+import io.envoyproxy.envoymobile.StreamIntel
+import io.envoyproxy.envoymobile.FinalStreamIntel
+import io.envoyproxy.envoymobile.ResponseHeaders
+import io.envoyproxy.envoymobile.FilterDataStatus
+import io.envoyproxy.envoymobile.FilterHeadersStatus
+import io.envoyproxy.envoymobile.FilterTrailersStatus
+import io.envoyproxy.envoymobile.ResponseTrailers
+import io.envoyproxy.envoymobile.RequestTrailersBuilder
+import io.envoyproxy.envoymobile.UpstreamHttpProtocol
+import io.envoyproxy.envoymobile.engine.JniLibrary
+import java.nio.ByteBuffer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Test
+
+private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+private const val matcherTrailerName = "test-trailer"
+private const val matcherTrailerValue = "test.code"
+
+class SendTrailersTest {
+
+  init {
+    JniLibrary.loadTestLibrary()
+  }
+
+
+  class ErrorValidationFilter(
+    private val onTrailers: CountDownLatch
+  ) : ResponseFilter {
+    override fun onResponseHeaders(
+      headers: ResponseHeaders,
+      endStream: Boolean,
+      streamIntel: StreamIntel
+    ): FilterHeadersStatus<ResponseHeaders> {
+      return FilterHeadersStatus.Continue(headers)
+    }
+
+    override fun onResponseData(
+      body: ByteBuffer,
+      endStream: Boolean,
+      streamIntel: StreamIntel
+    ): FilterDataStatus<ResponseHeaders> {
+      return FilterDataStatus.Continue(body)
+    }
+
+    override fun onResponseTrailers(
+      trailers: ResponseTrailers,
+      streamIntel: StreamIntel
+    ): FilterTrailersStatus<ResponseHeaders, ResponseTrailers> {
+      onTrailers.countDown()
+      return FilterTrailersStatus.Continue(trailers)
+    }
+
+    override fun onError(error: EnvoyError, finalStreamIntel: FinalStreamIntel) {
+    }
+    override fun onComplete(finalStreamIntel: FinalStreamIntel) {}
+
+    override fun onCancel(finalStreamIntel: FinalStreamIntel) {
+    }
+  }
+
+  @Test
+  fun `successful sending of trailers`() {
+    val trailersReceived = CountDownLatch(2)
+    val expectation = CountDownLatch(2)
+    val engine = EngineBuilder(Standard())
+    .addPlatformFilter(
+        name = "test_platform_filter",
+        factory = { ErrorValidationFilter(trailersReceived) }
+    )
+      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+      .setOnEngineRunning { }
+      .build()
+
+    val client = engine.streamClient()
+
+    val builder = RequestHeadersBuilder(
+      method = RequestMethod.GET,
+      scheme = "https",
+      authority = "example.com",
+      path = "/test"
+    )
+      .addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2)
+    builder.add("send-trailers", "true")
+    val requestHeadersDefault = builder.build()
+
+    val body = ByteBuffer.wrap("match_me".toByteArray(Charsets.UTF_8))
+    val requestTrailers = RequestTrailersBuilder()
+      .add(matcherTrailerName, matcherTrailerValue)
+      .build()
+
+    var responseStatus: Int? = null
+    client.newStreamPrototype()
+      .setOnResponseHeaders { headers, _, _ ->
+        responseStatus = headers.httpStatus
+        expectation.countDown()
+      }
+      .setOnError { _, _ ->
+        fail("Unexpected error")
+      }
+      .start()
+      .sendHeaders(requestHeadersDefault, false)
+      .sendData(body)
+      .close(requestTrailers)
+
+    expectation.await(10, TimeUnit.SECONDS)
+
+    // TODO(jpsim) fix and uncomment
+    //builder.remove("send-trailers")
+    //builder.add("send-trailers", "empty")
+    val requestHeadersEmpty = builder.build()
+    client.newStreamPrototype()
+      .setOnResponseHeaders { headers, _, _ ->
+        responseStatus = headers.httpStatus
+        expectation.countDown()
+      }
+      .setOnError { _, _ ->
+        fail("Unexpected error")
+      }
+      .start()
+      .sendHeaders(requestHeadersEmpty, false)
+      .sendData(body)
+      .close(requestTrailers)
+    expectation.await(10, TimeUnit.SECONDS)
+
+    builder.remove("send-trailers")
+    builder.add("send-trailers", "empty-value")
+    val requestHeadersEmptyValue = builder.build()
+    client.newStreamPrototype()
+      .setOnResponseHeaders { headers, _, _ ->
+        responseStatus = headers.httpStatus
+        expectation.countDown()
+      }
+      .setOnError { _, _ ->
+        fail("Unexpected error")
+      }
+      .start()
+      .sendHeaders(requestHeadersEmptyValue, false)
+      .sendData(body)
+      .close(requestTrailers)
+    expectation.await(10, TimeUnit.SECONDS)
+
+    engine.terminate()
+
+    assertThat(trailersReceived.count).isEqualTo(0)
+    trailersReceived.await(10, TimeUnit.SECONDS)
+    assertThat(expectation.count).isEqualTo(0)
+    assertThat(responseStatus).isEqualTo(200)
+  }
+}

--- a/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
@@ -117,9 +117,8 @@ class SendTrailersTest {
 
     expectation.await(10, TimeUnit.SECONDS)
 
-    // TODO(jpsim) fix and uncomment
-    //builder.remove("send-trailers")
-    //builder.add("send-trailers", "empty")
+    builder.remove("send-trailers")
+    builder.add("send-trailers", "empty")
     val requestHeadersEmpty = builder.build()
     client.newStreamPrototype()
       .setOnResponseHeaders { headers, _, _ ->


### PR DESCRIPTION
We started seeing crashes in these codepaths last week and although I haven't been able to reproduce it, it seems prudent to stop iteration rather than crash due to an out-of-bounds array access.

@alyssawilk added unit tests (thank you!)

Commit Message:
Additional Description:
Risk Level: Low to Envoy, Medium to Envoy Mobile. Instead of crashing this could lead to incorrect behavior if my patch is the wrong way to fix this.
Testing: `//test/java/...` & Alyssa added some regression tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]