### PR TITLE
lua: Upgrade the LuaJIT version to 2022-12-22

### DIFF
--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Makefile b/src/Makefile
-index e65b55e..f0a61dd 100644
+index 30d64be2..ae7ec875 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -27,7 +27,7 @@ NODOTABIVER= 51
@@ -36,13 +36,13 @@ index e65b55e..f0a61dd 100644
 @@ -212,7 +212,7 @@ TARGET_STCC= $(STATIC_CC)
  TARGET_DYNCC= $(DYNAMIC_CC)
  TARGET_LD= $(CROSS)$(CC)
- TARGET_AR= $(CROSS)ar rcus 2>/dev/null
+ TARGET_AR= $(CROSS)ar rcus
 -TARGET_STRIP= $(CROSS)strip
 +TARGET_STRIP?= $(CROSS)strip
  
  TARGET_LIBPATH= $(or $(PREFIX),/usr/local)/$(or $(MULTILIB),lib)
  TARGET_SONAME= libluajit-$(ABIVER).so.$(MAJVER)
-@@ -591,7 +591,7 @@ endif
+@@ -598,7 +598,7 @@ endif
  
  Q= @
  E= @echo
@@ -52,7 +52,7 @@ index e65b55e..f0a61dd 100644
  
  ##############################################################################
 diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
-index ae035dc..0e7eac9 100644
+index d323d8d4..2e08a3a1 100644
 --- a/src/msvcbuild.bat
 +++ b/src/msvcbuild.bat
 @@ -13,9 +13,7 @@
@@ -71,7 +71,7 @@ index ae035dc..0e7eac9 100644
  @set LJDLLNAME=lua51.dll
  @set LJLIBNAME=lua51.lib
 -@set BUILDTYPE=release
- @set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
+ @set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c lib_buffer.c
  
 -%LJCOMPILE% host\minilua.c
 +%LJCOMPILE% /O2 host\minilua.c
@@ -131,7 +131,7 @@ index ae035dc..0e7eac9 100644
  @if errorlevel 1 goto :BAD
 diff --git a/build.py b/build.py
 new file mode 100755
-index 0000000..3eb74ff
+index 00000000..1201542c
 --- /dev/null
 +++ b/build.py
 @@ -0,0 +1,52 @@

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -423,13 +423,12 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "LuaJIT",
         project_desc = "Just-In-Time compiler for Lua",
         project_url = "https://luajit.org",
-        # The last release version, 2.1.0-beta3 has a number of CVEs filed
-        # against it. These may not impact correct non-malicious Lua code, but for prudence we bump.
+        # LuaJIT only provides rolling releases
         version = "a04480e311f93d3ceb2f92549cad3fffa38250ef",
         sha256 = "297e9c06d934753f9553fa7d1c1e43381e20094ed3289e0e145dd5f3c203a27e",
         strip_prefix = "LuaJIT-{version}",
         urls = ["https://github.com/LuaJIT/LuaJIT/archive/{version}.tar.gz"],
-        release_date = "2020-10-12",
+        release_date = "2022-12-21",
         use_category = ["dataplane_ext"],
         extensions = ["envoy.filters.http.lua"],
         cpe = "cpe:2.3:a:luajit:luajit:*",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -425,8 +425,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_url = "https://luajit.org",
         # The last release version, 2.1.0-beta3 has a number of CVEs filed
         # against it. These may not impact correct non-malicious Lua code, but for prudence we bump.
-        version = "1d8b747c161db457e032a023ebbff511f5de5ec2",
-        sha256 = "20a159c38a98ecdb6368e8d655343b6036622a29a1621da9dc303f7ed9bf37f3",
+        version = "a04480e311f93d3ceb2f92549cad3fffa38250ef",
+        sha256 = "297e9c06d934753f9553fa7d1c1e43381e20094ed3289e0e145dd5f3c203a27e",
         strip_prefix = "LuaJIT-{version}",
         urls = ["https://github.com/LuaJIT/LuaJIT/archive/{version}.tar.gz"],
         release_date = "2020-10-12",

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -723,12 +723,6 @@ class FormatChecker:
                         "Don't introduce throws into exception-free files, use error "
                         + "statuses instead.")
 
-        if "lua_pushlightuserdata" in line:
-            report_error(
-                "Don't use lua_pushlightuserdata, since it can cause unprotected error in call to"
-                + "Lua API (bad light userdata pointer) on ARM64 architecture. See "
-                + "https://github.com/LuaJIT/LuaJIT/issues/450#issuecomment-433659873 for details.")
-
     def check_build_line(self, line, file_path, report_error):
         if "@bazel_tools" in line and not (self.is_starlark_file(file_path)
                                            or file_path.startswith("./bazel/")


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: lua: Upgrade the LuaJIT version to 2022-12-22
Additional Description: The current LuaJIT version used in Envoy is 1d8b747c161db457e032a023ebbff511f5de5ec2, which is created on 2020-10-12, more than 2 years ago. Plenty of bugfix and new features happen after that.
Risk Level: Middle
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes #25763
