### PR TITLE
mobile: disable global index store

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -39,6 +39,8 @@ build --copt -Wno-deprecated-declarations
 
 build:rules_xcodeproj --config=ios
 build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0
+# Disable global index store to work around https://github.com/buildbuddy-io/rules_xcodeproj/issues/1878
+build:rules_xcodeproj --features=-swift.use_global_index_store
 
 # The defaults are JDK 11 on newer versions of Bazel
 build --java_runtime_version=remotejdk_11


### PR DESCRIPTION
To work around this issue: https://github.com/buildbuddy-io/rules_xcodeproj/issues/1878

Commit Message:
Additional Description:
Risk Level: Low, local Xcode usage only
Testing: Locally in Xcode
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]