### PR TITLE
mobile: Improve xDS APIs in EngineBuilder

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -18,6 +18,7 @@ envoy_cc_library(
     }),
     repository = "@envoy",
     visibility = ["//visibility:public"],
+    external_deps = ["abseil_optional"],
     deps = [
         ":envoy_engine_cc_lib_no_stamp",
         "@envoy//source/common/common:assert_lib",

--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -16,9 +16,9 @@ envoy_cc_library(
         "//bazel:exclude_certificates": ["-DEXCLUDE_CERTIFICATES"],
         "//conditions:default": [],
     }),
+    external_deps = ["abseil_optional"],
     repository = "@envoy",
     visibility = ["//visibility:public"],
-    external_deps = ["abseil_optional"],
     deps = [
         ":envoy_engine_cc_lib_no_stamp",
         "@envoy//source/common/common:assert_lib",

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -404,6 +404,7 @@ std::string EngineBuilder::generateConfigStr() const {
 #else
         {"force_ipv6", always_use_v6_ ? "true" : "false"},
 #endif
+        {"node_id", node_id_.empty() ? "envoy-mobile" : node_id_},
   };
   if (!stats_domain_.empty()) {
     replacements.push_back({"stats_domain", stats_domain_});
@@ -1174,7 +1175,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 
   // Set up node
   auto* node = bootstrap->mutable_node();
-  node->set_id("envoy-mobile");
+  node->set_id(node_id_.empty() ? "envoy-mobile" : node_id_);
   node->set_cluster("envoy-mobile");
   if (!node_locality_region_.empty()) {
     node->mutable_locality()->set_region(node_locality_region_);

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -499,7 +499,8 @@ std::string EngineBuilder::generateConfigStr() const {
     }
     std::string call_credentials;
     if (!jwt_token_.empty()) {
-      call_credentials = fmt::format(ads_call_credentials_insert, jwt_token_, jwt_token_lifetime_seconds_);
+      call_credentials =
+          fmt::format(ads_call_credentials_insert, jwt_token_, jwt_token_lifetime_seconds_);
     }
     std::string ads_insert_replaced = ads_insert;
     absl::StrReplaceAll({{"#{custom_ads_channel_credentials}", channel_credentials}},
@@ -1272,13 +1273,11 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   if (enable_cds_) {
     auto* cds_config = bootstrap->mutable_dynamic_resources()->mutable_cds_config();
     if (cds_resources_locator_.empty()) {
-    cds_config->mutable_ads();
+      cds_config->mutable_ads();
     } else {
-    bootstrap->mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
-    cds_config->mutable_api_config_source()->set_api_type(
-        envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
-    cds_config->mutable_api_config_source()->set_transport_api_version(
-        envoy::config::core::v3::ApiVersion::V3);
+      bootstrap->mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
+      cds_config->mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
+      cds_config->mutable_api_config_source()->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
     }
     cds_config->mutable_initial_fetch_timeout()->set_seconds(cds_timeout_seconds_);
     cds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -1276,8 +1276,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       cds_config->mutable_ads();
     } else {
       bootstrap->mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
-      cds_config->mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
-      cds_config->mutable_api_config_source()->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
+      cds_config->mutable_api_config_source()->set_api_type(
+          envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
+      cds_config->mutable_api_config_source()->set_transport_api_version(
+          envoy::config::core::v3::ApiVersion::V3);
     }
     cds_config->mutable_initial_fetch_timeout()->set_seconds(cds_timeout_seconds_);
     cds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -76,9 +76,11 @@ public:
   EngineBuilder& setNodeLocality(std::string region, std::string zone, std::string sub_zone);
   // Adds an ADS layer. Note that only the state-of-the-world gRPC protocol is supported, not Delta
   // gRPC.
-  EngineBuilder& setAggregatedDiscoveryService(
-      const std::string& address, const int port, std::string jwt_token = "",
-      int jwt_token_lifetime_seconds = DefaultJwtTokenLifetimeSeconds, std::string ssl_root_certs = "");
+  EngineBuilder&
+  setAggregatedDiscoveryService(const std::string& address, const int port,
+                                std::string jwt_token = "",
+                                int jwt_token_lifetime_seconds = DefaultJwtTokenLifetimeSeconds,
+                                std::string ssl_root_certs = "");
   // Adds an RTDS layer to default config. Requires that ADS be configured.
   EngineBuilder& addRtdsLayer(const std::string& layer_name,
                               const int timeout_seconds = DefaultXdsTimeout);

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -178,9 +178,9 @@ private:
   std::string node_locality_sub_zone_;
   std::string ads_address_ = "";
   int ads_port_;
-  std::string jwt_token_;
-  int jwt_token_lifetime_seconds_;
-  std::string ssl_root_certs_;
+  std::string ads_jwt_token_;
+  int ads_jwt_token_lifetime_seconds_;
+  std::string ads_ssl_root_certs_;
   bool enable_cds_ = false;
   std::string cds_resources_locator_;
   int cds_timeout_seconds_;

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -8,6 +8,7 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/types/optional.h"
 #include "direct_response_testing.h"
 #include "engine.h"
 #include "engine_callbacks.h"
@@ -20,6 +21,13 @@ namespace Platform {
 
 constexpr int DefaultJwtTokenLifetimeSeconds = 31536000; // 1 year
 constexpr int DefaultXdsTimeout = 5;
+
+// Represents the locality information in the Bootstrap's node.
+struct NodeLocality {
+  std::string region;
+  std::string zone;
+  std::string sub_zone;
+};
 
 // The C++ Engine builder supports 2 ways of building Envoy Mobile config, the 'legacy mode'
 // which uses a yaml config header, blocks of well known yaml configs, and uses string manipulation
@@ -73,7 +81,7 @@ public:
   // Sets the node.id field in the Bootstrap configuration.
   EngineBuilder& setNodeId(std::string node_id);
   // Sets the node.locality field in the Bootstrap configuration.
-  EngineBuilder& setNodeLocality(std::string region, std::string zone, std::string sub_zone);
+  EngineBuilder& setNodeLocality(const NodeLocality& node_locality);
   // Adds an ADS layer. Note that only the state-of-the-world gRPC protocol is supported, not Delta
   // gRPC.
   EngineBuilder&
@@ -172,10 +180,7 @@ private:
   std::string rtds_layer_name_ = "";
   int rtds_timeout_seconds_;
   std::string node_id_;
-  bool set_node_locality_ = false;
-  std::string node_locality_region_;
-  std::string node_locality_zone_;
-  std::string node_locality_sub_zone_;
+  absl::optional<NodeLocality> node_locality_ = absl::nullopt;
   std::string ads_address_ = "";
   int ads_port_;
   std::string ads_jwt_token_;

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -589,7 +589,7 @@ watchdogs:
     megamiss_timeout: 60s
     miss_timeout: 60s
 node:
-  id: envoy-mobile
+  id: *node_id
   cluster: envoy-mobile
   metadata: *metadata
   locality: *node_locality

--- a/mobile/library/common/config/config.cc
+++ b/mobile/library/common/config/config.cc
@@ -186,6 +186,8 @@ const std::string config_header = R"(
 - &persistent_dns_cache_config NULL
 - &persistent_dns_cache_save_interval 1
 - &force_ipv6 false
+- &node_id envoy-mobile
+- &node_locality NULL
 )"
 #if defined(__APPLE__)
 R"(- &dns_resolver_name envoy.network.dns_resolver.apple
@@ -432,7 +434,7 @@ typed_dns_resolver_config:
   name: *dns_resolver_name
   typed_config: *dns_resolver_config
 dynamic_resources:
-#{custom_dynamic_resources}
+#{custom_cds}
 #{custom_ads}
 static_resources:
   listeners:
@@ -590,6 +592,7 @@ node:
   id: envoy-mobile
   cluster: envoy-mobile
   metadata: *metadata
+  locality: *node_locality
 layered_runtime:
   layers:
     - name: static_layer_0
@@ -621,21 +624,45 @@ const char* rtds_layer_insert = R"(
           resource_api_version: V3
           ads: {{}})";
 
+const char* ads_channel_credentials_insert = R"(
+        channel_credentials:
+          ssl_credentials:
+            root_certs:
+              inline_string: {})";
+
+const char* ads_call_credentials_insert = R"(
+        call_credentials:
+        - service_account_jwt_access:
+            json_key: {}
+            token_lifetime_seconds: {})";
+
 const char* ads_insert = R"(
   ads_config:
     transport_api_version: V3
-    api_type: {}
+    api_type: GRPC
     set_node_on_first_message_only: true
     grpc_services:
       google_grpc:
         target_uri: '{}:{}'
-        stat_prefix: ads)";
+        stat_prefix: ads
+        #{custom_ads_channel_credentials}
+        #{custom_ads_call_credentials})";
 
 const char* cds_layer_insert = R"(
   cds_config:
+    ads: {{}}
     initial_fetch_timeout:
       seconds: {}
-    resource_api_version: V3
-    ads: {{}})";
+    resource_api_version: V3)";
+
+const char* xdstp_cds_layer_insert = R"(
+  cds_resources_locator: {}
+  cds_config:
+    api_config_source:
+      api_type: AGGREGATED_GRPC
+      transport_api_version: V3
+    initial_fetch_timeout:
+      seconds: {}
+    resource_api_version: V3)";
 
 // clang-format on

--- a/mobile/library/common/config/templates.h
+++ b/mobile/library/common/config/templates.h
@@ -108,16 +108,31 @@ extern const char* default_cert_validation_context_template;
 extern const char* platform_cert_validation_context_template;
 
 /**
- * Config template for an RTDS layer
+ * Config template for an RTDS layer in the dynamic resources field.
  */
 extern const char* rtds_layer_insert;
 
 /**
- * Config template for a CDS layer
+ * Config template for a CDS layer in the dynamic resources field.
  */
 extern const char* cds_layer_insert;
 
 /**
- * ADS config
+ * Config template for a CDS layer using xdstp in the dynamic resources field.
+ */
+extern const char* xdstp_cds_layer_insert;
+
+/**
+ * Insert that sets the ADS config in the dynamic resources field.
  */
 extern const char* ads_insert;
+
+/**
+ * Insert that sets the ADS config's call credentials.
+ */
+extern const char* ads_call_credentials_insert;
+
+/**
+ * Insert that sets the ADS config's channel credentials.
+ */
+extern const char* ads_channel_credentials_insert;

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -554,7 +554,7 @@ TEST(TestConfig, SetNodeLocality) {
   const std::string region = "us-west-1";
   const std::string zone = "some_zone";
   const std::string sub_zone = "some_sub_zone";
-  engine_builder.setNodeLocality(region, zone, sub_zone);
+  engine_builder.setNodeLocality({region, zone, sub_zone});
   const std::string yaml_config_str = engine_builder.generateConfigStr();
   EXPECT_THAT(yaml_config_str, AllOf(HasSubstr(region), HasSubstr(zone), HasSubstr(sub_zone)));
   std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap =

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -48,6 +48,7 @@ TEST(TestConfig, ConfigIsApplied) {
       .enableAdminInterface(true)
 #endif
       .setForceAlwaysUsev6(true)
+      .setNodeId("my_test_node")
       .setDeviceOs("probably-ubuntu-on-CI");
   std::string config_str = engine_builder.generateConfigStr();
 
@@ -63,6 +64,7 @@ TEST(TestConfig, ConfigIsApplied) {
                                            "- &stats_flush_interval 654s",
                                            "  key: dns_persistent_cache",
                                            "- &force_ipv6 true",
+                                           "- &node_id my_test_node",
                                            "- &persistent_dns_cache_save_interval 101",
                                            " test_feature_false: true",
                                            ("- &metadata { device_os: \"probably-ubuntu-on-CI\", "

--- a/mobile/test/common/integration/cds_integration_test.cc
+++ b/mobile/test/common/integration/cds_integration_test.cc
@@ -34,7 +34,7 @@ public:
 
   void SetUp() override { setUpstreamProtocol(Http::CodecType::HTTP1); }
 
- protected:
+protected:
   void executeCdsRequestsAndVerify() {
     initialize();
     const std::string cluster_name =

--- a/mobile/test/common/integration/cds_integration_test.cc
+++ b/mobile/test/common/integration/cds_integration_test.cc
@@ -8,7 +8,6 @@
 
 namespace Envoy {
 namespace {
-constexpr char ClusterName[] = "newcluster";
 
 class CdsIntegrationTest : public XdsIntegrationTest {
 public:
@@ -19,36 +18,62 @@ public:
 
   void createEnvoy() override {
     sotw_or_delta_ = sotwOrDelta();
-    const std::string api_type = sotw_or_delta_ == Grpc::SotwOrDelta::Sotw ||
-                                         sotw_or_delta_ == Grpc::SotwOrDelta::UnifiedSotw
-                                     ? "GRPC"
-                                     : "DELTA_GRPC";
-    builder_.addCdsLayer(/*timeout_seconds=*/1);
-    builder_.setAggregatedDiscoveryService(api_type,
-                                           Network::Test::getLoopbackAddressUrlString(ipVersion()),
+    const std::string target_uri = Network::Test::getLoopbackAddressUrlString(ipVersion());
+    builder_.setAggregatedDiscoveryService(target_uri,
                                            fake_upstreams_[1]->localAddress()->ip()->port());
+
+    std::string cds_resources_locator;
+    if (use_xdstp_) {
+      cds_namespace_ = "xdstp://" + target_uri + "/envoy.config.cluster.v3.Cluster";
+      cds_resources_locator = cds_namespace_ + "/*";
+    }
+    builder_.addCdsLayer(cds_resources_locator, /*timeout_seconds=*/1);
+
     XdsIntegrationTest::createEnvoy();
   }
+
   void SetUp() override { setUpstreamProtocol(Http::CodecType::HTTP1); }
+
+ protected:
+  void executeCdsRequestsAndVerify() {
+    initialize();
+    const std::string cluster_name =
+        use_xdstp_ ? cds_namespace_ + "/my_cluster?xds.node.cluster=envoy-mobile" : "my_cluster";
+    envoy::config::cluster::v3::Cluster cluster1 = ConfigHelper::buildStaticCluster(
+        cluster_name, fake_upstreams_[0]->localAddress()->ip()->port(),
+        Network::Test::getLoopbackAddressString(ipVersion()), "ROUND_ROBIN");
+    initializeXdsStream();
+    int cluster_count = getGaugeValue("cluster_manager.active_clusters");
+    // Do the initial compareDiscoveryRequest / sendDiscoveryResponse for cluster_1.
+    std::vector<std::string> expected_resources;
+    if (use_xdstp_) {
+      expected_resources.push_back(cds_namespace_ + "/*");
+    }
+    EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", expected_resources, {},
+                                        {}, true));
+    sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster,
+                                                               {cluster1}, {cluster1}, {}, "55");
+    // Wait for cluster to be added
+    ASSERT_TRUE(waitForCounterGe("cluster_manager.cluster_added", 1));
+    ASSERT_TRUE(waitForGaugeGe("cluster_manager.active_clusters", cluster_count + 1));
+  }
+
+  bool use_xdstp_;
+  std::string cds_namespace_;
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDelta, CdsIntegrationTest,
-                         DELTA_SOTW_GRPC_CLIENT_INTEGRATION_PARAMS);
+INSTANTIATE_TEST_SUITE_P(
+    IpVersionsClientTypeSotw, CdsIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::ValuesIn(TestEnvironment::getsGrpcVersionsForTest()),
+                     // Envoy Mobile's xDS APIs only support state-of-the-world, not delta.
+                     testing::Values(Grpc::SotwOrDelta::Sotw, Grpc::SotwOrDelta::UnifiedSotw)));
 
-TEST_P(CdsIntegrationTest, Basic) {
-  initialize();
-  envoy::config::cluster::v3::Cluster cluster1 = ConfigHelper::buildStaticCluster(
-      ClusterName, fake_upstreams_[0]->localAddress()->ip()->port(),
-      Network::Test::getLoopbackAddressString(ipVersion()), "ROUND_ROBIN");
-  initializeXdsStream();
-  int cluster_count = getGaugeValue("cluster_manager.active_clusters");
-  // Do the initial compareDiscoveryRequest / sendDiscoveryResponse for cluster_1.
-  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", {}, {}, {}, true));
-  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster,
-                                                             {cluster1}, {cluster1}, {}, "55");
-  // Wait for cluster to be added
-  ASSERT_TRUE(waitForCounterGe("cluster_manager.cluster_added", 1));
-  ASSERT_TRUE(waitForGaugeGe("cluster_manager.active_clusters", cluster_count + 1));
+TEST_P(CdsIntegrationTest, Basic) { executeCdsRequestsAndVerify(); }
+
+TEST_P(CdsIntegrationTest, BasicWithXdstp) {
+  use_xdstp_ = true;
+  executeCdsRequestsAndVerify();
 }
 
 } // namespace

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -29,6 +29,7 @@ BSON
 BPF
 Bdecoded
 Bencoded
+DFP
 GiB
 IPTOS
 Repick
@@ -239,6 +240,7 @@ LEV
 LF
 LHS
 hls
+ingressed
 integrations
 jkl
 lang


### PR DESCRIPTION
This commit does a few things:
  - adds an API to EngineBuilder for setting the Bootstrap's node locality.
  - adds the ability to set call and channel credentials in ADS.
  - adds the ability to use xdstp for CDS via the cds_resources_locator field.
  - removes the `api_type` parameter from the ADS API, since the only supported API type is `GRPC`.
  - adds tests for all of these in envoy_config_test.cc.
  - adds an xdstp integration test in CdsIntegrationTest.
  - removes the Delta parameter in CdsIntegrationTest since mobile xDS doesn't support Delta.

Signed-off-by: Ali Beyad <abeyad@google.com>