### PR TITLE
matchers: moving network matchers to their own extension

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -294,6 +294,8 @@ extensions/filters/http/oauth2 @derekargueta @snowp
 /*/extensions/load_balancing_policies/maglev @wbpcode @UNOWNED
 # Early header mutation
 /*/extensions/http/early_header_mutation/header_mutation @wbpcode @UNOWNED
+# Network matching extensions
+/*/extensions/matching/network/ @kyessenov @snowp
 
 # Intentionally exempt (treated as core code)
 /*/extensions/filters/common @UNOWNED @UNOWNED

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -32,6 +32,9 @@ minor_behavior_changes:
 - area: custom response
   change: |
     Changed how the uri for redirect policy is specified. It can now be specified either as a single fully qualified string, or by specifying individual components of the uri.
+- area: matchers
+  change: |
+    Moved the application protocol input matcher to extensions. If you use this matcher and override extensions_build_config.bzl you will now need to include it explicitly.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/mobile/envoy_build_config/extension_registry.cc
+++ b/mobile/envoy_build_config/extension_registry.cc
@@ -122,7 +122,6 @@ void ExtensionRegistry::registerFactories() {
   Network::forceRegisterGetAddrInfoDnsResolverFactory();
   Network::forceRegisterSocketInterfaceImpl();
   Network::forceRegisterUdpDefaultWriterFactoryFactory();
-  Network::Matching::forceRegisterApplicationProtocolInputFactory();
   Network::Matching::forceRegisterDestinationPortInputFactory();
   Network::Matching::forceRegisterDirectSourceIPInputFactory();
   Network::Matching::forceRegisterHttpDestinationIPInputFactory();

--- a/source/common/network/matching/inputs.cc
+++ b/source/common/network/matching/inputs.cc
@@ -18,15 +18,6 @@ Matcher::DataInputGetResult TransportProtocolInput::get(const MatchingData& data
   return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
 }
 
-Matcher::DataInputGetResult ApplicationProtocolInput::get(const MatchingData& data) const {
-  const auto& protocols = data.socket().requestedApplicationProtocols();
-  if (!protocols.empty()) {
-    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-            absl::StrCat("'", absl::StrJoin(protocols, "','"), "'")};
-  }
-  return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
-}
-
 Matcher::DataInputGetResult FilterStateInput::get(const MatchingData& data) const {
   const auto* filter_state_object =
       data.filterState().getDataReadOnly<StreamInfo::FilterState::Object>(filter_state_key_);
@@ -87,7 +78,6 @@ REGISTER_FACTORY(SourceTypeInputFactory, Matcher::DataInputFactory<MatchingData>
 REGISTER_FACTORY(HttpSourceTypeInputFactory, Matcher::DataInputFactory<Http::HttpMatchingData>);
 
 REGISTER_FACTORY(TransportProtocolInputFactory, Matcher::DataInputFactory<MatchingData>);
-REGISTER_FACTORY(ApplicationProtocolInputFactory, Matcher::DataInputFactory<MatchingData>);
 REGISTER_FACTORY(FilterStateInputFactory, Matcher::DataInputFactory<MatchingData>);
 
 } // namespace Matching

--- a/source/common/network/matching/inputs.h
+++ b/source/common/network/matching/inputs.h
@@ -252,22 +252,6 @@ public:
 
 DECLARE_FACTORY(TransportProtocolInputFactory);
 
-class ApplicationProtocolInput : public Matcher::DataInput<MatchingData> {
-public:
-  Matcher::DataInputGetResult get(const MatchingData& data) const override;
-};
-
-class ApplicationProtocolInputFactory
-    : public BaseFactory<
-          ApplicationProtocolInput,
-          envoy::extensions::matching::common_inputs::network::v3::ApplicationProtocolInput,
-          MatchingData> {
-public:
-  ApplicationProtocolInputFactory() : BaseFactory("application_protocol") {}
-};
-
-DECLARE_FACTORY(ApplicationProtocolInputFactory);
-
 class FilterStateInput : public Matcher::DataInput<MatchingData> {
 public:
   FilterStateInput(

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -71,6 +71,11 @@ EXTENSIONS = {
     "envoy.matching.matchers.ip":                       "//source/extensions/matching/input_matchers/ip:config",
 
     #
+    # Network Matchers
+    #
+    "envoy.matching.inputs.application_protocol":       "//source/extensions/matching/network/application_protocol:config",
+
+    #
     # Generic Inputs
     #
 

--- a/source/extensions/matching/network/application_protocol/BUILD
+++ b/source/extensions/matching/network/application_protocol/BUILD
@@ -1,0 +1,24 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        "//envoy/http:filter_interface",
+        "//envoy/matcher:matcher_interface",
+        "//envoy/network:filter_interface",
+        "//envoy/registry",
+        "//source/common/network:utility_lib",
+        "//source/common/network/matching:inputs_lib",
+        "@envoy_api//envoy/extensions/matching/common_inputs/network/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/matching/network/application_protocol/config.cc
+++ b/source/extensions/matching/network/application_protocol/config.cc
@@ -1,0 +1,25 @@
+#include "source/extensions/matching/network/application_protocol/config.h"
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace Envoy {
+namespace Network {
+namespace Matching {
+
+Matcher::DataInputGetResult ApplicationProtocolInput::get(const MatchingData& data) const {
+  const auto& protocols = data.socket().requestedApplicationProtocols();
+  if (!protocols.empty()) {
+    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
+            absl::StrCat("'", absl::StrJoin(protocols, "','"), "'")};
+  }
+  return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::nullopt};
+}
+
+REGISTER_FACTORY(ApplicationProtocolInputFactory, Matcher::DataInputFactory<MatchingData>);
+
+} // namespace Matching
+} // namespace Network
+} // namespace Envoy

--- a/source/extensions/matching/network/application_protocol/config.h
+++ b/source/extensions/matching/network/application_protocol/config.h
@@ -1,0 +1,32 @@
+#include "envoy/extensions/matching/common_inputs/network/v3/network_inputs.pb.h"
+#include "envoy/extensions/matching/common_inputs/network/v3/network_inputs.pb.validate.h"
+#include "envoy/matcher/matcher.h"
+#include "envoy/network/filter.h"
+#include "envoy/registry/registry.h"
+
+#include "source/common/network/matching/inputs.h"
+#include "source/common/network/utility.h"
+
+namespace Envoy {
+namespace Network {
+namespace Matching {
+
+class ApplicationProtocolInput : public Matcher::DataInput<MatchingData> {
+public:
+  Matcher::DataInputGetResult get(const MatchingData& data) const override;
+};
+
+class ApplicationProtocolInputFactory
+    : public BaseFactory<
+          ApplicationProtocolInput,
+          envoy::extensions::matching::common_inputs::network::v3::ApplicationProtocolInput,
+          MatchingData> {
+public:
+  ApplicationProtocolInputFactory() : BaseFactory("application_protocol") {}
+};
+
+DECLARE_FACTORY(ApplicationProtocolInputFactory);
+
+} // namespace Matching
+} // namespace Network
+} // namespace Envoy

--- a/test/extensions/matching/network/common/BUILD
+++ b/test/extensions/matching/network/common/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+# For legacy reasons, the various network input tests are in one place.
 envoy_cc_test(
     name = "inputs_test",
     srcs = ["inputs_test.cc"],
@@ -17,6 +18,7 @@ envoy_cc_test(
         "//source/common/network/matching:data_impl_lib",
         "//source/common/network/matching:inputs_lib",
         "//source/common/router:string_accessor_lib",
+        "//source/extensions/matching/network/application_protocol:config",
         "//test/mocks/network:network_mocks",
     ],
 )
@@ -29,6 +31,7 @@ envoy_cc_test(
         "//source/common/network/matching:data_impl_lib",
         "//source/common/network/matching:inputs_lib",
         "//source/common/router:string_accessor_lib",
+        "//source/extensions/matching/network/application_protocol:config",
         "//test/common/matcher:test_utility_lib",
         "//test/mocks/matcher:matcher_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/extensions/matching/network/common/inputs_integration_test.cc
+++ b/test/extensions/matching/network/common/inputs_integration_test.cc
@@ -3,6 +3,7 @@
 #include "source/common/network/matching/inputs.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
+#include "source/extensions/matching/network/application_protocol/config.h"
 
 #include "test/common/matcher/test_utility.h"
 #include "test/mocks/matcher/mocks.h"

--- a/test/extensions/matching/network/common/inputs_test.cc
+++ b/test/extensions/matching/network/common/inputs_test.cc
@@ -6,6 +6,7 @@
 #include "source/common/network/matching/inputs.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
+#include "source/extensions/matching/network/application_protocol/config.h"
 
 #include "test/mocks/network/mocks.h"
 


### PR DESCRIPTION
Starting with one - if you're OK with directory paths and non-split tests I'll go and move the rest of the network matches and ping back for review.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: yes