### PR TITLE
ci: Use more CPUs for non-RBE

### DIFF
--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -35,7 +35,7 @@ if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
   fi
 
   if [[ -z "${ENVOY_RBE}" ]]; then
-    export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.9 --remote_timeout=600"
+    export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.99 --remote_timeout=600"
     echo "using local build cache."
   fi
 


### PR DESCRIPTION
This provides a small but significant speed up for the arm and coverage jobs which have a lot cpus in CI and probably reflects better the intention in terms of CPU usage

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
