### PR TITLE
network: share filter state objects always

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -888,6 +888,16 @@ ClientConnectionImpl::ClientConnectionImpl(
       stream_info_(dispatcher_.timeSource(), socket_->connectionInfoProviderSharedPtr()) {
 
   stream_info_.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
+
+  if (transport_options) {
+    for (const auto& object : transport_options->downstreamSharedFilterStateObjects()) {
+      // This does not throw as all objects are distinctly named and the stream info is empty.
+      stream_info_.filterState()->setData(object.name_, object.data_, object.state_type_,
+                                          StreamInfo::FilterState::LifeSpan::Connection,
+                                          object.stream_sharing_);
+    }
+  }
+
   // There are no meaningful socket options or source address semantics for
   // non-IP sockets, so skip.
   if (socket_->connectionInfoProviderSharedPtr()->remoteAddress()->ip() == nullptr) {
@@ -922,15 +932,6 @@ ClientConnectionImpl::ClientConnectionImpl(
 
       // Trigger a write event to close this connection out-of-band.
       ioHandle().activateFileEvents(Event::FileReadyType::Write);
-    }
-  }
-
-  if (transport_options) {
-    for (const auto& object : transport_options->downstreamSharedFilterStateObjects()) {
-      // This does not throw as all objects are distinctly named and the stream info is empty.
-      stream_info_.filterState()->setData(object.name_, object.data_, object.state_type_,
-                                          StreamInfo::FilterState::LifeSpan::Connection,
-                                          object.stream_sharing_);
     }
   }
 }

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -137,12 +137,12 @@ public:
   Buffer::Instance& readBuffer() { return *read_buffer_; }
 };
 
-class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {
+class ConnectionImplTestBase {
 protected:
-  ConnectionImplTest()
+  ConnectionImplTestBase()
       : api_(Api::createApiForTest(time_system_)), stream_info_(time_system_, nullptr) {}
 
-  ~ConnectionImplTest() override {
+  virtual ~ConnectionImplTestBase() {
     EXPECT_TRUE(timer_destroyed_ || timer_ == nullptr);
     if (!timer_destroyed_) {
       delete timer_;
@@ -153,12 +153,11 @@ protected:
     return Network::Test::createRawBufferSocket();
   }
 
-  void setUpBasicConnection() {
+  void setUpBasicConnectionWithAddress(const Address::InstanceConstSharedPtr& address) {
     if (dispatcher_ == nullptr) {
       dispatcher_ = api_->allocateDispatcher("test_thread");
     }
-    socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
-        Network::Test::getCanonicalLoopbackAddress(GetParam()));
+    socket_ = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(address);
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, runtime_, true, false);
     client_connection_ = std::make_unique<Network::TestClientConnectionImpl>(
         *dispatcher_, socket_->connectionInfoProvider().localAddress(), source_address_,
@@ -295,6 +294,14 @@ protected:
   Socket::OptionsSharedPtr socket_options_;
   StreamInfo::StreamInfoImpl stream_info_;
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options_ = nullptr;
+};
+
+class ConnectionImplTest : public ConnectionImplTestBase,
+                           public testing::TestWithParam<Address::IpVersion> {
+protected:
+  void setUpBasicConnection() {
+    setUpBasicConnectionWithAddress(Network::Test::getCanonicalLoopbackAddress(GetParam()));
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectionImplTest,
@@ -3086,8 +3093,23 @@ TEST_F(InternalClientConnectionImplTest,
       "");
 }
 
-class ClientConnectionWithCustomRawBufferSocketTest : public ConnectionImplTest {
+class ClientConnectionWithCustomRawBufferSocketTest : public ConnectionImplTestBase,
+                                                      public testing::TestWithParam<Address::Type> {
 protected:
+  void setUpBasicConnection() {
+    Address::InstanceConstSharedPtr address;
+    switch (GetParam()) {
+    case Address::Type::Pipe:
+      address = Utility::resolveUrl("unix://" + path_);
+      break;
+    case Address::Type::Ip:
+    default:
+      address = Network::Test::getCanonicalLoopbackAddress(Address::IpVersion::v4);
+      break;
+    }
+    setUpBasicConnectionWithAddress(address);
+  }
+
   class TestRawBufferSocket : public RawBufferSocket {
   public:
     bool compareCallbacks(TransportSocketCallbacks* callback) const {
@@ -3103,11 +3125,13 @@ protected:
     Network::TestClientConnectionImpl* client_conn_impl = testClientConnection();
     return dynamic_cast<TestRawBufferSocket*>(client_conn_impl->transportSocket().get());
   }
+
+private:
+  const std::string path_{TestEnvironment::unixDomainSocketPath("foo")};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClientConnectionWithCustomRawBufferSocketTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
+                         testing::ValuesIn({Address::Type::Ip, Address::Type::Pipe}));
 
 class TestObject : public StreamInfo::FilterState::Object {};
 


### PR DESCRIPTION
Commit Message: Move sharing code to support internal listeners. Because of hashing, the downstream filters can only use the upstream filter state to access the objects shared with the upstream internal listener. This allows easy access from the downstream filters for the back-propagated information.
Additional Description: Example:

HTTP Listener 1 writes a shared object `x_i` per request,
Cluster 1 has internal endpoint for listener 2. One of `x_i` objects from the transport options is written.
Listener 2 writes CONNECT response headers back to `x_i` from cluster 1.

Because the upstream is shared, HTTP filter on listener 1 should consult the connection filter state of listener 2 for the tunnel headers. But because of the user space socket, it's not directly accessible. The work around, is to create shared place holders that would be available in the upstream cluster 1 connection filter state.

Risk Level: low
Testing: regression
Docs Changes: none
Release Notes: none