### PR TITLE
cleanup: use ProtobufWkt::BoolValue instead of Protobuf::BoolValue

### DIFF
--- a/source/common/http/http1/settings.cc
+++ b/source/common/http/http1/settings.cc
@@ -36,7 +36,7 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
 
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
                                  ProtobufMessage::ValidationVisitor& validation_visitor,
-                                 const Protobuf::BoolValue& hcm_stream_error,
+                                 const ProtobufWkt::BoolValue& hcm_stream_error,
                                  bool validate_scheme) {
   Http1Settings ret = parseHttp1Settings(config, validation_visitor);
   ret.validate_scheme_ = validate_scheme;

--- a/source/common/http/http1/settings.h
+++ b/source/common/http/http1/settings.h
@@ -17,7 +17,7 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
 
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
                                  ProtobufMessage::ValidationVisitor& validation_visitor,
-                                 const Protobuf::BoolValue& hcm_stream_error, bool validate_scheme);
+                                 const ProtobufWkt::BoolValue& hcm_stream_error, bool validate_scheme);
 
 } // namespace Http1
 } // namespace Http

--- a/source/common/http/http1/settings.h
+++ b/source/common/http/http1/settings.h
@@ -17,7 +17,8 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
 
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
                                  ProtobufMessage::ValidationVisitor& validation_visitor,
-                                 const ProtobufWkt::BoolValue& hcm_stream_error, bool validate_scheme);
+                                 const ProtobufWkt::BoolValue& hcm_stream_error,
+                                 bool validate_scheme);
 
 } // namespace Http1
 } // namespace Http

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -188,7 +188,7 @@ const uint32_t OptionsLimits::DEFAULT_MAX_INBOUND_WINDOW_UPDATE_FRAMES_PER_DATA_
 envoy::config::core::v3::Http2ProtocolOptions
 initializeAndValidateOptions(const envoy::config::core::v3::Http2ProtocolOptions& options,
                              bool hcm_stream_error_set,
-                             const Protobuf::BoolValue& hcm_stream_error) {
+                             const ProtobufWkt::BoolValue& hcm_stream_error) {
   auto ret = initializeAndValidateOptions(options);
   if (!options.has_override_stream_error_on_invalid_http_message() && hcm_stream_error_set) {
     ret.mutable_override_stream_error_on_invalid_http_message()->set_value(
@@ -271,7 +271,7 @@ const uint32_t OptionsLimits::DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE;
 envoy::config::core::v3::Http3ProtocolOptions
 initializeAndValidateOptions(const envoy::config::core::v3::Http3ProtocolOptions& options,
                              bool hcm_stream_error_set,
-                             const Protobuf::BoolValue& hcm_stream_error) {
+                             const ProtobufWkt::BoolValue& hcm_stream_error) {
   if (options.has_override_stream_error_on_invalid_http_message()) {
     return options;
   }

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -103,7 +103,7 @@ initializeAndValidateOptions(const envoy::config::core::v3::Http2ProtocolOptions
 envoy::config::core::v3::Http2ProtocolOptions
 initializeAndValidateOptions(const envoy::config::core::v3::Http2ProtocolOptions& options,
                              bool hcm_stream_error_set,
-                             const Protobuf::BoolValue& hcm_stream_error);
+                             const ProtobufWkt::BoolValue& hcm_stream_error);
 } // namespace Utility
 } // namespace Http2
 namespace Http3 {
@@ -120,7 +120,7 @@ struct OptionsLimits {
 envoy::config::core::v3::Http3ProtocolOptions
 initializeAndValidateOptions(const envoy::config::core::v3::Http3ProtocolOptions& options,
                              bool hcm_stream_error_set,
-                             const Protobuf::BoolValue& hcm_stream_error);
+                             const ProtobufWkt::BoolValue& hcm_stream_error);
 
 } // namespace Utility
 } // namespace Http3

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -582,7 +582,7 @@ TEST(HttpUtility, ValidateStreamErrorsWithHcm) {
                   .value());
 
   // If the HCM value is present it will take precedence over the old value.
-  Protobuf::BoolValue hcm_value;
+  ProtobufWkt::BoolValue hcm_value;
   hcm_value.set_value(false);
   EXPECT_FALSE(Envoy::Http2::Utility::initializeAndValidateOptions(http2_options, true, hcm_value)
                    .override_stream_error_on_invalid_http_message()
@@ -602,7 +602,7 @@ TEST(HttpUtility, ValidateStreamErrorsWithHcm) {
 
 TEST(HttpUtility, ValidateStreamErrorConfigurationForHttp1) {
   envoy::config::core::v3::Http1ProtocolOptions http1_options;
-  Protobuf::BoolValue hcm_value;
+  ProtobufWkt::BoolValue hcm_value;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
 
   // nothing explicitly configured, default to false (i.e. default stream error behavior for HCM)


### PR DESCRIPTION
BoolValue is a protobuf "Well known type" so should be referenced via the ProtobufWkt namespace not Protobuf. 

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A