### PR TITLE
mobile: fix `setRuntimeGuard` Swift API

### DIFF
--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -96,6 +96,13 @@ NS_ASSUME_NONNULL_BEGIN
                                        (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
                                            keyValueStores
                                        statsSinks:(NSArray<NSString *> *)statsSinks;
+
+/**
+ Generate a string description of the C++ Envoy bootstrap from this configuration.
+ For testing purposes only.
+ */
+- (NSString *)bootstrapDebugString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  Generate a string description of the C++ Envoy bootstrap from this configuration.
  For testing purposes only.
  */
-- (NSString *)bootstrapDebugString;
+- (NSString *)bootstrapDebugDescription;
 
 @end
 

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -249,7 +249,7 @@
   }
 }
 
-- (NSString *)bootstrapDebugString {
+- (NSString *)bootstrapDebugDescription {
   std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap = [self generateBootstrap];
   return @(bootstrap->ShortDebugString().c_str());
 }

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -177,6 +177,11 @@
   builder.enableGzipDecompression(self.enableGzipDecompression);
   builder.enableBrotliDecompression(self.enableBrotliDecompression);
 
+  for (NSString *key in self.runtimeGuards) {
+    BOOL value = [[self.runtimeGuards objectForKey:key] isEqualToString:@"true"];
+    builder.setRuntimeGuard([key toCXXString], value);
+  }
+
   for (EMODirectResponse *directResponse in self.typedDirectResponses) {
     builder.addDirectResponse([directResponse toCXX]);
   }
@@ -242,6 +247,11 @@
     NSLog(@"[Envoy] error generating bootstrap: %@", @(e.what()));
     return nullptr;
   }
+}
+
+- (NSString *)bootstrapDebugString {
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap = [self generateBootstrap];
+  return @(bootstrap->ShortDebugString().c_str());
 }
 
 @end

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -649,7 +649,7 @@ open class EngineBuilder: NSObject {
     )
   }
 
-  func bootstrapDebugString() -> String {
-    self.makeConfig().bootstrapDebugString()
+  func bootstrapDebugDescription() -> String {
+    self.makeConfig().bootstrapDebugDescription()
   }
 }

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -30,6 +30,19 @@ final class EngineBuilderTests: XCTestCase {
     MockEnvoyEngine.onRunWithYAML = nil
   }
 
+  func testSetRuntimeGuard() {
+    let bootstrapDebugString = EngineBuilder()
+      .setRuntimeGuard("test_feature_false", true)
+      .setRuntimeGuard("test_feature_true", false)
+      .bootstrapDebugString()
+    XCTAssertTrue(
+      bootstrapDebugString.contains(#""test_feature_false" value { bool_value: true }"#)
+    )
+    XCTAssertTrue(
+      bootstrapDebugString.contains(#""test_feature_true" value { bool_value: false }"#)
+    )
+  }
+
   func testMonitoringModeDefaultsToPathMonitor() {
     let builder = EngineBuilder()
     XCTAssertEqual(builder.monitoringMode, .pathMonitor)

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -31,15 +31,15 @@ final class EngineBuilderTests: XCTestCase {
   }
 
   func testSetRuntimeGuard() {
-    let bootstrapDebugString = EngineBuilder()
+    let bootstrapDebugDescription = EngineBuilder()
       .setRuntimeGuard("test_feature_false", true)
       .setRuntimeGuard("test_feature_true", false)
-      .bootstrapDebugString()
+      .bootstrapDebugDescription()
     XCTAssertTrue(
-      bootstrapDebugString.contains(#""test_feature_false" value { bool_value: true }"#)
+      bootstrapDebugDescription.contains(#""test_feature_false" value { bool_value: true }"#)
     )
     XCTAssertTrue(
-      bootstrapDebugString.contains(#""test_feature_true" value { bool_value: false }"#)
+      bootstrapDebugDescription.contains(#""test_feature_true" value { bool_value: false }"#)
     )
   }
 


### PR DESCRIPTION
This was never fully hooked up to the C++ builder in `-[EnvoyConfiguration applyToCXXBuilder]`.

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Low
Testing: Yes
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
