### PR TITLE
Reduce overhead in health_checker_impl by fixing alignment

### DIFF
--- a/envoy/http/protocol.h
+++ b/envoy/http/protocol.h
@@ -9,7 +9,7 @@ namespace Http {
  * Possible HTTP connection/request protocols. The parallel NumProtocols constant allows defining
  * fixed arrays for each protocol, but does not pollute the enum.
  */
-enum class Protocol { Http10, Http11, Http2, Http3 };
+enum class Protocol : uint8_t { Http10, Http11, Http2, Http3 };
 const size_t NumProtocols = 4;
 
 } // namespace Http

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -306,7 +306,7 @@ HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSessio
       local_connection_info_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
           Network::Utility::getCanonicalIpv4LoopbackAddress(),
           Network::Utility::getCanonicalIpv4LoopbackAddress())),
-      protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)), expect_reset_{},
+      protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)), expect_reset_(false),
       reuse_connection_(false), request_in_flight_(false) {}
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::~HttpActiveHealthCheckSession() {

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -302,10 +302,12 @@ HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSessio
     : ActiveHealthCheckSession(parent, host), parent_(parent),
       response_body_(std::make_unique<Buffer::OwnedImpl>()),
       hostname_(getHostname(host, parent_.host_value_, parent_.cluster_.info())),
-      protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)),
+
       local_connection_info_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
           Network::Utility::getCanonicalIpv4LoopbackAddress(),
-          Network::Utility::getCanonicalIpv4LoopbackAddress())) {}
+          Network::Utility::getCanonicalIpv4LoopbackAddress())),
+      protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)), expect_reset_{},
+      reuse_connection_(false), request_in_flight_(false) {}
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::~HttpActiveHealthCheckSession() {
   ASSERT(client_ == nullptr);

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -206,11 +206,11 @@ private:
     Http::ResponseHeaderMapPtr response_headers_;
     Buffer::InstancePtr response_body_;
     const std::string& hostname_;
-    const Http::Protocol protocol_;
     Network::ConnectionInfoProviderSharedPtr local_connection_info_provider_;
-    bool expect_reset_{};
-    bool reuse_connection_ = false;
-    bool request_in_flight_ = false;
+    const Http::Protocol protocol_;
+    bool expect_reset_ : 1;
+    bool reuse_connection_ : 1;
+    bool request_in_flight_ : 1;
   };
 
   using HttpActiveHealthCheckSessionPtr = std::unique_ptr<HttpActiveHealthCheckSession>;

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -207,6 +207,7 @@ private:
     Buffer::InstancePtr response_body_;
     const std::string& hostname_;
     Network::ConnectionInfoProviderSharedPtr local_connection_info_provider_;
+    // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
     const Http::Protocol protocol_;
     bool expect_reset_ : 1;
     bool reuse_connection_ : 1;


### PR DESCRIPTION
Commit Message:  Reduce overhead in health_checker_impl by fixing alignment
Additional Description: Moves many of the smaller members of the class to the end to save small amounts of memory
Risk Level: Low