### PR TITLE
mobile: add optional `tag` field to some structs

### DIFF
--- a/mobile/library/cc/engine_callbacks.cc
+++ b/mobile/library/cc/engine_callbacks.cc
@@ -5,7 +5,8 @@ namespace Platform {
 
 namespace {
 
-void c_on_engine_running(void* context) {
+void c_on_engine_running(void* context, int tag) {
+  (void)tag;
   auto engine_callbacks = *static_cast<EngineCallbacksSharedPtr*>(context);
   engine_callbacks->on_engine_running();
 }
@@ -22,6 +23,7 @@ envoy_engine_callbacks EngineCallbacks::asEnvoyEngineCallbacks() {
       &c_on_engine_running,
       &c_on_exit,
       new EngineCallbacksSharedPtr(shared_from_this()),
+      0,
   };
 }
 

--- a/mobile/library/common/common/lambda_logger_delegate.cc
+++ b/mobile/library/common/common/lambda_logger_delegate.cc
@@ -17,7 +17,7 @@ void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, abs
   event_tracker_.track(Bridge::Utility::makeEnvoyMap({{"name", "event_log"},
                                                       {"log_name", std::string(stable_name)},
                                                       {"message", std::string(msg)}}),
-                       event_tracker_.context);
+                       event_tracker_.context, event_tracker_.tag);
 }
 
 LambdaDelegate::LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink)
@@ -27,11 +27,11 @@ LambdaDelegate::LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr l
 
 LambdaDelegate::~LambdaDelegate() {
   restoreDelegate();
-  logger_.release(logger_.context);
+  logger_.release(logger_.context, logger_.tag);
 }
 
 void LambdaDelegate::log(absl::string_view msg, const spdlog::details::log_msg&) {
-  logger_.log(Data::Utility::copyToBridgeData(msg), logger_.context);
+  logger_.log(Data::Utility::copyToBridgeData(msg), logger_.context, logger_.tag);
 }
 
 DefaultDelegate::DefaultDelegate(absl::Mutex& mutex, DelegatingLogSinkSharedPtr log_sink)

--- a/mobile/library/common/engine.cc
+++ b/mobile/library/common/engine.cc
@@ -55,13 +55,13 @@ envoy_status_t Engine::main(std::unique_ptr<Envoy::OptionsImpl>&& options) {
             Assert::addDebugAssertionFailureRecordAction([this](const char* location) {
               const auto event = Bridge::Utility::makeEnvoyMap(
                   {{"name", "assertion"}, {"location", std::string(location)}});
-              event_tracker_.track(event, event_tracker_.context);
+              event_tracker_.track(event, event_tracker_.context, event_tracker_.tag);
             });
         bug_handler_registration_ =
             Assert::addEnvoyBugFailureRecordAction([this](const char* location) {
               const auto event = Bridge::Utility::makeEnvoyMap(
                   {{"name", "bug"}, {"location", std::string(location)}});
-              event_tracker_.track(event, event_tracker_.context);
+              event_tracker_.track(event, event_tracker_.context, event_tracker_.tag);
             });
       }
 
@@ -116,7 +116,7 @@ envoy_status_t Engine::main(std::unique_ptr<Envoy::OptionsImpl>&& options) {
                                                         server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
           if (callbacks_.on_engine_running != nullptr) {
-            callbacks_.on_engine_running(callbacks_.context);
+            callbacks_.on_engine_running(callbacks_.context, callbacks_.tag);
           }
         });
   } // mutex_

--- a/mobile/library/common/extensions/filters/http/test_event_tracker/filter.h
+++ b/mobile/library/common/extensions/filters/http/test_event_tracker/filter.h
@@ -21,7 +21,7 @@ public:
   std::vector<std::pair<std::string, std::string>> attributes() { return attributes_; };
   void track(envoy_map event) {
     if (event_tracker_->track != nullptr) {
-      event_tracker_->track(event, event_tracker_->context);
+      event_tracker_->track(event, event_tracker_->context, event_tracker_->tag);
     }
   };
 

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -28,7 +28,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
 
 // JniLibrary
 
-static void jvm_on_engine_running(void* context) {
+static void jvm_on_engine_running(void* context, int) {
   if (context == nullptr) {
     return;
   }
@@ -47,7 +47,7 @@ static void jvm_on_engine_running(void* context) {
   env->DeleteGlobalRef(j_context);
 }
 
-static void jvm_on_log(envoy_data data, const void* context) {
+static void jvm_on_log(envoy_data data, const void* context, int) {
   if (context == nullptr) {
     return;
   }
@@ -74,7 +74,7 @@ static void jvm_on_exit(void*) {
   jvm_detach_thread();
 }
 
-static void jvm_on_track(envoy_map events, const void* context) {
+static void jvm_on_track(envoy_map events, const void* context, int) {
   jni_log("[Envoy]", "jvm_on_track");
   if (context == nullptr) {
     return;
@@ -104,7 +104,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   const jobject retained_logger_context = env->NewGlobalRef(envoy_logger_context);
   envoy_logger logger = {nullptr, nullptr, nullptr};
   if (envoy_logger_context != nullptr) {
-    logger = envoy_logger{jvm_on_log, jni_delete_const_global_ref, retained_logger_context};
+    logger = envoy_logger{jvm_on_log, jni_delete_const_global_ref_tag, retained_logger_context};
   }
 
   envoy_event_tracker event_tracker = {nullptr, nullptr};

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -66,6 +66,10 @@ void jni_delete_const_global_ref(const void* context) {
   jni_delete_global_ref(const_cast<void*>(context));
 }
 
+void jni_delete_const_global_ref_tag(const void* context, int) {
+  jni_delete_global_ref(const_cast<void*>(context));
+}
+
 bool clear_pending_exceptions(JNIEnv* env) {
   if (env->ExceptionCheck() == JNI_TRUE) {
     env->ExceptionClear();

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -44,6 +44,8 @@ void jni_delete_global_ref(void* context);
 
 void jni_delete_const_global_ref(const void* context);
 
+void jni_delete_const_global_ref_tag(const void* context, int tag);
+
 /**
  * Clears any pending exceptions that may have been rides in result to a call into Java code.
  *

--- a/mobile/library/common/types/c_types.cc
+++ b/mobile/library/common/types/c_types.cc
@@ -26,7 +26,7 @@ void* safe_calloc(size_t count, size_t size) {
 
 void envoy_noop_release(void* context) { (void)context; }
 
-void envoy_noop_const_release(const void* context) { (void)context; }
+void envoy_noop_const_release(const void* context, int tag) { (void)context; (void)tag; }
 
 void release_envoy_data(envoy_data data) { data.release(data.context); }
 

--- a/mobile/library/common/types/c_types.cc
+++ b/mobile/library/common/types/c_types.cc
@@ -26,7 +26,10 @@ void* safe_calloc(size_t count, size_t size) {
 
 void envoy_noop_release(void* context) { (void)context; }
 
-void envoy_noop_const_release(const void* context, int tag) { (void)context; (void)tag; }
+void envoy_noop_const_release(const void* context, int tag) {
+  (void)context;
+  (void)tag;
+}
 
 void release_envoy_data(envoy_data data) { data.release(data.context); }
 

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -92,7 +92,7 @@ void envoy_noop_release(void* context);
 /**
  * Const version of no-op release callback.
  */
-void envoy_noop_const_release(const void* context);
+void envoy_noop_const_release(const void* context, int tag);
 
 #ifdef __cplusplus
 } // release function
@@ -413,7 +413,7 @@ typedef void (*envoy_on_exit_f)(void* context);
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  */
-typedef void (*envoy_on_engine_running_f)(void* context);
+typedef void (*envoy_on_engine_running_f)(void* context, int tag);
 
 /**
  * Called when envoy's logger logs data.
@@ -422,7 +422,7 @@ typedef void (*envoy_on_engine_running_f)(void* context);
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  */
-typedef void (*envoy_logger_log_f)(envoy_data data, const void* context);
+typedef void (*envoy_logger_log_f)(envoy_data data, const void* context, int tag);
 
 /**
  * Called when Envoy is done with the logger.
@@ -430,7 +430,7 @@ typedef void (*envoy_logger_log_f)(envoy_data data, const void* context);
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  */
-typedef void (*envoy_logger_release_f)(const void* context);
+typedef void (*envoy_logger_release_f)(const void* context, int tag);
 
 /**
  * Callback signature which notify when there is buffer available for request
@@ -455,7 +455,7 @@ typedef void* (*envoy_on_send_window_available_f)(envoy_stream_intel stream_inte
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  */
-typedef void (*envoy_event_tracker_track_f)(envoy_map event, const void* context);
+typedef void (*envoy_event_tracker_track_f)(envoy_map event, const void* context, int tag);
 
 #ifdef __cplusplus
 } // function pointers
@@ -485,6 +485,8 @@ typedef struct {
   envoy_on_exit_f on_exit;
   // Context passed through to callbacks to provide dispatch and execution state.
   void* context;
+  // Tag to disambiguate between instances of this struct.
+  int tag;
 } envoy_engine_callbacks;
 
 /**
@@ -495,6 +497,8 @@ typedef struct {
   envoy_logger_release_f release;
   // Context passed through to callbacks to provide dispatch and execution state.
   const void* context;
+  // Tag to disambiguate between instances of this struct.
+  int tag;
 } envoy_logger;
 
 /**
@@ -504,6 +508,8 @@ typedef struct {
   envoy_event_tracker_track_f track;
   // Context passed through to callbacks to provide dispatch and execution state.
   const void* context;
+  // Tag to disambiguate between instances of this struct.
+  int tag;
 } envoy_event_tracker;
 
 /**

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -20,7 +20,8 @@
 - (std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap>)generateBootstrap;
 @end
 
-static void ios_on_engine_running(void *context) {
+static void ios_on_engine_running(void *context, int tag) {
+  (void)tag;
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
   // is necessary to act as a breaker for any Objective-C allocation that happens.
   @autoreleasepool {
@@ -39,7 +40,8 @@ static void ios_on_exit(void *context) {
   }
 }
 
-static void ios_on_log(envoy_data data, const void *context) {
+static void ios_on_log(envoy_data data, const void *context, int tag) {
+  (void)tag;
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
   // is necessary to act as a breaker for any Objective-C allocation that happens.
   @autoreleasepool {
@@ -48,7 +50,10 @@ static void ios_on_log(envoy_data data, const void *context) {
   }
 }
 
-static void ios_on_logger_release(const void *context) { CFRelease(context); }
+static void ios_on_logger_release(const void *context, int tag) {
+  (void)tag;
+  CFRelease(context);
+}
 
 static const void *ios_http_filter_init(const void *context) {
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
@@ -389,7 +394,8 @@ static envoy_data ios_get_string(const void *context) {
   return toManagedNativeString(accessor.getEnvoyString());
 }
 
-static void ios_track_event(envoy_map map, const void *context) {
+static void ios_track_event(envoy_map map, const void *context, int tag) {
+  (void)tag;
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
   // is necessary to act as a breaker for any Objective-C allocation that happens.
   @autoreleasepool {

--- a/mobile/test/common/common/lambda_logger_delegate_test.cc
+++ b/mobile/test/common/common/lambda_logger_delegate_test.cc
@@ -42,7 +42,7 @@ TEST_F(LambdaDelegateTest, ReleaseCb) {
   bool released = false;
 
   {
-    LambdaDelegate({[](envoy_data data, const void*) -> void { release_envoy_data(data); },
+    LambdaDelegate({[](envoy_data data, const void*, int) -> void { release_envoy_data(data); },
                     [](const void* context) -> void {
                       bool* released = static_cast<bool*>(const_cast<void*>(context));
                       *released = true;

--- a/mobile/test/common/common/lambda_logger_delegate_test.cc
+++ b/mobile/test/common/common/lambda_logger_delegate_test.cc
@@ -31,7 +31,7 @@ TEST_F(LambdaDelegateTest, LogCb) {
                              *actual_msg = Data::Utility::copyToString(data);
                              release_envoy_data(data);
                            },
-                           [](const void*) -> void {}, &actual_msg},
+                           [](const void*, int) -> void {}, &actual_msg, 0 /*tag*/},
                           Registry::getSink());
 
   ENVOY_LOG_MISC(error, expected_msg);
@@ -43,11 +43,11 @@ TEST_F(LambdaDelegateTest, ReleaseCb) {
 
   {
     LambdaDelegate({[](envoy_data data, const void*, int) -> void { release_envoy_data(data); },
-                    [](const void* context) -> void {
+                    [](const void* context, int) -> void {
                       bool* released = static_cast<bool*>(const_cast<void*>(context));
                       *released = true;
                     },
-                    &released},
+                    &released, 0 /*tag*/},
                    Registry::getSink());
   }
 

--- a/mobile/test/common/common/lambda_logger_delegate_test.cc
+++ b/mobile/test/common/common/lambda_logger_delegate_test.cc
@@ -25,7 +25,7 @@ TEST_F(LambdaDelegateTest, LogCb) {
   std::string expected_msg = "Hello LambdaDelegate";
   std::string actual_msg;
 
-  LambdaDelegate delegate({[](envoy_data data, const void* context) -> void {
+  LambdaDelegate delegate({[](envoy_data data, const void* context, int) -> void {
                              auto* actual_msg =
                                  static_cast<std::string*>(const_cast<void*>(context));
                              *actual_msg = Data::Utility::copyToString(data);

--- a/mobile/test/common/engine_test.cc
+++ b/mobile/test/common/engine_test.cc
@@ -98,13 +98,12 @@ TEST_F(EngineTest, AccessEngineAfterInitialization) {
   const std::string level = "debug";
 
   engine_test_context test_context{};
-  envoy_engine_callbacks callbacks{[](void* context, int) -> void {
-                                     auto* engine_running =
-                                         static_cast<engine_test_context*>(context);
-                                     engine_running->on_engine_running.Notify();
-                                   } /*on_engine_running*/,
-                                   [](void*) -> void {} /*on_exit*/, &test_context /*context*/,
-                                   0 /*tag*/};
+  envoy_engine_callbacks callbacks{
+      [](void* context, int) -> void {
+        auto* engine_running = static_cast<engine_test_context*>(context);
+        engine_running->on_engine_running.Notify();
+      } /*on_engine_running*/,
+      [](void*) -> void {} /*on_exit*/, &test_context /*context*/, 0 /*tag*/};
 
   engine_ = std::make_unique<TestEngineHandle>(callbacks, level);
   envoy_engine_t handle = engine_->handle_;

--- a/mobile/test/common/engine_test.cc
+++ b/mobile/test/common/engine_test.cc
@@ -71,7 +71,7 @@ TEST_F(EngineTest, EarlyExit) {
   const std::string level = "debug";
 
   engine_test_context test_context{};
-  envoy_engine_callbacks callbacks{[](void* context) -> void {
+  envoy_engine_callbacks callbacks{[](void* context, int) -> void {
                                      auto* engine_running =
                                          static_cast<engine_test_context*>(context);
                                      engine_running->on_engine_running.Notify();
@@ -80,7 +80,7 @@ TEST_F(EngineTest, EarlyExit) {
                                      auto* exit = static_cast<engine_test_context*>(context);
                                      exit->on_exit.Notify();
                                    } /*on_exit*/,
-                                   &test_context /*context*/};
+                                   &test_context /*context*/, 0 /*tag*/};
 
   engine_ = std::make_unique<TestEngineHandle>(callbacks, level);
   envoy_engine_t handle = engine_->handle_;
@@ -98,12 +98,13 @@ TEST_F(EngineTest, AccessEngineAfterInitialization) {
   const std::string level = "debug";
 
   engine_test_context test_context{};
-  envoy_engine_callbacks callbacks{[](void* context) -> void {
+  envoy_engine_callbacks callbacks{[](void* context, int) -> void {
                                      auto* engine_running =
                                          static_cast<engine_test_context*>(context);
                                      engine_running->on_engine_running.Notify();
                                    } /*on_engine_running*/,
-                                   [](void*) -> void {} /*on_exit*/, &test_context /*context*/};
+                                   [](void*) -> void {} /*on_exit*/, &test_context /*context*/,
+                                   0 /*tag*/};
 
   engine_ = std::make_unique<TestEngineHandle>(callbacks, level);
   envoy_engine_t handle = engine_->handle_;


### PR DESCRIPTION
To disambiguate between instances if we can't create unique context pointers for each set of callbacks.

Nothing uses them right now, but this prepares the way for upcoming usage when I add Swift / C++ interop.

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Low
Testing: Existing
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
