### PR TITLE
examples: Use a build stage for go compiling 

### DIFF
--- a/examples/dynamic-config-cp/Dockerfile-control-plane
+++ b/examples/dynamic-config-cp/Dockerfile-control-plane
@@ -1,4 +1,11 @@
-FROM golang@sha256:a452d6273ad03a47c2f29b898d6bb57630e77baf839651ef77d03e4e049c5bf3
+FROM golang:1.20.1-bullseye@sha256:63ed3bc6b428713c2bb1980e534d70e8ab82a4484ec044183df9caca6e9d82cb as builder
+
+RUN git clone https://github.com/envoyproxy/go-control-plane && cd go-control-plane && git checkout b4adc3bb5fe5288bff01cd452dad418ef98c676e
+ADD ./resource.go /go/go-control-plane/internal/example/resource.go
+RUN cd go-control-plane && make bin/example
+WORKDIR /go/go-control-plane
+
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,7 +15,4 @@ RUN apt-get -qq update \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
-RUN git clone https://github.com/envoyproxy/go-control-plane && cd go-control-plane && git checkout b4adc3bb5fe5288bff01cd452dad418ef98c676e
-ADD ./resource.go /go/go-control-plane/internal/example/resource.go
-RUN cd go-control-plane && make bin/example
-WORKDIR /go/go-control-plane
+COPY --from=builder /go/go-control-plane/bin/example /usr/local/bin/example

--- a/examples/dynamic-config-cp/docker-compose.yaml
+++ b/examples/dynamic-config-cp/docker-compose.yaml
@@ -26,6 +26,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-control-plane
-    command: bin/example
+    command: /usr/local/bin/example
     healthcheck:
       test: nc -zv localhost 18000

--- a/examples/ext_authz/auth/grpc-service/Dockerfile
+++ b/examples/ext_authz/auth/grpc-service/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:alpine@sha256:87d0a3309b34e2ca732efd69fb899d3c420d3382370fd6e7e6d2cb5c930f27f9 AS builder
+FROM golang:1.20.1-bullseye@sha256:63ed3bc6b428713c2bb1980e534d70e8ab82a4484ec044183df9caca6e9d82cb as builder
 
-RUN apk --no-cache add make
 COPY . /app
 RUN make -C /app/grpc-service
 
-FROM alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
+FROM debian:bullseye-slim
 
 COPY --from=builder /app/grpc-service/server /app/server
 CMD ["/app/server", "-users", "/etc/users.json"]

--- a/examples/load-reporting-service/Dockerfile-lrs
+++ b/examples/load-reporting-service/Dockerfile-lrs
@@ -1,4 +1,4 @@
-FROM golang@sha256:a452d6273ad03a47c2f29b898d6bb57630e77baf839651ef77d03e4e049c5bf3
+FROM golang:1.20.1-bullseye@sha256:63ed3bc6b428713c2bb1980e534d70e8ab82a4484ec044183df9caca6e9d82cb as builder
 
 COPY ./server /go/src/github.com/envoyproxy/envoy/example/load-reporting-service/server
 COPY *.go /go/src/github.com/envoyproxy/envoy/example/load-reporting-service/
@@ -6,7 +6,11 @@ COPY go.sum /go/src/github.com/envoyproxy/envoy/example/load-reporting-service
 COPY go.mod /go/src/github.com/envoyproxy/envoy/example/load-reporting-service
 
 WORKDIR /go/src/github.com/envoyproxy/envoy/example/load-reporting-service
-RUN go mod download
-RUN go install /go/src/github.com/envoyproxy/envoy/example/load-reporting-service
+RUN go mod download \
+    && go install /go/src/github.com/envoyproxy/envoy/example/load-reporting-service
 
-CMD ["go","run","main.go"]
+FROM debian:bullseye-slim
+
+COPY --from=builder /go/bin/load-reporting-service /usr/local/bin/load-reporting-service
+
+CMD ["load-reporting-service"]


### PR DESCRIPTION
This makes the very large build images ephemeral and reduces CI disk pressure

also makes go image use more consistent

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
