### PR TITLE
ci: Fix bazel invokation for dockerhub README

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -648,12 +648,12 @@ stages:
       displayName: "Generate docs"
 
     - script: |
-        ci/run_envoy_docker.sh 'bazel run //tools/distribution:update_dockerhub_repository'
+        bazel run //tools/distribution:update_dockerhub_repository
       displayName: "Publish Dockerhub description and README"
       env:
         DOCKERHUB_USERNAME: $(DockerUsername)
         DOCKERHUB_PASSWORD: $(DockerPassword)
-      condition: eq(variables['isMain'], 'true')
+      condition: and(eq(variables['isMain'], 'true'), eq(variables['PostSubmit'], true))
 
     - script: |
         ci/run_envoy_docker.sh 'ci/upload_gcs_artifact.sh /source/generated/docs docs'


### PR DESCRIPTION
moves the `bazel` call of of `run_envoy_docker` as the env vars are not accessible there

also fixes a case where CI is run manually on presubmit

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
