### PR TITLE
[cache-filter] Add disabled option

### DIFF
--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -56,8 +56,9 @@ message CacheConfig {
   google.protobuf.Any typed_config = 1;
 
   // When true, the cache filter is a no-op filter.
+  //
   // Possible use-cases for this include:
-  // * Turning a filter on and off with [ECDS](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/extension/v3/config_discovery.proto).
+  // - Turning a filter on and off with [ECDS](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/extension/v3/config_discovery.proto).
   // [#comment: once route-specific overrides are implemented, they are the more likely use-case.]
   google.protobuf.BoolValue disabled = 5;
 

--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -58,7 +58,7 @@ message CacheConfig {
   // When true, the cache filter is a no-op filter.
   //
   // Possible use-cases for this include:
-  // - Turning a filter on and off with [ECDS](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/extension/v3/config_discovery.proto).
+  // - Turning a filter on and off with :ref:`ECDS <envoy_v3_api_file_envoy/service/extension/v3/config_discovery.proto>`.
   // [#comment: once route-specific overrides are implemented, they are the more likely use-case.]
   google.protobuf.BoolValue disabled = 5;
 

--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -10,7 +10,6 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.cache.v3";
 option java_outer_classname = "CacheProto";

--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -20,6 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: HTTP Cache Filter]
 
 // [#extension: envoy.filters.http.cache]
+// [#next-free-field: 6]
 message CacheConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.cache.v2alpha.CacheConfig";
@@ -49,9 +50,16 @@ message CacheConfig {
     repeated config.route.v3.QueryParameterMatcher query_parameters_excluded = 4;
   }
 
-  // Config specific to the cache storage implementation.
-  // [#extension-category: envoy.http.cache]
-  google.protobuf.Any typed_config = 1 [(validate.rules).any = {required: true}];
+  oneof cache_implementation {
+    option (validate.required) = true;
+
+    // Config specific to the cache storage implementation.
+    // [#extension-category: envoy.http.cache]
+    google.protobuf.Any typed_config = 1;
+
+    // When set, the cache filter is a no-op filter.
+    bool disabled = 5 [(validate.rules).bool = {const: true}];
+  }
 
   // List of matching rules that defines allowed ``Vary`` headers.
   //

--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -56,6 +56,9 @@ message CacheConfig {
   google.protobuf.Any typed_config = 1;
 
   // When true, the cache filter is a no-op filter.
+  // Possible use-cases for this include:
+  // * Turning a filter on and off with [ECDS](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/extension/v3/config_discovery.proto).
+  // [#comment: once route-specific overrides are implemented, they are the more likely use-case.]
   google.protobuf.BoolValue disabled = 5;
 
   // List of matching rules that defines allowed ``Vary`` headers.

--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -6,6 +6,7 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -50,16 +51,13 @@ message CacheConfig {
     repeated config.route.v3.QueryParameterMatcher query_parameters_excluded = 4;
   }
 
-  oneof cache_implementation {
-    option (validate.required) = true;
+  // Config specific to the cache storage implementation. Required unless ``disabled``
+  // is true.
+  // [#extension-category: envoy.http.cache]
+  google.protobuf.Any typed_config = 1;
 
-    // Config specific to the cache storage implementation.
-    // [#extension-category: envoy.http.cache]
-    google.protobuf.Any typed_config = 1;
-
-    // When set, the cache filter is a no-op filter.
-    bool disabled = 5 [(validate.rules).bool = {const: true}];
-  }
+  // When true, the cache filter is a no-op filter.
+  google.protobuf.BoolValue disabled = 5;
 
   // List of matching rules that defines allowed ``Vary`` headers.
   //

--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -54,7 +54,7 @@ class CacheFilter : public Http::PassThroughFilter,
 public:
   CacheFilter(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
               const std::string& stats_prefix, Stats::Scope& scope, TimeSource& time_source,
-              HttpCache& http_cache);
+              OptRef<HttpCache> http_cache);
   // Http::StreamFilterBase
   void onDestroy() override;
   void onStreamComplete() override;
@@ -127,7 +127,7 @@ private:
   InsertStatus insertStatus() const;
 
   TimeSource& time_source_;
-  HttpCache& cache_;
+  OptRef<HttpCache> cache_;
   LookupContextPtr lookup_;
   InsertContextPtr insert_;
   LookupResultPtr lookup_result_;

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -10,15 +10,18 @@ namespace Cache {
 Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  const std::string type{TypeUtil::typeUrlToDescriptorFullName(config.typed_config().type_url())};
-  HttpCacheFactory* const http_cache_factory =
-      Registry::FactoryRegistry<HttpCacheFactory>::getFactoryByType(type);
-  if (http_cache_factory == nullptr) {
-    throw EnvoyException(
-        fmt::format("Didn't find a registered implementation for type: '{}'", type));
-  }
+  std::shared_ptr<HttpCache> cache;
+  if (!config.disabled()) {
+    const std::string type{TypeUtil::typeUrlToDescriptorFullName(config.typed_config().type_url())};
+    HttpCacheFactory* const http_cache_factory =
+        Registry::FactoryRegistry<HttpCacheFactory>::getFactoryByType(type);
+    if (http_cache_factory == nullptr) {
+      throw EnvoyException(
+          fmt::format("Didn't find a registered implementation for type: '{}'", type));
+    }
 
-  auto cache = http_cache_factory->getCache(config, context);
+    cache = http_cache_factory->getCache(config, context);
+  }
 
   return [config, stats_prefix, &context,
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -11,7 +11,10 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   std::shared_ptr<HttpCache> cache;
-  if (!config.disabled()) {
+  if (!config.disabled().value()) {
+    if (!config.has_typed_config()) {
+      throw EnvoyException("at least one of typed_config or disabled must be set");
+    }
     const std::string type{TypeUtil::typeUrlToDescriptorFullName(config.typed_config().type_url())};
     HttpCacheFactory* const http_cache_factory =
         Registry::FactoryRegistry<HttpCacheFactory>::getFactoryByType(type);

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -26,7 +26,8 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
   return [config, stats_prefix, &context,
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
-                                                            context.timeSource(), *cache));
+                                                            context.timeSource(),
+                                                            cache ? *cache : OptRef<HttpCache>{}));
   };
 }
 

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -254,7 +254,7 @@ TEST_F(CacheFilterTest, CacheMiss) {
 TEST_F(CacheFilterTest, Disabled) {
   request_headers_.setHost("CacheDisabled");
   CacheFilterSharedPtr filter = makeFilter(OptRef<HttpCache>{});
-  EXPECT_EQ(filter->decodeHeaders(request_headers_, false), Http::FilterHeadersStatus::Continue);
+  EXPECT_EQ(filter->decodeHeaders(request_headers_, true), Http::FilterHeadersStatus::Continue);
   filter->onDestroy();
 }
 

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -27,7 +27,7 @@ class CacheFilterTest : public ::testing::Test {
 protected:
   // The filter has to be created as a shared_ptr to enable shared_from_this() which is used in the
   // cache callbacks.
-  CacheFilterSharedPtr makeFilter(HttpCache& cache) {
+  CacheFilterSharedPtr makeFilter(OptRef<HttpCache> cache) {
     auto filter = std::make_shared<CacheFilter>(config_, /*stats_prefix=*/"", context_.scope(),
                                                 context_.timeSource(), cache);
     filter_state_ = std::make_shared<StreamInfo::FilterStateImpl>(
@@ -249,6 +249,13 @@ TEST_F(CacheFilterTest, CacheMiss) {
 
     filter->onDestroy();
   }
+}
+
+TEST_F(CacheFilterTest, Disabled) {
+  request_headers_.setHost("CacheDisabled");
+  CacheFilterSharedPtr filter = makeFilter(OptRef<HttpCache>{});
+  EXPECT_EQ(filter->decodeHeaders(request_headers_, false), Http::FilterHeadersStatus::Continue);
+  filter->onDestroy();
 }
 
 TEST_F(CacheFilterTest, CacheMissWithTrailers) {

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -34,7 +34,7 @@ TEST_F(CacheFilterFactoryTest, Basic) {
 }
 
 TEST_F(CacheFilterFactoryTest, Disabled) {
-  config_.set_disabled(true);
+  config_.mutable_disabled()->set_value(true);
   Http::FilterFactoryCb cb = factory_.createFilterFactoryFromProto(config_, "stats", context_);
   Http::StreamFilterSharedPtr filter;
   EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -33,6 +33,16 @@ TEST_F(CacheFilterFactoryTest, Basic) {
   ASSERT(dynamic_cast<CacheFilter*>(filter.get()));
 }
 
+TEST_F(CacheFilterFactoryTest, Disabled) {
+  config_.set_disabled(true);
+  Http::FilterFactoryCb cb = factory_.createFilterFactoryFromProto(config_, "stats", context_);
+  Http::StreamFilterSharedPtr filter;
+  EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
+  cb(filter_callback_);
+  ASSERT(filter);
+  ASSERT(dynamic_cast<CacheFilter*>(filter.get()));
+}
+
 TEST_F(CacheFilterFactoryTest, NoTypedConfig) {
   EXPECT_THROW(factory_.createFilterFactoryFromProto(config_, "stats", context_), EnvoyException);
 }


### PR DESCRIPTION
Commit Message: [cache-filter] Add disabled option
Additional Description: Adds the ability to have cache filter present but disabled. This makes it so a cache filter can more easily be configured with ECDS, and is a good precursor to making the configuration "inheritable". Addresses part of #25819.
This model is forward-compatible with the idea of inheritable/overrideable config, and the implementation is backward-compatible with existing config.
Risk Level: Low - cache filter is WIP, and change should be no-op for existing configs.
Testing: Added unit test coverage.
Docs Changes: Automatic from proto.
Release Notes: n/a
Platform Specific Features: n/a
