### PR TITLE
match: Pass streamInfo as input to Http matching data

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -1116,6 +1116,7 @@ public:
   virtual RequestTrailerMapOptConstRef requestTrailers() const PURE;
   virtual ResponseHeaderMapOptConstRef responseHeaders() const PURE;
   virtual ResponseTrailerMapOptConstRef responseTrailers() const PURE;
+  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
   virtual const Network::ConnectionInfoProvider& connectionInfoProvider() const PURE;
 
   const Network::Address::Instance& localAddress() const {

--- a/source/common/http/match_delegate/config.h
+++ b/source/common/http/match_delegate/config.h
@@ -30,8 +30,7 @@ public:
     bool skipFilter() const { return skip_filter_; }
     void onStreamInfo(const StreamInfo::StreamInfo& stream_info) {
       if (has_match_tree_ && matching_data_ == nullptr) {
-        matching_data_ = std::make_shared<Envoy::Http::Matching::HttpMatchingDataImpl>(
-            stream_info.downstreamAddressProvider());
+        matching_data_ = std::make_shared<Envoy::Http::Matching::HttpMatchingDataImpl>(stream_info);
       }
     }
     void setBaseFilter(Envoy::Http::StreamFilterBase* base_filter) { base_filter_ = base_filter; }

--- a/source/common/http/matching/data_impl.h
+++ b/source/common/http/matching/data_impl.h
@@ -13,8 +13,8 @@ namespace Matching {
  */
 class HttpMatchingDataImpl : public HttpMatchingData {
 public:
-  explicit HttpMatchingDataImpl(const Network::ConnectionInfoProvider& connection_info_provider)
-      : connection_info_provider_(connection_info_provider) {}
+  explicit HttpMatchingDataImpl(const StreamInfo::StreamInfo& stream_info)
+      : stream_info_(stream_info) {}
 
   static absl::string_view name() { return "http"; }
 
@@ -50,12 +50,14 @@ public:
     return makeOptRefFromPtr(response_trailers_);
   }
 
+  const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
+
   const Network::ConnectionInfoProvider& connectionInfoProvider() const override {
-    return connection_info_provider_;
+    return stream_info_.downstreamAddressProvider();
   }
 
 private:
-  const Network::ConnectionInfoProvider& connection_info_provider_;
+  const StreamInfo::StreamInfo& stream_info_;
   const RequestHeaderMap* request_headers_{};
   const ResponseHeaderMap* response_headers_{};
   const RequestTrailerMap* request_trailers_{};

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1967,7 +1967,7 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
   }
 
   if (matcher_) {
-    Http::Matching::HttpMatchingDataImpl data(stream_info.downstreamAddressProvider());
+    Http::Matching::HttpMatchingDataImpl data(stream_info);
     data.onRequestHeaders(headers);
 
     auto match = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -58,7 +58,7 @@ public:
   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry, const std::string&,
                           const Http::RequestHeaderMap& headers,
                           const StreamInfo::StreamInfo& info) const override {
-    Http::Matching::HttpMatchingDataImpl data(info.downstreamAddressProvider());
+    Http::Matching::HttpMatchingDataImpl data(info);
     data.onRequestHeaders(headers);
     auto result = data_input_->get(data);
     if (result.data_) {

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -131,7 +131,7 @@ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(const Network::Connec
 bool RoleBasedAccessControlMatcherEngineImpl::handleAction(
     const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
     StreamInfo::StreamInfo& info, std::string* effective_policy_id) const {
-  Http::Matching::HttpMatchingDataImpl data(connection.connectionInfoProvider());
+  Http::Matching::HttpMatchingDataImpl data(connection.streamInfo());
   data.onRequestHeaders(headers);
   const auto& result = Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
   ASSERT(result.match_state_ == Envoy::Matcher::MatchState::MatchComplete);

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -129,9 +129,9 @@ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(const Network::Connec
 }
 
 bool RoleBasedAccessControlMatcherEngineImpl::handleAction(
-    const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
+    const Network::Connection&, const Envoy::Http::RequestHeaderMap& headers,
     StreamInfo::StreamInfo& info, std::string* effective_policy_id) const {
-  Http::Matching::HttpMatchingDataImpl data(connection.streamInfo());
+  Http::Matching::HttpMatchingDataImpl data(info);
   data.onRequestHeaders(headers);
   const auto& result = Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
   ASSERT(result.match_state_ == Envoy::Matcher::MatchState::MatchComplete);

--- a/source/extensions/filters/http/custom_response/config.cc
+++ b/source/extensions/filters/http/custom_response/config.cc
@@ -55,7 +55,7 @@ PolicySharedPtr FilterConfig::getPolicy(::Envoy::Http::ResponseHeaderMap& header
     return PolicySharedPtr{};
   }
 
-  ::Envoy::Http::Matching::HttpMatchingDataImpl data(stream_info.downstreamAddressProvider());
+  ::Envoy::Http::Matching::HttpMatchingDataImpl data(stream_info);
   data.onResponseHeaders(headers);
   auto match = Matcher::evaluateMatch<::Envoy::Http::HttpMatchingData>(*matcher_, data);
   if (!match.result_) {

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -54,8 +54,7 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
   // This avoids creating the data object for every request, which is expensive.
   if (data_ptr_ == nullptr) {
     if (callbacks_ != nullptr) {
-      data_ptr_ = std::make_unique<Http::Matching::HttpMatchingDataImpl>(
-          callbacks_->streamInfo().downstreamAddressProvider());
+      data_ptr_ = std::make_unique<Http::Matching::HttpMatchingDataImpl>(callbacks_->streamInfo());
     } else {
       return absl::InternalError("Filter callback has not been initialized successfully yet.");
     }

--- a/test/common/http/matching/BUILD
+++ b/test/common/http/matching/BUILD
@@ -16,6 +16,7 @@ envoy_cc_test(
         "//source/common/http/matching:inputs_lib",
         "//source/common/network:address_lib",
         "//source/common/network:socket_lib",
+        "//test/test_common:test_time_lib",
     ],
 )
 
@@ -27,5 +28,6 @@ envoy_cc_test(
         "//source/common/http/matching:status_code_input_lib",
         "//source/common/network:address_lib",
         "//source/common/network:socket_lib",
+        "//test/test_common:test_time_lib",
     ],
 )

--- a/test/common/http/matching/inputs_test.cc
+++ b/test/common/http/matching/inputs_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/http/filter.h"
 
 #include "source/common/http/matching/data_impl.h"
@@ -8,7 +10,6 @@
 
 #include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
-#include <memory>
 
 namespace Envoy {
 namespace Http {
@@ -22,10 +23,10 @@ std::shared_ptr<Network::ConnectionInfoSetterImpl> connectionInfoProvider() {
 }
 
 StreamInfo::StreamInfoImpl createStreamInfo() {
-  CONSTRUCT_ON_FIRST_USE(
-      StreamInfo::StreamInfoImpl,
-      StreamInfo::StreamInfoImpl(Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(),
-                                     connectionInfoProvider()));
+  CONSTRUCT_ON_FIRST_USE(StreamInfo::StreamInfoImpl,
+                         StreamInfo::StreamInfoImpl(Http::Protocol::Http2,
+                                                    Event::GlobalTimeSystem().timeSystem(),
+                                                    connectionInfoProvider()));
 }
 
 TEST(MatchingData, HttpRequestHeadersDataInput) {

--- a/test/common/http/matching/inputs_test.cc
+++ b/test/common/http/matching/inputs_test.cc
@@ -8,17 +8,24 @@
 
 #include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
+#include <memory>
 
 namespace Envoy {
 namespace Http {
 namespace Matching {
 
-// Helper function to create the stream info.
+std::shared_ptr<Network::ConnectionInfoSetterImpl> connectionInfoProvider() {
+  CONSTRUCT_ON_FIRST_USE(std::shared_ptr<Network::ConnectionInfoSetterImpl>,
+                         std::make_shared<Network::ConnectionInfoSetterImpl>(
+                             std::make_shared<Network::Address::Ipv4Instance>(80),
+                             std::make_shared<Network::Address::Ipv4Instance>(80)));
+}
+
 StreamInfo::StreamInfoImpl createStreamInfo() {
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
-  return {Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider};
+  CONSTRUCT_ON_FIRST_USE(
+      StreamInfo::StreamInfoImpl,
+      StreamInfo::StreamInfoImpl(Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(),
+                                     connectionInfoProvider()));
 }
 
 TEST(MatchingData, HttpRequestHeadersDataInput) {

--- a/test/common/http/matching/inputs_test.cc
+++ b/test/common/http/matching/inputs_test.cc
@@ -18,8 +18,7 @@ StreamInfo::StreamInfoImpl createStreamInfo() {
   auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  return StreamInfo::StreamInfoImpl(Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(),
-                                    connection_info_provider);
+  return {Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider};
 }
 
 TEST(MatchingData, HttpRequestHeadersDataInput) {

--- a/test/common/http/matching/inputs_test.cc
+++ b/test/common/http/matching/inputs_test.cc
@@ -14,7 +14,7 @@ namespace Http {
 namespace Matching {
 
 // Helper function to create the stream info.
-StreamInfo::StreamInfoImpl CreateStreamInfo() {
+StreamInfo::StreamInfoImpl createStreamInfo() {
   auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
@@ -24,7 +24,7 @@ StreamInfo::StreamInfoImpl CreateStreamInfo() {
 
 TEST(MatchingData, HttpRequestHeadersDataInput) {
   HttpRequestHeadersDataInput input("header");
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
 
   {
     TestRequestHeaderMapImpl request_headers({{"header", "bar"}});
@@ -45,7 +45,7 @@ TEST(MatchingData, HttpRequestHeadersDataInput) {
 
 TEST(MatchingData, HttpRequestTrailersDataInput) {
   HttpRequestTrailersDataInput input("header");
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
 
   {
     TestRequestTrailerMapImpl request_trailers({{"header", "bar"}});
@@ -69,7 +69,7 @@ TEST(MatchingData, HttpResponseHeadersDataInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
 
   {
     TestResponseHeaderMapImpl response_headers({{"header", "bar"}});
@@ -93,7 +93,7 @@ TEST(MatchingData, HttpResponseTrailersDataInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
 
   {
     TestResponseTrailerMapImpl response_trailers({{"header", "bar"}});
@@ -116,7 +116,7 @@ TEST(MatchingData, HttpRequestQueryParamsDataInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
 
   {
     HttpRequestQueryParamsDataInput input("arg");

--- a/test/common/http/matching/inputs_test.cc
+++ b/test/common/http/matching/inputs_test.cc
@@ -4,19 +4,27 @@
 #include "source/common/http/matching/inputs.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/socket_impl.h"
+#include "source/common/stream_info/stream_info_impl.h"
 
+#include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Http {
 namespace Matching {
 
-TEST(MatchingData, HttpRequestHeadersDataInput) {
-  HttpRequestHeadersDataInput input("header");
-  Network::ConnectionInfoSetterImpl connection_info_provider(
+// Helper function to create the stream info.
+StreamInfo::StreamInfoImpl CreateStreamInfo() {
+  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  return StreamInfo::StreamInfoImpl(Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(),
+                                    connection_info_provider);
+}
+
+TEST(MatchingData, HttpRequestHeadersDataInput) {
+  HttpRequestHeadersDataInput input("header");
+  HttpMatchingDataImpl data(CreateStreamInfo());
 
   {
     TestRequestHeaderMapImpl request_headers({{"header", "bar"}});
@@ -37,10 +45,7 @@ TEST(MatchingData, HttpRequestHeadersDataInput) {
 
 TEST(MatchingData, HttpRequestTrailersDataInput) {
   HttpRequestTrailersDataInput input("header");
-  Network::ConnectionInfoSetterImpl connection_info_provider(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  HttpMatchingDataImpl data(CreateStreamInfo());
 
   {
     TestRequestTrailerMapImpl request_trailers({{"header", "bar"}});
@@ -64,7 +69,7 @@ TEST(MatchingData, HttpResponseHeadersDataInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  HttpMatchingDataImpl data(CreateStreamInfo());
 
   {
     TestResponseHeaderMapImpl response_headers({{"header", "bar"}});
@@ -88,7 +93,7 @@ TEST(MatchingData, HttpResponseTrailersDataInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  HttpMatchingDataImpl data(CreateStreamInfo());
 
   {
     TestResponseTrailerMapImpl response_trailers({{"header", "bar"}});
@@ -111,7 +116,7 @@ TEST(MatchingData, HttpRequestQueryParamsDataInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  HttpMatchingDataImpl data(CreateStreamInfo());
 
   {
     HttpRequestQueryParamsDataInput input("arg");

--- a/test/common/http/matching/status_code_input_test.cc
+++ b/test/common/http/matching/status_code_input_test.cc
@@ -13,14 +13,19 @@ namespace Envoy {
 namespace Http {
 namespace Matching {
 
-// Helper function to create the stream info.
-StreamInfo::StreamInfoImpl createStreamInfo() {
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
-  return {Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider};
+std::shared_ptr<Network::ConnectionInfoSetterImpl> connectionInfoProvider() {
+  CONSTRUCT_ON_FIRST_USE(std::shared_ptr<Network::ConnectionInfoSetterImpl>,
+                         std::make_shared<Network::ConnectionInfoSetterImpl>(
+                             std::make_shared<Network::Address::Ipv4Instance>(80),
+                             std::make_shared<Network::Address::Ipv4Instance>(80)));
 }
 
+StreamInfo::StreamInfoImpl createStreamInfo() {
+  CONSTRUCT_ON_FIRST_USE(StreamInfo::StreamInfoImpl,
+                         StreamInfo::StreamInfoImpl(Http::Protocol::Http2,
+                                                    Event::GlobalTimeSystem().timeSystem(),
+                                                    connectionInfoProvider()));
+}
 TEST(MatchingData, HttpResponseStatusCodeInput) {
   HttpResponseStatusCodeInput input;
   Network::ConnectionInfoSetterImpl connection_info_provider(

--- a/test/common/http/matching/status_code_input_test.cc
+++ b/test/common/http/matching/status_code_input_test.cc
@@ -18,8 +18,7 @@ StreamInfo::StreamInfoImpl createStreamInfo() {
   auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  return StreamInfo::StreamInfoImpl(Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(),
-                                    connection_info_provider);
+  return {Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider};
 }
 
 TEST(MatchingData, HttpResponseStatusCodeInput) {

--- a/test/common/http/matching/status_code_input_test.cc
+++ b/test/common/http/matching/status_code_input_test.cc
@@ -14,7 +14,7 @@ namespace Http {
 namespace Matching {
 
 // Helper function to create the stream info.
-StreamInfo::StreamInfoImpl CreateStreamInfo() {
+StreamInfo::StreamInfoImpl createStreamInfo() {
   auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
@@ -27,7 +27,7 @@ TEST(MatchingData, HttpResponseStatusCodeInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
 
   {
     auto result = input.get(data);
@@ -58,7 +58,7 @@ TEST(MatchingData, HttpResponseStatusCodeClassInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(CreateStreamInfo());
+  HttpMatchingDataImpl data(createStreamInfo());
   {
     auto result = input.get(data);
     EXPECT_EQ(result.data_availability_,

--- a/test/common/http/matching/status_code_input_test.cc
+++ b/test/common/http/matching/status_code_input_test.cc
@@ -4,19 +4,30 @@
 #include "source/common/http/matching/status_code_input.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/socket_impl.h"
+#include "source/common/stream_info/stream_info_impl.h"
 
+#include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Http {
 namespace Matching {
 
+// Helper function to create the stream info.
+StreamInfo::StreamInfoImpl CreateStreamInfo() {
+  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
+      std::make_shared<Network::Address::Ipv4Instance>(80),
+      std::make_shared<Network::Address::Ipv4Instance>(80));
+  return StreamInfo::StreamInfoImpl(Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(),
+                                    connection_info_provider);
+}
+
 TEST(MatchingData, HttpResponseStatusCodeInput) {
   HttpResponseStatusCodeInput input;
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  HttpMatchingDataImpl data(CreateStreamInfo());
 
   {
     auto result = input.get(data);
@@ -47,7 +58,7 @@ TEST(MatchingData, HttpResponseStatusCodeClassInput) {
   Network::ConnectionInfoSetterImpl connection_info_provider(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  HttpMatchingDataImpl data(connection_info_provider);
+  HttpMatchingDataImpl data(CreateStreamInfo());
   {
     auto result = input.get(data);
     EXPECT_EQ(result.data_availability_,

--- a/test/common/network/matching/inputs_test.cc
+++ b/test/common/network/matching/inputs_test.cc
@@ -36,14 +36,23 @@ TEST(MatchingData, DestinationIPInput) {
 }
 
 TEST(MatchingData, HttpDestinationIPInput) {
-  ConnectionInfoSetterImpl connection_info_provider(
+  // ConnectionInfoSetterImpl connection_info_provider(
+  //     std::make_shared<Address::Ipv4Instance>("127.0.0.1", 8080),
+  //     std::make_shared<Address::Ipv4Instance>("10.0.0.1", 9090));
+  // connection_info_provider.setDirectRemoteAddressForTest(
+  //     std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2", 8081));
+  // auto host = "example.com";
+  // connection_info_provider.setRequestedServerName(host);
+  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Address::Ipv4Instance>("127.0.0.1", 8080),
       std::make_shared<Address::Ipv4Instance>("10.0.0.1", 9090));
-  connection_info_provider.setDirectRemoteAddressForTest(
+  connection_info_provider->setDirectRemoteAddressForTest(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2", 8081));
   auto host = "example.com";
-  connection_info_provider.setRequestedServerName(host);
-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
+  connection_info_provider->setRequestedServerName(host);
+  StreamInfo::StreamInfoImpl stream_info(
+      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider);
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
   {
     DestinationIPInput<Http::HttpMatchingData> input;
     const auto result = input.get(data);
@@ -87,7 +96,7 @@ TEST(MatchingData, HttpDestinationIPInput) {
     EXPECT_EQ(result.data_, host);
   }
 
-  connection_info_provider.setRemoteAddress(
+  connection_info_provider->setRemoteAddress(
       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8081));
   {
     SourceTypeInput<Http::HttpMatchingData> input;

--- a/test/common/network/matching/inputs_test.cc
+++ b/test/common/network/matching/inputs_test.cc
@@ -36,13 +36,6 @@ TEST(MatchingData, DestinationIPInput) {
 }
 
 TEST(MatchingData, HttpDestinationIPInput) {
-  // ConnectionInfoSetterImpl connection_info_provider(
-  //     std::make_shared<Address::Ipv4Instance>("127.0.0.1", 8080),
-  //     std::make_shared<Address::Ipv4Instance>("10.0.0.1", 9090));
-  // connection_info_provider.setDirectRemoteAddressForTest(
-  //     std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2", 8081));
-  // auto host = "example.com";
-  // connection_info_provider.setRequestedServerName(host);
   auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Address::Ipv4Instance>("127.0.0.1", 8080),
       std::make_shared<Address::Ipv4Instance>("10.0.0.1", 9090));

--- a/test/common/ssl/matching/BUILD
+++ b/test/common/ssl/matching/BUILD
@@ -30,5 +30,6 @@ envoy_cc_test(
         "//test/common/matcher:test_utility_lib",
         "//test/mocks/matcher:matcher_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:test_time_lib",
     ],
 )

--- a/test/common/ssl/matching/BUILD
+++ b/test/common/ssl/matching/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test(
         "//source/common/network:socket_lib",
         "//source/common/ssl/matching:inputs_lib",
         "//test/mocks/ssl:ssl_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
     ],
 )
 

--- a/test/common/ssl/matching/inputs_integration_test.cc
+++ b/test/common/ssl/matching/inputs_integration_test.cc
@@ -119,15 +119,12 @@ TEST_F(HttpInputsIntegrationTest, UriSanInput) {
 
   initialize("UriSanInput", host);
 
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider->setSslConnection(ssl);
+  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
   std::vector<std::string> uri_sans{host};
   EXPECT_CALL(*ssl, uriSanPeerCertificate()).WillOnce(Return(uri_sans));
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   const auto result = match_tree_()->match(data);
   EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
@@ -139,15 +136,12 @@ TEST_F(HttpInputsIntegrationTest, DnsSanInput) {
 
   initialize("DnsSanInput", host);
 
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider->setSslConnection(ssl);
+  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
   std::vector<std::string> dns_sans{host};
   EXPECT_CALL(*ssl, dnsSansPeerCertificate()).WillOnce(Return(dns_sans));
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   const auto result = match_tree_()->match(data);
   EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
@@ -159,14 +153,11 @@ TEST_F(HttpInputsIntegrationTest, SubjectInput) {
 
   initialize("SubjectInput", host);
 
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider->setSslConnection(ssl);
+  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
   EXPECT_CALL(*ssl, subjectPeerCertificate()).WillOnce(testing::ReturnRef(host));
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   const auto result = match_tree_()->match(data);
   EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);

--- a/test/common/ssl/matching/inputs_test.cc
+++ b/test/common/ssl/matching/inputs_test.cc
@@ -2,8 +2,10 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/ssl/matching/inputs.h"
+#include "source/common/stream_info/stream_info_impl.h"
 
 #include "test/mocks/ssl/mocks.h"
+#include "test/test_common/test_time.h"
 
 namespace Envoy {
 namespace Ssl {
@@ -14,10 +16,11 @@ using testing::ReturnRef;
 
 TEST(Authentication, UriSanInput) {
   UriSanInput<Http::HttpMatchingData> input;
-  Network::ConnectionInfoSetterImpl connection_info_provider(
+  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
+  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
+      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
 
   {
     const auto result = input.get(data);
@@ -27,7 +30,7 @@ TEST(Authentication, UriSanInput) {
   }
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider.setSslConnection(ssl);
+  connection_info_provider->setSslConnection(ssl);
 
   {
     std::vector<std::string> uri_sans;
@@ -62,10 +65,11 @@ TEST(Authentication, UriSanInput) {
 
 TEST(Authentication, DnsSanInput) {
   DnsSanInput<Http::HttpMatchingData> input;
-  Network::ConnectionInfoSetterImpl connection_info_provider(
+  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
+  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
+      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
 
   {
     const auto result = input.get(data);
@@ -75,7 +79,7 @@ TEST(Authentication, DnsSanInput) {
   }
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider.setSslConnection(ssl);
+  connection_info_provider->setSslConnection(ssl);
 
   {
     std::vector<std::string> dns_sans;
@@ -110,10 +114,11 @@ TEST(Authentication, DnsSanInput) {
 
 TEST(Authentication, SubjectInput) {
   SubjectInput<Http::HttpMatchingData> input;
-  Network::ConnectionInfoSetterImpl connection_info_provider(
+  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
       std::make_shared<Network::Address::Ipv4Instance>(80),
       std::make_shared<Network::Address::Ipv4Instance>(80));
-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
+  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
+      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
 
   {
     const auto result = input.get(data);
@@ -123,7 +128,7 @@ TEST(Authentication, SubjectInput) {
   }
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider.setSslConnection(ssl);
+  connection_info_provider->setSslConnection(ssl);
   std::string subject;
   EXPECT_CALL(*ssl, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject));
 

--- a/test/common/ssl/matching/inputs_test.cc
+++ b/test/common/ssl/matching/inputs_test.cc
@@ -72,8 +72,6 @@ TEST(Authentication, DnsSanInput) {
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
   stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
-  // connection_info_provider->setSslConnection(ssl);
-
   {
     std::vector<std::string> dns_sans;
     EXPECT_CALL(*ssl, dnsSansPeerCertificate()).WillRepeatedly(Return(dns_sans));
@@ -107,11 +105,6 @@ TEST(Authentication, DnsSanInput) {
 
 TEST(Authentication, SubjectInput) {
   SubjectInput<Http::HttpMatchingData> input;
-  // auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-  //     std::make_shared<Network::Address::Ipv4Instance>(80),
-  //     std::make_shared<Network::Address::Ipv4Instance>(80));
-  // Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-  //     Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
 
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   Http::Matching::HttpMatchingDataImpl data(stream_info);

--- a/test/common/ssl/matching/inputs_test.cc
+++ b/test/common/ssl/matching/inputs_test.cc
@@ -2,11 +2,9 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/ssl/matching/inputs.h"
-// #include "source/common/stream_info/stream_info_impl.h"
 
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
-// #include "test/test_common/test_time.h"
 
 namespace Envoy {
 namespace Ssl {

--- a/test/common/ssl/matching/inputs_test.cc
+++ b/test/common/ssl/matching/inputs_test.cc
@@ -2,10 +2,11 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/ssl/matching/inputs.h"
-#include "source/common/stream_info/stream_info_impl.h"
+// #include "source/common/stream_info/stream_info_impl.h"
 
 #include "test/mocks/ssl/mocks.h"
-#include "test/test_common/test_time.h"
+#include "test/mocks/stream_info/mocks.h"
+// #include "test/test_common/test_time.h"
 
 namespace Envoy {
 namespace Ssl {
@@ -16,11 +17,14 @@ using testing::ReturnRef;
 
 TEST(Authentication, UriSanInput) {
   UriSanInput<Http::HttpMatchingData> input;
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  // auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
+  //     std::make_shared<Network::Address::Ipv4Instance>(80),
+  //     std::make_shared<Network::Address::Ipv4Instance>(80));
+  // StreamInfo::StreamInfoImpl stream_info(
+  //     Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider)
+
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   {
     const auto result = input.get(data);
@@ -30,7 +34,8 @@ TEST(Authentication, UriSanInput) {
   }
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider->setSslConnection(ssl);
+  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+  // connection_info_provider->setSslConnection(ssl);
 
   {
     std::vector<std::string> uri_sans;
@@ -65,12 +70,13 @@ TEST(Authentication, UriSanInput) {
 
 TEST(Authentication, DnsSanInput) {
   DnsSanInput<Http::HttpMatchingData> input;
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
-
+  // auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
+  //     std::make_shared<Network::Address::Ipv4Instance>(80),
+  //     std::make_shared<Network::Address::Ipv4Instance>(80));
+  // Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
+  //     Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
   {
     const auto result = input.get(data);
     EXPECT_EQ(result.data_availability_,
@@ -79,7 +85,8 @@ TEST(Authentication, DnsSanInput) {
   }
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider->setSslConnection(ssl);
+  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+  // connection_info_provider->setSslConnection(ssl);
 
   {
     std::vector<std::string> dns_sans;
@@ -114,11 +121,14 @@ TEST(Authentication, DnsSanInput) {
 
 TEST(Authentication, SubjectInput) {
   SubjectInput<Http::HttpMatchingData> input;
-  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-      std::make_shared<Network::Address::Ipv4Instance>(80),
-      std::make_shared<Network::Address::Ipv4Instance>(80));
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  // auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
+  //     std::make_shared<Network::Address::Ipv4Instance>(80),
+  //     std::make_shared<Network::Address::Ipv4Instance>(80));
+  // Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
+  //     Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   {
     const auto result = input.get(data);
@@ -128,7 +138,8 @@ TEST(Authentication, SubjectInput) {
   }
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
-  connection_info_provider->setSslConnection(ssl);
+  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+  // connection_info_provider->setSslConnection(ssl);
   std::string subject;
   EXPECT_CALL(*ssl, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject));
 

--- a/test/common/ssl/matching/inputs_test.cc
+++ b/test/common/ssl/matching/inputs_test.cc
@@ -15,12 +15,6 @@ using testing::ReturnRef;
 
 TEST(Authentication, UriSanInput) {
   UriSanInput<Http::HttpMatchingData> input;
-  // auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-  //     std::make_shared<Network::Address::Ipv4Instance>(80),
-  //     std::make_shared<Network::Address::Ipv4Instance>(80));
-  // StreamInfo::StreamInfoImpl stream_info(
-  //     Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider)
-
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   Http::Matching::HttpMatchingDataImpl data(stream_info);
 
@@ -33,7 +27,6 @@ TEST(Authentication, UriSanInput) {
 
   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
   stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
-  // connection_info_provider->setSslConnection(ssl);
 
   {
     std::vector<std::string> uri_sans;
@@ -68,11 +61,6 @@ TEST(Authentication, UriSanInput) {
 
 TEST(Authentication, DnsSanInput) {
   DnsSanInput<Http::HttpMatchingData> input;
-  // auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
-  //     std::make_shared<Network::Address::Ipv4Instance>(80),
-  //     std::make_shared<Network::Address::Ipv4Instance>(80));
-  // Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-  //     Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   Http::Matching::HttpMatchingDataImpl data(stream_info);
   {

--- a/test/extensions/common/matcher/trie_matcher_test.cc
+++ b/test/extensions/common/matcher/trie_matcher_test.cc
@@ -16,7 +16,6 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
-#include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -623,13 +622,16 @@ matcher_tree:
       context, factory_context, validation_visitor);
   auto match_tree = matcher_factory.create(matcher);
 
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
   const Network::Address::InstanceConstSharedPtr address =
       std::make_shared<Network::Address::Ipv4Instance>("192.168.0.1", 8080);
-  Network::ConnectionInfoSetterImpl connection_info(address, address);
-  auto connection_info_provider =
-      std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
-  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
-      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
+  stream_info.downstream_connection_info_provider_->setLocalAddress(address);
+  stream_info.downstream_connection_info_provider_->setRemoteAddress(address);
+
+  // Network::ConnectionInfoSetterImpl connection_info(address, address);
+  // auto connection_info_provider =
+  //     std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   const auto result = match_tree()->match(data);
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);

--- a/test/extensions/common/matcher/trie_matcher_test.cc
+++ b/test/extensions/common/matcher/trie_matcher_test.cc
@@ -8,7 +8,6 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/matching/data_impl.h"
 #include "source/common/protobuf/utility.h"
-#include "source/common/stream_info/stream_info_impl.h"
 #include "source/extensions/common/matcher/trie_matcher.h"
 
 #include "test/common/matcher/test_utility.h"
@@ -628,9 +627,6 @@ matcher_tree:
   stream_info.downstream_connection_info_provider_->setLocalAddress(address);
   stream_info.downstream_connection_info_provider_->setRemoteAddress(address);
 
-  // Network::ConnectionInfoSetterImpl connection_info(address, address);
-  // auto connection_info_provider =
-  //     std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
   Http::Matching::HttpMatchingDataImpl data(stream_info);
 
   const auto result = match_tree()->match(data);

--- a/test/extensions/common/matcher/trie_matcher_test.cc
+++ b/test/extensions/common/matcher/trie_matcher_test.cc
@@ -8,6 +8,7 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/matching/data_impl.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/stream_info/stream_info_impl.h"
 #include "source/extensions/common/matcher/trie_matcher.h"
 
 #include "test/common/matcher/test_utility.h"
@@ -15,6 +16,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -624,7 +626,10 @@ matcher_tree:
   const Network::Address::InstanceConstSharedPtr address =
       std::make_shared<Network::Address::Ipv4Instance>("192.168.0.1", 8080);
   Network::ConnectionInfoSetterImpl connection_info(address, address);
-  Http::Matching::HttpMatchingDataImpl data(connection_info);
+  auto connection_info_provider =
+      std::make_shared<Network::ConnectionInfoSetterImpl>(address, address);
+  Http::Matching::HttpMatchingDataImpl data(StreamInfo::StreamInfoImpl(
+      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider));
 
   const auto result = match_tree()->match(data);
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 
 using testing::Const;
+using testing::ReturnPointee;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -66,7 +67,8 @@ void checkMatcherEngine(
     StreamInfo::StreamInfo& info,
     const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
     const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl()) {
-
+  // std::cout << "before handle action: "  <<
+  // connection.streamInfo().downstreamAddressProvider().localAddress()->asString() << std::endl;
   bool engineRes = engine.handleAction(connection, headers, info, nullptr);
   EXPECT_EQ(expected, engineRes);
 
@@ -88,7 +90,6 @@ void checkMatcherEngine(
     RBAC::RoleBasedAccessControlMatcherEngineImpl& engine, bool expected, LogResult expected_log,
     const Envoy::Network::Connection& connection,
     const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl()) {
-
   NiceMock<StreamInfo::MockStreamInfo> empty_info;
   checkMatcherEngine(engine, expected, expected_log, empty_info, connection, headers);
 }
@@ -473,11 +474,7 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, Disabled) {
   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
                                                        validation_visitor);
 
-  Envoy::Network::MockConnection conn;
-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
-
+  NiceMock<Envoy::Network::MockConnection> conn;
   checkMatcherEngine(engine, false, LogResult::Undecided, conn);
 }
 
@@ -510,20 +507,30 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, AllowedAllowlist) {
   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
                                                        validation_visitor);
 
-  Envoy::Network::MockConnection conn;
+  NiceMock<Envoy::Network::MockConnection> conn;
   Envoy::Http::TestRequestHeaderMapImpl headers;
-  NiceMock<StreamInfo::MockStreamInfo> info;
-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
+  EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
+
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
-  provider.setLocalAddress(addr);
-  checkMatcherEngine(engine, true, LogResult::Undecided, info, conn, headers);
+  stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
+
+  // ON_CALL(stream_info,
+  // downstreamAddressProvider()).WillByDefault(ReturnPointee(stream_info.downstream_connection_info_provider_));
+  // ON_CALL(conn, streamInfo()).WillByDefault(ReturnRef(stream_info));
+  // ON_CALL(conn.streamInfo(),
+  // downstreamAddressProvider()).WillByDefault(ReturnRef(stream_info.downstreamAddressProvider()));
+  // EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, downstreamAddressProvider())
+      .WillRepeatedly(ReturnRef(stream_info.downstreamAddressProvider()));
+
+  checkMatcherEngine(engine, true, LogResult::Undecided, stream_info, conn, headers);
 
   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
-  provider.setLocalAddress(addr);
-  checkMatcherEngine(engine, false, LogResult::Undecided, info, conn, headers);
+  stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
+  checkMatcherEngine(engine, false, LogResult::Undecided, stream_info, conn, headers);
 }
 
 TEST(RoleBasedAccessControlMatcherEngineImpl, DeniedDenylist) {
@@ -555,19 +562,22 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, DeniedDenylist) {
   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
                                                        validation_visitor);
 
-  Envoy::Network::MockConnection conn;
+  NiceMock<Envoy::Network::MockConnection> conn;
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
+
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
-  provider.setLocalAddress(addr);
+  info.downstream_connection_info_provider_->setLocalAddress(addr);
+  EXPECT_CALL(info, downstreamAddressProvider())
+      .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
+  // EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(info));
+  // std::cout << "data input: "  <<
+  // conn.streamInfo().downstreamAddressProvider().localAddress()->asString() << std::endl;
   checkMatcherEngine(engine, false, LogResult::Undecided, info, conn, headers);
 
   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
-  provider.setLocalAddress(addr);
+  info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkMatcherEngine(engine, true, LogResult::Undecided, info, conn, headers);
 }
 
@@ -638,21 +648,28 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, LogIfMatched) {
   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
                                                        validation_visitor);
 
-  Envoy::Network::MockConnection conn;
+  NiceMock<Envoy::Network::MockConnection> conn;
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
+  // Network::ConnectionInfoSetterImpl
+  // provider(std::make_shared<Network::Address::Ipv4Instance>(80),
+  //                                            std::make_shared<Network::Address::Ipv4Instance>(80));
+  // EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
   onMetadata(info);
 
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
-  provider.setLocalAddress(addr);
+  info.downstream_connection_info_provider_->setLocalAddress(addr);
+  // ON_CALL(info,
+  // downstreamAddressProvider()).WillByDefault(ReturnPointee(info.downstream_connection_info_provider_));
+  // ON_CALL(conn, streamInfo()).WillByDefault(ReturnRef(info));
+  EXPECT_CALL(info, downstreamAddressProvider())
+      .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
+  EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(info));
   checkMatcherEngine(engine, true, RBAC::LogResult::Yes, info, conn, headers);
 
   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
-  provider.setLocalAddress(addr);
+  info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkMatcherEngine(engine, true, RBAC::LogResult::No, info, conn, headers);
 }
 

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -515,12 +515,6 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, AllowedAllowlist) {
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
   stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
 
-  // ON_CALL(stream_info,
-  // downstreamAddressProvider()).WillByDefault(ReturnPointee(stream_info.downstream_connection_info_provider_));
-  // ON_CALL(conn, streamInfo()).WillByDefault(ReturnRef(stream_info));
-  // ON_CALL(conn.streamInfo(),
-  // downstreamAddressProvider()).WillByDefault(ReturnRef(stream_info.downstreamAddressProvider()));
-  // EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
   EXPECT_CALL(stream_info, downstreamAddressProvider())
       .WillRepeatedly(ReturnRef(stream_info.downstreamAddressProvider()));
 

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -67,8 +67,6 @@ void checkMatcherEngine(
     StreamInfo::StreamInfo& info,
     const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
     const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl()) {
-  // std::cout << "before handle action: "  <<
-  // connection.streamInfo().downstreamAddressProvider().localAddress()->asString() << std::endl;
   bool engineRes = engine.handleAction(connection, headers, info, nullptr);
   EXPECT_EQ(expected, engineRes);
 
@@ -571,9 +569,6 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, DeniedDenylist) {
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   EXPECT_CALL(info, downstreamAddressProvider())
       .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
-  // EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(info));
-  // std::cout << "data input: "  <<
-  // conn.streamInfo().downstreamAddressProvider().localAddress()->asString() << std::endl;
   checkMatcherEngine(engine, false, LogResult::Undecided, info, conn, headers);
 
   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
@@ -651,18 +646,11 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, LogIfMatched) {
   NiceMock<Envoy::Network::MockConnection> conn;
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
-  // Network::ConnectionInfoSetterImpl
-  // provider(std::make_shared<Network::Address::Ipv4Instance>(80),
-  //                                            std::make_shared<Network::Address::Ipv4Instance>(80));
-  // EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
   onMetadata(info);
 
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
-  // ON_CALL(info,
-  // downstreamAddressProvider()).WillByDefault(ReturnPointee(info.downstream_connection_info_provider_));
-  // ON_CALL(conn, streamInfo()).WillByDefault(ReturnRef(info));
   EXPECT_CALL(info, downstreamAddressProvider())
       .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
   EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(info));

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -22,6 +22,7 @@
 using testing::_;
 using testing::NiceMock;
 using testing::Return;
+using testing::ReturnPointee;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -172,24 +173,23 @@ on_no_match:
     filter_->setDecoderFilterCallbacks(callbacks_);
   }
 
-  RoleBasedAccessControlFilterTest()
-      : provider_(std::make_shared<Network::Address::Ipv4Instance>(80),
-                  std::make_shared<Network::Address::Ipv4Instance>(80)){};
+  RoleBasedAccessControlFilterTest(){};
 
   void setDestinationPort(uint16_t port) {
     address_ = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", port, false);
     req_info_.downstream_connection_info_provider_->setLocalAddress(address_);
 
-    provider_.setLocalAddress(address_);
-    ON_CALL(connection_, connectionInfoProvider()).WillByDefault(ReturnRef(provider_));
+    ON_CALL(connection_.stream_info_, downstreamAddressProvider())
+        .WillByDefault(ReturnPointee(req_info_.downstream_connection_info_provider_));
   }
 
   void setRequestedServerName(std::string server_name) {
     requested_server_name_ = server_name;
     ON_CALL(connection_, requestedServerName()).WillByDefault(Return(requested_server_name_));
 
-    provider_.setRequestedServerName(server_name);
-    ON_CALL(connection_, connectionInfoProvider()).WillByDefault(ReturnRef(provider_));
+    req_info_.downstream_connection_info_provider_->setRequestedServerName(server_name);
+    ON_CALL(connection_.stream_info_, downstreamAddressProvider())
+        .WillByDefault(ReturnPointee(req_info_.downstream_connection_info_provider_));
   }
 
   void checkAccessLogMetadata(LogResult expected) {
@@ -233,7 +233,6 @@ on_no_match:
   std::unique_ptr<RoleBasedAccessControlFilter> filter_;
 
   Network::Address::InstanceConstSharedPtr address_;
-  Network::ConnectionInfoSetterImpl provider_;
   std::string requested_server_name_;
   Http::TestRequestHeaderMapImpl headers_;
   Http::TestRequestTrailerMapImpl trailers_;

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -173,7 +173,7 @@ on_no_match:
     filter_->setDecoderFilterCallbacks(callbacks_);
   }
 
-  RoleBasedAccessControlFilterTest(){};
+  RoleBasedAccessControlFilterTest() = default;
 
   void setDestinationPort(uint16_t port) {
     address_ = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", port, false);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
With streamInfo as the input to Http matching data, it not only fulfills the existing functionality provided by ConnectionInfoProvider (ConnectionInfoProvider is got from stream_info.downstreamAddressProvider()), it but also provides more info that is available in streamInfo, via, for example, dynamic_metatdata and filter state.
The use case could be : the matching library like CEL expression could match on, for example, client_ip, upstream cluster name, etc that can be retrieved  from stream info.

Signed-off-by: tyxia [tyxia@google.com](mailto:tyxia@google.com)
