### PR TITLE
mobile: remove unused test method from EngineBuilder

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -1280,11 +1280,6 @@ EngineSharedPtr EngineBuilder::build() {
     }
     options->setLogLevel(options->parseAndValidateLogLevel(logLevelToString(log_level_).c_str()));
     options->setConcurrency(1);
-#ifdef ENVOY_ADMIN_FUNCTIONALITY
-    if (!admin_address_path_for_tests_.empty()) {
-      options->setAdminAddressPath(admin_address_path_for_tests_);
-    }
-#endif
     cast_engine->run(std::move(options));
   }
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -117,7 +117,6 @@ protected:
     config_bootstrap_incompatible_ = true;
     config_override_for_tests_ = config;
   }
-  void setAdminAddressPathForTests(std::string admin) { admin_address_path_for_tests_ = admin; }
 
 private:
   friend BaseClientIntegrationTest;
@@ -147,7 +146,6 @@ private:
   std::string app_id_ = "unspecified";
   std::string device_os_ = "unspecified";
   std::string config_override_for_tests_ = "";
-  std::string admin_address_path_for_tests_ = "";
   int stream_idle_timeout_seconds_ = 15;
   int per_try_idle_timeout_seconds_ = 15;
   bool gzip_decompression_filter_ = true;

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -55,9 +55,7 @@ protected:
   void setOverrideConfigForTests(Platform::EngineBuilder builder, std::string config) {
     builder.setOverrideConfigForTests(config);
   }
-  void setAdminAddressPathForTests(Platform::EngineBuilder& builder, std::string admin) {
-    builder.setAdminAddressPathForTests(admin);
-  }
+
   // Converts TestRequestHeaderMapImpl to Envoy::Platform::RequestHeadersSharedPtr
   Envoy::Platform::RequestHeadersSharedPtr
   envoyToMobileHeaders(const Http::TestRequestHeaderMapImpl& request_headers);


### PR DESCRIPTION
`setAdminAddressPathForTests` is not used anywhere.