### PR TITLE
[ZK filter] make multi request support delete operation

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -299,7 +299,7 @@ void DecoderImpl::skipAcls(Buffer::Instance& data, uint64_t& offset) {
 
 void DecoderImpl::parseCreateRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len,
                                      OpCodes opcode) {
-  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + (3 * INT_LENGTH));
+  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + (4 * INT_LENGTH));
 
   const std::string path = helper_.peekString(data, offset);
 
@@ -375,7 +375,7 @@ std::string DecoderImpl::pathOnlyRequest(Buffer::Instance& data, uint64_t& offse
 }
 
 void DecoderImpl::parseCheckRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len) {
-  ensureMinLength(len, (2 * INT_LENGTH));
+  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + (2 * INT_LENGTH));
 
   const std::string path = helper_.peekString(data, offset);
   const int32_t version = helper_.peekInt32(data, offset);
@@ -406,6 +406,9 @@ void DecoderImpl::parseMultiRequest(Buffer::Instance& data, uint64_t& offset, ui
       break;
     case OpCodes::Check:
       parseCheckRequest(data, offset, len);
+      break;
+    case OpCodes::Delete:
+      parseDeleteRequest(data, offset, len);
       break;
     default:
       throw EnvoyException(fmt::format("Unknown opcode within a transaction: {}", opcode));

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -367,7 +367,7 @@ public:
     // If this operation is part of the multi request (txn is true), we do not need to encode its
     // metadata (packet len, xid and opcode). This is because these information will be replaced by
     // the metadata of the multi request. If this operation comes from a separate request (txn is
-    // false), we need to encode these metadata to the request.
+    // false), we need to encode its metadata to the request.
     if (!txn) {
       buffer.writeBEInt<int32_t>(16 + path.length());
       buffer.writeBEInt<int32_t>(1000);

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -364,6 +364,10 @@ public:
                                         const bool txn = false) const {
     Buffer::OwnedImpl buffer;
 
+    // If this operation is part of the multi request (txn is true), we do not need to encode its
+    // metadata (packet len, xid and opcode). This is because these information will be replaced by
+    // the metadata of the multi request. If this operation comes from a separate request (txn is
+    // false), we need to encode these metadata to the request.
     if (!txn) {
       buffer.writeBEInt<int32_t>(16 + path.length());
       buffer.writeBEInt<int32_t>(1000);

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -364,10 +364,10 @@ public:
                                         const bool txn = false) const {
     Buffer::OwnedImpl buffer;
 
-    // If this operation is part of the multi request (txn is true), we do not need to encode its
-    // metadata (packet len, xid and opcode). This is because these information will be replaced by
-    // the metadata of the multi request. If this operation comes from a separate request (txn is
-    // false), we need to encode its metadata to the request.
+    // If this operation is part of a multi request, we do not need to encode its
+    // metadata (packet length, xid and opcode). This is because these information will be replaced
+    // by the metadata of the multi request. If this operation comes from a separate request, we
+    // need to encode its metadata to the request.
     if (!txn) {
       buffer.writeBEInt<int32_t>(16 + path.length());
       buffer.writeBEInt<int32_t>(1000);


### PR DESCRIPTION
Commit Message: [ZK filter] make multi request support delete operation
Additional Description: Based on the [ZK codebase](https://github.com/apache/zookeeper/blob/f4f0bed00dd254e34aedfe408799f557d60fd0e7/zookeeper-client/zookeeper-client-c/include/zookeeper.h#L339-L384), the multi request should support four operations (create, delete, set, and check). This diff add the support for the delete operation.
Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A