### PR TITLE
build: new option to force envoy to use dynamic linking stdlib

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -429,6 +429,11 @@ config_setting(
 )
 
 config_setting(
+    name = "force_dynamic_stdlib",
+    values = {"define": "stdlib_linking=dynamic"},
+)
+
+config_setting(
     name = "force_libcpp",
     values = {"define": "force_libcpp=enabled"},
 )

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -155,6 +155,7 @@ def envoy_stdlib_deps():
         "@envoy//bazel:asan_build": ["@envoy//bazel:dynamic_stdlib"],
         "@envoy//bazel:msan_build": ["@envoy//bazel:dynamic_stdlib"],
         "@envoy//bazel:tsan_build": ["@envoy//bazel:dynamic_stdlib"],
+        "@envoy//bazel:force_dynamic_stdlib": ["@envoy//bazel:dynamic_stdlib"],
         "//conditions:default": ["@envoy//bazel:static_stdlib"],
     })
 


### PR DESCRIPTION


Commit Message: build: new option to force envoy to use dynamic linking stdlib
Additional Description:

See #25533

Risk Level: ?
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.