### PR TITLE
test: fixing a tsan flake

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -928,6 +928,7 @@ TEST_P(TcpTunnelingIntegrationTest, Goaway) {
   // Make sure the last stream is finished before doing test teardown.
   fake_upstream_connection->encodeGoAway();
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_cx_destroy", 2);
+  ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
 }
 
 TEST_P(TcpTunnelingIntegrationTest, InvalidResponseHeaders) {


### PR DESCRIPTION
Avoiding deleting the upstream while it's still serializing a goaway
Part of https://github.com/envoyproxy/envoy/issues/26068
Passes 2k runs clearly (before 7/2000 failed)