### PR TITLE
ci: Make clang-tidy repo/diff more robust

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -47,6 +47,10 @@ steps:
     SLACK_TOKEN: $(SLACK_TOKEN)
     REPO_URI: $(Build.Repository.Uri)
     BUILD_URI: $(Build.BuildUri)
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      AZP_TARGET_BRANCH: "origin/$(System.PullRequest.TargetBranch)"
+    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      AZP_TARGET_BRANCH: "origin/$(Build.SourceBranchName)"
     ${{ if parameters.rbe }}:
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
       ENVOY_RBE: "1"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -461,10 +461,13 @@ elif [[ "$CI_TARGET" == "bazel.clang_tidy" ]]; then
   export CLANG_TIDY_APPLY_FIXES=1
   mkdir -p "${TEST_TMPDIR}/lint-fixes"
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" NUM_CPUS=$NUM_CPUS "${ENVOY_SRCDIR}"/ci/run_clang_tidy.sh "$@" || {
-      echo >&2
-      echo "Diff/yaml files with (some) fixes will be uploaded. Please check the artefacts for this PR run in the azure pipeline." >&2
-      echo >&2
-
+      if [[ -s "$FIX_YAML" ]]; then
+          echo >&2
+          echo "Diff/yaml files with (some) fixes will be uploaded. Please check the artefacts for this PR run in the azure pipeline." >&2
+          echo >&2
+      else
+          echo "Clang-tidy failed." >&2
+      fi
       exit 1
   }
   exit 0

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -91,6 +91,7 @@ docker run --rm \
        "${VOLUMES[@]}" \
        -e AZP_BRANCH \
        -e AZP_COMMIT_SHA \
+       -e AZP_TARGET_BRANCH \
        -e HTTP_PROXY \
        -e HTTPS_PROXY \
        -e NO_PROXY \


### PR DESCRIPTION
Fix #25871 

this also fixes `run_clang_tidy` when run against other CI branches (eg release) which would have broken after the next release otherwise

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
