### PR TITLE
test: waiting for the upstream connection disconnected before invoke EXPECT_LOG_CONTAINS

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -1582,6 +1582,7 @@ TEST_P(ListenerFilterIntegrationTest,
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
   ASSERT_TRUE(fake_upstream_connection->waitForData(data.size(), &data));
   tcp_client->close();
+  ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
 
   auto* socket_option = listener_config_.add_socket_options();
   socket_option->set_level(IPPROTO_IP);

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -1598,15 +1598,14 @@ TEST_P(ListenerFilterIntegrationTest,
       {
         sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "2");
         test_server_->waitForCounterGe("listener_manager.lds.update_rejected", 1);
+        IntegrationTcpClientPtr tcp_client2 = makeTcpConnection(lookupPort("test_listener"));
+        ASSERT_TRUE(tcp_client2->write(data));
+        FakeRawConnectionPtr fake_upstream_connection2;
+        ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
+        ASSERT_TRUE(fake_upstream_connection2->waitForData(data.size(), &data));
+        tcp_client2->close();
+        ASSERT_TRUE(fake_upstream_connection2->waitForDisconnect());
       });
-
-  IntegrationTcpClientPtr tcp_client2 = makeTcpConnection(lookupPort("test_listener"));
-  ASSERT_TRUE(tcp_client2->write(data));
-  FakeRawConnectionPtr fake_upstream_connection2;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
-  ASSERT_TRUE(fake_upstream_connection2->waitForData(data.size(), &data));
-  tcp_client2->close();
-  ASSERT_TRUE(fake_upstream_connection2->waitForDisconnect());
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsAndGrpcTypes, ListenerFilterIntegrationTest,

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -1598,14 +1598,15 @@ TEST_P(ListenerFilterIntegrationTest,
       {
         sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "2");
         test_server_->waitForCounterGe("listener_manager.lds.update_rejected", 1);
-        IntegrationTcpClientPtr tcp_client2 = makeTcpConnection(lookupPort("test_listener"));
-        ASSERT_TRUE(tcp_client2->write(data));
-        FakeRawConnectionPtr fake_upstream_connection2;
-        ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
-        ASSERT_TRUE(fake_upstream_connection2->waitForData(data.size(), &data));
-        tcp_client2->close();
-        ASSERT_TRUE(fake_upstream_connection2->waitForDisconnect());
       });
+
+  IntegrationTcpClientPtr tcp_client2 = makeTcpConnection(lookupPort("test_listener"));
+  ASSERT_TRUE(tcp_client2->write(data));
+  FakeRawConnectionPtr fake_upstream_connection2;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
+  ASSERT_TRUE(fake_upstream_connection2->waitForData(data.size(), &data));
+  tcp_client2->close();
+  ASSERT_TRUE(fake_upstream_connection2->waitForDisconnect());
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsAndGrpcTypes, ListenerFilterIntegrationTest,


### PR DESCRIPTION
Commit Message: test: waiting for the upstream connection disconnected before invoke EXPECT_LOG_CONTAINS 
Additional Description:
There is a race when `EXPECT_LOG_CONTAINS` invoke `Envoy::Logger::DelegatingLogSink::setShouldEscape(bool)` in the main test thread and the FakeUpstreamConnection will invoke `Envoy::Logger::DelegatingLogSink::setShouldEscape(bool)` in their own thread also.

So this PR will wait for the FakeUpstreamConnection disconnect first, then invoke the `EXPECT_LOG_CONTAINS`


Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #26082
