### PR TITLE
Rename ProcessHeadersOrTrailersImpl() method.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -247,10 +247,10 @@ void BalsaParser::OnTrailerInput(absl::string_view /*input*/) {}
 void BalsaParser::OnHeader(absl::string_view /*key*/, absl::string_view /*value*/) {}
 
 void BalsaParser::ProcessHeaders(const BalsaHeaders& headers) {
-  ProcessHeadersOrTrailersImpl(headers);
+  processHeadersOrTrailersImpl(headers);
 }
 void BalsaParser::ProcessTrailers(const BalsaHeaders& trailer) {
-  ProcessHeadersOrTrailersImpl(trailer);
+  processHeadersOrTrailersImpl(trailer);
 }
 
 void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
@@ -360,7 +360,7 @@ void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode error_code) {
   }
 }
 
-void BalsaParser::ProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers) {
+void BalsaParser::processHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers) {
   for (const std::pair<absl::string_view, absl::string_view>& key_value : headers.lines()) {
     if (status_ == ParserStatus::Error) {
       return;

--- a/source/common/http/http1/balsa_parser.h
+++ b/source/common/http/http1/balsa_parser.h
@@ -58,7 +58,7 @@ private:
   void HandleWarning(quiche::BalsaFrameEnums::ErrorCode error_code) override;
 
   // Shared implementation for ProcessHeaders() and ProcessTrailers().
-  void ProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers);
+  void processHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers);
 
   // Return ParserStatus::Error if `result` is CallbackResult::Error.
   // Return current value of `status_` otherwise.


### PR DESCRIPTION
Change first letter from uppercase to lowercase to conform to Envoy naming conventions.

Resolves #25632.

Commit Message: Rename ProcessHeadersOrTrailersImpl() method.
Additional Description:
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a