### PR TITLE
clang-tidy: fix rest of source/extensions

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -216,7 +216,7 @@ DnsCacheImpl::PrimaryHostInfo& DnsCacheImpl::getPrimaryHost(const std::string& h
   absl::ReaderMutexLock reader_lock{&primary_hosts_lock_};
   const auto primary_host_it = primary_hosts_.find(host);
   ASSERT(primary_host_it != primary_hosts_.end());
-  return *(primary_host_it->second.get());
+  return *(primary_host_it->second);
 }
 
 void DnsCacheImpl::onResolveTimeout(const std::string& host) {

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -24,7 +24,6 @@ constexpr absl::string_view DEFAULT_SERVICE_AND_INSTANCE = "EnvoyProxy";
 
 using cpp2sky::createSpanContext;
 using cpp2sky::SpanContextPtr;
-using cpp2sky::TracerException;
 
 Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
                Server::Configuration::TracerFactoryContext& context)

--- a/source/extensions/tracers/xray/localized_sampling.cc
+++ b/source/extensions/tracers/xray/localized_sampling.cc
@@ -78,7 +78,7 @@ bool validateRule(const ProtobufWkt::Struct& rule) {
 } // namespace
 
 LocalizedSamplingRule LocalizedSamplingRule::createDefault() {
-  return LocalizedSamplingRule(DefaultFixedTarget, DefaultRate);
+  return {DefaultFixedTarget, DefaultRate};
 }
 
 bool LocalizedSamplingRule::appliesTo(const SamplingRequest& request) const {

--- a/source/extensions/tracers/xray/reservoir.h
+++ b/source/extensions/tracers/xray/reservoir.h
@@ -20,8 +20,7 @@ public:
   /**
    * Creates a new reservoir that allows up to |traces_per_second| samples.
    */
-  explicit Reservoir(uint32_t traces_per_second)
-      : traces_per_second_(traces_per_second), used_(0) {}
+  explicit Reservoir(uint32_t traces_per_second) : traces_per_second_(traces_per_second) {}
 
   Reservoir(const Reservoir& other)
       : traces_per_second_(other.traces_per_second_), used_(other.used_),
@@ -62,7 +61,7 @@ public:
 
 private:
   uint32_t traces_per_second_;
-  uint32_t used_;
+  uint32_t used_{0};
   Envoy::MonotonicTime time_point_;
   Envoy::Thread::MutexBasicLockable sync_;
 };

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -42,8 +42,7 @@ public:
    */
   Span(TimeSource& time_source, Random::RandomGenerator& random, DaemonBroker& broker)
       : time_source_(time_source), random_(random), broker_(broker),
-        id_(Hex::uint64ToHex(random_.random())), server_error_(false), response_status_code_(0),
-        sampled_(true) {}
+        id_(Hex::uint64ToHex(random_.random())) {}
 
   /**
    * Sets the Span's trace ID.
@@ -258,9 +257,9 @@ private:
   absl::flat_hash_map<std::string, ProtobufWkt::Value> http_request_annotations_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> http_response_annotations_;
   absl::flat_hash_map<std::string, std::string> custom_annotations_;
-  bool server_error_;
-  uint64_t response_status_code_;
-  bool sampled_;
+  bool server_error_{false};
+  uint64_t response_status_code_{0};
+  bool sampled_{true};
 };
 
 using SpanPtr = std::unique_ptr<Span>;

--- a/source/extensions/tracers/zipkin/zipkin_core_types.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.h
@@ -314,9 +314,7 @@ public:
   /**
    * Default constructor. Creates an empty span.
    */
-  explicit Span(TimeSource& time_source)
-      : trace_id_(0), id_(0), debug_(false), sampled_(false), monotonic_start_time_(0),
-        tracer_(nullptr), time_source_(time_source) {}
+  explicit Span(TimeSource& time_source) : time_source_(time_source) {}
 
   /**
    * Sets the span's trace id attribute.
@@ -590,19 +588,19 @@ public:
 
 private:
   static const std::string EMPTY_HEX_STRING_;
-  uint64_t trace_id_;
+  uint64_t trace_id_{0};
   std::string name_;
-  uint64_t id_;
+  uint64_t id_{0};
   absl::optional<uint64_t> parent_id_;
-  bool debug_;
-  bool sampled_;
+  bool debug_{false};
+  bool sampled_{false};
   std::vector<Annotation> annotations_;
   std::vector<BinaryAnnotation> binary_annotations_;
   absl::optional<int64_t> timestamp_;
   absl::optional<int64_t> duration_;
   absl::optional<uint64_t> trace_id_high_;
-  int64_t monotonic_start_time_;
-  TracerInterface* tracer_;
+  int64_t monotonic_start_time_{0};
+  TracerInterface* tracer_{nullptr};
   TimeSource& time_source_;
 };
 


### PR DESCRIPTION
Commit Message: clang-tidy: fix rest of source/extensions
Additional Description:
Fixing clang-tidy on source/extensions (continuation of #25772).

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
