### PR TITLE
[balsa] Enable custom request methods.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -23,30 +23,7 @@ constexpr absl::string_view kColonSlashSlash = "://";
 // Response must start with "HTTP".
 constexpr char kResponseFirstByte = 'H';
 
-// TODO(#18819): Add flag to support custom methods.
-bool isFirstCharacterOfValidMethod(char c) {
-  static constexpr char kValidFirstCharacters[] = {'A', 'B', 'C', 'D', 'G', 'H', 'L', 'M',
-                                                   'N', 'O', 'P', 'R', 'S', 'T', 'U'};
-
-  const auto* begin = &kValidFirstCharacters[0];
-  const auto* end = &kValidFirstCharacters[ABSL_ARRAYSIZE(kValidFirstCharacters) - 1] + 1;
-  return std::binary_search(begin, end, c);
-}
-
-bool isMethodValid(absl::string_view method) {
-  static constexpr absl::string_view kValidMethods[] = {
-      "ACL",       "BIND",    "CHECKOUT", "CONNECT", "COPY",       "DELETE",     "GET",
-      "HEAD",      "LINK",    "LOCK",     "MERGE",   "MKACTIVITY", "MKCALENDAR", "MKCOL",
-      "MOVE",      "MSEARCH", "NOTIFY",   "OPTIONS", "PATCH",      "POST",       "PROPFIND",
-      "PROPPATCH", "PURGE",   "PUT",      "REBIND",  "REPORT",     "SEARCH",     "SOURCE",
-      "SUBSCRIBE", "TRACE",   "UNBIND",   "UNLINK",  "UNLOCK",     "UNSUBSCRIBE"};
-
-  const auto* begin = &kValidMethods[0];
-  const auto* end = &kValidMethods[ABSL_ARRAYSIZE(kValidMethods) - 1] + 1;
-  return std::binary_search(begin, end, method);
-}
-
-// This method is crafted to match the URL validation behavior of the http-parser library.
+// This function is crafted to match the URL validation behavior of the http-parser library.
 bool isUrlValid(absl::string_view url, bool is_connect) {
   if (url.empty()) {
     return false;
@@ -155,11 +132,7 @@ size_t BalsaParser::execute(const char* slice, int len) {
   ASSERT(status_ != ParserStatus::Error);
 
   if (len > 0 && !first_byte_processed_) {
-    if (message_type_ == MessageType::Request && !isFirstCharacterOfValidMethod(*slice)) {
-      status_ = ParserStatus::Error;
-      error_message_ = "HPE_INVALID_METHOD";
-      return 0;
-    } else if (message_type_ == MessageType::Response && *slice != kResponseFirstByte) {
+    if (message_type_ == MessageType::Response && *slice != kResponseFirstByte) {
       status_ = ParserStatus::Error;
       error_message_ = "HPE_INVALID_CONSTANT";
       return 0;
@@ -258,11 +231,6 @@ void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
                                           absl::string_view request_uri,
                                           absl::string_view version_input) {
   if (status_ == ParserStatus::Error) {
-    return;
-  }
-  if (!isMethodValid(method_input)) {
-    status_ = ParserStatus::Error;
-    error_message_ = "HPE_INVALID_METHOD";
     return;
   }
   const bool is_connect = method_input == Headers::get().MethodValues.Connect;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1242,7 +1242,7 @@ TEST_P(Http1ServerConnectionImplTest, CustomMethod) {
     return;
   }
 
-  EXPECT_TRUE(status.ok());
+  ASSERT_TRUE(status.ok());
 
   TestRequestHeaderMapImpl expected_headers{
       {":authority", "example.com"}, {":path", "/"}, {":method", "BAD"}, {"foo", "bar"}};

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1035,7 +1035,7 @@ TEST_P(IntegrationTest, TestClientAllowChunkedLength) {
 TEST_P(IntegrationTest, BadFirstline) {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse(lookupPort("http"), "hello", &response);
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "hello\r\n", &response);
   EXPECT_THAT(response, StartsWith("HTTP/1.1 400 Bad Request\r\n"));
 }
 
@@ -1053,6 +1053,11 @@ TEST_P(IntegrationTest, MissingDelimiter) {
 }
 
 TEST_P(IntegrationTest, InvalidCharacterInFirstline) {
+  if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
+    // BalsaParser allows custom methods.
+    return;
+  }
+
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GE(T / HTTP/1.1\r\nHost: host\r\n\r\n",

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1053,10 +1053,12 @@ TEST_P(IntegrationTest, MissingDelimiter) {
 }
 
 TEST_P(IntegrationTest, InvalidCharacterInFirstline) {
+#ifndef ENVOY_ENABLE_UHV
   if (http1_implementation_ == Http1ParserImpl::BalsaParser) {
-    // BalsaParser allows custom methods.
+    // BalsaParser allows custom methods if UHV is enabled.
     return;
   }
+#endif
 
   initialize();
   std::string response;

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2374,19 +2374,15 @@ TEST_P(ProtocolIntegrationTest, LargeRequestMethod) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("400", response->headers().getStatusValue());
+  } else if (upstream_proto_rejects_large_method) {
+    auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+    ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("400", response->headers().getStatusValue());
   } else {
-    if (upstream_proto_rejects_large_method) {
-      auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
-      ASSERT_TRUE(
-          fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-      ASSERT_TRUE(response->waitForEndStream());
-      EXPECT_TRUE(response->complete());
-      EXPECT_EQ("400", response->headers().getStatusValue());
-    } else {
-      auto response =
-          sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
-      EXPECT_TRUE(response->complete());
-    }
+    auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+    EXPECT_TRUE(response->complete());
   }
 }
 


### PR DESCRIPTION
This long-standing feature request is one of the major drivers of the http-parser to Balsa migration.

There are two projects happening in parallel: HTTP/1 codec migration from http-parser to BalsaParser, and UHV (universal header validator).  http-parser rejects custom methods.  UHV has a configuration option to reject them, but allows them by default.  It is possible that BalsaParser will be deployed before UHV.  Since the status quo is to reject custom methods, and the end goal (when both Balsa and UHV have launched) is to have configurable behavior, it would be too risky to unconditinally allow custom methods in BalsaParser when UHV is disabled.  Therefore this PR changes BalsaParser (which currently rejects custom methods for parity with http-parser) to only allow custom methods when UHV is enabled.

Also remove a fistful of unnecessary absl::StrCat() calls from codec_impl_test.cc.

Tracking issue: #21245

Commit Message: [balsa] Enable custom request methods.
Additional Description:
Risk Level: low, changed code is protected by existing default-false runtime flag.
Testing: //test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser