### PR TITLE
examples: Add locality_weighted_lb_config to locality-load-balancing example

### DIFF
--- a/docs/root/start/sandboxes/locality_load_balancing.rst
+++ b/docs/root/start/sandboxes/locality_load_balancing.rst
@@ -42,6 +42,9 @@ To build this sandbox example and start the example services, run the following 
 
 The locality configuration is set in the client container via static Envoy configuration file. Please refer to the ``cluster`` section of the :download:`proxy configuration <_include/locality-load-balancing/envoy-proxy.yaml>` file.
 
+.. note::
+    The ``locality_weighted_lb_config`` must be set in ``common_lb_config`` for the ``load_balancing_weight`` to be used.
+
 Step 2: Scenario with one replica in the highest priority locality
 ******************************************************************
 

--- a/examples/locality-load-balancing/envoy-proxy.yaml
+++ b/examples/locality-load-balancing/envoy-proxy.yaml
@@ -39,6 +39,8 @@ static_resources:
   - name: backend
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
+    common_lb_config:
+      locality_weighted_lb_config: {} # Must be set for load_balancing_weight to be used
     health_checks:
     - interval: 2s
       timeout: 3s

--- a/examples/locality-load-balancing/envoy-proxy.yaml
+++ b/examples/locality-load-balancing/envoy-proxy.yaml
@@ -40,7 +40,7 @@ static_resources:
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     common_lb_config:
-      locality_weighted_lb_config: {} # Must be set for load_balancing_weight to be used
+      locality_weighted_lb_config: {}
     health_checks:
     - interval: 2s
       timeout: 3s


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add locality_weighted_lb_config to locality-load-balancing example
Additional Description: For the load_balancing_weight option to be used, this option must be set. Discussed in https://github.com/envoyproxy/envoy/issues/25692
Risk Level: None
Testing:
Docs Changes: 
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]


Wasn't sure if there was a good spot to update the docs. The page on the locality weighted load balancer does describe that you need to set this [field](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight#arch-overview-load-balancing-locality-weighted-lb:~:text=Locality%20weighted%20load%20balancing%20is%20configured%20by%20setting%20locality_weighted_lb_config%20in%20the%20cluster), it was just user error in not knowing that you need to have the `{}` present. :) 