### PR TITLE
mobile: add `useSwiftBootstrap(...)` option to Swift engine builder

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -39,6 +39,9 @@ build --copt -Wno-deprecated-declarations
 
 build:rules_xcodeproj --config=ios
 build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0
+build:rules_xcodeproj --features=-swift.use_global_index_store
+build:rules_xcodeproj --define=admin_functionality=enabled
+build:rules_xcodeproj --define envoy_mobile_listener=enabled
 
 # The defaults are JDK 11 on newer versions of Bazel
 build --java_runtime_version=remotejdk_11

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -39,9 +39,6 @@ build --copt -Wno-deprecated-declarations
 
 build:rules_xcodeproj --config=ios
 build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0
-build:rules_xcodeproj --features=-swift.use_global_index_store
-build:rules_xcodeproj --define=admin_functionality=enabled
-build:rules_xcodeproj --define envoy_mobile_listener=enabled
 
 # The defaults are JDK 11 on newer versions of Bazel
 build --java_runtime_version=remotejdk_11

--- a/mobile/BUILD
+++ b/mobile/BUILD
@@ -147,6 +147,12 @@ xcodeproj(
             ]),
         ),
         xcode_schemes.scheme(
+            name = "Swift C++ Interop Tests",
+            test_action = xcode_schemes.test_action([
+                "//test/swift/cxx:test",
+            ]),
+        ),
+        xcode_schemes.scheme(
             name = "Objective-C Library",
             build_action = xcode_schemes.build_action(["//library/objective-c:envoy_engine_objc_lib"]),
             test_action = xcode_schemes.test_action(["//test/objective-c:envoy_bridge_utility_test"]),
@@ -171,6 +177,7 @@ xcodeproj(
         # Tests
         "//experimental/swift:quic_stream_test",
         "//test/objective-c:envoy_bridge_utility_test",
+        "//test/swift/cxx:test",
         "//test/swift/integration:test",
         "//test/swift/stats:test",
         "//test/swift:test",

--- a/mobile/bazel/apple.bzl
+++ b/mobile/bazel/apple.bzl
@@ -76,3 +76,15 @@ def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = [], visibili
         visibility = visibility,
         flaky = flaky,
     )
+
+def envoy_mobile_swift_copts(enable_cxx_interop):
+    if enable_cxx_interop:
+        return [
+            "-enable-experimental-cxx-interop",
+            "-Xcc",
+            "-std=c++17",
+            "-Xcc",
+            "-Wno-deprecated-declarations",
+        ]
+    else:
+        return []

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -46,8 +46,8 @@ Features:
 - api: Add support for Native Filters and Platform Filters to the C++ EngineBuilder. (:issue:`#2498 <2498>`)
 - api: added upstream protocol to final stream intel. (:issue:`#2613 <2613>`)
 - build: Add a build feature ``exclude_certificates`` to disable inclusion of the Envoy Mobile certificate list, for use when using platform certificate validation.
-- swift: Switch to a new Swift implementation of generating the Envoy bootstrap that replaces the previous Objective-C implementation.
-  This can be disabled by setting ``useSwiftBootstrap(false)`` or building with ``--define=envoy_mobile_swift_cxx_interop=disabled``. (:issue:`#26111 <26111>`)
+- swift: Add a new Swift implementation of generating the Envoy bootstrap that replaces the previous Objective-C implementation.
+  This can be enabled by setting ``useSwiftBootstrap(true)`` and requires building with ``--define=envoy_mobile_swift_cxx_interop=enabled``. (:issue:`#26111 <26111>`)
 
 0.5.0 (September 2, 2022)
 ===========================

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -46,6 +46,8 @@ Features:
 - api: Add support for Native Filters and Platform Filters to the C++ EngineBuilder. (:issue:`#2498 <2498>`)
 - api: added upstream protocol to final stream intel. (:issue:`#2613 <2613>`)
 - build: Add a build feature ``exclude_certificates`` to disable inclusion of the Envoy Mobile certificate list, for use when using platform certificate validation.
+- swift: Switch to a new Swift implementation of generating the Envoy bootstrap that replaces the previous Objective-C implementation.
+  This can be disabled by setting ``useSwiftBootstrap(false)`` or building with ``--define=envoy_mobile_swift_cxx_interop=disabled``. (:issue:`#26011 <26011>`)
 
 0.5.0 (September 2, 2022)
 ===========================

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -47,7 +47,7 @@ Features:
 - api: added upstream protocol to final stream intel. (:issue:`#2613 <2613>`)
 - build: Add a build feature ``exclude_certificates`` to disable inclusion of the Envoy Mobile certificate list, for use when using platform certificate validation.
 - swift: Switch to a new Swift implementation of generating the Envoy bootstrap that replaces the previous Objective-C implementation.
-  This can be disabled by setting ``useSwiftBootstrap(false)`` or building with ``--define=envoy_mobile_swift_cxx_interop=disabled``. (:issue:`#26011 <26011>`)
+  This can be disabled by setting ``useSwiftBootstrap(false)`` or building with ``--define=envoy_mobile_swift_cxx_interop=disabled``. (:issue:`#26111 <26111>`)
 
 0.5.0 (September 2, 2022)
 ===========================

--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -57,6 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *nodeRegion;
 @property (nonatomic, strong, nullable) NSString *nodeZone;
 @property (nonatomic, strong, nullable) NSString *nodeSubZone;
+@property (nonatomic, assign) intptr_t bootstrapPointer;
+
 /**
  Create a new instance of the configuration.
  */

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -176,6 +176,7 @@
   self.nodeRegion = nodeRegion;
   self.nodeZone = nodeZone;
   self.nodeSubZone = nodeSubZone;
+  self.bootstrapPointer = 0;
 
   return self;
 }

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -515,7 +515,14 @@ static void ios_track_event(envoy_map map, const void *context) {
 }
 
 - (int)runWithConfig:(EnvoyConfiguration *)config logLevel:(NSString *)logLevel {
-  auto bootstrap = [config generateBootstrap];
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap;
+  if (config.bootstrapPointer > 0) {
+    bootstrap = absl::WrapUnique(
+        reinterpret_cast<envoy::config::bootstrap::v3::Bootstrap *>(config.bootstrapPointer));
+  } else {
+    bootstrap = [config generateBootstrap];
+  }
+
   if (bootstrap == nullptr) {
     return kEnvoyFailure;
   }

--- a/mobile/library/swift/BUILD
+++ b/mobile/library/swift/BUILD
@@ -1,3 +1,4 @@
+load("//bazel:apple.bzl", "envoy_mobile_swift_copts")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("//bazel:swift_header_collector.bzl", "swift_header_collector")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_xcframework")
@@ -75,15 +76,19 @@ swift_library(
         "stats/Element.swift",
         "stats/Tags.swift",
         "stats/TagsBuilder.swift",
-    ] + ["@envoy_mobile_extra_swift_sources//:extra_swift_srcs"],
-    copts = select({
+    ] + [
+        "@envoy_mobile_extra_swift_sources//:extra_swift_srcs",
+    ] + select({
         "//bazel:envoy_mobile_swift_cxx_interop": [
-            "-enable-experimental-cxx-interop",
-            "-Xcc",
-            "-std=c++17",
-            "-Xcc",
-            "-Wno-deprecated-declarations",
+            "cxx/Bootstrap.swift",
+            "cxx/DirectResponse+Cxx.swift",
+            "cxx/LogLevel+Cxx.swift",
+            "cxx/Swift+Cxx.swift",
         ],
+        "//conditions:default": [],
+    }),
+    copts = select({
+        "//bazel:envoy_mobile_swift_cxx_interop": envoy_mobile_swift_copts(True),
         "//conditions:default": [],
     }),
     defines = envoy_mobile_defines("@envoy"),
@@ -96,7 +101,12 @@ swift_library(
     private_deps = [
         "//library/objective-c:envoy_engine_objc_lib",
         "@envoy_mobile_extra_swift_sources//:extra_private_dep",
-    ],
+    ] + select({
+        "//bazel:envoy_mobile_swift_cxx_interop": [
+            "//library/swift/EnvoyCxxSwiftInterop:EnvoyCxxSwiftInterop",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -73,11 +73,7 @@ open class EngineBuilder: NSObject {
   private var nodeRegion: String?
   private var nodeZone: String?
   private var nodeSubZone: String?
-#if canImport(EnvoyCxxSwiftInterop)
-  private(set) var useSwiftBootstrap = true
-#else
-  private(set) var useSwiftBootstrap = false
-#endif
+  private var enableSwiftBootstrap = false
 
   // MARK: - Public
 
@@ -642,13 +638,13 @@ open class EngineBuilder: NSObject {
   /// Use Swift's experimental C++ interop support to generate the bootstrap object
   /// instead of going through the Objective-C layer.
   ///
-  /// - parameter useSwiftBootstrap: Whether or not to use the Swift / C++ interop
-  ///                                to generate the bootstrap object.
+  /// - parameter enableSwiftBootstrap: Whether or not to use the Swift / C++ interop
+  ///                                   to generate the bootstrap object.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func useSwiftBootstrap(_ useSwiftBootstrap: Bool) -> Self {
-    self.useSwiftBootstrap = useSwiftBootstrap
+  public func enableSwiftBootstrap(_ enableSwiftBootstrap: Bool) -> Self {
+    self.enableSwiftBootstrap = enableSwiftBootstrap
     return self
   }
 #endif
@@ -664,7 +660,7 @@ open class EngineBuilder: NSObject {
                                       networkMonitoringMode: Int32(self.monitoringMode.rawValue))
     let config = self.makeConfig()
 #if canImport(EnvoyCxxSwiftInterop)
-    if self.useSwiftBootstrap {
+    if self.enableSwiftBootstrap {
       config.bootstrapPointer = self.generateBootstrap().pointer
     }
 #endif

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -1,5 +1,10 @@
+#if canImport(EnvoyCxxSwiftInterop)
+@_implementationOnly import EnvoyCxxSwiftInterop
+#endif
 @_implementationOnly import EnvoyEngine
 import Foundation
+
+// swiftlint:disable file_length
 
 /// Builder used for creating and running a new Engine instance.
 @objcMembers
@@ -68,6 +73,11 @@ open class EngineBuilder: NSObject {
   private var nodeRegion: String?
   private var nodeZone: String?
   private var nodeSubZone: String?
+#if canImport(EnvoyCxxSwiftInterop)
+  private(set) var useSwiftBootstrap = true
+#else
+  private(set) var useSwiftBootstrap = false
+#endif
 
   // MARK: - Public
 
@@ -628,6 +638,21 @@ open class EngineBuilder: NSObject {
   }
 #endif
 
+#if canImport(EnvoyCxxSwiftInterop)
+  /// Use Swift's experimental C++ interop support to generate the bootstrap object
+  /// instead of going through the Objective-C layer.
+  ///
+  /// - parameter useSwiftBootstrap: Whether or not to use the Swift / C++ interop
+  ///                                to generate the bootstrap object.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func useSwiftBootstrap(_ useSwiftBootstrap: Bool) -> Self {
+    self.useSwiftBootstrap = useSwiftBootstrap
+    return self
+  }
+#endif
+
   /// Builds and runs a new `Engine` instance with the provided configuration.
   ///
   /// - note: Must be strongly retained in order for network requests to be performed correctly.
@@ -638,6 +663,11 @@ open class EngineBuilder: NSObject {
                                       eventTracker: self.eventTracker,
                                       networkMonitoringMode: Int32(self.monitoringMode.rawValue))
     let config = self.makeConfig()
+#if canImport(EnvoyCxxSwiftInterop)
+    if self.useSwiftBootstrap {
+      config.bootstrapPointer = self.generateBootstrap().pointer
+    }
+#endif
 
     switch self.base {
     case .custom(let yaml):
@@ -726,6 +756,114 @@ open class EngineBuilder: NSObject {
   }
 
   func bootstrapDebugDescription() -> String {
-    self.makeConfig().bootstrapDebugDescription()
+    let objcDescription = self.makeConfig().bootstrapDebugDescription()
+#if canImport(EnvoyCxxSwiftInterop)
+    assert(
+      self.generateBootstrap().debugDescription == objcDescription,
+      "Swift bootstrap is different from ObjC bootstrap"
+    )
+#endif
+    return objcDescription
   }
 }
+
+#if canImport(EnvoyCxxSwiftInterop)
+private extension EngineBuilder {
+  func generateBootstrap() -> Bootstrap {
+    var cxxBuilder = Envoy.Platform.EngineBuilder()
+    cxxBuilder.addLogLevel(self.logLevel.toCXX())
+#if ENVOY_ADMIN_FUNCTIONALITY
+    cxxBuilder.enableAdminInterface(self.adminInterfaceEnabled)
+#endif
+    if let grpcStatsDomain = self.grpcStatsDomain {
+      cxxBuilder.addGrpcStatsDomain(grpcStatsDomain.toCXX())
+    }
+
+    cxxBuilder.addConnectTimeoutSeconds(Int32(self.connectTimeoutSeconds))
+    cxxBuilder.addDnsRefreshSeconds(Int32(self.dnsRefreshSeconds))
+    cxxBuilder.addDnsFailureRefreshSeconds(Int32(self.dnsFailureRefreshSecondsBase),
+                                           Int32(self.dnsFailureRefreshSecondsMax))
+    cxxBuilder.addDnsQueryTimeoutSeconds(Int32(self.dnsQueryTimeoutSeconds))
+    cxxBuilder.addDnsMinRefreshSeconds(Int32(self.dnsMinRefreshSeconds))
+    cxxBuilder.addDnsPreresolveHostnames(self.dnsPreresolveHostnames.toCXX())
+    cxxBuilder.enableDnsCache(self.enableDNSCache, Int32(self.dnsCacheSaveIntervalSeconds))
+    cxxBuilder.enableHappyEyeballs(self.enableHappyEyeballs)
+#if ENVOY_ENABLE_QUIC
+    cxxBuilder.enableHttp3(self.enableHttp3)
+#endif
+    cxxBuilder.enableGzipDecompression(self.enableGzipDecompression)
+    cxxBuilder.enableBrotliDecompression(self.enableBrotliDecompression)
+    cxxBuilder.enableInterfaceBinding(self.enableInterfaceBinding)
+    cxxBuilder.enableDrainPostDnsRefresh(self.enableDrainPostDnsRefresh)
+    cxxBuilder.enforceTrustChainVerification(self.enforceTrustChainVerification)
+    cxxBuilder.setForceAlwaysUsev6(self.forceIPv6)
+    cxxBuilder.enablePlatformCertificatesValidation(true)
+    cxxBuilder.addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+      Int32(self.h2ConnectionKeepaliveIdleIntervalMilliseconds)
+    )
+    cxxBuilder.addH2ConnectionKeepaliveTimeoutSeconds(
+      Int32(self.h2ConnectionKeepaliveTimeoutSeconds)
+    )
+    cxxBuilder.addMaxConnectionsPerHost(Int32(self.maxConnectionsPerHost))
+    cxxBuilder.addStatsFlushSeconds(Int32(self.statsFlushSeconds))
+    cxxBuilder.setStreamIdleTimeoutSeconds(Int32(self.streamIdleTimeoutSeconds))
+    cxxBuilder.setPerTryIdleTimeoutSeconds(Int32(self.perTryIdleTimeoutSeconds))
+    cxxBuilder.setAppVersion(self.appVersion.toCXX())
+    cxxBuilder.setAppId(self.appId.toCXX())
+    cxxBuilder.setDeviceOs("iOS".toCXX())
+    for cluster in self.virtualClusters {
+      cxxBuilder.addVirtualCluster(cluster.toCXX())
+    }
+
+    for (runtimeGuard, value) in self.runtimeGuards {
+      cxxBuilder.setRuntimeGuard(runtimeGuard.toCXX(), value)
+    }
+
+    for directResponse in self.directResponses {
+      cxxBuilder.addDirectResponse(directResponse.toCXX())
+    }
+
+    for filter in self.nativeFilterChain.reversed() {
+      cxxBuilder.addNativeFilter(filter.name.toCXX(), filter.typedConfig.toCXX())
+    }
+
+    for filter in self.platformFilterChain.reversed() {
+      cxxBuilder.addPlatformFilter(filter.filterName.toCXX())
+    }
+
+    cxxBuilder.addStatsSinks(self.statsSinks.toCXX())
+
+    if
+      let nodeRegion = self.nodeRegion,
+      let nodeZone = self.nodeZone,
+      let nodeSubZone = self.nodeSubZone
+    {
+      cxxBuilder.setNodeLocality(nodeRegion.toCXX(), nodeZone.toCXX(), nodeSubZone.toCXX())
+    }
+
+    if let nodeID = self.nodeID {
+      cxxBuilder.setNodeId(nodeID.toCXX())
+    }
+
+    if let rtdsLayerName = self.rtdsLayerName {
+      cxxBuilder.addRtdsLayer(rtdsLayerName.toCXX(), Int32(self.rtdsTimeoutSeconds))
+    }
+
+    if
+      let adsAddress = self.adsAddress,
+      let adsJwtToken = self.adsJwtToken,
+      let adsSslRootCerts = self.adsSslRootCerts
+    {
+      cxxBuilder.setAggregatedDiscoveryService(
+        adsAddress.toCXX(),
+        Int32(self.adsPort),
+        adsJwtToken.toCXX(),
+        Int32(self.adsJwtTokenLifetimeSeconds),
+        adsSslRootCerts.toCXX()
+      )
+    }
+
+    return cxxBuilder.generateBootstrap()
+  }
+}
+#endif

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.cc
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.cc
@@ -9,9 +9,7 @@ namespace CxxSwift {
 
 void run(BootstrapPtr bootstrap_ptr, Platform::LogLevel log_level, envoy_engine_t engine_handle) {
   auto options = std::make_unique<Envoy::OptionsImpl>();
-  auto bootstrap =
-      absl::WrapUnique(reinterpret_cast<envoy::config::bootstrap::v3::Bootstrap*>(bootstrap_ptr));
-  options->setConfigProto(std::move(bootstrap));
+  options->setConfigProto(bootstrapFromPtr(bootstrap_ptr));
   options->setLogLevel(static_cast<spdlog::level::level_enum>(log_level));
   options->setConcurrency(1);
   reinterpret_cast<Envoy::Engine*>(engine_handle)->run(std::move(options));

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
@@ -42,6 +42,16 @@ inline BootstrapPtr generateBootstrapPtr(Platform::EngineBuilder builder) {
   return reinterpret_cast<BootstrapPtr>(builder.generateBootstrap().release());
 }
 
+inline std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap>
+bootstrapFromPtr(BootstrapPtr bootstrap_ptr) {
+  return absl::WrapUnique(
+      reinterpret_cast<envoy::config::bootstrap::v3::Bootstrap*>(bootstrap_ptr));
+}
+
+inline std::string bootstrapDebugDescription(BootstrapPtr bootstrap_ptr) {
+  return bootstrapFromPtr(bootstrap_ptr)->ShortDebugString();
+}
+
 /**
  * Run the engine with the provided configuration.
  * @param bootstrap_ptr, the Envoy bootstrap configuration to use.

--- a/mobile/library/swift/cxx/Bootstrap.swift
+++ b/mobile/library/swift/cxx/Bootstrap.swift
@@ -1,0 +1,27 @@
+@_implementationOnly import EnvoyCxxSwiftInterop
+
+/// Wrapper around Envoy's bootstrap configuration.
+final class Bootstrap {
+  /// The underlying pointer to the C++ bootstrap configuration object.
+  let pointer: Envoy.CxxSwift.BootstrapPtr
+
+  /// Creates a Swift `Bootstrap` object from an underlying pointer to
+  /// the C++ bootstrap configuration object.
+  ///
+  /// - parameter pointer: The underlying pointer to the C++ bootstrap configuration object.
+  init(pointer: Envoy.CxxSwift.BootstrapPtr) {
+    self.pointer = pointer
+  }
+
+  /// Generates a string description of this instance for debugging purposes.
+  var debugDescription: String {
+    .fromCXX(Envoy.CxxSwift.bootstrapDebugDescription(self.pointer))
+  }
+}
+
+extension Envoy.Platform.EngineBuilder {
+  /// - returns: A generated bootstrap object.
+  func generateBootstrap() -> Bootstrap {
+    Bootstrap(pointer: Envoy.CxxSwift.generateBootstrapPtr(self))
+  }
+}

--- a/mobile/library/swift/cxx/DirectResponse+Cxx.swift
+++ b/mobile/library/swift/cxx/DirectResponse+Cxx.swift
@@ -1,0 +1,68 @@
+@_implementationOnly import EnvoyCxxSwiftInterop
+
+// MARK: - Internal
+
+extension DirectResponse {
+  func toCXX() -> Envoy.DirectResponseTesting.DirectResponse {
+    var result = Envoy.DirectResponseTesting.DirectResponse()
+    result.status = UInt32(self.status)
+    if let body = self.body {
+      result.body = body.toCXX()
+    }
+    result.matcher = self.matcher.toCXX()
+    result.headers = self.headers.toCXX()
+    return result
+  }
+}
+
+// MARK: - Private
+
+private extension RouteMatcher {
+  func toCXX() -> Envoy.DirectResponseTesting.RouteMatcher {
+    var result = Envoy.DirectResponseTesting.RouteMatcher()
+    if let fullPath = self.fullPath {
+      result.fullPath = fullPath.toCXX()
+    }
+    if let pathPrefix = self.pathPrefix {
+      result.pathPrefix = pathPrefix.toCXX()
+    }
+    result.headers = self.headers.toCXX()
+    return result
+  }
+}
+
+private extension RouteMatcher.HeaderMatcher {
+  func toCXX() -> Envoy.DirectResponseTesting.HeaderMatcher {
+    return Envoy.DirectResponseTesting.HeaderMatcher(
+      name: self.name.toCXX(),
+      value: self.value.toCXX(),
+      mode: self.mode.toCXX()
+    )
+  }
+}
+
+private extension Array<RouteMatcher.HeaderMatcher> {
+  func toCXX() -> Envoy.CxxSwift.HeaderMatcherVector {
+    var vector = Envoy.CxxSwift.HeaderMatcherVector()
+    for element in self {
+      var cppElement = element.toCXX()
+      vector.push_back(&cppElement)
+    }
+    return vector
+  }
+}
+
+private extension RouteMatcher.HeaderMatcher.MatchMode {
+  func toCXX() -> Envoy.DirectResponseTesting.MatchMode {
+    switch self {
+    case .contains:
+      return .Contains
+    case .exact:
+      return .Exact
+    case .prefix:
+      return .Prefix
+    case .suffix:
+      return .Suffix
+    }
+  }
+}

--- a/mobile/library/swift/cxx/LogLevel+Cxx.swift
+++ b/mobile/library/swift/cxx/LogLevel+Cxx.swift
@@ -24,7 +24,7 @@ extension LogLevel {
 // MARK: - Test Helpers
 
 extension LogLevel {
-  func toCXXDescription() -> String {
+  var cxxDescription: String {
     .fromCXX(Envoy.Platform.logLevelToString(self.toCXX()))
   }
 }

--- a/mobile/library/swift/cxx/LogLevel+Cxx.swift
+++ b/mobile/library/swift/cxx/LogLevel+Cxx.swift
@@ -1,0 +1,30 @@
+@_implementationOnly import EnvoyCxxSwiftInterop
+
+extension LogLevel {
+  func toCXX() -> Envoy.Platform.LogLevel {
+    switch self {
+    case .trace:
+      return .trace
+    case .debug:
+      return .debug
+    case .info:
+      return .info
+    case .warn:
+      return .warn
+    case .error:
+      return .error
+    case .critical:
+      return .critical
+    case .off:
+      return .off
+    }
+  }
+}
+
+// MARK: - Test Helpers
+
+extension LogLevel {
+  func toCXXDescription() -> String {
+    .fromCXX(Envoy.Platform.logLevelToString(self.toCXX()))
+  }
+}

--- a/mobile/library/swift/cxx/Swift+Cxx.swift
+++ b/mobile/library/swift/cxx/Swift+Cxx.swift
@@ -1,0 +1,37 @@
+@_implementationOnly import EnvoyCxxSwiftInterop
+import Foundation
+@_implementationOnly import std
+
+// MARK: - String
+
+extension String {
+  static func fromCXX(_ cxxString: std.string) -> String {
+    return String(cString: cxxString.c_str())
+  }
+
+  func toCXX() -> std.string {
+    return self.utf8.reduce(into: std.string()) { result, codeUnit in
+      result.push_back(Int8(codeUnit))
+    }
+  }
+}
+
+// MARK: - Collections
+
+extension Array<String> {
+  func toCXX() -> Envoy.CxxSwift.StringVector {
+    return self.reduce(into: Envoy.CxxSwift.StringVector()) { result, string in
+      var cxxString = string.toCXX()
+      result.push_back(&cxxString)
+    }
+  }
+}
+
+extension Dictionary<String, String> {
+  func toCXX() -> Envoy.CxxSwift.StringMap {
+    return self.reduce(into: Envoy.CxxSwift.StringMap()) { result, keyValue in
+      let (key, value) = keyValue
+      Envoy.CxxSwift.string_map_set(&result, key.toCXX(), value.toCXX())
+    }
+  }
+}

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -376,7 +376,9 @@ final class EngineBuilderTests: XCTestCase {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
       XCTAssertEqual([
-        #"{"name":"test","headers":[{"name":":authority","string_match":{"exact":"envoymobile.io"}}]}"#,
+        """
+        {"name":"test","headers":[{"name":":authority","string_match":{"exact":"envoymobile.io"}}]}
+        """,
       ], config.virtualClusters)
       expectation.fulfill()
     }
@@ -384,7 +386,9 @@ final class EngineBuilderTests: XCTestCase {
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addVirtualClusters([
-        #"{"name":"test","headers":[{"name":":authority","string_match":{"exact":"envoymobile.io"}}]}"#,
+        """
+        {"name":"test","headers":[{"name":":authority","string_match":{"exact":"envoymobile.io"}}]}
+        """,
       ])
       .build()
     self.waitForExpectations(timeout: 0.01)

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -375,13 +375,17 @@ final class EngineBuilderTests: XCTestCase {
   func testAddingVirtualClustersAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual(["test"], config.virtualClusters)
+      XCTAssertEqual([
+        #"{"name":"test","headers":[{"name":":authority","string_match":{"exact":"envoymobile.io"}}]}"#,
+      ], config.virtualClusters)
       expectation.fulfill()
     }
 
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addVirtualClusters(["test"])
+      .addVirtualClusters([
+        #"{"name":"test","headers":[{"name":":authority","string_match":{"exact":"envoymobile.io"}}]}"#,
+      ])
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
@@ -395,7 +399,15 @@ final class EngineBuilderTests: XCTestCase {
 
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addNativeFilter(name: "test_name", typedConfig: "config")
+      .addNativeFilter(
+        name: "envoy.filters.http.buffer",
+        typedConfig: """
+          {
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer",
+            "max_request_bytes": 5242880
+          }
+          """
+      )
       .build()
     self.waitForExpectations(timeout: 0.01)
   }

--- a/mobile/test/swift/apps/experimental/ViewController.swift
+++ b/mobile/test/swift/apps/experimental/ViewController.swift
@@ -32,17 +32,18 @@ final class ViewController: UITableViewController {
       .addNativeFilter(
         name: "envoy.filters.http.buffer",
         typedConfig: """
-            {\
-            "@type":"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer",\
-            "max_request_bytes":5242880\
-            }
-            """
+          {
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer",
+            "max_request_bytes": 5242880
+          }
+          """
       )
       .setOnEngineRunning { NSLog("Envoy async internal setup completed") }
       .addStringAccessor(name: "demo-accessor", accessor: { return "PlatformString" })
       .addKeyValueStore(name: "demo-kv-store", keyValueStore: UserDefaults.standard)
       .setEventTracker { NSLog("Envoy event emitted: \($0)") }
       .forceIPv6(true)
+      .enableSwiftBootstrap(true)
       .build()
     self.streamClient = engine.streamClient()
     self.pulseClient = engine.pulseClient()

--- a/mobile/test/swift/cxx/BUILD
+++ b/mobile/test/swift/cxx/BUILD
@@ -1,0 +1,14 @@
+load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_swift_test")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_swift_test(
+    name = "test",
+    srcs = [
+        "LogLevelCxxTests.swift",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//library/swift/EnvoyCxxSwiftInterop",
+    ],
+)

--- a/mobile/test/swift/cxx/LogLevelCxxTests.swift
+++ b/mobile/test/swift/cxx/LogLevelCxxTests.swift
@@ -2,13 +2,13 @@
 import XCTest
 
 final class LogLevelCxxTests: XCTestCase {
-  func testToCxxDescription() {
-    XCTAssertEqual(LogLevel.trace.toCXXDescription(), "trace")
-    XCTAssertEqual(LogLevel.debug.toCXXDescription(), "debug")
-    XCTAssertEqual(LogLevel.info.toCXXDescription(), "info")
-    XCTAssertEqual(LogLevel.warn.toCXXDescription(), "warn")
-    XCTAssertEqual(LogLevel.error.toCXXDescription(), "error")
-    XCTAssertEqual(LogLevel.critical.toCXXDescription(), "critical")
-    XCTAssertEqual(LogLevel.off.toCXXDescription(), "off")
+  func testCxxDescription() {
+    XCTAssertEqual(LogLevel.trace.cxxDescription, "trace")
+    XCTAssertEqual(LogLevel.debug.cxxDescription, "debug")
+    XCTAssertEqual(LogLevel.info.cxxDescription, "info")
+    XCTAssertEqual(LogLevel.warn.cxxDescription, "warn")
+    XCTAssertEqual(LogLevel.error.cxxDescription, "error")
+    XCTAssertEqual(LogLevel.critical.cxxDescription, "critical")
+    XCTAssertEqual(LogLevel.off.cxxDescription, "off")
   }
 }

--- a/mobile/test/swift/cxx/LogLevelCxxTests.swift
+++ b/mobile/test/swift/cxx/LogLevelCxxTests.swift
@@ -1,0 +1,15 @@
+@testable import Envoy
+@_implementationOnly import EnvoyCxxSwiftInterop
+import XCTest
+
+final class LogLevelCxxTests: XCTestCase {
+  func testToCxxDescription() {
+    XCTAssertEqual(LogLevel.trace.toCXXDescription(), "trace")
+    XCTAssertEqual(LogLevel.debug.toCXXDescription(), "debug")
+    XCTAssertEqual(LogLevel.info.toCXXDescription(), "info")
+    XCTAssertEqual(LogLevel.warn.toCXXDescription(), "warn")
+    XCTAssertEqual(LogLevel.error.toCXXDescription(), "error")
+    XCTAssertEqual(LogLevel.critical.toCXXDescription(), "critical")
+    XCTAssertEqual(LogLevel.off.toCXXDescription(), "off")
+  }
+}

--- a/mobile/test/swift/cxx/LogLevelCxxTests.swift
+++ b/mobile/test/swift/cxx/LogLevelCxxTests.swift
@@ -1,5 +1,4 @@
 @testable import Envoy
-@_implementationOnly import EnvoyCxxSwiftInterop
 import XCTest
 
 final class LogLevelCxxTests: XCTestCase {


### PR DESCRIPTION
Which will generate the `envoy::config::bootstrap::v3::Bootstrap` config using Swift / C++ interop instead of going through Objective-C.

This will allow us to remove the duplication between `EngineBuilder.swift` and `EnvoyConfiguration.{h,mm}` after we've run some experiments ensuring this performs well.

This is a lower risk alternative to https://github.com/envoyproxy/envoy/pull/26010 and https://github.com/envoyproxy/envoy/pull/26011.

Commit Message:
Additional Description:
Risk Level: Low, passing all tests, limited to generating the bootstrap config, validated that the bootstrap debug strings match between ObjC and Swift in Lyft's apps.
Testing: Yes
Docs Changes: No, intended to be a temporary transition and should be removed after experimentation.
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]