### PR TITLE
mobile: make `Envoy::DirectResponseTesting::MatchMode` an `enum class`

### DIFF
--- a/mobile/library/cc/direct_response_testing.h
+++ b/mobile/library/cc/direct_response_testing.h
@@ -9,7 +9,7 @@ namespace Envoy {
 namespace DirectResponseTesting {
 
 // The match operation to perform.
-enum class MatchMode { contains, exact, prefix, suffix };
+enum class MatchMode { Contains, Exact, Prefix, Suffix };
 
 // A configuration for when a header should be matched.
 struct HeaderMatcher {

--- a/mobile/library/cc/direct_response_testing.h
+++ b/mobile/library/cc/direct_response_testing.h
@@ -9,7 +9,7 @@ namespace Envoy {
 namespace DirectResponseTesting {
 
 // The match operation to perform.
-enum MatchMode { contains, exact, prefix, suffix };
+enum class MatchMode { contains, exact, prefix, suffix };
 
 // A configuration for when a header should be matched.
 struct HeaderMatcher {

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -351,16 +351,16 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       auto* direct_response_headers = direct_response_route_match->add_headers();
       direct_response_headers->set_name(header.name);
       switch (header.mode) {
-      case DirectResponseTesting::contains:
+      case DirectResponseTesting::MatchMode::contains:
         direct_response_headers->set_contains_match(header.value);
         break;
-      case DirectResponseTesting::exact:
+      case DirectResponseTesting::MatchMode::exact:
         direct_response_headers->set_exact_match(header.value);
         break;
-      case DirectResponseTesting::prefix:
+      case DirectResponseTesting::MatchMode::prefix:
         direct_response_headers->set_prefix_match(header.value);
         break;
-      case DirectResponseTesting::suffix:
+      case DirectResponseTesting::MatchMode::suffix:
         direct_response_headers->set_suffix_match(header.value);
         break;
       }
@@ -406,16 +406,16 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       auto* direct_response_headers = direct_response_route_match->add_headers();
       direct_response_headers->set_name(header.name);
       switch (header.mode) {
-      case DirectResponseTesting::contains:
+      case DirectResponseTesting::MatchMode::contains:
         direct_response_headers->set_contains_match(header.value);
         break;
-      case DirectResponseTesting::exact:
+      case DirectResponseTesting::MatchMode::exact:
         direct_response_headers->set_exact_match(header.value);
         break;
-      case DirectResponseTesting::prefix:
+      case DirectResponseTesting::MatchMode::prefix:
         direct_response_headers->set_prefix_match(header.value);
         break;
-      case DirectResponseTesting::suffix:
+      case DirectResponseTesting::MatchMode::suffix:
         direct_response_headers->set_suffix_match(header.value);
         break;
       }

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -351,16 +351,16 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       auto* direct_response_headers = direct_response_route_match->add_headers();
       direct_response_headers->set_name(header.name);
       switch (header.mode) {
-      case DirectResponseTesting::MatchMode::contains:
+      case DirectResponseTesting::MatchMode::Contains:
         direct_response_headers->set_contains_match(header.value);
         break;
-      case DirectResponseTesting::MatchMode::exact:
+      case DirectResponseTesting::MatchMode::Exact:
         direct_response_headers->set_exact_match(header.value);
         break;
-      case DirectResponseTesting::MatchMode::prefix:
+      case DirectResponseTesting::MatchMode::Prefix:
         direct_response_headers->set_prefix_match(header.value);
         break;
-      case DirectResponseTesting::MatchMode::suffix:
+      case DirectResponseTesting::MatchMode::Suffix:
         direct_response_headers->set_suffix_match(header.value);
         break;
       }
@@ -406,16 +406,16 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       auto* direct_response_headers = direct_response_route_match->add_headers();
       direct_response_headers->set_name(header.name);
       switch (header.mode) {
-      case DirectResponseTesting::MatchMode::contains:
+      case DirectResponseTesting::MatchMode::Contains:
         direct_response_headers->set_contains_match(header.value);
         break;
-      case DirectResponseTesting::MatchMode::exact:
+      case DirectResponseTesting::MatchMode::Exact:
         direct_response_headers->set_exact_match(header.value);
         break;
-      case DirectResponseTesting::MatchMode::prefix:
+      case DirectResponseTesting::MatchMode::Prefix:
         direct_response_headers->set_prefix_match(header.value);
         break;
-      case DirectResponseTesting::MatchMode::suffix:
+      case DirectResponseTesting::MatchMode::Suffix:
         direct_response_headers->set_suffix_match(header.value);
         break;
       }

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -17,16 +17,16 @@
   result.value = [self.value toCXXString];
   switch (self.mode) {
   case EMOMatchModeContains:
-    result.mode = Envoy::DirectResponseTesting::contains;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::contains;
     break;
   case EMOMatchModeExact:
-    result.mode = Envoy::DirectResponseTesting::exact;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::exact;
     break;
   case EMOMatchModePrefix:
-    result.mode = Envoy::DirectResponseTesting::prefix;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::prefix;
     break;
   case EMOMatchModeSuffix:
-    result.mode = Envoy::DirectResponseTesting::suffix;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::suffix;
     break;
   }
   return result;

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -17,16 +17,16 @@
   result.value = [self.value toCXXString];
   switch (self.mode) {
   case EMOMatchModeContains:
-    result.mode = Envoy::DirectResponseTesting::MatchMode::contains;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::Contains;
     break;
   case EMOMatchModeExact:
-    result.mode = Envoy::DirectResponseTesting::MatchMode::exact;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::Exact;
     break;
   case EMOMatchModePrefix:
-    result.mode = Envoy::DirectResponseTesting::MatchMode::prefix;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::Prefix;
     break;
   case EMOMatchModeSuffix:
-    result.mode = Envoy::DirectResponseTesting::MatchMode::suffix;
+    result.mode = Envoy::DirectResponseTesting::MatchMode::Suffix;
     break;
   }
   return result;

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
@@ -48,15 +48,6 @@ inline const LogLevel LogLevelError = LogLevel::err;
 inline const LogLevel LogLevelCritical = LogLevel::critical;
 inline const LogLevel LogLevelOff = LogLevel::off;
 
-inline const DirectResponseTesting::MatchMode DirectResponseMatchModeContains =
-    DirectResponseTesting::contains;
-inline const DirectResponseTesting::MatchMode DirectResponseMatchModeExact =
-    DirectResponseTesting::exact;
-inline const DirectResponseTesting::MatchMode DirectResponseMatchModePrefix =
-    DirectResponseTesting::prefix;
-inline const DirectResponseTesting::MatchMode DirectResponseMatchModeSuffix =
-    DirectResponseTesting::suffix;
-
 // Smart pointers aren't currently supported by Swift / C++ interop, so we "erase"
 // it into a `BootstrapPtr` / `intptr_t`, which we can import from Swift.
 inline BootstrapPtr generateBootstrapPtr(Platform::EngineBuilder builder) {


### PR DESCRIPTION
They seem to have a number of advantages over "plain" enums according to https://stackoverflow.com/a/18335862, and this will allow them to be imported properly into Swift.

Also change case names to be PascalCase to conform to the style guide: https://github.com/envoyproxy/envoy/blob/main/STYLE.md

Similar to https://github.com/envoyproxy/envoy/pull/26036

Commit Message:
Additional Description:
Risk Level: Low, only used for Swift tests at the moment.
Testing: Existing tests.
Docs Changes: None.
Release Notes: None.
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]