### PR TITLE
[ZK filter] Add support for setwatches2 ZK opcode

### DIFF
--- a/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
@@ -59,6 +59,7 @@ following counters are available:
   reconfig_rq, Counter, Number of reconfig requests
   close_rq, Counter, Number of close requests
   setwatches_rq, Counter, Number of setwatches requests
+  setwatches2_rq, Counter, Number of setwatches2 requests
   checkwatches_rq, Counter, Number of checkwatches requests
   removewatches_rq, Counter, Number of removewatches requests
   check_rq, Counter, Number of check requests
@@ -87,6 +88,7 @@ following counters are available:
   close_resp, Counter, Number of close responses
   setauth_resp, Counter, Number of setauth responses
   setwatches_resp, Counter, Number of setwatches responses
+  setwatches2_resp, Counter, Number of setwatches2 responses
   checkwatches_resp, Counter, Number of checkwatches responses
   removewatches_resp, Counter, Number of removewatches responses
   check_resp, Counter, Number of check responses
@@ -128,6 +130,7 @@ Latency stats are in milliseconds:
   close_response_latency, Histogram, Opcode execution time in milliseconds
   setauth_response_latency, Histogram, Opcode execution time in milliseconds
   setwatches_response_latency, Histogram, Opcode execution time in milliseconds
+  setwatches2_response_latency, Histogram, Opcode execution time in milliseconds
   checkwatches_response_latency, Histogram, Opcode execution time in milliseconds
   removewatches_response_latency, Histogram, Opcode execution time in milliseconds
   check_response_latency, Histogram, Opcode execution time in milliseconds

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -146,6 +146,9 @@ void DecoderImpl::decodeOnData(Buffer::Instance& data, uint64_t& offset) {
   case OpCodes::SetWatches:
     parseSetWatchesRequest(data, offset, len);
     break;
+  case OpCodes::SetWatches2:
+    parseSetWatches2Request(data, offset, len);
+    break;
   case OpCodes::CheckWatches:
     parseXWatchesRequest(data, offset, len, OpCodes::CheckWatches);
     break;
@@ -428,7 +431,7 @@ void DecoderImpl::parseReconfigRequest(Buffer::Instance& data, uint64_t& offset,
 }
 
 void DecoderImpl::parseSetWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len) {
-  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + (3 * INT_LENGTH));
+  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + LONG_LENGTH + (3 * INT_LENGTH));
 
   // Ignore relative Zxid.
   helper_.peekInt64(data, offset);
@@ -440,6 +443,25 @@ void DecoderImpl::parseSetWatchesRequest(Buffer::Instance& data, uint64_t& offse
   skipStrings(data, offset);
 
   callbacks_.onSetWatchesRequest();
+}
+
+void DecoderImpl::parseSetWatches2Request(Buffer::Instance& data, uint64_t& offset, uint32_t len) {
+  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + LONG_LENGTH + (5 * INT_LENGTH));
+
+  //Ignore relative Zxid.
+  helper_.peekInt64(data, offset);
+  // Data watches.
+  skipStrings(data, offset);
+  // Exist watches.
+  skipStrings(data, offset);
+  // Child watches.
+  skipStrings(data, offset);
+  // Persistent watches.
+  skipStrings(data, offset);
+  // Persistent recursive watches.
+  skipStrings(data, offset);
+
+  callbacks_.onSetWatches2Request();
 }
 
 void DecoderImpl::parseXWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len,

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -448,7 +448,7 @@ void DecoderImpl::parseSetWatchesRequest(Buffer::Instance& data, uint64_t& offse
 void DecoderImpl::parseSetWatches2Request(Buffer::Instance& data, uint64_t& offset, uint32_t len) {
   ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + LONG_LENGTH + (5 * INT_LENGTH));
 
-  //Ignore relative Zxid.
+  // Ignore relative Zxid.
   helper_.peekInt64(data, offset);
   // Data watches.
   skipStrings(data, offset);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -50,7 +50,8 @@ enum class OpCodes {
   SetAuth = 100,
   SetWatches = 101,
   GetEphemerals = 103,
-  GetAllChildrenNumber = 104
+  GetAllChildrenNumber = 104,
+  SetWatches2 = 105
 };
 
 enum class WatcherType { Children = 1, Data = 2, Any = 3 };
@@ -94,6 +95,7 @@ public:
   virtual void onMultiRequest() PURE;
   virtual void onReconfigRequest() PURE;
   virtual void onSetWatchesRequest() PURE;
+  virtual void onSetWatches2Request() PURE;
   virtual void onCheckWatchesRequest(const std::string& path, int32_t type) PURE;
   virtual void onRemoveWatchesRequest(const std::string& path, int32_t type) PURE;
   virtual void onCloseRequest() PURE;
@@ -158,6 +160,7 @@ private:
   void parseMultiRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseReconfigRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseSetWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
+  void parseSetWatches2Request(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseXWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len, OpCodes opcode);
   void skipString(Buffer::Instance& data, uint64_t& offset);
   void skipStrings(Buffer::Instance& data, uint64_t& offset);

--- a/source/extensions/filters/network/zookeeper_proxy/filter.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.cc
@@ -51,6 +51,7 @@ ZooKeeperFilterConfig::ZooKeeperFilterConfig(const std::string& stat_prefix,
   initOpCode(OpCodes::Multi, stats_.multi_resp_, "multi_resp");
   initOpCode(OpCodes::Reconfig, stats_.reconfig_resp_, "reconfig_resp");
   initOpCode(OpCodes::SetWatches, stats_.setwatches_resp_, "setwatches_resp");
+  initOpCode(OpCodes::SetWatches2, stats_.setwatches2_resp_, "setwatches2_resp");
   initOpCode(OpCodes::CheckWatches, stats_.checkwatches_resp_, "checkwatches_resp");
   initOpCode(OpCodes::RemoveWatches, stats_.removewatches_resp_, "removewatches_resp");
   initOpCode(OpCodes::GetEphemerals, stats_.getephemerals_resp_, "getephemerals_resp");
@@ -265,6 +266,11 @@ void ZooKeeperFilter::onReconfigRequest() {
 void ZooKeeperFilter::onSetWatchesRequest() {
   config_->stats_.setwatches_rq_.inc();
   setDynamicMetadata("opname", "setwatches");
+}
+
+void ZooKeeperFilter::onSetWatches2Request() {
+  config_->stats_.setwatches2_rq_.inc();
+  setDynamicMetadata("opname", "setwatches2");
 }
 
 void ZooKeeperFilter::onGetEphemeralsRequest(const std::string& path) {

--- a/source/extensions/filters/network/zookeeper_proxy/filter.h
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.h
@@ -49,6 +49,7 @@ namespace ZooKeeperProxy {
   COUNTER(close_rq)                                                                                \
   COUNTER(setauth_rq)                                                                              \
   COUNTER(setwatches_rq)                                                                           \
+  COUNTER(setwatches2_rq)                                                                          \
   COUNTER(checkwatches_rq)                                                                         \
   COUNTER(removewatches_rq)                                                                        \
   COUNTER(check_rq)                                                                                \
@@ -76,6 +77,7 @@ namespace ZooKeeperProxy {
   COUNTER(close_resp)                                                                              \
   COUNTER(setauth_resp)                                                                            \
   COUNTER(setwatches_resp)                                                                         \
+  COUNTER(setwatches2_resp)                                                                        \
   COUNTER(checkwatches_resp)                                                                       \
   COUNTER(removewatches_resp)                                                                      \
   COUNTER(check_resp)                                                                              \
@@ -166,6 +168,7 @@ public:
   void onMultiRequest() override;
   void onReconfigRequest() override;
   void onSetWatchesRequest() override;
+  void onSetWatches2Request() override;
   void onCheckWatchesRequest(const std::string& path, int32_t type) override;
   void onRemoveWatchesRequest(const std::string& path, int32_t type) override;
   void onGetEphemeralsRequest(const std::string& path) override;

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -1045,7 +1045,7 @@ TEST_F(ZooKeeperFilterTest, SetWatches2Request) {
   const std::vector<std::string> existw = {"/foo1", "/bar1"};
   const std::vector<std::string> childw = {"/foo1", "/bar1"};
   const std::vector<std::string> persistentw = {"/baz", "/qux"};
-  const std::vector<std::string> persistent_recursivew = {"/baz1", "/qux1"};
+  const std::vector<std::string> persistent_recursivew = {"/baz1", "/qux2"};
 
   Buffer::OwnedImpl data =
       encodeSetWatches2Request(dataw, existw, childw, persistentw, persistent_recursivew);

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -1047,7 +1047,8 @@ TEST_F(ZooKeeperFilterTest, SetWatches2Request) {
   const std::vector<std::string> persistentw = {"/baz", "/qux"};
   const std::vector<std::string> persistent_recursivew = {"/baz1", "/qux1"};
 
-  Buffer::OwnedImpl data = encodeSetWatches2Request(dataw, existw, childw, persistentw, persistent_recursivew);
+  Buffer::OwnedImpl data =
+      encodeSetWatches2Request(dataw, existw, childw, persistentw, persistent_recursivew);
 
   testRequest(data, {{{"opname", "setwatches2"}}, {{"bytes", "126"}}},
               config_->stats().setwatches2_rq_, 126);


### PR DESCRIPTION
Commit Message: [ZK filter] Add support for setwatches2 ZK opcode
Additional Description: Add support for setwatches2 ZK opcode: https://github.com/apache/zookeeper/blob/de7c5869d372e46af43979134d0e30b49d2319b1/zookeeper-jute/src/main/resources/zookeeper.jute#L83-L90
Risk Level: low
Testing: unit tests
Docs Changes: [Updates the ZK filter statistics](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/zookeeper_proxy_filter#statistics) 