### PR TITLE
mobile: Add the stats prefix to the ADS xDS registration

### DIFF
--- a/.github/workflows/compile_time_options.yml
+++ b/.github/workflows/compile_time_options.yml
@@ -38,6 +38,7 @@ jobs:
             --define=admin_html=enabled \
             --define=envoy_mobile_request_compression=disabled \
             --@envoy//bazel:http3=False \
+            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             //library/cc/...
   swift_build:
     if: github.repository == 'envoyproxy/envoy'
@@ -67,6 +68,7 @@ jobs:
             --define=admin_html=enabled \
             --define=envoy_mobile_request_compression=disabled \
             --@envoy//bazel:http3=False \
+            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             //library/swift:ios_framework
   kotlin_build:
     if: github.repository == 'envoyproxy/envoy'
@@ -102,4 +104,5 @@ jobs:
           --define=admin_html=enabled \
           --define=envoy_mobile_request_compression=disabled \
           --@envoy//bazel:http3=False \
+          --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
           //:android_dist

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -1043,7 +1043,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     envoy::config::core::v3::ApiConfigSource::ApiType api_type_enum;
     envoy::config::core::v3::ApiConfigSource::ApiType_Parse(ads_api_type_, &api_type_enum);
     ads_config->set_api_type(api_type_enum);
-    ads_config->add_grpc_services()->mutable_google_grpc()->set_target_uri(target_uri);
+    auto& grpc_service = *ads_config->add_grpc_services();
+    grpc_service.mutable_google_grpc()->set_target_uri(target_uri);
+    grpc_service.mutable_google_grpc()->set_stat_prefix("ads");
   }
   if (enable_cds_) {
     auto* cds_config = bootstrap->mutable_dynamic_resources()->mutable_cds_config();

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -601,7 +601,8 @@ const char* ads_insert = R"(
     set_node_on_first_message_only: true
     grpc_services:
       google_grpc:
-        target_uri: '{}:{}')";
+        target_uri: '{}:{}'
+        stat_prefix: ads)";
 
 const char* cds_layer_insert = R"(
   cds_config:

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -376,6 +376,22 @@ TEST(TestConfig, RtdsWithoutAds) {
   }
 }
 
+TEST(TestConfig, AdsConfig) {
+  EngineBuilder engine_builder;
+  engine_builder.setAggregatedDiscoveryService(
+      /*api_type=*/"GRPC", /*target_uri=*/"fake-td.googleapis.com", /*port=*/12345);
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap =
+      engine_builder.generateBootstrap();
+  auto& ads_config = bootstrap->dynamic_resources().ads_config();
+  EXPECT_EQ(ads_config.api_type(), envoy::config::core::v3::ApiConfigSource::GRPC);
+  EXPECT_EQ(ads_config.grpc_services(0).google_grpc().target_uri(), "fake-td.googleapis.com:12345");
+  EXPECT_EQ(ads_config.grpc_services(0).google_grpc().stat_prefix(), "ads");
+  const std::string config_str = engine_builder.generateConfigStr();
+  EXPECT_THAT(config_str, HasSubstr("api_type: GRPC"));
+  EXPECT_THAT(config_str, HasSubstr("target_uri: 'fake-td.googleapis.com:12345'"));
+  EXPECT_THAT(config_str, HasSubstr("stat_prefix: ads"));
+}
+
 TEST(TestConfig, EnablePlatformCertificatesValidation) {
   EngineBuilder engine_builder;
   envoy::config::bootstrap::v3::Bootstrap bootstrap;


### PR DESCRIPTION
The stats_prefix field in the GoogleGrpc config has a proto validation rule that the field must be populated and have a length of at least 1.

This change adds the stat_prefix field whenever the ADS builder API is used, and adds tests to validate it.

Lastly, this change makes the mobile_compile_time_options CI job turn on proto validation, so we can ensure we never commit invalid proto, even though mobile normally disables proto validation for binary size purposes. The default value for the PVG template is the empty string (https://github.com/bufbuild/protoc-gen-validate/blob/38260ee45796b420276ac925d826ecec8fc3e9a8/bazel/BUILD#L11), so the mobile_compile_time_options sets template-flavor to the empty string instead of the default `nop` for mobile.

Signed-off-by: Ali Beyad <abeyad@google.com>
