### PR TITLE
ci: make the mobile compile options workflow run C++ tests

### DIFF
--- a/.github/workflows/compile_time_options.yml
+++ b/.github/workflows/compile_time_options.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cc_build:
+  cc_test:
     if: github.repository == 'envoyproxy/envoy'
-    name: cc_build
+    name: cc_test
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     container:
@@ -32,14 +32,14 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile && ./bazelw test \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --define=admin_html=enabled \
             --define=envoy_mobile_request_compression=disabled \
             --@envoy//bazel:http3=False \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //library/cc/...
+            //test/cc/...
   swift_build:
     if: github.repository == 'envoyproxy/envoy'
     name: swift_build

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -78,7 +78,11 @@ bool generatedStringMatchesGeneratedBoostrap(
 
 EngineBuilder::EngineBuilder(std::string config_template)
     : callbacks_(std::make_shared<EngineCallbacks>()), config_template_(config_template),
-      config_bootstrap_incompatible_(true) {}
+      config_bootstrap_incompatible_(true) {
+#ifndef ENVOY_ENABLE_QUIC
+  enable_http3_ = false;
+#endif
+}
 
 EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {
   // Using the default config template is bootstrap compatible.

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -329,12 +329,14 @@ TEST(TestConfig, DisableHttp3) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 
+#ifdef ENVOY_ENABLE_QUIC
   engine_builder.enableHttp3(false);
   config_str = engine_builder.generateConfigStr();
   ASSERT_THAT(
       config_str,
       Not(HasSubstr("envoy.extensions.filters.http.alternate_protocols_cache.v3.FilterConfig")));
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
+#endif
 }
 
 TEST(TestConfig, RemainingTemplatesThrows) {

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -324,8 +324,15 @@ TEST(TestConfig, DisableHttp3) {
   EngineBuilder engine_builder;
 
   std::string config_str = engine_builder.generateConfigStr();
+#ifdef ENVOY_ENABLE_QUIC
   ASSERT_THAT(config_str,
               HasSubstr("envoy.extensions.filters.http.alternate_protocols_cache.v3.FilterConfig"));
+#endif
+#ifndef ENVOY_ENABLE_QUIC
+  ASSERT_THAT(
+      config_str,
+      Not(HasSubstr("envoy.extensions.filters.http.alternate_protocols_cache.v3.FilterConfig")));
+#endif
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 


### PR DESCRIPTION
Currently, the `mobile_compile_time_options` workflow just builds the C++ library using the custom compile time options. However, this won't necessarily catch runtime errors (e.g. protoc validation errors). This commit changes the C++ build to run the C++ tests instead.

The new cc_test workflow also uncovered a bug related to enabling HTTP3 in the mobile EngineBuilder, which is fixed in 
this same commit.
