### PR TITLE
Run batch of clang tidy fixes (140 of the 612)

### DIFF
--- a/contrib/generic_proxy/filters/network/test/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/config_test.cc
@@ -23,6 +23,8 @@ namespace NetworkFilters {
 namespace GenericProxy {
 namespace {
 
+using ::testing::Return;
+
 // Keep empty until merge the latest API from main.
 TEST(FactoryTest, FactoryTest) {
   const std::string yaml_config = R"EOF(

--- a/contrib/sip_proxy/filters/network/test/config_test.cc
+++ b/contrib/sip_proxy/filters/network/test/config_test.cc
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::Return;
 
 namespace Envoy {
 namespace Extensions {

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -854,7 +854,7 @@ public:
     static constexpr uint64_t HTTP3 = 0x10;
   };
 
-  virtual ~ClusterInfo() = default;
+  ~ClusterInfo() override = default;
 
   /**
    * @return bool whether the cluster was added via API (if false the cluster was present in the

--- a/source/common/common/cleanup.h
+++ b/source/common/common/cleanup.h
@@ -10,7 +10,7 @@ namespace Envoy {
 // RAII cleanup via functor.
 class Cleanup {
 public:
-  Cleanup(std::function<void()> f) : f_(std::move(f)), cancelled_(false) {}
+  Cleanup(std::function<void()> f) : f_(std::move(f)) {}
   ~Cleanup() { f_(); }
 
   void cancel() {
@@ -22,14 +22,14 @@ public:
 
 private:
   std::function<void()> f_;
-  bool cancelled_;
+  bool cancelled_{false};
 };
 
 // RAII helper class to add an element to an std::list on construction and erase
 // it on destruction, unless the cancel method has been called.
 template <class T> class RaiiListElement {
 public:
-  RaiiListElement(std::list<T>& container, T element) : container_(container), cancelled_(false) {
+  RaiiListElement(std::list<T>& container, T element) : container_(container) {
     it_ = container.emplace(container.begin(), element);
   }
   virtual ~RaiiListElement() {
@@ -52,7 +52,7 @@ public:
 private:
   std::list<T>& container_;
   typename std::list<T>::iterator it_;
-  bool cancelled_;
+  bool cancelled_{false};
 };
 
 // RAII helper class to add an element to a std::list held inside an absl::flat_hash_map on
@@ -64,7 +64,7 @@ public:
 
   template <typename ConvertibleToKey>
   RaiiMapOfListElement(MapOfList& map, const ConvertibleToKey& key, Value value)
-      : map_(map), key_(key), cancelled_(false) {
+      : map_(map), key_(key) {
     // The list reference itself cannot be saved because it is not stable in the event of a
     // absl::flat_hash_map rehash.
     std::list<Value>& list = map_.try_emplace(key).first->second;
@@ -96,6 +96,6 @@ private:
   // Because of absl::flat_hash_map iterator instability we have to keep a copy of the key.
   const Key key_;
   typename MapOfList::mapped_type::iterator it_;
-  bool cancelled_;
+  bool cancelled_{false};
 };
 } // namespace Envoy

--- a/source/common/common/mem_block_builder.h
+++ b/source/common/common/mem_block_builder.h
@@ -53,7 +53,7 @@ public:
    * @param object the object to append.
    */
   void appendOne(T object) {
-    SECURITY_ASSERT(write_span_.size() >= 1, "insufficient capacity");
+    SECURITY_ASSERT(!write_span_.empty(), "insufficient capacity");
     *write_span_.data() = object;
     write_span_.remove_prefix(1);
   }

--- a/source/common/common/packed_struct.h
+++ b/source/common/common/packed_struct.h
@@ -148,7 +148,7 @@ public:
 
   // Move constructor and assignment operator.
   PackedStruct(PackedStruct&& other) noexcept = default;
-  PackedStruct& operator=(PackedStruct&& other) = default;
+  PackedStruct& operator=(PackedStruct&& other) noexcept = default;
 
   friend class PackedStructTest;
 

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -565,7 +565,7 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
           trace, "inserting an empty data frame for end_stream due metadata being added.", *this);
       // Metadata frame doesn't carry end of stream bit. We need an empty data frame to end the
       // stream.
-      addDecodedData(*((*entry).get()), empty_data, true);
+      addDecodedData(*(*entry), empty_data, true);
     }
 
     if (!continue_iteration && std::next(entry) != decoder_filters_.end()) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1122,8 +1122,7 @@ bool shouldPercentDecodeChar(char c) { return testChar(kUrlDecodedCharTable, c);
 std::string Utility::PercentEncoding::urlEncodeQueryParameter(absl::string_view value) {
   std::string encoded;
   encoded.reserve(value.size());
-  for (size_t i = 0; i < value.size(); ++i) {
-    const char ch = value[i];
+  for (char ch : value) {
     if (shouldPercentEncodeChar(ch)) {
       // For consistency, URI producers should use uppercase hexadecimal digits for all
       // percent-encodings. https://tools.ietf.org/html/rfc3986#section-2.1.

--- a/source/common/shared_pool/shared_pool.h
+++ b/source/common/shared_pool/shared_pool.h
@@ -117,7 +117,7 @@ private:
     Element() = delete;
     Element(const Element&) = delete;
 
-    Element(Element&&) = default;
+    Element(Element&&) noexcept = default;
 
     std::shared_ptr<T> lock() const { return weak_ptr_.lock(); }
     long use_count() const { return weak_ptr_.use_count(); }

--- a/source/common/stats/histogram_impl.cc
+++ b/source/common/stats/histogram_impl.cc
@@ -15,8 +15,7 @@ const ConstSupportedBuckets default_buckets{};
 }
 
 HistogramStatisticsImpl::HistogramStatisticsImpl()
-    : supported_buckets_(default_buckets), computed_quantiles_(supportedQuantiles().size(), 0.0),
-      unit_(Histogram::Unit::Unspecified) {}
+    : supported_buckets_(default_buckets), computed_quantiles_(supportedQuantiles().size(), 0.0) {}
 
 HistogramStatisticsImpl::HistogramStatisticsImpl(const histogram_t* histogram_ptr,
                                                  Histogram::Unit unit,

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -396,10 +396,10 @@ private:
   void incRefCount(const StatName& stat_name);
 
   struct SharedSymbol {
-    SharedSymbol(Symbol symbol) : symbol_(symbol), ref_count_(1) {}
+    SharedSymbol(Symbol symbol) : symbol_(symbol) {}
 
     Symbol symbol_;
-    uint32_t ref_count_;
+    uint32_t ref_count_{1};
   };
 
   // This must be held during both encode() and free().

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1057,7 +1057,7 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
 
   for (uint32_t choice_idx = 0; choice_idx < choice_count_; ++choice_idx) {
     const int rand_idx = random_.random() % hosts_to_use.size();
-    HostSharedPtr sampled_host = hosts_to_use[rand_idx];
+    const HostSharedPtr& sampled_host = hosts_to_use[rand_idx];
 
     if (candidate_host == nullptr) {
 

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -90,7 +90,7 @@ private:
 class SuccessRateMonitor {
 public:
   SuccessRateMonitor(envoy::data::cluster::v3::OutlierEjectionType ejection_type)
-      : ejection_type_(ejection_type), success_rate_(-1) {
+      : ejection_type_(ejection_type) {
     // Point the success_rate_accumulator_bucket_ pointer to a bucket.
     updateCurrentSuccessRateBucket();
   }
@@ -111,7 +111,7 @@ private:
   SuccessRateAccumulator success_rate_accumulator_;
   std::atomic<SuccessRateAccumulatorBucket*> success_rate_accumulator_bucket_;
   envoy::data::cluster::v3::OutlierEjectionType ejection_type_;
-  double success_rate_;
+  double success_rate_{-1};
 };
 
 class DetectorImpl;

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -92,8 +92,8 @@ int main(int argc, char** argv) {
                      runtime_feature_arg);
       return 1;
     }
-    const auto feature_name = runtime_feature_split[0];
-    const auto feature_val = runtime_feature_split[1];
+    const auto& feature_name = runtime_feature_split[0];
+    const auto& feature_val = runtime_feature_split[1];
     runtime.mergeValues({{feature_name, feature_val}});
   }
 

--- a/test/common/config/delta_subscription_impl_test.cc
+++ b/test/common/config/delta_subscription_impl_test.cc
@@ -12,6 +12,8 @@ namespace Envoy {
 namespace Config {
 namespace {
 
+using ::testing::Return;
+
 class DeltaSubscriptionImplTest : public DeltaSubscriptionTestHarness,
                                   public testing::TestWithParam<LegacyOrUnified> {
 protected:

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 using testing::InSequence;
+using testing::Return;
 
 namespace Envoy {
 namespace Config {

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -8,6 +8,8 @@ namespace Envoy {
 namespace Config {
 namespace {
 
+using ::testing::Return;
+
 class HttpSubscriptionImplTest : public testing::Test, public HttpSubscriptionTestHarness {};
 
 // Validate that we start the retry timer when there is no cluster.

--- a/test/common/config/new_grpc_mux_impl_test.cc
+++ b/test/common/config/new_grpc_mux_impl_test.cc
@@ -32,7 +32,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::DoAll;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;

--- a/test/common/config/registry_test.cc
+++ b/test/common/config/registry_test.cc
@@ -15,8 +15,6 @@ namespace Envoy {
 namespace Config {
 namespace {
 
-using ::testing::Optional;
-
 class InternalFactory : public Config::UntypedFactory {
 public:
   ~InternalFactory() override = default;

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -5,12 +5,10 @@
 
 using testing::_;
 using testing::AtLeast;
-using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
 using testing::Mock;
-using testing::Property;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -8,7 +8,6 @@ using testing::AtLeast;
 using testing::InSequence;
 using testing::InvokeWithoutArgs;
 using testing::Return;
-using testing::ReturnRef;
 
 namespace Envoy {
 namespace Http {

--- a/test/common/http/http1/http1_codec_impl_fuzz_test.cc
+++ b/test/common/http/http1/http1_codec_impl_fuzz_test.cc
@@ -14,7 +14,6 @@
 
 using testing::_;
 using testing::Invoke;
-using testing::InvokeWithoutArgs;
 
 namespace Envoy {
 namespace Http {

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -23,7 +23,6 @@
 using testing::_;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
-using testing::Return;
 
 namespace Envoy {
 namespace Http {

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -29,7 +29,6 @@ using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
-using testing::WithArgs;
 
 namespace Envoy {
 namespace Network {

--- a/test/common/network/io_socket_handle_impl_test.cc
+++ b/test/common/network/io_socket_handle_impl_test.cc
@@ -14,7 +14,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::DoAll;
 using testing::Eq;
 using testing::Invoke;
 using testing::NiceMock;

--- a/test/common/network/udp_fuzz.cc
+++ b/test/common/network/udp_fuzz.cc
@@ -20,6 +20,8 @@
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
 
+using testing::Return;
+
 namespace Envoy {
 namespace {
 

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -28,7 +28,6 @@
 
 using testing::_;
 using testing::Invoke;
-using testing::Return;
 
 namespace Envoy {
 namespace Quic {

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -40,7 +40,6 @@ using testing::_;
 using testing::AnyNumber;
 using testing::Invoke;
 using testing::Return;
-using testing::ReturnRef;
 
 namespace Envoy {
 namespace Quic {

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -50,7 +50,6 @@
 using quiche::GetLogger;
 using quiche::getVerbosityLogThreshold;
 using quiche::setVerbosityLogThreshold;
-using testing::_;
 using testing::HasSubstr;
 
 namespace quic {

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -34,6 +34,7 @@ using testing::_;
 using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
+using testing::Return;
 using testing::ReturnRef;
 using testing::SaveArg;
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -54,7 +54,6 @@
 
 using testing::_;
 using testing::AtLeast;
-using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;

--- a/test/common/router/router_test_base.h
+++ b/test/common/router/router_test_base.h
@@ -23,6 +23,7 @@ namespace Envoy {
 namespace Router {
 
 using ::testing::NiceMock;
+using ::testing::Return;
 
 class RouterTestFilter : public Filter {
 public:

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -27,6 +27,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Return;
 using testing::ReturnRef;
 using testing::StrictMock;
 

--- a/test/common/ssl/matching/inputs_integration_test.cc
+++ b/test/common/ssl/matching/inputs_integration_test.cc
@@ -15,6 +15,8 @@ namespace Envoy {
 namespace Ssl {
 namespace Matching {
 
+using ::testing::Return;
+
 constexpr absl::string_view yaml = R"EOF(
 matcher_tree:
   input:

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -6,6 +6,9 @@ namespace Envoy {
 namespace TcpProxy {
 
 namespace {
+
+using ::testing::Return;
+
 TEST(ConfigTest, DefaultTimeout) {
   const std::string yaml = R"EOF(
 stat_prefix: name

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -51,7 +51,6 @@ namespace {
 
 using ::testing::_;
 using ::testing::DoAll;
-using ::testing::Eq;
 using ::testing::InSequence;
 using ::testing::Invoke;
 using ::testing::InvokeWithoutArgs;

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -38,7 +38,6 @@ using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
-using testing::ReturnNew;
 using testing::ReturnRef;
 
 namespace Envoy {

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -34,8 +34,6 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
-using testing::StrEq;
-using testing::StrNe;
 
 namespace Envoy {
 namespace ConfigTest {

--- a/test/extensions/common/async_files/async_file_manager_factory_test.cc
+++ b/test/extensions/common/async_files/async_file_manager_factory_test.cc
@@ -24,6 +24,7 @@ namespace Extensions {
 namespace Common {
 namespace AsyncFiles {
 
+using ::testing::Return;
 using ::testing::StrictMock;
 
 class AsyncFileManagerFactoryTest : public ::testing::Test {

--- a/test/extensions/config/validators/minimum_clusters/minimum_clusters_validator_test.cc
+++ b/test/extensions/config/validators/minimum_clusters/minimum_clusters_validator_test.cc
@@ -13,6 +13,8 @@ namespace Config {
 namespace Validators {
 namespace {
 
+using ::testing::Return;
+
 class MinimumClustersValidatorTest : public testing::Test {
 public:
   MinimumClustersValidatorTest() {

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
@@ -19,6 +19,7 @@ using Common::Aws::MockSigner;
 using ::testing::An;
 using ::testing::InSequence;
 using ::testing::NiceMock;
+using ::testing::Return;
 using ::testing::StrictMock;
 
 class MockFilterConfig : public FilterConfig {

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -17,6 +17,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace {
 
+using ::testing::Return;
+
 // Limit the number of threads for the FileSystemBufferFilterConfig.manager_config.thread_count to
 // 8 to ensure test stays responsive.
 static const uint32_t kMaxAsyncFileManagerThreadCount = 8;

--- a/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
@@ -16,6 +16,8 @@
 #include "gtest/gtest.h"
 #include "utility.h"
 
+using testing::Return;
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -18,6 +18,7 @@
 using testing::_;
 using testing::Invoke;
 using testing::NiceMock;
+using testing::Return;
 using testing::StrictMock;
 
 namespace Envoy {

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_test.cc
@@ -14,6 +14,8 @@
 
 #include "gmock/gmock.h"
 
+using testing::Return;
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -47,6 +47,7 @@ using Http::LowerCaseString;
 using testing::AnyNumber;
 using testing::Eq;
 using testing::Invoke;
+using testing::Return;
 using testing::ReturnRef;
 using testing::Unused;
 

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
@@ -25,6 +25,7 @@ using Server::Configuration::MockFactoryContext;
 using ::testing::_;
 using ::testing::Invoke;
 using ::testing::NiceMock;
+using testing::Return;
 using Upstream::MockThreadLocalCluster;
 
 constexpr char DefaultConfig[] = R"EOF(

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -24,6 +24,7 @@ namespace {
 using envoy::extensions::filters::http::jwt_authn::JwtAuthnFuzzInput;
 using envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig;
 using testing::NiceMock;
+using testing::Return;
 
 class MockJwksUpstream {
 public:

--- a/test/extensions/filters/http/local_ratelimit/filter_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/filter_test.cc
@@ -9,6 +9,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Return;
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {

--- a/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter_test.cc
@@ -17,6 +17,8 @@ namespace PayloadToMetadataFilter {
 
 namespace {
 
+using ::testing::Return;
+
 MATCHER_P(MapEq, rhs, "") {
   const ProtobufWkt::Struct& obj = arg;
   EXPECT_TRUE(!rhs.empty());

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -37,6 +37,7 @@ using Common::AsyncFiles::MockAsyncFileManagerFactory;
 using ::envoy::extensions::filters::http::cache::v3::CacheConfig;
 using ::testing::HasSubstr;
 using ::testing::NiceMock;
+using ::testing::Return;
 using ::testing::StrictMock;
 
 absl::string_view yaml_config = R"(

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_quic_only_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_quic_only_test.cc
@@ -13,6 +13,8 @@ namespace Envoy {
 namespace Server {
 namespace {
 
+using ::testing::Return;
+
 class MockSupportsUdpGso : public Api::OsSysCallsImpl {
 public:
   MOCK_METHOD(bool, supportsUdpGso, (), (const));

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -36,6 +36,7 @@
 using Envoy::Protobuf::util::MessageDifferencer;
 using testing::EndsWith;
 using testing::NiceMock;
+using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -665,9 +665,10 @@ AssertionResult BaseIntegrationTest::waitForPortAvailable(uint32_t port,
   Event::TestTimeSystem::RealTimeBound bound(timeout);
   while (bound.withinBound()) {
     try {
-      Network::TcpListenSocket(Network::Utility::getAddressWithPort(
-                                   *Network::Test::getCanonicalLoopbackAddress(version_), port),
-                               nullptr, true);
+      Network::TcpListenSocket give_me_a_name(
+          Network::Utility::getAddressWithPort(
+              *Network::Test::getCanonicalLoopbackAddress(version_), port),
+          nullptr, true);
       return AssertionSuccess();
     } catch (const EnvoyException&) {
       // The nature of this function requires using a real sleep here.

--- a/test/integration/fake_resource_monitor.h
+++ b/test/integration/fake_resource_monitor.h
@@ -12,7 +12,7 @@ class FakeResourceMonitorFactory;
 class FakeResourceMonitor : public Server::ResourceMonitor {
 public:
   FakeResourceMonitor(Event::Dispatcher& dispatcher, FakeResourceMonitorFactory& factory)
-      : dispatcher_(dispatcher), factory_(factory), pressure_(0.0) {}
+      : dispatcher_(dispatcher), factory_(factory) {}
   // Server::ResourceMonitor
   ~FakeResourceMonitor() override;
   void updateResourceUsage(Server::ResourceUpdateCallbacks& callbacks) override;
@@ -24,7 +24,7 @@ public:
 private:
   Event::Dispatcher& dispatcher_;
   FakeResourceMonitorFactory& factory_;
-  double pressure_;
+  double pressure_{0.0};
 };
 
 class FakeResourceMonitorFactory : public Server::Configuration::ResourceMonitorFactory {

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1205,7 +1205,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLogging) {
 
   std::string log = waitForAccessLog(access_log_name_);
 
-  std::vector<std::string> metrics = absl::StrSplit(log, ",");
+  std::vector<std::string> metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
   EXPECT_GT(/* ROUNDTRIP_DURATION */ std::stoi(metrics.at(1)), 0);
@@ -1238,7 +1238,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingDisabled) {
 
   // Do not flush client acks.
   std::string log = waitForAccessLog(access_log_name_, 0, false, nullptr);
-  std::vector<std::string> metrics = absl::StrSplit(log, ",");
+  std::vector<std::string> metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
   EXPECT_EQ(/* ROUNDTRIP_DURATION */ metrics.at(1), "-");
@@ -1266,7 +1266,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithReset) {
   EXPECT_FALSE(response->complete());
 
   std::string log = waitForAccessLog(access_log_name_);
-  std::vector<std::string> metrics = absl::StrSplit(log, ",");
+  std::vector<std::string> metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
   EXPECT_EQ(/* ROUNDTRIP_DURATION */ metrics.at(1), "-");
@@ -1299,7 +1299,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithQuicReset) {
   ASSERT_TRUE(response->complete());
 
   std::string log = waitForAccessLog(access_log_name_);
-  std::vector<std::string> metrics = absl::StrSplit(log, ",");
+  std::vector<std::string> metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
   EXPECT_EQ(/* ROUNDTRIP_DURATION */ metrics.at(1), "-");
@@ -1341,7 +1341,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithInternalRedirect) {
 
   upstream_request_->encodeHeaders(redirect_response, true);
   std::string log = waitForAccessLog(access_log_name_, 0);
-  std::vector<std::string> metrics = absl::StrSplit(log, ",");
+  std::vector<std::string> metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 22);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
   // no roundtrip duration for internal redirect.
@@ -1373,7 +1373,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithInternalRedirect) {
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_2xx")->value());
 
   log = waitForAccessLog(access_log_name_, 1);
-  metrics = absl::StrSplit(log, ",");
+  metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 22);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
   // roundtrip duration populated on final log.

--- a/test/mocks/buffer/mocks.cc
+++ b/test/mocks/buffer/mocks.cc
@@ -17,12 +17,11 @@ MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase()
 }
 template <>
 MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()>, std::function<void()>,
-                                                  std::function<void()>)
-    : Buffer::OwnedImpl() {
+                                                  std::function<void()>) {
   ASSERT(0); // This constructor is not supported for OwnedImpl.
 }
 
-template <> MockBufferBase<Buffer::OwnedImpl>::MockBufferBase() : Buffer::OwnedImpl() {}
+template <> MockBufferBase<Buffer::OwnedImpl>::MockBufferBase() {}
 
 MockBufferFactory::MockBufferFactory() = default;
 MockBufferFactory::~MockBufferFactory() = default;

--- a/test/mocks/grpc/mocks.cc
+++ b/test/mocks/grpc/mocks.cc
@@ -2,6 +2,8 @@
 
 #include "test/mocks/http/mocks.h"
 
+using testing::Return;
+
 namespace Envoy {
 namespace Grpc {
 

--- a/test/mocks/http/conn_pool.cc
+++ b/test/mocks/http/conn_pool.cc
@@ -1,6 +1,7 @@
 #include "test/mocks/http/conn_pool.h"
 
 using testing::_;
+using testing::Return;
 using testing::SaveArg;
 
 namespace Envoy {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -38,8 +38,6 @@
 #include "absl/strings/str_join.h"
 #include "gmock/gmock.h"
 
-using testing::Return;
-
 namespace Envoy {
 namespace Http {
 

--- a/test/mocks/http/stateful_session.cc
+++ b/test/mocks/http/stateful_session.cc
@@ -1,6 +1,7 @@
 #include "test/mocks/http/stateful_session.h"
 
 using testing::_;
+using testing::Return;
 
 namespace Envoy {
 namespace Http {

--- a/test/mocks/server/factory_context.cc
+++ b/test/mocks/server/factory_context.cc
@@ -11,6 +11,7 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
+using ::testing::Return;
 using ::testing::ReturnRef;
 
 MockFactoryContext::MockFactoryContext()

--- a/test/mocks/server/listener_factory_context.cc
+++ b/test/mocks/server/listener_factory_context.cc
@@ -11,6 +11,7 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
+using ::testing::Return;
 using ::testing::ReturnRef;
 
 MockListenerFactoryContext::MockListenerFactoryContext()

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -10,7 +10,6 @@
 using testing::_;
 using testing::Const;
 using testing::Invoke;
-using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
 

--- a/test/mocks/tcp/mocks.cc
+++ b/test/mocks/tcp/mocks.cc
@@ -2,6 +2,7 @@
 
 #include "gmock/gmock.h"
 
+using testing::Return;
 using testing::ReturnRef;
 
 using testing::_;

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -26,7 +26,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::HasSubstr;
 using testing::StartsWith;
 
 namespace Envoy {

--- a/test/server/admin/stats_handler_test.cc
+++ b/test/server/admin/stats_handler_test.cc
@@ -15,13 +15,11 @@
 #include "test/test_common/utility.h"
 
 using testing::Combine;
-using testing::EndsWith;
 using testing::HasSubstr;
 using testing::InSequence;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
-using testing::StartsWith;
 using testing::Values;
 using testing::ValuesIn;
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -127,7 +127,7 @@ private:
 template <class ConfigType>
 class FakeResourceMonitorFactory : public Server::Configuration::ResourceMonitorFactory {
 public:
-  FakeResourceMonitorFactory(const std::string& name) : monitor_(nullptr), name_(name) {}
+  FakeResourceMonitorFactory(const std::string& name) : name_(name) {}
 
   Server::ResourceMonitorPtr
   createResourceMonitor(const Protobuf::Message&,
@@ -143,7 +143,7 @@ public:
 
   std::string name() const override { return name_; }
 
-  FakeResourceMonitor* monitor_; // not owned
+  FakeResourceMonitor* monitor_{nullptr}; // not owned
   const std::string name_;
 };
 
@@ -151,7 +151,7 @@ template <class ConfigType>
 class FakeProactiveResourceMonitorFactory
     : public Server::Configuration::ProactiveResourceMonitorFactory {
 public:
-  FakeProactiveResourceMonitorFactory(const std::string& name) : monitor_(nullptr), name_(name) {}
+  FakeProactiveResourceMonitorFactory(const std::string& name) : name_(name) {}
 
   Server::ProactiveResourceMonitorPtr
   createProactiveResourceMonitor(const Protobuf::Message&,
@@ -167,7 +167,7 @@ public:
 
   std::string name() const override { return name_; }
 
-  FakeProactiveResourceMonitor* monitor_; // not owned
+  FakeProactiveResourceMonitor* monitor_{nullptr}; // not owned
   const std::string name_;
 };
 

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -21,7 +21,6 @@ using testing::Invoke;
 using testing::InvokeWithoutArgs;
 using testing::NiceMock;
 using testing::Return;
-using testing::Throw;
 
 namespace Envoy {
 namespace Server {

--- a/test/tools/router_check/test/router_test.cc
+++ b/test/tools/router_check/test/router_test.cc
@@ -53,7 +53,7 @@ TEST(RouterCheckTest, RouterCheckTestRoutesFailuresTest) {
   const std::vector<envoy::RouterCheckToolSchema::ValidationItemResult> test_results =
       checktool.compareEntries(tests_filename_);
   EXPECT_EQ(test_results.size(), 1);
-  envoy::RouterCheckToolSchema::ValidationItemResult test_result = test_results[0];
+  const envoy::RouterCheckToolSchema::ValidationItemResult& test_result = test_results[0];
   std::string expected_result_str = R"pb(
       test_name: "ResponseHeaderMatches Failures"
       failure {


### PR DESCRIPTION
Skips diagnostics: readability-identifier-naming,
modernize-return-braced-init-list and a few paths.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
