### PR TITLE
test: fix the race of release read filter in FakeRawConnection

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -872,7 +872,7 @@ void FakeUpstream::FakeListenSocketFactory::doFinalPreWorkerInit() {
 FakeRawConnection::~FakeRawConnection() {
   // If the filter was already deleted, it means the shared_connection_ was too, so don't try to
   // access it.
-  if (read_filter_ != nullptr) {
+  if (read_filter_ != nullptr && read_filter_.use_count() == 1) {
     EXPECT_TRUE(shared_connection_.executeOnDispatcher(
         [filter = std::move(read_filter_)](Network::Connection& connection) {
           connection.removeReadFilter(filter);

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -872,7 +872,7 @@ void FakeUpstream::FakeListenSocketFactory::doFinalPreWorkerInit() {
 FakeRawConnection::~FakeRawConnection() {
   // If the filter was already deleted, it means the shared_connection_ was too, so don't try to
   // access it.
-  if (read_filter_ != nullptr && read_filter_.use_count() > 1) {
+  if (read_filter_ != nullptr) {
     EXPECT_TRUE(shared_connection_.executeOnDispatcher(
         [filter = std::move(read_filter_)](Network::Connection& connection) {
           connection.removeReadFilter(filter);

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -872,7 +872,7 @@ void FakeUpstream::FakeListenSocketFactory::doFinalPreWorkerInit() {
 FakeRawConnection::~FakeRawConnection() {
   // If the filter was already deleted, it means the shared_connection_ was too, so don't try to
   // access it.
-  if (read_filter_ != nullptr && read_filter_.use_count() == 1) {
+  if (read_filter_ != nullptr && read_filter_.use_count() > 1) {
     EXPECT_TRUE(shared_connection_.executeOnDispatcher(
         [filter = std::move(read_filter_)](Network::Connection& connection) {
           connection.removeReadFilter(filter);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -597,7 +597,7 @@ private:
   };
 
   std::string data_ ABSL_GUARDED_BY(lock_);
-  std::weak_ptr<Network::ReadFilter> read_filter_;
+  std::shared_ptr<Network::ReadFilter> read_filter_;
 };
 
 using FakeRawConnectionPtr = std::unique_ptr<FakeRawConnection>;


### PR DESCRIPTION
Commit Message: test: fix the race of release read filter in FakeRawConnection
Additional Description:
There is a race when the destructor of FakeRawConnection is invoked in the test main thread.

The shared ptr of `FakeRawConnection::read_filter_` will be released both in the test main thread and upstream connection's own thread by calling `removeReadFilter`.

This PR just use the shared ptr for `FakeRawConnection::read_filter_`, then after the read_filter_ move into the lambda, there will be no release work for the read_filter in the test main thread anymore.

Risk Level: low
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes part of #26082


