### PR TITLE
mobile: cleaning up some test TODOs

### DIFF
--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -123,7 +123,7 @@ NetworkConfigurationFilter::decodeHeaders(Http::RequestHeaderMap& request_header
 
 void NetworkConfigurationFilter::setInfo(absl::string_view authority,
                                          Network::Address::InstanceConstSharedPtr address) {
-  ENVOY_LOG(trace, "netconf_filter_set_proxy_for_request", authority, address->asString());
+  ENVOY_LOG(trace, "netconf_filter_set_proxy_for_request {} {}", authority, address->asString());
   decoder_callbacks_->streamInfo().filterState()->setData(
       Network::Http11ProxyInfoFilterState::key(),
       std::make_unique<Network::Http11ProxyInfoFilterState>(authority, address),

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -289,18 +289,14 @@ TEST_P(ClientIntegrationTest, TimeoutOnResponsePath) {
   ASSERT_EQ(cc_.on_error_calls, 1);
 }
 
-// TODO(alyssawilk) get this working in a follow-up.
-TEST_P(ClientIntegrationTest, DISABLED_Proxying) {
+TEST_P(ClientIntegrationTest, Proxying) {
   builder_.addLogLevel(Platform::LogLevel::trace);
   initialize();
-  if (version_ == Network::Address::IpVersion::v6) {
-    // Localhost only resolves to an ipv4 address - alas no kernel happy eyeballs.
-    return;
-  }
 
-  set_proxy_settings(rawEngine(), "localhost", fake_upstreams_[0]->localAddress()->ip()->port());
+  set_proxy_settings(rawEngine(), fake_upstreams_[0]->localAddress()->asString().c_str(),
+                     fake_upstreams_[0]->localAddress()->ip()->port());
 
-  // The initial request will do the DNS lookup and resolve localhost to 127.0.0.1
+  // The initial request will do the DNS lookup.
   stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
   terminal_callback_.waitReady();
   ASSERT_EQ(cc_.status, "200");

--- a/mobile/test/common/integration/xds_integration_test.cc
+++ b/mobile/test/common/integration/xds_integration_test.cc
@@ -21,7 +21,7 @@ using ::testing::AssertionSuccess;
 XdsIntegrationTest::XdsIntegrationTest() : BaseClientIntegrationTest(ipVersion()) {
   Grpc::forceRegisterDefaultGoogleGrpcCredentialsFactory();
   override_builder_config_ = false;
-  expect_dns_ = false; // TODO(alyssawilk) debug.
+  expect_dns_ = false; // doesn't use DFP.
   create_xds_upstream_ = true;
   sotw_or_delta_ = sotwOrDelta();
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -505,9 +505,10 @@ Host::CreateConnectionData HostImpl::createConnection(
   // redirected to a proxy, create the TCP connection to the proxy's address not
   // the host's address.
   if (transport_socket_options && transport_socket_options->http11ProxyInfo().has_value()) {
-    ENVOY_LOG(debug, "Connecting to configured HTTP/1.1 proxy");
     auto upstream_local_address =
         source_address_selector->getUpstreamLocalAddress(address, options);
+    ENVOY_LOG(debug, "Connecting to configured HTTP/1.1 proxy at {}",
+              transport_socket_options->http11ProxyInfo()->proxy_address->asString());
     connection = dispatcher.createClientConnection(
         transport_socket_options->http11ProxyInfo()->proxy_address, upstream_local_address.address_,
         socket_factory.createTransportSocket(transport_socket_options, host),


### PR DESCRIPTION
documenting why xDS tests don't have DNS timing metrics and fixing proxying test to use explicit IPs (loopback on CI resolved to an IPv6 address on IPv4 builds)
