### PR TITLE
fix a small annotation mistake in go extension

### DIFF
--- a/contrib/golang/filters/http/source/go/pkg/http/type.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/type.go
@@ -117,7 +117,7 @@ func (h *httpHeaderMap) Del(key string) {
 	if h.isTrailer {
 		panic("unsupported yet")
 	}
-	// Get all header values first before removing a key, since the set operation may not take affects immediately
+	// Get all header values first before removing a key, since the del operation may not take affects immediately
 	// when it's invoked in a Go thread, instead, it will post a callback to run in the envoy worker thread.
 	// Otherwise, we may get outdated values in a following Get call.
 	if h.headers != nil {


### PR DESCRIPTION
Commit Message: fix a small annotation mistake in go extension
Additional Description: N/A
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
