### PR TITLE
Revert "Revert "add idle active hc for TCP/HTTP/GRPC (#24903)" (#25694)" 

### DIFF
--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -60,7 +60,7 @@ message HealthStatusSet {
       [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 }
 
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message HealthCheck {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.HealthCheck";
 
@@ -414,4 +414,13 @@ message HealthCheck {
   // the cluster's :ref:`transport socket <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket>`
   // will be used for health check socket configuration.
   google.protobuf.Struct transport_socket_match_criteria = 23;
+
+  // When the health status of a host is healthy, if this field is enabled, when envoy wants to send an active health check packet to a target host, it will first check whether
+  // there was successful non-health check traffic that targeted the host during the previous interval. If there was successful non-health check traffic, Envoy will not send a health check packet.
+  // For HTTP, if the traffic response is 2xx, it will be considered as successful traffic.
+  // For TCP, if any TCP connections successfully connect, it will be considered as successful traffic.
+  // For gRPC, if grpc_status is not one of ( DeadlineExceeded, Unimplemented, Internal, Unavailable, Unknown, DataLoss), it will be considered as successful traffic. Refer to UpstreamEndpointStats.
+  // For Custom health check, this option can not be used.
+  // The default value is false.
+  bool disable_health_check_if_active_traffic = 25;
 }

--- a/envoy/upstream/BUILD
+++ b/envoy/upstream/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
         "//envoy/stats:primitive_stats_macros",
         "//envoy/stats:stats_macros",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/data/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -7,6 +7,7 @@
 
 #include "envoy/common/time.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/data/core/v3/health_check_event.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/transport_socket.h"
 #include "envoy/stats/primitive_stats_macros.h"
@@ -202,6 +203,19 @@ public:
    *         healthy state via an active healthchecking.
    */
   virtual absl::optional<MonotonicTime> lastHcPassTime() const PURE;
+
+  /**
+   * @return last successful non-health check traffic time
+   */
+  virtual MonotonicTime lastSuccessfulTrafficTime(
+      envoy::data::core::v3::HealthCheckerType health_checker_type) const PURE;
+
+  /**
+   * set last successful non-health check traffic time
+   */
+  virtual void
+  setLastSuccessfulTrafficTime(envoy::data::core::v3::HealthCheckerType health_checker_type,
+                               MonotonicTime last_successful_traffic_time) const PURE;
 };
 
 using HostDescriptionConstSharedPtr = std::shared_ptr<const HostDescription>;

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -206,6 +206,8 @@ void ConnPoolImplBase::attachStreamToClient(Envoy::ConnectionPool::ActiveClient&
   traffic_stats.upstream_rq_total_.inc();
   traffic_stats.upstream_rq_active_.inc();
   host_->cluster().resourceManager(priority_).requests().inc();
+  host_->setLastSuccessfulTrafficTime(envoy::data::core::v3::HealthCheckerType::TCP,
+                                      dispatcher_.timeSource().monotonicTime());
 
   onPoolReady(client, context);
 }

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -336,6 +336,7 @@ envoy_cc_library(
         "//source/common/upstream:upstream_http_factory_context_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "@envoy_api//envoy/data/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/upstream_codec/v3:pkg_cc_proto",
     ],

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/data/core/v3/health_check_event.pb.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/grpc/status.h"
@@ -366,6 +367,11 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
     }
     if (upstream_host && Http::CodeUtility::is5xx(response_status_code)) {
       upstream_host->stats().rq_error_.inc();
+    }
+    if (upstream_host && Http::CodeUtility::is2xx(response_status_code)) {
+      upstream_host->setLastSuccessfulTrafficTime(
+          envoy::data::core::v3::HealthCheckerType::HTTP,
+          callbacks_->dispatcher().timeSource().monotonicTime());
     }
   }
 }
@@ -1368,6 +1374,9 @@ void Filter::handleNon5xxResponseHeaders(absl::optional<Grpc::Status::GrpcStatus
     if (end_stream) {
       if (grpc_status && !Http::CodeUtility::is5xx(grpc_to_http_status)) {
         upstream_request.upstreamHost()->stats().rq_success_.inc();
+        upstream_request.upstreamHost()->setLastSuccessfulTrafficTime(
+            envoy::data::core::v3::HealthCheckerType::GRPC,
+            callbacks_->dispatcher().timeSource().monotonicTime());
       } else {
         upstream_request.upstreamHost()->stats().rq_error_.inc();
       }
@@ -1616,6 +1625,9 @@ void Filter::onUpstreamTrailers(Http::ResponseTrailerMapPtr&& trailers,
     if (grpc_status &&
         !Http::CodeUtility::is5xx(Grpc::Utility::grpcToHttpStatus(grpc_status.value()))) {
       upstream_request.upstreamHost()->stats().rq_success_.inc();
+      upstream_request.upstreamHost()->setLastSuccessfulTrafficTime(
+          envoy::data::core::v3::HealthCheckerType::GRPC,
+          callbacks_->dispatcher().timeSource().monotonicTime());
     } else {
       upstream_request.upstreamHost()->stats().rq_error_.inc();
     }

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -429,7 +429,7 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::onIntervalBase() {
         host_->lastSuccessfulTrafficTime(parent_.healthCheckerType());
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
         time_source_.monotonicTime() - traffic_successful_time);
-    if (duration.count() < parent_.interval_.count()) {
+    if (duration.count() <= parent_.interval_.count()) {
       // During the time, there was already successful non-health check traffic for the host, no
       // need to send HC packet
       parent_.stats_.attempt_.inc();

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -122,6 +122,7 @@ protected:
   virtual envoy::data::core::v3::HealthCheckerType healthCheckerType() const PURE;
 
   const bool always_log_health_check_failures_;
+  const bool disable_health_check_if_active_traffic_;
   const Cluster& cluster_;
   Event::Dispatcher& dispatcher_;
   const std::chrono::milliseconds timeout_;

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -131,6 +131,10 @@ HealthCheckerSharedPtr HealthCheckerFactory::create(
     std::unique_ptr<Server::Configuration::HealthCheckerFactoryContext> context(
         new HealthCheckerFactoryContextImpl(cluster, runtime, dispatcher, std::move(event_logger),
                                             validation_visitor, api));
+    if (health_check_config.disable_health_check_if_active_traffic()) {
+      throw EnvoyException(
+          "disable_health_check_if_active_traffic only supports TCP/HTTP/gRPC healthchecking");
+    }
     return factory.createCustomHealthChecker(health_check_config, *context);
   }
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -229,6 +229,36 @@ public:
   resolveTransportSocketFactory(const Network::Address::InstanceConstSharedPtr& dest_address,
                                 const envoy::config::core::v3::Metadata* metadata) const;
   absl::optional<MonotonicTime> lastHcPassTime() const override { return last_hc_pass_time_; }
+  MonotonicTime lastSuccessfulTrafficTime(
+      envoy::data::core::v3::HealthCheckerType health_checker_type) const override {
+    switch (health_checker_type) {
+    case envoy::data::core::v3::HealthCheckerType::TCP:
+      return last_traffic_pass_time_;
+    case envoy::data::core::v3::HealthCheckerType::HTTP:
+      return last_traffic_pass_time_2xx_;
+    case envoy::data::core::v3::HealthCheckerType::GRPC:
+      return last_traffic_pass_time_grpc_;
+    default:
+      break;
+    }
+    return creation_time_;
+  }
+
+  void setLastSuccessfulTrafficTime(envoy::data::core::v3::HealthCheckerType health_checker_type,
+                                    MonotonicTime last_successful_traffic_time) const override {
+    switch (health_checker_type) {
+    case envoy::data::core::v3::HealthCheckerType::TCP:
+      last_traffic_pass_time_ = last_successful_traffic_time;
+      break;
+    case envoy::data::core::v3::HealthCheckerType::HTTP:
+      last_traffic_pass_time_2xx_ = last_successful_traffic_time;
+      break;
+    case envoy::data::core::v3::HealthCheckerType::GRPC:
+      last_traffic_pass_time_grpc_ = last_successful_traffic_time;
+    default:
+      break;
+    }
+  }
 
   void setAddressList(const std::vector<Network::Address::InstanceConstSharedPtr>& address_list) {
     address_list_ = address_list;
@@ -274,6 +304,9 @@ private:
       socket_factory_ ABSL_GUARDED_BY(metadata_mutex_);
   const MonotonicTime creation_time_;
   absl::optional<MonotonicTime> last_hc_pass_time_;
+  mutable MonotonicTime last_traffic_pass_time_;
+  mutable MonotonicTime last_traffic_pass_time_2xx_;
+  mutable MonotonicTime last_traffic_pass_time_grpc_;
 };
 
 /**

--- a/source/extensions/clusters/common/logical_host.h
+++ b/source/extensions/clusters/common/logical_host.h
@@ -122,8 +122,17 @@ public:
   absl::optional<MonotonicTime> lastHcPassTime() const override {
     return logical_host_->lastHcPassTime();
   }
+  MonotonicTime lastSuccessfulTrafficTime(
+      envoy::data::core::v3::HealthCheckerType health_checker_type) const override {
+    return logical_host_->lastSuccessfulTrafficTime(health_checker_type);
+  }
   uint32_t priority() const override { return logical_host_->priority(); }
   void priority(uint32_t) override {}
+
+  void setLastSuccessfulTrafficTime(envoy::data::core::v3::HealthCheckerType health_checker_type,
+                                    MonotonicTime last_successful_traffic_time) const override {
+    logical_host_->setLastSuccessfulTrafficTime(health_checker_type, last_successful_traffic_time);
+  }
 
 private:
   const Network::Address::InstanceConstSharedPtr address_;

--- a/test/extensions/clusters/common/logical_host_test.cc
+++ b/test/extensions/clusters/common/logical_host_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "source/extensions/clusters/common/logical_host.h"
 
 #include "test/mocks/upstream/host.h"
@@ -23,8 +25,10 @@ public:
 TEST_F(RealHostDescription, UnitTest) {
   // No-op unit tests
   description_.canary();
+  description_.canary(true);
   description_.metadata();
   description_.priority();
+  description_.priority(0);
   EXPECT_EQ(nullptr, description_.healthCheckAddress());
 
   // Pass through functions
@@ -36,6 +40,14 @@ TEST_F(RealHostDescription, UnitTest) {
 
   EXPECT_CALL(*mock_host_, loadMetricStats());
   description_.loadMetricStats();
+
+  EXPECT_CALL(*mock_host_, lastSuccessfulTrafficTime(_));
+  description_.lastSuccessfulTrafficTime(envoy::data::core::v3::HealthCheckerType::TCP);
+
+  EXPECT_CALL(*mock_host_, setLastSuccessfulTrafficTime(_, _));
+  description_.setLastSuccessfulTrafficTime(
+      envoy::data::core::v3::HealthCheckerType::TCP,
+      std::chrono::steady_clock::now()); // NO_CHECK_FORMAT(real_time)
 
   std::vector<Network::Address::InstanceConstSharedPtr> address_list;
   EXPECT_CALL(*mock_host_, addressList()).WillOnce(ReturnRef(address_list));

--- a/test/integration/health_check_integration_test.cc
+++ b/test/integration/health_check_integration_test.cc
@@ -177,7 +177,9 @@ public:
   // Adds a HTTP active health check specifier to the given cluster, and waits for the first health
   // check probe to be received.
   void initHttpHealthCheck(uint32_t cluster_idx, int unhealthy_threshold = 1,
-                           std::unique_ptr<envoy::type::v3::Int64Range> retriable_range = nullptr) {
+                           std::unique_ptr<envoy::type::v3::Int64Range> retriable_range = nullptr,
+                           int interval = 100,
+                           bool disable_health_check_if_active_traffic = false) {
     const envoy::type::v3::CodecClientType codec_client_type =
         (Http::CodecType::HTTP1 == upstream_protocol_) ? envoy::type::v3::CodecClientType::HTTP1
                                                        : envoy::type::v3::CodecClientType::HTTP2;
@@ -186,7 +188,18 @@ public:
     auto* health_check = addHealthCheck(cluster_data.cluster_);
     health_check->mutable_http_health_check()->set_path("/healthcheck");
     health_check->mutable_http_health_check()->set_codec_client_type(codec_client_type);
+    health_check->mutable_interval()->CopyFrom(
+        Protobuf::util::TimeUtil::MillisecondsToDuration(interval));
     health_check->mutable_unhealthy_threshold()->set_value(unhealthy_threshold);
+    health_check->set_disable_health_check_if_active_traffic(
+        disable_health_check_if_active_traffic);
+
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions protocol_options;
+    if (Http::CodecType::HTTP1 == upstream_protocol_) {
+      protocol_options.mutable_explicit_http_config()->mutable_http_protocol_options();
+    }
+    ConfigHelper::setProtocolOptions(cluster_data.cluster_, protocol_options);
+
     if (retriable_range != nullptr) {
       auto* range = health_check->mutable_http_health_check()->add_retriable_statuses();
       range->set_start(retriable_range->start());
@@ -538,6 +551,46 @@ TEST_P(RealTimeHttpHealthCheckIntegrationTest, SingleEndpointGoAwayErroSingleEnd
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
 }
 
+TEST_P(HttpHealthCheckIntegrationTest, DisableHCForActiveTraffic) {
+  const uint32_t cluster_idx = 0;
+  auto& cluster_data = clusters_[cluster_idx];
+  initialize();
+  initHttpHealthCheck(cluster_idx, 1, nullptr, 5000, true);
+
+  clusters_[cluster_idx].host_stream_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  clusters_[cluster_idx].host_stream_->encodeData(1024, true);
+
+  test_server_->waitForCounterGe("cluster.cluster_1.health_check.success", 1);
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(1));
+
+  auto codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/cluster1"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-lyft-user-id", absl::StrCat(1)}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+  ASSERT_TRUE(cluster_data.host_upstream_->waitForHttpConnection(
+      *dispatcher_, cluster_data.host_fake_connection_));
+  ASSERT_TRUE(cluster_data.host_fake_connection_->waitForNewStream(*dispatcher_,
+                                                                   cluster_data.host_stream_));
+  ASSERT_TRUE(cluster_data.host_stream_->waitForEndStream(*dispatcher_));
+
+  // Send the response headers.
+  clusters_[cluster_idx].host_stream_->encodeHeaders(default_response_headers_, false);
+  clusters_[cluster_idx].host_stream_->encodeData(1024, true);
+  test_server_->waitForCounterEq("cluster.cluster_1.health_check.attempt", 2);
+
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+  codec_client_->close();
+}
+
 class TcpHealthCheckIntegrationTest : public Event::TestUsingSimulatedTime,
                                       public testing::TestWithParam<Network::Address::IpVersion>,
                                       public HealthCheckIntegrationTestBase {
@@ -551,11 +604,14 @@ public:
 
   // Adds a TCP active health check specifier to the given cluster, and waits for the first health
   // check probe to be received.
-  void initTcpHealthCheck(uint32_t cluster_idx) {
+  void initTcpHealthCheck(uint32_t cluster_idx,
+                          bool disable_health_check_if_active_traffic = false) {
     auto& cluster_data = clusters_[cluster_idx];
     auto health_check = addHealthCheck(cluster_data.cluster_);
     health_check->mutable_tcp_health_check()->mutable_send()->set_text("50696E67"); // "Ping"
     health_check->mutable_tcp_health_check()->add_receive()->set_text("506F6E67");  // "Pong"
+    health_check->set_disable_health_check_if_active_traffic(
+        disable_health_check_if_active_traffic);
 
     // Introduce the cluster using compareDiscoveryRequest / sendDiscoveryResponse.
     EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", {}, {}, {}, true));
@@ -585,6 +641,46 @@ TEST_P(TcpHealthCheckIntegrationTest, SingleEndpointHealthyTcp) {
 
   test_server_->waitForCounterGe("cluster.cluster_1.health_check.success", 1);
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+}
+
+TEST_P(TcpHealthCheckIntegrationTest, DisableHCForActiveTraffic) {
+  const uint32_t cluster_idx = 0;
+  auto& cluster_data = clusters_[cluster_idx];
+  initialize();
+  initTcpHealthCheck(cluster_idx, true);
+
+  AssertionResult result = clusters_[cluster_idx].host_fake_raw_connection_->write("Pong");
+  RELEASE_ASSERT(result, result.message());
+
+  test_server_->waitForCounterGe("cluster.cluster_1.health_check.success", 1);
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+
+  auto codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/cluster1"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-lyft-user-id", absl::StrCat(1)}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+  test_server_->waitForCounterEq("cluster.cluster_1.health_check.attempt", 2);
+  codec_client_->close();
+
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+
+  timeSystem().advanceTimeWait(std::chrono::seconds(10));
+
+  test_server_->waitForCounterEq("cluster.cluster_1.health_check.attempt", 3);
+
+  ASSERT_TRUE(cluster_data.host_fake_raw_connection_->waitForData(
+      FakeRawConnection::waitForInexactMatch("Ping")));
+  result = clusters_[cluster_idx].host_fake_raw_connection_->write("Pong");
+  RELEASE_ASSERT(result, result.message());
+
+  EXPECT_EQ(2, test_server_->counter("cluster.cluster_1.health_check.success")->value());
   EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
 }
 
@@ -634,10 +730,15 @@ public:
 
   // Adds a gRPC active health check specifier to the given cluster, and waits for the first health
   // check probe to be received.
-  void initGrpcHealthCheck(uint32_t cluster_idx) {
+  void initGrpcHealthCheck(uint32_t cluster_idx, int interval = 100,
+                           bool disable_health_check_if_active_traffic = false) {
     auto& cluster_data = clusters_[cluster_idx];
     auto health_check = addHealthCheck(cluster_data.cluster_);
     health_check->mutable_grpc_health_check();
+    health_check->mutable_interval()->CopyFrom(
+        Protobuf::util::TimeUtil::MillisecondsToDuration(interval));
+    health_check->set_disable_health_check_if_active_traffic(
+        disable_health_check_if_active_traffic);
 
     // Introduce the cluster using compareDiscoveryRequest / sendDiscoveryResponse.
     EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", {}, {}, {}, true));
@@ -777,6 +878,61 @@ TEST_P(GrpcHealthCheckIntegrationTest, SingleEndpointUnknownStatusGrpc) {
   test_server_->waitForCounterGe("cluster.cluster_1.health_check.failure", 1);
   EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.success")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+}
+
+TEST_P(GrpcHealthCheckIntegrationTest, DisableHCForActiveTraffic) {
+  const uint32_t cluster_idx = 0;
+  auto& cluster_data = clusters_[cluster_idx];
+  initialize();
+  initGrpcHealthCheck(cluster_idx, 5000, true);
+  // Endpoint responds to the health check
+  grpc::health::v1::HealthCheckResponse response;
+  response.set_status(grpc::health::v1::HealthCheckResponse::SERVING);
+  // Send a grpc response.
+  sendGrpcResponse(
+      cluster_idx,
+      Http::TestResponseHeaderMapImpl{
+          {":status", "200"}, {"content-type", Http::Headers::get().ContentTypeValues.Grpc}},
+      response);
+
+  test_server_->waitForCounterGe("cluster.cluster_1.health_check.success", 1);
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(1));
+
+  auto codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/cluster1"},
+                                     {":scheme", "http"},
+                                     {":authority", "sni.lyft.com"},
+                                     {"content-type", "application/grpc"},
+                                     {"x-envoy-retry-grpc-on", "cancelled"}});
+  grpc::health::v1::HealthCheckRequest request;
+  request_encoder_ = &encoder_decoder.first;
+  request_encoder_->encodeData(*Grpc::Common::serializeToGrpcFrame(request), true);
+
+  ASSERT_TRUE(cluster_data.host_upstream_->waitForHttpConnection(
+      *dispatcher_, cluster_data.host_fake_connection_));
+  ASSERT_TRUE(cluster_data.host_fake_connection_->waitForNewStream(*dispatcher_,
+                                                                   cluster_data.host_stream_));
+  ASSERT_TRUE(cluster_data.host_stream_->waitForGrpcMessage(*dispatcher_, request));
+  ASSERT_TRUE(cluster_data.host_stream_->waitForEndStream(*dispatcher_));
+
+  // Send a grpc response.
+  response.set_status(grpc::health::v1::HealthCheckResponse::SERVING);
+  sendGrpcResponse(
+      cluster_idx,
+      Http::TestResponseHeaderMapImpl{
+          {":status", "200"}, {"content-type", Http::Headers::get().ContentTypeValues.Grpc}},
+      response);
+
+  test_server_->waitForCounterEq("cluster.cluster_1.health_check.attempt", 2);
+
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.health_check.success")->value());
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_1.health_check.failure")->value());
+  codec_client_->close();
 }
 
 class ExternalHealthCheckIntegrationTest

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -103,6 +103,10 @@ public:
   MOCK_METHOD(uint32_t, priority, (), (const));
   MOCK_METHOD(void, priority, (uint32_t));
   MOCK_METHOD(absl::optional<MonotonicTime>, lastHcPassTime, (), (const));
+  MOCK_METHOD(MonotonicTime, lastSuccessfulTrafficTime, (envoy::data::core::v3::HealthCheckerType),
+              (const));
+  MOCK_METHOD(void, setLastSuccessfulTrafficTime,
+              (envoy::data::core::v3::HealthCheckerType, MonotonicTime), (const));
   Stats::StatName localityZoneStatName() const override {
     Stats::SymbolTable& symbol_table = *symbol_table_;
     locality_zone_stat_name_ =
@@ -215,6 +219,10 @@ public:
   MOCK_METHOD(void, priority, (uint32_t));
   MOCK_METHOD(bool, warmed, (), (const));
   MOCK_METHOD(absl::optional<MonotonicTime>, lastHcPassTime, (), (const));
+  MOCK_METHOD(MonotonicTime, lastSuccessfulTrafficTime, (envoy::data::core::v3::HealthCheckerType),
+              (const));
+  MOCK_METHOD(void, setLastSuccessfulTrafficTime,
+              (envoy::data::core::v3::HealthCheckerType, MonotonicTime), (const));
 
   testing::NiceMock<MockClusterInfo> cluster_;
   Network::UpstreamTransportSocketFactoryPtr socket_factory_;


### PR DESCRIPTION
The CI test failure is fixed, so resumite the original PR #24903 