### PR TITLE
docs: warn against shared objects

### DIFF
--- a/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
+++ b/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
@@ -73,6 +73,9 @@ convert it into a typed class object that’s stored with the route
 itself. HTTP filters can then query the route-specific filter config during
 request processing.
 
+
+.. _arch_overview_advanced_dynamic_state:
+
 Dynamic State
 ^^^^^^^^^^^^^
 
@@ -88,3 +91,13 @@ the class definition (e.g., HTTP protocol, requested server name, etc.). In
 addition, it provides a facility to store typed objects in a map
 (``map<string, FilterState::Object>``). The state stored per filter can be
 either write-once (immutable), or write-many (mutable).
+
+Filter state objects are bound to the lifespan of the associated stream.
+However, by marking a downstream object as shared with the upstream connection
+during creation, the object is shared with the upstream connection filter
+state, and its lifespan is extended beyond the original stream. These marked
+objects also affect the connection pooling decisions if they implement a
+hashing interface. Whenever a shared hashable object is added, an upstream
+connection is created for each distinct hash value, which ensures that these
+objects are not overwritten by subsequent downstream requests to the same
+upstream connection.

--- a/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
+++ b/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
@@ -103,10 +103,17 @@ TCP or HTTP filter can access the shared object. Upstream transport sockets can
 also read the shared objects and customize the creation of the upstream
 transport. For example, the :ref:`internal upstream transport socket
 <envoy_v3_api_msg_extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport>`
-copies the shared objects to the internal connection downstream filter state.
+copies references to the shared objects to the internal connection downstream
+filter state.
 
 The filter state objects that are shared with the upstream also affect the
 connection pooling decisions if they implement a hashing interface. Whenever a
 shared hashable object is added, an upstream connection is created for each
 distinct hash value, which ensures that these objects are not overwritten by
-subsequent downstream requests to the same upstream connection.
+subsequent downstream requests to the same upstream connection. For example, a
+custom HTTP filter may create a shared hashable object from the value of a
+special header. In this case, a separate upstream connection is created for
+each distinct special header value, so that no two requests with different
+header values share an upstream connection. The same procedure applies to each
+shared hashable object individually, creating a combination matrix of the
+upstream connections per distinct combination of the object values.

--- a/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
+++ b/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
@@ -74,8 +74,6 @@ itself. HTTP filters can then query the route-specific filter config during
 request processing.
 
 
-.. _arch_overview_advanced_dynamic_state:
-
 Dynamic State
 ^^^^^^^^^^^^^
 
@@ -91,6 +89,8 @@ the class definition (e.g., HTTP protocol, requested server name, etc.). In
 addition, it provides a facility to store typed objects in a map
 (``map<string, FilterState::Object>``). The state stored per filter can be
 either write-once (immutable), or write-many (mutable).
+
+.. _arch_overview_advanced_filter_state_sharing:
 
 Filter state sharing
 --------------------

--- a/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
+++ b/docs/root/intro/arch_overview/advanced/data_sharing_between_filters.rst
@@ -92,12 +92,21 @@ addition, it provides a facility to store typed objects in a map
 (``map<string, FilterState::Object>``). The state stored per filter can be
 either write-once (immutable), or write-many (mutable).
 
-Filter state objects are bound to the lifespan of the associated stream.
+Filter state sharing
+--------------------
+
+Filter state objects are bound to the lifespan of the associated parent stream.
 However, by marking a downstream object as shared with the upstream connection
 during creation, the object is shared with the upstream connection filter
-state, and its lifespan is extended beyond the original stream. These marked
-objects also affect the connection pooling decisions if they implement a
-hashing interface. Whenever a shared hashable object is added, an upstream
-connection is created for each distinct hash value, which ensures that these
-objects are not overwritten by subsequent downstream requests to the same
-upstream connection.
+state, and its lifespan is extended beyond the original stream. Any upstream
+TCP or HTTP filter can access the shared object. Upstream transport sockets can
+also read the shared objects and customize the creation of the upstream
+transport. For example, the :ref:`internal upstream transport socket
+<envoy_v3_api_msg_extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport>`
+copies the shared objects to the internal connection downstream filter state.
+
+The filter state objects that are shared with the upstream also affect the
+connection pooling decisions if they implement a hashing interface. Whenever a
+shared hashable object is added, an upstream connection is created for each
+distinct hash value, which ensures that these objects are not overwritten by
+subsequent downstream requests to the same upstream connection.

--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -114,7 +114,7 @@ connection pools are also allocated for each of the following features:
 * :ref:`Routing priority <arch_overview_http_routing_priority>`
 * :ref:`Socket options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
 * :ref:`Transport socket (e.g. TLS) options <envoy_v3_api_msg_config.core.v3.TransportSocket>`
-* Downstream :ref:`filter state objects <arch_overview_advanced_filter_state` that are hashable
+* Downstream :ref:`filter state objects <arch_overview_advanced_filter_state>` that are hashable
   and marked as shared with the upstream connection.
 
 Each worker thread maintains its own connection pools for each cluster, so if an Envoy has two

--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -114,7 +114,7 @@ connection pools are also allocated for each of the following features:
 * :ref:`Routing priority <arch_overview_http_routing_priority>`
 * :ref:`Socket options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
 * :ref:`Transport socket (e.g. TLS) options <envoy_v3_api_msg_config.core.v3.TransportSocket>`
-* Downstream :ref:`filter state objects <arch_overview_advanced_filter_state>` that are hashable
+* Downstream :ref:`filter state objects <arch_overview_advanced_filter_state_sharing>` that are hashable
   and marked as shared with the upstream connection.
 
 Each worker thread maintains its own connection pools for each cluster, so if an Envoy has two

--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -114,6 +114,8 @@ connection pools are also allocated for each of the following features:
 * :ref:`Routing priority <arch_overview_http_routing_priority>`
 * :ref:`Socket options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>`
 * :ref:`Transport socket (e.g. TLS) options <envoy_v3_api_msg_config.core.v3.TransportSocket>`
+* Downstream :ref:`filter state objects <arch_overview_advanced_filter_state` that are hashable
+  and marked as shared with the upstream connection.
 
 Each worker thread maintains its own connection pools for each cluster, so if an Envoy has two
 threads and a cluster with both HTTP/1 and HTTP/2 support, there will be at least 4 connection pools.

--- a/source/common/stream_info/filter_state_impl.cc
+++ b/source/common/stream_info/filter_state_impl.cc
@@ -7,7 +7,7 @@ namespace StreamInfo {
 
 void FilterStateImpl::setData(absl::string_view data_name, std::shared_ptr<Object> data,
                               FilterState::StateType state_type, FilterState::LifeSpan life_span,
-                              FilterState::StreamSharing stream_sharing) {
+                              StreamSharingMayImpactPooling stream_sharing) {
   if (life_span > life_span_) {
     if (hasDataWithNameInternally(data_name)) {
       IS_ENVOY_BUG("FilterStateAccessViolation: FilterState::setData<T> called twice with "
@@ -105,11 +105,12 @@ FilterState::ObjectsPtr FilterStateImpl::objectsSharedWithUpstreamConnection() c
                          : std::make_unique<FilterState::Objects>();
   for (const auto& [name, object] : data_storage_) {
     switch (object->stream_sharing_) {
-    case StreamSharing::SharedWithUpstreamConnection:
+    case StreamSharingMayImpactPooling::SharedWithUpstreamConnection:
       objects->push_back({object->data_, object->state_type_, object->stream_sharing_, name});
       break;
-    case StreamSharing::SharedWithUpstreamConnectionOnce:
-      objects->push_back({object->data_, object->state_type_, StreamSharing::None, name});
+    case StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce:
+      objects->push_back(
+          {object->data_, object->state_type_, StreamSharingMayImpactPooling::None, name});
       break;
     default:
       break;

--- a/source/common/stream_info/filter_state_impl.h
+++ b/source/common/stream_info/filter_state_impl.h
@@ -40,11 +40,10 @@ public:
   }
 
   // FilterState
-  void
-  setData(absl::string_view data_name, std::shared_ptr<Object> data,
-          FilterState::StateType state_type,
-          FilterState::LifeSpan life_span = FilterState::LifeSpan::FilterChain,
-          FilterState::StreamSharing stream_sharing = FilterState::StreamSharing::None) override;
+  void setData(
+      absl::string_view data_name, std::shared_ptr<Object> data, FilterState::StateType state_type,
+      FilterState::LifeSpan life_span = FilterState::LifeSpan::FilterChain,
+      StreamSharingMayImpactPooling stream_sharing = StreamSharingMayImpactPooling::None) override;
   bool hasDataWithName(absl::string_view) const override;
   const Object* getDataReadOnlyGeneric(absl::string_view data_name) const override;
   Object* getDataMutableGeneric(absl::string_view data_name) override;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -3147,7 +3147,7 @@ TEST_P(ClientConnectionWithCustomRawBufferSocketTest, TransportSocketCallbacks) 
   filter_state.setData("test-filter-state", filter_state_object,
                        StreamInfo::FilterState::StateType::ReadOnly,
                        StreamInfo::FilterState::LifeSpan::Connection,
-                       StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+                       StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   transport_socket_options_ = TransportSocketOptionsUtility::fromFilterState(filter_state);
   setUpBasicConnection();
 

--- a/test/common/network/transport_socket_options_impl_test.cc
+++ b/test/common/network/transport_socket_options_impl_test.cc
@@ -35,7 +35,7 @@ TEST_F(TransportSocketOptionsImplTest, SharedFilterState) {
   filter_state_.setData(
       "random_key_has_effect", std::make_unique<UpstreamServerName>("www.example.com"),
       StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain,
-      StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+      StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   auto transport_socket_options = TransportSocketOptionsUtility::fromFilterState(filter_state_);
   auto objects = transport_socket_options->downstreamSharedFilterStateObjects();
   EXPECT_EQ(1, objects.size());
@@ -108,7 +108,7 @@ TEST_F(TransportSocketOptionsImplTest, FilterStateHashable) {
   filter_state_.setData("hashable", std::make_shared<HashableObj>(),
                         StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain,
-                        StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+                        StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   auto transport_socket_options = TransportSocketOptionsUtility::fromFilterState(filter_state_);
   TestTransportSocketFactory factory;
   std::vector<uint8_t> keys;
@@ -120,7 +120,7 @@ TEST_F(TransportSocketOptionsImplTest, FilterStateNonHashable) {
   filter_state_.setData("non-hashable", std::make_shared<NonHashableObj>(),
                         StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain,
-                        StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+                        StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   auto transport_socket_options = TransportSocketOptionsUtility::fromFilterState(filter_state_);
   TestTransportSocketFactory factory;
   std::vector<uint8_t> keys;

--- a/test/common/stream_info/filter_state_impl_test.cc
+++ b/test/common/stream_info/filter_state_impl_test.cc
@@ -354,22 +354,22 @@ TEST_F(FilterStateImplTest, SharedWithUpstream) {
   auto shared = std::make_shared<SimpleType>(1);
   filterState().setData("shared_1", shared, FilterState::StateType::ReadOnly,
                         FilterState::LifeSpan::FilterChain,
-                        FilterState::StreamSharing::SharedWithUpstreamConnection);
+                        StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   filterState().setData("test_2", std::make_shared<SimpleType>(2), FilterState::StateType::Mutable,
                         FilterState::LifeSpan::FilterChain);
   filterState().setData("test_3", std::make_shared<SimpleType>(3), FilterState::StateType::ReadOnly,
                         FilterState::LifeSpan::Request);
   filterState().setData("shared_4", std::make_shared<SimpleType>(4),
                         FilterState::StateType::Mutable, FilterState::LifeSpan::Request,
-                        FilterState::StreamSharing::SharedWithUpstreamConnection);
+                        StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   filterState().setData("shared_5", std::make_shared<SimpleType>(5),
                         FilterState::StateType::ReadOnly, FilterState::LifeSpan::Connection,
-                        FilterState::StreamSharing::SharedWithUpstreamConnection);
+                        StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   filterState().setData("test_6", std::make_shared<SimpleType>(6), FilterState::StateType::Mutable,
                         FilterState::LifeSpan::Connection);
   filterState().setData("shared_7", std::make_shared<SimpleType>(7),
                         FilterState::StateType::ReadOnly, FilterState::LifeSpan::Connection,
-                        FilterState::StreamSharing::SharedWithUpstreamConnectionOnce);
+                        StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
   auto objects = filterState().objectsSharedWithUpstreamConnection();
   EXPECT_EQ(objects->size(), 4);
   std::sort(objects->begin(), objects->end(),
@@ -377,19 +377,19 @@ TEST_F(FilterStateImplTest, SharedWithUpstream) {
   EXPECT_EQ(objects->at(0).name_, "shared_1");
   EXPECT_EQ(objects->at(0).state_type_, FilterState::StateType::ReadOnly);
   EXPECT_EQ(objects->at(0).stream_sharing_,
-            FilterState::StreamSharing::SharedWithUpstreamConnection);
+            StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   EXPECT_EQ(objects->at(0).data_.get(), shared.get());
   EXPECT_EQ(objects->at(1).name_, "shared_4");
   EXPECT_EQ(objects->at(1).state_type_, FilterState::StateType::Mutable);
   EXPECT_EQ(objects->at(1).stream_sharing_,
-            FilterState::StreamSharing::SharedWithUpstreamConnection);
+            StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   EXPECT_EQ(objects->at(2).name_, "shared_5");
   EXPECT_EQ(objects->at(2).state_type_, FilterState::StateType::ReadOnly);
   EXPECT_EQ(objects->at(2).stream_sharing_,
-            FilterState::StreamSharing::SharedWithUpstreamConnection);
+            StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   EXPECT_EQ(objects->at(3).name_, "shared_7");
   EXPECT_EQ(objects->at(3).state_type_, FilterState::StateType::ReadOnly);
-  EXPECT_EQ(objects->at(3).stream_sharing_, FilterState::StreamSharing::None);
+  EXPECT_EQ(objects->at(3).stream_sharing_, StreamSharingMayImpactPooling::None);
 }
 
 TEST_F(FilterStateImplTest, HasDataAtOrAboveLifeSpan) {

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -121,7 +121,7 @@ public:
     filter_state.setData(
         "envoy.upstream.dynamic_host", std::make_shared<Router::StringAccessorImpl>(host),
         StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection,
-        StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+        StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
 
     return &lb_context_;
   }

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -1135,7 +1135,7 @@ TEST_F(IoHandleImplTest, PassthroughState) {
   auto object = std::make_shared<TestObject>(1000);
   source_filter_state.push_back(
       {object, StreamInfo::FilterState::StateType::ReadOnly,
-       StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection, "object_key"});
+       StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection, "object_key"});
   ASSERT_NE(nullptr, io_handle_->passthroughState());
   io_handle_->passthroughState()->initialize(std::move(source_metadata), source_filter_state);
 

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
@@ -82,7 +82,7 @@ TEST_F(InternalSocketTest, PassthroughStateInjected) {
   auto filter_state_object = std::make_shared<TestObject>();
   filter_state_objects_.push_back(
       {filter_state_object, StreamInfo::FilterState::StateType::ReadOnly,
-       StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection, "test.object"});
+       StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection, "test.object"});
   ProtobufWkt::Struct& map = (*metadata_->mutable_filter_metadata())["envoy.test"];
   ProtobufWkt::Value val;
   val.set_string_value("val");

--- a/test/integration/filters/header_to_filter_state.cc
+++ b/test/integration/filters/header_to_filter_state.cc
@@ -24,13 +24,13 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
     const auto entry = headers.get(header_);
     if (!entry.empty()) {
-      auto shared = StreamInfo::FilterState::StreamSharing::None;
+      auto shared = StreamInfo::StreamSharingMayImpactPooling::None;
       switch (shared_) {
       case test::integration::filters::SharingConfig::ONCE:
-        shared = StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnectionOnce;
+        shared = StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce;
         break;
       case test::integration::filters::SharingConfig::TRANSITIVE:
-        shared = StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection;
+        shared = StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection;
         break;
       default:
         break;


### PR DESCRIPTION
Commit Message: Add warning to documentation about using filter state "shared with upstream". Rename the enum to explicitly warn.
Risk Level: low
Testing: none
Docs Changes: yes
Release Notes: none