### PR TITLE
Set permissions to workflows

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
@@ -15,6 +17,8 @@ jobs:
     if: github.repository == 'envoyproxy/envoy'
     name: android_build
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # to upload assets to release
     timeout-minutes: 90
     container:
       image: envoyproxy/envoy-build-ubuntu:mobile-458cb49ca2013c0ccf057d00ad1d4407920c4e52
@@ -46,6 +50,8 @@ jobs:
     name: java_helloworld
     needs: androidbuild
     runs-on: macos-12
+    permissions:
+      contents: write # to upload asserts to release
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
@@ -94,6 +100,8 @@ jobs:
     name: kotlin_helloworld
     needs: androidbuild
     runs-on: macos-12
+    permissions:
+      contents: write # to upload asserts to release
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
@@ -142,6 +150,8 @@ jobs:
     name: kotlin_baseline_app
     needs: androidbuild
     runs-on: macos-12
+    permissions:
+      contents: write # to upload asserts to release
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
@@ -190,6 +200,8 @@ jobs:
     name: kotlin_experimental_app
     needs: androidbuild
     runs-on: macos-12
+    permissions:
+      contents: write # to upload asserts to release
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -8,12 +8,13 @@ on:
 
 permissions:
   contents: read # to fetch code (actions/checkout)
-  issues: write # required to open/close dependency issues
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'
+    permissions:
+      issues: write # required to open/close dependency issues
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -8,6 +8,9 @@ on:
     - 'dependabot/**'
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -3,11 +3,16 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   retest:
     if: github.repository == 'envoyproxy/envoy'
     name: Retest
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to edit comments
     steps:
     - uses: jpsim/retest@c158dec0a7f67cb85f8367468dc8a9a75308bb7f
       with:

--- a/.github/workflows/compile_time_options.yml
+++ b/.github/workflows/compile_time_options.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true
@@ -44,6 +46,8 @@ jobs:
     if: github.repository == 'envoyproxy/envoy'
     name: swift_build
     runs-on: macos-12
+    permissions:
+      contents: write # to upload assets to release
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
@@ -74,6 +78,8 @@ jobs:
     if: github.repository == 'envoyproxy/envoy'
     name: kotlin_build
     runs-on: macos-12
+    permissions:
+      contents: write # to upload assets to release
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,6 +1,8 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
     - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,8 @@ on:
   schedule:
   - cron: '0 */4 * * *'
 
+permissions: {}
+
 jobs:
   prune_stale:
     permissions:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -6,6 +6,8 @@ on:
     - main
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.head_ref-github.workflow || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Closes #25770 

I tried to test the maximum number of workflows in advance but not all of them seems to be possible to test on a forked repo (Even withouth any changes, it was not working). Any workflow that is not working I'll fix ASAP.

### Changes

file | running | reason
-- | -- | --
check-deps.yml | YES | No permission changed
codeql-daily.yml | YES | https://github.com/joycebrum/envoy/actions/runs/4314017378
commands.yml | YES | https://github.com/joycebrum/envoy/actions/runs/4316268255
depsreview.yml | YES | https://github.com/joycebrum/envoy/actions/runs/4316700806
docs.yml | YES | https://github.com/joycebrum/envoy/actions/runs/4316287707
stale.yml | YES | https://github.com/joycebrum/envoy/actions/runs/4315957063
android_build.yml | NO | Bazel Script Failing
android_tests.yml | NO | Bazel Script Failing
asan.yml | NO | Bazel Script Failing
cc_tests.yml | NO | Bazel Script Failing
compile_time_options.yml | NO | Bazel Script Failing
core.yml | NO | Bazel Script Failing
coverage.yml | NO | Bazel Script Failing
format.yml | NO | Bazel Script Failing
ios_build.yml | NO | Bazel Script Failing
ios_tests.yml | NO | Bazel Script Failing
perf.yml | NO | Bazel Script Failing
release_validation.yml | NO | Bazel Script Failing
tsan.yml | NO | Bazel Script Failing
codeql-push.yml | NOT FINISHED | https://github.com/joycebrum/envoy/actions/runs/4316287715/workflow

