### PR TITLE
ci/examples: Use bazel cache directories for compiling

### DIFF
--- a/examples/golang/docker-compose-go.yaml
+++ b/examples/golang/docker-compose-go.yaml
@@ -4,7 +4,7 @@ services:
       context: ../shared/build
     command: >
       bash -c "
-      bazel build  //examples/golang/simple:simple.so
+      bazel build --experimental_repository_downloader_retries=2 --disk_cache=/tmp/disk_cache --repository_cache=/tmp/repository_cache --experimental_repository_cache_hardlinks //examples/golang/simple:simple.so
       && cp -a ./bazel-bin/examples/golang/simple/simple.so /output"
     entrypoint: /source/examples/shared/build/build-entrypoint.sh
     environment:

--- a/examples/wasm-cc/docker-compose-wasm.yaml
+++ b/examples/wasm-cc/docker-compose-wasm.yaml
@@ -4,7 +4,7 @@ services:
       context: ../shared/build
     command: >
       bash -c "
-      bazel build //examples/wasm-cc:envoy_filter_http_wasm_updated_example.wasm
+      bazel build --experimental_repository_downloader_retries=2 --disk_cache=/tmp/disk_cache --repository_cache=/tmp/repository_cache --experimental_repository_cache_hardlinks //examples/wasm-cc:envoy_filter_http_wasm_updated_example.wasm
       && cp -a bazel-bin/examples/wasm-cc/*updated*.wasm /output"
     entrypoint: /source/examples/shared/build/build-entrypoint.sh
     environment:
@@ -21,7 +21,7 @@ services:
       context: ../shared/build
     command: >
       bash -c "
-      bazel build //examples/wasm-cc:envoy_filter_http_wasm_example.wasm
+      bazel build --experimental_repository_downloader_retries=2 --disk_cache=/tmp/disk_cache --repository_cache=/tmp/repository_cache --experimental_repository_cache_hardlinks //examples/wasm-cc:envoy_filter_http_wasm_example.wasm
       && cp -a bazel-bin/examples/wasm-cc/* /output"
     entrypoint: /source/examples/shared/build/build-entrypoint.sh
     environment:


### PR DESCRIPTION
this is a minor cleanup/optimization in which the go/wasm bazel compile examples re/use a bazel cache. 

also adds retry flags for those jobs

partial/possible fix for #26074 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
