### PR TITLE
examples: Improve mysql version information

### DIFF
--- a/docs/root/configuration/listeners/network_filters/mysql_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/mysql_proxy_filter.rst
@@ -18,9 +18,10 @@ won't affect the normal progress of client and server.
 
 .. warning::
 
-   The mysql_proxy filter was tested with MySQL v5.7. The filter may not work
-   with other versions of MySQL due to differences in the protocol implementation.
-   The filter won't work when client turns on ssl communication.
+   The mysql_proxy filter was originally tested with MySQL v5.7, although the filter may work
+   with other versions of MySQL also.
+
+   The filter won't work when client turns on SSL/TLS communication.
 
 .. _config_network_filters_mysql_proxy_config:
 

--- a/docs/root/start/sandboxes/mysql.rst
+++ b/docs/root/start/sandboxes/mysql.rst
@@ -15,14 +15,17 @@ In this example, we show how the :ref:`MySQL filter <config_network_filters_mysq
 The Envoy proxy configuration includes a MySQL filter that parses queries and collects MySQL-specific
 metrics.
 
+.. note::
+   The current implementation of the protocol filter was tested extensively with MySQL
+   v5.7. It may also work with other versions. This example uses the current latest version.
+
+
 Step 1: Build the sandbox
 *************************
 
 Change to the ``examples/mysql`` directory.
 
 Build and start the containers.
-
-Terminal 1
 
 .. code-block:: console
 
@@ -40,12 +43,7 @@ Terminal 1
 Step 2: Issue commands using mysql
 **********************************
 
-Use ``mysql`` to issue some commands and verify they are routed via Envoy. Note
-that the current implementation of the protocol filter was tested with MySQL
-v5.7. It may, however, not work with other versions of MySQL due to differences
-in the protocol implementation, but it won't affect normal progress of client-server communication.
-
-Terminal 1
+Use ``mysql`` to issue some commands and verify they are routed via Envoy.
 
 .. code-block:: console
 
@@ -87,8 +85,6 @@ Step 3: Check egress stats
 
 Check egress stats were updated.
 
-Terminal 1
-
 .. code-block:: console
 
   $ curl -s "http://localhost:8001/stats?filter=egress_mysql"
@@ -108,8 +104,6 @@ Step 4: Check TCP stats
 ***********************
 
 Check TCP stats were updated.
-
-Terminal 1
 
 .. code-block:: console
 

--- a/examples/mysql/verify.sh
+++ b/examples/mysql/verify.sh
@@ -9,8 +9,7 @@ export PORT_ADMIN="${MYSQL_PORT_ADMIN:-11300}"
 
 _mysql () {
     local mysql_client
-    # TODO(phlax): pin mysql client
-    mysql_client=(docker run --network mysql_default mysql:5.7 mysql -h proxy -P 1999 -u root)
+    mysql_client=(docker run --network mysql_default mysql:latest mysql -h proxy -P 1999 -u root)
     "${mysql_client[@]}" "${@}"
 }
 


### PR DESCRIPTION
The mysql example tracks the `latest` mysql version so limiting the client to 5.7 (ie different from server) seems wrong.

This unpins the client version and improves the example/documentation about tested mysql versions.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
