### PR TITLE
ci: Automate creation of release branch from `main`

### DIFF
--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -1,0 +1,43 @@
+name: Create release branch
+
+on:
+  release:
+    types:
+    - published
+    branches:
+    - main
+
+permissions: read-all
+
+jobs:
+  fork_release_branch:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'envoyproxy/envoy'
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Create release branch
+      run: ./ci/create_release_branch.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  reopen_branch:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'envoyproxy/envoy'
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: refs/heads/main
+
+    - name: Reopen branch
+      run: ./ci/reopen_branch.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/create_release_branch.sh
+++ b/ci/create_release_branch.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+ENVOY_GIT_USERNAME="${ENVOY_GIT_USERNAME:-envoy-bot}"
+ENVOY_GIT_EMAIL="${ENVOY_GIT_EMAIL:-envoy-bot@users.noreply.github.com}"
+ENVOY_RELEASE_VERSION="${ENVOY_RELEASE_VERSION:-}"
+
+MAIN_BRANCH=refs/heads/main
+MAIN_BRANCH_SHORTNAME=main
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+
+if [[ "$CURRENT_BRANCH" != "$MAIN_BRANCH" ]] && [[ "$CURRENT_BRANCH" != "$MAIN_BRANCH_SHORTNAME" ]]; then
+    echo "Current branch ($CURRENT_BRANCH) must be \`main\`, exiting" >&2
+    exit 1
+else
+    # TODO(phlax): remove once its clear what this should be
+    echo "Current branch: $CURRENT_BRANCH"
+fi
+
+
+configure_git_user () {
+    if [[ -z "$ENVOY_GIT_USERNAME" || -z "$ENVOY_GIT_EMAIL" ]]; then
+        echo 'Unable to set git name/email, using existing git config' >&2
+        return
+    fi
+    git config --global user.name "$ENVOY_GIT_USERNAME"
+    git config --global user.email "$ENVOY_GIT_EMAIL"
+}
+
+create_dev_commit () {
+    bazel run @envoy_repo//:dev -- --patch
+}
+
+get_release_name () {
+    local version
+    if [[ -z "$ENVOY_RELEASE_VERSION" ]]; then
+        version="$(cut -d- -f1 < VERSION.txt | cut -d. -f-2)"
+    else
+        version="$ENVOY_RELEASE_VERSION"
+    fi
+    echo -n "release/v${version}"
+}
+
+create_branch () {
+    local release_name commit_sha
+    release_name="$(get_release_name)"
+    commit_sha="$(git rev-parse HEAD)"
+
+    echo "Creating ${release_name} from ${commit_sha}"
+    git checkout -b "$release_name"
+    git push origin "$release_name"
+}
+
+create_release_branch () {
+    configure_git_user
+    create_dev_commit
+    create_branch
+}
+
+create_release_branch

--- a/ci/reopen_branch.sh
+++ b/ci/reopen_branch.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+
+ENVOY_GIT_USERNAME="${ENVOY_GIT_USERNAME:-envoy-bot}"
+ENVOY_GIT_EMAIL="${ENVOY_GIT_EMAIL:-envoy-bot@users.noreply.github.com}"
+
+MAIN_BRANCH=refs/heads/main
+MAIN_BRANCH_SHORTNAME=main
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+
+if [[ "$CURRENT_BRANCH" != "$MAIN_BRANCH" ]] && [[ "$CURRENT_BRANCH" != "$MAIN_BRANCH_SHORTNAME" ]]; then
+    echo "Current branch ($CURRENT_BRANCH) must be \`main\`, exiting" >&2
+    exit 1
+else
+    # TODO(phlax): remove once its clear what this should be
+    echo "Current branch: $CURRENT_BRANCH"
+fi
+
+
+configure_git_user () {
+    if [[ -z "$ENVOY_GIT_USERNAME" || -z "$ENVOY_GIT_EMAIL" ]]; then
+        echo 'Unable to set git name/email, using existing git config' >&2
+        return
+    fi
+    git config --global user.name "$ENVOY_GIT_USERNAME"
+    git config --global user.email "$ENVOY_GIT_EMAIL"
+}
+
+create_dev_commit () {
+    bazel run @envoy_repo//:dev
+}
+
+get_release_name () {
+    local version
+    version="$(cut -d- -f1 < VERSION.txt | cut -d. -f-2)"
+    echo -n "release/v${version}"
+}
+
+push_commit () {
+    local release_name commit_sha
+    release_name="$(get_release_name)"
+    commit_sha="$(git rev-parse HEAD)"
+
+    echo "Re-opening \`main\` branch ${release_name} from ${commit_sha}"
+    git push origin "$release_name"
+}
+
+reopen_branch () {
+    configure_git_user
+    create_dev_commit
+    push_branch
+}
+
+reopen_branch


### PR DESCRIPTION
This PR:

- forks `main` to a new release branch upon a tagged release
- reopens the `main` branch

As a follow up we could lock `main` when a release commit lands and then unlock it here

I was tempted to do this but figured leave that to a further iteration as it requires some thought about failure handling

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
