### PR TITLE
[cache-filter] Make filter configurable per-route

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -163,6 +163,8 @@ private:
   // The status of the insert operation or header update, or decision not to insert or update.
   // If it's too early to determine the final status, this is empty.
   absl::optional<InsertStatus> insert_status_;
+
+  friend class CacheFilterTest;
 };
 
 using CacheFilterSharedPtr = std::shared_ptr<CacheFilter>;

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -6,10 +6,10 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
-
-Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+namespace {
+std::shared_ptr<HttpCache>
+getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+         Server::Configuration::CommonFactoryContext& context) {
   const std::string type{TypeUtil::typeUrlToDescriptorFullName(config.typed_config().type_url())};
   HttpCacheFactory* const http_cache_factory =
       Registry::FactoryRegistry<HttpCacheFactory>::getFactoryByType(type);
@@ -17,14 +17,26 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
     throw EnvoyException(
         fmt::format("Didn't find a registered implementation for type: '{}'", type));
   }
+  return http_cache_factory->getCache(config, context);
+}
+} // namespace
 
-  auto cache = http_cache_factory->getCache(config, context);
-
-  return [config, stats_prefix, &context,
-          cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
-                                                            context.timeSource(), *cache));
+Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  auto filter_config = std::make_shared<CacheFilterConfig>(getCache(config, context), config);
+  return [filter_config, stats_prefix,
+          &context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<CacheFilter>(*filter_config, stats_prefix,
+                                                            context.scope(), context.timeSource()));
   };
+}
+
+Router::RouteSpecificFilterConfigConstSharedPtr
+CacheFilterFactory::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+  return std::make_shared<CacheFilterConfig>(getCache(config, context), config);
 }
 
 REGISTER_FACTORY(CacheFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/cache/config.h
+++ b/source/extensions/filters/http/cache/config.h
@@ -19,6 +19,11 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::cache::v3::CacheConfig& proto_config,
+      Server::Configuration::ServerFactoryContext& context,
+      ProtobufMessage::ValidationVisitor& validator) override;
 };
 
 } // namespace Cache

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -279,7 +279,7 @@ public:
   // etc.
   virtual std::shared_ptr<HttpCache>
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-           Server::Configuration::FactoryContext& context) PURE;
+           Server::Configuration::CommonFactoryContext& context) PURE;
   ~HttpCacheFactory() override = default;
 
 private:

--- a/source/extensions/http/cache/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache/file_system_http_cache/config.cc
@@ -97,7 +97,7 @@ public:
   // From HttpCacheFactory
   std::shared_ptr<HttpCache>
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& filter_config,
-           Server::Configuration::FactoryContext& context) override {
+           Server::Configuration::CommonFactoryContext& context) override {
     ConfigProto config;
     MessageUtil::unpackTo(filter_config.typed_config(), config);
     std::shared_ptr<CacheSingleton> caches = context.singletonManager().getTyped<CacheSingleton>(

--- a/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
@@ -302,7 +302,7 @@ public:
   // From HttpCacheFactory
   std::shared_ptr<HttpCache>
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig&,
-           Server::Configuration::FactoryContext& context) override {
+           Server::Configuration::CommonFactoryContext& context) override {
     return context.singletonManager().getTyped<SimpleHttpCache>(
         SINGLETON_MANAGER_REGISTERED_NAME(simple_http_cache_singleton), &createCache);
   }

--- a/test/extensions/filters/http/cache/BUILD
+++ b/test/extensions/filters/http/cache/BUILD
@@ -91,6 +91,7 @@ envoy_extension_cc_test(
         "//test/test_common:utility_lib",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@envoy_api//envoy/extensions/http/cache/simple_http_cache/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -22,6 +22,18 @@ protected:
   Http::MockFilterChainFactoryCallbacks filter_callback_;
 };
 
+TEST_F(CacheFilterFactoryTest, PerRoute) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  config_.mutable_typed_config()->PackFrom(
+      envoy::extensions::http::cache::simple_http_cache::v3::SimpleHttpCacheConfig());
+  auto per_route_config = factory_.createRouteSpecificFilterConfig(
+      config_, context, ProtobufMessage::getNullValidationVisitor());
+  ASSERT_THAT(per_route_config, testing::NotNull());
+  auto per_route_cache_config =
+      std::dynamic_pointer_cast<const CacheFilterConfig>(per_route_config);
+  ASSERT_THAT(per_route_cache_config, testing::NotNull());
+};
+
 TEST_F(CacheFilterFactoryTest, Basic) {
   config_.mutable_typed_config()->PackFrom(
       envoy::extensions::http::cache::simple_http_cache::v3::SimpleHttpCacheConfig());


### PR DESCRIPTION
Commit Message: [cache-filter] Make filter configurable per-route
Additional Description: This makes it so the cache filter config can be applied per-route as well as per-listener, with the more specific config simply overriding the less specific config.
This addresses one of the points in #25819.
This also addresses #12901, by rolling the VaryAllowList and cache into a shared config object rather than generating the VaryAllowList per filter instance.
Risk Level: Low, cache filter is WIP.
Testing: Passes existing tests. Adding test for per-route override.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
