### PR TITLE
RequestIDExtension: Make usable for upstream filters

### DIFF
--- a/envoy/server/request_id_extension_config.h
+++ b/envoy/server/request_id_extension_config.h
@@ -24,8 +24,8 @@ public:
    * @param config the custom configuration for this request id extension type.
    * @param context general filter context through which persistent resources can be accessed.
    */
-  virtual Http::RequestIDExtensionSharedPtr createExtensionInstance(const Protobuf::Message& config,
-                                                                    FactoryContext& context) PURE;
+  virtual Http::RequestIDExtensionSharedPtr
+  createExtensionInstance(const Protobuf::Message& config, CommonFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.request_id"; }
 };

--- a/source/common/http/request_id_extension_impl.cc
+++ b/source/common/http/request_id_extension_impl.cc
@@ -8,7 +8,7 @@ namespace Http {
 RequestIDExtensionSharedPtr RequestIDExtensionFactory::fromProto(
     const envoy::extensions::filters::network::http_connection_manager::v3::RequestIDExtension&
         config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::CommonFactoryContext& context) {
   const std::string type{TypeUtil::typeUrlToDescriptorFullName(config.typed_config().type_url())};
   auto* factory =
       Registry::FactoryRegistry<Server::Configuration::RequestIDExtensionFactory>::getFactoryByType(

--- a/source/common/http/request_id_extension_impl.h
+++ b/source/common/http/request_id_extension_impl.h
@@ -17,7 +17,7 @@ public:
   static RequestIDExtensionSharedPtr fromProto(
       const envoy::extensions::filters::network::http_connection_manager::v3::RequestIDExtension&
           config,
-      Server::Configuration::FactoryContext& context);
+      Server::Configuration::CommonFactoryContext& context);
 };
 
 } // namespace Http

--- a/source/extensions/request_id/uuid/config.h
+++ b/source/extensions/request_id/uuid/config.h
@@ -73,7 +73,7 @@ public:
   }
   Envoy::Http::RequestIDExtensionSharedPtr
   createExtensionInstance(const Protobuf::Message& config,
-                          Server::Configuration::FactoryContext& context) override {
+                          Server::Configuration::CommonFactoryContext& context) override {
     return std::make_shared<UUIDRequestIDExtension>(
         MessageUtil::downcastAndValidate<
             const envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig&>(

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1936,7 +1936,7 @@ public:
 
   Http::RequestIDExtensionSharedPtr
   createExtensionInstance(const Protobuf::Message& config,
-                          Server::Configuration::FactoryContext& context) override {
+                          Server::Configuration::CommonFactoryContext& context) override {
     const auto& custom_config = MessageUtil::downcastAndValidate<
         const test::http_connection_manager::CustomRequestIDExtension&>(
         config, context.messageValidationVisitor());


### PR DESCRIPTION
Commit Message:

Change factory context to CommonFactoryContext so that RequestIDExtension can also be used from upstream filters.

Additional Description:
Risk Level: Low
Testing: Covered by existing tests (e.g., //test/extensions/request_id/uuid:config_test)
Docs Changes:
Release Notes:
Platform Specific Features:
