### PR TITLE
docker: Reorder layers by change frequency

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -1,65 +1,64 @@
 ARG BUILD_OS=ubuntu
 ARG BUILD_TAG=20.04
-ARG ENVOY_VRP_BASE_IMAGE=envoy
+ARG ENVOY_VRP_BASE_IMAGE=envoy-base
 
 
 FROM scratch AS binary
-
+COPY ci/docker-entrypoint.sh /
+ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 ARG ENVOY_BINARY=envoy
-ARG ENVOY_BINARY_SUFFIX=_stripped
-ADD ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release${ENVOY_BINARY_SUFFIX}/envoy* /usr/local/bin/
-ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
 COPY --chown=0:0 ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release/su-exec /usr/local/bin/
 COPY ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release/schema_validator_tool /usr/local/bin/schema_validator_tool
-COPY ci/docker-entrypoint.sh /
+ARG ENVOY_BINARY_SUFFIX=_stripped
+ADD ${TARGETPLATFORM}/build_${ENVOY_BINARY}_release${ENVOY_BINARY_SUFFIX}/envoy* /usr/local/bin/
 
 
 # STAGE: envoy
-FROM ${BUILD_OS}:${BUILD_TAG} AS envoy
-
+FROM ${BUILD_OS}:${BUILD_TAG} AS envoy-base
 ENV DEBIAN_FRONTEND=noninteractive
-
+RUN mkdir -p /etc/envoy
+RUN adduser --group --system envoy
 RUN apt-get -qq update && apt-get -qq upgrade -y \
     && apt-get -qq install --no-install-recommends -y ca-certificates \
     && apt-get -qq autoremove -y && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /etc/envoy
-
-COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
-COPY --from=binary /usr/local/bin/su-exec /usr/local/bin/
-COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
-COPY --from=binary /docker-entrypoint.sh /
-
-RUN adduser --group --system envoy
-
 EXPOSE 10000
-
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
+
+
+# STAGE: envoy
+FROM envoy-base AS envoy
+COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY --from=binary /docker-entrypoint.sh /
+COPY --from=binary /usr/local/bin/su-exec /usr/local/bin/
+COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 
 
 # STAGE: envoy-distroless
 # gcr.io/distroless/base-nossl-debian11:nonroot
 FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:8c880faa0cb8c3fe60cae75de2cf4f6e7b53bd977a351a7e5ab510394e509f24 AS envoy-distroless
-
-COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
-COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
-
 EXPOSE 10000
-
 ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]
+COPY --from=binary /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY --from=binary /usr/local/bin/envoy* /usr/local/bin/
 
 
 # STAGE: envoy-google-vrp-base
 FROM ${ENVOY_VRP_BASE_IMAGE} AS envoy-google-vrp-base
-
-ENV DEBIAN_FRONTEND=noninteractive
-
+EXPOSE 10000
+EXPOSE 10001
+CMD ["supervisord", "-c", "/etc/supervisor.conf"]
+ENTRYPOINT []
+ADD configs/google-vrp/envoy-edge.yaml /etc/envoy/envoy-edge.yaml
+ADD configs/google-vrp/envoy-origin.yaml /etc/envoy/envoy-origin.yaml
+ADD configs/google-vrp/launch_envoy.sh /usr/local/bin/launch_envoy.sh
+ADD test/config/integration/certs/serverkey.pem /etc/envoy/certs/serverkey.pem
+ADD test/config/integration/certs/servercert.pem /etc/envoy/certs/servercert.pem
 RUN apt-get -qq update \
     && apt-get -qq upgrade -y \
     && apt-get -qq install -y libc++1 supervisor gdb strace tshark \
@@ -67,21 +66,10 @@ RUN apt-get -qq update \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
-
-ADD configs/google-vrp/envoy-edge.yaml /etc/envoy/envoy-edge.yaml
-ADD configs/google-vrp/envoy-origin.yaml /etc/envoy/envoy-origin.yaml
-ADD configs/google-vrp/launch_envoy.sh /usr/local/bin/launch_envoy.sh
 ADD configs/google-vrp/supervisor.conf /etc/supervisor.conf
-ADD test/config/integration/certs/serverkey.pem /etc/envoy/certs/serverkey.pem
-ADD test/config/integration/certs/servercert.pem /etc/envoy/certs/servercert.pem
 RUN chmod 777 /var/log/supervisor
 RUN chmod a+r /etc/supervisor.conf /etc/envoy/* /etc/envoy/certs/*
 RUN chmod a+rx /usr/local/bin/launch_envoy.sh
-
-EXPOSE 10000
-EXPOSE 10001
-
-CMD ["supervisord", "-c", "/etc/supervisor.conf"]
 
 
 # STAGE: envoy-google-vrp
@@ -96,8 +84,7 @@ ADD "${ENVOY_CTX_BINARY_PATH}" /usr/local/bin/envoy
 
 
 # STAGE: envoy-tools
-FROM ${BUILD_OS}:${BUILD_TAG} AS envoy-tools
-
+FROM envoy AS envoy-tools
 COPY --from=binary /usr/local/bin/schema_validator_tool /usr/local/bin/
 
 


### PR DESCRIPTION
The Envoy binary changes the most frequently (at least when publishing `dev` from `main`) and so should be last in the Docker recipes to preserve cached layers.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
