### PR TITLE
[WIP] Make admin handlers through registered factories

### DIFF
--- a/envoy/server/BUILD
+++ b/envoy/server/BUILD
@@ -20,7 +20,9 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "admin_interface",
-    hdrs = ["admin.h"],
+    hdrs = [
+        "admin.h",
+    ],
     deps = [
         ":config_tracker_interface",
         "//envoy/buffer:buffer_interface",
@@ -28,6 +30,17 @@ envoy_cc_library(
         "//envoy/http:header_map_interface",
         "//envoy/http:query_params_interface",
         "//envoy/network:listen_socket_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "admin_handler_factory",
+    hdrs = [
+        "admin_handler_factory.h",
+    ],
+    deps = [
+        ":admin_interface",
+        ":instance_interface",
     ],
 )
 

--- a/envoy/server/admin_handler_factory.h
+++ b/envoy/server/admin_handler_factory.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/pure.h"
+#include "envoy/http/codes.h"
+#include "envoy/http/header_map.h"
+#include "envoy/server/admin.h"
+#include "envoy/server/instance.h"
+
+namespace Envoy {
+namespace Server {
+
+class AdminHandler {
+public:
+  virtual Http::Code runCallback(Http::ResponseHeaderMap& response_headers,
+                                 Buffer::Instance& response, AdminStream& admin_stream) PURE;
+  virtual const std::string& prefix() const PURE;
+  virtual const std::string& helpText() const PURE;
+  Admin::HandlerCb callback() { return MAKE_ADMIN_HANDLER(runCallback); }
+  virtual bool removable() const PURE;
+  virtual bool mutatesServerState() const PURE;
+  virtual const Admin::ParamDescriptorVec& params() const PURE;
+
+  virtual ~AdminHandler() = default;
+};
+
+class AdminHandlerFactory : public Config::UntypedFactory {
+public:
+  virtual std::unique_ptr<AdminHandler> createHandler(Admin& admin,
+                                                      Server::Instance& server) const PURE;
+  std::string category() const override { return "envoy.admin_handlers"; }
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_package",
     "envoy_select_admin_functionality",
@@ -19,13 +20,29 @@ envoy_cc_library(
     deps = [] + envoy_select_admin_functionality(["//source/server/admin:admin_lib_internal"]),
 )
 
-envoy_cc_library(
-    name = "admin_lib_internal",
-    srcs = ["admin.cc"] + envoy_select_admin_html([
+envoy_cc_extension(
+    name = "admin_html",
+    srcs = envoy_select_admin_html([
         "admin_html.cc",
     ]) + envoy_select_admin_no_html([
         "admin_no_html.cc",
     ]),
+    deps = [
+        ":admin_lib_internal",
+        "//envoy/server:admin_handler_factory",
+    ],
+)
+
+envoy_cc_library(
+    name = "admin_extensions",
+    deps = [
+        ":admin_html",
+    ],
+)
+
+envoy_cc_library(
+    name = "admin_lib_internal",
+    srcs = ["admin.cc"],
     hdrs = ["admin.h"],
     deps = [
         ":admin_filter_lib",
@@ -45,6 +62,7 @@ envoy_cc_library(
         "//envoy/http:filter_interface",
         "//envoy/network:filter_interface",
         "//envoy/network:listen_socket_interface",
+        "//envoy/server:admin_handler_factory",
         "//envoy/server:admin_interface",
         "//envoy/server:hot_restart_interface",
         "//envoy/server:instance_interface",

--- a/source/server/admin/admin_html.cc
+++ b/source/server/admin/admin_html.cc
@@ -1,3 +1,5 @@
+#include "envoy/server/admin_handler_factory.h"
+
 #include "source/common/html/utility.h"
 #include "source/server/admin/admin.h"
 #include "source/server/admin/stats_html_render.h"
@@ -5,22 +7,53 @@
 namespace Envoy {
 namespace Server {
 
-Http::Code AdminImpl::handlerAdminHome(Http::ResponseHeaderMap& response_headers,
-                                       Buffer::Instance& response, AdminStream&) {
-  StatsHtmlRender html(response_headers, response, StatsParams());
-  html.tableBegin(response);
+class AdminHandlerHome : public AdminHandler {
+public:
+  AdminHandlerHome(AdminImpl& admin) : admin_(admin) {}
+  const std::string& prefix() const override {
+    static const std::string prefix = "/";
+    return prefix;
+  }
+  const std::string& helpText() const override {
+    static const std::string help_text = "Admin home page";
+    return help_text;
+  }
+  bool removable() const override { return false; }
+  bool mutatesServerState() const override { return false; }
+  const Admin::ParamDescriptorVec& params() const override {
+    static const Admin::ParamDescriptorVec& params{};
+    return params;
+  }
+  Http::Code runCallback(Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                         AdminStream&) override {
+    StatsHtmlRender html(response_headers, response, StatsParams());
+    html.tableBegin(response);
 
-  // Prefix order is used during searching, but for printing do them in alpha order.
-  OptRef<const Http::Utility::QueryParams> no_query_params;
-  for (const UrlHandler* handler : sortedHandlers()) {
-    html.urlHandler(response, *handler, no_query_params);
+    // Prefix order is used during searching, but for printing do them in alpha order.
+    OptRef<const Http::Utility::QueryParams> no_query_params;
+    for (const Admin::UrlHandler* handler : admin_.sortedHandlers()) {
+      html.urlHandler(response, *handler, no_query_params);
+    }
+
+    html.tableEnd(response);
+    html.finalize(response);
+
+    return Http::Code::OK;
   }
 
-  html.tableEnd(response);
-  html.finalize(response);
+private:
+  AdminImpl& admin_;
+};
 
-  return Http::Code::OK;
-}
+class AdminHandlerHomeFactory : public AdminHandlerFactory {
+public:
+  std::unique_ptr<AdminHandler> createHandler(Admin& admin, Server::Instance&) const override {
+    return std::make_unique<AdminHandlerHome>(dynamic_cast<AdminImpl&>(admin));
+  }
+  std::string name() const override { return "home"; }
+};
+
+REGISTER_FACTORY(AdminHandlerHomeFactory, AdminHandlerFactory);
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/admin/admin_no_html.cc
+++ b/source/server/admin/admin_no_html.cc
@@ -1,14 +1,41 @@
-#include "source/server/admin/admin.h"
+#include "envoy/server/admin_handler_factory.h"
 
 namespace Envoy {
 namespace Server {
 
-Http::Code AdminImpl::handlerAdminHome(Http::ResponseHeaderMap& response_headers,
-                                       Buffer::Instance& response, AdminStream&) {
-  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Text);
-  response.add("HTML output was disabled by building with --define=admin_html=disabled");
-  return Http::Code::OK;
-}
+class AdminHandlerHome : public AdminHandler {
+public:
+  const std::string& prefix() const override {
+    static const std::string prefix = "/";
+    return prefix;
+  }
+  const std::string& helpText() const override {
+    static const std::string help_text = "Admin home page";
+    return help_text;
+  }
+  bool removable() const override { return false; }
+  bool mutatesServerState() const override { return false; }
+  const Admin::ParamDescriptorVec& params() const override {
+    static const Admin::ParamDescriptorVec& params{};
+    return params;
+  }
+  Http::Code runCallback(Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                         AdminStream&) override {
+    response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Text);
+    response.add("HTML output was disabled by building with --define=admin_html=disabled");
+    return Http::Code::OK;
+  }
+};
+
+class AdminHandlerHomeFactory : public AdminHandlerFactory {
+public:
+  std::unique_ptr<AdminHandler> createHandler(Admin&, Server::Instance&) const override {
+    return std::make_unique<AdminHandlerHome>();
+  }
+  std::string name() const override { return "home"; }
+};
+
+REGISTER_FACTORY(AdminHandlerHomeFactory, AdminHandlerFactory);
 
 } // namespace Server
 } // namespace Envoy

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -38,6 +38,7 @@ envoy_cc_test(
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
         "//source/common/stats:thread_local_store_lib",
+        "//source/server/admin:admin_extensions",
         "//source/server/admin:admin_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_mocks",
@@ -63,6 +64,7 @@ envoy_cc_test(
     srcs = envoy_select_admin_html(["admin_html_test.cc"]),
     deps = [
         ":admin_instance_lib",
+        "//source/server/admin:admin_extensions",
         "//source/server/admin:admin_lib",
     ],
 )


### PR DESCRIPTION
Commit Message: Make admin handlers through REGISTER_FACTORY
Additional Description: This allows extensions to add admin handlers without having to somehow execute a server->addHandler call (e.g. by also binding them through a BootstrapExtension config, or by calling it in a custom `main()`), and cleans up the dependency tangle of the prior long chain of makeHandler calls.
Risk Level: Unknown
Testing: Passes existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
