### PR TITLE
core: log caught exceptions

### DIFF
--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -610,11 +610,10 @@ static void ios_track_event(envoy_map map, const void *context) {
 - (void)logException:(NSException *)exception {
   NSLog(@"[Envoy] exception caught: %@", exception);
 
-  NSString *message = [NSString stringWithFormat:@"%@;%@;%@",
-                       exception.name, exception.reason, exception.callStackSymbols.description];
-  ENVOY_LOG_EVENT_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::misc),
-                            error, "handled_cxx_exception",
-                            [message UTF8String]);
+  NSString *message = [NSString stringWithFormat:@"%@;%@;%@", exception.name, exception.reason,
+                                                 exception.callStackSymbols.description];
+  ENVOY_LOG_EVENT_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::misc), error,
+                            "handled_cxx_exception", [message UTF8String]);
 
   [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:exception];
 }

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -615,7 +615,8 @@ static void ios_track_event(envoy_map map, const void *context) {
   ENVOY_LOG_EVENT_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::misc), error,
                             "handled_cxx_exception", [message UTF8String]);
 
-  [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:exception];
+  [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyHandledCXXException"
+                                                    object:exception];
 }
 
 @end

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -616,7 +616,7 @@ static void ios_track_event(envoy_map map, const void *context) {
                             error, "handled_cxx_exception",
                             [message UTF8String]);
 
-  [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:self];
+  [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:exception];
 }
 
 @end

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -530,8 +530,7 @@ static void ios_track_event(envoy_map map, const void *context) {
     options->setConcurrency(1);
     return reinterpret_cast<Envoy::Engine *>(_engineHandle)->run(std::move(options));
   } @catch (NSException *exception) {
-    NSLog(@"[Envoy] exception caught: %@", exception);
-    [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:self];
+    [self logException:exception];
     return kEnvoyFailure;
   }
 }
@@ -545,8 +544,7 @@ static void ios_track_event(envoy_map map, const void *context) {
   @try {
     return (int)run_engine(_engineHandle, yaml.UTF8String, logLevel.UTF8String, "");
   } @catch (NSException *exception) {
-    NSLog(@"[Envoy] exception caught: %@", exception);
-    [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:self];
+    [self logException:exception];
     return kEnvoyFailure;
   }
 }
@@ -607,6 +605,18 @@ static void ios_track_event(envoy_map map, const void *context) {
 - (void)terminateNotification:(NSNotification *)notification {
   NSLog(@"[Envoy %ld] terminating engine (%@)", _engineHandle, notification.name);
   terminate_engine(_engineHandle, /* release */ false);
+}
+
+- (void)logException:(NSException *)exception {
+  NSLog(@"[Envoy] exception caught: %@", exception);
+
+  NSString *message = [NSString stringWithFormat:@"%@;%@;%@",
+                       exception.name, exception.reason, exception.callStackSymbols.description];
+  ENVOY_LOG_EVENT_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::misc),
+                            error, "handled_cxx_exception",
+                            [message UTF8String]);
+
+  [NSNotificationCenter.defaultCenter postNotificationName:@"EnvoyError" object:self];
 }
 
 @end


### PR DESCRIPTION
Commit Message: https://github.com/envoyproxy/envoy/pull/26010 replaces obj-c with Swift. Swift interop with C++ does not support all c++ features: all uncaught c++ exceptions become UB in Swift. Adding logging of C++ exceptions to see whether we have any. If yes, we may need to rethink whether we want to migrate to Swift.
Additional Description:
Risk Level: Low
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
