### PR TITLE
conn pool: relax assertion for pending streams in draining

### DIFF
--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -107,7 +107,6 @@ float ConnPoolImplBase::perUpstreamPreconnectRatio() const {
 }
 
 ConnPoolImplBase::ConnectionResult ConnPoolImplBase::tryCreateNewConnections() {
-  ASSERT(!is_draining_for_deletion_);
   ConnPoolImplBase::ConnectionResult result;
   // Somewhat arbitrarily cap the number of connections preconnected due to new
   // incoming connections. The preconnect ratio is capped at 3, so in steady
@@ -121,6 +120,7 @@ ConnPoolImplBase::ConnectionResult ConnPoolImplBase::tryCreateNewConnections() {
       break;
     }
   }
+  ASSERT(!is_draining_for_deletion_ || result != ConnectionResult::CreatedNewConnection);
   return result;
 }
 


### PR DESCRIPTION
Commit Message: Relax the over-zealous assertion. The assertion is triggered in the following scenario:
* pool has 2 pending streams and 2 connecting clients;
* pool is put into drain&delete mode;
* 1 client connects, onUpstreamReady is invoked
* 1 pending stream attached to a ready client, 2nd pending stream triggers tryCreateNewConnections
* assertion failure

Additional Description:
Risk Level: low, debug assertion
Testing: manually verified no longer triggered
Docs Changes: none
Release Notes: none