### PR TITLE
envoy: changing a release assert to envoy bug

### DIFF
--- a/source/common/network/socket_interface_impl.cc
+++ b/source/common/network/socket_interface_impl.cc
@@ -98,9 +98,8 @@ IoHandlePtr SocketInterfaceImpl::socket(Socket::Type socket_type,
     // Setting IPV6_V6ONLY restricts the IPv6 socket to IPv6 connections only.
     const Api::SysCallIntResult result = io_handle->setOption(
         IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&v6only), sizeof(v6only));
-    ENVOY_BUG(
-        !SOCKET_FAILURE(result.return_value_),
-        fmt::format("Unable to set socket v6-only: got error: {}", result.return_value_));
+    ENVOY_BUG(!SOCKET_FAILURE(result.return_value_),
+              fmt::format("Unable to set socket v6-only: got error: {}", result.return_value_));
   }
   return io_handle;
 }

--- a/source/common/network/socket_interface_impl.cc
+++ b/source/common/network/socket_interface_impl.cc
@@ -98,9 +98,9 @@ IoHandlePtr SocketInterfaceImpl::socket(Socket::Type socket_type,
     // Setting IPV6_V6ONLY restricts the IPv6 socket to IPv6 connections only.
     const Api::SysCallIntResult result = io_handle->setOption(
         IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char*>(&v6only), sizeof(v6only));
-    RELEASE_ASSERT(
+    ENVOY_BUG(
         !SOCKET_FAILURE(result.return_value_),
-        fmt::format("Unable to set socket non-blocking: got error: {}", result.return_value_));
+        fmt::format("Unable to set socket v6-only: got error: {}", result.return_value_));
   }
   return io_handle;
 }


### PR DESCRIPTION
Failing to set the socket to v6 is no longer a fatal error. Instead it will be an ENVOY_BUG and using the socket (connect) may fail.

Risk Level: low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/24801