### PR TITLE
udp: normalize local address if using dual stack socket

### DIFF
--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -8,6 +8,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/network/io_socket_error_impl.h"
+#include "source/common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Network {
@@ -19,7 +20,10 @@ class IoSocketHandleImpl : public IoHandle, protected Logger::Loggable<Logger::I
 public:
   explicit IoSocketHandleImpl(os_fd_t fd = INVALID_SOCKET, bool socket_v6only = false,
                               absl::optional<int> domain = absl::nullopt)
-      : fd_(fd), socket_v6only_(socket_v6only), domain_(domain) {}
+      : fd_(fd), socket_v6only_(socket_v6only), domain_(domain),
+        udp_read_normalize_addresses_(
+            Runtime::runtimeFeatureEnabled("envoy.restart_features.udp_read_normalize_addresses")) {
+  }
 
   // Close underlying socket if close() hasn't been call yet.
   ~IoSocketHandleImpl() override;
@@ -112,6 +116,8 @@ protected:
   // and IPV6 addresses.
   const size_t cmsg_space_{CMSG_SPACE(sizeof(int)) + CMSG_SPACE(sizeof(struct in_pktinfo)) +
                            CMSG_SPACE(sizeof(struct in6_pktinfo)) + CMSG_SPACE(sizeof(uint16_t))};
+
+  const bool udp_read_normalize_addresses_;
 };
 } // namespace Network
 } // namespace Envoy

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -71,6 +71,7 @@ RUNTIME_GUARD(envoy_reloadable_features_validate_connect);
 RUNTIME_GUARD(envoy_reloadable_features_validate_detailed_override_host_statuses);
 RUNTIME_GUARD(envoy_restart_features_explicit_wildcard_resource);
 RUNTIME_GUARD(envoy_restart_features_remove_runtime_singleton);
+RUNTIME_GUARD(envoy_restart_features_udp_read_normalize_addresses);
 RUNTIME_GUARD(envoy_restart_features_use_apple_api_for_dns_lookups);
 
 // Begin false flags. These should come with a TODO to flip true.

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1695,5 +1695,62 @@ TEST_P(QuicHttpIntegrationTest, UsesPreferredAddress) {
   }
 }
 
+TEST_P(QuicHttpIntegrationTest, UsesPreferredAddressDualStack) {
+  if (!(TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v6) &&
+        version_ == Network::Address::IpVersion::v4)) {
+    return;
+  }
+  // Only run this test with a v4 client if the test environment supports dual stack socket.
+  autonomous_upstream_ = true;
+  config_helper_.addConfigModifier([=](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* listen_address = bootstrap.mutable_static_resources()
+                               ->mutable_listeners(0)
+                               ->mutable_address()
+                               ->mutable_socket_address();
+    // Change listening address to Any. As long as the test environment support IPv6 use [::] as
+    // listening address.
+    listen_address->set_address("::");
+    listen_address->set_ipv4_compat(true);
+    auto* preferred_address_config = bootstrap.mutable_static_resources()
+                                         ->mutable_listeners(0)
+                                         ->mutable_udp_listener_config()
+                                         ->mutable_quic_options()
+                                         ->mutable_server_preferred_address_config();
+    // Configure a loopback interface as the server's preferred address.
+    preferred_address_config->set_name("quic.server_preferred_address.fixed");
+    envoy::extensions::quic::server_preferred_address::v3::FixedServerPreferredAddressConfig
+        server_preferred_address;
+    server_preferred_address.set_ipv4_address("127.0.0.2");
+    preferred_address_config->mutable_typed_config()->PackFrom(server_preferred_address);
+  });
+
+  initialize();
+  quic::QuicTagVector connection_options{quic::kRVCM, quic::kSPAD};
+  dynamic_cast<Quic::PersistentQuicInfoImpl&>(*quic_connection_persistent_info_)
+      .quic_config_.SetConnectionOptionsToSend(connection_options);
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  EnvoyQuicClientSession* quic_session =
+      static_cast<EnvoyQuicClientSession*>(codec_client_->connection());
+  EXPECT_EQ(Network::Test::getLoopbackAddressString(version_),
+            quic_connection_->peer_address().host().ToString());
+  ASSERT_TRUE(quic_session->config()->HasReceivedIPv4AlternateServerAddress());
+  ASSERT_TRUE(quic_connection_->waitForHandshakeDone());
+  EXPECT_TRUE(quic_connection_->IsValidatingServerPreferredAddress());
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"},
+      {":path", "/test/long/url"},
+      {":authority", "sni.lyft.com"},
+      {":scheme", "http"},
+      {AutonomousStream::RESPONSE_SIZE_BYTES, std::to_string(1024 * 1024)}};
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  EXPECT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+
+  EXPECT_EQ("127.0.0.2", quic_connection_->peer_address().host().ToString());
+  test_server_->waitForCounterGe(
+      "listener.[__]_0.quic.connection.num_packets_rx_on_preferred_address", 2u);
+}
+
 } // namespace Quic
 } // namespace Envoy

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1700,6 +1700,7 @@ TEST_P(QuicHttpIntegrationTest, UsesPreferredAddressDualStack) {
         version_ == Network::Address::IpVersion::v4)) {
     return;
   }
+  config_helper_.addRuntimeOverride("envoy.restart_features.udp_read_normalize_addresses", "true");
   // Only run this test with a v4 client if the test environment supports dual stack socket.
   autonomous_upstream_ = true;
   config_helper_.addConfigModifier([=](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {


### PR DESCRIPTION
Commit Message: if a UDP listener is configured with `ipv4_compat: true`, normalize the source address and the destination address from the control message of each incoming packet.

Risk Level: low
Testing: added new dual stack integration test
Docs Changes: N/A
Release Notes: N/A
Runtime guard: envoy.restart_features.udp_read_normalize_addresses
Platform Specific Features: platforms supporting dual stack socket will see packet addresses normalized.