### PR TITLE
Add a missing build dep for mobile xds_integration_test

### DIFF
--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -120,6 +120,7 @@ envoy_cc_test_library(
     deps = [
         ":base_client_integration_test_lib",
         "@envoy//source/common/config:api_version_lib",
+        "@envoy//source/common/grpc:google_grpc_creds_lib",
         "@envoy//test/common/grpc:grpc_client_integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",


### PR DESCRIPTION
I think this test works without the dependency because it's included as a sub-dependency. But some build flags will cause the dependency to be missing because it's not directly included

Anyways I tested and this makes things work inside Google without breaking anything.