### PR TITLE
ci/cache: Use x86 agent to prime arm Docker cache

### DIFF
--- a/.azure-pipelines/cached.yml
+++ b/.azure-pipelines/cached.yml
@@ -39,7 +39,7 @@ steps:
     cacheHitVar: CACHE_RESTORED
 
 # Prime the cache for all jobs
-- script: sudo .azure-pipelines/docker/prime_cache.sh "${{ parameters.tmpDirectory }}"
+- script: sudo .azure-pipelines/docker/prime_cache.sh "${{ parameters.tmpDirectory }}" "${{ parameters.arch }}"
   displayName: "Cache/prime ${{ parameters.name }})"
   # TODO(phlax): figure if there is a way to test cache without downloading it
   condition: and(not(canceled()), eq(${{ parameters.prime }}, true), ne(variables.CACHE_RESTORED, 'true'))

--- a/.azure-pipelines/docker/prime_cache.sh
+++ b/.azure-pipelines/docker/prime_cache.sh
@@ -1,10 +1,17 @@
 #!/bin/bash -e
 
 DOCKER_CACHE_PATH="$1"
+DOCKER_CACHE_ARCH="$2"
 
 if [[ -z "$DOCKER_CACHE_PATH" ]]; then
     echo "prime_docker_cache called without path arg" >&2
     exit 1
+fi
+
+if [[ "$DOCKER_CACHE_ARCH" == ".arm64" ]]; then
+    DOCKER_CACHE_ARCH=linux/arm64
+else
+    DOCKER_CACHE_ARCH=linux/amd64
 fi
 
 DOCKER_CACHE_TARBALL="${DOCKER_CACHE_PATH}/docker.tar.zst"
@@ -19,8 +26,8 @@ systemctl start docker
 
 BUILD_IMAGE=$(head -n1 .devcontainer/Dockerfile  | cut -d: -f2)
 
-echo "Pulling build image (${BUILD_IMAGE}) ..."
-docker pull -q "envoyproxy/envoy-build-ubuntu:${BUILD_IMAGE}"
+echo "Pulling build image for ${DOCKER_CACHE_ARCH} (${BUILD_IMAGE}) ..."
+docker pull -q --platform "${DOCKER_CACHE_ARCH}" "envoyproxy/envoy-build-ubuntu:${BUILD_IMAGE}"
 
 echo "Stopping docker"
 systemctl stop docker

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -78,7 +78,8 @@ stages:
   - job: cache_arm
     dependsOn: []
     displayName: Cache (arm64)
-    pool: arm-large
+    pool:
+      vmImage: "ubuntu-20.04"
     steps:
     - template: cached.yml
       parameters:


### PR DESCRIPTION
Docker can pull images from other arches (now) so there is no need to use a huge arm instance to warm this cache

Doing this currently is creating a bottleneck on these expensive servers

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
