### PR TITLE
Adding MultiActions for composite filters. WIP

### DIFF
--- a/api/envoy/extensions/filters/http/composite/v3/composite.proto
+++ b/api/envoy/extensions/filters/http/composite/v3/composite.proto
@@ -44,4 +44,3 @@ message ExecuteFilterAction {
 message ExecuteFilterMultiAction {
   repeated config.core.v3.TypedExtensionConfig typed_config = 1;
 }
-

--- a/api/envoy/extensions/filters/http/composite/v3/composite.proto
+++ b/api/envoy/extensions/filters/http/composite/v3/composite.proto
@@ -38,7 +38,9 @@ message ExecuteFilterAction {
   config.core.v3.TypedExtensionConfig typed_config = 1;
 }
 
-
+// Composite match action (see :ref:`matching docs <arch_overview_matching_api>` for more info on match actions).
+// This allows multiple delegate filters to be linked to one action, executing individual parts in parallel.
+// The final filter in the list is the filter that returns the resulting status, all other filter statuses are dropped.
 message ExecuteFilterMultiAction {
   repeated config.core.v3.TypedExtensionConfig typed_config = 1;
 }

--- a/api/envoy/extensions/filters/http/composite/v3/composite.proto
+++ b/api/envoy/extensions/filters/http/composite/v3/composite.proto
@@ -37,3 +37,9 @@ message Composite {
 message ExecuteFilterAction {
   config.core.v3.TypedExtensionConfig typed_config = 1;
 }
+
+
+message ExecuteFilterMultiAction {
+  repeated config.core.v3.TypedExtensionConfig typed_config = 1;
+}
+

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -10,7 +10,8 @@ void ExecuteFilterAction::createFilters(Http::FilterChainFactoryCallbacks& callb
 REGISTER_FACTORY(ExecuteFilterActionFactory,
                  Matcher::ActionFactory<Http::Matching::HttpFilterActionContext>);
 
-void ExecuteFilterMultiAction::createFilters(std::function<void(Envoy::Http::FilterFactoryCb&)> parse_wrapper) const {
+void ExecuteFilterMultiAction::createFilters(
+    std::function<void(Envoy::Http::FilterFactoryCb&)> parse_wrapper) const {
   for (auto cb : cb_list_) {
     parse_wrapper(cb);
   }

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -9,6 +9,15 @@ void ExecuteFilterAction::createFilters(Http::FilterChainFactoryCallbacks& callb
 }
 REGISTER_FACTORY(ExecuteFilterActionFactory,
                  Matcher::ActionFactory<Http::Matching::HttpFilterActionContext>);
+
+void ExecuteFilterMultiAction::createFilters(std::function<void(Envoy::Http::FilterFactoryCb&)> parse_wrapper) const {
+  for (auto cb : cb_list_) {
+    parse_wrapper(cb);
+  }
+}
+REGISTER_FACTORY(ExecuteFilterMultiActionFactory,
+                 Matcher::ActionFactory<Http::Matching::HttpFilterActionContext>);
+
 } // namespace Composite
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -73,8 +73,9 @@ public:
   createActionFactoryCb(const Protobuf::Message& config,
                         Envoy::Http::Matching::HttpFilterActionContext& context,
                         ProtobufMessage::ValidationVisitor& validation) override {
-    const auto& composite_action =
-        MessageUtil::downcastAndValidate<const envoy::extensions::filters::http::composite::v3::ExecuteFilterMultiAction&>(config, validation);
+    const auto& composite_action = MessageUtil::downcastAndValidate<
+        const envoy::extensions::filters::http::composite::v3::ExecuteFilterMultiAction&>(
+        config, validation);
     std::vector<Http::FilterFactoryCb> callback_list;
     for (auto typed_config : composite_action.typed_config()) {
       auto& factory =
@@ -83,14 +84,15 @@ public:
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
           typed_config.typed_config(), validation, factory);
       callback_list.push_back(factory.createFilterFactoryFromProto(*message, context.stat_prefix_,
-                                                               context.factory_context_));
+                                                                   context.factory_context_));
     }
     return [cb_list = std::move(callback_list)]() -> Matcher::ActionPtr {
       return std::make_unique<ExecuteFilterMultiAction>(cb_list);
     };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<envoy::extensions::filters::http::composite::v3::ExecuteFilterMultiAction>();
+    return std::make_unique<
+        envoy::extensions::filters::http::composite::v3::ExecuteFilterMultiAction>();
   }
 };
 

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -57,10 +57,10 @@ public:
 
   // Http::StreamFilterBase
   void onDestroy() override {
-    if (delegated_filter_) {
+    for (auto delegated_filter : delegated_filter_list_){
       // We need to explicitly specify which base class to the conversion via due
       // to the diamond inheritance between StreamFilter and StreamFilterBase.
-      static_cast<Http::StreamDecoderFilter&>(*delegated_filter_).onDestroy();
+      static_cast<Http::StreamDecoderFilter&>(*delegated_filter).onDestroy();
     }
   }
 
@@ -86,6 +86,8 @@ private:
   // We should be protected against this by the match tree validation that only allows request
   // headers, this just provides some additional sanity checking.
   bool decoded_headers_ : 1;
+
+  void ApplyWrapper(FactoryCallbacksWrapper& wrapper);
 
   // Wraps a stream encoder OR a stream decoder filter into a stream filter, making it easier to
   // delegate calls.
@@ -124,9 +126,9 @@ private:
   };
   std::vector<AccessLog::InstanceSharedPtr> access_loggers_;
 
-  Http::StreamFilterSharedPtr delegated_filter_;
-  Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
-  Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
+  std::vector<Http::StreamFilterSharedPtr> delegated_filter_list_;
+  Http::StreamEncoderFilterCallbacks* encoder_callbacks_;
+  Http::StreamDecoderFilterCallbacks* decoder_callbacks_;
   FilterStats& stats_;
 };
 

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -57,7 +57,7 @@ public:
 
   // Http::StreamFilterBase
   void onDestroy() override {
-    for (auto delegated_filter : delegated_filter_list_){
+    for (auto delegated_filter : delegated_filter_list_) {
       // We need to explicitly specify which base class to the conversion via due
       // to the diamond inheritance between StreamFilter and StreamFilterBase.
       static_cast<Http::StreamDecoderFilter&>(*delegated_filter).onDestroy();

--- a/test/extensions/filters/http/composite/BUILD
+++ b/test/extensions/filters/http/composite/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/composite:filter_lib",
         "//test/integration:http_integration_lib",
         "//test/integration/filters:set_response_code_filter_lib",
+        "@envoy_api//envoy/extensions/common/matching/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/composite/composite_filter_integration_test.cc
+++ b/test/extensions/filters/http/composite/composite_filter_integration_test.cc
@@ -1,4 +1,5 @@
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/extensions/common/matching/v3/extension_matcher.pb.h"
 
 #include "test/integration/http_integration.h"
 #include "test/mocks/http/mocks.h"
@@ -41,6 +42,20 @@ public:
                     typed_config:
                       "@type": type.googleapis.com/test.integration.filters.SetResponseCodeFilterConfig
                       code: 403
+            multi-match:
+              action:
+                name: composite-multi-action
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterMultiAction
+                  typed_config:
+                  - name: skip
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+                  - name: set-response-code
+                    typed_config:
+                      "@type": type.googleapis.com/test.integration.filters.SetResponseCodeFilterConfig
+                      code: 404
+                
     )EOF");
     HttpIntegrationTest::initialize();
   }
@@ -74,6 +89,33 @@ TEST_P(CompositeFilterIntegrationTest, TestBasic) {
     auto response = codec_client_->makeRequestWithBody(request_headers, 1024);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), Http::HttpStatusIs("403"));
+  }
+}
+
+// Verifies that if we don't match the match action the request is proxied as normal, while if the
+// match action is hit we apply the specified filter to the stream.
+TEST_P(CompositeFilterIntegrationTest, TestBasicMultiAction) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  {
+    auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+    waitForNextUpstreamRequest();
+
+    upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
+  }
+
+  {
+    const Http::TestRequestHeaderMapImpl request_headers = {{":method", "GET"},
+                                                            {":path", "/somepath"},
+                                                            {":scheme", "http"},
+                                                            {"match-header", "multi-match"},
+                                                            {":authority", "blah"}};
+    auto response = codec_client_->makeRequestWithBody(request_headers, 1024);
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_THAT(response->headers(), Http::HttpStatusIs("404"));
   }
 }
 

--- a/test/extensions/filters/http/composite/composite_filter_integration_test.cc
+++ b/test/extensions/filters/http/composite/composite_filter_integration_test.cc
@@ -90,7 +90,11 @@ TEST_P(CompositeFilterIntegrationTest, TestBasic) {
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_THAT(response->headers(), Http::HttpStatusIs("403"));
   }
-
+}
+// Verifies that multi-actions are preformed in order of definition.
+TEST_P(CompositeFilterIntegrationTest, TestBasicMultiAction) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
   {
     const Http::TestRequestHeaderMapImpl request_headers = {{":method", "GET"},
                                                             {":path", "/somepath"},


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Adding a Multi Action Execution action to the composite filter.
Additional Description: Executes multiple actions as one route path in the filter.
Risk Level: n/a
Testing: [test/extensions/filters/http/composite/composite_filter_integration_test.cc](https://github.com/envoyproxy/envoy/compare/main...jstraceski:envoy:MultipleAction?expand=1#diff-5889ed11fe03931f7c4d34dbd55eb54042e374d4e678255c4aa932d91fcce475)
Docs Changes: TBD
Release Notes: TBD
Platform Specific Features: N/A
