### PR TITLE
Enable HTTP/3 in tests

### DIFF
--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -109,12 +109,7 @@ void Http3ConnPoolImpl::onConnectFailed(Envoy::ConnectionPool::ActiveClient& cli
 }
 
 // Make sure all connections are torn down before quic_info_ is deleted.
-Http3ConnPoolImpl::~Http3ConnPoolImpl() {
-  destructAllConnections();
-  // Set this to zero since state_ is not tracking connections for H3, only the initial capacity
-  // pending_streams_ and active_streams_ are verified to be zero in the destructor of state_.
-  state_.connecting_and_connected_stream_capacity_ = 0;
-}
+Http3ConnPoolImpl::~Http3ConnPoolImpl() { destructAllConnections(); }
 
 std::unique_ptr<Network::ClientConnection>
 Http3ConnPoolImpl::createClientConnection(Quic::QuicStatNames& quic_stat_names,

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -109,7 +109,12 @@ void Http3ConnPoolImpl::onConnectFailed(Envoy::ConnectionPool::ActiveClient& cli
 }
 
 // Make sure all connections are torn down before quic_info_ is deleted.
-Http3ConnPoolImpl::~Http3ConnPoolImpl() { destructAllConnections(); }
+Http3ConnPoolImpl::~Http3ConnPoolImpl() {
+  destructAllConnections();
+  // Set this to zero since state_ is not tracking connections for H3, only the initial capacity
+  // pending_streams_ and active_streams_ are verified to be zero in the destructor of state_.
+  state_.connecting_and_connected_stream_capacity_ = 0;
+}
 
 std::unique_ptr<Network::ClientConnection>
 Http3ConnPoolImpl::createClientConnection(Quic::QuicStatNames& quic_stat_names,

--- a/test/common/common/packed_struct_test.cc
+++ b/test/common/common/packed_struct_test.cc
@@ -65,7 +65,7 @@ TEST_F(PackedStructTest, StringStructMove) {
   EXPECT_FALSE(redirect_strings.get<RedirectStringElement::HostRedirect>().has_value());
 
   // Invoke move constructor.
-  RedirectStringsPackedStruct redirect_strings2(move(redirect_strings));
+  RedirectStringsPackedStruct redirect_strings2(std::move(redirect_strings));
   // Ensure no memory was allocated on the heap by the move constructor.
   EXPECT_MEMORY_LE(memory_test.consumedBytes(), 2 * sizeof(std::string) + 16);
 
@@ -77,7 +77,7 @@ TEST_F(PackedStructTest, StringStructMove) {
 
   // Invoke move assignment.
   RedirectStringsPackedStruct redirect_strings3(0);
-  redirect_strings3 = move(redirect_strings2);
+  redirect_strings3 = std::move(redirect_strings2);
   // Ensure no memory was allocated on the heap by the move assignment.
   EXPECT_MEMORY_LE(memory_test.consumedBytes(), 2 * sizeof(std::string) + 16);
 

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -94,7 +94,7 @@ public:
   MockQuicClientTransportSocketFactory(
       Ssl::ClientContextConfigPtr config,
       Server::Configuration::TransportSocketFactoryContext& factory_context)
-      : Quic::QuicClientTransportSocketFactory(move(config), factory_context) {}
+      : Quic::QuicClientTransportSocketFactory(std::move(config), factory_context) {}
 
   MOCK_METHOD(Envoy::Ssl::ClientContextSharedPtr, sslCtx, ());
 };

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -21,6 +21,11 @@ TEST_P(BufferIntegrationTest, RouterNotFoundBodyBuffer) {
 }
 
 TEST_P(BufferIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#26236) - Fix test flakiness over HTTP/3.
+    return;
+  }
   config_helper_.prependFilter(ConfigHelper::defaultBufferFilter(), testing_downstream_filter_);
   testRouterRequestAndResponseWithBody(4 * 1024 * 1024, 4 * 1024 * 1024, false);
 }
@@ -46,8 +51,11 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLength) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
-      {":method", "POST"}, {":scheme", "http"}, {":path", "/shelf"}, {":authority", "host"}});
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":scheme", "http"},
+                                                                 {":path", "/shelf"},
+                                                                 {":authority", "sni.lyft.com"}});
   request_encoder_ = &encoder_decoder.first;
   IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, "123", false);
@@ -74,8 +82,11 @@ TEST_P(BufferIntegrationTest, RouterRequestPopulateContentLengthOnTrailers) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder = codec_client_->startRequest(Http::TestRequestHeaderMapImpl{
-      {":method", "POST"}, {":scheme", "http"}, {":path", "/shelf"}, {":authority", "host"}});
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":scheme", "http"},
+                                                                 {":path", "/shelf"},
+                                                                 {":authority", "sni.lyft.com"}});
   request_encoder_ = &encoder_decoder.first;
   IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, "0123", false);
@@ -116,7 +127,7 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/dynamo/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"},
                                      {"x-envoy-retry-on", "5xx"}},
       1024 * 65, false);
@@ -159,7 +170,7 @@ TEST_P(BufferIntegrationTest, RouteDisabled) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"}},
       1024 * 65);
 
@@ -188,7 +199,7 @@ TEST_P(BufferIntegrationTest, RouteOverride) {
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"x-forwarded-for", "10.0.0.1"}},
       1024 * 65);
 

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -108,9 +108,11 @@ public:
   OptRef<const Http::TestResponseTrailerMapImpl> empty_trailers_;
 };
 
-INSTANTIATE_TEST_SUITE_P(Protocols, CacheIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CacheIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CacheIntegrationTest, MissInsertHit) {
   initializeFilter(default_config);

--- a/test/extensions/filters/http/compressor/compressor_integration_tests.cc
+++ b/test/extensions/filters/http/compressor/compressor_integration_tests.cc
@@ -119,9 +119,13 @@ void WebsocketWithCompressorIntegrationTest::validateUpgradeResponseHeaders(
   EXPECT_THAT(&proxied_response_headers, HeaderMapEqualIgnoreOrder(&original_response_headers));
 }
 
-INSTANTIATE_TEST_SUITE_P(Protocols, WebsocketWithCompressorIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, WebsocketWithCompressorIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
+        /*downstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2},
+        /*upstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2})),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 ConfigHelper::HttpModifierFunction setRouteUsingWebsocket() {
   return [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -244,9 +248,12 @@ TEST_P(WebsocketWithCompressorIntegrationTest, NonWebsocketUpgrade) {
   ASSERT_EQ(1, response_uncompressed_counter->value());
 }
 
-INSTANTIATE_TEST_SUITE_P(Protocols, CompressorProxyingConnectIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CompressorProxyingConnectIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
+        /*downstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2},
+        /*upstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2})),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 void CompressorProxyingConnectIntegrationTest::initialize() {
   config_helper_.addConfigModifier(

--- a/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
@@ -74,9 +74,11 @@ protected:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(Protocols, CsrfFilterIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CsrfFilterIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CsrfFilterIntegrationTest, TestCsrfSuccess) {
   config_helper_.prependFilter(CSRF_FILTER_ENABLED_CONFIG);

--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -643,9 +643,11 @@ TEST_P(CustomResponseIntegrationTest, ModifyRequestHeaders) {
   EXPECT_EQ("Modify action response body", response->body());
 }
 
-INSTANTIATE_TEST_SUITE_P(Protocols, CustomResponseIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CustomResponseIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 } // namespace CustomResponse
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -83,9 +83,12 @@ typed_config:
 // Fault integration tests that should run with all protocols, useful for testing various
 // end_stream permutations when rate limiting.
 class FaultIntegrationTestAllProtocols : public FaultIntegrationTest {};
-INSTANTIATE_TEST_SUITE_P(Protocols, FaultIntegrationTestAllProtocols,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, FaultIntegrationTestAllProtocols,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // No fault injected.
 TEST_P(FaultIntegrationTestAllProtocols, NoFault) {

--- a/test/extensions/filters/http/file_system_buffer/filter_integration_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/filter_integration_test.cc
@@ -57,9 +57,13 @@ std::string smallRequestBufferConfig() {
 
 using FileSystemBufferIntegrationTest = HttpProtocolIntegrationTest;
 
-INSTANTIATE_TEST_SUITE_P(Protocols, FileSystemBufferIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, FileSystemBufferIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
+        /*downstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2},
+        /*upstream_protocols = */ {Envoy::Http::CodecType::HTTP1, Envoy::Http::CodecType::HTTP2})),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(FileSystemBufferIntegrationTest, NotFoundBodyBuffer) {
   config_helper_.prependFilter(contentLengthConfig());

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -59,9 +59,11 @@ std::string getFilterConfig(bool use_local_jwks) {
 
 class LocalJwksIntegrationTest : public HttpProtocolIntegrationTest {};
 
-INSTANTIATE_TEST_SUITE_P(Protocols, LocalJwksIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, LocalJwksIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // With local Jwks, this test verifies a request is passed with a good Jwt token.
 TEST_P(LocalJwksIntegrationTest, WithGoodToken) {
@@ -385,9 +387,10 @@ public:
   FakeStreamPtr jwks_request_{};
 };
 
-INSTANTIATE_TEST_SUITE_P(Protocols, RemoteJwksIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, RemoteJwksIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // With remote Jwks, this test verifies a request is passed with a good Jwt token
 // and a good public key fetched from a remote server.
@@ -609,9 +612,10 @@ public:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(Protocols, PerRouteIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, PerRouteIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // This test verifies per-route config disabled.
 TEST_P(PerRouteIntegrationTest, PerRouteConfigDisabled) {

--- a/test/extensions/filters/http/kill_request/crash_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/crash_integration_test.cc
@@ -40,9 +40,12 @@ protected:
 
 // Tests should run with all protocols.
 class CrashIntegrationTestAllProtocols : public CrashIntegrationTest {};
-INSTANTIATE_TEST_SUITE_P(Protocols, CrashIntegrationTestAllProtocols,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CrashIntegrationTestAllProtocols,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CrashIntegrationTestAllProtocols, UnwindsTrackedObjectStack) {
   const std::string request_kill_config =

--- a/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
@@ -28,9 +28,12 @@ typed_config:
 
 // Tests should run with all protocols.
 class KillRequestFilterIntegrationTestAllProtocols : public KillRequestFilterIntegrationTest {};
-INSTANTIATE_TEST_SUITE_P(Protocols, KillRequestFilterIntegrationTestAllProtocols,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, KillRequestFilterIntegrationTestAllProtocols,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // Request crash Envoy controlled via header configuration.
 TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoy) {

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -179,9 +179,11 @@ virtual_hosts:
 )EOF";
 };
 
-INSTANTIATE_TEST_SUITE_P(Protocols, LocalRateLimitFilterIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, LocalRateLimitFilterIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(LocalRateLimitFilterIntegrationTest, DenyRequestPerProcess) {
   initializeFilter(fmt::format(fmt::runtime(filter_config_), "false"));

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -341,9 +341,11 @@ typed_config:
 
 using RBACIntegrationTest = HttpProtocolIntegrationTest;
 
-INSTANTIATE_TEST_SUITE_P(Protocols, RBACIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, RBACIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(RBACIntegrationTest, Allowed) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");
@@ -357,7 +359,7 @@ TEST_P(RBACIntegrationTest, Allowed) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -382,7 +384,7 @@ TEST_P(RBACIntegrationTest, Denied) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -405,7 +407,7 @@ TEST_P(RBACIntegrationTest, DeniedWithDenyAction) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -431,7 +433,7 @@ TEST_P(RBACIntegrationTest, DeniedWithPrefixRule) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -457,7 +459,7 @@ TEST_P(RBACIntegrationTest, RbacPrefixRuleUseNormalizePath) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -478,7 +480,7 @@ TEST_P(RBACIntegrationTest, DeniedHeadReply) {
           {":method", "HEAD"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -514,7 +516,7 @@ TEST_P(RBACIntegrationTest, RouteOverride) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -543,7 +545,7 @@ TEST_P(RBACIntegrationTest, PathWithQueryAndFragmentWithOverride) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "host"},
+            {":authority", "sni.lyft.com"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -567,7 +569,7 @@ TEST_P(RBACIntegrationTest, PathWithFragmentRejectedByDefault) {
           {":method", "POST"},
           {":path", "/allow?p1=v1#seg"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -597,7 +599,7 @@ TEST_P(RBACIntegrationTest, DenyExactMatchIgnoresQueryAndFragment) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "host"},
+            {":authority", "sni.lyft.com"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -626,7 +628,7 @@ TEST_P(RBACIntegrationTest, PathIgnoreCase) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "host"},
+            {":authority", "sni.lyft.com"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -650,7 +652,7 @@ TEST_P(RBACIntegrationTest, LogConnectionAllow) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -674,7 +676,7 @@ TEST_P(RBACIntegrationTest, HeaderMatchCondition) {
           {":method", "POST"},
           {":path", "/path"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"xxx", "yyy"},
       },
       1024);
@@ -699,7 +701,7 @@ TEST_P(RBACIntegrationTest, HeaderMatchConditionDuplicateHeaderNoMatch) {
           {":method", "POST"},
           {":path", "/path"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"xxx", "yyy"},
           {"xxx", "zzz"},
       },
@@ -722,7 +724,7 @@ TEST_P(RBACIntegrationTest, HeaderMatchConditionDuplicateHeaderMatch) {
           {":method", "POST"},
           {":path", "/path"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"xxx", "yyy"},
           {"xxx", "zzz"},
       },
@@ -747,7 +749,7 @@ TEST_P(RBACIntegrationTest, MatcherAllowed) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -772,7 +774,7 @@ TEST_P(RBACIntegrationTest, MatcherDenied) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -795,7 +797,7 @@ TEST_P(RBACIntegrationTest, MatcherDeniedWithDenyAction) {
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -821,7 +823,7 @@ TEST_P(RBACIntegrationTest, MatcherDeniedWithPrefixRule) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -847,7 +849,7 @@ TEST_P(RBACIntegrationTest, RbacPrefixRuleUseNormalizePathMatcher) {
           {":method", "POST"},
           {":path", "/foo/../bar"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -868,7 +870,7 @@ TEST_P(RBACIntegrationTest, MatcherDeniedHeadReply) {
           {":method", "HEAD"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -904,7 +906,7 @@ TEST_P(RBACIntegrationTest, MatcherRouteOverride) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -933,7 +935,7 @@ TEST_P(RBACIntegrationTest, PathMatcherWithQueryAndFragmentWithOverride) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "host"},
+            {":authority", "sni.lyft.com"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -957,7 +959,7 @@ TEST_P(RBACIntegrationTest, PathMatcherWithFragmentRejectedByDefault) {
           {":method", "POST"},
           {":path", "/allow?p1=v1#seg"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);
@@ -987,7 +989,7 @@ TEST_P(RBACIntegrationTest, MatcherDenyExactMatchIgnoresQueryAndFragment) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "host"},
+            {":authority", "sni.lyft.com"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -1016,7 +1018,7 @@ TEST_P(RBACIntegrationTest, PathIgnoreCaseMatcher) {
             {":method", "POST"},
             {":path", path},
             {":scheme", "http"},
-            {":authority", "host"},
+            {":authority", "sni.lyft.com"},
             {"x-forwarded-for", "10.0.0.1"},
         },
         1024);
@@ -1040,7 +1042,7 @@ TEST_P(RBACIntegrationTest, MatcherLogConnectionAllow) {
           {":method", "POST"},
           {":path", "/"},
           {":scheme", "http"},
-          {":authority", "host"},
+          {":authority", "sni.lyft.com"},
           {"x-forwarded-for", "10.0.0.1"},
       },
       1024);

--- a/test/extensions/internal_redirect/redirect_extension_integration_test.cc
+++ b/test/extensions/internal_redirect/redirect_extension_integration_test.cc
@@ -292,8 +292,10 @@ TEST_P(RedirectExtensionIntegrationTest, InternalRedirectPreventedBySafeCrossSch
             response->headers().get(test_header_key_)[0]->value().getStringView());
 }
 
-INSTANTIATE_TEST_SUITE_P(Protocols, RedirectExtensionIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, RedirectExtensionIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 } // namespace Envoy

--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -381,9 +381,8 @@ TEST_P(Http11ConnectHttpIntegrationTest, TestHttp2) {
 
 #ifdef ENVOY_ENABLE_QUIC
 
-// TODO(#26236) - Fix test flakiness over HTTP/3.
 // Test Http3 failing to HTTP/2 if proxy settings are enabled.
-TEST_P(Http11ConnectHttpIntegrationTest, DISABLED_TestHttp3Failover) {
+TEST_P(Http11ConnectHttpIntegrationTest, TestHttp3Failover) {
   setUpstreamProtocol(Http::CodecType::HTTP2);
   use_alpn_ = true;
   try_http3_ = true;

--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -381,8 +381,9 @@ TEST_P(Http11ConnectHttpIntegrationTest, TestHttp2) {
 
 #ifdef ENVOY_ENABLE_QUIC
 
+// TODO(#26236) - Fix test flakiness over HTTP/3.
 // Test Http3 failing to HTTP/2 if proxy settings are enabled.
-TEST_P(Http11ConnectHttpIntegrationTest, TestHttp3Failover) {
+TEST_P(Http11ConnectHttpIntegrationTest, DISABLED_TestHttp3Failover) {
   setUpstreamProtocol(Http::CodecType::HTTP2);
   use_alpn_ = true;
   try_http3_ = true;

--- a/test/integration/circuit_breakers_integration_test.cc
+++ b/test/integration/circuit_breakers_integration_test.cc
@@ -10,9 +10,11 @@ public:
   void initialize() override { HttpProtocolIntegrationTest::initialize(); }
 };
 
-INSTANTIATE_TEST_SUITE_P(Protocols, CircuitBreakersIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+// TODO(#26236): Fix test suite for HTTP/3.
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CircuitBreakersIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // This test checks that triggered max requests circuit breaker
 // doesn't force outlier detectors to eject an upstream host.

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -406,20 +406,20 @@ Http::RequestDecoder& FakeHttpConnection::newStream(Http::ResponseEncoder& encod
 }
 
 void FakeHttpConnection::onGoAway(Http::GoAwayErrorCode code) {
-  ASSERT(type_ >= Http::CodecType::HTTP2);
+  ASSERT(type_ != Http::CodecType::HTTP1);
   // Usually indicates connection level errors, no operations are needed since
   // the connection will be closed soon.
   ENVOY_LOG(info, "FakeHttpConnection receives GOAWAY: ", static_cast<int>(code));
 }
 
 void FakeHttpConnection::encodeGoAway() {
-  ASSERT(type_ >= Http::CodecType::HTTP2);
+  ASSERT(type_ != Http::CodecType::HTTP1);
 
   postToConnectionThread([this]() { codec_->goAway(); });
 }
 
 void FakeHttpConnection::updateConcurrentStreams(uint64_t max_streams) {
-  ASSERT(type_ >= Http::CodecType::HTTP2);
+  ASSERT(type_ != Http::CodecType::HTTP1);
 
   if (type_ == Http::CodecType::HTTP2) {
     postToConnectionThread([this, max_streams]() {
@@ -441,7 +441,7 @@ void FakeHttpConnection::updateConcurrentStreams(uint64_t max_streams) {
 }
 
 void FakeHttpConnection::encodeProtocolError() {
-  ASSERT(type_ >= Http::CodecType::HTTP2);
+  ASSERT(type_ != Http::CodecType::HTTP1);
 
   Http::Http2::ServerConnectionImpl* codec =
       dynamic_cast<Http::Http2::ServerConnectionImpl*>(codec_.get());

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -28,7 +28,7 @@ public:
   }
 
   void verifyUpStreamRequestAfterStopAllFilter() {
-    if (downstreamProtocol() >= Http::CodecType::HTTP2) {
+    if (downstreamProtocol() != Http::CodecType::HTTP1) {
       // decode-headers-return-stop-all-filter calls addDecodedData in decodeData and
       // decodeTrailers. 2 decoded data were added.
       EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 2, upstream_request_->bodyLength());
@@ -409,7 +409,7 @@ name: add-trailers-filter
   upstream_request_->encodeData(128, true);
   ASSERT_TRUE(response->waitForEndStream());
 
-  if (upstreamProtocol() >= Http::CodecType::HTTP2) {
+  if (upstreamProtocol() != Http::CodecType::HTTP1) {
     EXPECT_EQ("decode", upstream_request_->trailers()
                             ->get(Http::LowerCaseString("grpc-message"))[0]
                             ->value()
@@ -417,7 +417,7 @@ name: add-trailers-filter
   }
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
+  if (downstream_protocol_ != Http::CodecType::HTTP1) {
     EXPECT_EQ("encode", response->trailers()->getGrpcMessageValue());
   }
 }
@@ -502,7 +502,7 @@ TEST_P(FilterIntegrationTest, HittingDecoderFilterLimit) {
   // the 413-and-connection-close may be sent while the body is still being
   // sent, resulting in a write error and the connection being closed before the
   // response is read.
-  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
+  if (downstream_protocol_ != Http::CodecType::HTTP1) {
     ASSERT_TRUE(response->complete());
   }
   if (response->complete()) {

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -1422,7 +1422,7 @@ INSTANTIATE_TEST_SUITE_P(Protocols, EmptyHeaderIntegrationTest,
                          HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(EmptyHeaderIntegrationTest, AllProtocolsPassEmptyHeaders) {
-  auto vhost = config_helper_.createVirtualHost("empty-headers.com");
+  auto vhost = config_helper_.createVirtualHost("sni.lyft.com");
   *vhost.add_request_headers_to_add() = TestUtility::parseYaml<HeaderValueOption>(R"EOF(
     header:
       key: "x-ds-add-empty"
@@ -1451,10 +1451,8 @@ TEST_P(EmptyHeaderIntegrationTest, AllProtocolsPassEmptyHeaders) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = sendRequestAndWaitForResponse(
-      Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                     {":path", "/"},
-                                     {":scheme", "http"},
-                                     {":authority", "empty-headers.com"}},
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "sni.lyft.com"}},
       0,
       Http::TestResponseHeaderMapImpl{
           {"server", "envoy"}, {"content-length", "0"}, {":status", "200"}},

--- a/test/integration/http_conn_pool_integration_test.cc
+++ b/test/integration/http_conn_pool_integration_test.cc
@@ -30,6 +30,11 @@ INSTANTIATE_TEST_SUITE_P(Protocols, HttpConnPoolIntegrationTest,
 
 // Tests that conn pools are cleaned up after becoming idle due to a LocalClose
 TEST_P(HttpConnPoolIntegrationTest, PoolCleanupAfterLocalClose) {
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#26236) - Fix test flakiness over HTTP/3.
+    return;
+  }
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Make Envoy close the upstream connection after a single request.
     ConfigHelper::HttpProtocolOptions protocol_options;

--- a/test/integration/http_conn_pool_integration_test.cc
+++ b/test/integration/http_conn_pool_integration_test.cc
@@ -162,16 +162,16 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
 
   setUpstreamCount(2);
 
-  auto host = config_helper_.createVirtualHost("cluster_1.com", "/", "cluster_1");
+  auto host = config_helper_.createVirtualHost("cluster_1.lyft.com", "/", "cluster_1");
   config_helper_.addVirtualHost(host);
 
-  config_helper_.setDefaultHostAndRoute("cluster_0.com", "/");
+  config_helper_.setDefaultHostAndRoute("cluster_0.lyft.com", "/");
 
   initialize();
 
   // Request Flow to cluster_0.
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  default_request_headers_.setHost("cluster_0.com");
+  default_request_headers_.setHost("cluster_0.lyft.com");
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
   waitForNextUpstreamRequest();
 
@@ -190,7 +190,7 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
 
   // Request Flow to cluster_1.
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  default_request_headers_.setHost("cluster_1.com");
+  default_request_headers_.setHost("cluster_1.lyft.com");
   response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
   waitForNextUpstreamRequest(1);
 

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -42,11 +42,24 @@ public:
   //
   // Upstream and downstream protocols may be changed via the input vectors.
   // Address combinations are propagated from TestEnvironment::getIpVersionsForTest()
-  static std::vector<HttpProtocolTestParams> getProtocolTestParams(
-      const std::vector<Http::CodecType>& downstream_protocols = {Http::CodecType::HTTP1,
-                                                                  Http::CodecType::HTTP2},
-      const std::vector<Http::CodecType>& upstream_protocols = {Http::CodecType::HTTP1,
-                                                                Http::CodecType::HTTP2});
+  static std::vector<HttpProtocolTestParams>
+  getProtocolTestParams(const std::vector<Http::CodecType>& downstream_protocols =
+                            {
+                                Http::CodecType::HTTP1,
+                                Http::CodecType::HTTP2,
+                                Http::CodecType::HTTP3,
+                            },
+                        const std::vector<Http::CodecType>& upstream_protocols = {
+                            Http::CodecType::HTTP1,
+                            Http::CodecType::HTTP2,
+                            Http::CodecType::HTTP3,
+                        });
+
+  static std::vector<HttpProtocolTestParams> getProtocolTestParamsWithoutHTTP3() {
+    return getProtocolTestParams(
+        /*downstream_protocols = */ {Http::CodecType::HTTP1, Http::CodecType::HTTP2},
+        /*upstream_protocols = */ {Http::CodecType::HTTP1, Http::CodecType::HTTP2});
+  }
 
   // Allows pretty printed test names of the form
   // FooTestCase.BarInstance/IPv4_Http2Downstream_HttpUpstream
@@ -104,11 +117,18 @@ public:
                                   : "AllowReentrantFilterLocalReply");
   }
 
-  static std::vector<std::tuple<HttpProtocolTestParams, bool, bool>> getDefaultTestParams(
-      const std::vector<Http::CodecType>& downstream_protocols = {Http::CodecType::HTTP1,
-                                                                  Http::CodecType::HTTP2},
-      const std::vector<Http::CodecType>& upstream_protocols = {Http::CodecType::HTTP1,
-                                                                Http::CodecType::HTTP2}) {
+  static std::vector<std::tuple<HttpProtocolTestParams, bool, bool>>
+  getDefaultTestParams(const std::vector<Http::CodecType>& downstream_protocols =
+                           {
+                               Http::CodecType::HTTP1,
+                               Http::CodecType::HTTP2,
+                               Http::CodecType::HTTP3,
+                           },
+                       const std::vector<Http::CodecType>& upstream_protocols = {
+                           Http::CodecType::HTTP1,
+                           Http::CodecType::HTTP2,
+                           Http::CodecType::HTTP3,
+                       }) {
     std::vector<std::tuple<HttpProtocolTestParams, bool, bool>> ret;
     std::vector<HttpProtocolTestParams> protocol_defaults =
         HttpProtocolIntegrationTest::getProtocolTestParams(downstream_protocols,

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -66,7 +66,7 @@ public:
         codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", method},
                                                                    {":path", "/test/long/url"},
                                                                    {":scheme", "http"},
-                                                                   {":authority", "host"}});
+                                                                   {":authority", "sni.lyft.com"}});
     request_encoder_ = &encoder_decoder.first;
     auto response = std::move(encoder_decoder.second);
     AssertionResult result =
@@ -86,7 +86,7 @@ public:
         Http::TestRequestHeaderMapImpl{{":method", method},
                                        {":path", "/test/long/url"},
                                        {":scheme", "http"},
-                                       {":authority", "host"}});
+                                       {":authority", "sni.lyft.com"}});
     AssertionResult result =
         fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
     RELEASE_ASSERT(result, result.message());
@@ -489,8 +489,8 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutUnconfiguredDoesNotTriggerOnBod
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestWithHeaders) {
-  // Omitting \r\n\r\n does not indicate incomplete request in HTTP2
-  if (downstreamProtocol() == Envoy::Http::CodecType::HTTP2) {
+  // Omitting \r\n\r\n does not indicate incomplete request in HTTP2/3
+  if (downstreamProtocol() != Envoy::Http::CodecType::HTTP1) {
     return;
   }
   enable_request_timeout_ = true;
@@ -503,7 +503,7 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestW
 }
 
 TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutDoesNotTriggerOnRawCompleteRequestWithHeaders) {
-  if (downstreamProtocol() == Envoy::Http::CodecType::HTTP2) {
+  if (downstreamProtocol() != Envoy::Http::CodecType::HTTP1) {
     return;
   }
   enable_request_timeout_ = true;

--- a/test/integration/instantiate_protocol_integration_test.cc
+++ b/test/integration/instantiate_protocol_integration_test.cc
@@ -10,8 +10,9 @@ INSTANTIATE_TEST_SUITE_P(Protocols, DownstreamProtocolIntegrationTest,
                              {Http::CodecType::HTTP1})),
                          HttpProtocolIntegrationTest::protocolTestParamsToString);
 
-INSTANTIATE_TEST_SUITE_P(Protocols, ProtocolIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, ProtocolIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 } // namespace Envoy

--- a/test/integration/local_reply_integration_test.cc
+++ b/test/integration/local_reply_integration_test.cc
@@ -60,7 +60,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -123,7 +123,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -175,7 +175,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/package.service/method"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"content-type", "application/grpc"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -227,7 +227,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/package.service/method"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"content-type", "application/grpc"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -308,7 +308,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -385,7 +385,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -449,7 +449,7 @@ mappers:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value-2"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -507,7 +507,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value-2"}});
   auto response = std::move(encoder_decoder.second);
 
@@ -565,7 +565,7 @@ body_format:
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/test/long/url"},
                                      {":scheme", "http"},
-                                     {":authority", "host"},
+                                     {":authority", "sni.lyft.com"},
                                      {"test-header", "exact-match-value-2"}});
   auto response = std::move(encoder_decoder.second);
 

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -51,8 +51,10 @@ TEST_P(OverloadIntegrationTest, CloseStreamsWhenOverloaded) {
   updateResource(0.9);
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.stop_accepting_requests.active", 1);
 
-  Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"}};
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto response = codec_client_->makeRequestWithBody(request_headers, 10);
   ASSERT_TRUE(response->waitForEndStream());
@@ -104,8 +106,10 @@ TEST_P(OverloadIntegrationTest, DisableKeepaliveWhenOverloaded) {
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.disable_http_keepalive.active", 1);
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"}};
   auto response = sendRequestAndWaitForResponse(request_headers, 1, default_response_headers_, 1);
   ASSERT_TRUE(codec_client_->waitForDisconnect());
 
@@ -204,8 +208,10 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpConnections) {
           min_timeout: 5s
     )EOF"));
 
-  const Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                       {":path", "/test/long/url"},
+                                                       {":scheme", "http"},
+                                                       {":authority", "sni.lyft.com"}};
 
   // Create an HTTP connection and complete a request.
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
@@ -261,8 +267,10 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpStream) {
           min_timeout: 5s
     )EOF"));
 
-  const Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                       {":path", "/test/long/url"},
+                                                       {":scheme", "http"},
+                                                       {":authority", "sni.lyft.com"}};
 
   // Create an HTTP connection and start a request.
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
@@ -293,6 +301,11 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpStream) {
 }
 
 TEST_P(OverloadScaledTimerIntegrationTest, TlsHandshakeTimeout) {
+  if (downstreamProtocol() == Http::CodecClient::Type::HTTP3 ||
+      upstreamProtocol() == Http::CodecClient::Type::HTTP3) {
+    // TODO(#26236): Fix this test for H3.
+    return;
+  }
   // Set up the Envoy to expect a TLS connection, with a 20 second timeout that can scale down to 5
   // seconds.
   config_helper_.addSslConfig();

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -387,7 +387,7 @@ name: add-trailers-filter
   upstream_request_->encodeData(128, true);
   ASSERT_TRUE(response->waitForEndStream());
 
-  if (upstreamProtocol() >= Http::CodecType::HTTP2) {
+  if (upstreamProtocol() != Http::CodecType::HTTP1) {
     EXPECT_EQ("decode", upstream_request_->trailers()
                             ->get(Http::LowerCaseString("grpc-message"))[0]
                             ->value()
@@ -395,7 +395,7 @@ name: add-trailers-filter
   }
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
+  if (downstream_protocol_ != Http::CodecType::HTTP1) {
     EXPECT_EQ("encode", response->trailers()->getGrpcMessageValue());
   }
 }
@@ -1285,7 +1285,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
   // the 413-and-connection-close may be sent while the body is still being
   // sent, resulting in a write error and the connection being closed before the
   // response is read.
-  if (downstream_protocol_ >= Http::CodecType::HTTP2) {
+  if (downstream_protocol_ != Http::CodecType::HTTP1) {
     ASSERT_TRUE(response->complete());
   }
   if (response->complete()) {
@@ -1441,6 +1441,10 @@ TEST_P(ProtocolIntegrationTest, BasicDynamicMaxStreamDuration) {
 }
 
 TEST_P(ProtocolIntegrationTest, MaxStreamDurationWithRetryPolicy) {
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    return; // TODO(#26236) Fix this test for H3.
+  }
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     ConfigHelper::HttpProtocolOptions protocol_options;
     auto* http_protocol_options = protocol_options.mutable_common_http_protocol_options();
@@ -1781,8 +1785,8 @@ TEST_P(ProtocolIntegrationTest, 304WithBody) {
   // Only for HTTP/2 and Http/3, where streams are ended with an explicit end-stream so we
   // can differentiate between 304-with-advertised-but-absent-body and
   // 304-with-body, is there a protocol error on the active stream.
-  if (downstream_protocol_ >= Http::CodecType::HTTP2 &&
-      upstreamProtocol() >= Http::CodecType::HTTP2) {
+  if (downstream_protocol_ != Http::CodecType::HTTP1 &&
+      upstreamProtocol() != Http::CodecType::HTTP1) {
     ASSERT_TRUE(response->waitForReset());
   }
 }

--- a/test/integration/protocol_integration_test.h
+++ b/test/integration/protocol_integration_test.h
@@ -42,7 +42,7 @@ protected:
   }
 
   void verifyUpStreamRequestAfterStopAllFilter() {
-    if (downstreamProtocol() >= Http::CodecType::HTTP2) {
+    if (downstreamProtocol() != Http::CodecType::HTTP1) {
       // decode-headers-return-stop-all-filter calls addDecodedData in decodeData and
       // decodeTrailers. 2 decoded data were added.
       EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 2, upstream_request_->bodyLength());

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -21,7 +21,7 @@ namespace {
 
 Http::TestRequestHeaderMapImpl upgradeRequestHeaders(const char* upgrade_type = "websocket",
                                                      uint32_t content_length = 0) {
-  return Http::TestRequestHeaderMapImpl{{":authority", "host:80"},
+  return Http::TestRequestHeaderMapImpl{{":authority", "sni.lyft.com"},
                                         {"content-length", fmt::format("{}", content_length)},
                                         {":path", "/websocket/test"},
                                         {":method", "GET"},
@@ -60,7 +60,8 @@ void WebsocketIntegrationTest::validateUpgradeRequestHeaders(
     const Http::RequestHeaderMap& original_request_headers) {
   Http::TestRequestHeaderMapImpl proxied_request_headers(original_proxied_request_headers);
   if (proxied_request_headers.ForwardedProto()) {
-    ASSERT_EQ(proxied_request_headers.getForwardedProtoValue(), "http");
+    ASSERT_EQ(proxied_request_headers.getForwardedProtoValue(),
+              downstreamProtocol() == Http::CodecType::HTTP3 ? "https" : "http");
     proxied_request_headers.removeForwardedProto();
   }
 
@@ -117,7 +118,7 @@ ConfigHelper::HttpModifierFunction setRouteUsingWebsocket() {
 }
 
 void WebsocketIntegrationTest::initialize() {
-  if (upstreamProtocol() != Http::CodecType::HTTP1) {
+  if (upstreamProtocol() == Http::CodecType::HTTP2) {
     config_helper_.addConfigModifier(
         [&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
           ConfigHelper::HttpProtocolOptions protocol_options;
@@ -127,11 +128,27 @@ void WebsocketIntegrationTest::initialize() {
           ConfigHelper::setProtocolOptions(
               *bootstrap.mutable_static_resources()->mutable_clusters(0), protocol_options);
         });
+  } else if (upstreamProtocol() == Http::CodecType::HTTP3) {
+    config_helper_.addConfigModifier(
+        [&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+          ConfigHelper::HttpProtocolOptions protocol_options;
+          protocol_options.mutable_explicit_http_config()
+              ->mutable_http3_protocol_options()
+              ->set_allow_extended_connect(true);
+          ConfigHelper::setProtocolOptions(
+              *bootstrap.mutable_static_resources()->mutable_clusters(0), protocol_options);
+        });
   }
-  if (downstreamProtocol() != Http::CodecType::HTTP1) {
+  if (downstreamProtocol() == Http::CodecType::HTTP2) {
     config_helper_.addConfigModifier(
         [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                 hcm) -> void { hcm.mutable_http2_protocol_options()->set_allow_connect(true); });
+  } else if (downstreamProtocol() == Http::CodecType::HTTP3) {
+    config_helper_.addConfigModifier(
+        [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) -> void {
+          hcm.mutable_http3_protocol_options()->set_allow_extended_connect(true);
+        });
   }
   HttpProtocolIntegrationTest::initialize();
 }
@@ -181,6 +198,11 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionDownstreamDisconnect) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#23564) - Finish CONNECT-UDP support.
+    return;
+  }
 
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
   initialize();
@@ -200,7 +222,8 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionDownstreamDisconnect) {
 }
 
 TEST_P(WebsocketIntegrationTest, PortStrippingForHttp2) {
-  if (downstreamProtocol() != Http::CodecType::HTTP2) {
+  if (downstreamProtocol() != Http::CodecType::HTTP2 ||
+      upstreamProtocol() == Http::CodecType::HTTP3) {
     return;
   }
 
@@ -217,7 +240,7 @@ TEST_P(WebsocketIntegrationTest, PortStrippingForHttp2) {
   initialize();
 
   performUpgrade(upgradeRequestHeaders(), upgradeResponseHeaders());
-  ASSERT_EQ(upstream_request_->headers().getHostValue(), "host:80");
+  ASSERT_EQ(upstream_request_->headers().getHostValue(), "sni.lyft.com");
 
   codec_client_->sendData(*request_encoder_, "bye!", false);
   codec_client_->close();
@@ -227,8 +250,8 @@ TEST_P(WebsocketIntegrationTest, PortStrippingForHttp2) {
 }
 
 TEST_P(WebsocketIntegrationTest, EarlyData) {
-  if (downstreamProtocol() == Http::CodecType::HTTP2 ||
-      upstreamProtocol() == Http::CodecType::HTTP2) {
+  if (downstreamProtocol() != Http::CodecType::HTTP1 ||
+      upstreamProtocol() != Http::CodecType::HTTP1) {
     return;
   }
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
@@ -278,6 +301,11 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionIdleTimeout) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#23564) - Finish CONNECT-UDP support.
+    return;
+  }
 
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
   config_helper_.addConfigModifier(
@@ -307,6 +335,11 @@ TEST_P(WebsocketIntegrationTest, NonWebsocketUpgrade) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#23564) - Finish CONNECT-UDP support.
+    return;
+  }
 
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -340,6 +373,11 @@ TEST_P(WebsocketIntegrationTest, RouteSpecificUpgrade) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#23564) - Finish CONNECT-UDP support.
+    return;
+  }
 
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -348,7 +386,7 @@ TEST_P(WebsocketIntegrationTest, RouteSpecificUpgrade) {
         foo_upgrade->set_upgrade_type("foo");
         foo_upgrade->mutable_enabled()->set_value(false);
       });
-  auto host = config_helper_.createVirtualHost("host:80", "/websocket/test");
+  auto host = config_helper_.createVirtualHost("sni.lyft.com", "/websocket/test");
   host.mutable_routes(0)->mutable_route()->add_upgrade_configs()->set_upgrade_type("foo");
   config_helper_.addVirtualHost(host);
   initialize();
@@ -375,6 +413,11 @@ TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
   // TODO(#23286) - add web socket support for H2 UHV
   return;
 #endif
+  if (upstreamProtocol() == Http::CodecType::HTTP3 ||
+      downstreamProtocol() == Http::CodecType::HTTP3) {
+    // TODO(#23564) - Finish CONNECT-UDP support.
+    return;
+  }
 
   config_helper_.addConfigModifier(setRouteUsingWebsocket());
 


### PR DESCRIPTION
Commit Message: Enable HTTP/3 in tests
Additional Description: This PR sets the stage to work on HTTP/3 upgrade header normalization by enabling HTTP/3 in various tests
This PR is a relanding of #26197 with all the non-test changes reverted
This PR is based on https://github.com/envoyproxy/envoy/pull/26107 by @asingh-g
Risk Level: Low
Testing: Existing tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none