### PR TITLE
cleanup: use ProtobufWkt::BoolValue instead of Protobuf::BoolValue

### DIFF
--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -637,7 +637,7 @@ TEST(HttpUtility, ValidateStreamErrorConfigurationForHttp1) {
 
 TEST(HttpUtility, UseBalsaParser) {
   envoy::config::core::v3::Http1ProtocolOptions http1_options;
-  Protobuf::BoolValue hcm_value;
+  ProtobufWkt::BoolValue hcm_value;
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
 
   // If Http1ProtocolOptions::use_balsa_parser has no value set, then behavior is controlled by the


### PR DESCRIPTION
BoolValue is a protobuf "Well known type" so should be referenced via the ProtobufWkt namespace not Protobuf.

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A