### PR TITLE
mobile: set `-Xcc -Wno-deprecated-declarations` when building Swift

### DIFF
--- a/mobile/library/swift/BUILD
+++ b/mobile/library/swift/BUILD
@@ -81,6 +81,8 @@ swift_library(
             "-enable-experimental-cxx-interop",
             "-Xcc",
             "-std=c++17",
+            "-Xcc",
+            "-Wno-deprecated-declarations",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
Fixes the following diagnostics:

```
<module-includes>:1:9: note: in file included from <module-includes>:1:
        ^
/execroot/envoy_mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h:3:10: note: in file included from /execroot/envoy_mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h:3:
         ^
/execroot/envoy_mobile/./library/cc/engine_builder.h:8:10: note: in file included from /execroot/envoy_mobile/./library/cc/engine_builder.h:8:
         ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h:39:10: note: in file included from /execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h:39:
         ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/cluster/v3/cluster.pb.h:43:10: note: in file included from /execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/cluster/v3/cluster.pb.h:43:
         ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/core/v3/config_source.pb.h:122:73: warning: 'ApiConfigSource_ApiType_DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE' is deprecated
constexpr ApiConfigSource_ApiType ApiConfigSource_ApiType_ApiType_MIN = ApiConfigSource_ApiType_DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE;
                                                                        ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/core/v3/config_source.pb.h:112:65: note: 'ApiConfigSource_ApiType_DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE' has been explicitly marked deprecated here
  ApiConfigSource_ApiType_DEPRECATED_AND_UNAVAILABLE_DO_NOT_USE PROTOBUF_DEPRECATED_ENUM = 0,
                                                                ^
/execroot/envoy_mobile/external/com_google_protobuf/src/google/protobuf/port_def.inc:176:49: note: expanded from macro 'PROTOBUF_DEPRECATED_ENUM'
                                                ^
<module-includes>:1:9: note: in file included from <module-includes>:1:
        ^
/execroot/envoy_mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h:3:10: note: in file included from /execroot/envoy_mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h:3:
         ^
/execroot/envoy_mobile/./library/cc/engine_builder.h:8:10: note: in file included from /execroot/envoy_mobile/./library/cc/engine_builder.h:8:
         ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h:39:10: note: in file included from /execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/bootstrap/v3/bootstrap.pb.h:39:
         ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/cluster/v3/cluster.pb.h:43:10: note: in file included from /execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/cluster/v3/cluster.pb.h:43:
         ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/core/v3/config_source.pb.h:148:39: warning: 'AUTO' is deprecated
constexpr ApiVersion ApiVersion_MIN = AUTO;
                                      ^
/execroot/envoy_mobile/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-fastbuild-ST-8917dc8480bd/bin/external/envoy_api/envoy/config/core/v3/config_source.pb.h:141:8: note: 'AUTO' has been explicitly marked deprecated here
  AUTO PROTOBUF_DEPRECATED_ENUM = 0,
       ^
/execroot/envoy_mobile/external/com_google_protobuf/src/google/protobuf/port_def.inc:176:49: note: expanded from macro 'PROTOBUF_DEPRECATED_ENUM'
                                                ^
```

And in fact we also pass this to copts generally:
https://github.com/envoyproxy/envoy/blob/e05f4a3008f56ef39c5f0644a24e60a3a8318494/bazel/envoy_internal.bzl#L17

Maybe rules_swift should be passing all the Bazel `--copt` flags through
to `swift_library`'s `copts` automatically?

Signed-off-by: JP Simard <jp@jpsim.com>

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
