### PR TITLE
hyperscan: fix matching with uninitialized thread local

### DIFF
--- a/contrib/hyperscan/matching/input_matchers/source/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/source/BUILD
@@ -23,8 +23,11 @@ envoy_cmake(
     build_data = ["@org_boost//:header"],
     cache_entries = {
         "BOOST_ROOT": "$EXT_BUILD_ROOT/external/org_boost",
+        "BUILD_AVX512": "on",
+        "BUILD_AVX512VBMI": "on",
         "BUILD_EXAMPLES": "off",
         "CMAKE_INSTALL_LIBDIR": "lib",
+        "FAT_RUNTIME": "on",
         "RAGEL": "$EXT_BUILD_DEPS/ragel/bin/ragel",
     },
     env = select({

--- a/contrib/hyperscan/matching/input_matchers/source/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/source/BUILD
@@ -23,11 +23,8 @@ envoy_cmake(
     build_data = ["@org_boost//:header"],
     cache_entries = {
         "BOOST_ROOT": "$EXT_BUILD_ROOT/external/org_boost",
-        "BUILD_AVX512": "on",
-        "BUILD_AVX512VBMI": "on",
         "BUILD_EXAMPLES": "off",
         "CMAKE_INSTALL_LIBDIR": "lib",
-        "FAT_RUNTIME": "on",
         "RAGEL": "$EXT_BUILD_DEPS/ragel/bin/ragel",
     },
     env = select({

--- a/contrib/hyperscan/matching/input_matchers/source/config.cc
+++ b/contrib/hyperscan/matching/input_matchers/source/config.cc
@@ -65,7 +65,9 @@ Config::createInputMatcherFactoryCb(const Protobuf::Message& config,
       ids.push_back(regex.id());
     }
 
-    return std::make_unique<Matcher>(expressions, flags, ids, factory_context.threadLocal(), false);
+    return std::make_unique<Matcher>(expressions, flags, ids,
+                                     factory_context.mainThreadDispatcher(),
+                                     factory_context.threadLocal(), false);
   };
 #endif
 }

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.cc
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.cc
@@ -157,14 +157,14 @@ void Matcher::compile(const std::vector<const char*>& expressions,
 
 hs_scratch_t* Matcher::getScratch(ScratchThreadLocalPtr& local_scratch) const {
   if (!tls_->get().has_value()) {
-    local_scratch = std::make_unique<ScratchThreadLocal>(database_, start_of_match_database_);
-    return local_scratch->scratch_;
-
     dispatcher_.post([this]() {
       tls_->set([this](Event::Dispatcher&) {
         return std::make_shared<ScratchThreadLocal>(database_, start_of_match_database_);
       });
     });
+
+    local_scratch = std::make_unique<ScratchThreadLocal>(database_, start_of_match_database_);
+    return local_scratch->scratch_;
   }
 
   return tls_->get()->scratch_;

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.cc
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.cc
@@ -157,7 +157,7 @@ void Matcher::compile(const std::vector<const char*>& expressions,
 }
 
 hs_scratch_t* Matcher::getScratch(ScratchThreadLocalPtr& local_scratch) const {
-  // Some matchers are constructed before diaptching threads and set() method of thread local slot
+  // Some matchers are constructed before dispatching threads and set() method of thread local slot
   // will only initialize thread local object in existing threads, which may lead to unintialized
   // thread local object in threads which are dispatched later. E.g, stats matchers are constructed
   // before workers while there is chance to use these matchers in working threads. As a result,

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.h
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.h
@@ -19,6 +19,8 @@ struct ScratchThreadLocal : public ThreadLocal::ThreadLocalObject {
   hs_scratch_t* scratch_{};
 };
 
+using ScratchThreadLocalPtr = std::unique_ptr<ScratchThreadLocal>;
+
 struct Bound {
   Bound(uint64_t begin, uint64_t end);
 
@@ -51,6 +53,8 @@ private:
   // regex patterns and flags. Vector parameters should have the same size.
   void compile(const std::vector<const char*>& expressions, const std::vector<unsigned int>& flags,
                const std::vector<unsigned int>& ids, hs_database_t** database);
+
+  hs_scratch_t* getScratch(ScratchThreadLocalPtr& local_scratch) const;
 };
 
 } // namespace Hyperscan

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.h
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.h
@@ -33,8 +33,8 @@ struct Bound {
 class Matcher : public Envoy::Regex::CompiledMatcher, public Envoy::Matcher::InputMatcher {
 public:
   Matcher(const std::vector<const char*>& expressions, const std::vector<unsigned int>& flags,
-          const std::vector<unsigned int>& ids, ThreadLocal::SlotAllocator& tls,
-          bool report_start_of_matching);
+          const std::vector<unsigned int>& ids, Event::Dispatcher& dispatcher,
+          ThreadLocal::SlotAllocator& tls, bool report_start_of_matching);
   ~Matcher() override;
 
   // Envoy::Regex::CompiledMatcher
@@ -47,6 +47,7 @@ public:
 private:
   hs_database_t* database_{};
   hs_database_t* start_of_match_database_{};
+  Event::Dispatcher& dispatcher_;
   ThreadLocal::TypedSlotPtr<ScratchThreadLocal> tls_;
 
   // Compiles the Hyperscan database. It will throw on failure of insufficient memory or malformed

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.h
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.h
@@ -33,7 +33,7 @@ struct Bound {
 class Matcher : public Envoy::Regex::CompiledMatcher, public Envoy::Matcher::InputMatcher {
 public:
   Matcher(const std::vector<const char*>& expressions, const std::vector<unsigned int>& flags,
-          const std::vector<unsigned int>& ids, Event::Dispatcher& dispatcher,
+          const std::vector<unsigned int>& ids, Event::Dispatcher& main_thread_dispatcher,
           ThreadLocal::SlotAllocator& tls, bool report_start_of_matching);
   ~Matcher() override;
 

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.h
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.h
@@ -47,7 +47,7 @@ public:
 private:
   hs_database_t* database_{};
   hs_database_t* start_of_match_database_{};
-  Event::Dispatcher& dispatcher_;
+  Event::Dispatcher& main_thread_dispatcher_;
   ThreadLocal::TypedSlotPtr<ScratchThreadLocal> tls_;
 
   // Compiles the Hyperscan database. It will throw on failure of insufficient memory or malformed

--- a/contrib/hyperscan/matching/input_matchers/test/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/test/BUILD
@@ -24,6 +24,7 @@ envoy_cc_test(
     deps = [
         "//contrib/hyperscan/matching/input_matchers/source:matcher_lib",
         "//source/common/thread_local:thread_local_lib",
+        "//test/mocks/event:event_mocks",
         "//test/test_common:utility_lib",
     ],
 )
@@ -50,5 +51,6 @@ envoy_cc_benchmark_binary(
         "//source/common/common:regex_lib",
         "//source/common/common:utility_lib",
         "//source/common/thread_local:thread_local_lib",
+        "//test/mocks/event:event_mocks",
     ],
 )

--- a/contrib/hyperscan/matching/input_matchers/test/BUILD
+++ b/contrib/hyperscan/matching/input_matchers/test/BUILD
@@ -25,6 +25,7 @@ envoy_cc_test(
         "//contrib/hyperscan/matching/input_matchers/source:matcher_lib",
         "//source/common/thread_local:thread_local_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/contrib/hyperscan/matching/input_matchers/test/matcher_speed_test.cc
+++ b/contrib/hyperscan/matching/input_matchers/test/matcher_speed_test.cc
@@ -5,6 +5,8 @@
 #include "source/common/common/regex.h"
 #include "source/common/thread_local/thread_local_impl.h"
 
+#include "test/mocks/event/mocks.h"
+
 #include "benchmark/benchmark.h"
 #include "contrib/hyperscan/matching/input_matchers/source/matcher.h"
 
@@ -43,9 +45,10 @@ BENCHMARK(BM_CompiledGoogleReMatcher);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_HyperscanMatcher(benchmark::State& state) {
-  auto instance = ThreadLocal::InstanceImpl();
+  Event::MockDispatcher dispatcher;
+  ThreadLocal::InstanceImpl instance;
   auto matcher = Extensions::Matching::InputMatchers::Hyperscan::Matcher(
-      {std::string(ClusterRePattern).c_str()}, {0}, {0}, instance, false);
+      {std::string(ClusterRePattern).c_str()}, {0}, {0}, dispatcher, instance, false);
   uint32_t passes = 0;
   for (auto _ : state) { // NOLINT
     for (const std::string& cluster_input : clusterInputs()) {
@@ -55,6 +58,7 @@ static void BM_HyperscanMatcher(benchmark::State& state) {
     }
   }
   RELEASE_ASSERT(passes > 0, "");
+  instance.shutdownGlobalThreading();
 }
 BENCHMARK(BM_HyperscanMatcher);
 

--- a/contrib/hyperscan/matching/input_matchers/test/matcher_test.cc
+++ b/contrib/hyperscan/matching/input_matchers/test/matcher_test.cc
@@ -48,6 +48,20 @@ TEST(ThreadLocalTest, RaceScratchCreation) {
   }
 }
 
+// Verify that even if thread local is not initialized, matcher can work without crashes.
+TEST(ThreadLocalTest, NotInitialized) {
+  std::vector<const char*> expressions{"^/asdf/.+"};
+  std::vector<unsigned int> flags{0};
+  std::vector<unsigned int> ids{0};
+
+  ThreadLocal::InstanceImpl instance;
+  Matcher matcher(expressions, flags, ids, instance, false);
+  instance.shutdownThread();
+  instance.shutdownGlobalThreading();
+
+  EXPECT_TRUE(matcher.match("/asdf/1"));
+}
+
 // Verify that comparing works correctly for bounds.
 TEST(BoundTest, Compare) {
   EXPECT_LT(Bound(1, 1), Bound(2, 1));
@@ -71,7 +85,7 @@ protected:
   }
 
   ThreadLocal::InstanceImpl instance_;
-  std::shared_ptr<Matcher> matcher_;
+  std::unique_ptr<Matcher> matcher_;
 };
 
 // Verify that matching will be performed successfully.

--- a/contrib/hyperscan/regex_engines/source/config.cc
+++ b/contrib/hyperscan/regex_engines/source/config.cc
@@ -18,7 +18,8 @@ Config::createEngine(const Protobuf::Message& config,
 #ifdef HYPERSCAN_DISABLED
   throw EnvoyException("X86_64 architecture is required for Hyperscan.");
 #else
-  return std::make_shared<HyperscanEngine>(server_factory_context.threadLocal());
+  return std::make_shared<HyperscanEngine>(server_factory_context.mainThreadDispatcher(),
+                                           server_factory_context.threadLocal());
 #endif
 }
 

--- a/contrib/hyperscan/regex_engines/source/regex.cc
+++ b/contrib/hyperscan/regex_engines/source/regex.cc
@@ -5,7 +5,8 @@ namespace Extensions {
 namespace Regex {
 namespace Hyperscan {
 
-HyperscanEngine::HyperscanEngine(ThreadLocal::SlotAllocator& tls) : tls_(tls) {}
+HyperscanEngine::HyperscanEngine(Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator& tls)
+    : dispatcher_(dispatcher), tls_(tls) {}
 
 Envoy::Regex::CompiledMatcherPtr HyperscanEngine::matcher(const std::string& regex) const {
   std::vector<const char*> expressions{regex.c_str()};
@@ -13,7 +14,7 @@ Envoy::Regex::CompiledMatcherPtr HyperscanEngine::matcher(const std::string& reg
   std::vector<unsigned int> ids{0};
 
   return std::make_unique<Matching::InputMatchers::Hyperscan::Matcher>(expressions, flags, ids,
-                                                                       tls_, true);
+                                                                       dispatcher_, tls_, true);
 }
 
 } // namespace Hyperscan

--- a/contrib/hyperscan/regex_engines/source/regex.h
+++ b/contrib/hyperscan/regex_engines/source/regex.h
@@ -11,10 +11,11 @@ namespace Hyperscan {
 
 class HyperscanEngine : public Envoy::Regex::Engine {
 public:
-  explicit HyperscanEngine(ThreadLocal::SlotAllocator& tls);
+  explicit HyperscanEngine(Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator& tls);
   Envoy::Regex::CompiledMatcherPtr matcher(const std::string& regex) const override;
 
 private:
+  Event::Dispatcher& dispatcher_;
   ThreadLocal::SlotAllocator& tls_;
 };
 

--- a/contrib/hyperscan/regex_engines/test/BUILD
+++ b/contrib/hyperscan/regex_engines/test/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
     deps = [
         "//contrib/hyperscan/regex_engines/source:regex_lib",
         "//source/common/thread_local:thread_local_lib",
+        "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
     ],
 )

--- a/contrib/hyperscan/regex_engines/test/regex_test.cc
+++ b/contrib/hyperscan/regex_engines/test/regex_test.cc
@@ -1,6 +1,7 @@
 #ifndef HYPERSCAN_DISABLED
 #include "source/common/thread_local/thread_local_impl.h"
 
+#include "test/mocks/event/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "contrib/hyperscan/regex_engines/source/regex.h"
@@ -13,13 +14,14 @@ namespace Hyperscan {
 
 class EngineTest : public ::testing::Test {
 protected:
-  void setup() { engine_ = std::make_shared<HyperscanEngine>(instance_); }
+  void setup() { engine_ = std::make_shared<HyperscanEngine>(dispatcher_, instance_); }
 
   void TearDown() override {
     instance_.shutdownGlobalThreading();
     ::testing::Test::TearDown();
   }
 
+  Event::MockDispatcher dispatcher_;
   ThreadLocal::InstanceImpl instance_;
   std::shared_ptr<HyperscanEngine> engine_;
 };


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: hyperscan: fix matching with uninitialized thread local
Additional Description: when compiling and using stats matcher, TLS may not be initialized at that time. The patch allows Hyperscan to generate temporary scratch space for matching without TLS.
Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
