### PR TITLE
Create LbPolicyConfig class to store variant for LBConfigs

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -961,8 +961,6 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 }
 
 LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
-  // TODO: Need to verify that lb type and the config for the policy are forced to match in
-  // a 1-1 relationship. If they are, change this to a switch case using config.lb_policy()
   switch (config.lb_config_case()) {
   case envoy::config::cluster::v3::Cluster::kRoundRobinLbConfig:
     lbPolicy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -963,23 +963,23 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
   switch (config.lb_config_case()) {
   case envoy::config::cluster::v3::Cluster::kRoundRobinLbConfig:
-    lbPolicy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+    lb_policy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
         config.round_robin_lb_config());
     break;
   case envoy::config::cluster::v3::Cluster::kLeastRequestLbConfig:
-    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
+    lb_policy_ = std::make_unique<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
         config.least_request_lb_config());
     break;
   case envoy::config::cluster::v3::Cluster::kRingHashLbConfig:
-    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+    lb_policy_ = std::make_unique<envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
         config.ring_hash_lb_config());
     break;
   case envoy::config::cluster::v3::Cluster::kMaglevLbConfig:
-    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
+    lb_policy_ = std::make_unique<envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
         config.maglev_lb_config());
     break;
   case envoy::config::cluster::v3::Cluster::kOriginalDstLbConfig:
-    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
+    lb_policy_ = std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
         config.original_dst_lb_config());
     break;
   case envoy::config::cluster::v3::Cluster::LB_CONFIG_NOT_SET:

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -963,30 +963,29 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
   // TODO: Need to verify that lb type and the config for the policy are forced to match in
   // a 1-1 relationship. If they are, change this to a switch case using config.lb_policy()
-  if (config.has_round_robin_lb_config()) {
+  switch (config.lb_config_case()) {
+  case envoy::config::cluster::v3::Cluster::kRoundRobinLbConfig:
     lbPolicy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
         config.round_robin_lb_config());
-    return;
-  }
-  if (config.has_least_request_lb_config()) {
+    break;
+  case envoy::config::cluster::v3::Cluster::kLeastRequestLbConfig:
     lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
         config.least_request_lb_config());
-    return;
-  }
-  if (config.has_ring_hash_lb_config()) {
+    break;
+  case envoy::config::cluster::v3::Cluster::kRingHashLbConfig:
     lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
         config.ring_hash_lb_config());
-    return;
-  }
-  if (config.has_maglev_lb_config()) {
+    break;
+  case envoy::config::cluster::v3::Cluster::kMaglevLbConfig:
     lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
         config.maglev_lb_config());
-    return;
-  }
-  if (config.has_original_dst_lb_config()) {
+    break;
+  case envoy::config::cluster::v3::Cluster::kOriginalDstLbConfig:
     lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
         config.original_dst_lb_config());
-    return;
+    break;
+  case envoy::config::cluster::v3::Cluster::LB_CONFIG_NOT_SET:
+    break;
   }
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -962,7 +962,6 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 
 LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
   switch (config.lb_config_case()) {
-    PANIC_DUE_TO_CORRUPT_ENUM;
   case envoy::config::cluster::v3::Cluster::kRoundRobinLbConfig:
     lb_policy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
         config.round_robin_lb_config());
@@ -985,6 +984,7 @@ LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config
     break;
   case envoy::config::cluster::v3::Cluster::LB_CONFIG_NOT_SET:
     break;
+    PANIC_DUE_TO_CORRUPT_ENUM;
   }
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -983,8 +983,9 @@ LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config
         config.original_dst_lb_config());
     break;
   case envoy::config::cluster::v3::Cluster::LB_CONFIG_NOT_SET:
+    // The default value of the variant if there is no config would be nullptr
+    // Which is set when the class is initialized. No action needed if config isn't set
     break;
-    PANIC_DUE_TO_CORRUPT_ENUM;
   }
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -960,6 +960,44 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
       config.has_http2_protocol_options(), validation_visitor);
 }
 
+LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
+
+  switch (config.lb_policy()) {
+    PANIC_ON_PROTO_ENUM_SENTINEL_VALUES;
+  case envoy::config::cluster::v3::Cluster::ROUND_ROBIN:
+    if (config.has_round_robin_lb_config()) {
+      lbPolicy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+          config.round_robin_lb_config());
+    }
+    break;
+  case envoy::config::cluster::v3::Cluster::LEAST_REQUEST:
+    if (config.has_least_request_lb_config()) {
+      lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
+          config.least_request_lb_config());
+    }
+    break;
+  case envoy::config::cluster::v3::Cluster::RING_HASH:
+    if (config.has_ring_hash_lb_config()) {
+      lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+          config.ring_hash_lb_config());
+    }
+    break;
+  case envoy::config::cluster::v3::Cluster::MAGLEV:
+    if (config.has_maglev_lb_config()) {
+      lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
+          config.maglev_lb_config());
+    }
+    break;
+  default:
+    break;
+  };
+
+  if (config.has_original_dst_lb_config()) {
+    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
+        config.original_dst_lb_config());
+  }
+}
+
 ClusterInfoImpl::ClusterInfoImpl(
     Init::Manager& init_manager, Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::cluster::v3::Cluster& config,
@@ -1008,30 +1046,7 @@ ClusterInfoImpl::ClusterInfoImpl(
       maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),
       upstream_local_address_selector_(
           std::make_shared<UpstreamLocalAddressSelectorImpl>(config, bind_config)),
-      lb_round_robin_config_(
-          config.has_round_robin_lb_config()
-              ? std::make_unique<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
-                    config.round_robin_lb_config())
-              : nullptr),
-      lb_least_request_config_(
-          config.has_least_request_lb_config()
-              ? std::make_unique<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
-                    config.least_request_lb_config())
-              : nullptr),
-      lb_ring_hash_config_(
-          config.has_ring_hash_lb_config()
-              ? std::make_unique<envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
-                    config.ring_hash_lb_config())
-              : nullptr),
-      lb_maglev_config_(config.has_maglev_lb_config()
-                            ? std::make_unique<envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
-                                  config.maglev_lb_config())
-                            : nullptr),
-      lb_original_dst_config_(
-          config.has_original_dst_lb_config()
-              ? std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
-                    config.original_dst_lb_config())
-              : nullptr),
+      lb_policy_config_(std::make_unique<const LBPolicyConfig>(config)),
       upstream_config_(config.has_upstream_config()
                            ? std::make_unique<envoy::config::core::v3::TypedExtensionConfig>(
                                  config.upstream_config())

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -962,6 +962,13 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 
 LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
 
+  // Original DST LB is not in the lb_policy enum so can't be included in the switch
+  if (config.has_original_dst_lb_config()) {
+    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
+        config.original_dst_lb_config());
+    return;
+  }
+
   switch (config.lb_policy()) {
     PANIC_ON_PROTO_ENUM_SENTINEL_VALUES;
   case envoy::config::cluster::v3::Cluster::ROUND_ROBIN:
@@ -991,11 +998,6 @@ LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config
   default:
     break;
   };
-
-  if (config.has_original_dst_lb_config()) {
-    lbPolicy_ = std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
-        config.original_dst_lb_config());
-  }
 }
 
 ClusterInfoImpl::ClusterInfoImpl(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -962,6 +962,7 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
 
 LBPolicyConfig::LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config) {
   switch (config.lb_config_case()) {
+    PANIC_DUE_TO_CORRUPT_ENUM;
   case envoy::config::cluster::v3::Cluster::kRoundRobinLbConfig:
     lb_policy_ = std::make_unique<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
         config.round_robin_lb_config());

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "envoy/common/callback.h"
@@ -99,6 +100,80 @@ private:
   Network::ConnectionSocket::OptionsSharedPtr base_socket_options_;
   Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
   std::vector<UpstreamLocalAddress> upstream_local_addresses_;
+};
+
+/**
+ * Class for LBPolicies
+ * Uses a std::variant to store pointers for the LBPolicy
+ */
+class LBPolicyConfig {
+public:
+  LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
+
+  OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
+    if (auto lb_ptr = std::get_if<
+            std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>>(
+            &lbPolicy_)) {
+      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
+          (*lb_ptr).get());
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
+  lbLeastRequestConfig() const {
+    if (auto lb_ptr = std::get_if<
+            std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>>(
+            &lbPolicy_)) {
+      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
+          (*lb_ptr).get());
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lbRingHashConfig() const {
+    if (auto lb_ptr = std::get_if<
+            std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>>(
+            &lbPolicy_)) {
+      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
+          (*lb_ptr).get());
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lbMaglevConfig() const {
+    if (auto lb_ptr =
+            std::get_if<std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>>(
+                &lbPolicy_)) {
+      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
+          (*lb_ptr).get());
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
+  lbOriginalDstConfig() const {
+    if (auto lb_ptr = std::get_if<
+            std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>(
+            &lbPolicy_)) {
+      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
+          (*lb_ptr).get());
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+private:
+  std::variant<std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>,
+               std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>,
+               std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>,
+               std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>,
+               std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>
+      lbPolicy_;
 };
 
 /**
@@ -821,38 +896,23 @@ public:
   }
   OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
   lbRoundRobinConfig() const override {
-    if (lb_round_robin_config_ == nullptr) {
-      return absl::nullopt;
-    }
-    return *lb_round_robin_config_;
+    return lb_policy_config_->lbRoundRobinConfig();
   }
   OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const override {
-    if (lb_least_request_config_ == nullptr) {
-      return absl::nullopt;
-    }
-    return *lb_least_request_config_;
+    return lb_policy_config_->lbLeastRequestConfig();
   }
   OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
   lbRingHashConfig() const override {
-    if (lb_ring_hash_config_ == nullptr) {
-      return absl::nullopt;
-    }
-    return *lb_ring_hash_config_;
+    return lb_policy_config_->lbRingHashConfig();
   }
   OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
   lbMaglevConfig() const override {
-    if (lb_maglev_config_ == nullptr) {
-      return absl::nullopt;
-    }
-    return *lb_maglev_config_;
+    return lb_policy_config_->lbMaglevConfig();
   }
   OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
   lbOriginalDstConfig() const override {
-    if (lb_original_dst_config_ == nullptr) {
-      return absl::nullopt;
-    }
-    return *lb_original_dst_config_;
+    return lb_policy_config_->lbOriginalDstConfig();
   }
   OptRef<const envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const override {
     if (upstream_config_ == nullptr) {
@@ -1004,16 +1064,7 @@ private:
   mutable ResourceManagers resource_managers_;
   const std::string maintenance_mode_runtime_key_;
   std::shared_ptr<UpstreamLocalAddressSelector> upstream_local_address_selector_;
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>
-      lb_round_robin_config_;
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
-      lb_least_request_config_;
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
-      lb_ring_hash_config_;
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
-      lb_maglev_config_;
-  const std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
-      lb_original_dst_config_;
+  const std::unique_ptr<const LBPolicyConfig> lb_policy_config_;
   std::unique_ptr<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
   LoadBalancerSubsetInfoImpl lb_subset_;
   const envoy::config::core::v3::Metadata metadata_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -111,9 +111,9 @@ public:
   LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
 
   template <typename T> OptRef<const T> getConfig() const {
-    if (absl::holds_alternative<std::unique_ptr<const T>>(lbPolicy_)) {
-      if (absl::get<std::unique_ptr<const T>>(lbPolicy_) != nullptr)
-        return *(absl::get<std::unique_ptr<const T>>(lbPolicy_));
+    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lbPolicy_); lbPtr) {
+      if (*lbPtr != nullptr)
+        return *(*lbPtr);
       else
         return absl::nullopt;
     } else {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -111,11 +111,12 @@ public:
   LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
 
   template <typename T> OptRef<const T> getConfig() const {
-    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lbPolicy_); lbPtr) {
-      if (*lbPtr != nullptr)
+    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lb_policy_); lbPtr) {
+      if (*lbPtr != nullptr) {
         return *(*lbPtr);
-      else
+      } else {
         return absl::nullopt;
+      }
     } else {
       return absl::nullopt;
     }
@@ -149,7 +150,7 @@ private:
                 std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>,
                 std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>,
                 std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>
-      lbPolicy_;
+      lb_policy_;
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -111,12 +111,8 @@ public:
   LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
 
   template <typename T> OptRef<const T> getConfig() const {
-    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lb_policy_); lbPtr) {
-      if (*lbPtr != nullptr) {
-        return *(*lbPtr);
-      } else {
-        return absl::nullopt;
-      }
+    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lb_policy_); lbPtr && *lbPtr) {
+      return *(*lbPtr);
     } else {
       return absl::nullopt;
     }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -110,14 +110,6 @@ class LBPolicyConfig {
 public:
   LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
 
-  template <typename T> OptRef<const T> getConfig() const {
-    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lb_policy_); lbPtr && *lbPtr) {
-      return *(*lbPtr);
-    } else {
-      return absl::nullopt;
-    }
-  }
-
   OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
     return getConfig<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>();
   }
@@ -141,6 +133,16 @@ public:
   }
 
 private:
+  template <typename T> OptRef<const T> getConfig() const {
+    // Condition checks for the type of LbConfig, it also checks that the value is not nullptr
+    // The Round Robin config being set to nullptr is the default value of the variant
+    if (const auto lbPtr = absl::get_if<std::unique_ptr<const T>>(&lb_policy_); lbPtr && *lbPtr) {
+      return *(*lbPtr);
+    } else {
+      return absl::nullopt;
+    }
+  }
+
   absl::variant<std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>,
                 std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>,
                 std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -145,9 +145,9 @@ public:
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lbMaglevConfig() const {
-    if (auto lb_ptr =
-            absl::get_if<std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>>(
-                &lbPolicy_)) {
+    if (auto lb_ptr = absl::get_if<
+            std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>>(
+            &lbPolicy_)) {
       return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
           (*lb_ptr).get());
     } else {
@@ -169,10 +169,10 @@ public:
 
 private:
   absl::variant<std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>,
-               std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>,
-               std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>,
-               std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>,
-               std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>
+                std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>,
+                std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>,
+                std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>,
+                std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>
       lbPolicy_;
 };
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -111,7 +111,7 @@ public:
   LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
 
   OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
-    if (auto lb_ptr = std::get_if<
+    if (auto lb_ptr = absl::get_if<
             std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>>(
             &lbPolicy_)) {
       return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
@@ -123,7 +123,7 @@ public:
 
   OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const {
-    if (auto lb_ptr = std::get_if<
+    if (auto lb_ptr = absl::get_if<
             std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>>(
             &lbPolicy_)) {
       return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
@@ -134,7 +134,7 @@ public:
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lbRingHashConfig() const {
-    if (auto lb_ptr = std::get_if<
+    if (auto lb_ptr = absl::get_if<
             std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>>(
             &lbPolicy_)) {
       return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
@@ -146,7 +146,7 @@ public:
 
   OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lbMaglevConfig() const {
     if (auto lb_ptr =
-            std::get_if<std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>>(
+            absl::get_if<std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>>(
                 &lbPolicy_)) {
       return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
           (*lb_ptr).get());
@@ -157,7 +157,7 @@ public:
 
   OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
   lbOriginalDstConfig() const {
-    if (auto lb_ptr = std::get_if<
+    if (auto lb_ptr = absl::get_if<
             std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>(
             &lbPolicy_)) {
       return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
@@ -168,7 +168,7 @@ public:
   }
 
 private:
-  std::variant<std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>,
+  absl::variant<std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>,
                std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>,
                std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>,
                std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -112,7 +112,10 @@ public:
 
   template <typename T> OptRef<const T> getConfig() const {
     if (absl::holds_alternative<std::unique_ptr<const T>>(lbPolicy_)) {
-      return *(absl::get<std::unique_ptr<const T>>(lbPolicy_));
+      if (absl::get<std::unique_ptr<const T>>(lbPolicy_) != nullptr)
+        return *(absl::get<std::unique_ptr<const T>>(lbPolicy_));
+      else
+        return absl::nullopt;
     } else {
       return absl::nullopt;
     }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -110,61 +110,34 @@ class LBPolicyConfig {
 public:
   LBPolicyConfig(const envoy::config::cluster::v3::Cluster& config);
 
-  OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
-    if (auto lb_ptr = absl::get_if<
-            std::unique_ptr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>>(
-            &lbPolicy_)) {
-      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>(
-          (*lb_ptr).get());
+  template <typename T> OptRef<const T> getConfig() const {
+    if (absl::holds_alternative<std::unique_ptr<const T>>(lbPolicy_)) {
+      return *(absl::get<std::unique_ptr<const T>>(lbPolicy_));
     } else {
       return absl::nullopt;
     }
+  }
+
+  OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
+    return getConfig<envoy::config::cluster::v3::Cluster::RoundRobinLbConfig>();
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>
   lbLeastRequestConfig() const {
-    if (auto lb_ptr = absl::get_if<
-            std::unique_ptr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>>(
-            &lbPolicy_)) {
-      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>(
-          (*lb_ptr).get());
-    } else {
-      return absl::nullopt;
-    }
+    return getConfig<envoy::config::cluster::v3::Cluster::LeastRequestLbConfig>();
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> lbRingHashConfig() const {
-    if (auto lb_ptr = absl::get_if<
-            std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>>(
-            &lbPolicy_)) {
-      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
-          (*lb_ptr).get());
-    } else {
-      return absl::nullopt;
-    }
+    return getConfig<envoy::config::cluster::v3::Cluster::RingHashLbConfig>();
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> lbMaglevConfig() const {
-    if (auto lb_ptr = absl::get_if<
-            std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>>(
-            &lbPolicy_)) {
-      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>(
-          (*lb_ptr).get());
-    } else {
-      return absl::nullopt;
-    }
+    return getConfig<envoy::config::cluster::v3::Cluster::MaglevLbConfig>();
   }
 
   OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
   lbOriginalDstConfig() const {
-    if (auto lb_ptr = absl::get_if<
-            std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>>(
-            &lbPolicy_)) {
-      return makeOptRefFromPtr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
-          (*lb_ptr).get());
-    } else {
-      return absl::nullopt;
-    }
+    return getConfig<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>();
   }
 
 private:

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -104,7 +104,7 @@ private:
 
 /**
  * Class for LBPolicies
- * Uses a std::variant to store pointers for the LBPolicy
+ * Uses a absl::variant to store pointers for the LBPolicy
  */
 class LBPolicyConfig {
 public:


### PR DESCRIPTION
Additional Description: Since LBConfigs are one-ofs, storing them inside a std::variant will allow us to save a bit of space.
Sizeof(ClusterInfoImpl)
Before changes: 2624
After changes: 2592
Risk Level: Low
