### PR TITLE
mobile: always set metadata values as strings

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -366,7 +366,7 @@ std::string EngineBuilder::generateConfigStr() const {
          fmt::format("{}s", h2_connection_keepalive_timeout_seconds_)},
         {
             "metadata",
-            fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", device_os_,
+            fmt::format("{{ device_os: \"{}\", app_version: \"{}\", app_id: \"{}\" }}", device_os_,
                         app_version_, app_id_),
         },
         {"max_connections_per_host", fmt::format("{}", max_connections_per_host_)},

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -290,8 +290,9 @@ public class EnvoyConfiguration {
         .append(String.format("- &max_connections_per_host %s\n", maxConnectionsPerHost))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))
         .append(String.format("- &per_try_idle_timeout %ss\n", perTryIdleTimeoutSeconds))
-        .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",
-                              "Android", appVersion, appId))
+        .append(String.format(
+            "- &metadata { device_os: Android, app_version: \"%s\", app_id: \"%s\" }\n", appVersion,
+            appId))
         .append(String.format("- &trust_chain_verification %s\n", trustChainVerification.name()))
         .append(String.format("- &skip_dns_lookup_for_proxied_requests %s\n",
                               enableSkipDNSLookupForProxiedRequests ? "true" : "false"))

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -248,8 +248,9 @@
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions
       appendFormat:@"- &per_try_idle_timeout %lus\n", (unsigned long)self.perTryIdleTimeoutSeconds];
-  [definitions appendFormat:@"- &metadata { device_os: %@, app_version: %@, app_id: %@ }\n", @"iOS",
-                            self.appVersion, self.appId];
+  [definitions
+      appendFormat:@"- &metadata { device_os: iOS, app_version: \"%@\", app_id: \"%@\" }\n",
+                   self.appVersion, self.appId];
   [definitions appendFormat:@"- &virtual_clusters [%@]\n",
                             [self.virtualClusters componentsJoinedByString:@","]];
 

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -60,8 +60,8 @@ TEST(TestConfig, ConfigIsApplied) {
                                            "  key: dns_persistent_cache",
                                            "- &force_ipv6 true",
                                            "- &persistent_dns_cache_save_interval 101",
-                                           ("- &metadata { device_os: probably-ubuntu-on-CI, "
-                                            "app_version: 1.2.3, app_id: 1234-1234-1234 }"),
+                                           ("- &metadata { device_os: \"probably-ubuntu-on-CI\", "
+                                            "app_version: \"1.2.3\", app_id: \"1234-1234-1234\" }"),
                                            R"(- &validation_context
   trusted_ca:)"};
   for (const auto& string : must_contain) {

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -187,8 +187,8 @@ class EnvoyConfigurationTest {
 
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")
-    assertThat(resolvedTemplate).contains("app_version: v1.2.3")
-    assertThat(resolvedTemplate).contains("app_id: com.example.myapp")
+    assertThat(resolvedTemplate).contains("app_version: \"v1.2.3\"")
+    assertThat(resolvedTemplate).contains("app_id: \"com.example.myapp\"")
 
     assertThat(resolvedTemplate).contains("virtual_clusters [{name: test1},{name: test2}]")
 

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -539,8 +539,8 @@ final class EngineBuilderTests: XCTestCase {
 
     // Metadata
     XCTAssertTrue(resolvedYAML.contains("device_os: iOS"))
-    XCTAssertTrue(resolvedYAML.contains("app_version: v1.2.3"))
-    XCTAssertTrue(resolvedYAML.contains("app_id: com.envoymobile.ios"))
+    XCTAssertTrue(resolvedYAML.contains(#"app_version: "v1.2.3""#))
+    XCTAssertTrue(resolvedYAML.contains(#"app_id: "com.envoymobile.ios""#))
 
     XCTAssertTrue(resolvedYAML.contains("&virtual_clusters [test]"))
 


### PR DESCRIPTION
Otherwise if we set something that looks like an integer for app version it'll lead to C++ yaml comparison mismatches.

Commit Message:
Additional Description:
Risk Level:
Testing: Existing unit tests were updated, and Lyft's downstream tests are now passing when yaml validation is enabled.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]