### PR TITLE
CODEOWNERS: update qat and cryptomb extension owners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -333,10 +333,10 @@ extensions/filters/http/oauth2 @derekargueta @snowp
 /contrib/postgres_proxy/ @fabriziomello @cpakulski
 /contrib/sxg/ @cpapazian @alyssawilk
 /contrib/sip_proxy/ @durd07 @nearbyfly @dorisd0102
-/contrib/cryptomb/ @ipuustin @VillePihlava
+/contrib/cryptomb/ @giantcroc @soulxu
 /contrib/vcl/ @florincoras @KfreeZ
 /contrib/hyperscan/ @zhxie @soulxu
 /contrib/language/ @diceride @diceride
 /contrib/dlb/ @mattklein123 @daixiang0
-/contrib/qat/ @ipuustin @VillePihlava
+/contrib/qat/ @giantcroc @soulxu
 /contrib/generic_proxy/ @wbpcode @soulxu @zhaohuabing @rojkov @htuch


### PR DESCRIPTION
Commit Message:

Update codeowners for qat and cryptomb extensions.

Additional Description:

@VillePihlava @soulxu @giantcroc

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A