### PR TITLE
Revert "Enable HTTP/3 in tests (#26197)"

### DIFF
--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -109,12 +109,7 @@ void Http3ConnPoolImpl::onConnectFailed(Envoy::ConnectionPool::ActiveClient& cli
 }
 
 // Make sure all connections are torn down before quic_info_ is deleted.
-Http3ConnPoolImpl::~Http3ConnPoolImpl() {
-  destructAllConnections();
-  // Set this to zero since state_ is not tracking connections for H3, only the initial capacity
-  // pending_streams_ and active_streams_ are verified to be zero in the destructor of state_.
-  state_.connecting_and_connected_stream_capacity_ = 0;
-}
+Http3ConnPoolImpl::~Http3ConnPoolImpl() { destructAllConnections(); }
 
 std::unique_ptr<Network::ClientConnection>
 Http3ConnPoolImpl::createClientConnection(Quic::QuicStatNames& quic_stat_names,

--- a/test/common/common/packed_struct_test.cc
+++ b/test/common/common/packed_struct_test.cc
@@ -65,7 +65,7 @@ TEST_F(PackedStructTest, StringStructMove) {
   EXPECT_FALSE(redirect_strings.get<RedirectStringElement::HostRedirect>().has_value());
 
   // Invoke move constructor.
-  RedirectStringsPackedStruct redirect_strings2(std::move(redirect_strings));
+  RedirectStringsPackedStruct redirect_strings2(move(redirect_strings));
   // Ensure no memory was allocated on the heap by the move constructor.
   EXPECT_MEMORY_LE(memory_test.consumedBytes(), 2 * sizeof(std::string) + 16);
 
@@ -77,7 +77,7 @@ TEST_F(PackedStructTest, StringStructMove) {
 
   // Invoke move assignment.
   RedirectStringsPackedStruct redirect_strings3(0);
-  redirect_strings3 = std::move(redirect_strings2);
+  redirect_strings3 = move(redirect_strings2);
   // Ensure no memory was allocated on the heap by the move assignment.
   EXPECT_MEMORY_LE(memory_test.consumedBytes(), 2 * sizeof(std::string) + 16);
 

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -94,7 +94,7 @@ public:
   MockQuicClientTransportSocketFactory(
       Ssl::ClientContextConfigPtr config,
       Server::Configuration::TransportSocketFactoryContext& factory_context)
-      : Quic::QuicClientTransportSocketFactory(std::move(config), factory_context) {}
+      : Quic::QuicClientTransportSocketFactory(move(config), factory_context) {}
 
   MOCK_METHOD(Envoy::Ssl::ClientContextSharedPtr, sslCtx, ());
 };

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -21,11 +21,6 @@ TEST_P(BufferIntegrationTest, RouterNotFoundBodyBuffer) {
 }
 
 TEST_P(BufferIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    // TODO(#26236) - Fix test flakiness over HTTP/3.
-    return;
-  }
   config_helper_.prependFilter(ConfigHelper::defaultBufferFilter(), testing_downstream_filter_);
   testRouterRequestAndResponseWithBody(4 * 1024 * 1024, 4 * 1024 * 1024, false);
 }
@@ -51,11 +46,8 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder =
-      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                                                 {":scheme", "http"},
-                                                                 {":path", "/shelf"},
-                                                                 {":authority", "sni.lyft.com"}});
+  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "POST"}, {":scheme", "http"}, {":path", "/shelf"}, {":authority", "host"}});
   request_encoder_ = &encoder_decoder.first;
   IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, "123", false);
@@ -82,11 +74,8 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLengthOnTrailers) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder =
-      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                                                 {":scheme", "http"},
-                                                                 {":path", "/shelf"},
-                                                                 {":authority", "sni.lyft.com"}});
+  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "POST"}, {":scheme", "http"}, {":path", "/shelf"}, {":authority", "host"}});
   request_encoder_ = &encoder_decoder.first;
   IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, "0123", false);
@@ -127,7 +116,7 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/dynamo/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024 * 65, false);
@@ -170,7 +159,7 @@ TEST_P(BufferIntegrationTest, RouteDisabled) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"x-forwarded-for", "10.0.0.1"}},
       1024 * 65);
 
@@ -199,7 +188,7 @@ TEST_P(BufferIntegrationTest, RouteOverride) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"x-forwarded-for", "10.0.0.1"}},
       1024 * 65);
 

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -108,11 +108,9 @@ public:
   OptRef<const Http::TestResponseTrailerMapImpl> empty_trailers_;
 };
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, CacheIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, CacheIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CacheIntegrationTest, MissInsertHit) {
   initializeFilter(default_config);

--- a/test/extensions/filters/http/compressor/compressor_integration_tests.cc
+++ b/test/extensions/filters/http/compressor/compressor_integration_tests.cc
@@ -119,13 +119,9 @@ void WebsocketWithCompressorIntegrationTest::validateUpgradeResponseHeaders(
   EXPECT_THAT(&proxied_response_headers, HeaderMapEqualIgnoreOrder(&original_response_headers));
 }
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, WebsocketWithCompressorIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
-        /*downstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2},
-        /*upstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2})),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, WebsocketWithCompressorIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 ConfigHelper::HttpModifierFunction setRouteUsingWebsocket() {
   return [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -248,12 +244,9 @@ TEST_P(WebsocketWithCompressorIntegrationTest, NonWebsocketUpgrade) {
   ASSERT_EQ(1, response_uncompressed_counter->value());
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, CompressorProxyingConnectIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
-        /*downstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2},
-        /*upstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2})),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, CompressorProxyingConnectIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 void CompressorProxyingConnectIntegrationTest::initialize() {
   config_helper_.addConfigModifier(

--- a/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
@@ -74,11 +74,9 @@ protected:
   }
 };
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, CsrfFilterIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, CsrfFilterIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CsrfFilterIntegrationTest, TestCsrfSuccess) {
   config_helper_.prependFilter(CSRF_FILTER_ENABLED_CONFIG);

--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -643,11 +643,9 @@ TEST_P(CustomResponseIntegrationTest, ModifyRequestHeaders) {
   EXPECT_EQ("Modify action response body", response->body());
 }
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, CustomResponseIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, CustomResponseIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 } // namespace CustomResponse
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -83,12 +83,9 @@ typed_config:
 // Fault integration tests that should run with all protocols, useful for testing various
 // end_stream permutations when rate limiting.
 class FaultIntegrationTestAllProtocols : public FaultIntegrationTest {};
-
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, FaultIntegrationTestAllProtocols,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, FaultIntegrationTestAllProtocols,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // No fault injected.
 TEST_P(FaultIntegrationTestAllProtocols, NoFault) {

--- a/test/extensions/filters/http/file_system_buffer/filter_integration_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/filter_integration_test.cc
@@ -57,13 +57,9 @@ std::string smallRequestBufferConfig() {
 
 using FileSystemBufferIntegrationTest = HttpProtocolIntegrationTest;
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, FileSystemBufferIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
-        /*downstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2},
-        /*upstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2})),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, FileSystemBufferIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(FileSystemBufferIntegrationTest, NotFoundBodyBuffer) {
   config_helper_.prependFilter(contentLengthConfig());

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -59,11 +59,9 @@ std::string getFilterConfig(bool use_local_jwks) {
 
 class LocalJwksIntegrationTest : public HttpProtocolIntegrationTest {};
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, LocalJwksIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, LocalJwksIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // With local Jwks, this test verifies a request is passed with a good Jwt token.
 TEST_P(LocalJwksIntegrationTest, WithGoodToken) {
@@ -387,10 +385,9 @@ public:
   FakeStreamPtr jwks_request_{};
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, RemoteJwksIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, RemoteJwksIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // With remote Jwks, this test verifies a request is passed with a good Jwt token
 // and a good public key fetched from a remote server.
@@ -612,10 +609,9 @@ public:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, PerRouteIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, PerRouteIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // This test verifies per-route config disabled.
 TEST_P(PerRouteIntegrationTest, PerRouteConfigDisabled) {

--- a/test/extensions/filters/http/kill_request/crash_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/crash_integration_test.cc
@@ -40,12 +40,9 @@ protected:
 
 // Tests should run with all protocols.
 class CrashIntegrationTestAllProtocols : public CrashIntegrationTest {};
-
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, CrashIntegrationTestAllProtocols,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, CrashIntegrationTestAllProtocols,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CrashIntegrationTestAllProtocols, UnwindsTrackedObjectStack) {
   const std::string request_kill_config =

--- a/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
@@ -28,12 +28,9 @@ typed_config:
 
 // Tests should run with all protocols.
 class KillRequestFilterIntegrationTestAllProtocols : public KillRequestFilterIntegrationTest {};
-
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, KillRequestFilterIntegrationTestAllProtocols,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, KillRequestFilterIntegrationTestAllProtocols,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // Request crash Envoy controlled via header configuration.
 TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoy) {

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -179,11 +179,9 @@ virtual_hosts:
 )EOF";
 };
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, LocalRateLimitFilterIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, LocalRateLimitFilterIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(LocalRateLimitFilterIntegrationTest, DenyRequestPerProcess) {
   initializeFilter(fmt::format(fmt::runtime(filter_config_), "false"));

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -341,11 +341,9 @@ typed_config:
 
 using RBACIntegrationTest = HttpProtocolIntegrationTest;
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, RBACIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, RBACIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(RBACIntegrationTest, Allowed) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");
@@ -359,7 +357,7 @@ TEST_P(RBACIntegrationTest, Allowed) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -384,7 +382,7 @@ TEST_P(RBACIntegrationTest, Denied) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -407,7 +405,7 @@ TEST_P(RBACIntegrationTest, DeniedWithDenyAction) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -433,7 +431,7 @@ TEST_P(RBACIntegrationTest, DeniedWithPrefixRule) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -459,7 +457,7 @@ TEST_P(RBACIntegrationTest, RbacPrefixRuleUseNormalizePath) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -480,7 +478,7 @@ TEST_P(RBACIntegrationTest, DeniedHeadReply) {
           {":method", "HEAD"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -516,7 +514,7 @@ TEST_P(RBACIntegrationTest, RouteOverride) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -545,7 +543,7 @@ TEST_P(RBACIntegrationTest, PathWithQueryAndFragmentWithOverride) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "sni.lyft.com"},
+            {":authority", "host"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -569,7 +567,7 @@ TEST_P(RBACIntegrationTest, PathWithFragmentRejectedByDefault) {
           {":method", "POST"},
           {":path", "/allow?p1=v1#seg"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -599,7 +597,7 @@ TEST_P(RBACIntegrationTest, DenyExactMatchIgnoresQueryAndFragment) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "sni.lyft.com"},
+            {":authority", "host"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -628,7 +626,7 @@ TEST_P(RBACIntegrationTest, PathIgnoreCase) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "sni.lyft.com"},
+            {":authority", "host"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -652,7 +650,7 @@ TEST_P(RBACIntegrationTest, LogConnectionAllow) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -676,7 +674,7 @@ TEST_P(RBACIntegrationTest, HeaderMatchCondition) {
           {":method", "POST"},
           {":path", "/path"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"xxx", "yyy"},
       },
       1024);
@@ -701,7 +699,7 @@ TEST_P(RBACIntegrationTest, HeaderMatchConditionDuplicateHeaderNoMatch) {
           {":method", "POST"},
           {":path", "/path"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"xxx", "yyy"},
           {"xxx", "zzz"},
       },
@@ -724,7 +722,7 @@ TEST_P(RBACIntegrationTest, HeaderMatchConditionDuplicateHeaderMatch) {
           {":method", "POST"},
           {":path", "/path"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"xxx", "yyy"},
           {"xxx", "zzz"},
       },
@@ -749,7 +747,7 @@ TEST_P(RBACIntegrationTest, MatcherAllowed) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -774,7 +772,7 @@ TEST_P(RBACIntegrationTest, MatcherDenied) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -797,7 +795,7 @@ TEST_P(RBACIntegrationTest, MatcherDeniedWithDenyAction) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -823,7 +821,7 @@ TEST_P(RBACIntegrationTest, MatcherDeniedWithPrefixRule) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -849,7 +847,7 @@ TEST_P(RBACIntegrationTest, RbacPrefixRuleUseNormalizePathMatcher) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -870,7 +868,7 @@ TEST_P(RBACIntegrationTest, MatcherDeniedHeadReply) {
           {":method", "HEAD"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -906,7 +904,7 @@ TEST_P(RBACIntegrationTest, MatcherRouteOverride) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -935,7 +933,7 @@ TEST_P(RBACIntegrationTest, PathMatcherWithQueryAndFragmentWithOverride) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "sni.lyft.com"},
+            {":authority", "host"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -959,7 +957,7 @@ TEST_P(RBACIntegrationTest, PathMatcherWithFragmentRejectedByDefault) {
           {":method", "POST"},
           {":path", "/allow?p1=v1#seg"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -989,7 +987,7 @@ TEST_P(RBACIntegrationTest, MatcherDenyExactMatchIgnoresQueryAndFragment) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "sni.lyft.com"},
+            {":authority", "host"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -1018,7 +1016,7 @@ TEST_P(RBACIntegrationTest, PathIgnoreCaseMatcher) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "sni.lyft.com"},
+            {":authority", "host"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -1042,7 +1040,7 @@ TEST_P(RBACIntegrationTest, MatcherLogConnectionAllow) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "sni.lyft.com"},
+          {":authority", "host"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);

--- a/test/extensions/internal_redirect/redirect_extension_integration_test.cc
+++ b/test/extensions/internal_redirect/redirect_extension_integration_test.cc
@@ -292,10 +292,8 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedBySafeCrossSch
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, RedirectExtensionIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, RedirectExtensionIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 } // namespace Envoy

--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -381,9 +381,8 @@ TEST_P(Http11ConnectHttpIntegrationTest, TestHttp2) {
 
 #ifdef ENVOY_ENABLE_QUIC
 
-// TODO(#26236) - Fix test flakiness over HTTP/3.
 // Test Http3 failing to HTTP/2 if proxy settings are enabled.
-TEST_P(Http11ConnectHttpIntegrationTest, DISABLED_TestHttp3Failover) {
+TEST_P(Http11ConnectHttpIntegrationTest, TestHttp3Failover) {
   setUpstreamProtocol(Http::CodecType::HTTP2);
   use_alpn_ = true;
   try_http3_ = true;

--- a/test/integration/circuit_breakers_integration_test.cc
+++ b/test/integration/circuit_breakers_integration_test.cc
@@ -10,11 +10,9 @@ public:
   void initialize() override { HttpProtocolIntegrationTest::initialize(); }
 };
 
-// TODO(#26236): Fix test suite for HTTP/3.
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, CircuitBreakersIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, CircuitBreakersIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // This test checks that triggered max requests circuit breaker
 // doesn't force outlier detectors to eject an upstream host.

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -406,20 +406,20 @@ Http::RequestDecoder& FakeHttpConnection::newStream(Http::ResponseEncoder& encod
 }
 
 void FakeHttpConnection::onGoAway(Http::GoAwayErrorCode code) {
-  ASSERT(type_ != Http::CodecType::HTTP1);
+  ASSERT(type_ >= Http::CodecType::HTTP2);
   // Usually indicates connection level errors, no operations are needed since
   // the connection will be closed soon.
   ENVOY_LOG(info, "FakeHttpConnection receives GOAWAY: ", static_cast<int>(code));
 }
 
 void FakeHttpConnection::encodeGoAway() {
-  ASSERT(type_ != Http::CodecType::HTTP1);
+  ASSERT(type_ >= Http::CodecType::HTTP2);
 
   postToConnectionThread([this]() { codec_->goAway(); });
 }
 
 void FakeHttpConnection::updateConcurrentStreams(uint64_t max_streams) {
-  ASSERT(type_ != Http::CodecType::HTTP1);
+  ASSERT(type_ >= Http::CodecType::HTTP2);
 
   if (type_ == Http::CodecType::HTTP2) {
     postToConnectionThread([this, max_streams]() {
@@ -441,7 +441,7 @@ void FakeHttpConnection::updateConcurrentStreams(uint64_t max_streams) {
 }
 
 void FakeHttpConnection::encodeProtocolError() {
-  ASSERT(type_ != Http::CodecType::HTTP1);
+  ASSERT(type_ >= Http::CodecType::HTTP2);
 
   Http::Http2::ServerConnectionImpl* codec =
       dynamic_cast<Http::Http2::ServerConnectionImpl*>(codec_.get());

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -28,7 +28,7 @@ public:
   }
 
   void verifyUpStreamRequestAfterStopAllFilter() {
-    if (downstreamProtocol() != Http::CodecType::HTTP1) {
+    if (downstreamProtocol() >= Http::CodecType::HTTP2) {
       // decode-headers-return-stop-all-filter calls addDecodedData in decodeData and
       // decodeTrailers. 2 decoded data were added.
       EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 2, upstream_request_->bodyLength());
@@ -409,7 +409,7 @@ name: add-trailers-filter
   upstream_request_->encodeData(128, true);
   ASSERT_TRUE(response->waitForEndStream());
 
-  if (upstreamProtocol() != Http::CodecType::HTTP1) {
+  if (upstreamProtocol() >= Http::CodecType::HTTP2) {
     EXPECT_EQ("decode", upstream_request_->trailers()
                             ->get(Http::LowerCaseString("grpc-message"))[0]
                             ->value()
@@ -417,7 +417,7 @@ name: add-trailers-filter
   }
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  if (downstream_protocol_ != Http::CodecType::HTTP1) {
+  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
     EXPECT_EQ("encode", response->trailers()->getGrpcMessageValue());
   }
 }
@@ -502,7 +502,7 @@ TEST_P(FilterIntegrationTest, HittingDecoderFilterLimit) {
   // the 413-and-connection-close may be sent while the body is still being
   // sent, resulting in a write error and the connection being closed before the
   // response is read.
-  if (downstream_protocol_ != Http::CodecType::HTTP1) {
+  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
     ASSERT_TRUE(response->complete());
   }
   if (response->complete()) {

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -1422,7 +1422,7 @@ INSTANTIATE_TEST_SUITE_P(Protocols, EmptyHeaderIntegrationTest,
                          HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(EmptyHeaderIntegrationTest, AllProtocolsPassEmptyHeaders) {
-  auto vhost = config_helper_.createVirtualHost("sni.lyft.com");
+  auto vhost = config_helper_.createVirtualHost("empty-headers.com");
   *vhost.add_request_headers_to_add() = TestUtility::parseYaml<HeaderValueOption>(R"EOF(
     header:
       key: "x-ds-add-empty"
@@ -1451,8 +1451,10 @@ TEST_P(EmptyHeaderIntegrationTest, AllProtocolsPassEmptyHeaders) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = sendRequestAndWaitForResponse(
-      Http::TestRequestHeaderMapImpl{
-          {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "sni.lyft.com"}},
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "empty-headers.com"}},
       0,
       Http::TestResponseHeaderMapImpl{
           {"server", "envoy"}, {"content-length", "0"}, {":status", "200"}},

--- a/test/integration/http_conn_pool_integration_test.cc
+++ b/test/integration/http_conn_pool_integration_test.cc
@@ -162,16 +162,16 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
 
   setUpstreamCount(2);
 
-  auto host = config_helper_.createVirtualHost("cluster_1.lyft.com", "/", "cluster_1");
+  auto host = config_helper_.createVirtualHost("cluster_1.com", "/", "cluster_1");
   config_helper_.addVirtualHost(host);
 
-  config_helper_.setDefaultHostAndRoute("cluster_0.lyft.com", "/");
+  config_helper_.setDefaultHostAndRoute("cluster_0.com", "/");
 
   initialize();
 
   // Request Flow to cluster_0.
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  default_request_headers_.setHost("cluster_0.lyft.com");
+  default_request_headers_.setHost("cluster_0.com");
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
   waitForNextUpstreamRequest();
 
@@ -190,7 +190,7 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
 
   // Request Flow to cluster_1.
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  default_request_headers_.setHost("cluster_1.lyft.com");
+  default_request_headers_.setHost("cluster_1.com");
   response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
   waitForNextUpstreamRequest(1);
 

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -42,24 +42,11 @@ public:
   //
   // Upstream and downstream protocols may be changed via the input vectors.
   // Address combinations are propagated from TestEnvironment::getIpVersionsForTest()
-  static std::vector<HttpProtocolTestParams>
-  getProtocolTestParams(const std::vector<Http::CodecType>& downstream_protocols =
-                            {
-                                Http::CodecType::HTTP1,
-                                Http::CodecType::HTTP2,
-                                Http::CodecType::HTTP3,
-                            },
-                        const std::vector<Http::CodecType>& upstream_protocols = {
-                            Http::CodecType::HTTP1,
-                            Http::CodecType::HTTP2,
-                            Http::CodecType::HTTP3,
-                        });
-
-  static std::vector<HttpProtocolTestParams> getProtocolTestParamsWithoutHTTP3() {
-    return getProtocolTestParams(
-        /*downstream_protocols = */ {Http::CodecType::HTTP1, Http::CodecType::HTTP2},
-        /*upstream_protocols = */ {Http::CodecType::HTTP1, Http::CodecType::HTTP2});
-  }
+  static std::vector<HttpProtocolTestParams> getProtocolTestParams(
+      const std::vector<Http::CodecType>& downstream_protocols = {Http::CodecType::HTTP1,
+                                                                  Http::CodecType::HTTP2},
+      const std::vector<Http::CodecType>& upstream_protocols = {Http::CodecType::HTTP1,
+                                                                Http::CodecType::HTTP2});
 
   // Allows pretty printed test names of the form
   // FooTestCase.BarInstance/IPv4_Http2Downstream_HttpUpstream
@@ -117,18 +104,11 @@ public:
                                   : "AllowReentrantFilterLocalReply");
   }
 
-  static std::vector<std::tuple<HttpProtocolTestParams, bool, bool>>
-  getDefaultTestParams(const std::vector<Http::CodecType>& downstream_protocols =
-                           {
-                               Http::CodecType::HTTP1,
-                               Http::CodecType::HTTP2,
-                               Http::CodecType::HTTP3,
-                           },
-                       const std::vector<Http::CodecType>& upstream_protocols = {
-                           Http::CodecType::HTTP1,
-                           Http::CodecType::HTTP2,
-                           Http::CodecType::HTTP3,
-                       }) {
+  static std::vector<std::tuple<HttpProtocolTestParams, bool, bool>> getDefaultTestParams(
+      const std::vector<Http::CodecType>& downstream_protocols = {Http::CodecType::HTTP1,
+                                                                  Http::CodecType::HTTP2},
+      const std::vector<Http::CodecType>& upstream_protocols = {Http::CodecType::HTTP1,
+                                                                Http::CodecType::HTTP2}) {
     std::vector<std::tuple<HttpProtocolTestParams, bool, bool>> ret;
     std::vector<HttpProtocolTestParams> protocol_defaults =
         HttpProtocolIntegrationTest::getProtocolTestParams(downstream_protocols,

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -66,7 +66,7 @@ public:
         codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", method},
                                                                    {":path", "/test/long/url"},
                                                                    {":scheme", "http"},
-                                                                   {":authority", "sni.lyft.com"}});
+                                                                   {":authority", "host"}});
     request_encoder_ = &encoder_decoder.first;
     auto response = std::move(encoder_decoder.second);
     AssertionResult result =
@@ -86,7 +86,7 @@ public:
         Http::TestRequestHeaderMapImpl{{":method", method},
                                        {":path", "/test/long/url"},
                                        {":scheme", "http"},
-                                       {":authority", "sni.lyft.com"}});
+                                       {":authority", "host"}});
     AssertionResult result =
         fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
     RELEASE_ASSERT(result, result.message());
@@ -489,8 +489,8 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutUnconfiguredDoesNotTriggerOnBod
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestWithHeaders) {
-  // Omitting \r\n\r\n does not indicate incomplete request in HTTP2/3
-  if (downstreamProtocol() != Envoy::Http::CodecType::HTTP1) {
+  // Omitting \r\n\r\n does not indicate incomplete request in HTTP2
+  if (downstreamProtocol() == Envoy::Http::CodecType::HTTP2) {
     return;
   }
   enable_request_timeout_ = true;
@@ -503,7 +503,7 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestW
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutDoesNotTriggerOnRawCompleteRequestWithHeaders) {
-  if (downstreamProtocol() != Envoy::Http::CodecType::HTTP1) {
+  if (downstreamProtocol() == Envoy::Http::CodecType::HTTP2) {
     return;
   }
   enable_request_timeout_ = true;

--- a/test/integration/instantiate_protocol_integration_test.cc
+++ b/test/integration/instantiate_protocol_integration_test.cc
@@ -10,9 +10,8 @@ INSTANTIATE_TEST_SUITE_P(Protocols, DownstreamProtocolIntegrationTest,
                              {Http::CodecType::HTTP1})),
                          HttpProtocolIntegrationTest::protocolTestParamsToString);
 
-INSTANTIATE_TEST_SUITE_P(
-    Protocols, ProtocolIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-    HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(Protocols, ProtocolIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 } // namespace Envoy

--- a/test/integration/local_reply_integration_test.cc
+++ b/test/integration/local_reply_integration_test.cc
@@ -60,7 +60,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -123,7 +123,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -175,7 +175,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/package.service/method"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"content-type", "application/grpc"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -227,7 +227,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/package.service/method"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"content-type", "application/grpc"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -308,7 +308,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -385,7 +385,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -449,7 +449,7 @@ mappers:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value-2"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -507,7 +507,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value-2"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -565,7 +565,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "sni.lyft.com"},
+                                     {":authority", "host"},
                                      {"test-header", "exact-match-value-2"}});
   auto response = std::move(encoder_decoder.second);
 

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -51,10 +51,8 @@ TEST_P(OverloadIntegrationTest, CloseStreamsWhenOverloaded) {
   updateResource(0.9);
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.stop_accepting_requests.active", 1);
 
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                 {":path", "/test/long/url"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "sni.lyft.com"}};
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto response = codec_client_->makeRequestWithBody(request_headers, 10);
   ASSERT_TRUE(response->waitForEndStream());
@@ -106,10 +104,8 @@ TEST_P(OverloadIntegrationTest, DisableKeepaliveWhenOverloaded) {
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.disable_http_keepalive.active", 1);
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                 {":path", "/test/long/url"},
-                                                 {":scheme", "http"},
-                                                 {":authority", "sni.lyft.com"}};
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
   auto response = sendRequestAndWaitForResponse(request_headers, 1, default_response_headers_, 1);
   ASSERT_TRUE(codec_client_->waitForDisconnect());
 
@@ -208,10 +204,8 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpConnections) {
           min_timeout: 5s
     )EOF"));
 
-  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                       {":path", "/test/long/url"},
-                                                       {":scheme", "http"},
-                                                       {":authority", "sni.lyft.com"}};
+  const Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
   // Create an HTTP connection and complete a request.
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
@@ -267,10 +261,8 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpStream) {
           min_timeout: 5s
     )EOF"));
 
-  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                       {":path", "/test/long/url"},
-                                                       {":scheme", "http"},
-                                                       {":authority", "sni.lyft.com"}};
+  const Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
   // Create an HTTP connection and start a request.
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
@@ -301,11 +293,6 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpStream) {
 }
 
 TEST_P(OverloadScaledTimerIntegrationTest, TlsHandshakeTimeout) {
-  if (downstreamProtocol() == Http::CodecClient::Type::HTTP3 ||
-      upstreamProtocol() == Http::CodecClient::Type::HTTP3) {
-    // TODO(#26236): Fix this test for H3.
-    return;
-  }
   // Set up the Envoy to expect a TLS connection, with a 20 second timeout that can scale down to 5
   // seconds.
   config_helper_.addSslConfig();

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -387,7 +387,7 @@ name: add-trailers-filter
   upstream_request_->encodeData(128, true);
   ASSERT_TRUE(response->waitForEndStream());
 
-  if (upstreamProtocol() != Http::CodecType::HTTP1) {
+  if (upstreamProtocol() >= Http::CodecType::HTTP2) {
     EXPECT_EQ("decode", upstream_request_->trailers()
                             ->get(Http::LowerCaseString("grpc-message"))[0]
                             ->value()
@@ -395,7 +395,7 @@ name: add-trailers-filter
   }
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  if (downstream_protocol_ != Http::CodecType::HTTP1) {
+  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
     EXPECT_EQ("encode", response->trailers()->getGrpcMessageValue());
   }
 }
@@ -1285,7 +1285,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
   // the 413-and-connection-close may be sent while the body is still being
   // sent, resulting in a write error and the connection being closed before the
   // response is read.
-  if (downstream_protocol_ != Http::CodecType::HTTP1) {
+  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
     ASSERT_TRUE(response->complete());
   }
   if (response->complete()) {
@@ -1441,10 +1441,6 @@ TEST_P(ProtocolIntegrationTest, BasicDynamicMaxStreamDuration) {
 }
 
 TEST_P(ProtocolIntegrationTest, MaxStreamDurationWithRetryPolicy) {
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    return; // TODO(#26236) Fix this test for H3.
-  }
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     ConfigHelper::HttpProtocolOptions protocol_options;
     auto* http_protocol_options = protocol_options.mutable_common_http_protocol_options();
@@ -1785,8 +1781,8 @@ TEST_P(ProtocolIntegrationTest, 304WithBody) {
   // Only for HTTP/2 and Http/3, where streams are ended with an explicit end-stream so we
   // can differentiate between 304-with-advertised-but-absent-body and
   // 304-with-body, is there a protocol error on the active stream.
-  if (downstream_protocol_ != Http::CodecType::HTTP1 &&
-      upstreamProtocol() != Http::CodecType::HTTP1) {
+  if (downstream_protocol_ >= Http::CodecType::HTTP2 &&
+      upstreamProtocol() >= Http::CodecType::HTTP2) {
     ASSERT_TRUE(response->waitForReset());
   }
 }

--- a/test/integration/protocol_integration_test.h
+++ b/test/integration/protocol_integration_test.h
@@ -42,7 +42,7 @@ protected:
   }
 
   void verifyUpStreamRequestAfterStopAllFilter() {
-    if (downstreamProtocol() != Http::CodecType::HTTP1) {
+    if (downstreamProtocol() >= Http::CodecType::HTTP2) {
       // decode-headers-return-stop-all-filter calls addDecodedData in decodeData and
       // decodeTrailers. 2 decoded data were added.
       EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 2, upstream_request_->bodyLength());

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -21,7 +21,7 @@ namespace {
 
 Http::TestRequestHeaderMapImpl upgradeRequestHeaders(const char* upgrade_type = "websocket",
                                                      uint32_t content_length = 0) {
-  return Http::TestRequestHeaderMapImpl{{":authority", "sni.lyft.com"},
+  return Http::TestRequestHeaderMapImpl{{":authority", "host:80"},
                                         {"content-length", fmt::format("{}", content_length)},
                                         {":path", "/websocket/test"},
                                         {":method", "GET"},
@@ -60,8 +60,7 @@ void WebsocketIntegrationTest::validateUpgradeRequestHeaders(
     const Http::RequestHeaderMap& original_request_headers) {
   Http::TestRequestHeaderMapImpl proxied_request_headers(original_proxied_request_headers);
   if (proxied_request_headers.ForwardedProto()) {
-    ASSERT_EQ(proxied_request_headers.getForwardedProtoValue(),
-              downstreamProtocol() == Http::CodecType::HTTP3 ? "https" : "http");
+    ASSERT_EQ(proxied_request_headers.getForwardedProtoValue(), "http");
     proxied_request_headers.removeForwardedProto();
   }
 
@@ -118,7 +117,7 @@ ConfigHelper::HttpModifierFunction setRouteUsingWebsocket() {
 }
 
 void WebsocketIntegrationTest::initialize() {
-  if (upstreamProtocol() == Http::CodecType::HTTP2) {
+  if (upstreamProtocol() != Http::CodecType::HTTP1) {
     config_helper_.addConfigModifier(
         [&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
           ConfigHelper::HttpProtocolOptions protocol_options;
@@ -128,27 +127,11 @@ void WebsocketIntegrationTest::initialize() {
           ConfigHelper::setProtocolOptions(
               *bootstrap.mutable_static_resources()->mutable_clusters(0), protocol_options);
         });
-  } else if (upstreamProtocol() == Http::CodecType::HTTP3) {
-    config_helper_.addConfigModifier(
-        [&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
-          ConfigHelper::HttpProtocolOptions protocol_options;
-          protocol_options.mutable_explicit_http_config()
-              ->mutable_http3_protocol_options()
-              ->set_allow_extended_connect(true);
-          ConfigHelper::setProtocolOptions(
-              *bootstrap.mutable_static_resources()->mutable_clusters(0), protocol_options);
-        });
   }
-  if (downstreamProtocol() == Http::CodecType::HTTP2) {
+  if (downstreamProtocol() != Http::CodecType::HTTP1) {
     config_helper_.addConfigModifier(
         [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                 hcm) -> void { hcm.mutable_http2_protocol_options()->set_allow_connect(true); });
-  } else if (downstreamProtocol() == Http::CodecType::HTTP3) {
-    config_helper_.addConfigModifier(
-        [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-                hcm) -> void {
-          hcm.mutable_http3_protocol_options()->set_allow_extended_connect(true);
-        });
   }
   HttpProtocolIntegrationTest::initialize();
 }
@@ -198,11 +181,6 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionDownstreamDisconnect) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    // TODO(#23564) - Finish CONNECT-UDP support.
-    return;
-  }
 
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
   initialize();
@@ -222,8 +200,7 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionDownstreamDisconnect) {
 }
 
 TEST_P(WebsocketIntegrationTest, PortStrippingForHttp2) {
-  if (downstreamProtocol() != Http::CodecType::HTTP2 ||
-      upstreamProtocol() == Http::CodecType::HTTP3) {
+  if (downstreamProtocol() != Http::CodecType::HTTP2) {
     return;
   }
 
@@ -240,7 +217,7 @@ TEST_P(WebsocketIntegrationTest, PortStrippingForHttp2) {
   initialize();
 
   performUpgrade(upgradeRequestHeaders(), upgradeResponseHeaders());
-  ASSERT_EQ(upstream_request_->headers().getHostValue(), "sni.lyft.com");
+  ASSERT_EQ(upstream_request_->headers().getHostValue(), "host:80");
 
   codec_client_->sendData(*request_encoder_, "bye!", false);
   codec_client_->close();
@@ -250,8 +227,8 @@ TEST_P(WebsocketIntegrationTest, PortStrippingForHttp2) {
 }
 
 TEST_P(WebsocketIntegrationTest, EarlyData) {
-  if (downstreamProtocol() != Http::CodecType::HTTP1 ||
-      upstreamProtocol() != Http::CodecType::HTTP1) {
+  if (downstreamProtocol() == Http::CodecType::HTTP2 ||
+      upstreamProtocol() == Http::CodecType::HTTP2) {
     return;
   }
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
@@ -301,11 +278,6 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionIdleTimeout) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    // TODO(#23564) - Finish CONNECT-UDP support.
-    return;
-  }
 
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
   config_helper_.addConfigModifier(
@@ -335,11 +307,6 @@ TEST_P(WebsocketIntegrationTest, NonWebsocketUpgrade) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    // TODO(#23564) - Finish CONNECT-UDP support.
-    return;
-  }
 
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -373,11 +340,6 @@ TEST_P(WebsocketIntegrationTest, RouteSpecificUpgrade) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    // TODO(#23564) - Finish CONNECT-UDP support.
-    return;
-  }
 
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -386,7 +348,7 @@ TEST_P(WebsocketIntegrationTest, RouteSpecificUpgrade) {
         foo_upgrade->set_upgrade_type("foo");
         foo_upgrade->mutable_enabled()->set_value(false);
       });
-  auto host = config_helper_.createVirtualHost("sni.lyft.com", "/websocket/test");
+  auto host = config_helper_.createVirtualHost("host:80", "/websocket/test");
   host.mutable_routes(0)->mutable_route()->add_upgrade_configs()->set_upgrade_type("foo");
   config_helper_.addVirtualHost(host);
   initialize();
@@ -413,11 +375,6 @@ TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
-  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
-      downstreamProtocol() == Http::CodecType::HTTP3) {
-    // TODO(#23564) - Finish CONNECT-UDP support.
-    return;
-  }
 
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
 


### PR DESCRIPTION
This reverts commit 284401eae767d94bd9eb5b0205aa546f423b77d5.
Signed-off-by: Alyssa Wilk <alyssar@chromium.org>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
