### PR TITLE
mobile: silence `-Wshorten-64-to-32` warnings when building ObjC

### DIFF
--- a/mobile/bazel/apple.bzl
+++ b/mobile/bazel/apple.bzl
@@ -8,7 +8,7 @@ def envoy_objc_library(name, hdrs = [], visibility = [], data = [], deps = [], m
         name = name,
         srcs = srcs,
         hdrs = hdrs,
-        copts = envoy_mobile_copts("@envoy") + ["-ObjC++", "-std=c++17"],
+        copts = envoy_mobile_copts("@envoy") + ["-ObjC++", "-std=c++17", "-Wno-shorten-64-to-32"],
         module_name = module_name,
         sdk_frameworks = sdk_frameworks,
         visibility = visibility,


### PR DESCRIPTION
These started being reported when we switched to building ObjC++.

Commit Message: mobile: silence `-Wshorten-64-to-32` warnings when building ObjC
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]