### PR TITLE
mobile: skip most example apps on main branch CI

### DIFF
--- a/mobile/tools/should_run_ci.sh
+++ b/mobile/tools/should_run_ci.sh
@@ -23,7 +23,16 @@ function failure() {
 }
 
 if [[ $branch_name == "main" ]]; then
-  # Run all mobile CI jobs on `main`
+  # Skip some example apps on `main` to reduce CI load
+  case "$job" in
+    swiftbaselineapp|swiftexperimentalapp|swiftasyncawait|objchelloworld|javahelloworld|kotlinbaselineapp|kotlinexperimentalapp)
+      echo "Skipping $job because current branch is main"
+      echo "run_ci_job=false" >> "$GITHUB_OUTPUT"
+      exit 0
+      ;;
+  esac
+
+  # Run all other mobile CI jobs on `main`
   echo "Running $job because current branch is main"
   echo "run_ci_job=true" >> "$GITHUB_OUTPUT"
   exit 0


### PR DESCRIPTION
This will save 7 macOS CI jobs for every `main` commit, reducing CI load.

The Swift and Kotlin "Hello World" example apps will still run on main branch CI.

All mobile CI jobs still run for PRs touching mobile files.

Tested with the following invocations:

```console
$ GITHUB_JOB=swiftbaselineapp GITHUB_REF_NAME=main ./mobile/tools/should_run_ci.sh
Skipping swiftbaselineapp because current branch is main
$ GITHUB_JOB=swifthelloworld GITHUB_REF_NAME=main ./mobile/tools/should_run_ci.sh
Running swifthelloworld because current branch is main
```

Risk Level: Low
Testing: Yes, see above
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A