### PR TITLE
api: audit_log api specific to RBAC http filters

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -145,7 +145,7 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
-  // Audit logging options that includes the condition for audit logging to happen
+  // Audit logging options that include the condition for audit logging to happen
   // and audit logger configurations.
   //
   // [#not-implemented-hide:]

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -95,21 +95,6 @@ message RBAC {
     LOG = 2;
   }
 
-  // Deny and allow here refer to RBAC decisions, not actions.
-  enum AuditCondition {
-    // Never audit.
-    NONE = 0;
-
-    // Audit when RBAC denies the request.
-    ON_DENY = 1;
-
-    // Audit when RBAC allows the request.
-    ON_ALLOW = 2;
-
-    // Audit whether RBAC allows or denies the request.
-    ON_DENY_AND_ALLOW = 3;
-  }
-
   // The action to take if a policy matches. Every action either allows or denies a request,
   // and can also carry out action-specific operations.
   //
@@ -130,17 +115,36 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
-  // Condition for the audit logging to be happen.
-  // If this condition is met, all the audit loggers configured here will be invoked.
-  //
-  // [#not-implemented-hide:]
-  AuditCondition audit_condition = 3;
+  message AuditLog {
+    // Deny and allow here refer to RBAC decisions, not actions.
+    enum AuditCondition {
+      // Never audit.
+      NONE = 0;
 
-  // Configurations for RBAC-based authorization audit loggers.
-  //
-  // [#not-implemented-hide:]
-  // [#extension-category: envoy.rbac.audit_loggers]
-  repeated core.v3.TypedExtensionConfig audit_log = 4;
+      // Audit when RBAC denies the request.
+      ON_DENY = 1;
+
+      // Audit when RBAC allows the request.
+      ON_ALLOW = 2;
+
+      // Audit whether RBAC allows or denies the request.
+      ON_DENY_AND_ALLOW = 3;
+    }
+
+    // Condition for the audit logging to be happen.
+    // If this condition is met, all the audit loggers configured here will be invoked.
+    //
+    // [#not-implemented-hide:]
+    AuditCondition audit_condition = 1 [(validate.rules).enum.defined_only = true];
+
+    // Configurations for RBAC-based authorization audit loggers.
+    //
+    // [#not-implemented-hide:]
+    // [#extension-category: envoy.rbac.audit_loggers]
+    repeated core.v3.TypedExtensionConfig audit_log = 2 [(validate.rules).repeated = {min_items: 1}];
+  }
+
+  AuditLog audit_log = 3;
 }
 
 // Policy specifies a role and the principals that are assigned/denied the role.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -145,6 +145,8 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
+  // Audit options that includes the condition for audit logging to happen and
+  // audit logger configurations.
   AuditOptions audit_options = 3;
 }
 

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -132,7 +132,7 @@ message RBAC {
   map<string, Policy> policies = 2;
 
   // Condition for the audit logging to be happen. Specific to HTTP filters.
-  // If condition is met, all the audit loggers configured here will be invoked.
+  // If this condition is met, all the audit loggers configured here will be invoked.
   //
   // [#not-implemented-hide:]
   AuditCondition audit_condition = 3;

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -130,11 +130,19 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
-  // Condition for the audit logging to be happen, specific to HTTP filters.
+  // Condition for the audit logging to be happen. Specific to HTTP filters.
   // If condition is met, all the audit loggers configured in the HCM will be invoked.
   //
   // [#not-implemented-hide:]
   AuditCondition audit_condition = 3;
+
+  // Configurations for RBAC-based authorization audit loggers. Specific to HTTP filters.
+  // Any RBAC filter in the HTTP filter chain will invoke all the audit loggers configured
+  // here if the audit condition specified in the RBAC is met.
+  //
+  // [#not-implemented-hide:]
+  // [#extension-category: envoy.rbac.audit_loggers]
+  repeated config.core.v3.TypedExtensionConfig audit_log = 54;
 }
 
 // Policy specifies a role and the principals that are assigned/denied the role.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -115,7 +115,7 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
-  message AuditLog {
+  message AuditOptions {
     // Deny and allow here refer to RBAC decisions, not actions.
     enum AuditCondition {
       // Never audit.
@@ -160,7 +160,7 @@ message RBAC {
     repeated core.v3.TypedExtensionConfig audit_log = 2 [(validate.rules).repeated = {min_items: 1}];
   }
 
-  AuditLog audit_log = 3;
+  AuditOptions audit_options = 3;
 }
 
 // Policy specifies a role and the principals that are assigned/denied the role.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -77,6 +77,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       principals:
 //         - any: true
 //
+// [#next-free-field: 5]
 message RBAC {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.RBAC";
 
@@ -131,18 +132,16 @@ message RBAC {
   map<string, Policy> policies = 2;
 
   // Condition for the audit logging to be happen. Specific to HTTP filters.
-  // If condition is met, all the audit loggers configured in the HCM will be invoked.
+  // If condition is met, all the audit loggers configured here will be invoked.
   //
   // [#not-implemented-hide:]
   AuditCondition audit_condition = 3;
 
   // Configurations for RBAC-based authorization audit loggers. Specific to HTTP filters.
-  // Any RBAC filter in the HTTP filter chain will invoke all the audit loggers configured
-  // here if the audit condition specified in the RBAC is met.
   //
   // [#not-implemented-hide:]
   // [#extension-category: envoy.rbac.audit_loggers]
-  repeated config.core.v3.TypedExtensionConfig audit_log = 54;
+  repeated core.v3.TypedExtensionConfig audit_log = 4;
 }
 
 // Policy specifies a role and the principals that are assigned/denied the role.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -130,13 +130,13 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
-  // Condition for the audit logging to be happen. Specific to HTTP filters.
+  // Condition for the audit logging to be happen.
   // If this condition is met, all the audit loggers configured here will be invoked.
   //
   // [#not-implemented-hide:]
   AuditCondition audit_condition = 3;
 
-  // Configurations for RBAC-based authorization audit loggers. Specific to HTTP filters.
+  // Configurations for RBAC-based authorization audit loggers.
   //
   // [#not-implemented-hide:]
   // [#extension-category: envoy.rbac.audit_loggers]

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -95,6 +95,21 @@ message RBAC {
     LOG = 2;
   }
 
+  // Deny and allow here refer to RBAC decisions, not actions.
+  enum AuditCondition {
+    // Never audit.
+    NONE = 0;
+
+    // Audit when RBAC denies the request.
+    ON_DENY = 1;
+
+    // Audit when RBAC allows the request.
+    ON_ALLOW = 2;
+
+    // Audit whether RBAC allows or denies the request.
+    ON_DENY_AND_ALLOW = 3;
+  }
+
   // The action to take if a policy matches. Every action either allows or denies a request,
   // and can also carry out action-specific operations.
   //
@@ -114,21 +129,6 @@ message RBAC {
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
-
-  // Deny and allow here refer to RBAC decisions, not actions.
-  enum AuditCondition {
-    // Never audit.
-    NONE = 0;
-
-    // Audit when RBAC denies the request.
-    ON_DENY = 1;
-
-    // Audit when RBAC allows the request.
-    ON_ALLOW = 2;
-
-    // Audit whether RBAC allows or denies the request.
-    ON_DENY_AND_ALLOW = 3;
-  }
 
   // Condition for the audit logging to be happen, specific to HTTP filters.
   // If condition is met, all the audit loggers configured in the HCM will be invoked.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -77,7 +77,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       principals:
 //         - any: true
 //
-// [#next-free-field: 5]
 message RBAC {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.RBAC";
 

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -95,7 +95,7 @@ message RBAC {
     LOG = 2;
   }
 
-  message AuditOptions {
+  message AuditLoggingOptions {
     // Deny and allow here refer to RBAC decisions, not actions.
     enum AuditCondition {
       // Never audit.
@@ -121,7 +121,7 @@ message RBAC {
     //
     // [#not-implemented-hide:]
     // [#extension-category: envoy.rbac.audit_loggers]
-    repeated core.v3.TypedExtensionConfig audit_log = 2
+    repeated core.v3.TypedExtensionConfig audit_logger = 2
         [(validate.rules).repeated = {min_items: 1}];
   }
 
@@ -145,9 +145,11 @@ message RBAC {
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
 
-  // Audit options that includes the condition for audit logging to happen and
-  // audit logger configurations.
-  AuditOptions audit_options = 3;
+  // Audit logging options that includes the condition for audit logging to happen
+  // and audit logger configurations.
+  //
+  // [#not-implemented-hide:]
+  AuditLoggingOptions audit_logging_options = 3;
 }
 
 // Policy specifies a role and the principals that are assigned/denied the role.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -131,11 +131,27 @@ message RBAC {
       ON_DENY_AND_ALLOW = 3;
     }
 
-    // Condition for the audit logging to be happen.
-    // If this condition is met, all the audit loggers configured here will be invoked.
-    //
-    // [#not-implemented-hide:]
-    AuditCondition audit_condition = 1 [(validate.rules).enum.defined_only = true];
+  message AuditLog {
+    // Deny and allow here refer to RBAC decisions, not actions.
+    enum AuditCondition {
+      // Never audit.
+      NONE = 0;
+
+      // Audit when RBAC denies the request.
+      ON_DENY = 1;
+
+      // Audit when RBAC allows the request.
+      ON_ALLOW = 2;
+
+      // Audit whether RBAC allows or denies the request.
+      ON_DENY_AND_ALLOW = 3;
+    }
+
+  // Condition for the audit logging to happen.
+  // If this condition is met, all the audit loggers configured here will be invoked.
+  //
+  // [#not-implemented-hide:]
+  AuditCondition audit_condition = 3 [(validate.rules).enum = {defined_only: true}];
 
     // Configurations for RBAC-based authorization audit loggers.
     //

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -114,6 +114,27 @@ message RBAC {
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
+
+  // Deny and allow here refer to RBAC decisions, not actions.
+  enum AuditCondition {
+    // Never audit.
+    NONE = 0;
+
+    // Audit when RBAC denies the request.
+    ON_DENY = 1;
+
+    // Audit when RBAC allows the request.
+    ON_ALLOW = 2;
+
+    // Audit whether RBAC allows or denies the request.
+    ON_DENY_AND_ALLOW = 3;
+  }
+
+  // Condition for the audit logging to be happen, specific to HTTP filters.
+  // If condition is met, all the audit loggers configured in the HCM will be invoked.
+  //
+  // [#not-implemented-hide:]
+  AuditCondition audit_condition = 3;
 }
 
 // Policy specifies a role and the principals that are assigned/denied the role.

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -95,6 +95,36 @@ message RBAC {
     LOG = 2;
   }
 
+  message AuditOptions {
+    // Deny and allow here refer to RBAC decisions, not actions.
+    enum AuditCondition {
+      // Never audit.
+      NONE = 0;
+
+      // Audit when RBAC denies the request.
+      ON_DENY = 1;
+
+      // Audit when RBAC allows the request.
+      ON_ALLOW = 2;
+
+      // Audit whether RBAC allows or denies the request.
+      ON_DENY_AND_ALLOW = 3;
+    }
+
+    // Condition for the audit logging to happen.
+    // If this condition is met, all the audit loggers configured here will be invoked.
+    //
+    // [#not-implemented-hide:]
+    AuditCondition audit_condition = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Configurations for RBAC-based authorization audit loggers.
+    //
+    // [#not-implemented-hide:]
+    // [#extension-category: envoy.rbac.audit_loggers]
+    repeated core.v3.TypedExtensionConfig audit_log = 2
+        [(validate.rules).repeated = {min_items: 1}];
+  }
+
   // The action to take if a policy matches. Every action either allows or denies a request,
   // and can also carry out action-specific operations.
   //
@@ -114,51 +144,6 @@ message RBAC {
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   // The policies are evaluated in lexicographic order of the policy name.
   map<string, Policy> policies = 2;
-
-  message AuditOptions {
-    // Deny and allow here refer to RBAC decisions, not actions.
-    enum AuditCondition {
-      // Never audit.
-      NONE = 0;
-
-      // Audit when RBAC denies the request.
-      ON_DENY = 1;
-
-      // Audit when RBAC allows the request.
-      ON_ALLOW = 2;
-
-      // Audit whether RBAC allows or denies the request.
-      ON_DENY_AND_ALLOW = 3;
-    }
-
-  message AuditLog {
-    // Deny and allow here refer to RBAC decisions, not actions.
-    enum AuditCondition {
-      // Never audit.
-      NONE = 0;
-
-      // Audit when RBAC denies the request.
-      ON_DENY = 1;
-
-      // Audit when RBAC allows the request.
-      ON_ALLOW = 2;
-
-      // Audit whether RBAC allows or denies the request.
-      ON_DENY_AND_ALLOW = 3;
-    }
-
-  // Condition for the audit logging to happen.
-  // If this condition is met, all the audit loggers configured here will be invoked.
-  //
-  // [#not-implemented-hide:]
-  AuditCondition audit_condition = 3 [(validate.rules).enum = {defined_only: true}];
-
-    // Configurations for RBAC-based authorization audit loggers.
-    //
-    // [#not-implemented-hide:]
-    // [#extension-category: envoy.rbac.audit_loggers]
-    repeated core.v3.TypedExtensionConfig audit_log = 2 [(validate.rules).repeated = {min_items: 1}];
-  }
 
   AuditOptions audit_options = 3;
 }

--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -121,7 +121,7 @@ message RBAC {
     //
     // [#not-implemented-hide:]
     // [#extension-category: envoy.rbac.audit_loggers]
-    repeated core.v3.TypedExtensionConfig audit_logger = 2
+    repeated core.v3.TypedExtensionConfig audit_loggers = 2
         [(validate.rules).repeated = {min_items: 1}];
   }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -36,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 54]
+// [#next-free-field: 55]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -836,6 +836,7 @@ message HttpConnectionManager {
   // condition specified in the RBAC is met.
   //
   // [#not-implemented-hide:]
+  // [#extension-category: envoy.audit_loggers]
   repeated config.core.v3.TypedExtensionConfig audit_log = 54;
 }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -36,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 55]
+// [#next-free-field: 54]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -830,14 +830,6 @@ message HttpConnectionManager {
   // This should be set to `false` in cases where Envoy's view of the downstream address may not correspond to the
   // actual client address, for example, if there's another proxy in front of the Envoy.
   google.protobuf.BoolValue add_proxy_protocol_connection_state = 53;
-
-  // Configurations for RBAC-based authorization audit loggers.
-  // Any RBAC filter in the HTTP filter chain will invoke all the audit loggers configured here if the audit
-  // condition specified in the RBAC is met.
-  //
-  // [#not-implemented-hide:]
-  // [#extension-category: envoy.audit_loggers]
-  repeated config.core.v3.TypedExtensionConfig audit_log = 54;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -830,6 +830,13 @@ message HttpConnectionManager {
   // This should be set to `false` in cases where Envoy's view of the downstream address may not correspond to the
   // actual client address, for example, if there's another proxy in front of the Envoy.
   google.protobuf.BoolValue add_proxy_protocol_connection_state = 53;
+
+  // Configurations for RBAC-based authorization audit loggers.
+  // Any RBAC filter in the HTTP filter chain will invoke all the audit loggers configured here if the audit
+  // condition specified in the RBAC is met.
+  //
+  // [#not-implemented-hide:]
+  repeated config.core.v3.TypedExtensionConfig audit_log = 54;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/tools/extensions/extensions_schema.yaml
+++ b/tools/extensions/extensions_schema.yaml
@@ -60,7 +60,6 @@ security_postures:
 # Extension categories as defined by factories
 categories:
 - envoy.access_loggers
-- envoy.audit_loggers
 - envoy.bootstrap
 - envoy.clusters
 - envoy.compression.compressor
@@ -110,6 +109,7 @@ categories:
 - envoy.network.dns_resolver
 - envoy.network.connection_balance
 - envoy.rbac.matchers
+- envoy.rbac.audit_loggers
 - envoy.access_loggers.extension_filters
 - envoy.http.stateful_session
 - envoy.matching.action

--- a/tools/extensions/extensions_schema.yaml
+++ b/tools/extensions/extensions_schema.yaml
@@ -60,6 +60,7 @@ security_postures:
 # Extension categories as defined by factories
 categories:
 - envoy.access_loggers
+- envoy.audit_loggers
 - envoy.bootstrap
 - envoy.clusters
 - envoy.compression.compressor


### PR DESCRIPTION
Commit Message: Add audit_log typed config in HCM and audit_condition enum in RBAC config protos.
Risk Level: low
Docs Changes: N/A
Release Notes: N/A

[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):
This API change is proposed for the feature implementation in gRPC first.
gRPC authorization is based on xDS RBAC proto. The audit logging support we are trying to add is to enable users configure loggers and audit authorization events when the audit condition is met.

The primary difference from the access log is that audit log should be invoked right after the RBAC evaluation is done and will not wait till after the entire call finishes. It seems to me this is something Envoy also lacks and could potentially benefit from.

The API change presented here has gone through some preliminary reviews by @markdroth and @ejona86. I'm working on a gRFC which will be linked here as soon as it's available. Meanwhile, I am opening this PR now such that any question or concern could be raised early.