### PR TITLE
Reduce overhead in LoadBalancerSubsetInfoImpl by fixing alignment

### DIFF
--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -770,10 +770,10 @@ class LoadBalancerSubsetInfoImpl : public LoadBalancerSubsetInfo {
 public:
   LoadBalancerSubsetInfoImpl(
       const envoy::config::cluster::v3::Cluster::LbSubsetConfig& subset_config)
-      : enabled_(!subset_config.subset_selectors().empty()),
-        fallback_policy_(subset_config.fallback_policy()),
-        metadata_fallback_policy_(subset_config.metadata_fallback_policy()),
+      : fallback_policy_(subset_config.fallback_policy()),
         default_subset_(subset_config.default_subset()),
+        metadata_fallback_policy_(subset_config.metadata_fallback_policy()),
+        enabled_(!subset_config.subset_selectors().empty()),
         locality_weight_aware_(subset_config.locality_weight_aware()),
         scale_locality_weight_(subset_config.scale_locality_weight()),
         panic_mode_any_(subset_config.panic_mode_any()), list_as_any_(subset_config.list_as_any()) {
@@ -806,17 +806,17 @@ public:
   bool listAsAny() const override { return list_as_any_; }
 
 private:
-  const bool enabled_;
   const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
       fallback_policy_;
-  const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetMetadataFallbackPolicy
-      metadata_fallback_policy_;
   const ProtobufWkt::Struct default_subset_;
   std::vector<SubsetSelectorPtr> subset_selectors_;
-  const bool locality_weight_aware_;
-  const bool scale_locality_weight_;
-  const bool panic_mode_any_;
-  const bool list_as_any_;
+  const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetMetadataFallbackPolicy
+      metadata_fallback_policy_;
+  const bool enabled_ : 1;
+  const bool locality_weight_aware_ : 1;
+  const bool scale_locality_weight_ : 1;
+  const bool panic_mode_any_ : 1;
+  const bool list_as_any_ : 1;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -770,8 +770,8 @@ class LoadBalancerSubsetInfoImpl : public LoadBalancerSubsetInfo {
 public:
   LoadBalancerSubsetInfoImpl(
       const envoy::config::cluster::v3::Cluster::LbSubsetConfig& subset_config)
-      : fallback_policy_(subset_config.fallback_policy()),
-        default_subset_(subset_config.default_subset()),
+      : default_subset_(subset_config.default_subset()),
+        fallback_policy_(subset_config.fallback_policy()),
         metadata_fallback_policy_(subset_config.metadata_fallback_policy()),
         enabled_(!subset_config.subset_selectors().empty()),
         locality_weight_aware_(subset_config.locality_weight_aware()),
@@ -806,10 +806,11 @@ public:
   bool listAsAny() const override { return list_as_any_; }
 
 private:
-  const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
-      fallback_policy_;
   const ProtobufWkt::Struct default_subset_;
   std::vector<SubsetSelectorPtr> subset_selectors_;
+  // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
+      fallback_policy_;
   const envoy::config::cluster::v3::Cluster::LbSubsetConfig::LbSubsetMetadataFallbackPolicy
       metadata_fallback_policy_;
   const bool enabled_ : 1;


### PR DESCRIPTION
Commit Message: Reduce overhead in LoadBalancerSubsetInfoImpl by fixing alignment
Additional Description: Moves many of the smaller members of the class to the end to save small amounts of memory
Risk Level: Low