### PR TITLE
mobile: add `EnvoyCxxSwiftInterop` library

### DIFF
--- a/mobile/library/swift/EnvoyCxxSwiftInterop/BUILD
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/BUILD
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_c_module")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+licenses(["notice"])  # Apache 2
+
+envoy_cc_library(
+    name = "cxx_swift_interop_lib",
+    srcs = ["cxx_swift_interop.cc"],
+    hdrs = ["cxx_swift_interop.h"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:engine_builder_lib",
+        "//library/common/network:apple_platform_cert_verifier",
+    ],
+)
+
+swift_c_module(
+    name = "EnvoyCxxSwiftInterop",
+    module_map = "module.modulemap",
+    module_name = "EnvoyCxxSwiftInterop",
+    visibility = ["//visibility:public"],
+    deps = [":cxx_swift_interop_lib"],
+)

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.cc
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.cc
@@ -1,16 +1,18 @@
-#import "cxx_swift_interop.h"
-#import "source/server/options_impl.h"
-#import "library/common/engine.h"
+#include "cxx_swift_interop.h"
+
+#include "source/server/options_impl.h"
+
+#include "library/common/engine.h"
 
 namespace Envoy {
 namespace CxxSwift {
 
-void run(BootstrapPtr bootstrap_ptr, std::string log_level, envoy_engine_t engine_handle) {
+void run(BootstrapPtr bootstrap_ptr, LogLevel log_level, envoy_engine_t engine_handle) {
   auto options = std::make_unique<Envoy::OptionsImpl>();
-  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap(
-      reinterpret_cast<envoy::config::bootstrap::v3::Bootstrap*>(bootstrap_ptr));
+  auto bootstrap =
+      absl::WrapUnique(reinterpret_cast<envoy::config::bootstrap::v3::Bootstrap*>(bootstrap_ptr));
   options->setConfigProto(std::move(bootstrap));
-  options->setLogLevel(options->parseAndValidateLogLevel(log_level));
+  options->setLogLevel(log_level);
   options->setConcurrency(1);
   reinterpret_cast<Envoy::Engine*>(engine_handle)->run(std::move(options));
 }

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.cc
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.cc
@@ -1,0 +1,19 @@
+#import "cxx_swift_interop.h"
+#import "source/server/options_impl.h"
+#import "library/common/engine.h"
+
+namespace Envoy {
+namespace CxxSwift {
+
+void run(BootstrapPtr bootstrap_ptr, std::string log_level, envoy_engine_t engine_handle) {
+  auto options = std::make_unique<Envoy::OptionsImpl>();
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap(
+      reinterpret_cast<envoy::config::bootstrap::v3::Bootstrap*>(bootstrap_ptr));
+  options->setConfigProto(std::move(bootstrap));
+  options->setLogLevel(options->parseAndValidateLogLevel(log_level));
+  options->setConcurrency(1);
+  reinterpret_cast<Envoy::Engine*>(engine_handle)->run(std::move(options));
+}
+
+} // namespace CxxSwift
+} // namespace Envoy

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
@@ -1,15 +1,24 @@
-#import "library/cc/bridge_utility.h"
-#import "library/cc/direct_response_testing.h"
-#import "library/cc/engine_builder.h"
-#import "library/common/data/utility.h"
-#import "library/common/extensions/filters/http/platform_bridge/c_types.h"
-#import "library/common/main_interface.h"
-#import "library/common/network/apple_platform_cert_verifier.h"
-#import "library/common/stats/utility.h"
+#include "library/cc/bridge_utility.h"
+#include "library/cc/direct_response_testing.h"
+#include "library/cc/engine_builder.h"
+#include "library/common/data/utility.h"
+#include "library/common/extensions/filters/http/platform_bridge/c_types.h"
+#include "library/common/main_interface.h"
+#include "library/common/network/apple_platform_cert_verifier.h"
+#include "library/common/stats/utility.h"
+
+// This file exists in order to expose headers for Envoy's C++ libraries
+// to Envoy Mobile's Swift implementation.
+// Further, Swift only supports interacting with a subset of C++ language features
+// so some types are renamed with the `using` keyword, and some features that
+// cannot be imported into Swift are abstracted via interfaces that are supported.
+// See this document on Swift's C++ interoperability status to learn more:
+// https://github.com/apple/swift/blob/swift-5.7.3-RELEASE/docs/CppInteroperability/CppInteroperabilityStatus.md
 
 namespace Envoy {
 namespace CxxSwift {
 
+using LogLevel = spdlog::level::level_enum;
 using StringVector = std::vector<std::string>;
 using StringPair = std::pair<std::string, std::string>;
 using StringPairVector = std::vector<StringPair>;
@@ -17,12 +26,27 @@ using StringMap = absl::flat_hash_map<std::string, std::string>;
 using HeaderMatcherVector = std::vector<DirectResponseTesting::HeaderMatcher>;
 using BootstrapPtr = intptr_t;
 
-inline void string_map_set(StringMap& map, std::string key, std::string value) { map[key] = value; }
+// Exposes `map[std::move(key)] = std::move(value)` to Swift.
+inline void string_map_set(StringMap& map, std::string key, std::string value) {
+  map[std::move(key)] = std::move(value);
+}
 
+// Exposes `map[std::move(key)] = std::move(value)` to Swift.
 inline void raw_header_map_set(Platform::RawHeaderMap& map, std::string key,
                                std::vector<std::string> value) {
-  map[key] = value;
+  map[std::move(key)] = std::move(value);
 }
+
+// TODO(jpsim): Replace `inline const` uses with `constexpr` when
+// https://github.com/apple/swift/issues/64217 is fixed.
+
+inline const LogLevel LogLevelTrace = LogLevel::trace;
+inline const LogLevel LogLevelDebug = LogLevel::debug;
+inline const LogLevel LogLevelInfo = LogLevel::info;
+inline const LogLevel LogLevelWarn = LogLevel::warn;
+inline const LogLevel LogLevelError = LogLevel::err;
+inline const LogLevel LogLevelCritical = LogLevel::critical;
+inline const LogLevel LogLevelOff = LogLevel::off;
 
 inline const DirectResponseTesting::MatchMode DirectResponseMatchModeContains =
     DirectResponseTesting::contains;
@@ -33,11 +57,19 @@ inline const DirectResponseTesting::MatchMode DirectResponseMatchModePrefix =
 inline const DirectResponseTesting::MatchMode DirectResponseMatchModeSuffix =
     DirectResponseTesting::suffix;
 
+// Smart pointers aren't currently supported by Swift / C++ interop, so we "erase"
+// it into a `BootstrapPtr` / `intptr_t`, which we can import from Swift.
 inline BootstrapPtr generateBootstrapPtr(Platform::EngineBuilder builder) {
   return reinterpret_cast<BootstrapPtr>(builder.generateBootstrap().release());
 }
 
-void run(BootstrapPtr bootstrap_ptr, std::string log_level, envoy_engine_t engine_handle);
+/**
+ * Run the engine with the provided configuration.
+ * @param bootstrap_ptr, the Envoy bootstrap configuration to use.
+ * @param log_level, the log level.
+ * @param engine_handle, the handle to an Envoy engine instance.
+ */
+void run(BootstrapPtr bootstrap_ptr, LogLevel log_level, envoy_engine_t engine_handle);
 
 } // namespace CxxSwift
 } // namespace Envoy

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
@@ -1,0 +1,43 @@
+#import "library/cc/bridge_utility.h"
+#import "library/cc/direct_response_testing.h"
+#import "library/cc/engine_builder.h"
+#import "library/common/data/utility.h"
+#import "library/common/extensions/filters/http/platform_bridge/c_types.h"
+#import "library/common/main_interface.h"
+#import "library/common/network/apple_platform_cert_verifier.h"
+#import "library/common/stats/utility.h"
+
+namespace Envoy {
+namespace CxxSwift {
+
+using StringVector = std::vector<std::string>;
+using StringPair = std::pair<std::string, std::string>;
+using StringPairVector = std::vector<StringPair>;
+using StringMap = absl::flat_hash_map<std::string, std::string>;
+using HeaderMatcherVector = std::vector<DirectResponseTesting::HeaderMatcher>;
+using BootstrapPtr = intptr_t;
+
+inline void string_map_set(StringMap& map, std::string key, std::string value) { map[key] = value; }
+
+inline void raw_header_map_set(Platform::RawHeaderMap& map, std::string key,
+                               std::vector<std::string> value) {
+  map[key] = value;
+}
+
+inline const DirectResponseTesting::MatchMode DirectResponseMatchModeContains =
+    DirectResponseTesting::contains;
+inline const DirectResponseTesting::MatchMode DirectResponseMatchModeExact =
+    DirectResponseTesting::exact;
+inline const DirectResponseTesting::MatchMode DirectResponseMatchModePrefix =
+    DirectResponseTesting::prefix;
+inline const DirectResponseTesting::MatchMode DirectResponseMatchModeSuffix =
+    DirectResponseTesting::suffix;
+
+inline BootstrapPtr generateBootstrapPtr(Platform::EngineBuilder builder) {
+  return reinterpret_cast<BootstrapPtr>(builder.generateBootstrap().release());
+}
+
+void run(BootstrapPtr bootstrap_ptr, std::string log_level, envoy_engine_t engine_handle);
+
+} // namespace CxxSwift
+} // namespace Envoy

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/module.modulemap
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/module.modulemap
@@ -1,0 +1,4 @@
+module EnvoyCxxSwiftInterop {
+    header "cxx_swift_interop.h"
+    requires cplusplus
+}


### PR DESCRIPTION
This exposes some headers and adds a minimal amount of C++ in order to be able to interact with Envoy's C++ code from Swift.

It will be tested via the Swift tests once hooked up.

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Low/None, not used
Testing: Upcoming via Swift tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
