### PR TITLE
quic: plumb ProcessContext reference into QUIC listener and server preferred address factory

### DIFF
--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -225,11 +225,13 @@ void ActiveQuicListener::closeConnectionsWithFilterChain(const Network::FilterCh
 
 ActiveQuicListenerFactory::ActiveQuicListenerFactory(
     const envoy::config::listener::v3::QuicProtocolOptions& config, uint32_t concurrency,
-    QuicStatNames& quic_stat_names, ProtobufMessage::ValidationVisitor& validation_visitor)
+    QuicStatNames& quic_stat_names, ProtobufMessage::ValidationVisitor& validation_visitor,
+    ProcessContextOptRef context)
     : concurrency_(concurrency), enabled_(config.enabled()), quic_stat_names_(quic_stat_names),
       packets_to_read_to_connection_count_ratio_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, packets_to_read_to_connection_count_ratio,
-                                          DEFAULT_PACKETS_TO_READ_PER_CONNECTION)) {
+                                          DEFAULT_PACKETS_TO_READ_PER_CONNECTION)),
+      context_(context) {
   const int64_t idle_network_timeout_ms =
       config.has_idle_timeout() ? DurationUtil::durationToMilliseconds(config.idle_timeout())
                                 : 300000;
@@ -298,7 +300,7 @@ ActiveQuicListenerFactory::ActiveQuicListenerFactory(
             *Config::Utility::translateToFactoryConfig(config.server_preferred_address_config(),
                                                        validation_visitor,
                                                        server_preferred_address_config_factory),
-            validation_visitor);
+            validation_visitor, context_);
   }
 
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -5,6 +5,7 @@
 #include "envoy/network/listener.h"
 #include "envoy/network/socket.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/server/process_context.h"
 
 #include "source/common/protobuf/utility.h"
 #include "source/common/quic/envoy_quic_connection_id_generator_factory.h"
@@ -95,7 +96,8 @@ class ActiveQuicListenerFactory : public Network::ActiveUdpListenerFactory,
 public:
   ActiveQuicListenerFactory(const envoy::config::listener::v3::QuicProtocolOptions& config,
                             uint32_t concurrency, QuicStatNames& quic_stat_names,
-                            ProtobufMessage::ValidationVisitor& validation_visitor);
+                            ProtobufMessage::ValidationVisitor& validation_visitor,
+                            ProcessContextOptRef context);
 
   // Network::ActiveUdpListenerFactory.
   Network::ConnectionHandler::ActiveUdpListenerPtr
@@ -126,6 +128,7 @@ private:
   const uint32_t packets_to_read_to_connection_count_ratio_;
   const Network::Socket::OptionsSharedPtr options_{std::make_shared<Network::Socket::Options>()};
   bool kernel_worker_routing_{};
+  ProcessContextOptRef context_;
 
   static bool disable_kernel_bpf_packet_routing_for_test_;
 };

--- a/source/common/quic/envoy_quic_server_preferred_address_config_factory.h
+++ b/source/common/quic/envoy_quic_server_preferred_address_config_factory.h
@@ -3,6 +3,7 @@
 #include "envoy/config/typed_config.h"
 #include "envoy/network/address.h"
 #include "envoy/protobuf/message_validator.h"
+#include "envoy/server/process_context.h"
 
 #include "quiche/quic/platform/api/quic_socket_address.h"
 
@@ -38,7 +39,8 @@ public:
    */
   virtual EnvoyQuicServerPreferredAddressConfigPtr
   createServerPreferredAddressConfig(const Protobuf::Message& config,
-                                     ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+                                     ProtobufMessage::ValidationVisitor& validation_visitor,
+                                     ProcessContextOptRef context) PURE;
 };
 
 } // namespace Quic

--- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
@@ -616,7 +616,7 @@ void ListenerImpl::buildUdpListenerFactory(uint32_t concurrency) {
     }
     udp_listener_config_->listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
         config_.udp_listener_config().quic_options(), concurrency, quic_stat_names_,
-        validation_visitor_);
+        validation_visitor_, listener_factory_context_->processContext());
 #if UDP_GSO_BATCH_WRITER_COMPILETIME_SUPPORT
     // TODO(mattklein123): We should be able to use GSO without QUICHE/QUIC. Right now this causes
     // non-QUIC integration tests to fail, which I haven't investigated yet. Additionally, from

--- a/source/extensions/quic/server_preferred_address/fixed_server_preferred_address_config.cc
+++ b/source/extensions/quic/server_preferred_address/fixed_server_preferred_address_config.cc
@@ -12,7 +12,8 @@ FixedServerPreferredAddressConfig::getServerPreferredAddresses(
 
 Quic::EnvoyQuicServerPreferredAddressConfigPtr
 FixedServerPreferredAddressConfigFactory::createServerPreferredAddressConfig(
-    const Protobuf::Message& message, ProtobufMessage::ValidationVisitor& validation_visitor) {
+    const Protobuf::Message& message, ProtobufMessage::ValidationVisitor& validation_visitor,
+    ProcessContextOptRef /*context*/) {
   auto& config =
       MessageUtil::downcastAndValidate<const envoy::extensions::quic::server_preferred_address::v3::
                                            FixedServerPreferredAddressConfig&>(message,

--- a/source/extensions/quic/server_preferred_address/fixed_server_preferred_address_config.h
+++ b/source/extensions/quic/server_preferred_address/fixed_server_preferred_address_config.h
@@ -28,9 +28,10 @@ class FixedServerPreferredAddressConfigFactory
 public:
   std::string name() const override { return "quic.server_preferred_address.fixed"; }
 
-  Quic::EnvoyQuicServerPreferredAddressConfigPtr createServerPreferredAddressConfig(
-      const Protobuf::Message& message,
-      ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Quic::EnvoyQuicServerPreferredAddressConfigPtr
+  createServerPreferredAddressConfig(const Protobuf::Message& message,
+                                     ProtobufMessage::ValidationVisitor& validation_visitor,
+                                     ProcessContextOptRef context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return ProtobufTypes::MessagePtr{new envoy::extensions::quic::server_preferred_address::v3::

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -147,7 +147,7 @@ protected:
     envoy::config::listener::v3::QuicProtocolOptions options;
     TestUtility::loadFromYamlAndValidate(yaml, options);
     return std::make_unique<ActiveQuicListenerFactory>(options, /*concurrency=*/1, quic_stat_names_,
-                                                       validation_visitor_);
+                                                       validation_visitor_, absl::nullopt);
   }
 
   void maybeConfigureMocks(int connection_count) {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -815,7 +815,8 @@ private:
       if (is_quic) {
 #if defined(ENVOY_ENABLE_QUIC)
         udp_listener_config_.listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
-            parent_.quic_options_, 1, parent_.quic_stat_names_, parent_.validation_visitor_);
+            parent_.quic_options_, 1, parent_.quic_stat_names_, parent_.validation_visitor_,
+            absl::nullopt);
         // Initialize QUICHE flags.
         quiche::FlagRegistry::getInstance();
 #else


### PR DESCRIPTION
Commit Message: add ProcessContextOptRef into a bunch of factory interfaces.

Risk Level: low, no behavior change
Testing: existing tests passs
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
