### PR TITLE
ext-authz: send SNI in CheckRequest to the authorization server

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -26,7 +26,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -179,6 +179,12 @@ message ExtAuthz {
   //  consequently the value of *Content-Length* of the authorization request reflects the size of
   //  its payload size.
   type.matcher.v3.ListStringMatcher allowed_headers = 17;
+
+  // Specifies if the TLS session level details like SNI are sent to the external service.
+  //
+  // When this field is true, Envoy will include the SNI name used for TLSClientHello, if available, in the
+  // :ref:`tls_session<envoy_v3_api_field_service.auth.v3.AttributeContext.tls_session>`.
+  bool include_tls_session = 18;
 }
 
 // Configuration for buffering the request data.

--- a/api/envoy/service/auth/v3/attribute_context.proto
+++ b/api/envoy/service/auth/v3/attribute_context.proto
@@ -38,7 +38,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // - field mask to send
 // - which return values from request_context are copied back
 // - which return values are copied into request_headers]
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message AttributeContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.auth.v2.AttributeContext";
@@ -155,6 +155,12 @@ message AttributeContext {
     bytes raw_body = 12;
   }
 
+  // This message defines attributes for the underlying TLS session.
+  message TLSSession {
+    // SNI used for TLS session.
+    string sni = 1;
+  }
+
   // The source of a network activity, such as starting a TCP connection.
   // In a multi hop network activity, the source represents the sender of the
   // last hop.
@@ -176,4 +182,9 @@ message AttributeContext {
 
   // Dynamic metadata associated with the request.
   config.core.v3.Metadata metadata_context = 11;
+
+  // TLS session details of the underlying connection.
+  // This is not populated by default and will be populated if ext_authz filter's
+  // :ref:`include_tls_session <config_http_filters_ext_authz>` is set to true.
+  TLSSession tls_session = 12;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -211,6 +211,10 @@ new_features:
 - area: redis
   change: |
     added :ref:`wait_for_warm_on_init <envoy_v3_api_field_config.cluster.v3.Cluster.wait_for_warm_on_init>` support for :ref:`Redis Cluster<arch_overview_redis>`.
+- area: ext_authz
+  change: |
+    added :ref:`include_tls_session <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.include_tls_session>` to support sending TLS SNI data
+    as part of CheckRequest for authorization check.
 
 deprecated:
 - area: ext_authz

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -87,6 +87,7 @@ public:
    * @param with_request_body when true, will add the request body to the check request.
    * @param pack_as_bytes when true, will set the check request body as bytes.
    * @param include_peer_certificate whether to include the peer certificate in the check request.
+   * @param include_tls_session whether to include the TLS session details in the check request.
    */
   static void createHttpCheck(const Envoy::Http::StreamDecoderFilterCallbacks* callbacks,
                               const Envoy::Http::RequestHeaderMap& headers,
@@ -94,7 +95,7 @@ public:
                               envoy::config::core::v3::Metadata&& metadata_context,
                               envoy::service::auth::v3::CheckRequest& request,
                               uint64_t max_request_bytes, bool pack_as_bytes,
-                              bool include_peer_certificate,
+                              bool include_peer_certificate, bool include_tls_session,
                               const Protobuf::Map<std::string, std::string>& destination_labels,
                               const MatcherSharedPtr& request_header_matchers);
 

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -68,7 +68,7 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   Filters::Common::ExtAuthz::CheckRequestUtils::createHttpCheck(
       decoder_callbacks_, headers, std::move(context_extensions), std::move(metadata_context),
       check_request_, config_->maxRequestBytes(), config_->packAsBytes(),
-      config_->includePeerCertificate(), config_->destinationLabels(),
+      config_->includePeerCertificate(), config_->includeTLSSession(), config_->destinationLabels(),
       config_->requestHeaderMatchers());
 
   ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server", *decoder_callbacks_);

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -83,6 +83,7 @@ public:
         typed_metadata_context_namespaces_(config.typed_metadata_context_namespaces().begin(),
                                            config.typed_metadata_context_namespaces().end()),
         include_peer_certificate_(config.include_peer_certificate()),
+        include_tls_session_(config.include_tls_session()),
         stats_(generateStats(stats_prefix, config.stat_prefix(), scope)),
         ext_authz_ok_(pool_.add(createPoolStatName(config.stat_prefix(), "ok"))),
         ext_authz_denied_(pool_.add(createPoolStatName(config.stat_prefix(), "denied"))),
@@ -165,6 +166,7 @@ public:
   }
 
   bool includePeerCertificate() const { return include_peer_certificate_; }
+  bool includeTLSSession() const { return include_tls_session_; }
   const LabelsMap& destinationLabels() const { return destination_labels_; }
 
   const Filters::Common::ExtAuthz::MatcherSharedPtr& requestHeaderMatchers() const {
@@ -218,6 +220,7 @@ private:
   const std::vector<std::string> typed_metadata_context_namespaces_;
 
   const bool include_peer_certificate_;
+  const bool include_tls_session_;
 
   // The stats for the filter.
   ExtAuthzFilterStats stats_;


### PR DESCRIPTION
There isn't any way to pass along SNI used for the underlying connection to the external authorization server.
This patch introduces a new field on the CheckRequest to send TLS session data to the authorization server. Only SNI is sent with this patch, more TLS session-related data can be introduced in the future.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: ext-authz: send SNI in CheckRequest to the authorization server
Additional Description:
Risk Level: Low because this is an optional feature in a filter

Work in progress, I will fill the below out if the change seems acceptable from an API perspective.

Testing: added a unit test to ensure that the additional data is correctly populated
Docs Changes: No docs changes are done assuming that the doc string in filter configuration is sufficient 
Release Notes: Included
Platform Specific Features: N/A
