### PR TITLE
Reduce overhead in RetryStateImpl by fixing alignment

### DIFF
--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -70,13 +70,13 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy,
                                Upstream::ResourcePriority priority, bool auto_configured_for_http3)
     : cluster_(cluster), vcluster_(vcluster), route_stats_context_(route_stats_context),
       runtime_(runtime), random_(random), dispatcher_(dispatcher), time_source_(time_source),
-      retry_on_(route_policy.retryOn()), retries_remaining_(route_policy.numRetries()),
-      priority_(priority), retry_host_predicates_(route_policy.retryHostPredicates()),
+      retry_host_predicates_(route_policy.retryHostPredicates()),
       retry_priority_(route_policy.retryPriority()),
       retriable_status_codes_(route_policy.retriableStatusCodes()),
       retriable_headers_(route_policy.retriableHeaders()),
       reset_headers_(route_policy.resetHeaders()),
-      reset_max_interval_(route_policy.resetMaxInterval()),
+      reset_max_interval_(route_policy.resetMaxInterval()), retry_on_(route_policy.retryOn()),
+      retries_remaining_(route_policy.numRetries()), priority_(priority),
       auto_configured_for_http3_(auto_configured_for_http3) {
   if ((cluster.features() & Upstream::ClusterInfo::Features::HTTP3) &&
       Http::Utility::isSafeRequest(request_headers)) {

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -134,7 +134,7 @@ private:
   std::vector<ResetHeaderParserSharedPtr> reset_headers_{};
   std::chrono::milliseconds reset_max_interval_{};
 
-  // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  // Keep small members (bools, enums and int32s) at the end of class, to reduce alignment overhead.
   uint32_t retry_on_{};
   uint32_t retries_remaining_{};
   uint32_t host_selection_max_attempts_;

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -122,21 +122,23 @@ private:
   Random::RandomGenerator& random_;
   Event::Dispatcher& dispatcher_;
   TimeSource& time_source_;
-  uint32_t retry_on_{};
-  uint32_t retries_remaining_{};
   DoRetryCallback backoff_callback_;
   Event::SchedulableCallbackPtr next_loop_callback_;
   Event::TimerPtr retry_timer_;
-  Upstream::ResourcePriority priority_;
   BackOffStrategyPtr backoff_strategy_;
   BackOffStrategyPtr ratelimited_backoff_strategy_{};
   std::vector<Upstream::RetryHostPredicateSharedPtr> retry_host_predicates_;
   Upstream::RetryPrioritySharedPtr retry_priority_;
-  uint32_t host_selection_max_attempts_;
   std::vector<uint32_t> retriable_status_codes_;
   std::vector<Http::HeaderMatcherSharedPtr> retriable_headers_;
   std::vector<ResetHeaderParserSharedPtr> reset_headers_{};
   std::chrono::milliseconds reset_max_interval_{};
+
+  // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
+  uint32_t retry_on_{};
+  uint32_t retries_remaining_{};
+  uint32_t host_selection_max_attempts_;
+  Upstream::ResourcePriority priority_;
   const bool auto_configured_for_http3_{};
 };
 


### PR DESCRIPTION
Commit Message: Reduce overhead in RetryStateImpl by fixing alignment
Risk Level: Low

Sizeof test
Before changes: 280
After changes: 264

