### PR TITLE
Use string_view for requestMethod* functions

### DIFF
--- a/mobile/library/cc/request_headers_builder.cc
+++ b/mobile/library/cc/request_headers_builder.cc
@@ -22,7 +22,7 @@ RequestHeadersBuilder::RequestHeadersBuilder(RequestMethod request_method, absl:
 
 void RequestHeadersBuilder::initialize(RequestMethod request_method, std::string scheme,
                                        std::string authority, std::string path) {
-  internalSet(":method", {requestMethodToString(request_method)});
+  internalSet(":method", {std::string(requestMethodToString(request_method))});
   internalSet(":scheme", {std::move(scheme)});
   internalSet(":authority", {std::move(authority)});
   internalSet(":path", {std::move(path)});

--- a/mobile/library/cc/request_method.cc
+++ b/mobile/library/cc/request_method.cc
@@ -1,19 +1,24 @@
 #include "request_method.h"
 
 #include <stdexcept>
-#include <vector>
+
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Platform {
 
-static const std::pair<RequestMethod, std::string> REQUEST_METHOD_LOOKUP[]{
+namespace {
+
+const std::pair<RequestMethod, absl::string_view> REQUEST_METHOD_LOOKUP[]{
     {RequestMethod::DELETE, "DELETE"}, {RequestMethod::GET, "GET"},
     {RequestMethod::HEAD, "HEAD"},     {RequestMethod::OPTIONS, "OPTIONS"},
     {RequestMethod::PATCH, "PATCH"},   {RequestMethod::POST, "POST"},
     {RequestMethod::PUT, "PUT"},       {RequestMethod::TRACE, "TRACE"},
 };
 
-std::string requestMethodToString(RequestMethod method) {
+} // namespace
+
+absl::string_view requestMethodToString(RequestMethod method) {
   for (const auto& pair : REQUEST_METHOD_LOOKUP) {
     if (pair.first == method) {
       return pair.second;
@@ -23,7 +28,7 @@ std::string requestMethodToString(RequestMethod method) {
   throw std::out_of_range("unknown request method type");
 }
 
-RequestMethod requestMethodFromString(const std::string& str) {
+RequestMethod requestMethodFromString(absl::string_view str) {
   for (const auto& pair : REQUEST_METHOD_LOOKUP) {
     if (pair.second == str) {
       return pair.first;

--- a/mobile/library/cc/request_method.h
+++ b/mobile/library/cc/request_method.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Platform {
@@ -16,8 +16,8 @@ enum RequestMethod {
   TRACE,
 };
 
-std::string requestMethodToString(RequestMethod method);
-RequestMethod requestMethodFromString(const std::string& str);
+absl::string_view requestMethodToString(RequestMethod method);
+RequestMethod requestMethodFromString(absl::string_view str);
 
 } // namespace Platform
 } // namespace Envoy


### PR DESCRIPTION
This is just a minor improvement to avoid unnecessary usages of std::string.