### PR TITLE
[mobile] gate grpc api calls

### DIFF
--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -858,6 +858,7 @@ private extension EngineBuilder {
 
     cxxBuilder.addStatsSinks(self.statsSinks.toCXX())
 
+#if ENVOY_GOOGLE_GRPC
     if
       let nodeRegion = self.nodeRegion,
       let nodeZone = self.nodeZone,
@@ -890,6 +891,7 @@ private extension EngineBuilder {
     if self.enableCds {
       cxxBuilder.addCdsLayer(self.cdsResourcesLocator.toCXX(), Int32(self.cdsTimeoutSeconds))
     }
+  #endif
     return cxxBuilder.generateBootstrap()
   }
   // swiftlint:enable cyclomatic_complexity


### PR DESCRIPTION
Commit Message: gRPC API calls are available only if `ENVOY_GOOGLE_GRPC` is true. Otherwise, they are compiled out. This prevents Envoy Mobile from building for cases when `ENVOY_GOOGLE_GRPC` is false.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
