### PR TITLE
api: add error_utilization_penalty param to WRR

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -23,11 +23,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // the endpoint weights are sent by the control plane via EDS. However,
 // in this policy, the endpoint weights are instead determined via
 // qps (queries per second), eps (errors per second), and CPU utilization
-// metrics collected and sent by the endpoint using the Open Request Cost
-// Aggregation (ORCA) protocol. A config parameter error_utilization_penalty
-// controls the penalty to adjust endpoint weights using eps and qps. The
-// weight of a given endpoint is computed as:
-//   qps / (cpu_utilization + eps/qps * error_utilization_penalty)
+// metrics sent by the endpoint using the Open Request Cost Aggregation (ORCA)
+// protocol. A query counts towards qps when successful, otherwise towards both
+// qps and eps. What counts as an error is up to the application to define.
+// A config parameter error_utilization_penalty controls the penalty to adjust
+// endpoint weights using eps and qps. The weight of a given endpoint is
+// computed as: qps / (cpu_utilization + eps/qps * error_utilization_penalty)
 //
 // See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
 //

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // qps (queries per second), eps (errors per second), and CPU utilization
 // metrics sent by the endpoint using the Open Request Cost Aggregation (ORCA)
 // protocol. A query counts towards qps when successful, otherwise towards both
-// qps and eps. What counts as an error is up to the service to define.
+// qps and eps. What counts as an error is up to the endpoint to define.
 // A config parameter error_utilization_penalty controls the penalty to adjust
 // endpoint weights using eps and qps. The weight of a given endpoint is
 // computed as: qps / (cpu_utilization + eps/qps * error_utilization_penalty)

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // qps (queries per second), eps (errors per second), and CPU utilization
 // metrics sent by the endpoint using the Open Request Cost Aggregation (ORCA)
 // protocol. A query counts towards qps when successful, otherwise towards both
-// qps and eps. What counts as an error is up to the application to define.
+// qps and eps. What counts as an error is up to the service to define.
 // A config parameter error_utilization_penalty controls the penalty to adjust
 // endpoint weights using eps and qps. The weight of a given endpoint is
 // computed as: qps / (cpu_utilization + eps/qps * error_utilization_penalty)

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -24,11 +24,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // in this policy, the endpoint weights are instead determined via
 // qps and CPU utilization metrics sent by the endpoint using the Open
 // Request Cost Aggregation (ORCA) protocol. The weight of a given endpoint
-// is computed as qps / cpu_utilization.
+// is computed as qps / (cpu_utilization + eps/qps * error_utilization_penalty).
 //
 // See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
 //
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message ClientSideWeightedRoundRobin {
   // Whether to enable out-of-band utilization reporting collection from
   // the endpoints. By default, per-request utilization reporting is used.
@@ -56,4 +56,8 @@ message ClientSideWeightedRoundRobin {
 
   // How often endpoint weights are recalculated. Default is 1 second.
   google.protobuf.Duration weight_update_period = 5;
+
+  // The penalty used to adjust utilization with errors per second (eps).
+  // Default is 1.0.
+  google.protobuf.FloatValue error_utilization_penalty = 6;
 }

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -23,10 +23,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // the endpoint weights are sent by the control plane via EDS. However,
 // in this policy, the endpoint weights are instead determined via
 // qps (queries per second), eps (errors per second), and CPU utilization
-// metrics sent by the endpoint using the Open Request Cost Aggregation (ORCA)
-// protocol. A config parameter error_utilization_penalty controls the penalty
-// to adjust endpoint weights using eps and qps. The weight of a given endpoint
-// is computed as: qps / (cpu_utilization + eps/qps * error_utilization_penalty)
+// metrics collected and sent by the endpoint using the Open Request Cost
+// Aggregation (ORCA) protocol. A config parameter error_utilization_penalty
+// controls the penalty to adjust endpoint weights using eps and qps. The
+// weight of a given endpoint is computed as:
+//   qps / (cpu_utilization + eps/qps * error_utilization_penalty)
 //
 // See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
 //

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -22,9 +22,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // how the endpoint weights are determined. In the ROUND_ROBIN policy,
 // the endpoint weights are sent by the control plane via EDS. However,
 // in this policy, the endpoint weights are instead determined via
-// qps and CPU utilization metrics sent by the endpoint using the Open
-// Request Cost Aggregation (ORCA) protocol. The weight of a given endpoint
-// is computed as qps / (cpu_utilization + eps/qps * error_utilization_penalty).
+// qps (queries per second), eps (errors per second), and CPU utilization
+// metrics sent by the endpoint using the Open Request Cost Aggregation (ORCA)
+// protocol. A config parameter error_utilization_penalty controls the penalty
+// to adjust endpoint weights using eps and qps. The weight of a given endpoint
+// is computed as: qps / (cpu_utilization + eps/qps * error_utilization_penalty)
 //
 // See the :ref:`load balancing architecture overview<arch_overview_load_balancing_types>` for more information.
 //
@@ -57,7 +59,7 @@ message ClientSideWeightedRoundRobin {
   // How often endpoint weights are recalculated. Default is 1 second.
   google.protobuf.Duration weight_update_period = 5;
 
-  // The penalty used to adjust utilization with errors per second (eps).
-  // Default is 1.0.
+  // The multiplier used to adjust endpoint weights with the error rate
+  // calculated as eps/qps. Default is 1.0.
   google.protobuf.FloatValue error_utilization_penalty = 6;
 }

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -169,6 +169,7 @@ dereferencing
 differentially
 dnsresolvers
 endpos
+eps
 fo
 ghi
 golang


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: api: add error_utilization_penalty param to WRR
Additional Description: Client-wide WRR added with #24520 needs to support the weight penalty using the error rate. This change adds a parameter that configures this behavior.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

CC @markdroth 