### PR TITLE
mobile: replace `envoy_mobile_copts` with `envoy_mobile_defines`

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -50,8 +50,8 @@ load(
     _envoy_sh_test = "envoy_sh_test",
 )
 load(
-    ":envoy_mobile_copts.bzl",
-    _envoy_mobile_copts = "envoy_mobile_copts",
+    ":envoy_mobile_defines.bzl",
+    _envoy_mobile_defines = "envoy_mobile_defines",
 )
 load(
     "@envoy_build_config//:extensions_build_config.bzl",
@@ -268,5 +268,5 @@ envoy_py_test = _envoy_py_test
 envoy_py_test_binary = _envoy_py_test_binary
 envoy_sh_test = _envoy_sh_test
 
-# Envoy Mobile copts (from envoy_mobile_copts.bz)
-envoy_mobile_copts = _envoy_mobile_copts
+# Envoy Mobile defines (from envoy_mobile_defines.bz)
+envoy_mobile_defines = _envoy_mobile_defines

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -1,7 +1,6 @@
 # DO NOT LOAD THIS FILE. Targets from this file should be considered private
 # and not used outside of the @envoy//bazel package.
 load(":envoy_select.bzl", "envoy_select_admin_html", "envoy_select_disable_logging", "envoy_select_google_grpc", "envoy_select_hot_restart", "envoy_select_static_extension_registration")
-load(":envoy_mobile_copts.bzl", "envoy_mobile_copts")
 
 # Compute the final copts based on various options.
 def envoy_copts(repository, test = False):
@@ -129,8 +128,7 @@ def envoy_copts(repository, test = False):
            _envoy_select_perf_annotation(["-DENVOY_PERF_ANNOTATION"]) + \
            _envoy_select_perfetto(["-DENVOY_PERFETTO"]) + \
            envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository) + \
-           _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository) + \
-           envoy_mobile_copts(repository)
+           _envoy_select_path_normalization_by_default(["-DENVOY_NORMALIZE_PATH_BY_DEFAULT"], repository)
 
 # References to Envoy external dependencies should be wrapped with this function.
 def envoy_external_dep_path(dep):

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -13,6 +13,7 @@ load(
     "CONTRIB_EXTENSION_PACKAGE_VISIBILITY",
     "EXTENSION_CONFIG_VISIBILITY",
 )
+load(":envoy_mobile_defines.bzl", "envoy_mobile_defines")
 
 # As above, but wrapped in list form for adding to dep lists. This smell seems needed as
 # SelectorValue values have to match the attribute type. See
@@ -138,7 +139,7 @@ def envoy_cc_library(
         linkstatic = envoy_linkstatic(),
         strip_include_prefix = strip_include_prefix,
         include_prefix = include_prefix,
-        defines = defines,
+        defines = envoy_mobile_defines(repository) + defines,
     )
 
     # Intended for usage by external consumers. This allows them to disambiguate

--- a/bazel/envoy_mobile_copts.bzl
+++ b/bazel/envoy_mobile_copts.bzl
@@ -1,9 +1,0 @@
-# DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
-load(":envoy_select.bzl", "envoy_select_admin_functionality", "envoy_select_enable_http3", "envoy_select_envoy_mobile_listener", "envoy_select_envoy_mobile_request_compression")
-
-# Compute the copts needed for Envoy Mobile libraries that don't use Envoy's main library wrappers.
-def envoy_mobile_copts(repository):
-    return envoy_select_admin_functionality(["-DENVOY_ADMIN_FUNCTIONALITY"], repository) + \
-           envoy_select_enable_http3(["-DENVOY_ENABLE_QUIC"], repository) + \
-           envoy_select_envoy_mobile_listener(["-DENVOY_MOBILE_ENABLE_LISTENER"], repository) + \
-           envoy_select_envoy_mobile_request_compression(["-DENVOY_MOBILE_REQUEST_COMPRESSION"], repository)

--- a/bazel/envoy_mobile_defines.bzl
+++ b/bazel/envoy_mobile_defines.bzl
@@ -1,0 +1,9 @@
+# DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
+load(":envoy_select.bzl", "envoy_select_admin_functionality", "envoy_select_enable_http3", "envoy_select_envoy_mobile_listener", "envoy_select_envoy_mobile_request_compression")
+
+# Compute the defines needed for Envoy Mobile libraries that don't use Envoy's main library wrappers.
+def envoy_mobile_defines(repository):
+    return envoy_select_admin_functionality(["ENVOY_ADMIN_FUNCTIONALITY"], repository) + \
+           envoy_select_enable_http3(["ENVOY_ENABLE_QUIC"], repository) + \
+           envoy_select_envoy_mobile_listener(["ENVOY_MOBILE_ENABLE_LISTENER"], repository) + \
+           envoy_select_envoy_mobile_request_compression(["ENVOY_MOBILE_REQUEST_COMPRESSION"], repository)

--- a/mobile/bazel/apple.bzl
+++ b/mobile/bazel/apple.bzl
@@ -1,6 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_copts")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 def envoy_objc_library(name, hdrs = [], visibility = [], data = [], deps = [], module_name = None, sdk_frameworks = [], srcs = []):
@@ -8,7 +8,8 @@ def envoy_objc_library(name, hdrs = [], visibility = [], data = [], deps = [], m
         name = name,
         srcs = srcs,
         hdrs = hdrs,
-        copts = envoy_mobile_copts("@envoy") + ["-ObjC++", "-std=c++17", "-Wno-shorten-64-to-32"],
+        copts = ["-ObjC++", "-std=c++17", "-Wno-shorten-64-to-32"],
+        defines = envoy_mobile_defines("@envoy"),
         module_name = module_name,
         sdk_frameworks = sdk_frameworks,
         visibility = visibility,

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -1,5 +1,5 @@
 load("//bazel:android_debug_info.bzl", "android_debug_info")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_copts", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines", "envoy_package")
 
 licenses(["notice"])  # Apache 2
 
@@ -55,7 +55,7 @@ cc_library(
     srcs = [
         "jni_interface.cc",
     ],
-    copts = envoy_mobile_copts("@envoy"),
+    defines = envoy_mobile_defines("@envoy"),
     deps = [
         ":android_network_utility_lib",
         ":jni_utility_lib",

--- a/mobile/library/swift/BUILD
+++ b/mobile/library/swift/BUILD
@@ -3,7 +3,7 @@ load("//bazel:swift_header_collector.bzl", "swift_header_collector")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_xcframework")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_copts")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines")
 
 licenses(["notice"])  # Apache 2
 
@@ -77,7 +77,7 @@ swift_library(
         "stats/Tags.swift",
         "stats/TagsBuilder.swift",
     ] + ["@envoy_mobile_extra_swift_sources//:extra_swift_srcs"],
-    copts = envoy_mobile_copts("@envoy"),
+    defines = envoy_mobile_defines("@envoy"),
     features = [
         "swift.emit_symbol_graph",
         "swift.enable_library_evolution",


### PR DESCRIPTION
This is more correct and will work with upcoming changes to enable Swift and C++ interop.

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Medium.
Testing: Existing.
Docs Changes: None.
Release Notes: None.
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
