### PR TITLE
tcp_proxy: add on-upstream-connected access log flush

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -218,4 +218,7 @@ message TcpProxy {
   // The interval must be at least 1ms.
   google.protobuf.Duration access_log_flush_interval = 15
       [(validate.rules).duration = {gte {nanos: 1000000}}];
+
+  // If set to true, access log will be flushed when the TCP proxy has established connection with the upstream.
+  bool flush_access_log_on_connected = 16;
 }

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -24,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -219,6 +219,7 @@ message TcpProxy {
   google.protobuf.Duration access_log_flush_interval = 15
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 
-  // If set to true, access log will be flushed when the TCP proxy has established connection with the upstream.
+  // If set to true, access log will be flushed when the TCP proxy has successfully established a
+  // connection with the upstream. If the connection failed, the access log will not be flushed.
   bool flush_access_log_on_connected = 16;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -186,8 +186,8 @@ new_features:
     added an option to dynamically disable TCP tunneling even if set in the filter config, by setting a filter state object for the key ``envoy.tcp_proxy.disable_tunneling``.
 - area: tcp_proxy
   change: |
-    add :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>` to allow flushing access log state
-    after a connection has established with the upstream.
+    add :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>` to allow recording an access log entry
+    on the connection open event. This option does not require periodic access logging enabled, and the other way around.
 - area: http
   change: |
     add :ref:`periodic access logging <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -184,6 +184,10 @@ new_features:
 - area: tcp_proxy
   change: |
     added an option to dynamically disable TCP tunneling even if set in the filter config, by setting a filter state object for the key ``envoy.tcp_proxy.disable_tunneling``.
+- area: tcp_proxy
+  change: |
+    add :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>` to allow flushing access log state
+    after a connection has established with the upstream.
 - area: http
   change: |
     add :ref:`periodic access logging <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -22,9 +22,10 @@ filter access logs.
 Periodic access logs
 --------------------
 
-If access log is enabled, then by default it will be flushed to the configured sinks at the end of a TCP
-stream, or HTTP request. It is possible to extend this behavior and flush access logs periodically, and
-at the beginning of a TCP stream.
+If access log is enabled, then by default it will be reported to the configured sinks at the end of a TCP
+stream, or HTTP request. It is possible to extend this behavior and report  access logs periodically, and
+right after the TCP Proxy has successfully established a connection with the upstream. Reporting access logs
+right after upstream connection establishment does not depend on periodic reporting, and and the other way around.
 
 TCP Proxy
 *********

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -29,13 +29,13 @@ at the beginning of a TCP stream.
 TCP Proxy
 *********
 
-* Periodic access logs can be anbled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.access_log_flush_interval>`
+* Periodic access logs can be enabled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.access_log_flush_interval>`
 * Access log after upstream connection can be enabled using :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>`
 
 HTTP Connection Manager
 ***********************
 
-* Periodic access logs can be anbled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`
+* Periodic access logs can be enabled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`
 
 .. _arch_overview_access_log_filters:
 

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -17,6 +17,26 @@ logs<envoy_v3_api_field_config.listener.v3.Listener.access_log>`. The listener a
 HTTP request access logging and can be enabled separately and independently from
 filter access logs.
 
+.. _arch_overview_access_log_periodic:
+
+Periodic access logs
+--------------------
+
+If access log is enabled, then by default it will be flushed to the configured sinks at the end of a TCP
+stream, or HTTP request. It is possible to extend this behavior and flush access logs periodically, and
+at the beginning of a TCP stream.
+
+TCP Proxy
+*********
+
+* Periodic access logs can be anbled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.access_log_flush_interval>`
+* Access log after upstream connection can be enabled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>`
+
+HTTP Connection Manager
+*********
+
+* Periodic access logs can be anbled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`
+
 .. _arch_overview_access_log_filters:
 
 Access log filters

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -33,7 +33,7 @@ TCP Proxy
 * Access log after upstream connection can be enabled using :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>`
 
 HTTP Connection Manager
-*********
+***********************
 
 * Periodic access logs can be anbled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`
 

--- a/docs/root/intro/arch_overview/observability/access_logging.rst
+++ b/docs/root/intro/arch_overview/observability/access_logging.rst
@@ -30,7 +30,7 @@ TCP Proxy
 *********
 
 * Periodic access logs can be anbled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.access_log_flush_interval>`
-* Access log after upstream connection can be enabled using :ref:`access log flush interval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>`
+* Access log after upstream connection can be enabled using :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>`
 
 HTTP Connection Manager
 *********

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -310,9 +310,7 @@ public:
   // This function must not be called if on demand is disabled.
   const OnDemandStats& onDemandStats() const { return shared_config_->onDemandConfig()->stats(); }
   Random::RandomGenerator& randomGenerator() { return random_generator_; }
-  bool flushAccessLogOnConnected() const {
-    return shared_config_->flushAccessLogOnConnected();
-  }
+  bool flushAccessLogOnConnected() const { return shared_config_->flushAccessLogOnConnected(); }
 
 private:
   struct SimpleRouteImpl : public Route {

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -222,7 +222,7 @@ public:
                  Server::Configuration::FactoryContext& context);
     const TcpProxyStats& stats() { return stats_; }
     const absl::optional<std::chrono::milliseconds>& idleTimeout() { return idle_timeout_; }
-    const bool& flushAccessLogOnConnected() const { return flush_access_log_on_connected_; }
+    const bool flushAccessLogOnConnected() const { return flush_access_log_on_connected_; }
     const absl::optional<std::chrono::milliseconds>& maxDownstreamConnectionDuration() const {
       return max_downstream_connection_duration_;
     }
@@ -310,7 +310,7 @@ public:
   // This function must not be called if on demand is disabled.
   const OnDemandStats& onDemandStats() const { return shared_config_->onDemandConfig()->stats(); }
   Random::RandomGenerator& randomGenerator() { return random_generator_; }
-  const bool& flushAccessLogOnConnected() const {
+  const bool flushAccessLogOnConnected() const {
     return shared_config_->flushAccessLogOnConnected();
   }
 

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -222,7 +222,7 @@ public:
                  Server::Configuration::FactoryContext& context);
     const TcpProxyStats& stats() { return stats_; }
     const absl::optional<std::chrono::milliseconds>& idleTimeout() { return idle_timeout_; }
-    const bool flushAccessLogOnConnected() const { return flush_access_log_on_connected_; }
+    bool flushAccessLogOnConnected() const { return flush_access_log_on_connected_; }
     const absl::optional<std::chrono::milliseconds>& maxDownstreamConnectionDuration() const {
       return max_downstream_connection_duration_;
     }
@@ -310,7 +310,7 @@ public:
   // This function must not be called if on demand is disabled.
   const OnDemandStats& onDemandStats() const { return shared_config_->onDemandConfig()->stats(); }
   Random::RandomGenerator& randomGenerator() { return random_generator_; }
-  const bool flushAccessLogOnConnected() const {
+  bool flushAccessLogOnConnected() const {
     return shared_config_->flushAccessLogOnConnected();
   }
 

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -222,6 +222,7 @@ public:
                  Server::Configuration::FactoryContext& context);
     const TcpProxyStats& stats() { return stats_; }
     const absl::optional<std::chrono::milliseconds>& idleTimeout() { return idle_timeout_; }
+    const bool& flushAccessLogOnConnected() const { return flush_access_log_on_connected_; }
     const absl::optional<std::chrono::milliseconds>& maxDownstreamConnectionDuration() const {
       return max_downstream_connection_duration_;
     }
@@ -241,9 +242,6 @@ public:
       } else {
         return {};
       }
-    }
-    const bool& flushAccessLogOnConnected() const {
-      return flush_access_log_on_connected_;
     }
 
   private:

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -242,6 +242,9 @@ public:
         return {};
       }
     }
+    const bool& flushAccessLogOnConnected() const {
+      return flush_access_log_on_connected_;
+    }
 
   private:
     static TcpProxyStats generateStats(Stats::Scope& scope);
@@ -251,6 +254,7 @@ public:
     const Stats::ScopeSharedPtr stats_scope_;
 
     const TcpProxyStats stats_;
+    const bool flush_access_log_on_connected_;
     absl::optional<std::chrono::milliseconds> idle_timeout_;
     absl::optional<std::chrono::milliseconds> max_downstream_connection_duration_;
     absl::optional<std::chrono::milliseconds> access_log_flush_interval_;
@@ -308,6 +312,9 @@ public:
   // This function must not be called if on demand is disabled.
   const OnDemandStats& onDemandStats() const { return shared_config_->onDemandConfig()->stats(); }
   Random::RandomGenerator& randomGenerator() { return random_generator_; }
+  const bool& flushAccessLogOnConnected() const {
+    return shared_config_->flushAccessLogOnConnected();
+  }
 
 private:
   struct SimpleRouteImpl : public Route {

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -979,6 +979,19 @@ TEST_F(TcpProxyTest, IntermediateLogEntry) {
   filter_.reset();
 }
 
+TEST_F(TcpProxyTest, TestAccessLogOnUpstreamConnected) {
+  auto config = accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%");
+  config.set_flush_access_log_on_connected(true);
+
+  setup(1, config);
+  raiseEventUpstreamConnected(0);
+
+  EXPECT_EQ(access_log_data_, "127.0.0.1:80 observability_name");
+
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  filter_.reset();
+}
+
 TEST_F(TcpProxyTest, AccessLogUpstreamSSLConnection) {
   setup(1);
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -986,6 +986,9 @@ TEST_F(TcpProxyTest, TestAccessLogOnUpstreamConnected) {
   setup(1, config);
   raiseEventUpstreamConnected(0);
 
+  // Default access log will only be flushed after the stream is closed.
+  // Passing the following check makes sure that the access log was flushed
+  // before the stream was closed.
   EXPECT_EQ(access_log_data_, "127.0.0.1:80");
 
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -980,13 +980,13 @@ TEST_F(TcpProxyTest, IntermediateLogEntry) {
 }
 
 TEST_F(TcpProxyTest, TestAccessLogOnUpstreamConnected) {
-  auto config = accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%");
+  auto config = accessLogConfig("%UPSTREAM_HOST%");
   config.set_flush_access_log_on_connected(true);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);
 
-  EXPECT_EQ(access_log_data_, "127.0.0.1:80 observability_name");
+  EXPECT_EQ(access_log_data_, "127.0.0.1:80");
 
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
   filter_.reset();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -547,6 +547,54 @@ TEST_P(TcpProxyIntegrationTest, AccessLogUpstreamConnectFailure) {
   EXPECT_THAT(log_result, testing::StartsWith("delayed_connect_error:"));
 }
 
+TEST_P(TcpProxyIntegrationTest, AccessLogOnUpstreamConnect) {
+  std::string access_log_path = TestEnvironment::temporaryPath(
+      fmt::format("access_log{}{}.txt", version_ == Network::Address::IpVersion::v4 ? "v4" : "v6",
+                  TestUtility::uniqueFilename()));
+
+  setupByteMeterAccessLog();
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+    auto* filter_chain = listener->mutable_filter_chains(0);
+    auto* config_blob = filter_chain->mutable_filters(0)->mutable_typed_config();
+
+    ASSERT_TRUE(config_blob->Is<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>());
+    auto tcp_proxy_config =
+        MessageUtil::anyConvert<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+            *config_blob);
+
+    tcp_proxy_config.set_flush_access_log_on_connected(true);
+    auto* access_log = tcp_proxy_config.add_access_log();
+    access_log->set_name("accesslog");
+    envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
+    access_log_config.set_path(access_log_path);
+    access_log_config.mutable_log_format()->mutable_text_format_source()->set_inline_string(
+                "DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%");
+    access_log->mutable_typed_config()->PackFrom(access_log_config);
+    config_blob->PackFrom(tcp_proxy_config);
+  });
+
+  const std::string ip_regex =
+      (version_ == Network::Address::IpVersion::v4) ? R"EOF(127\.0\.0\.1)EOF" : R"EOF(::1)EOF";
+
+  initialize();
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
+  ASSERT_TRUE(tcp_client->write("hello"));
+  FakeRawConnectionPtr fake_upstream_connection;
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  auto log_result = waitForAccessLog(access_log_path);
+  EXPECT_THAT(log_result, MatchesRegex(fmt::format("DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT={}", ip_regex)));
+
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+  ASSERT_TRUE(tcp_client->write("", true));
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
+  ASSERT_TRUE(fake_upstream_connection->write("", true));
+  ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
+  tcp_client->waitForDisconnect();
+  test_server_.reset();
+}
+
 // Make sure no bytes are logged when no data is sent.
 TEST_P(TcpProxyIntegrationTest, TcpProxyNoDataBytesMeter) {
   setupByteMeterAccessLog();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -569,7 +569,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLogOnUpstreamConnect) {
     envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
     access_log_config.set_path(access_log_path);
     access_log_config.mutable_log_format()->mutable_text_format_source()->set_inline_string(
-                "DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%");
+        "DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%");
     access_log->mutable_typed_config()->PackFrom(access_log_config);
     config_blob->PackFrom(tcp_proxy_config);
   });
@@ -584,7 +584,8 @@ TEST_P(TcpProxyIntegrationTest, AccessLogOnUpstreamConnect) {
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
   auto log_result = waitForAccessLog(access_log_path);
-  EXPECT_THAT(log_result, MatchesRegex(fmt::format("DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT={}", ip_regex)));
+  EXPECT_THAT(log_result,
+              MatchesRegex(fmt::format("DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT={}", ip_regex)));
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(5));
   ASSERT_TRUE(tcp_client->write("", true));


### PR DESCRIPTION
Commit Message: Add on-upstream-connected access log flush for TCP Proxy.
Additional Description:  None
Risk Level: Low
Testing: Unit test, integration tests
Docs Changes: Access logs
Release Notes: None
Platform Specific Features: None

Resolves #26058