### PR TITLE
ci: Cache build image

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -20,10 +20,17 @@ parameters:
 
 steps:
 - task: Cache@2
+  env:
+    VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: 5
   inputs:
     key: '"${{ parameters.ciTarget }}" | "${{ parameters.artifactSuffix }}" | ./WORKSPACE | **/*.bzl, !mobile/**, !envoy-docs/**'
     path: $(Build.StagingDirectory)/repository_cache
   continueOnError: true
+
+- template: cached.yml
+  parameters:
+    version: "$(buildImageCacheVersion)"
+    arch: "${{ parameters.artifactSuffix }}"
 
 - bash: |
     echo "disk space at beginning of build:"

--- a/.azure-pipelines/cached.yml
+++ b/.azure-pipelines/cached.yml
@@ -1,0 +1,50 @@
+
+parameters:
+- name: name
+  type: string
+  default: envoy_build_image
+- name: version
+  type: string
+  default: ""
+- name: arch
+  type: string
+  default: ""
+- name: key
+  type: string
+  default: ".devcontainer/Dockerfile"
+- name: tmpDirectory
+  type: string
+  default: /mnt/docker_cache
+- name: path
+  type: string
+  default: /mnt/docker
+- name: cacheTimeoutWorkaround
+  type: number
+  default: 5
+- name: prime
+  type: boolean
+  default: false
+
+
+steps:
+- script: sudo .azure-pipelines/docker/prepare_cache.sh "${{ parameters.tmpDirectory }}"
+  displayName: "Cache/prepare (${{ parameters.name }})"
+- task: Cache@2
+  env:
+    VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: "${{ parameters.cacheTimeoutWorkaround }}"
+  displayName: "Cache/fetch ${{ parameters.name }})"
+  inputs:
+    key: '${{ parameters.name }} | "${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.key }}'
+    path: "${{ parameters.tmpDirectory }}"
+    cacheHitVar: CACHE_RESTORED
+
+# Prime the cache for all jobs
+- script: sudo .azure-pipelines/docker/prime_cache.sh "${{ parameters.tmpDirectory }}"
+  displayName: "Cache/prime ${{ parameters.name }})"
+  # TODO(phlax): figure if there is a way to test cache without downloading it
+  condition: and(not(canceled()), eq(${{ parameters.prime }}, true), ne(variables.CACHE_RESTORED, 'true'))
+
+# Load the cache for a job
+- script: sudo .azure-pipelines/docker/load_cache.sh "${{ parameters.tmpDirectory }}" "${{ parameters.path }}"
+  displayName: "Cache/restore (${{ parameters.name }})"
+  condition: and(not(canceled()), eq(${{ parameters.prime }}, false), eq(variables.CACHE_RESTORED, 'true'))

--- a/.azure-pipelines/docker/load_cache.sh
+++ b/.azure-pipelines/docker/load_cache.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+
+DOCKER_CACHE_PATH="$1"
+DOCKER_BIND_PATH="$2"
+
+if [[ -z "$DOCKER_CACHE_PATH" ]]; then
+    echo "load_docker_cache called without path arg" >&2
+    exit 1
+fi
+
+
+DOCKER_CACHE_TARBALL="${DOCKER_CACHE_PATH}/docker.tar.zst"
+
+echo "Stopping Docker daemon ..."
+systemctl stop docker docker.socket
+
+mv /var/lib/docker/ /var/lib/docker.old
+mkdir -p /var/lib/docker
+
+if id -u vsts &> /dev/null && [[ -n "$DOCKER_BIND_PATH" ]]; then
+    # use separate disk on windows hosted
+    echo "Binding docker directory ${DOCKER_BIND_PATH} -> /var/lib/docker ..."
+    mkdir -p "$DOCKER_BIND_PATH"
+    mount -o bind "$DOCKER_BIND_PATH" /var/lib/docker
+else
+    echo "Mounting tmpfs directory -> /var/lib/docker ..."
+    # Use a ramdisk to load docker (avoids Docker slow start on big disk)
+    mount -t tmpfs none /var/lib/docker
+fi
+
+echo "Extracting docker cache ${DOCKER_CACHE_TARBALL} -> /var/lib/docker ..."
+tar -I "zstd -d -T0 " -axf "$DOCKER_CACHE_TARBALL" -C /var/lib/docker
+
+echo "Starting Docker daemon ..."
+systemctl start docker
+
+echo "Unmount cache tmp ${DOCKER_CACHE_PATH} ..."
+umount "${DOCKER_CACHE_PATH}"
+
+docker images
+df -h
+
+# this takes time but may be desirable in some situations
+if [[ -n "$DOCKER_REMOVE_EXISTING" ]]; then
+    rm -rf /var/lib/docker.old
+fi

--- a/.azure-pipelines/docker/prepare_cache.sh
+++ b/.azure-pipelines/docker/prepare_cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+DOCKER_CACHE_PATH="$1"
+DOCKER_CACHE_OWNERSHIP="vsts:vsts"
+
+
+if [[ -z "$DOCKER_CACHE_PATH" ]]; then
+    echo "prepare_docker_cache called without path arg" >&2
+    exit 1
+fi
+
+if ! id -u vsts &> /dev/null; then
+    DOCKER_CACHE_OWNERSHIP=azure-pipelines
+fi
+
+echo "Mounting tmpfs cache directory (${DOCKER_CACHE_PATH}) ..."
+mkdir -p "${DOCKER_CACHE_PATH}"
+mount -t tmpfs none "${DOCKER_CACHE_PATH}"
+chown -R "$DOCKER_CACHE_OWNERSHIP" "${DOCKER_CACHE_PATH}"

--- a/.azure-pipelines/docker/prime_cache.sh
+++ b/.azure-pipelines/docker/prime_cache.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+DOCKER_CACHE_PATH="$1"
+
+if [[ -z "$DOCKER_CACHE_PATH" ]]; then
+    echo "prime_docker_cache called without path arg" >&2
+    exit 1
+fi
+
+DOCKER_CACHE_TARBALL="${DOCKER_CACHE_PATH}/docker.tar.zst"
+
+echo "Stopping Docker ..."
+systemctl stop docker
+
+echo "Restarting Docker with empty /var/lib/docker ..."
+mv /var/lib/docker/ /var/lib/docker.old
+mkdir /var/lib/docker
+systemctl start docker
+
+BUILD_IMAGE=$(head -n1 .devcontainer/Dockerfile  | cut -d: -f2)
+
+echo "Pulling build image (${BUILD_IMAGE}) ..."
+docker pull -q "envoyproxy/envoy-build-ubuntu:${BUILD_IMAGE}"
+
+echo "Stopping docker"
+systemctl stop docker
+
+echo "Exporting /var/lib/docker -> ${DOCKER_CACHE_PATH}"
+mkdir -p "$DOCKER_CACHE_PATH"
+tar -I "zstd -T0 --fast " -acf "$DOCKER_CACHE_TARBALL" -C /var/lib/docker .
+
+echo "Docker cache tarball created: ${DOCKER_CACHE_TARBALL}"
+ls -lh "$DOCKER_CACHE_TARBALL"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -26,6 +26,10 @@ variables:
   # A release branch can be either `main` or a `release/v1.x` stable branch
   value: $[or(eq(variables['isMain'], 'true'), eq(variables['isReleaseBranch'], 'true'))]
 
+# Variable settings
+- name: buildImageCacheVersion
+  value: v0
+
 
 stages:
 # Presubmit

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -65,7 +65,29 @@ stages:
   #
 
   jobs:
+  # Warm build image caches
+  - job: cache
+    displayName: Cache
+    pool:
+      vmImage: "ubuntu-20.04"
+    steps:
+    - template: cached.yml
+      parameters:
+        version: "$(buildImageCacheVersion)"
+        prime: true
+  - job: cache_arm
+    dependsOn: []
+    displayName: Cache (arm64)
+    pool: arm-large
+    steps:
+    - template: cached.yml
+      parameters:
+        prime: true
+        arch: .arm64
+        version: "$(buildImageCacheVersion)"
+
   - job: repo
+    dependsOn: []
     displayName: Repository
     pool:
       vmImage: "ubuntu-20.04"
@@ -161,6 +183,10 @@ stages:
         path: $(Build.StagingDirectory)/repository_cache
       continueOnError: true
 
+    - template: cached.yml
+      parameters:
+        version: "$(buildImageCacheVersion)"
+
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format'
       workingDirectory: $(Build.SourcesDirectory)
       env:
@@ -192,6 +218,10 @@ stages:
         path: $(Build.StagingDirectory)/repository_cache
       continueOnError: true
 
+    - template: cached.yml
+      parameters:
+        version: "$(buildImageCacheVersion)"
+
     - script: ci/run_envoy_docker.sh 'ci/check_and_fix_format.sh'
       workingDirectory: $(Build.SourcesDirectory)
       env:
@@ -222,6 +252,10 @@ stages:
         key: "docs | ./WORKSPACE | **/*.bzl"
         path: $(Build.StagingDirectory)/repository_cache
       continueOnError: true
+
+    - template: cached.yml
+      parameters:
+        version: "$(buildImageCacheVersion)"
 
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh docs'
       workingDirectory: $(Build.SourcesDirectory)
@@ -255,6 +289,10 @@ stages:
         key: "dependencies | ./WORKSPACE | **/*.bzl"
         path: $(Build.StagingDirectory)/repository_cache
       continueOnError: true
+
+    - template: cached.yml
+      parameters:
+        version: "$(buildImageCacheVersion)"
 
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh deps'
       workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
This uses azp cache to store the envoy-build-ubuntu image

To make it work the cache is restored to/from tmpfs 

it also restores to/from `/var/lib/docker` as this was the only way to make it faster

It is slightly faster than just pulling the image from dockerhub

ive tested it quite a bit and its a lot more reliable (when the fix from #26056 is included) and brings down the average CI times by a consistent amount

priming the cache is slow and due to the issue discussed in #26050 it will currently happen on every pr by default, but that is easy to (manually atm) work around

partial fix for #25545 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
