### PR TITLE
docker: Refactor `docker_ci.sh`

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -253,6 +253,23 @@ stages:
         GITHUB_TOKEN: $(GitHubPublicRepoOnlyAccessToken)
       displayName: "Verify dependency information"
 
+  - job: docker_ci
+    displayName: Docker checks
+    dependsOn: []
+    pool:
+      vmImage: "ubuntu-20.04"
+    steps:
+    - script: |
+        DOCKER_CI_FIX_DIFF=$(Build.StagingDirectory)/fix_docker.diff DOCKER_CI_FIX=1 ci/test_docker_ci.sh
+      workingDirectory: $(Build.SourcesDirectory)
+      displayName: Docker build regression test
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: "$(Build.StagingDirectory)/fix_docker.diff"
+        artifactName: "docker_ci"
+        timeoutInMinutes: 10
+      condition: failed()
+
 - stage: sync
   condition: and(succeeded(), eq(variables['PostSubmit'], true), ne(variables['NoSync'], true))
   dependsOn: []

--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -19,9 +19,11 @@ COPY ci/docker-entrypoint.sh /
 # STAGE: envoy
 FROM ${BUILD_OS}:${BUILD_TAG} AS envoy
 
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y ca-certificates \
-    && apt-get autoremove -y && apt-get clean \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get upgrade -qq -y \
+    && apt-get install -qq --no-install-recommends -y ca-certificates \
+    && apt-get autoremove -y -qq && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
 
@@ -57,8 +59,8 @@ CMD ["-c", "/etc/envoy/envoy.yaml"]
 FROM ${ENVOY_VRP_BASE_IMAGE} AS envoy-google-vrp
 
 RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y libc++1 supervisor gdb strace tshark \
+    && apt-get upgrade -y -qq \
+    && apt-get install -y -qq libc++1 supervisor gdb strace tshark \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -20,132 +20,93 @@ set -e
 # AZP_BRANCH=refs/tags/v1.77.3
 ##
 
+function is_windows() {
+    [[ -n "$DOCKER_FAKE_WIN" ]]  || [[ "$(uname -s)" == *NT* ]]
+}
+
 if [[ -n "$DOCKER_CI_DRYRUN" ]]; then
     AZP_SHA1="${AZP_SHA1:-MOCKSHA}"
+
+    if is_windows; then
+        WINDOWS_IMAGE_BASE="${WINDOWS_IMAGE_BASE:-mcr.microsoft.com/windows/fakecore}"
+        WINDOWS_IMAGE_TAG="${WINDOWS_IMAGE_TAG:-ltsc1992}"
+        WINDOWS_BUILD_TYPE="${WINDOWS_BUILD_TYPE:-legacy}"
+    fi
 fi
-
-VERSION="$(cat VERSION.txt)"
-
-function is_windows() {
-  [[ "$(uname -s)" == *NT* ]]
-}
-
-ENVOY_DOCKER_IMAGE_DIRECTORY="${ENVOY_DOCKER_IMAGE_DIRECTORY:-${BUILD_STAGINGDIRECTORY:-.}/build_images}"
-
-# Setting environments for buildx tools
-config_env() {
-  # Install QEMU emulators
-  docker run --rm --privileged tonistiigi/binfmt --install all
-
-  # Remove older build instance
-  docker buildx rm multi-builder || :
-  docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
-}
-
-build_platforms() {
-  TYPE=$1
-
-  if is_windows; then
-    echo "windows/amd64"
-  elif [[ "${TYPE}" == *-google-vrp ]]; then
-    echo "linux/amd64"
-  else
-    echo "linux/arm64,linux/amd64"
-  fi
-}
-
-build_args() {
-  TYPE=$1
-
-  if [[ "${TYPE}" == *-windows* ]]; then
-    printf ' -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=%s --build-arg BUILD_TAG=%s' "${WINDOWS_IMAGE_BASE}" "${WINDOWS_IMAGE_TAG}"
-  else
-    TARGET="${TYPE/-debug/}"
-    TARGET="${TARGET/-contrib/}"
-    printf ' -f ci/Dockerfile-envoy --target %s' "envoy${TARGET}"
-  fi
-
-  if [[ "${TYPE}" == *-contrib* ]]; then
-    printf ' --build-arg ENVOY_BINARY=envoy-contrib'
-  fi
-
-  if [[ "${TYPE}" == *-debug ]]; then
-    printf ' --build-arg ENVOY_BINARY_SUFFIX='
-  fi
-}
-
-use_builder() {
-  # BuildKit is not available for Windows images, skip this
-  if ! is_windows; then
-    docker buildx use multi-builder
-  fi
-}
-
-build_images() {
-  local _args args=()
-  TYPE=$1
-  BUILD_TAG=$2
-
-  use_builder "${TYPE}"
-  _args=$(build_args "${TYPE}")
-  read -ra args <<<"$_args"
-  PLATFORM="$(build_platforms "${TYPE}")"
-
-  if ! is_windows && ! [[ "${TYPE}" =~ debug ]]; then
-    args+=("-o" "type=oci,dest=${ENVOY_DOCKER_IMAGE_DIRECTORY}/envoy${TYPE}.tar")
-  fi
-
-  echo ">> BUILD: ${BUILD_TAG}"
-  echo "> docker ${BUILD_COMMAND[*]} --platform ${PLATFORM} ${args[*]} -t ${BUILD_TAG} ."
-  if [[ -n "$DOCKER_CI_DRYRUN" ]]; then
-      echo ""
-      return
-  fi
-  echo "..."
-  docker "${BUILD_COMMAND[@]}" --platform "${PLATFORM}" "${args[@]}" -t "${BUILD_TAG}" .
-  echo ""
-}
-
-push_images() {
-  local _args args=()
-  TYPE=$1
-  BUILD_TAG=$2
-
-  use_builder "${TYPE}"
-  _args=$(build_args "${TYPE}")
-  read -ra args <<<"$_args"
-  PLATFORM="$(build_platforms "${TYPE}")"
-
-  echo ">> PUSH: ${BUILD_TAG}"
-  echo "> docker ${BUILD_COMMAND[*]} --platform ${PLATFORM} ${args[*]} -t ${BUILD_TAG} . --push ||
-    docker push ${BUILD_TAG}"
-  if [[ -n "$DOCKER_CI_DRYRUN" ]]; then
-      echo ""
-      return
-  fi
-  echo "..."
-  # docker buildx doesn't do push with default builder
-  docker "${BUILD_COMMAND[@]}" --platform "${PLATFORM}" "${args[@]}" -t "${BUILD_TAG}" . --push ||
-    docker push "${BUILD_TAG}"
-  echo ""
-}
 
 MAIN_BRANCH="refs/heads/main"
 RELEASE_BRANCH_REGEX="^refs/heads/release/v.*"
 DEV_VERSION_REGEX="-dev$"
+DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
+PUSH_IMAGES_TO_REGISTRY=
+if [[ -z "$ENVOY_VERSION" ]]; then
+    ENVOY_VERSION="$(cat VERSION.txt)"
+fi
 
-if [[ "$VERSION" =~ $DEV_VERSION_REGEX ]]; then
+if [[ "$ENVOY_VERSION" =~ $DEV_VERSION_REGEX ]]; then
     # Dev version
     IMAGE_POSTFIX="-dev"
     IMAGE_NAME="${AZP_SHA1}"
 else
     # Non-dev version
     IMAGE_POSTFIX=""
-    IMAGE_NAME="v${VERSION}"
+    IMAGE_NAME="v${ENVOY_VERSION}"
 fi
 
-image_tag_name () {
+# Only push images for main builds, and non-dev release branch builds
+if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
+    echo "Pushing images for main."
+    PUSH_IMAGES_TO_REGISTRY=1
+elif [[ "${AZP_BRANCH}" =~ ${RELEASE_BRANCH_REGEX} ]] && ! [[ "$ENVOY_VERSION" =~ $DEV_VERSION_REGEX ]]; then
+    echo "Pushing images for release branch ${AZP_BRANCH}."
+    PUSH_IMAGES_TO_REGISTRY=1
+else
+    echo 'Ignoring non-release branch for docker push.'
+fi
+
+ENVOY_DOCKER_IMAGE_DIRECTORY="${ENVOY_DOCKER_IMAGE_DIRECTORY:-${BUILD_STAGINGDIRECTORY:-.}/build_images}"
+# This prefix is altered for the private security images on setec builds.
+DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/envoy}"
+if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
+    mkdir -p "${ENVOY_DOCKER_IMAGE_DIRECTORY}"
+fi
+
+# Setting environments for buildx tools
+config_env() {
+    echo ">> BUILDX: install"
+    echo "> docker run --rm --privileged tonistiigi/binfmt --install all"
+    echo "> docker buildx rm multi-builder 2> /dev/null || :"
+    echo "> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64"
+
+    if [[ -n "$DOCKER_CI_DRYRUN" ]]; then
+        return
+    fi
+
+    # Install QEMU emulators
+    docker run --rm --privileged tonistiigi/binfmt --install all
+
+    # Remove older build instance
+    docker buildx rm multi-builder 2> /dev/null || :
+    docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+}
+
+if is_windows; then
+    BUILD_TYPES=("-${WINDOWS_BUILD_TYPE}")
+    # BuildKit is not available for Windows images, use standard build command
+    BUILD_COMMAND=("build")
+else
+    # "-google-vrp" must come afer "" to ensure we rebuild the local base image dependency.
+    BUILD_TYPES=("" "-debug" "-contrib" "-contrib-debug" "-distroless" "-google-vrp" "-tools")
+
+    # Configure docker-buildx tools
+    BUILD_COMMAND=("buildx" "build")
+    config_env
+fi
+
+old_image_tag_name () {
     # envoyproxy/envoy-dev:latest
+    # envoyproxy/envoy-debug:v1.73.3
+    # envoyproxy/envoy-debug:v1.73-latest
     local build_type="$1" image_name="$2"
     if [[ -z "$image_name" ]]; then
         image_name="$IMAGE_NAME"
@@ -154,7 +115,10 @@ image_tag_name () {
 }
 
 new_image_tag_name () {
-    # envoyproxy/envoy:dev-latest
+    # envoyproxy/envoy:dev
+    # envoyproxy/envoy:debug-v1.73.3
+    # envoyproxy/envoy:debug-v1.73-latest
+
     local build_type="$1" image_name="$2" image_tag
     parts=()
     if [[ -n "$build_type" ]]; then
@@ -172,68 +136,223 @@ new_image_tag_name () {
     echo -n "${DOCKER_IMAGE_PREFIX}:${image_tag}"
 }
 
-# This prefix is altered for the private security images on setec builds.
-DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/envoy}"
-mkdir -p "${ENVOY_DOCKER_IMAGE_DIRECTORY}"
+build_platforms() {
+    local build_type=$1
 
-if is_windows; then
-  BUILD_TYPES=("-${WINDOWS_BUILD_TYPE}")
-  # BuildKit is not available for Windows images, use standard build command
-  BUILD_COMMAND=("build")
-else
-  # "-google-vrp" must come afer "" to ensure we rebuild the local base image dependency.
-  BUILD_TYPES=("" "-debug" "-contrib" "-contrib-debug" "-distroless" "-google-vrp" "-tools")
+    if is_windows; then
+        echo -n "windows/amd64"
+    elif [[ "${build_type}" == *-google-vrp ]]; then
+        echo -n "linux/amd64"
+    else
+        echo -n "linux/arm64,linux/amd64"
+    fi
+}
 
-  # Configure docker-buildx tools
-  BUILD_COMMAND=("buildx" "build")
-  if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
-      config_env
-  fi
-fi
+build_args() {
+    local build_type=$1 target
 
-# Test the docker build in all cases, but use a local tag that we will overwrite before push in the
-# cases where we do push.
-for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-  build_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}")"
+    if is_windows; then
+        printf ' -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=%s --build-arg BUILD_TAG=%s' "${WINDOWS_IMAGE_BASE}" "${WINDOWS_IMAGE_TAG}"
+    else
+        target="${build_type/-debug/}"
+        target="${target/-contrib/}"
+        printf ' -f ci/Dockerfile-envoy --target %s' "envoy${target}"
+    fi
 
-  if ! is_windows; then
-      build_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}")"
-  fi
-done
+    if [[ "${build_type}" == *-contrib* ]]; then
+        printf ' --build-arg ENVOY_BINARY=envoy-contrib'
+    fi
 
-# Only push images for main builds, and release branch builds
-if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]] &&
-  ! [[ "${AZP_BRANCH}" =~ ${RELEASE_BRANCH_REGEX} ]]; then
-  echo 'Ignoring non-release branch for docker push.'
-  exit 0
-fi
+    if [[ "${build_type}" == *-debug ]]; then
+        printf ' --build-arg ENVOY_BINARY_SUFFIX='
+    fi
+}
 
-if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
-    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-fi
+use_builder() {
+    # BuildKit is not available for Windows images, skip this
+    if is_windows; then
+        return
+    fi
+    echo ">> BUILDX: use multi-builder"
+    echo "> docker buildx use multi-builder"
 
-for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-    push_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}")"
+    if [[ -n "$DOCKER_CI_DRYRUN" ]]; then
+        return
+    fi
+    docker buildx use multi-builder
+}
+
+build_and_maybe_push_image () {
+    # If the image is not required for local testing and this is main or a release this will push immediately
+    # If it is required for testing on a main or release branch (ie non-debug) it will push to a tar archive
+    # and then push to the registry from there.
+    local image_type="$1" platform docker_build_args _args args=() docker_build_args docker_image_tarball build_tag action platform
+
+    action="BUILD"
+    use_builder "${image_type}"
+    _args=$(build_args "${image_type}")
+    read -ra args <<<"$_args"
+    platform="$(build_platforms "${image_type}")"
+    build_tag="$(old_image_tag_name "${image_type}")"
+    docker_image_tarball="${ENVOY_DOCKER_IMAGE_DIRECTORY}/envoy${image_type}.tar"
+
     if ! is_windows; then
-        push_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}")"
+        if [[ "${image_type}" =~ debug ]]; then
+            # For linux if its the debug image then push immediately for release branches,
+            # otherwise just test the build
+            if [[ -n "$PUSH_IMAGES_TO_REGISTRY" ]]; then
+                action="BUILD+PUSH"
+                args+=("--push")
+            fi
+        else
+            # For linux non-debug builds, save it first in the tarball, we will push it
+            # with skopeo from there if needed.
+            args+=("-o" "type=oci,dest=${docker_image_tarball}")
+        fi
+    fi
+
+    docker_build_args=(
+        "${BUILD_COMMAND[@]}"
+        "--platform" "${platform}"
+        "${args[@]}"
+        -t "${build_tag}"
+        .)
+    echo ">> ${action}: ${build_tag}"
+    echo "> docker ${docker_build_args[*]}"
+
+    if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
+        echo "..."
+        docker "${docker_build_args[@]}"
+    fi
+    if [[ -z "$PUSH_IMAGES_TO_REGISTRY" ]]; then
+        return
+    fi
+
+    if is_windows; then
+        echo ">> PUSH: ${build_tag}"
+        echo "> docker push ${build_tag}"
+        if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
+            docker push "$build_tag"
+        fi
+    elif ! [[ "${image_type}" =~ debug ]]; then
+        push_image_from_tarball "$build_tag" "$docker_image_tarball"
+    fi
+}
+
+tag_image () {
+    local build_tag="$1" tag="$2" docker_tag_args
+
+    if [[ "$build_tag" == "$tag" ]]; then
+        return
+    fi
+
+    echo ">> TAG: ${build_tag} -> ${tag}"
+
+    if is_windows; then
+        # we cant use buildx to tag remote images on windows
+        echo "> docker tag ${build_tag} ${tag}"
+        echo ">> PUSH: ${tag}"
+        echo "> docker push ${tag}"
+        if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
+            docker tag "$build_tag" "$tag"
+            docker push "$tag"
+        fi
+        return
+    fi
+
+    docker_tag_args=(
+        buildx imagetools create
+        "${DOCKER_REGISTRY}/${build_tag}"
+        "--tag" "${DOCKER_REGISTRY}/${tag}")
+
+    echo "> docker ${docker_tag_args[*]}"
+
+    if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
+        echo "..."
+        docker "${docker_tag_args[@]}"
+    fi
+}
+
+push_image_from_tarball () {
+    # Use skopeo to push from the created oci archive
+
+    local build_tag="$1" docker_image_tarball="$2" src dest
+
+    src="oci-archive:${docker_image_tarball}"
+    dest="docker://${DOCKER_REGISTRY}/${build_tag}"
+    # dest="oci-archive:${docker_image_tarball2}"
+
+    echo ">> PUSH: ${src} -> ${dest}"
+    echo "> skopeo copy --multi-arch all ${src} ${dest}"
+
+    if [[ -n "$DOCKER_CI_DRYRUN" ]]; then
+        return
+    fi
+    skopeo copy --multi-arch all "${src}" "${dest}"
+}
+
+tag_variants () {
+    # Tag image variants
+    local image_type="$1" build_tag new_image_name release_line variant_type tag_name new_tag_name
+
+    if [[ -z "$PUSH_IMAGES_TO_REGISTRY" ]]; then
+        return
+    fi
+
+    build_tag="$(old_image_tag_name "${image_type}")"
+    new_image_name="$(new_image_tag_name "${image_type}")"
+
+    if ! is_windows && [[ "$build_tag" != "$new_image_name" ]]; then
+        tag_image "${build_tag}" "${new_image_name}"
     fi
 
     # Only push latest on main/dev builds.
-    if [[ "$VERSION" =~ $DEV_VERSION_REGEX ]]; then
+    if [[ "$ENVOY_VERSION" =~ $DEV_VERSION_REGEX ]]; then
         if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
-            is_windows && docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
-            push_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}" latest)"
-            if ! is_windows; then
-                push_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}" latest)"
-            fi
+            variant_type="latest"
         fi
     else
         # Push vX.Y-latest to tag the latest image in a release line
-        RELEASE_LINE=$(echo "$VERSION" | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')
-        is_windows && docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:v${RELEASE_LINE}"
-        push_images "${BUILD_TYPE}" "$(image_tag_name "${BUILD_TYPE}" "v${RELEASE_LINE}")"
-        if ! is_windows; then
-            push_images "${BUILD_TYPE}" "$(new_image_tag_name "${BUILD_TYPE}" "v${RELEASE_LINE}")"
+        release_line="$(echo "$ENVOY_VERSION" | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')"
+        variant_type="v${release_line}"
+    fi
+    if [[ -n "$variant_type" ]]; then
+        tag_name="$(old_image_tag_name "${image_type}" "${variant_type}")"
+        new_tag_name="$(new_image_tag_name "${image_type}" "${variant_type}")"
+        tag_image "${build_tag}" "${tag_name}"
+        if ! is_windows && ! [[ "$tag_name" == "$new_tag_name" ]]; then
+            tag_image "${build_tag}" "${new_tag_name}"
         fi
     fi
-done
+}
+
+build_and_maybe_push_image_and_variants () {
+    local image_type="$1"
+
+    build_and_maybe_push_image "$image_type"
+    tag_variants "$image_type"
+
+    # Leave blank line before next build
+    echo
+}
+
+login_docker () {
+    echo ">> LOGIN"
+    if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
+       docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+    fi
+}
+
+do_docker_ci () {
+    local build_type
+
+    if [[ -n "$PUSH_IMAGES_TO_REGISTRY" ]]; then
+        login_docker
+    fi
+
+    for build_type in "${BUILD_TYPES[@]}"; do
+        build_and_maybe_push_image_and_variants "${build_type}"
+    done
+}
+
+do_docker_ci

--- a/ci/test/docker/linux/dev/main
+++ b/ci/test/docker/linux/dev/main
@@ -1,0 +1,85 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> LOGIN
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy-dev:MOCKSHA .
+>> PUSH: oci-archive:/non/existent/test/path/envoy.tar -> docker://docker.io/envoyproxy/envoy-dev:MOCKSHA
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy.tar docker://docker.io/envoyproxy/envoy-dev:MOCKSHA
+>> TAG: envoyproxy/envoy-dev:MOCKSHA -> envoyproxy/envoy:dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:dev-MOCKSHA
+>> TAG: envoyproxy/envoy-dev:MOCKSHA -> envoyproxy/envoy-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-dev:latest
+>> TAG: envoyproxy/envoy-dev:MOCKSHA -> envoyproxy/envoy:dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:dev
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD+PUSH: envoyproxy/envoy-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= --push -t envoyproxy/envoy-debug-dev:MOCKSHA .
+>> TAG: envoyproxy/envoy-debug-dev:MOCKSHA -> envoyproxy/envoy:debug-dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:debug-dev-MOCKSHA
+>> TAG: envoyproxy/envoy-debug-dev:MOCKSHA -> envoyproxy/envoy-debug-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-debug-dev:latest
+>> TAG: envoyproxy/envoy-debug-dev:MOCKSHA -> envoyproxy/envoy:debug-dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:debug-dev
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib-dev:MOCKSHA .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-contrib.tar -> docker://docker.io/envoyproxy/envoy-contrib-dev:MOCKSHA
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-contrib.tar docker://docker.io/envoyproxy/envoy-contrib-dev:MOCKSHA
+>> TAG: envoyproxy/envoy-contrib-dev:MOCKSHA -> envoyproxy/envoy:contrib-dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:contrib-dev-MOCKSHA
+>> TAG: envoyproxy/envoy-contrib-dev:MOCKSHA -> envoyproxy/envoy-contrib-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-contrib-dev:latest
+>> TAG: envoyproxy/envoy-contrib-dev:MOCKSHA -> envoyproxy/envoy:contrib-dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:contrib-dev
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD+PUSH: envoyproxy/envoy-contrib-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= --push -t envoyproxy/envoy-contrib-debug-dev:MOCKSHA .
+>> TAG: envoyproxy/envoy-contrib-debug-dev:MOCKSHA -> envoyproxy/envoy:contrib-debug-dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:contrib-debug-dev-MOCKSHA
+>> TAG: envoyproxy/envoy-contrib-debug-dev:MOCKSHA -> envoyproxy/envoy-contrib-debug-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-contrib-debug-dev:latest
+>> TAG: envoyproxy/envoy-contrib-debug-dev:MOCKSHA -> envoyproxy/envoy:contrib-debug-dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:contrib-debug-dev
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless-dev:MOCKSHA .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-distroless.tar -> docker://docker.io/envoyproxy/envoy-distroless-dev:MOCKSHA
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-distroless.tar docker://docker.io/envoyproxy/envoy-distroless-dev:MOCKSHA
+>> TAG: envoyproxy/envoy-distroless-dev:MOCKSHA -> envoyproxy/envoy:distroless-dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:distroless-dev-MOCKSHA
+>> TAG: envoyproxy/envoy-distroless-dev:MOCKSHA -> envoyproxy/envoy-distroless-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-distroless-dev:latest
+>> TAG: envoyproxy/envoy-distroless-dev:MOCKSHA -> envoyproxy/envoy:distroless-dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:distroless-dev
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp-dev:MOCKSHA
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp-dev:MOCKSHA .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-google-vrp.tar -> docker://docker.io/envoyproxy/envoy-google-vrp-dev:MOCKSHA
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-google-vrp.tar docker://docker.io/envoyproxy/envoy-google-vrp-dev:MOCKSHA
+>> TAG: envoyproxy/envoy-google-vrp-dev:MOCKSHA -> envoyproxy/envoy:google-vrp-dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:google-vrp-dev-MOCKSHA
+>> TAG: envoyproxy/envoy-google-vrp-dev:MOCKSHA -> envoyproxy/envoy-google-vrp-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-google-vrp-dev:latest
+>> TAG: envoyproxy/envoy-google-vrp-dev:MOCKSHA -> envoyproxy/envoy:google-vrp-dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:google-vrp-dev
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools-dev:MOCKSHA .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-tools.tar -> docker://docker.io/envoyproxy/envoy-tools-dev:MOCKSHA
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-tools.tar docker://docker.io/envoyproxy/envoy-tools-dev:MOCKSHA
+>> TAG: envoyproxy/envoy-tools-dev:MOCKSHA -> envoyproxy/envoy:tools-dev-MOCKSHA
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:tools-dev-MOCKSHA
+>> TAG: envoyproxy/envoy-tools-dev:MOCKSHA -> envoyproxy/envoy-tools-dev:latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools-dev:MOCKSHA --tag docker.io/envoyproxy/envoy-tools-dev:latest
+>> TAG: envoyproxy/envoy-tools-dev:MOCKSHA -> envoyproxy/envoy:tools-dev
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools-dev:MOCKSHA --tag docker.io/envoyproxy/envoy:tools-dev

--- a/ci/test/docker/linux/dev/other
+++ b/ci/test/docker/linux/dev/other
@@ -1,0 +1,32 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-debug-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-contrib-debug-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp-dev:MOCKSHA
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools-dev:MOCKSHA .

--- a/ci/test/docker/linux/dev/release
+++ b/ci/test/docker/linux/dev/release
@@ -1,0 +1,32 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-debug-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-contrib-debug-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp-dev:MOCKSHA
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools-dev:MOCKSHA .

--- a/ci/test/docker/linux/dev/tag
+++ b/ci/test/docker/linux/dev/tag
@@ -1,0 +1,32 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-debug-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-debug-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-contrib-debug-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp-dev:MOCKSHA
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp-dev:MOCKSHA .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools-dev:MOCKSHA
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools-dev:MOCKSHA .

--- a/ci/test/docker/linux/nondev/main
+++ b/ci/test/docker/linux/nondev/main
@@ -1,0 +1,81 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> LOGIN
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy:v1.73.0
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy:v1.73.0 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy.tar -> docker://docker.io/envoyproxy/envoy:v1.73.0
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy.tar docker://docker.io/envoyproxy/envoy:v1.73.0
+>> TAG: envoyproxy/envoy:v1.73.0 -> envoyproxy/envoy:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy:v1.73.0 --tag docker.io/envoyproxy/envoy:v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD+PUSH: envoyproxy/envoy-debug:v1.73.0
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= --push -t envoyproxy/envoy-debug:v1.73.0 .
+>> TAG: envoyproxy/envoy-debug:v1.73.0 -> envoyproxy/envoy:debug-v1.73.0
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug:v1.73.0 --tag docker.io/envoyproxy/envoy:debug-v1.73.0
+>> TAG: envoyproxy/envoy-debug:v1.73.0 -> envoyproxy/envoy-debug:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug:v1.73.0 --tag docker.io/envoyproxy/envoy-debug:v1.73-latest
+>> TAG: envoyproxy/envoy-debug:v1.73.0 -> envoyproxy/envoy:debug-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug:v1.73.0 --tag docker.io/envoyproxy/envoy:debug-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib:v1.73.0
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib:v1.73.0 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-contrib.tar -> docker://docker.io/envoyproxy/envoy-contrib:v1.73.0
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-contrib.tar docker://docker.io/envoyproxy/envoy-contrib:v1.73.0
+>> TAG: envoyproxy/envoy-contrib:v1.73.0 -> envoyproxy/envoy:contrib-v1.73.0
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib:v1.73.0 --tag docker.io/envoyproxy/envoy:contrib-v1.73.0
+>> TAG: envoyproxy/envoy-contrib:v1.73.0 -> envoyproxy/envoy-contrib:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib:v1.73.0 --tag docker.io/envoyproxy/envoy-contrib:v1.73-latest
+>> TAG: envoyproxy/envoy-contrib:v1.73.0 -> envoyproxy/envoy:contrib-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib:v1.73.0 --tag docker.io/envoyproxy/envoy:contrib-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD+PUSH: envoyproxy/envoy-contrib-debug:v1.73.0
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= --push -t envoyproxy/envoy-contrib-debug:v1.73.0 .
+>> TAG: envoyproxy/envoy-contrib-debug:v1.73.0 -> envoyproxy/envoy:contrib-debug-v1.73.0
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug:v1.73.0 --tag docker.io/envoyproxy/envoy:contrib-debug-v1.73.0
+>> TAG: envoyproxy/envoy-contrib-debug:v1.73.0 -> envoyproxy/envoy-contrib-debug:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug:v1.73.0 --tag docker.io/envoyproxy/envoy-contrib-debug:v1.73-latest
+>> TAG: envoyproxy/envoy-contrib-debug:v1.73.0 -> envoyproxy/envoy:contrib-debug-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug:v1.73.0 --tag docker.io/envoyproxy/envoy:contrib-debug-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless:v1.73.0
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless:v1.73.0 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-distroless.tar -> docker://docker.io/envoyproxy/envoy-distroless:v1.73.0
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-distroless.tar docker://docker.io/envoyproxy/envoy-distroless:v1.73.0
+>> TAG: envoyproxy/envoy-distroless:v1.73.0 -> envoyproxy/envoy:distroless-v1.73.0
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless:v1.73.0 --tag docker.io/envoyproxy/envoy:distroless-v1.73.0
+>> TAG: envoyproxy/envoy-distroless:v1.73.0 -> envoyproxy/envoy-distroless:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless:v1.73.0 --tag docker.io/envoyproxy/envoy-distroless:v1.73-latest
+>> TAG: envoyproxy/envoy-distroless:v1.73.0 -> envoyproxy/envoy:distroless-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless:v1.73.0 --tag docker.io/envoyproxy/envoy:distroless-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp:v1.73.0
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp:v1.73.0 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-google-vrp.tar -> docker://docker.io/envoyproxy/envoy-google-vrp:v1.73.0
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-google-vrp.tar docker://docker.io/envoyproxy/envoy-google-vrp:v1.73.0
+>> TAG: envoyproxy/envoy-google-vrp:v1.73.0 -> envoyproxy/envoy:google-vrp-v1.73.0
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp:v1.73.0 --tag docker.io/envoyproxy/envoy:google-vrp-v1.73.0
+>> TAG: envoyproxy/envoy-google-vrp:v1.73.0 -> envoyproxy/envoy-google-vrp:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp:v1.73.0 --tag docker.io/envoyproxy/envoy-google-vrp:v1.73-latest
+>> TAG: envoyproxy/envoy-google-vrp:v1.73.0 -> envoyproxy/envoy:google-vrp-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp:v1.73.0 --tag docker.io/envoyproxy/envoy:google-vrp-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools:v1.73.0
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools:v1.73.0 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-tools.tar -> docker://docker.io/envoyproxy/envoy-tools:v1.73.0
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-tools.tar docker://docker.io/envoyproxy/envoy-tools:v1.73.0
+>> TAG: envoyproxy/envoy-tools:v1.73.0 -> envoyproxy/envoy:tools-v1.73.0
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools:v1.73.0 --tag docker.io/envoyproxy/envoy:tools-v1.73.0
+>> TAG: envoyproxy/envoy-tools:v1.73.0 -> envoyproxy/envoy-tools:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools:v1.73.0 --tag docker.io/envoyproxy/envoy-tools:v1.73-latest
+>> TAG: envoyproxy/envoy-tools:v1.73.0 -> envoyproxy/envoy:tools-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools:v1.73.0 --tag docker.io/envoyproxy/envoy:tools-v1.73-latest

--- a/ci/test/docker/linux/nondev/other
+++ b/ci/test/docker/linux/nondev/other
@@ -1,0 +1,32 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-debug:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-debug:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-debug:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-contrib-debug:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp:v1.73.3
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools:v1.73.3 .

--- a/ci/test/docker/linux/nondev/release
+++ b/ci/test/docker/linux/nondev/release
@@ -1,0 +1,81 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> LOGIN
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy:v1.73.3 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy.tar -> docker://docker.io/envoyproxy/envoy:v1.73.3
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy.tar docker://docker.io/envoyproxy/envoy:v1.73.3
+>> TAG: envoyproxy/envoy:v1.73.3 -> envoyproxy/envoy:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy:v1.73.3 --tag docker.io/envoyproxy/envoy:v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD+PUSH: envoyproxy/envoy-debug:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= --push -t envoyproxy/envoy-debug:v1.73.3 .
+>> TAG: envoyproxy/envoy-debug:v1.73.3 -> envoyproxy/envoy:debug-v1.73.3
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug:v1.73.3 --tag docker.io/envoyproxy/envoy:debug-v1.73.3
+>> TAG: envoyproxy/envoy-debug:v1.73.3 -> envoyproxy/envoy-debug:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug:v1.73.3 --tag docker.io/envoyproxy/envoy-debug:v1.73-latest
+>> TAG: envoyproxy/envoy-debug:v1.73.3 -> envoyproxy/envoy:debug-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-debug:v1.73.3 --tag docker.io/envoyproxy/envoy:debug-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib:v1.73.3 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-contrib.tar -> docker://docker.io/envoyproxy/envoy-contrib:v1.73.3
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-contrib.tar docker://docker.io/envoyproxy/envoy-contrib:v1.73.3
+>> TAG: envoyproxy/envoy-contrib:v1.73.3 -> envoyproxy/envoy:contrib-v1.73.3
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib:v1.73.3 --tag docker.io/envoyproxy/envoy:contrib-v1.73.3
+>> TAG: envoyproxy/envoy-contrib:v1.73.3 -> envoyproxy/envoy-contrib:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib:v1.73.3 --tag docker.io/envoyproxy/envoy-contrib:v1.73-latest
+>> TAG: envoyproxy/envoy-contrib:v1.73.3 -> envoyproxy/envoy:contrib-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib:v1.73.3 --tag docker.io/envoyproxy/envoy:contrib-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD+PUSH: envoyproxy/envoy-contrib-debug:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= --push -t envoyproxy/envoy-contrib-debug:v1.73.3 .
+>> TAG: envoyproxy/envoy-contrib-debug:v1.73.3 -> envoyproxy/envoy:contrib-debug-v1.73.3
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug:v1.73.3 --tag docker.io/envoyproxy/envoy:contrib-debug-v1.73.3
+>> TAG: envoyproxy/envoy-contrib-debug:v1.73.3 -> envoyproxy/envoy-contrib-debug:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug:v1.73.3 --tag docker.io/envoyproxy/envoy-contrib-debug:v1.73-latest
+>> TAG: envoyproxy/envoy-contrib-debug:v1.73.3 -> envoyproxy/envoy:contrib-debug-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-contrib-debug:v1.73.3 --tag docker.io/envoyproxy/envoy:contrib-debug-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless:v1.73.3 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-distroless.tar -> docker://docker.io/envoyproxy/envoy-distroless:v1.73.3
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-distroless.tar docker://docker.io/envoyproxy/envoy-distroless:v1.73.3
+>> TAG: envoyproxy/envoy-distroless:v1.73.3 -> envoyproxy/envoy:distroless-v1.73.3
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless:v1.73.3 --tag docker.io/envoyproxy/envoy:distroless-v1.73.3
+>> TAG: envoyproxy/envoy-distroless:v1.73.3 -> envoyproxy/envoy-distroless:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless:v1.73.3 --tag docker.io/envoyproxy/envoy-distroless:v1.73-latest
+>> TAG: envoyproxy/envoy-distroless:v1.73.3 -> envoyproxy/envoy:distroless-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-distroless:v1.73.3 --tag docker.io/envoyproxy/envoy:distroless-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp:v1.73.3
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp:v1.73.3 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-google-vrp.tar -> docker://docker.io/envoyproxy/envoy-google-vrp:v1.73.3
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-google-vrp.tar docker://docker.io/envoyproxy/envoy-google-vrp:v1.73.3
+>> TAG: envoyproxy/envoy-google-vrp:v1.73.3 -> envoyproxy/envoy:google-vrp-v1.73.3
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp:v1.73.3 --tag docker.io/envoyproxy/envoy:google-vrp-v1.73.3
+>> TAG: envoyproxy/envoy-google-vrp:v1.73.3 -> envoyproxy/envoy-google-vrp:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp:v1.73.3 --tag docker.io/envoyproxy/envoy-google-vrp:v1.73-latest
+>> TAG: envoyproxy/envoy-google-vrp:v1.73.3 -> envoyproxy/envoy:google-vrp-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-google-vrp:v1.73.3 --tag docker.io/envoyproxy/envoy:google-vrp-v1.73-latest
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools:v1.73.3 .
+>> PUSH: oci-archive:/non/existent/test/path/envoy-tools.tar -> docker://docker.io/envoyproxy/envoy-tools:v1.73.3
+> skopeo copy --multi-arch all oci-archive:/non/existent/test/path/envoy-tools.tar docker://docker.io/envoyproxy/envoy-tools:v1.73.3
+>> TAG: envoyproxy/envoy-tools:v1.73.3 -> envoyproxy/envoy:tools-v1.73.3
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools:v1.73.3 --tag docker.io/envoyproxy/envoy:tools-v1.73.3
+>> TAG: envoyproxy/envoy-tools:v1.73.3 -> envoyproxy/envoy-tools:v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools:v1.73.3 --tag docker.io/envoyproxy/envoy-tools:v1.73-latest
+>> TAG: envoyproxy/envoy-tools:v1.73.3 -> envoyproxy/envoy:tools-v1.73-latest
+> docker buildx imagetools create docker.io/envoyproxy/envoy-tools:v1.73.3 --tag docker.io/envoyproxy/envoy:tools-v1.73-latest

--- a/ci/test/docker/linux/nondev/tag
+++ b/ci/test/docker/linux/nondev/tag
@@ -1,0 +1,32 @@
+>> BUILDX: install
+> docker run --rm --privileged tonistiigi/binfmt --install all
+> docker buildx rm multi-builder 2> /dev/null || :
+> docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy -o type=oci,dest=/non/existent/test/path/envoy.tar -t envoyproxy/envoy:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-debug:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-debug:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib -o type=oci,dest=/non/existent/test/path/envoy-contrib.tar -t envoyproxy/envoy-contrib:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-contrib-debug:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy --build-arg ENVOY_BINARY=envoy-contrib --build-arg ENVOY_BINARY_SUFFIX= -t envoyproxy/envoy-contrib-debug:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-distroless:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-distroless -o type=oci,dest=/non/existent/test/path/envoy-distroless.tar -t envoyproxy/envoy-distroless:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-google-vrp:v1.73.3
+> docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy --target envoy-google-vrp -o type=oci,dest=/non/existent/test/path/envoy-google-vrp.tar -t envoyproxy/envoy-google-vrp:v1.73.3 .
+>> BUILDX: use multi-builder
+> docker buildx use multi-builder
+>> BUILD: envoyproxy/envoy-tools:v1.73.3
+> docker buildx build --platform linux/arm64,linux/amd64 -f ci/Dockerfile-envoy --target envoy-tools -o type=oci,dest=/non/existent/test/path/envoy-tools.tar -t envoyproxy/envoy-tools:v1.73.3 .

--- a/ci/test/docker/windows/dev/main
+++ b/ci/test/docker/windows/dev/main
@@ -1,0 +1,9 @@
+>> LOGIN
+>> BUILD: envoyproxy/envoy-legacy-dev:MOCKSHA
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy-dev:MOCKSHA .
+>> PUSH: envoyproxy/envoy-legacy-dev:MOCKSHA
+> docker push envoyproxy/envoy-legacy-dev:MOCKSHA
+>> TAG: envoyproxy/envoy-legacy-dev:MOCKSHA -> envoyproxy/envoy-legacy-dev:latest
+> docker tag envoyproxy/envoy-legacy-dev:MOCKSHA envoyproxy/envoy-legacy-dev:latest
+>> PUSH: envoyproxy/envoy-legacy-dev:latest
+> docker push envoyproxy/envoy-legacy-dev:latest

--- a/ci/test/docker/windows/dev/other
+++ b/ci/test/docker/windows/dev/other
@@ -1,0 +1,2 @@
+>> BUILD: envoyproxy/envoy-legacy-dev:MOCKSHA
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy-dev:MOCKSHA .

--- a/ci/test/docker/windows/dev/release
+++ b/ci/test/docker/windows/dev/release
@@ -1,0 +1,2 @@
+>> BUILD: envoyproxy/envoy-legacy-dev:MOCKSHA
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy-dev:MOCKSHA .

--- a/ci/test/docker/windows/dev/tag
+++ b/ci/test/docker/windows/dev/tag
@@ -1,0 +1,2 @@
+>> BUILD: envoyproxy/envoy-legacy-dev:MOCKSHA
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy-dev:MOCKSHA .

--- a/ci/test/docker/windows/nondev/main
+++ b/ci/test/docker/windows/nondev/main
@@ -1,0 +1,9 @@
+>> LOGIN
+>> BUILD: envoyproxy/envoy-legacy:v1.73.0
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy:v1.73.0 .
+>> PUSH: envoyproxy/envoy-legacy:v1.73.0
+> docker push envoyproxy/envoy-legacy:v1.73.0
+>> TAG: envoyproxy/envoy-legacy:v1.73.0 -> envoyproxy/envoy-legacy:v1.73-latest
+> docker tag envoyproxy/envoy-legacy:v1.73.0 envoyproxy/envoy-legacy:v1.73-latest
+>> PUSH: envoyproxy/envoy-legacy:v1.73-latest
+> docker push envoyproxy/envoy-legacy:v1.73-latest

--- a/ci/test/docker/windows/nondev/other
+++ b/ci/test/docker/windows/nondev/other
@@ -1,0 +1,2 @@
+>> BUILD: envoyproxy/envoy-legacy:v1.73.3
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy:v1.73.3 .

--- a/ci/test/docker/windows/nondev/release
+++ b/ci/test/docker/windows/nondev/release
@@ -1,0 +1,9 @@
+>> LOGIN
+>> BUILD: envoyproxy/envoy-legacy:v1.73.3
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy:v1.73.3 .
+>> PUSH: envoyproxy/envoy-legacy:v1.73.3
+> docker push envoyproxy/envoy-legacy:v1.73.3
+>> TAG: envoyproxy/envoy-legacy:v1.73.3 -> envoyproxy/envoy-legacy:v1.73-latest
+> docker tag envoyproxy/envoy-legacy:v1.73.3 envoyproxy/envoy-legacy:v1.73-latest
+>> PUSH: envoyproxy/envoy-legacy:v1.73-latest
+> docker push envoyproxy/envoy-legacy:v1.73-latest

--- a/ci/test/docker/windows/nondev/tag
+++ b/ci/test/docker/windows/nondev/tag
@@ -1,0 +1,2 @@
+>> BUILD: envoyproxy/envoy-legacy:v1.73.3
+> docker build --platform windows/amd64 -f ci/Dockerfile-envoy-windows --build-arg BUILD_OS=mcr.microsoft.com/windows/fakecore --build-arg BUILD_TAG=ltsc1992 -t envoyproxy/envoy-legacy:v1.73.3 .

--- a/ci/test_docker_ci.sh
+++ b/ci/test_docker_ci.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Run this with `./ci/test_docker_ci.sh`.
+#
+# Compares against data stored in `ci/test/docker`
+#
+# To commit what is currently produced use:
+#    `DOCKER_CI_TEST_COMMIT=1 ./ci/test_docker_ci.sh`
+#
+
+TESTS_MATCHING="$1"
+
+FAILED=()
+DOCKER_CI_FIX="${DOCKER_CI_FIX:-}"
+DOCKER_CI_FIX_DIFF="${DOCKER_CI_FIX_DIFF:-}"
+
+VERSION="1.73"
+RELEASE_BRANCH="refs/heads/release/vXXX"
+TAG_BRANCH="refs/tags/vXXX"
+MAIN_BRANCH="refs/heads/main"
+OTHER_BRANCH="refs/heads/something/else"
+
+PLATFORMS=(linux windows)
+TEST_TYPES=(dev nondev)
+BRANCH_TYPES=(tag release main other)
+
+
+_test () {
+    local test_type="$1" branch_type="$2" version branch platform name testdata
+    local platform="${3:-linux}"
+
+    name="${platform}_${test_type}_${branch_type}"
+    testdata="ci/test/docker/${platform}/${test_type}/${branch_type}"
+
+    if ! test_matches "${name}"; then
+        return
+    fi
+
+    if [[ "$branch_type" == "release" ]]; then
+       version="${VERSION}.3"
+       branch="$RELEASE_BRANCH"
+    elif [[ "$branch_type" == "tag" ]]; then
+       version="${VERSION}.3"
+       branch="$TAG_BRANCH"
+    elif [[ "$branch_type" == "other" ]]; then
+       version="${VERSION}.3"
+       branch="$OTHER_BRANCH"
+    else
+       branch="$MAIN_BRANCH"
+       version="${VERSION}.0"
+    fi
+    if [[ "$test_type" == "dev" ]]; then
+        version="${version}-dev"
+    fi
+
+    export ENVOY_VERSION="${version}"
+    export AZP_BRANCH="$branch"
+    export DOCKER_CI_DRYRUN=1
+    export ENVOY_DOCKER_IMAGE_DIRECTORY=/non/existent/test/path
+
+    if [[ "$platform" == "windows" ]]; then
+        export DOCKER_FAKE_WIN=1
+    fi
+
+    if [[ "$DOCKER_CI_TEST_COMMIT" ]]; then
+        echo "COMMIT(${name}): > ${testdata}"
+        echo "  DOCKER_FAKE_WIN=${DOCKER_FAKE_WIN} ENVOY_VERSION=${version} ENVOY_DOCKER_IMAGE_DIRECTORY=/non/existent/test/path AZP_BRANCH=${branch} DOCKER_CI_DRYRUN=1 ./ci/docker_ci.sh | grep -E \"^>\""
+        ./ci/docker_ci.sh | grep -E "^>" > "$testdata"
+        return
+    fi
+
+    echo "TEST(${name}): <> ${testdata}"
+    echo "  DOCKER_FAKE_WIN=${DOCKER_FAKE_WIN} ENVOY_VERSION=${version} ENVOY_DOCKER_IMAGE_DIRECTORY=/non/existent/test/path AZP_BRANCH=${branch} DOCKER_CI_DRYRUN=1 ./ci/docker_ci.sh | grep -E \"^>\""
+    generated="$(mktemp)"
+
+    ./ci/docker_ci.sh | grep -E "^>" > "$generated"
+
+    cmp --silent "$testdata" "$generated" || {
+        echo "files are different" >&2
+        diff "$testdata" "$generated" >&2
+        echo >&2
+        echo "--------------------------" >&2
+        cat "$generated"
+        echo >&2
+        FAILED+=("$name")
+        echo >&2
+        echo "--------------------------" >&2
+    }
+
+    rm "$generated"
+}
+
+test_matches () {
+    local test_type="$1"
+    if [[ -z "$TESTS_MATCHING" ]]; then
+        return 0
+    fi
+    if [[ "$test_type" =~ $TESTS_MATCHING ]]; then
+        return 0
+    fi
+    return 1
+}
+
+run_tests () {
+    local platform test_type branch_type
+
+    for platform in "${PLATFORMS[@]}"; do
+        for test_type in "${TEST_TYPES[@]}"; do
+            for branch_type in "${BRANCH_TYPES[@]}"; do
+                _test "$test_type" "$branch_type" "$platform"
+            done
+        done
+    done
+}
+
+handle_failure () {
+    local platform test_type branch_type
+    if [[ "${#FAILED[@]}" -eq 0 ]]; then
+        return
+    fi
+    echo >&2
+    echo "----------------------" >&2
+    echo "FAILED" >&2
+
+    for FAILURE in "${FAILED[@]}"; do
+        echo "$FAILURE" >&2
+        if [[ -n "$DOCKER_CI_FIX" ]]; then
+            platform="$(echo "$FAILURE" | cut -d_ -f1)"
+            test_type="$(echo "$FAILURE" | cut -d_ -f2)"
+            branch_type="$(echo "$FAILURE" | cut -d_ -f3)"
+            DOCKER_CI_TEST_COMMIT=1 _test "$test_type" "$branch_type" "$platform"
+        fi
+    done
+
+    if [[ -n "$DOCKER_CI_FIX" ]]; then
+        git add -N ci/test/docker
+        echo >&2
+        echo "----------------------" >&2
+        echo "DIFF APPLIED" >&2
+        echo >&2
+        git diff ci/test/docker >&2
+
+        if [[ -n "$DOCKER_CI_FIX_DIFF" ]]; then
+            git diff ci/test/docker > "$DOCKER_CI_FIX_DIFF"
+        fi
+        echo "----------------------" >&2
+        if [[ -e "$DOCKER_CI_FIX_DIFF" ]]; then
+            echo >&2
+            echo "Diff file with fixes will be uploaded. Please check the artefacts for this PR run in the azure pipeline." >&2
+            echo >&2
+            echo "Fixes will need to be checked before being committed." >&2
+        fi
+    fi
+
+    return 1
+}
+
+run_tests
+handle_failure || {
+    exit 1
+}


### PR DESCRIPTION
This refactors and adds regression tests to `./ci/docker_ci.sh`.

Images are no longer built repeatedly (in postsubmit) so it should be much faster.

Fixes missing `-latest` images from release builds.

Fix #25767 
Fix #25766 
Fix #25765 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
