### PR TITLE
Reduce overhead in SubsetSelectorImpl by fixing alignment

### DIFF
--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1108,9 +1108,9 @@ SubsetSelectorImpl::SubsetSelectorImpl(
         LbSubsetSelectorFallbackPolicy fallback_policy,
     const Protobuf::RepeatedPtrField<std::string>& fallback_keys_subset,
     bool single_host_per_subset)
-    : selector_keys_(selector_keys.begin(), selector_keys.end()), fallback_policy_(fallback_policy),
+    : selector_keys_(selector_keys.begin(), selector_keys.end()),
       fallback_keys_subset_(fallback_keys_subset.begin(), fallback_keys_subset.end()),
-      single_host_per_subset_(single_host_per_subset) {
+      fallback_policy_(fallback_policy), single_host_per_subset_(single_host_per_subset) {
 
   if (fallback_policy_ !=
       envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetSelector::KEYS_SUBSET) {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -757,10 +757,10 @@ public:
 
 private:
   const std::set<std::string> selector_keys_;
+  const std::set<std::string> fallback_keys_subset_;
   const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetSelector::
       LbSubsetSelectorFallbackPolicy fallback_policy_;
-  const std::set<std::string> fallback_keys_subset_;
-  const bool single_host_per_subset_;
+  const bool single_host_per_subset_ : 1;
 };
 
 /**

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -758,6 +758,7 @@ public:
 private:
   const std::set<std::string> selector_keys_;
   const std::set<std::string> fallback_keys_subset_;
+  // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetSelector::
       LbSubsetSelectorFallbackPolicy fallback_policy_;
   const bool single_host_per_subset_ : 1;


### PR DESCRIPTION
Commit Message: Reduce overhead in SubsetSelectorImpl by fixing alignment
Additional Description: Moves many of the smaller members of the class to the end to save small amounts of memory
Risk Level: Low