### PR TITLE
mobile: add `EngineBuilder.useLegacyBuilder()` to Kotlin

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -64,7 +64,7 @@ public class EnvoyConfiguration {
   public final List<String> statSinks;
   public final Boolean enablePlatformCertificatesValidation;
   public final Boolean enableSkipDNSLookupForProxiedRequests;
-  public Boolean useLegacyBuilder;
+  public final Boolean useLegacyBuilder;
 
   private static final Pattern UNRESOLVED_KEY_PATTERN = Pattern.compile("\\{\\{ (.+) \\}\\}");
 
@@ -128,6 +128,9 @@ public class EnvoyConfiguration {
    * @param keyValueStores                                platform key-value store implementations.
    * @param enableSkipDNSLookupForProxiedRequests         whether to skip waiting on DNS response
    *     for proxied requests.
+   * @param enablePlatformCertificatesValidation          whether to use the platform verifier.
+   * @param useLegacyBuilder                              whether the string-based legacy mode
+   *     should be used to build the engine.
    */
   public EnvoyConfiguration(
       boolean adminInterfaceEnabled, String grpcStatsDomain, int connectTimeoutSeconds,
@@ -145,7 +148,8 @@ public class EnvoyConfiguration {
       List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
       Map<String, EnvoyStringAccessor> stringAccessors,
       Map<String, EnvoyKeyValueStore> keyValueStores, List<String> statSinks,
-      Boolean enableSkipDNSLookupForProxiedRequests, boolean enablePlatformCertificatesValidation) {
+      Boolean enableSkipDNSLookupForProxiedRequests, boolean enablePlatformCertificatesValidation,
+      boolean useLegacyBuilder) {
     JniLibrary.load();
     this.adminInterfaceEnabled = adminInterfaceEnabled;
     this.grpcStatsDomain = grpcStatsDomain;
@@ -196,17 +200,8 @@ public class EnvoyConfiguration {
     this.statSinks = statSinks;
     this.enablePlatformCertificatesValidation = enablePlatformCertificatesValidation;
     this.enableSkipDNSLookupForProxiedRequests = enableSkipDNSLookupForProxiedRequests;
-    this.useLegacyBuilder = false;
+    this.useLegacyBuilder = useLegacyBuilder;
   }
-
-  /**
-   * Sets the mode the Engine builder will use for config generation.
-   *
-   * @param legacyMode true if the string-based legacy mode should be used
-   */
-  void setUseLegacyBuilder(Boolean legacyMode) { useLegacyBuilder = legacyMode; }
-
-  Boolean useLegacyBuilder() { return useLegacyBuilder; }
 
   /**
    * Creates configuration YAML based on the configuration of the class

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -124,7 +124,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   @Override
   public EnvoyStatus runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
     performRegistration(envoyConfiguration);
-    if (envoyConfiguration.useLegacyBuilder()) {
+    if (envoyConfiguration.useLegacyBuilder) {
       return runWithConfigLegacy(envoyConfiguration, logLevel);
     }
     try {

--- a/mobile/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -134,6 +134,6 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mMaxConnectionsPerHost, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
         mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters,
         nativeFilterChain, platformFilterChain, stringAccessors, keyValueStores, statSinks,
-        mEnableSkipDNSLookupForProxiedRequests, mEnablePlatformCertificatesValidation);
+        mEnableSkipDNSLookupForProxiedRequests, mEnablePlatformCertificatesValidation, false);
   }
 }

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -78,6 +78,7 @@ open class EngineBuilder(
   private var keyValueStores = mutableMapOf<String, EnvoyKeyValueStore>()
   private var statsSinks = listOf<String>()
   private var enablePlatformCertificatesValidation = false
+  private var useLegacyBuilder = false
 
   /**
    * Add a log level to use with Envoy.
@@ -593,7 +594,8 @@ open class EngineBuilder(
       keyValueStores,
       statsSinks,
       enableSkipDNSLookupForProxiedRequests,
-      enablePlatformCertificatesValidation
+      enablePlatformCertificatesValidation,
+      useLegacyBuilder
     )
 
     return when (configuration) {
@@ -636,6 +638,19 @@ open class EngineBuilder(
   fun enablePlatformCertificatesValidation(enablePlatformCertificatesValidation: Boolean):
     EngineBuilder {
     this.enablePlatformCertificatesValidation = enablePlatformCertificatesValidation
+    return this
+  }
+
+  /**
+   * Specify whether the string-based legacy mode should be used to build the engine.
+   * Defaults to false.
+   *
+   * @param useLegacyBuilder true if the string-based legacy mode should be used.
+   *
+   * @return This builder.
+   */
+  fun useLegacyBuilder(useLegacyBuilder: Boolean): EngineBuilder {
+    this.useLegacyBuilder = useLegacyBuilder
     return this
   }
 

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -99,7 +99,8 @@ class EnvoyConfigurationTest {
     platformFilterFactories: MutableList<EnvoyHTTPFilterFactory> = mutableListOf(TestEnvoyHTTPFilterFactory("name1"), TestEnvoyHTTPFilterFactory("name2")),
     enableSkipDNSLookupForProxiedRequests: Boolean = false,
     statSinks: MutableList<String> = mutableListOf(),
-    enablePlatformCertificatesValidation: Boolean = false
+    enablePlatformCertificatesValidation: Boolean = false,
+    useLegacyBuilder: Boolean = false
   ): EnvoyConfiguration {
     return EnvoyConfiguration(
       adminInterfaceEnabled,
@@ -138,7 +139,8 @@ class EnvoyConfigurationTest {
       emptyMap(),
       statSinks,
       enableSkipDNSLookupForProxiedRequests,
-      enablePlatformCertificatesValidation
+      enablePlatformCertificatesValidation,
+      useLegacyBuilder
     )
   }
 

--- a/mobile/test/kotlin/apps/experimental/MainActivity.kt
+++ b/mobile/test/kotlin/apps/experimental/MainActivity.kt
@@ -75,6 +75,7 @@ class MainActivity : Activity() {
       .setLogger {
         Log.d("MainActivity", it)
       }
+      .useLegacyBuilder(true)
       .build()
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView


### PR DESCRIPTION
I missed this when reviewing https://github.com/envoyproxy/envoy/pull/25392.

Also add additional coverage by setting this to true in the experimental Kotlin app, mirroring what we did on the Swift side.

Commit Message:
Additional Description:
Risk Level: Low
Testing: Updated unit tests, enabled this for the experimental Kotlin app
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]