### PR TITLE
test: split out the test interlock so it can be re-used from test in other with guarddog functionality.

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -188,6 +188,7 @@ envoy_cc_test(
     size = "small",
     srcs = ["guarddog_impl_test.cc"],
     deps = [
+        ":guarddog_test_interlock",
         "//envoy/common:time_interface",
         "//source/common/api:api_lib",
         "//source/common/common:macros",
@@ -201,6 +202,14 @@ envoy_cc_test(
         "//test/test_common:registry_lib",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "guarddog_test_interlock",
+    hdrs = ["guarddog_test_interlock.h"],
+    deps = [
+        "//source/server:guarddog_lib",
     ],
 )
 

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -20,6 +20,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/server/watchdog_config.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/server/guarddog_test_interlock.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/test_time.h"
@@ -45,28 +46,6 @@ const int DISABLE_MULTIKILL = 0;
 const int DISABLE_MISS = 1000000;
 const int DISABLE_MEGAMISS = 1000000;
 
-class DebugTestInterlock : public GuardDogImpl::TestInterlockHook {
-public:
-  // GuardDogImpl::TestInterlockHook
-  void signalFromImpl() override {
-    waiting_for_signal_ = false;
-    impl_.notifyAll();
-  }
-
-  void waitFromTest(Thread::MutexBasicLockable& mutex) override
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
-    ASSERT(!waiting_for_signal_);
-    waiting_for_signal_ = true;
-    while (waiting_for_signal_) {
-      impl_.wait(mutex);
-    }
-  }
-
-private:
-  Thread::CondVar impl_;
-  bool waiting_for_signal_ = false;
-};
-
 // We want to make sure guard-dog is tested with both simulated time and real
 // time, to ensure that it works in production, and that it works in the context
 // of integration tests which are much easier to control with simulated time.
@@ -87,7 +66,7 @@ protected:
 
   void initGuardDog(Stats::Store& stats_store, const Server::Configuration::Watchdog& config) {
     guard_dog_ = std::make_unique<GuardDogImpl>(*stats_store.rootScope(), config, *api_, "server",
-                                                std::make_unique<DebugTestInterlock>());
+                                                std::make_unique<GuardDogTestInterlock>());
   }
 
   std::unique_ptr<Event::TestTimeSystem> time_system_;

--- a/test/server/guarddog_test_interlock.h
+++ b/test/server/guarddog_test_interlock.h
@@ -1,4 +1,5 @@
 #include "envoy/thread/thread.h"
+
 #include "source/server/guarddog_impl.h"
 
 #pragma once
@@ -6,6 +7,10 @@
 namespace Envoy {
 namespace Server {
 
+// Helps make tests using the GuardDog more robust by providing a way of
+// blocking in the test on GuardDog loop completion when
+// GuardDogImpl::forceCheckForTest() is called. If this interlock is not
+// provided, the default interlock is a no-op.
 class GuardDogTestInterlock : public GuardDogImpl::TestInterlockHook {
 public:
   // GuardDogImpl::TestInterlockHook
@@ -30,4 +35,3 @@ private:
 
 } // namespace Server
 } // namespace Envoy
-

--- a/test/server/guarddog_test_interlock.h
+++ b/test/server/guarddog_test_interlock.h
@@ -1,0 +1,33 @@
+#include "envoy/thread/thread.h"
+#include "source/server/guarddog_impl.h"
+
+#pragma once
+
+namespace Envoy {
+namespace Server {
+
+class GuardDogTestInterlock : public GuardDogImpl::TestInterlockHook {
+public:
+  // GuardDogImpl::TestInterlockHook
+  void signalFromImpl() override {
+    waiting_for_signal_ = false;
+    impl_.notifyAll();
+  }
+
+  void waitFromTest(Thread::MutexBasicLockable& mutex) override
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+    ASSERT(!waiting_for_signal_);
+    waiting_for_signal_ = true;
+    while (waiting_for_signal_) {
+      impl_.wait(mutex);
+    }
+  }
+
+private:
+  Thread::CondVar impl_;
+  bool waiting_for_signal_ = false;
+};
+
+} // namespace Server
+} // namespace Envoy
+


### PR DESCRIPTION
Commit Message: We need to run our own guard dog tests internally, and to make them non-flaky we need to share this interlock override. So this PR just pulls that out of the test.cc file and gives it a better name.

Additional Description:  n/a
Risk Level: low
Testing: test/server:guarddog_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

