### PR TITLE
mobile: assert on Swift yaml comparison

### DIFF
--- a/mobile/examples/swift/async_await/ContentView.swift
+++ b/mobile/examples/swift/async_await/ContentView.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import Foundation
 import SwiftUI
@@ -10,7 +11,7 @@ private struct ContentRow: Identifiable {
 }
 
 private extension EngineBuilder {
-    static let demoEngine = EngineBuilder()
+    static let demoEngine = YAMLValidatingEngineBuilder()
         .addLogLevel(.debug)
         .build()
 }

--- a/mobile/examples/swift/hello_world/ViewController.swift
+++ b/mobile/examples/swift/hello_world/ViewController.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import UIKit
 
@@ -17,13 +18,20 @@ final class ViewController: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.debug)
       .addPlatformFilter(DemoFilter.init)
       .addPlatformFilter(BufferDemoFilter.init)
       .addPlatformFilter(AsyncDemoFilter.init)
-      // swiftlint:disable:next line_length
-      .addNativeFilter(name: "envoy.filters.http.buffer", typedConfig: "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
+      .addNativeFilter(
+        name: "envoy.filters.http.buffer",
+        typedConfig: """
+            {\
+            "@type":"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer",\
+            "max_request_bytes":5242880\
+            }
+            """
+      )
       .setOnEngineRunning { NSLog("Envoy async internal setup completed") }
       .addStringAccessor(name: "demo-accessor", accessor: { return "PlatformString" })
       .setEventTracker { NSLog("Envoy event emitted: \($0)") }

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -3,19 +3,11 @@
 #import "library/common/main_interface.h"
 #import "library/cc/engine_builder.h"
 
-@interface NSString (CXX)
-
-- (std::string)toCXXString;
-
-@end
-
 @implementation NSString (CXX)
-
 - (std::string)toCXXString {
   return std::string([self UTF8String],
                      (int)[self lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
 }
-
 @end
 
 @implementation EnvoyConfiguration
@@ -310,29 +302,20 @@
 - (BOOL)compareYAMLWithProtoBuilder:(NSString *)yaml {
   Envoy::Platform::EngineBuilder builder;
 
-  builder.addGrpcStatsDomain([self.grpcStatsDomain toCXXString]);
-  builder.addConnectTimeoutSeconds(self.connectTimeoutSeconds);
-  builder.addDnsRefreshSeconds(self.dnsRefreshSeconds);
-  builder.addDnsFailureRefreshSeconds(self.dnsFailureRefreshSecondsBase,
-                                      self.dnsFailureRefreshSecondsMax);
-  builder.addDnsQueryTimeoutSeconds(self.dnsQueryTimeoutSeconds);
-  builder.addDnsMinRefreshSeconds(self.dnsMinRefreshSeconds);
-  builder.enableDnsCache(self.enableDNSCache, self.dnsCacheSaveIntervalSeconds);
-  builder.addMaxConnectionsPerHost(self.maxConnectionsPerHost);
-  builder.addH2ConnectionKeepaliveIdleIntervalMilliseconds(
-      self.h2ConnectionKeepaliveIdleIntervalMilliseconds);
-  builder.addH2ConnectionKeepaliveTimeoutSeconds(self.h2ConnectionKeepaliveTimeoutSeconds);
-  builder.addStatsFlushSeconds(self.statsFlushSeconds);
+  for (EnvoyNativeFilterConfig *nativeFilterConfig in self.nativeFilterChain) {
+    builder.addNativeFilter(
+        /* name */ [nativeFilterConfig.name toCXXString],
+        /* typed_config */ [nativeFilterConfig.typedConfig toCXXString]);
+  }
+  for (EnvoyHTTPFilterFactory *filterFactory in
+       [self.httpPlatformFilterFactories reverseObjectEnumerator]) {
+    builder.addPlatformFilter([filterFactory.filterName toCXXString]);
+  }
 
-  builder.setAppVersion([self.appVersion toCXXString]);
-  builder.setAppId([self.appId toCXXString]);
-  builder.setDeviceOs("iOS");
-
-  builder.setStreamIdleTimeoutSeconds(self.streamIdleTimeoutSeconds);
-  builder.setPerTryIdleTimeoutSeconds(self.perTryIdleTimeoutSeconds);
-#ifdef ENVOY_ADMIN_FUNCTIONALITY
-  builder.enableAdminInterface(self.adminInterfaceEnabled);
+#ifdef ENVOY_ENABLE_QUIC
+  builder.enableHttp3(self.enableHttp3);
 #endif
+
   builder.enableGzipDecompression(self.enableGzipDecompression);
 #ifdef ENVOY_MOBILE_REQUEST_COMPRESSION
   builder.enableGzipCompression(self.enableGzipCompression);
@@ -341,29 +324,44 @@
 #ifdef ENVOY_MOBILE_REQUEST_COMPRESSION
   builder.enableBrotliCompression(self.enableBrotliCompression);
 #endif
-  builder.enableHappyEyeballs(self.enableHappyEyeballs);
-#ifdef ENVOY_ENABLE_QUIC
-  builder.enableHttp3(self.enableHttp3);
-#endif
-  builder.enableInterfaceBinding(self.enableInterfaceBinding);
-  builder.enableDrainPostDnsRefresh(self.enableDrainPostDnsRefresh);
-  builder.enforceTrustChainVerification(self.enforceTrustChainVerification);
-  builder.enablePlatformCertificatesValidation(self.enablePlatformCertificateValidation);
-  builder.setForceAlwaysUsev6(self.forceIPv6);
-  for (EnvoyHTTPFilterFactory *filterFactory in
-       [self.httpPlatformFilterFactories reverseObjectEnumerator]) {
-    builder.addPlatformFilter([filterFactory.filterName toCXXString]);
-  }
-  for (EnvoyNativeFilterConfig *nativeFilterConfig in self.nativeFilterChain) {
-    builder.addNativeFilter(
-        /* name */ [nativeFilterConfig.name toCXXString],
-        /* typed_config */ [nativeFilterConfig.typedConfig toCXXString]);
-  }
 
+  builder.addConnectTimeoutSeconds(self.connectTimeoutSeconds);
+
+  builder.addDnsFailureRefreshSeconds(self.dnsFailureRefreshSecondsBase,
+                                      self.dnsFailureRefreshSecondsMax);
+
+  builder.addDnsQueryTimeoutSeconds(self.dnsQueryTimeoutSeconds);
+  builder.addDnsMinRefreshSeconds(self.dnsMinRefreshSeconds);
+  if (self.dnsPreresolveHostnames.count > 0) {
+    std::vector<std::string> hostnames;
+    hostnames.reserve(self.dnsPreresolveHostnames.count);
+    for (NSString *hostname in self.dnsPreresolveHostnames) {
+      hostnames.push_back([hostname toCXXString]);
+    }
+    builder.addDnsPreresolveHostnames(hostnames);
+  }
+  builder.enableHappyEyeballs(self.enableHappyEyeballs);
+  builder.addDnsRefreshSeconds(self.dnsRefreshSeconds);
+  builder.enableDrainPostDnsRefresh(self.enableDrainPostDnsRefresh);
+  builder.enableInterfaceBinding(self.enableInterfaceBinding);
+  builder.enforceTrustChainVerification(self.enforceTrustChainVerification);
+  builder.setForceAlwaysUsev6(self.forceIPv6);
+  builder.addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+      self.h2ConnectionKeepaliveIdleIntervalMilliseconds);
+  builder.addH2ConnectionKeepaliveTimeoutSeconds(self.h2ConnectionKeepaliveTimeoutSeconds);
+  builder.addMaxConnectionsPerHost(self.maxConnectionsPerHost);
+  builder.setStreamIdleTimeoutSeconds(self.streamIdleTimeoutSeconds);
+  builder.setPerTryIdleTimeoutSeconds(self.perTryIdleTimeoutSeconds);
+  builder.setAppVersion([self.appVersion toCXXString]);
+  builder.setAppId([self.appId toCXXString]);
+  builder.setDeviceOs("iOS");
   for (NSString *cluster in self.virtualClusters) {
     builder.addVirtualCluster([cluster toCXXString]);
   }
-
+  builder.addStatsFlushSeconds(self.statsFlushSeconds);
+  builder.enablePlatformCertificatesValidation(self.enablePlatformCertificateValidation);
+  builder.enableDnsCache(self.enableDNSCache, self.dnsCacheSaveIntervalSeconds);
+  builder.addGrpcStatsDomain([self.grpcStatsDomain toCXXString]);
   if (self.statsSinks.count > 0) {
     std::vector<std::string> sinks;
     sinks.reserve(self.statsSinks.count);
@@ -373,14 +371,9 @@
     builder.addStatsSinks(std::move(sinks));
   }
 
-  if (self.dnsPreresolveHostnames.count > 0) {
-    std::vector<std::string> hostnames;
-    hostnames.reserve(self.dnsPreresolveHostnames.count);
-    for (NSString *hostname in self.dnsPreresolveHostnames) {
-      hostnames.push_back([hostname toCXXString]);
-    }
-    builder.addDnsPreresolveHostnames(hostnames);
-  }
+#ifdef ENVOY_ADMIN_FUNCTIONALITY
+  builder.enableAdminInterface(self.adminInterfaceEnabled);
+#endif
 
   try {
     return builder.generateBootstrapAndCompare([yaml toCXXString]);

--- a/mobile/library/swift/BUILD
+++ b/mobile/library/swift/BUILD
@@ -45,6 +45,7 @@ swift_library(
         "TestEngineBuilder.swift",
         "Trailers.swift",
         "UpstreamHttpProtocol.swift",
+        "YAMLValidatingEngineBuilder.swift",
         "extensions/UserDefaults+KeyValueStore.swift",
         "filters/AsyncRequestFilter.swift",
         "filters/AsyncResponseFilter.swift",

--- a/mobile/library/swift/YAMLValidatingEngineBuilder.swift
+++ b/mobile/library/swift/YAMLValidatingEngineBuilder.swift
@@ -1,0 +1,15 @@
+/// An engine builder that validates the YAML configuration and asserts on failure.
+/// Not part of the stable public API.
+///
+/// - returns: The `EngineBuilder`.
+@_spi(YAMLValidation)
+public func YAMLValidatingEngineBuilder() -> EngineBuilder {
+  EngineBuilder()
+    .setExperimentalValidateYAMLCallback { success in
+      if success {
+        print("YAML comparison succeeded")
+      } else {
+        assertionFailure("YAML comparison failed")
+      }
+    }
+}

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 @testable import Envoy
 import EnvoyEngine
 import Foundation
@@ -29,12 +30,12 @@ final class EngineBuilderTests: XCTestCase {
   }
 
   func testMonitoringModeDefaultsToPathMonitor() {
-    let builder = EngineBuilder()
+    let builder = YAMLValidatingEngineBuilder()
     XCTAssertEqual(builder.monitoringMode, .pathMonitor)
   }
 
   func testMonitoringModeSetsToValue() {
-    let builder = EngineBuilder()
+    let builder = YAMLValidatingEngineBuilder()
       .setNetworkMonitoringMode(.disabled)
     XCTAssertEqual(builder.monitoringMode, .disabled)
     builder.setNetworkMonitoringMode(.reachability)
@@ -61,7 +62,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addLogLevel(.trace)
       .build()
@@ -75,7 +76,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .build()
     self.waitForExpectations(timeout: 0.01)
@@ -89,7 +90,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .enableAdminInterface()
       .build()
@@ -104,7 +105,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .enableHappyEyeballs(true)
       .build()
@@ -118,7 +119,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .enableInterfaceBinding(true)
       .build()
@@ -132,7 +133,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .enforceTrustChainVerification(true)
       .build()
@@ -146,7 +147,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .forceIPv6(true)
       .build()
@@ -160,7 +161,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addGrpcStatsDomain("stats.envoyproxy.io")
       .build()
@@ -174,7 +175,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addConnectTimeoutSeconds(12345)
       .build()
@@ -188,7 +189,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addDNSRefreshSeconds(23)
       .build()
@@ -202,7 +203,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addDNSMinRefreshSeconds(23)
       .build()
@@ -216,7 +217,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addDNSQueryTimeoutSeconds(234)
       .build()
@@ -231,7 +232,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addDNSFailureRefreshSeconds(base: 1234, max: 5678)
       .build()
@@ -245,7 +246,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addH2ConnectionKeepaliveIdleIntervalMilliseconds(234)
       .build()
@@ -259,7 +260,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addH2ConnectionKeepaliveTimeoutSeconds(234)
       .build()
@@ -273,7 +274,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .setMaxConnectionsPerHost(23)
       .build()
@@ -287,7 +288,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addPlatformFilter(TestFilter.init)
       .build()
@@ -301,7 +302,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addStatsFlushSeconds(42)
       .build()
@@ -315,7 +316,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addStreamIdleTimeoutSeconds(42)
       .build()
@@ -329,7 +330,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addPerTryIdleTimeoutSeconds(21)
       .build()
@@ -343,7 +344,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addAppVersion("v1.2.3")
       .build()
@@ -357,7 +358,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addAppId("com.envoymobile.ios")
       .build()
@@ -371,7 +372,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addVirtualClusters(["test"])
       .build()
@@ -385,7 +386,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addNativeFilter(name: "test_name", typedConfig: "config")
       .build()
@@ -399,7 +400,7 @@ final class EngineBuilderTests: XCTestCase {
       expectation.fulfill()
     }
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addStringAccessor(name: "name", accessor: { "hello" })
       .build()
@@ -435,7 +436,7 @@ final class EngineBuilderTests: XCTestCase {
 
     testStore.saveValue("bar", toKey: "foo")
 
-    _ = EngineBuilder()
+    _ = YAMLValidatingEngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addKeyValueStore(name: "name", keyValueStore: testStore)
       .build()

--- a/mobile/test/swift/apps/baseline/ViewController.swift
+++ b/mobile/test/swift/apps/baseline/ViewController.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import UIKit
 
@@ -17,21 +18,21 @@ final class ViewController: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.debug)
       .addPlatformFilter(DemoFilter.init)
-      // swiftlint:disable:next line_length
-      .addNativeFilter(name: "envoy.filters.http.buffer", typedConfig: "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
+      .addNativeFilter(
+        name: "envoy.filters.http.buffer",
+        typedConfig: """
+            {\
+            "@type":"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer",\
+            "max_request_bytes":5242880\
+            }
+            """
+      )
       .setOnEngineRunning { NSLog("Envoy async internal setup completed") }
       .addStringAccessor(name: "demo-accessor", accessor: { return "PlatformString" })
       .setEventTracker { NSLog("Envoy event emitted: \($0)") }
-      .setExperimentalValidateYAMLCallback { success in
-        if success {
-          print("YAML comparison succeeded!")
-        } else {
-          print("YAML comparison failed!")
-        }
-      }
       .build()
     self.streamClient = engine.streamClient()
     self.pulseClient = engine.pulseClient()

--- a/mobile/test/swift/apps/experimental/ViewController.swift
+++ b/mobile/test/swift/apps/experimental/ViewController.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import UIKit
 
@@ -17,7 +18,7 @@ final class ViewController: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.debug)
       .addPlatformFilter(DemoFilter.init)
       .addPlatformFilter(BufferDemoFilter.init)
@@ -44,13 +45,6 @@ final class ViewController: UITableViewController {
       .addKeyValueStore(name: "demo-kv-store", keyValueStore: UserDefaults.standard)
       .setEventTracker { NSLog("Envoy event emitted: \($0)") }
       .forceIPv6(true)
-      .setExperimentalValidateYAMLCallback { success in
-        if success {
-          print("YAML comparison succeeded!")
-        } else {
-          print("YAML comparison failed!")
-        }
-      }
       .build()
     self.streamClient = engine.streamClient()
     self.pulseClient = engine.pulseClient()

--- a/mobile/test/swift/integration/EngineApiTest.swift
+++ b/mobile/test/swift/integration/EngineApiTest.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import Foundation
 import TestExtensions
@@ -12,7 +13,7 @@ final class EngineApiTest: XCTestCase {
   func testEngineApis() throws {
     let engineExpectation = self.expectation(description: "Engine Running")
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.debug)
       .addStatsFlushSeconds(1)
       .setOnEngineRunning {

--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import EnvoyEngine
 import Foundation
@@ -14,7 +15,7 @@ final class SetEventTrackerTest: XCTestCase {
     let eventExpectation =
       self.expectation(description: "Passed event tracker receives an event")
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .setEventTracker { event in
         XCTAssertEqual("bar", event["foo"])
         eventExpectation.fulfill()

--- a/mobile/test/swift/integration/SetEventTrackerTestNoTracker.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTestNoTracker.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import EnvoyEngine
 import Foundation
@@ -14,7 +15,7 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
   func skipped_testSetEventTracker() throws {
     let expectation = self.expectation(description: "Response headers received")
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.trace)
       .addNativeFilter(
         name: "envoy.filters.http.test_event_tracker",

--- a/mobile/test/swift/integration/StatFlushIntegrationTest.swift
+++ b/mobile/test/swift/integration/StatFlushIntegrationTest.swift
@@ -1,3 +1,4 @@
+@_spi(YAMLValidation)
 import Envoy
 import Foundation
 import TestExtensions
@@ -12,7 +13,7 @@ final class StatFlushIntegrationTest: XCTestCase {
   func testLotsOfFlushesWithHistograms() throws {
     let engineExpectation = self.expectation(description: "Engine Running")
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.debug)
       .addStatsFlushSeconds(1)
       .setOnEngineRunning {
@@ -39,7 +40,7 @@ final class StatFlushIntegrationTest: XCTestCase {
   func testMultipleStatSinks() throws {
     let engineExpectation = self.expectation(description: "Engine Running")
 
-    let engine = EngineBuilder()
+    let engine = YAMLValidatingEngineBuilder()
       .addLogLevel(.debug)
       .addStatsFlushSeconds(1)
       .addGrpcStatsDomain("example.com")


### PR DESCRIPTION
So that CI will fail if a mismatch is introduced.

Note that this doesn't assert that comparison succeeds for cases that the C++ engine builder doesn't support today, such as when using direct responses or raw yaml configurations.

Commit Message:
Additional Description:
Risk Level: Low, test only
Testing: Ran all Swift tests and sample apps, confirmed that `YAML comparison succeeded` is logged and the assertion isn't triggered. Also confirmed that the assertion crashes the app/test if there's any mismatch.
Docs Changes: None, not a user-facing change
Release Notes: None, not a user-facing change
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
