### PR TITLE
[ZK filter] Implement ZK filter buffer

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -543,6 +543,8 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
     if (has_full_packets) {
       offset -= INT_LENGTH + len;
       // Decode full packets.
+      temp_data.reserve(offset);
+      temp_data.resize(offset);
       data.copyOut(0, offset, temp_data.data());
       Buffer::OwnedImpl full_packets;
       full_packets.add(temp_data.data(), temp_data.length());
@@ -550,10 +552,14 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
       // Drain the ZooKeeper filter buffer.
       zk_filter_buffer.drain(zk_filter_buffer_len);
       // Copy out the rest of the data to the ZooKeeper filter buffer.
+      temp_data.reserve(data_len - offset);
+      temp_data.resize(data_len - offset);
       data.copyOut(offset, data_len - offset, temp_data.data());
       zk_filter_buffer.add(temp_data.data(), temp_data.length());
     } else {
       // Copy out all the new data to the ZooKeeper filter buffer.
+      temp_data.reserve(data_len - zk_filter_buffer_len);
+      temp_data.resize(data_len - zk_filter_buffer_len);
       data.copyOut(zk_filter_buffer_len, data_len - zk_filter_buffer_len, temp_data.data());
       zk_filter_buffer.add(temp_data.data(), temp_data.length());
     }

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -537,6 +537,11 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
 
   if (offset == data_len) {
     decode(data, dtype);
+
+    if (zk_filter_buffer_len > 0) {
+      // Drain the ZooKeeper filter buffer.
+      zk_filter_buffer.drain(zk_filter_buffer_len);
+    }
   } else if (offset > data_len) {
     std::string temp_data;
 
@@ -549,8 +554,10 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
       Buffer::OwnedImpl full_packets;
       full_packets.add(temp_data.data(), temp_data.length());
       decode(full_packets, dtype);
+
       // Drain the ZooKeeper filter buffer.
       zk_filter_buffer.drain(zk_filter_buffer_len);
+
       // Copy out the rest of the data to the ZooKeeper filter buffer.
       temp_data.reserve(data_len - offset);
       temp_data.resize(data_len - offset);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -489,7 +489,7 @@ Network::FilterStatus DecoderImpl::decodeAndBuffer(Buffer::Instance& data,
   uint32_t data_len = data.length();
   uint32_t zk_filter_buffer_len = zk_filter_buffer.length();
 
-  if (zk_filter_buffer.empty()) {
+  if (zk_filter_buffer_len == 0) {
     decodeAndBufferHelper(data, zk_filter_buffer, dtype);
     return Network::FilterStatus::Continue;
   }

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -486,28 +486,29 @@ Network::FilterStatus DecoderImpl::onWrite(Buffer::Instance& data) {
 Network::FilterStatus DecoderImpl::decodeAndBuffer(Buffer::Instance& data,
                                                    Buffer::OwnedImpl& zk_filter_buffer,
                                                    DecodeType dtype) {
-  uint32_t zk_filter_buffer_len = zk_filter_buffer.length();
   uint32_t data_len = data.length();
+  uint32_t zk_filter_buffer_len = zk_filter_buffer.length();
 
   if (zk_filter_buffer_len > 0) {
     if (zk_filter_buffer_len + data_len > INT_LENGTH) {
       // Prepend ZooKeeper filter buffer to current buffer.
       data.prepend(zk_filter_buffer);
-      decodeAndBufferHelper(data, data_len, zk_filter_buffer, zk_filter_buffer_len, dtype);
+      decodeAndBufferHelper(data, zk_filter_buffer, dtype);
       // Drain the prepended ZooKeeper filter buffer.
       data.drain(zk_filter_buffer_len);
     } else {
       zk_filter_buffer.add(data);
     }
   } else if (zk_filter_buffer_len == 0) {
-    decodeAndBufferHelper(data, data_len, zk_filter_buffer, zk_filter_buffer_len, dtype);
+    decodeAndBufferHelper(data, zk_filter_buffer, dtype);
   }
   return Network::FilterStatus::Continue;
 }
 
-void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, uint32_t data_len,
-                                        Buffer::OwnedImpl& zk_filter_buffer,
-                                        uint32_t zk_filter_buffer_len, DecodeType dtype) {
+void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
+                                        DecodeType dtype) {
+  uint32_t data_len = data.length();
+  uint32_t zk_filter_buffer_len = zk_filter_buffer.length();
   uint64_t offset = 0;
   uint32_t len = 0;
   // Boolean to check whether there is at least one full packet in the buffer.

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -494,9 +494,12 @@ Network::FilterStatus DecoderImpl::decodeAndBuffer(Buffer::Instance& data,
     return Network::FilterStatus::Continue;
   }
 
-  // The length of ZooKeeper filter buffer and network filter buffer should be bigger than 4 bytes in order to peek the packet length.
+  // The length of ZooKeeper filter buffer and network filter buffer should be bigger than 4 bytes
+  // in order to peek the packet length.
   if (zk_filter_buffer_len + data_len > INT_LENGTH) {
-    // ZooKeeper filter buffer contains partial packet data from the previous network filter buffer. Prepending ZooKeeper filter buffer to the current network filter buffer can help to generate full packets.
+    // ZooKeeper filter buffer contains partial packet data from the previous network filter buffer.
+    // Prepending ZooKeeper filter buffer to the current network filter buffer can help to generate
+    // full packets.
     data.prepend(zk_filter_buffer);
     decodeAndBufferHelper(data, zk_filter_buffer, dtype);
     // Drain the prepended ZooKeeper filter buffer.
@@ -515,14 +518,16 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
   uint32_t zk_filter_buffer_len = zk_filter_buffer.length();
   uint64_t offset = 0;
   uint32_t len = 0;
-  // Boolean to check whether there is at least one full packet in the network filter buffer (to which the ZooKeeper filter buffer is prepended).
+  // Boolean to check whether there is at least one full packet in the network filter buffer (to
+  // which the ZooKeeper filter buffer is prepended).
   bool has_full_packets = false;
 
   while (offset < data_len) {
     try {
       // Peek packet length.
       len = helper_.peekInt32(data, offset);
-      ensureMinLength(len, dtype == DecodeType::READ ? XID_LENGTH + INT_LENGTH : XID_LENGTH + ZXID_LENGTH + INT_LENGTH);
+      ensureMinLength(len, dtype == DecodeType::READ ? XID_LENGTH + INT_LENGTH
+                                                     : XID_LENGTH + ZXID_LENGTH + INT_LENGTH);
       ensureMaxLength(len);
       offset += len;
       if (offset <= data_len) {
@@ -539,7 +544,12 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
     decode(data, dtype);
 
     if (zk_filter_buffer_len > 0) {
-      // After prepending the ZooKeeper filter buffer to the network filter buffer, the network filter buffer here includes one or more full packets without any partial data, the decoder is able to decode the entire network filter buffer. So the we need to drain the ZooKeeper filter buffer here, since its data has been decoded already. Otherwise, the ZooKeeper filter will prepend the ZooKeeper filter buffer to the network filter buffer again next time, which is not what we want.
+      // After prepending the ZooKeeper filter buffer to the network filter buffer, the network
+      // filter buffer here includes one or more full packets without any partial data, the decoder
+      // is able to decode the entire network filter buffer. So the we need to drain the ZooKeeper
+      // filter buffer here, since its data has been decoded already. Otherwise, the ZooKeeper
+      // filter will prepend the ZooKeeper filter buffer to the network filter buffer again next
+      // time, which is not what we want.
       zk_filter_buffer.drain(zk_filter_buffer_len);
     }
   } else if (offset > data_len) {
@@ -553,7 +563,12 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImp
       Buffer::OwnedImpl full_packets;
       full_packets.add(temp_data.data(), temp_data.length());
       decode(full_packets, dtype);
-      // After prepending the ZooKeeper filter buffer to the network filter buffer, the network filter buffer here includes one or more full packets with partial data of a packet, the decoder is able to decode all full packets. So we need to drain the ZooKeeper filter buffer here, since its data has been decoded already. Otherwise, the ZooKeeper filter will prepend the ZooKeeper filter buffer to the network filter buffer again next time, which is not what we want.
+      // After prepending the ZooKeeper filter buffer to the network filter buffer, the network
+      // filter buffer here includes one or more full packets with partial data of a packet, the
+      // decoder is able to decode all full packets. So we need to drain the ZooKeeper filter buffer
+      // here, since its data has been decoded already. Otherwise, the ZooKeeper filter will prepend
+      // the ZooKeeper filter buffer to the network filter buffer again next time, which is not what
+      // we want.
       zk_filter_buffer.drain(zk_filter_buffer_len);
 
       // Copy out the rest of the data to the ZooKeeper filter buffer.

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -142,10 +142,10 @@ private:
   // (2) decodes all full packet(s),
   // (3) adds the rest of the data to the ZooKeeper filter buffer,
   // (4) removes the prepended data.
-  Network::FilterStatus decodeAndBuffer(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
-                                        DecodeType dtype);
-  void decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
-                             DecodeType dtype);
+  Network::FilterStatus decodeAndBuffer(Buffer::Instance& data, DecodeType dtype,
+                                        Buffer::OwnedImpl& zk_filter_buffer);
+  void decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype,
+                             Buffer::OwnedImpl& zk_filter_buffer);
   void decode(Buffer::Instance& data, DecodeType dtype);
   void decodeOnData(Buffer::Instance& data, uint64_t& offset);
   void decodeOnWrite(Buffer::Instance& data, uint64_t& offset);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -138,10 +138,10 @@ private:
   };
 
   // decodeAndBuffer
-  //       (1) prepends previous partial data to the current buffer,
-  //       (2) decodes all full packet(s),
-  //       (3) adds the rest of the data to the ZooKeeper filter buffer,
-  //       (4) removes the prepended data.
+  // (1) prepends previous partial data to the current buffer,
+  // (2) decodes all full packet(s),
+  // (3) adds the rest of the data to the ZooKeeper filter buffer,
+  // (4) removes the prepended data.
   Network::FilterStatus decodeAndBuffer(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
                                         DecodeType dtype);
   void decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -144,8 +144,7 @@ private:
   //       (4) removes the prepended data.
   Network::FilterStatus decodeAndBuffer(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
                                         DecodeType dtype);
-  void decodeAndBufferHelper(Buffer::Instance& data, uint32_t data_len,
-                             Buffer::OwnedImpl& zk_filter_buffer, uint32_t zk_filter_buffer_len,
+  void decodeAndBufferHelper(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
                              DecodeType dtype);
   void decode(Buffer::Instance& data, DecodeType dtype);
   void decodeOnData(Buffer::Instance& data, uint64_t& offset);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -137,9 +137,16 @@ private:
     MonotonicTime start_time;
   };
 
-  // decodeAfterBuffer waits until the buffer contains all data for one or more packets before
-  // decoding.
-  Network::FilterStatus decodeAfterBuffer(Buffer::Instance& data, DecodeType dtype);
+  // decodeAndBuffer
+  //       (1) prepends previous partial data to the current buffer,
+  //       (2) decodes all full packet(s),
+  //       (3) adds the rest of the data to the ZooKeeper filter buffer,
+  //       (4) removes the prepended data.
+  Network::FilterStatus decodeAndBuffer(Buffer::Instance& data, Buffer::OwnedImpl& zk_filter_buffer,
+                                        DecodeType dtype);
+  void decodeAndBufferHelper(Buffer::Instance& data, uint32_t data_len,
+                             Buffer::OwnedImpl& zk_filter_buffer, uint32_t zk_filter_buffer_len,
+                             DecodeType dtype);
   void decode(Buffer::Instance& data, DecodeType dtype);
   void decodeOnData(Buffer::Instance& data, uint64_t& offset);
   void decodeOnWrite(Buffer::Instance& data, uint64_t& offset);
@@ -175,6 +182,8 @@ private:
   BufferHelper helper_;
   TimeSource& time_source_;
   absl::node_hash_map<int32_t, RequestBegin> requests_by_xid_;
+  Buffer::OwnedImpl zk_filter_read_buffer_;
+  Buffer::OwnedImpl zk_filter_write_buffer_;
 };
 
 } // namespace ZooKeeperProxy

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -1086,7 +1086,7 @@ TEST_F(ZooKeeperFilterTest, OneRequestWithMultipleOnDataCalls) {
   // Request.
   Buffer::OwnedImpl data =
       encodeCreateRequestWithPartialData("/foo", "bar", false, enumToSignedInt(OpCodes::Create));
-  EXPECT_EQ(Envoy::Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(data, false));
   EXPECT_EQ(0UL, config_->stats().create_rq_.value());
   EXPECT_EQ(0UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
@@ -1115,7 +1115,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithMultipleOnDataCalls) {
   // Request.
   Buffer::OwnedImpl data =
       encodeCreateRequestWithPartialData("/foo", "bar", false, enumToSignedInt(OpCodes::Create));
-  EXPECT_EQ(Envoy::Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(data, false));
   EXPECT_EQ(0UL, config_->stats().create_rq_.value());
   EXPECT_EQ(0UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
@@ -1130,7 +1130,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithMultipleOnDataCalls) {
   data.writeBEInt<int32_t>(1000);
   data.writeBEInt<int32_t>(enumToSignedInt(OpCodes::Create));
 
-  EXPECT_EQ(Envoy::Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(data, false));
   EXPECT_EQ(0UL, config_->stats().create_rq_.value());
   EXPECT_EQ(0UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
@@ -1167,7 +1167,7 @@ TEST_F(ZooKeeperFilterTest, OneResponseWithMultipleOnWriteCalls) {
 
   // Response.
   Buffer::OwnedImpl resp_data = encodeResponseWithPartialData(1000, 2000, 0);
-  EXPECT_EQ(Envoy::Network::FilterStatus::StopIteration, filter_->onWrite(resp_data, false));
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onWrite(resp_data, false));
   EXPECT_EQ(0UL, config_->stats().getdata_resp_.value());
   EXPECT_EQ(0UL, config_->stats().response_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
@@ -1197,7 +1197,7 @@ TEST_F(ZooKeeperFilterTest, MultipleResponsesWithMultipleOnWriteCalls) {
 
   // Response.
   Buffer::OwnedImpl resp_data = encodeResponseWithPartialData(1000, 2000, 0);
-  EXPECT_EQ(Envoy::Network::FilterStatus::StopIteration, filter_->onWrite(resp_data, false));
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onWrite(resp_data, false));
   EXPECT_EQ(0UL, config_->stats().getdata_resp_.value());
   EXPECT_EQ(0UL, config_->stats().response_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
@@ -1209,7 +1209,7 @@ TEST_F(ZooKeeperFilterTest, MultipleResponsesWithMultipleOnWriteCalls) {
   resp_data.writeBEInt<uint32_t>(1001);
   resp_data.writeBEInt<uint64_t>(2001);
 
-  EXPECT_EQ(Envoy::Network::FilterStatus::StopIteration, filter_->onWrite(resp_data, false));
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onWrite(resp_data, false));
   EXPECT_EQ(0UL, config_->stats().getdata_resp_.value());
   EXPECT_EQ(0UL, config_->stats().response_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -1141,7 +1141,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithOneOnDataCall) {
   EXPECT_EQ(71UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
 
-  // Response.
+  // Responses.
   testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
                config_->stats().create_resp_, 1000, 2000);
   testResponse({{{"opname", "create_resp"}, {"zxid", "2001"}, {"error", "0"}}, {{"bytes", "20"}}},
@@ -1196,7 +1196,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithMultipleOnDataCalls) {
   EXPECT_EQ(71UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
 
-  // Response.
+  // Responses.
   testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
                config_->stats().create_resp_, 1000, 2000);
   testResponse({{{"opname", "create_resp"}, {"zxid", "2001"}, {"error", "0"}}, {{"bytes", "20"}}},
@@ -1236,7 +1236,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithMultipleOnDataCalls2) {
   EXPECT_EQ(108UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
 
-  // Response.
+  // Responses.
   testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
                config_->stats().create_resp_, 1000, 2000);
   testResponse({{{"opname", "create_resp"}, {"zxid", "2001"}, {"error", "0"}}, {{"bytes", "20"}}},
@@ -1277,7 +1277,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithMultipleOnDataCalls3) {
   EXPECT_EQ(108UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
 
-  // Response.
+  // Responses.
   testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
                config_->stats().create_resp_, 1000, 2000);
   testResponse({{{"opname", "create_resp"}, {"zxid", "2001"}, {"error", "0"}}, {{"bytes", "20"}}},
@@ -1330,7 +1330,7 @@ TEST_F(ZooKeeperFilterTest, MultipleRequestsWithMultipleOnDataCalls4) {
   EXPECT_EQ(108UL, config_->stats().request_bytes_.value());
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
 
-  // Response.
+  // Responses.
   testResponse({{{"opname", "create_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
                config_->stats().create_resp_, 1000, 2000);
   testResponse({{{"opname", "create_resp"}, {"zxid", "2001"}, {"error", "0"}}, {{"bytes", "20"}}},


### PR DESCRIPTION
Commit Message: [ZK filter] Implement ZK filter buffer
Additional Description: Whenever new data appended to the read/write buffer, in general, the ZK filter will 
(1) prepends previous partial data fetched from the ZK filter buffer to the read/write buffer,
(2) decodes all full packet(s),
(3) adds the rest of the data to the ZooKeeper filter buffer,
(4) removes the prepended data.
In this case, the ZK filter will not prevent packets from being sent to the ZK service.

- Scenario 1:
```
| REQ 1 ---------- |
(onData1 )(onData2 )
```
  - The `onData1` data will be copied to ZK filter buffer since it is not a full packet.
  - When `onData2` data comes, ZK filter will
    - prepend data from the ZK filter buffer to `onData2` data
    - decode the REQ1 data since it is a full packet,
    - drain ZK filter buffer,
    - remove the prepended data to avoid messing up the next filter.

- Scenario 2:
```
| REQ 1 ----------  |  REQ 2 ----------|
(onData1   )(onData2    )(onData3      )
```
  - The `onData1` data will be copied to the ZK filter buffer since it is not a full packet.
  - When `onData2` data comes, ZK filter will
    - prepend data from the ZK filter buffer to `onData2` data,
    - decode the REQ1 data since it is a full packet,
    - update the ZK filter buffer with the REQ2-related `onData2` data,
    - remove the prepended data to avoid messing up the next filter.
  - When `onData3` data comes, ZK filter will
    - prepend data from the ZK filter buffer to `onData3` data,
    - decode the REQ2 data since it is a full packet,
    - drain the ZK filter buffer,
    - remove the prepended data to avoid messing up the next filter.

> Note. Responses with `onWrite` methods should be similar to above examples.

Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #Issue: #25482 and #25024