### PR TITLE
docker: Unify image names (part2)

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -196,7 +196,7 @@ fi
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
   build_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}")"
 
-  if ! is_windows && [[ "${BUILD_TYPE}" != *-google-vrp  && "${BUILD_TYPE}" != *-tools ]]; then
+  if ! is_windows; then
       build_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}")"
   fi
 done
@@ -214,7 +214,7 @@ fi
 
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
     push_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}")"
-    if ! is_windows && [[ "${BUILD_TYPE}" != *-google-vrp  && "${BUILD_TYPE}" != *-tools ]]; then
+    if ! is_windows; then
         push_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}")"
     fi
 
@@ -223,7 +223,7 @@ for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
         if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
             is_windows && docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
             push_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}" latest)"
-            if ! is_windows && [[ "${BUILD_TYPE}" != *-google-vrp  && "${BUILD_TYPE}" != *-tools ]]; then
+            if ! is_windows; then
                 push_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}" latest)"
             fi
         fi
@@ -232,7 +232,7 @@ for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
         RELEASE_LINE=$(echo "$VERSION" | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')
         is_windows && docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:v${RELEASE_LINE}"
         push_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}" "v${RELEASE_LINE}")"
-        if ! is_windows && [[ "${BUILD_TYPE}" != *-google-vrp  && "${BUILD_TYPE}" != *-tools ]]; then
+        if ! is_windows; then
             push_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}" "v${RELEASE_LINE}")"
         fi
     fi


### PR DESCRIPTION
Include `tools` and `google-vrp` images as variants.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
