### PR TITLE
Add a couple of missing fields to StreamInfoImpl::setFrom

### DIFF
--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -371,6 +371,8 @@ struct StreamInfoImpl : public StreamInfo {
     filter_chain_name_ = info.filterChainName();
     attempt_count_ = info.attemptCount();
     upstream_bytes_meter_ = info.getUpstreamBytesMeter();
+    bytes_sent_ = info.bytesSent();
+    is_shadow_ = info.isShadow();
   }
 
   void setIsShadow(bool is_shadow) { is_shadow_ = is_shadow; }

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -298,6 +298,8 @@ TEST_F(StreamInfoImplTest, SetFrom) {
   s1.setFilterChainName("foobar");
   s1.setAttemptCount(5);
   s1.setDownstreamTransportFailureReason("error");
+  s1.addBytesSent(1);
+  s1.setIsShadow(true);
 
 #ifdef __clang__
 #if defined(__linux__)
@@ -350,6 +352,8 @@ TEST_F(StreamInfoImplTest, SetFrom) {
   EXPECT_EQ(s1.filterChainName(), s2.filterChainName());
   EXPECT_EQ(s1.attemptCount(), s2.attemptCount());
   EXPECT_EQ(s1.getUpstreamBytesMeter(), s2.getUpstreamBytesMeter());
+  EXPECT_EQ(s1.bytesSent(), s2.bytesSent());
+  EXPECT_EQ(s1.isShadow(), s2.isShadow());
 }
 
 TEST_F(StreamInfoImplTest, DynamicMetadataTest) {


### PR DESCRIPTION
These were missed in https://github.com/envoyproxy/envoy/pull/23648.

Commit Message: Add a couple of missing fields to StreamInfoImpl::setFrom
Risk Level: Low
Testing: Unit tested.
Docs Changes: N/A
