### PR TITLE
clang-tidy: fix source/extensions/filters

### DIFF
--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -85,7 +85,7 @@ inline absl::string_view getStringViewFromLuaString(lua_State* state, int index)
   // string, since Lua provides automatic conversion between string and number values at run time
   // (https://www.lua.org/manual/5.1/manual.html#2.2.1).
   const char* input = luaL_checklstring(state, index, &input_size);
-  return absl::string_view(input, input_size);
+  return {input, input_size};
 }
 
 /**

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -4,7 +4,6 @@
 
 using Envoy::Protobuf::io::CodedInputStream;
 using Envoy::Protobuf::io::CodedOutputStream;
-using Envoy::Protobuf::io::StringOutputStream;
 using Envoy::Protobuf::io::ZeroCopyInputStream;
 
 namespace Envoy {

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -25,7 +25,6 @@ namespace HttpFilters {
 namespace RateLimitQuota {
 
 using ::envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaBucketSettings;
-using ::envoy::service::rate_limit_quota::v3::BucketId;
 using FilterConfig =
     envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaFilterConfig;
 using FilterConfigConstSharedPtr = std::shared_ptr<const FilterConfig>;

--- a/source/extensions/filters/http/rate_limit_quota/matcher.cc
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.cc
@@ -7,7 +7,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace RateLimitQuota {
 
-using ::envoy::type::v3::RateLimitStrategy;
 using ValueSpecifierCase = ::envoy::extensions::filters::http::rate_limit_quota::v3::
     RateLimitQuotaBucketSettings_BucketIdBuilder_ValueBuilder::ValueSpecifierCase;
 

--- a/source/extensions/filters/network/connection_limit/connection_limit.h
+++ b/source/extensions/filters/network/connection_limit/connection_limit.h
@@ -69,7 +69,7 @@ class Filter : public Network::ReadFilter,
                public Network::ConnectionCallbacks,
                Logger::Loggable<Logger::Id::filter> {
 public:
-  Filter(const ConfigSharedPtr& config) : config_(config), is_rejected_(false) {}
+  Filter(const ConfigSharedPtr& config) : config_(config) {}
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance&, bool) override;
@@ -90,7 +90,7 @@ private:
   const ConfigSharedPtr config_;
   Network::ReadFilterCallbacks* read_callbacks_{};
   Event::TimerPtr delay_timer_ = nullptr;
-  bool is_rejected_;
+  bool is_rejected_{false};
 };
 
 } // namespace ConnectionLimitFilter

--- a/source/extensions/filters/network/dubbo_proxy/app_exception.h
+++ b/source/extensions/filters/network/dubbo_proxy/app_exception.h
@@ -20,9 +20,7 @@ struct AppExceptionBase : public EnvoyException,
                           public DubboFilters::DirectResponse,
                           Logger::Loggable<Logger::Id::dubbo> {
   AppExceptionBase(const AppExceptionBase& ex) = default;
-  AppExceptionBase(T status, const std::string& what)
-      : EnvoyException(what), status_(status),
-        response_type_(RpcResponseType::ResponseWithException) {}
+  AppExceptionBase(T status, const std::string& what) : EnvoyException(what), status_(status) {}
 
   ResponseType encode(MessageMetadata& metadata, DubboProxy::Protocol& protocol,
                       Buffer::Instance& buffer) const override {
@@ -40,7 +38,7 @@ struct AppExceptionBase : public EnvoyException,
   }
 
   const T status_;
-  const RpcResponseType response_type_;
+  const RpcResponseType response_type_{RpcResponseType::ResponseWithException};
 };
 
 using AppException = AppExceptionBase<>;

--- a/source/extensions/filters/network/dubbo_proxy/decoder.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder.h
@@ -71,7 +71,7 @@ public:
   };
 
   DecoderStateMachine(Protocol& protocol, Delegate& delegate)
-      : protocol_(protocol), delegate_(delegate), state_(ProtocolState::OnDecodeStreamHeader) {}
+      : protocol_(protocol), delegate_(delegate) {}
 
   /**
    * Consumes as much data from the configured Buffer as possible and executes the decoding state
@@ -112,7 +112,7 @@ private:
   Protocol& protocol_;
   Delegate& delegate_;
 
-  ProtocolState state_;
+  ProtocolState state_{ProtocolState::OnDecodeStreamHeader};
   ActiveStream* active_stream_{nullptr};
 };
 

--- a/source/extensions/filters/network/thrift_proxy/decoder.h
+++ b/source/extensions/filters/network/thrift_proxy/decoder.h
@@ -67,8 +67,7 @@ class DecoderStateMachine : public Logger::Loggable<Logger::Id::thrift> {
 public:
   DecoderStateMachine(Protocol& proto, MessageMetadataSharedPtr& metadata,
                       DecoderEventHandler& handler, DecoderCallbacks& callbacks)
-      : proto_(proto), metadata_(metadata), handler_(handler), callbacks_(callbacks),
-        state_(ProtocolState::MessageBegin) {}
+      : proto_(proto), metadata_(metadata), handler_(handler), callbacks_(callbacks) {}
 
   /**
    * Consumes as much data from the configured Buffer as possible and executes the decoding state
@@ -182,7 +181,7 @@ private:
   MessageMetadataSharedPtr metadata_;
   DecoderEventHandler& handler_;
   DecoderCallbacks& callbacks_;
-  ProtocolState state_;
+  ProtocolState state_{ProtocolState::MessageBegin};
   std::vector<Frame> stack_;
   uint32_t body_start_{};
   uint32_t body_bytes_{};

--- a/source/extensions/filters/udp/dns_filter/dns_parser.h
+++ b/source/extensions/filters/udp/dns_filter/dns_parser.h
@@ -174,13 +174,13 @@ public:
   DnsQueryContext(Network::Address::InstanceConstSharedPtr local,
                   Network::Address::InstanceConstSharedPtr peer, DnsParserCounters& counters,
                   uint64_t retry_count)
-      : local_(std::move(local)), peer_(std::move(peer)), counters_(counters), parse_status_(false),
+      : local_(std::move(local)), peer_(std::move(peer)), counters_(counters),
         response_code_(DNS_RESPONSE_CODE_NO_ERROR), retry_(retry_count) {}
 
   const Network::Address::InstanceConstSharedPtr local_;
   const Network::Address::InstanceConstSharedPtr peer_;
   DnsParserCounters& counters_;
-  bool parse_status_;
+  bool parse_status_{false};
   uint16_t response_code_;
   uint64_t retry_;
   uint16_t id_;


### PR DESCRIPTION
Commit Message: clang-tidy: fix source/extensions/filters
Additional Description:
Fixing some of the clang-tidy errors.
Risk Level: Low
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
