### PR TITLE
Mobile: add google_grpc=disabled to compile_time_options test

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -39,6 +39,7 @@ jobs:
             --define=admin_html=enabled \
             --define=envoy_mobile_request_compression=disabled \
             --define=envoy_enable_http_datagrams=disabled \
+            --define=google_grpc=disabled \
             --@envoy//bazel:http3=False \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             //test/cc/...
@@ -71,6 +72,7 @@ jobs:
             --define=envoy_mobile_stats_reporting=disabled \
             --define=envoy_mobile_swift_cxx_interop=disabled \
             --define=envoy_enable_http_datagrams=disabled \
+            --define=google_grpc=disabled \
             --@envoy//bazel:http3=False \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             //library/swift:ios_framework
@@ -107,6 +109,7 @@ jobs:
           --define=admin_html=enabled \
           --define=envoy_mobile_request_compression=disabled \
           --define=envoy_enable_http_datagrams=disabled \
+          --define=google_grpc=disabled \
           --@envoy//bazel:http3=False \
           --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
           //:android_dist

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -49,7 +49,9 @@ TEST(TestConfig, ConfigIsApplied) {
       .enableAdminInterface(true)
 #endif
       .setForceAlwaysUsev6(true)
+#ifdef ENVOY_GOOGLE_GRPC
       .setNodeId("my_test_node")
+#endif
       .setDeviceOs("probably-ubuntu-on-CI");
 
   std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
@@ -457,6 +459,7 @@ TEST(TestConfig, AddVirtualCluster) {
   EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("cluster2"));
 }
 
+#ifdef ENVOY_GOOGLE_GRPC
 TEST(TestConfig, SetNodeId) {
   EngineBuilder engine_builder;
   const std::string default_node_id = "envoy-mobile";
@@ -502,6 +505,7 @@ TEST(TestConfig, AddCdsLayer) {
   EXPECT_EQ(bootstrap->dynamic_resources().cds_config().api_config_source().transport_api_version(),
             envoy::config::core::v3::ApiVersion::V3);
 }
+#endif
 
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
This flag is enabled in regular tests, but we should test the case where it's disabled.  Seems like this test suite is the place intended for doing that!

Resolves https://github.com/envoyproxy/envoy/issues/26259