### PR TITLE
listener filters: improve logging levels

### DIFF
--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -50,7 +50,7 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
 }
 
 Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
-  ENVOY_LOG(debug, "http inspector: new connection accepted");
+  ENVOY_LOG(trace, "http inspector: new connection accepted");
 
   const Network::ConnectionSocket& socket = cb.socket();
 
@@ -136,7 +136,7 @@ void Filter::done(bool success) {
       // TODO(yxue): use detected protocol from http inspector and support h2c token in HCM
       protocol = Http::Utility::AlpnNames::get().Http2c;
     }
-    ENVOY_LOG(trace, "http inspector: set application protocol to {}", protocol);
+    ENVOY_LOG(debug, "http inspector: set application protocol to {}", protocol);
 
     cb_->socket().setRequestedApplicationProtocols({protocol});
   } else {

--- a/source/extensions/filters/listener/original_dst/original_dst.cc
+++ b/source/extensions/filters/listener/original_dst/original_dst.cc
@@ -17,7 +17,7 @@ Network::Address::InstanceConstSharedPtr OriginalDstFilter::getOriginalDst(Netwo
 }
 
 Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbacks& cb) {
-  ENVOY_LOG(debug, "original_dst: new connection accepted");
+  ENVOY_LOG(trace, "original_dst: new connection accepted");
   Network::ConnectionSocket& socket = cb.socket();
 
   if (socket.addressType() == Network::Address::Type::Ip) {
@@ -63,7 +63,7 @@ Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbac
         }
       }
 #endif
-      ENVOY_LOG(trace, "original_dst: set destination to {}", original_local_address->asString());
+      ENVOY_LOG(debug, "original_dst: set destination to {}", original_local_address->asString());
 
       // Restore the local address to the original one.
       socket.connectionInfoProvider().restoreLocalAddress(original_local_address);

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -83,7 +83,7 @@ Filter::Filter(const ConfigSharedPtr& config) : config_(config), ssl_(config_->n
 }
 
 Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
-  ENVOY_LOG(debug, "tls inspector: new connection accepted");
+  ENVOY_LOG(trace, "tls inspector: new connection accepted");
   cb_ = &cb;
 
   return Network::FilterStatus::StopIteration;


### PR DESCRIPTION
Currently, we have a generic "new connection accepted" at debug level, but "set to {}" at trace. This ends up being the inversion of what we typically want; we know any new connection will call the listener filter, but what is interesting is knowing the result.

This PR simply inverts the scopes, so we have the same amount of logs at `debug` but get more information.

Before this PR, a typical log would look like:

```
{"level":"debug","msg":"original_dst: new connection accepted"}
{"level":"trace","msg":"original_dst: set destination to 1.2.3.4:80"}
```

Inverting this will have a big impact for us, as folks usually send us `debug` level logs, which skips this critical bit of info


Commit Message: listener filters: improve logging levels
Additional Description:
Risk Level: LOW
Testing: NONE
Docs Changes: NONE
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
