### PR TITLE
date provider: using a ConstSingleton date formatter

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -221,7 +221,7 @@ DateFormatter::fromTimeAndPrepareSpecifierOffsets(time_t time, SpecifierOffsets&
   return formatted_time;
 }
 
-std::string DateFormatter::now(TimeSource& time_source) {
+std::string DateFormatter::now(TimeSource& time_source) const {
   return fromTime(time_source.systemTime());
 }
 

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -57,7 +57,7 @@ public:
    * @param time_source time keeping source.
    * @return std::string representing the GMT/UTC time of a TimeSource based on the format string.
    */
-  std::string now(TimeSource& time_source);
+  std::string now(TimeSource& time_source) const;
 
   /**
    * @return std::string the format string used.

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -6,7 +6,7 @@
 namespace Envoy {
 namespace Http {
 
-DateFormatter DateProviderImplBase::date_formatter_("%a, %d %b %Y %H:%M:%S GMT");
+static DateFormatter* date_formatter_ = new DateFormatter("%a, %d %b %Y %H:%M:%S GMT");
 
 TlsCachingDateProviderImpl::TlsCachingDateProviderImpl(Event::Dispatcher& dispatcher,
                                                        ThreadLocal::SlotAllocator& tls)
@@ -17,7 +17,7 @@ TlsCachingDateProviderImpl::TlsCachingDateProviderImpl(Event::Dispatcher& dispat
 }
 
 void TlsCachingDateProviderImpl::onRefreshDate() {
-  std::string new_date_string = date_formatter_.now(time_source_);
+  std::string new_date_string = date_formatter_->now(time_source_);
   tls_->set([new_date_string](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     return std::make_shared<ThreadLocalCachedDate>(new_date_string);
   });
@@ -30,7 +30,7 @@ void TlsCachingDateProviderImpl::setDateHeader(ResponseHeaderMap& headers) {
 }
 
 void SlowDateProviderImpl::setDateHeader(ResponseHeaderMap& headers) {
-  headers.setDate(date_formatter_.now(time_source_));
+  headers.setDate(date_formatter_->now(time_source_));
 }
 
 } // namespace Http

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -7,7 +7,7 @@ namespace Envoy {
 namespace Http {
 
 class TlsCachingDateFormatter : public DateFormatter {
- public:
+public:
   TlsCachingDateFormatter() : DateFormatter("%a, %d %b %Y %H:%M:%S GMT") {}
 };
 

--- a/source/common/http/date_provider_impl.cc
+++ b/source/common/http/date_provider_impl.cc
@@ -6,6 +6,9 @@
 namespace Envoy {
 namespace Http {
 
+// This uses the same memory model as ConstSingleton (which can't be used as it doesn't take
+// constructor arguments.) This will leak on program exit instead of causing shutdown
+// crashes (https://github.com/envoyproxy/envoy/issues/26091)
 static DateFormatter* date_formatter_ = new DateFormatter("%a, %d %b %Y %H:%M:%S GMT");
 
 TlsCachingDateProviderImpl::TlsCachingDateProviderImpl(Event::Dispatcher& dispatcher,

--- a/source/common/http/date_provider_impl.h
+++ b/source/common/http/date_provider_impl.h
@@ -22,7 +22,6 @@ public:
   explicit DateProviderImplBase(TimeSource& time_source) : time_source_(time_source) {}
 
 protected:
-  static DateFormatter date_formatter_;
   TimeSource& time_source_;
 };
 


### PR DESCRIPTION
We've seen shutdown crashes in E-M due to the deletion of this static object.

Risk Level: low
Testing: internal tsan now green
Docs Changes: n/a
Release Notes: n/a

Fixes https://github.com/envoyproxy/envoy/issues/26091