### PR TITLE
[fuzz] Only add filters that are whitelisted.

### DIFF
--- a/test/extensions/filters/network/common/fuzz/BUILD
+++ b/test/extensions/filters/network/common/fuzz/BUILD
@@ -6,15 +6,12 @@ load(
     "envoy_proto_library",
 )
 load(
-    "//source/extensions:all_extensions.bzl",
-    "envoy_all_network_filters",
+    "filter_fuzz_support.bzl",
+    "fuzz_filters_targets",
+    "generate_from_template",
 )
 
 licenses(["notice"])  # Apache 2
-
-exports_files([
-    "uber_per_readfilter.cc",
-])
 
 envoy_package()
 
@@ -36,11 +33,30 @@ envoy_proto_library(
     ],
 )
 
+_readfilter_fuzz_filters = [
+    "envoy.filters.network.client_ssl_auth",
+    "envoy.filters.network.ext_authz",
+    "envoy.filters.network.envoy_mobile_http_connection_manager",
+    # A dedicated http_connection_manager fuzzer can be found in
+    # test/common/http/conn_manager_impl_fuzz_test.cc
+    "envoy.filters.network.http_connection_manager",
+    "envoy.filters.network.local_ratelimit",
+    "envoy.filters.network.rbac",
+    # TODO(asraa): Remove when fuzzer sets up connections for TcpProxy properly.
+    # "envoy.filters.network.tcp_proxy",
+]
+
+generate_from_template(
+    name = "uber_per_readfilter",
+    filters = _readfilter_fuzz_filters,
+    template_file = "uber_per_readfilter.tmpl.cc",
+)
+
 envoy_cc_test_library(
     name = "uber_readfilter_lib",
     srcs = [
-        "uber_per_readfilter.cc",
         "uber_readfilter.cc",
+        ":uber_per_readfilter.cc",
     ],
     hdrs = ["uber_readfilter.h"],
     deps = [
@@ -64,21 +80,34 @@ envoy_cc_fuzz_test(
     srcs = ["network_readfilter_fuzz_test.cc"],
     corpus = "network_readfilter_corpus",
     dictionaries = ["network_readfilter_fuzz_test.dict"],
-    # All Envoy network filters must be linked to the test in order for the fuzzer to pick
-    # these up via the NamedNetworkFilterConfigFactory.
     deps = [
         ":uber_readfilter_lib",
         "//source/common/config:utility_lib",
         "//test/config:utility_lib",
         "//test/test_common:test_runtime_lib",
-    ] + envoy_all_network_filters(),
+    ] + fuzz_filters_targets(_readfilter_fuzz_filters),
+)
+
+_writefilter_fuzz_filters = [
+    "envoy.filters.network.zookeeper_proxy",
+    "envoy.filters.network.kafka_broker",
+    "envoy.filters.network.mongo_proxy",
+    "envoy.filters.network.mysql_proxy",
+    # TODO(jianwendong) Add "NetworkFilterNames::get().Postgres" after it
+    # supports untrusted data.
+]
+
+generate_from_template(
+    name = "uber_per_writefilter",
+    filters = _writefilter_fuzz_filters,
+    template_file = "uber_per_writefilter.tmpl.cc",
 )
 
 envoy_cc_test_library(
     name = "uber_writefilter_lib",
     srcs = [
-        "uber_per_writefilter.cc",
         "uber_writefilter.cc",
+        ":uber_per_writefilter.cc",
     ],
     hdrs = ["uber_writefilter.h"],
     deps = [
@@ -100,8 +129,6 @@ envoy_cc_fuzz_test(
     deps = [
         ":uber_writefilter_lib",
         "//source/common/config:utility_lib",
-        "//source/extensions/filters/network/mongo_proxy:config",
-        "//source/extensions/filters/network/zookeeper_proxy:config",
         "//test/config:utility_lib",
-    ],
+    ] + fuzz_filters_targets(_writefilter_fuzz_filters),
 )

--- a/test/extensions/filters/network/common/fuzz/filter_fuzz_support.bzl
+++ b/test/extensions/filters/network/common/fuzz/filter_fuzz_support.bzl
@@ -1,0 +1,37 @@
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
+
+def _selected_extension_target(target):
+    return target + "_envoy_extension"
+
+def fuzz_filters_targets(filters):
+    all_extensions = EXTENSIONS
+
+    return [ v for k, v in all_extensions.items() if (k in filters) ]
+
+def generate_from_template(**kwargs):
+    _generate_from_template(
+        source_file = "{name}.cc".format(**kwargs),
+        **kwargs
+    )
+
+def _generate_from_template_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template_file,
+        output = ctx.outputs.source_file,
+        substitutions = {
+            "{{FILTERS}}": "\"" + ( "\", \"".join(ctx.attr.filters)) + "\"",
+        },
+    )
+
+_generate_from_template = rule(
+    implementation = _generate_from_template_impl,
+    attrs = {
+        "filters": attr.string_list(mandatory = True),
+        "template_file": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "source_file": attr.output(mandatory = True),
+    },
+)

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.tmpl.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.tmpl.cc
@@ -19,20 +19,13 @@ static const int SecondsPerDay = 86400;
 std::vector<absl::string_view> UberFilterFuzzer::filterNames() {
   // Add filters that are in the process of being or are robust against untrusted downstream
   // traffic.
+  static const std::vector<std::string> supported_filter_names = {
+    {{FILTERS}}
+  };
   static std::vector<absl::string_view> filter_names;
   if (filter_names.empty()) {
     const auto factories = Registry::FactoryRegistry<
         Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
-    const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ClientSslAuth, NetworkFilterNames::get().ExtAuthorization,
-        NetworkFilterNames::get().EnvoyMobileHttpConnectionManager,
-        // A dedicated http_connection_manager fuzzer can be found in
-        // test/common/http/conn_manager_impl_fuzz_test.cc
-        NetworkFilterNames::get().HttpConnectionManager, NetworkFilterNames::get().LocalRateLimit,
-        NetworkFilterNames::get().RateLimit, NetworkFilterNames::get().Rbac,
-        // TODO(asraa): Remove when fuzzer sets up connections for TcpProxy properly.
-        // NetworkFilterNames::get().TcpProxy,
-    };
     // Check whether each filter is loaded into Envoy.
     // Some customers build Envoy without some filters. When they run fuzzing, the use of a filter
     // that does not exist will cause fatal errors.

--- a/test/extensions/filters/network/common/fuzz/uber_per_writefilter.tmpl.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_writefilter.tmpl.cc
@@ -8,16 +8,13 @@ namespace NetworkFilters {
 std::vector<absl::string_view> UberWriteFilterFuzzer::filterNames() {
   // These filters have already been covered by this fuzzer.
   // Will extend to cover other network filters one by one.
+  static const std::vector<std::string> supported_filter_names = {
+    {{FILTERS}}
+  };
   static std::vector<absl::string_view> filter_names;
   if (filter_names.empty()) {
     const auto factories = Registry::FactoryRegistry<
         Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
-    const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ZooKeeperProxy, NetworkFilterNames::get().KafkaBroker,
-        NetworkFilterNames::get().MongoProxy, NetworkFilterNames::get().MySQLProxy
-        // TODO(jianwendong) Add "NetworkFilterNames::get().Postgres" after it supports untrusted
-        // data.
-    };
     for (auto& filter_name : supported_filter_names) {
       if (factories.contains(filter_name)) {
         filter_names.push_back(filter_name);


### PR DESCRIPTION
Commit Message: [fuzz] Only add filters that are whitelisted.
Additional Description:
- Add only filters that are whitelisted to the build of:
	- network_readfilter_fuzz_test
	- network_writefilter_fuzz_test
- Use the same list to generate code for the white listing to prevent DRY.
 
Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
