### PR TITLE
mobile: remove chromium from main Android AAR

### DIFF
--- a/mobile/bazel/android_artifacts.bzl
+++ b/mobile/bazel/android_artifacts.bzl
@@ -238,7 +238,7 @@ def _create_classes_jar(name, manifest, android_library):
         classes_dir=$$(mktemp -d)
         echo "Creating classes.jar from $(SRCS)"
         pushd $$classes_dir
-        unzip $$original_directory/$(SRCS) "io/envoyproxy/*" "org/chromium/net/*" "META-INF/" > /dev/null
+        unzip $$original_directory/$(SRCS) "io/envoyproxy/*" "META-INF/" > /dev/null
         zip -r classes.jar * > /dev/null
         popd
         cp $$classes_dir/classes.jar $@

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -18,7 +18,6 @@ android_library(
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
         "//library/java/io/envoyproxy/envoymobile/engine/types:envoy_c_types_lib",
-        "//library/java/org/chromium/net",
         "@maven//:androidx_annotation_annotation",
         "@maven//:androidx_core_core",
     ],


### PR DESCRIPTION
Before:

```console
$ ./bazelw build --config release-android android_dist
...
INFO: Build completed successfully, 1 total action
$ rg chromium bazel-bin/library/kotlin/io/envoyproxy/envoymobile | wc -l
5
```

After:

```console
$ ./bazelw build --config release-android android_dist
...
INFO: Build completed successfully, 1 total action
$ rg chromium bazel-bin/library/kotlin/io/envoyproxy/envoymobile | wc -l
0
```

Slack discussion: https://envoyproxy.slack.com/archives/CKQ2LK23G/p1676228502975469

Commit Message:
Additional Description:
Risk Level: Only risk is to Envoy Mobile on Android, either using Cronvoy or the standard Java/Kotlin APIs.
Testing: See above
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]