### PR TITLE
mobile: ensuring the non-listener build works correctly

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -20,6 +20,8 @@ jobs:
       image: envoyproxy/envoy-build-ubuntu:458cb49ca2013c0ccf057d00ad1d4407920c4e52
     steps:
     - uses: actions/checkout@v3
+    - name: Ensure no listener leaks
+      run: rm source/extensions/listener_managers/listener_manager/listener_manager_impl.h
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
     - name: 'Run tests'

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -53,7 +53,6 @@ envoy_cc_library(
         "@envoy//source/common/common:random_generator_lib",
         "@envoy//source/common/runtime:runtime_lib",
         "@envoy//source/exe:stripped_main_base_lib",
-        "@envoy//source/extensions/listener_managers/listener_manager:listener_manager_lib",
     ] + select({
         "@envoy//bazel:disable_signal_trace": [],
         "//conditions:default": [

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -9,6 +9,7 @@ load(
     "envoy_proto_library",
     "envoy_select_admin_functionality",
     "envoy_select_enable_http3",
+    "envoy_select_envoy_mobile_listener",
     "envoy_sh_test",
 )
 
@@ -860,7 +861,6 @@ envoy_cc_test_library(
     deps = [
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/protobuf:protobuf_mocks",
-        "//source/extensions/listener_managers/listener_manager:listener_manager_lib",
         "//envoy/api:api_interface",
         "//envoy/grpc:status",
         "//envoy/http:codec_interface",
@@ -900,6 +900,8 @@ envoy_cc_test_library(
         "//source/common/quic:quic_client_factory_lib",
         "//source/common/quic:quic_server_factory_lib",
         "@com_github_google_quiche//:quic_test_tools_session_peer_lib",
+    ]) + envoy_select_envoy_mobile_listener([
+        "//source/extensions/listener_managers/listener_manager:listener_manager_lib",
     ]),
 )
 


### PR DESCRIPTION
Changing one of our CI builds to remove a listener file, to ensure the downstream listener code doesn't leak back into the envoy_mobile_listener=disabled build.

Also removing a spurious library include so the build passes.

Risk Level: low
Testing: CI update
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/pull/25852