### PR TITLE
docs: Fix introduction to config file formats

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -3,7 +3,7 @@
 Command line options
 ====================
 
-Envoy is driven both by a JSON configuration file as well as a set of command line options. The
+Envoy is driven both by a configuration file as well as a set of command line options. The
 following are the command line options that Envoy supports.
 
 .. option:: -c <path string>, --config-path <path string>


### PR DESCRIPTION
The section about [Command line options](https://www.envoyproxy.io/docs/envoy/v1.25.2/operations/cli) starts by introducing JSON as Envoy’s format for configuration files. But immediately after the introduction, in the section that documents `-c`/`--config-path`, other formats are mentioned as well.

Risk Level: Low
Signed-off-by: Sascha Brawer <sascha@brawer.ch>

