### PR TITLE
Skip stats validation in file_system_cache tests, due to flakes

### DIFF
--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -123,11 +123,13 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, InitialStatsAreSetCorrectly) {
   cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
       http_cache_factory_->getCache(cacheConfig(cfg), context_));
   waitForEvictionThreadIdle();
-  EXPECT_EQ(cache_->stats().size_limit_bytes_.value(), max_size);
-  EXPECT_EQ(cache_->stats().size_limit_count_.value(), max_count);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), file_1_contents.size() + file_2_contents.size());
-  EXPECT_EQ(cache_->stats().size_count_.value(), 2);
-  EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
+  // Stats validation disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().size_limit_bytes_.value(), max_size);
+  // EXPECT_EQ(cache_->stats().size_limit_count_.value(), max_count);
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), file_1_contents.size() +
+  // file_2_contents.size()); EXPECT_EQ(cache_->stats().size_count_.value(), 2);
+  // EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
 }
 
 TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderCountLimit) {
@@ -142,16 +144,20 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderCou
   cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
       http_cache_factory_->getCache(cacheConfig(cfg), context_));
   waitForEvictionThreadIdle();
-  EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 2);
+  // Stats validation disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 2);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-c"), file_contents, true);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-d"), file_contents, true);
   cache_->trackFileAdded(file_contents.size());
   cache_->trackFileAdded(file_contents.size());
   waitForEvictionThreadIdle();
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 2);
+  // Stats validation disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 2);
   EXPECT_FALSE(Filesystem::fileSystemForTest().fileExists(absl::StrCat(cache_path_, "cache-a")));
   EXPECT_FALSE(Filesystem::fileSystemForTest().fileExists(absl::StrCat(cache_path_, "cache-b")));
   EXPECT_TRUE(Filesystem::fileSystemForTest().fileExists(absl::StrCat(cache_path_, "cache-c")));
@@ -159,7 +165,9 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderCou
   // There may have been one or two eviction runs here, because there's a race
   // between the eviction and the second file being added. Either amount of runs
   // is valid, as the eventual consistency is achieved either way.
-  EXPECT_THAT(cache_->stats().eviction_runs_.value(), testing::AnyOf(1, 2));
+  // Stats validation disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_THAT(cache_->stats().eviction_runs_.value(), testing::AnyOf(1, 2));
 }
 
 TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderSizeLimit) {
@@ -175,18 +183,20 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderSiz
   cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
       http_cache_factory_->getCache(cacheConfig(cfg), context_));
   waitForEvictionThreadIdle();
-  EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
+  // Stats expectations disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-c"), large_file_contents, true);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 2);
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 2);
   cache_->trackFileAdded(large_file_contents.size());
   waitForEvictionThreadIdle();
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), large_file_contents.size());
-  EXPECT_EQ(cache_->stats().size_count_.value(), 1);
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), large_file_contents.size());
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 1);
   EXPECT_FALSE(Filesystem::fileSystemForTest().fileExists(absl::StrCat(cache_path_, "cache-a")));
   EXPECT_FALSE(Filesystem::fileSystemForTest().fileExists(absl::StrCat(cache_path_, "cache-b")));
   EXPECT_TRUE(Filesystem::fileSystemForTest().fileExists(absl::StrCat(cache_path_, "cache-c")));
-  EXPECT_EQ(cache_->stats().eviction_runs_.value(), 1);
+  // EXPECT_EQ(cache_->stats().eviction_runs_.value(), 1);
 }
 
 class FileSystemHttpCacheTest : public FileSystemCacheTestContext, public ::testing::Test {
@@ -207,26 +217,30 @@ MATCHER_P2(IsStatTag, name, value, "") {
 TEST_F(FileSystemHttpCacheTest, StatsAreConstructedCorrectly) {
   std::string cache_path_no_periods = absl::StrReplaceAll(cache_path_, {{".", "_"}});
   // Validate that a gauge has appropriate name and tags.
-  EXPECT_EQ(cache_->stats().size_bytes_.tagExtractedName(), "cache.size_bytes");
-  EXPECT_THAT(cache_->stats().size_bytes_.tags(),
-              ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
+  // Stats expectations disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().size_bytes_.tagExtractedName(), "cache.size_bytes");
+  // EXPECT_THAT(cache_->stats().size_bytes_.tags(),
+  //             ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
   // Validate that a counter has appropriate name and tags.
-  EXPECT_EQ(cache_->stats().eviction_runs_.tagExtractedName(), "cache.eviction_runs");
-  EXPECT_THAT(cache_->stats().eviction_runs_.tags(),
-              ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
+  // EXPECT_EQ(cache_->stats().eviction_runs_.tagExtractedName(), "cache.eviction_runs");
+  // EXPECT_THAT(cache_->stats().eviction_runs_.tags(),
+  //             ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
 }
 
 TEST_F(FileSystemHttpCacheTest, TrackFileRemovedClampsAtZero) {
   cache_->trackFileAdded(1);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), 1);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 1);
+  // Stats expectations disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), 1);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 1);
   cache_->trackFileRemoved(8);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), 0);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 0);
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), 0);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 0);
   // Remove a second time to ensure that count going below zero also clamps at zero.
   cache_->trackFileRemoved(8);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), 0);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 0);
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), 0);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 0);
 }
 
 TEST_F(FileSystemHttpCacheTest, ExceptionOnTryingToCreateCachesWithDistinctConfigsOnSamePath) {
@@ -515,9 +529,11 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertWithMultipleChunksBeforeCallb
   mock_async_file_manager_->nextActionCompletes(absl::OkStatus());
   // Should have been 4 callbacks; insertHeaders, insertBody, insertBody, insertTrailers.
   EXPECT_EQ(true_callbacks_called_, 4);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), headers_size_ + body1.size() + body2.size() +
-                                                     trailers_size_ + CacheFileFixedBlock::size());
-  EXPECT_EQ(cache_->stats().size_count_.value(), 1);
+  // Skipped as stats validation seems to be flaky. https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), headers_size_ + body1.size() + body2.size() +
+  //                                                    trailers_size_ +
+  //                                                    CacheFileFixedBlock::size());
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 1);
 }
 
 TEST_F(FileSystemHttpCacheTestWithMockFiles, FailedOpenForReadReturnsMiss) {
@@ -537,8 +553,10 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, FailedReadOfHeaderBlockInvalidatesT
   // Fake-add two files of size 12345, so we can validate the stats decrease of removing a file.
   cache_->trackFileAdded(12345);
   cache_->trackFileAdded(12345);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), 2 * 12345);
-  EXPECT_EQ(cache_->stats().size_count_.value(), 2);
+  // Stats validation disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), 2 * 12345);
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 2);
   auto lookup = testLookupContext();
   absl::Cleanup destroy_lookup([&lookup]() { lookup->onDestroy(); });
   LookupResult result;
@@ -558,12 +576,14 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, FailedReadOfHeaderBlockInvalidatesT
   // unlink
   mock_async_file_manager_->nextActionCompletes(absl::OkStatus());
   EXPECT_EQ(result.cache_entry_status_, CacheEntryStatus::Unusable);
-  // Should have deducted the size of the file that got deleted. Since we started at 2 * 12345,
-  // this should make the value 12345.
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), 12345);
-  // Should have deducted one file for the file that got deleted. Since we started at 2,
-  // this should make the value 1.
-  EXPECT_EQ(cache_->stats().size_count_.value(), 1);
+  // Stats validation disabled as stats validation seems to be flaky.
+  // https://github.com/envoyproxy/envoy/issues/26261
+  // // Should have deducted the size of the file that got deleted. Since we started at 2 * 12345,
+  // // this should make the value 12345.
+  // EXPECT_EQ(cache_->stats().size_bytes_.value(), 12345);
+  // // Should have deducted one file for the file that got deleted. Since we started at 2,
+  // // this should make the value 1.
+  // EXPECT_EQ(cache_->stats().size_count_.value(), 1);
 }
 
 Buffer::InstancePtr invalidHeaderBlock() {


### PR DESCRIPTION
Commit Message: Skip stats validation in file_system_cache tests, due to flakes
Additional Description: The stats validation aspect of these tests appears to be flaky. For quick deflaking, just commenting out those parts of the test, to be investigated and reenabled once the flakiness is resolved. #26261 is one example.
Risk Level: test-only
Testing: test-only
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
