### PR TITLE
ext_authz: make the ext_authz filter a dual filter

### DIFF
--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -154,6 +154,12 @@ public:
   ~ServerFactoryContext() override = default;
 
   /**
+   *
+   * @return the server-wide http context.
+   */
+  virtual Http::Context& httpContext() PURE;
+
+  /**
    * @return the server-wide grpc context.
    */
   virtual Grpc::Context& grpcContext() PURE;

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -300,6 +300,7 @@ envoy.filters.http.dynamic_forward_proxy:
 envoy.filters.http.ext_authz:
   categories:
   - envoy.filters.http
+  - envoy.filters.http.upstream
   security_posture: robust_to_untrusted_downstream
   status: stable
   type_urls:

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -14,24 +14,26 @@ namespace ExtAuthz {
 /**
  * Config registration for the external authorization filter. @see NamedHttpFilterConfigFactory.
  */
-class ExtAuthzFilterConfig
-    : public Common::FactoryBase<
+class ExtAuthzFilterFactory
+    : public Common::DualFactoryBase<
           envoy::extensions::filters::http::ext_authz::v3::ExtAuthz,
           envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute> {
 public:
-  ExtAuthzFilterConfig() : FactoryBase("envoy.filters.http.ext_authz") {}
+  ExtAuthzFilterFactory() : DualFactoryBase("envoy.filters.http.ext_authz") {}
 
 private:
   static constexpr uint64_t DefaultTimeout = 200;
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
+      const std::string& stats_prefix, DualInfo dual_info,
+      Server::Configuration::ServerFactoryContext& context) override;
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;
 };
+
+using UpstreamExtAuthzFilterFactory = ExtAuthzFilterFactory;
 
 } // namespace ExtAuthz
 } // namespace HttpFilters

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -192,6 +192,7 @@ public:
   OptRef<Admin> admin() override { return server_.admin(); }
   TimeSource& timeSource() override { return api().timeSource(); }
   Api::Api& api() override { return server_.api(); }
+  Http::Context& httpContext() override { return server_.httpContext(); }
   Grpc::Context& grpcContext() override { return server_.grpcContext(); }
   Router::Context& routerContext() override { return server_.routerContext(); }
   Envoy::Server::DrainManager& drainManager() override { return server_.drainManager(); }

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -62,13 +62,14 @@ public:
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& ext_authz_config) {
     // Delegate call to mock async client manager to real async client manager.
     ON_CALL(context_, getServerFactoryContext()).WillByDefault(testing::ReturnRef(server_context_));
-    ON_CALL(context_.cluster_manager_.async_client_manager_, getOrCreateRawAsyncClient(_, _, _))
+    ON_CALL(server_context_.cluster_manager_.async_client_manager_,
+            getOrCreateRawAsyncClient(_, _, _))
         .WillByDefault(Invoke([&](const envoy::config::core::v3::GrpcService& config,
                                   Stats::Scope& scope, bool skip_cluster_check) {
           return async_client_manager_->getOrCreateRawAsyncClient(config, scope,
                                                                   skip_cluster_check);
         }));
-    ExtAuthzFilterConfig factory;
+    ExtAuthzFilterFactory factory;
     return factory.createFilterFactoryFromProto(ext_authz_config, "stats", context_);
   }
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1006,6 +1006,86 @@ body_format:
   cleanup();
 }
 
+TEST_P(ExtAuthzLocalReplyIntegrationTest, UpstreamTest) {
+  setUpstreamProtocol(Http::CodecType::HTTP1);
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ext_authz_cluster->set_name("ext_authz");
+
+    envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config;
+    const std::string ext_authz_config = R"EOF(
+  transport_api_version: V3
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 300s
+  )EOF";
+    TestUtility::loadFromYaml(ext_authz_config, proto_config);
+
+    envoy::config::listener::v3::Filter ext_authz_filter;
+    ext_authz_filter.set_name("envoy.filters.http.ext_authz");
+    ext_authz_filter.mutable_typed_config()->PackFrom(proto_config);
+    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrDie(ext_authz_filter),
+                                 /*downstream_filter=*/false);
+  });
+
+  const std::string local_reply_yaml = R"EOF(
+body_format:
+  json_format:
+    code: "%RESPONSE_CODE%"
+    message: "%LOCAL_REPLY_BODY%"
+  )EOF";
+  envoy::extensions::filters::network::http_connection_manager::v3::LocalReplyConfig
+      local_reply_config;
+  TestUtility::loadFromYaml(local_reply_yaml, local_reply_config);
+  config_helper_.setLocalReply(local_reply_config);
+
+  HttpIntegrationTest::initialize();
+
+  auto conn = makeClientConnection(lookupPort("http"));
+  codec_client_ = makeHttpConnection(std::move(conn));
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  AssertionResult result =
+      fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, fake_ext_authz_connection_);
+  RELEASE_ASSERT(result, result.message());
+  FakeStreamPtr ext_authz_request;
+  result = fake_ext_authz_connection_->waitForNewStream(*dispatcher_, ext_authz_request);
+  RELEASE_ASSERT(result, result.message());
+  result = ext_authz_request->waitForEndStream(*dispatcher_);
+  RELEASE_ASSERT(result, result.message());
+
+  Http::TestResponseHeaderMapImpl ext_authz_response_headers{
+      {":status", "401"},
+      {"content-type", "fake-type"},
+  };
+  ext_authz_request->encodeHeaders(ext_authz_response_headers, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+
+  EXPECT_EQ("401", response->headers().Status()->value().getStringView());
+  // Without fixing the bug, "content-type" and "content-length" are overridden by the ext_authz
+  // responses as its "content-type: fake-type" and "content-length: 0".
+  EXPECT_EQ("application/json", response->headers().ContentType()->value().getStringView());
+  EXPECT_EQ("26", response->headers().ContentLength()->value().getStringView());
+
+  const std::string expected_body = R"({
+      "code": 401,
+      "message": ""
+})";
+  EXPECT_TRUE(TestUtility::jsonStringEqual(response->body(), expected_body));
+
+  cleanup();
+}
+
 TEST_P(ExtAuthzGrpcIntegrationTest, GoogleAsyncClientCreation) {
   initializeConfig();
   setDownstreamProtocol(Http::CodecType::HTTP2);

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -59,7 +59,8 @@ namespace Configuration {
 
 MockServerFactoryContext::MockServerFactoryContext()
     : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
-      grpc_context_(store_.symbolTable()), router_context_(store_.symbolTable()) {
+      http_context_(store_.symbolTable()), grpc_context_(store_.symbolTable()),
+      router_context_(store_.symbolTable()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, mainThreadDispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -166,6 +166,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
+  Http::Context& httpContext() override { return http_context_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Router::Context& routerContext() override { return router_context_; }
   envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { return bootstrap_; }
@@ -192,6 +193,7 @@ public:
   testing::NiceMock<MockAdmin> admin_;
   Event::GlobalTimeSystem time_system_;
   testing::NiceMock<Api::MockApi> api_;
+  Http::ContextImpl http_context_;
   Grpc::ContextImpl grpc_context_;
   Router::ContextImpl router_context_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;


### PR DESCRIPTION
Used #23071 as a model.

Signed-off-by: Eugene Chan <eugenechan@google.com>

Risk Level: low
Testing: integration tested
Docs Changes: n/a
Release Notes: Makes the ext_authz filter a dual filter.
See also #10455