### PR TITLE
Always populate the address type of internal client connection as EnvoyInternal

### DIFF
--- a/source/extensions/bootstrap/internal_listener/client_connection_factory.cc
+++ b/source/extensions/bootstrap/internal_listener/client_connection_factory.cc
@@ -26,11 +26,8 @@ Network::ClientConnectionPtr InternalClientConnectionFactory::createClientConnec
     const Network::ConnectionSocket::OptionsSharedPtr& options,
     const Network::TransportSocketOptionsConstSharedPtr& transport_options) {
   // OS does not fill the address automatically so a pivotal address is populated.
-  // TODO(lambdai): provide option to fill the downstream remote address here.
-  if (source_address == nullptr) {
-    source_address =
-        std::make_shared<Network::Address::EnvoyInternalInstance>("internal_client_address");
-  }
+  source_address =
+      std::make_shared<Network::Address::EnvoyInternalInstance>("internal_client_address");
 
   ENVOY_LOG(debug, "Internal client connection buffer size {}.", buffer_size_);
   auto [io_handle_client, io_handle_server] =

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
@@ -86,6 +86,14 @@ public:
                                     envoy::config::cluster::v3::Cluster* cluster) {
     cluster->set_name(listener_name);
     cluster->clear_load_assignment();
+
+    if (upstream_bind_config_) {
+      // Set upstream binding config in the internal_upstream cluster.
+      auto* source_address = cluster->mutable_upstream_bind_config()->mutable_source_address();
+      source_address->set_address("1.2.3.4");
+      source_address->set_port_value(0);
+    }
+
     auto* load_assignment = cluster->mutable_load_assignment();
     load_assignment->set_cluster_name(cluster->name());
     auto* endpoints = load_assignment->add_endpoints();
@@ -179,6 +187,7 @@ public:
   bool buffer_size_specified_{false};
   uint32_t buffer_size_{0};
   std::string access_log2_name_;
+  bool upstream_bind_config_{false};
 };
 
 TEST_F(InternalUpstreamIntegrationTest, BasicFlow) {
@@ -196,6 +205,23 @@ TEST_F(InternalUpstreamIntegrationTest, BasicFlow) {
               ::testing::HasSubstr("internal_listener,internal_listener,FOO,BAZ"));
   EXPECT_THAT(waitForAccessLog(access_log2_name_),
               ::testing::HasSubstr("internal_listener2,internal_listener2,FOO,-"));
+}
+
+// To verify that with the upstream binding configured in the internal_upstream cluster,
+// the socket address type of internal client connection is not overriden to be
+// Type::Ip. It stays as Type::EnvoyInternal, and with that traffic goes through.
+TEST_F(InternalUpstreamIntegrationTest, BasicFlowLookbackClusterHasUpstreamBindConfig) {
+  upstream_bind_config_ = true;
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(request_header_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  cleanupUpstreamAndDownstream();
 }
 
 TEST_F(InternalUpstreamIntegrationTest, BasicFlowMissing) {

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
@@ -208,7 +208,7 @@ TEST_F(InternalUpstreamIntegrationTest, BasicFlow) {
 }
 
 // To verify that with the upstream binding configured in the internal_upstream cluster,
-// the socket address type of internal client connection is not overriden to be
+// the socket address type of internal client connection is not overridden to be
 // Type::Ip. It stays as Type::EnvoyInternal, and with that traffic goes through.
 TEST_F(InternalUpstreamIntegrationTest, BasicFlowLookbackClusterHasUpstreamBindConfig) {
   upstream_bind_config_ = true;


### PR DESCRIPTION
Always populate the socket address type of internal client connection as Type::EnvoyInternal.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
