### PR TITLE
Fix accidentally included R classes in the android lib

### DIFF
--- a/mobile/bazel/android_artifacts.bzl
+++ b/mobile/bazel/android_artifacts.bzl
@@ -239,6 +239,8 @@ def _create_classes_jar(name, manifest, android_library):
         echo "Creating classes.jar from $(SRCS)"
         pushd $$classes_dir
         unzip $$original_directory/$(SRCS) "io/envoyproxy/*" "org/chromium/net/*" "META-INF/" > /dev/null
+        find . -name "R.class" -type f -exec rm {} \\;
+        find . -name "R\\$$*.class" -type f -exec rm {} \\;
         zip -r classes.jar * > /dev/null
         popd
         cp $$classes_dir/classes.jar $@


### PR DESCRIPTION
PR removes `R.class` and `R$*.class` from the final Android library `.aar` distribution because as per Android library publishing guidelines libraries must not include R classes — they're generated at the consumer side, otherwise consumer will get `Type X is defined multiple times` error during their build preventing them from using the Enovy Mobile as a `.aar` library!

Verified content before and after:

```swift
diff -r ~/Desktop/before ~/Desktop/after
Only in Desktop/before/io/envoyproxy/envoymobile: R$attr.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$color.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$dimen.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$drawable.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$id.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$integer.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$layout.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$string.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$style.class
Only in Desktop/before/io/envoyproxy/envoymobile: R$styleable.class
Only in Desktop/before/io/envoyproxy/envoymobile: R.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$attr.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$color.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$dimen.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$drawable.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$id.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$integer.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$layout.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$string.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$style.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R$styleable.class
Only in Desktop/before/io/envoyproxy/envoymobile/engine: R.class
```

co-authored with @codeman9 and @davidkurkov as requested from @jpsim with a repro build failure from @arunj-kp https://github.com/arunj-kp/envoybuild

```java
Execution failed for task ':app:mergeDexRelease'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.DexMergingTaskDelegate
   > There was a failure while executing work items
      > A failure occurred while executing com.android.build.gradle.internal.tasks.DexMergingWorkAction
         > com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives: 
           Type io.envoyproxy.envoymobile.R is defined multiple times: <user_directory>/envoybuild/app/build/intermediates/project_dex_archive/release/out/e17d2b7d3b3cd38559814e5bf3bad06f88686caea0b21925ac792110a6c8e56d_1.jar:classes.dex, <user_directory>/envoybuild/app/build/intermediates/external_libs_dex/release/mergeExtDexRelease/classes.dex
           Learn how to resolve the issue at https://developer.android.com/studio/build/dependencies#duplicate_classes.
```

Also verified that https://github.com/arunj-kp/envoybuild works with newly produced `.aar` by pointing it to `mavenLocal()`.