### PR TITLE
connection: Make isHalfCloseEnabled const

### DIFF
--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -131,7 +131,7 @@ public:
   /**
    * @return true if half-close semantics are enabled, false otherwise.
    */
-  virtual bool isHalfCloseEnabled() PURE;
+  virtual bool isHalfCloseEnabled() const PURE;
 
   /**
    * Close the connection.

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -65,7 +65,7 @@ public:
   // Network::Connection
   void addBytesSentCallback(BytesSentCb cb) override;
   void enableHalfClose(bool enabled) override;
-  bool isHalfCloseEnabled() override { return enable_half_close_; }
+  bool isHalfCloseEnabled() const override { return enable_half_close_; }
   void close(ConnectionCloseType type) final;
   void close(ConnectionCloseType type, absl::string_view details) override {
     if (!details.empty()) {

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -102,7 +102,9 @@ void MultiConnectionBaseImpl::enableHalfClose(bool enabled) {
   }
 }
 
-bool MultiConnectionBaseImpl::isHalfCloseEnabled() { return connections_[0]->isHalfCloseEnabled(); }
+bool MultiConnectionBaseImpl::isHalfCloseEnabled() const {
+  return connections_[0]->isHalfCloseEnabled();
+}
 
 std::string MultiConnectionBaseImpl::nextProtocol() const {
   return connections_[0]->nextProtocol();

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -100,7 +100,7 @@ public:
   absl::optional<uint64_t> congestionWindowInBytes() const override;
 
   // Simple getters which always delegate to the first connection in connections_.
-  bool isHalfCloseEnabled() override;
+  bool isHalfCloseEnabled() const override;
   std::string nextProtocol() const override;
   // Note, this might change before connect finishes.
   ConnectionInfoSetter& connectionInfoSetter() override;

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -53,7 +53,7 @@ void QuicFilterManagerConnectionImpl::enableHalfClose(bool enabled) {
   RELEASE_ASSERT(!enabled, "Quic connection doesn't support half close.");
 }
 
-bool QuicFilterManagerConnectionImpl::isHalfCloseEnabled() {
+bool QuicFilterManagerConnectionImpl::isHalfCloseEnabled() const {
   // Quic doesn't support half close.
   return false;
 }

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -51,7 +51,7 @@ public:
     IS_ENVOY_BUG("unexpected call to addBytesSentCallback");
   }
   void enableHalfClose(bool enabled) override;
-  bool isHalfCloseEnabled() override;
+  bool isHalfCloseEnabled() const override;
   void close(Network::ConnectionCloseType type) override;
   void close(Network::ConnectionCloseType type, absl::string_view details) override {
     if (!details.empty()) {

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -115,7 +115,7 @@ protected:
         IS_ENVOY_BUG("Unexpected function call");
       }
       void enableHalfClose(bool) override { IS_ENVOY_BUG("Unexpected function call"); }
-      bool isHalfCloseEnabled() override {
+      bool isHalfCloseEnabled() const override {
         IS_ENVOY_BUG("Unexpected function call");
         return false;
       }

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -55,7 +55,7 @@ public:
   MOCK_METHOD(void, addReadFilter, (ReadFilterSharedPtr filter));                                  \
   MOCK_METHOD(void, removeReadFilter, (ReadFilterSharedPtr filter));                               \
   MOCK_METHOD(void, enableHalfClose, (bool enabled));                                              \
-  MOCK_METHOD(bool, isHalfCloseEnabled, ());                                                       \
+  MOCK_METHOD(bool, isHalfCloseEnabled, (), (const));                                              \
   MOCK_METHOD(void, close, (ConnectionCloseType type));                                            \
   MOCK_METHOD(void, close, (ConnectionCloseType type, absl::string_view details));                 \
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());                                                 \


### PR DESCRIPTION
Commit Message: isHalfCloseEnabled() will work also on const Connections, as returned by many Envoy APIs, if we make it const.

Additional Description:
Risk Level: Low
Testing: Exiting test coverage is sufficient
Docs Changes:
Release Notes:
Platform Specific Features:
