### PR TITLE
ci: Remove `flaky_test_attempts`

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -16,7 +16,7 @@ parameters:
   default: true
 - name: bazelBuildExtraOptions
   type: string
-  default: "--flaky_test_attempts=2"
+  default: ""
 
 steps:
 - task: Cache@2

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -107,7 +107,6 @@ BAZEL_BUILD_OPTIONS=(
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 
 [[ "${ENVOY_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=(
-  "--flaky_test_attempts=2"
   "--test_env=HEAPCHECK=")
 
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && bazel clean --expunge

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -63,8 +63,6 @@ else
       "--test_tag_filters=-nocoverage,-fuzz_target")
 fi
 
-# Don't block coverage on flakes.
-BAZEL_BUILD_OPTIONS+=("--flaky_test_attempts=2")
 # Output unusually long logs due to trace logging.
 BAZEL_BUILD_OPTIONS+=("--experimental_ui_max_stdouterr_bytes=80000000")
 


### PR DESCRIPTION
Allowing flaky tests to pass hides a multitude of sins and means we dont actually deal with issues until they hit a critical mass of failure. Also, not all flakes are the same, most are just ~incorrect test assumptions and ~inconsequential, in some cases it can point to a critical failure or problem

Not allowing this still does not mean we will detect flakes immediately but it means we are going to see them a lot sooner and it will be a lot clearer where they started. Atm, we cant really trust CI without click, clikcking through to see what really happened.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
