### PR TITLE
listener: make address field required

### DIFF
--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -409,7 +409,7 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3:
     }
   }
 
-  if (!config.has_address()) {
+  if (!config.has_internal_listener() && !config.has_api_listener() && !config.has_address()) {
     throw EnvoyException(
         fmt::format("error adding listener named '{}': address is necessary", name));
   }

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -409,7 +409,8 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3:
     }
   }
 
-  if (!config.has_internal_listener() && !config.has_api_listener() && !config.has_address()) {
+  // Address field is not required for internal listeners.
+  if (!config.has_internal_listener() && !config.has_address()) {
     throw EnvoyException(
         fmt::format("error adding listener named '{}': address is necessary", name));
   }

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -409,6 +409,11 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3:
     }
   }
 
+  if (!config.has_address()) {
+    throw EnvoyException(
+        fmt::format("error adding listener named '{}': address is necessary", name));
+  }
+
   auto it = error_state_tracker_.find(name);
   TRY_ASSERT_MAIN_THREAD {
     return addOrUpdateListenerInternal(config, version_info, added_via_api, name);

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
@@ -789,6 +789,18 @@ TEST_P(ListenerManagerImplTest, MultipleSocketTypeSpecifiedInAddresses) {
                             "support same socket type for all the addresses.");
 }
 
+TEST_P(ListenerManagerImplTest, RejectNoAddresses) {
+  const std::string yaml = R"EOF(
+    name: "foo"
+    connection_balance_config:
+      exact_balance: {}
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(yaml), "", true),
+                            EnvoyException,
+                            "error adding listener named 'foo': address is necessary");
+}
+
 TEST_P(ListenerManagerImplTest, RejectMutlipleInternalAddresses) {
   const std::string yaml = R"EOF(
     name: "foo"


### PR DESCRIPTION
Now if we set a listener without address ,it would panic: https://github.com/envoyproxy/envoy/blob/73d776bea723cb69380bf2e44776d827c811d274/source/common/network/utility.cc#L536-L537

An example is like:
```

[2023-02-15 09:54:07.472][1415996][critical][assert] [source/common/network/utility.cc:534] panic: unset oneof             《====
[2023-02-15 09:54:07.472][1415996][critical][backtrace] [./source/server/backtrace.h:104] Caught Aborted, suspect faulting address 0x752f00159b3c
[2023-02-15 09:54:07.472][1415996][critical][backtrace] [./source/server/backtrace.h:91] Backtrace (use tools/stack_decode.py to get line numbers):
[2023-02-15 09:54:07.472][1415996][critical][backtrace] [./source/server/backtrace.h:92] Envoy version: bae2e9d642a6a8ae6c5d3810f77f3e888f0d97da/1.25.1/Clean/RELEASE/BoringSSL
[2023-02-15 09:54:07.472][1415996][critical][backtrace] [./source/server/backtrace.h:96] #0: __restore_rt [0x7f42dcbba420]->[0x292823ad0420] ??:0
[2023-02-15 09:54:07.482][1415996][critical][backtrace] [./source/server/backtrace.h:96] #1: Envoy::Server::ListenerImpl::ListenerImpl() [0x561abab4ab88]->[0x1a60b88] ??:0
[2023-02-15 09:54:07.491][1415996][critical][backtrace] [./source/server/backtrace.h:96] #2: Envoy::Server::ListenerManagerImpl::addOrUpdateListenerInternal() [0x561abab61fc1]->[0x1a77fc1] ??:0
[2023-02-15 09:54:07.501][1415996][critical][backtrace] [./source/server/backtrace.h:96] #3: Envoy::Server::ListenerManagerImpl::addOrUpdateListener() [0x561abab6106e]->[0x1a7706e] ??:0
[2023-02-15 09:54:07.510][1415996][critical][backtrace] [./source/server/backtrace.h:96] #4: Envoy::Server::Configuration::MainImpl::initialize() [0x561ababc394f]->[0x1ad994f] ??:0
[2023-02-15 09:54:07.520][1415996][critical][backtrace] [./source/server/backtrace.h:96] #5: Envoy::Server::InstanceImpl::initialize() [0x561aba747f63]->[0x165df63] ??:0
[2023-02-15 09:54:07.529][1415996][critical][backtrace] [./source/server/backtrace.h:96] #6: Envoy::Server::InstanceImpl::InstanceImpl() [0x561aba742ea5]->[0x1658ea5] ??:0
[2023-02-15 09:54:07.538][1415996][critical][backtrace] [./source/server/backtrace.h:96] #7: std::__1::make_unique<>() [0x561ab9111bd1]->[0x27bd1] ??:0
[2023-02-15 09:54:07.548][1415996][critical][backtrace] [./source/server/backtrace.h:96] #8: Envoy::StrippedMainBase::StrippedMainBase() [0x561ab911107d]->[0x2707d] ??:0
[2023-02-15 09:54:07.557][1415996][critical][backtrace] [./source/server/backtrace.h:96] #9: Envoy::MainCommon::MainCommon() [0x561ab90ec69c]->[0x269c] ??:0
[2023-02-15 09:54:07.566][1415996][critical][backtrace] [./source/server/backtrace.h:96] #10: Envoy::MainCommon::main() [0x561ab90ec81c]->[0x281c] ??:0
[2023-02-15 09:54:07.576][1415996][critical][backtrace] [./source/server/backtrace.h:96] #11: main [0x561ab90ea11c]->[0x11c] ??:0
[2023-02-15 09:54:07.576][1415996][critical][backtrace] [./source/server/backtrace.h:96] #12: __libc_start_main [0x7f42dc9d8083]->[0x2928238ee083] ??:0
```

The config is like:
```
static_resources:
  listeners:
  - connection_balance_config:
      exact_balance: {}
  - address:
      socket_address:
        address: 0.0.0.0
        port_value: 10000
```

Add check rather than make the field required since it isn't required by API/internal listener.

Commit Message:
Additional Description:
Risk Level: Low
Testing: Add UT
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/25578
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
