### PR TITLE
Reduce overhead by fixing alignment in SubsetLb

### DIFF
--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -32,8 +32,7 @@ SubsetLoadBalancer::SubsetLoadBalancer(
     OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig> least_request_config,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
     TimeSource& time_source)
-    : lb_type_(lb_type),
-      lb_ring_hash_config_(
+    : lb_ring_hash_config_(
           lb_ring_hash_config.has_value()
               ? std::make_unique<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>(
                     lb_ring_hash_config.ref())
@@ -59,10 +58,9 @@ SubsetLoadBalancer::SubsetLoadBalancer(
       default_subset_metadata_(subsets.defaultSubset().fields().begin(),
                                subsets.defaultSubset().fields().end()),
       subset_selectors_(subsets.subsetSelectors()), original_priority_set_(priority_set),
-      original_local_priority_set_(local_priority_set),
-      locality_weight_aware_(subsets.localityWeightAware()),
-      scale_locality_weight_(subsets.scaleLocalityWeight()), list_as_any_(subsets.listAsAny()),
-      time_source_(time_source) {
+      original_local_priority_set_(local_priority_set), time_source_(time_source),
+      lb_type_(lb_type), locality_weight_aware_(subsets.localityWeightAware()),
+      scale_locality_weight_(subsets.scaleLocalityWeight()), list_as_any_(subsets.listAsAny()) {
   ASSERT(subsets.isEnabled());
 
   if (fallback_policy_ != envoy::config::cluster::v3::Cluster::LbSubsetConfig::NO_FALLBACK) {

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -385,7 +385,6 @@ private:
     return absl::nullopt;
   }
 
-  const LoadBalancerType lb_type_;
   const std::unique_ptr<const envoy::config::cluster::v3::Cluster::RingHashLbConfig>
       lb_ring_hash_config_;
   const std::unique_ptr<const envoy::config::cluster::v3::Cluster::MaglevLbConfig>
@@ -426,11 +425,12 @@ private:
 
   Stats::Gauge* single_duplicate_stat_{};
 
-  const bool locality_weight_aware_;
-  const bool scale_locality_weight_;
-  const bool list_as_any_;
-
   TimeSource& time_source_;
+
+  const LoadBalancerType lb_type_;
+  const bool locality_weight_aware_ : 1;
+  const bool scale_locality_weight_ : 1;
+  const bool list_as_any_ : 1;
 
   friend class SubsetLoadBalancerInternalStateTester;
 };

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -427,6 +427,7 @@ private:
 
   TimeSource& time_source_;
 
+  // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   const LoadBalancerType lb_type_;
   const bool locality_weight_aware_ : 1;
   const bool scale_locality_weight_ : 1;


### PR DESCRIPTION
Commit Message: Reduce overhead by fixing alignment in SubsetLb
Additional Description: Moves many of the smaller members of the class to the end to save small amounts of memory
Risk Level: Low