### PR TITLE
util: special-case "-all" which was previously not working.

### DIFF
--- a/tools/local_fix_format.sh
+++ b/tools/local_fix_format.sh
@@ -31,7 +31,7 @@ fi
 
 # Runs the formatting functions on the specified args, echoing commands
 # if -vergbose was supplied to the script.
-function format() {
+function format_one() {
   (
     if [[ "$verbose" == "1" ]]; then
       set -x
@@ -41,9 +41,19 @@ function format() {
   )
 }
 
+function format_all() {
+  (
+    if [[ "$verbose" == "1" ]]; then
+      set -x
+    fi
+    ./tools/code_format/check_format.py fix
+    ./tools/spelling/check_spelling_pedantic.py fix
+  )
+}
+
 if [[ $# -gt 0 && "$1" == "-all" ]]; then
   echo "Checking all files in the repo...this may take a while."
-  format
+  format_all
 else
   if [[ $# -gt 0 && "$1" == "-main" ]]; then
     shift
@@ -61,6 +71,6 @@ else
     exit 0
   fi
   for arg in $args; do
-    format "$arg"
+    format_one "$arg"
   done
 fi


### PR DESCRIPTION
Commit Message: Fixes "-all" behavior, which needs a special case due to messy shell quoting.
Additional Description:
Risk Level: low
Testing: ran the formatter with and without -all
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

