### PR TITLE
bazel: Fix error handling in `setup_clang.sh`

### DIFF
--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/bin/bash -e
 
-BAZELRC_FILE="${BAZELRC_FILE:-$(bazel info workspace)/clang.bazelrc}"
+BAZEL_WORKSPACE="$(bazel info workspace)"
+BAZELRC_FILE="${BAZELRC_FILE:-${BAZEL_WORKSPACE}/clang.bazelrc}"
 
 LLVM_PREFIX=$1
 
@@ -12,7 +13,11 @@ fi
 PATH="$("${LLVM_PREFIX}"/bin/llvm-config --bindir):${PATH}"
 export PATH
 
-RT_LIBRARY_PATH="$(llvm-config --libdir)/clang/$(llvm-config --version)/lib/$(llvm-config --host-target)"
+LLVM_VERSION="$(llvm-config --version)"
+LLVM_LIBDIR="$(llvm-config --libdir)"
+LLVM_TARGET="$(llvm-config --host-target)"
+
+RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
 
 echo "# Generated file, do not edit. If you want to disable clang, just delete this file.
 build:clang --action_env='PATH=${PATH}'


### PR DESCRIPTION
Currently if any of this file fails it silently continues with borked filepaths etc

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
