### PR TITLE
Reduce overhead in UpstreamCodecFilter by fixing alignment

### DIFF
--- a/source/common/router/upstream_codec_filter.h
+++ b/source/common/router/upstream_codec_filter.h
@@ -93,9 +93,10 @@ public:
   };
   Http::StreamDecoderFilterCallbacks* callbacks_;
   CodecBridge bridge_;
+  OptRef<Http::RequestHeaderMap> latched_headers_;
+  // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   bool calling_encode_headers_ : 1;
   bool deferred_reset_ : 1;
-  OptRef<Http::RequestHeaderMap> latched_headers_;
   absl::optional<bool> latched_end_stream_;
 
 private:


### PR DESCRIPTION
Commit Message: Small reduction in memory by changing alignment in UpstreamCodecFilter
Risk Level: Low

Sizeof test:
Before changes: 88
After changes: 80