### PR TITLE
mobile: add CI job to publish aars to Sonatype

### DIFF
--- a/.github/workflows/mobile_release.yml
+++ b/.github/workflows/mobile_release.yml
@@ -3,8 +3,8 @@ name: mobile_release
 on:
   workflow_dispatch:
   schedule:
-    # Mondays at 1pm UTC (8am EST)
-    - cron: "0 13 * * 1"
+  # Mondays at 1pm UTC (8am EST)
+  - cron: "0 13 * * 1"
 
 jobs:
   android_release_artifacts:


### PR DESCRIPTION
Schedule it so it runs automatically on Mondays at 1pm UTC (8am EST).

This pulls from the CI jobs that were set up in the previous Envoy Mobile repo:

* https://github.com/envoyproxy/envoy-mobile/blob/main/.github/workflows/release.yml
* https://github.com/envoyproxy/envoy-mobile/blob/main/.github/workflows/weekly_release.yml

However, we don't want to create git tags or GitHub releases so not to interfere with the main Envoy tags and releases.

Commit Message:
Additional Description:
Risk Level: Low to Envoy, medium to Envoy's CI infra, since this will run a CI job once a week and might fail.
Testing: Confirmed an aar deployment in this PR
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]