### PR TITLE
bazel/tooling: Add `@envoy_repo//:project`

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -69,6 +69,21 @@ def _envoy_repo_impl(repository_ctx):
     within the constraints of a `genquery`, or that otherwise need access to the repository
     files.
 
+    Project and repo data can be accessed in JSON format using `@envoy_repo//:project`, eg:
+
+    ```starlark
+    load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+
+    jq(
+        name = "project_version",
+        srcs = ["@envoy_repo//:data"],
+        out = "version.txt",
+        args = ["-r"],
+        filter = ".version",
+    )
+
+    ```
+
     """
     repo_version_path = repository_ctx.path(repository_ctx.attr.envoy_version)
     api_version_path = repository_ctx.path(repository_ctx.attr.envoy_api_version)
@@ -78,12 +93,37 @@ def _envoy_repo_impl(repository_ctx):
     repository_ctx.file("path.bzl", "PATH = '%s'" % repo_version_path.dirname)
     repository_ctx.file("__init__.py", "PATH = '%s'\nVERSION = '%s'\nAPI_VERSION = '%s'" % (repo_version_path.dirname, version, api_version))
     repository_ctx.file("WORKSPACE", "")
-    repository_ctx.file("BUILD", """
+    repository_ctx.file("BUILD", '''
 load("@rules_python//python:defs.bzl", "py_library")
+load("@envoy//tools/base:envoy_python.bzl", "envoy_entry_point")
 
-py_library(name = "envoy_repo", srcs = ["__init__.py"], visibility = ["//visibility:public"])
+py_library(
+    name = "envoy_repo",
+    srcs = ["__init__.py"],
+    visibility = ["//visibility:public"],
+)
 
-""")
+envoy_entry_point(
+    name = "get_project_json",
+    pkg = "envoy.base.utils",
+    script = "envoy.project_data",
+)
+
+genrule(
+    name = "project",
+    outs = ["project.json"],
+    cmd = """
+    $(location :get_project_json) . > $@
+    """,
+    tools = [
+        ":get_project_json",
+        "@envoy//:VERSION.txt",
+        "@envoy//changelogs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+''')
 
 _envoy_repo = repository_rule(
     implementation = _envoy_repo_impl,

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -4,7 +4,7 @@ aiohttp>=3.8.1
 cffi>=1.15.0
 colorama
 coloredlogs
-envoy.base.utils>=0.4.1
+envoy.base.utils>=0.4.2
 envoy.code.check>=0.4.0
 envoy.dependency.check>=0.1.7
 envoy.dependency.pip_check>=0.1.4

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -414,9 +414,8 @@ docutils==0.19 \
     # via
     #   envoy-docs-sphinx-runner
     #   sphinx
-envoy-base-utils==0.4.1 \
-    --hash=sha256:5c1b3342c0261dd1282f142fdbbb3576b3b45012b8df3525877d2c64f6139d10 \
-    --hash=sha256:772e5805718e61e546010122ce14f28afb435a970270d26ca6f928bbe360d261
+envoy-base-utils==0.4.2 \
+    --hash=sha256:7c3162f69584abbf80ce01e95417415dcde86cb3aad06f31f0bf114d8347bea7
     # via
     #   -r requirements.in
     #   envoy-code-check


### PR DESCRIPTION
This adds a JSON data target to the repo repository rule.

The data is provided by pytooling from the repo environment, changelogs, etc, and can then be used to create eg Dockerhub pages with "supported version" information.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
