### PR TITLE
ext_authz support add failure-mode-allow header

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -26,7 +26,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -62,6 +62,12 @@ message ExtAuthz {
   // Note that errors can be ``always`` tracked in the :ref:`stats
   // <config_http_filters_ext_authz_stats>`.
   bool failure_mode_allow = 2;
+
+  // When ``failure_mode_allow`` and ``failure_mode_allow_header_add`` are both set to true,
+  // ``x-envoy-failure-mode-allowed: true`` will be added to request headers if the communication
+  // with the authorization service has failed, or if the authorization service has returned a 
+  // HTTP 5xx error.
+  bool failure_mode_allow_header_add = 18;
 
   // Enables filter to buffer the client request body and send it within the authorization request.
   // A ``x-envoy-auth-partial-body: false|true`` metadata header will be added to the authorization

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -411,6 +411,9 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
       if (cluster_) {
         config_->incCounter(cluster_->statsScope(), config_->ext_authz_failure_mode_allowed_);
       }
+      if (config_->failureModeAllowHeaderAdd()) {
+        request_headers_->addCopy(Http::LowerCaseString("x-envoy-failure-mode-allowed"), "true");
+      }
       continueDecoding();
     } else {
       ENVOY_STREAM_LOG(

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -60,6 +60,7 @@ public:
                const std::string& stats_prefix, envoy::config::bootstrap::v3::Bootstrap& bootstrap)
       : allow_partial_message_(config.with_request_body().allow_partial_message()),
         failure_mode_allow_(config.failure_mode_allow()),
+        failure_mode_allow_header_add_(config.failure_mode_allow_header_add()),
         clear_route_cache_(config.clear_route_cache()),
         max_request_bytes_(config.with_request_body().max_request_bytes()),
         pack_as_bytes_(config.with_request_body().pack_as_bytes()),
@@ -126,6 +127,8 @@ public:
   bool withRequestBody() const { return max_request_bytes_ > 0; }
 
   bool failureModeAllow() const { return failure_mode_allow_; }
+
+  bool failureModeAllowHeaderAdd() const { return failure_mode_allow_header_add_; }
 
   bool clearRouteCache() const { return clear_route_cache_; }
 
@@ -198,6 +201,7 @@ private:
 
   const bool allow_partial_message_;
   const bool failure_mode_allow_;
+  const bool failure_mode_allow_header_add_{};
   const bool clear_route_cache_;
   const uint32_t max_request_bytes_;
   const bool pack_as_bytes_;

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -386,6 +386,7 @@ TEST_F(HttpFilterTest, ErrorOpen) {
                     .counterFromString("ext_authz.error")
                     .value());
   EXPECT_EQ(1U, config_->stats().error_.value());
+  EXPECT_EQ(request_headers_.get_("x-envoy-failure-mode-allowed"), EMPTY_STRING);
 }
 
 // Test when failure_mode_allow is set and the response from the authorization service is an
@@ -429,6 +430,90 @@ TEST_F(HttpFilterTest, ImmediateErrorOpen) {
                     .value());
   EXPECT_EQ(1U, config_->stats().error_.value());
   EXPECT_EQ(1U, config_->stats().failure_mode_allowed_.value());
+  EXPECT_EQ(request_headers_.get_("x-envoy-failure-mode-allowed"), EMPTY_STRING);
+}
+
+// Test when failure_mode_allow and failure_mode_allow_header_add are set and the response from the
+// authorization service is Error that the request is allowed to continue.
+TEST_F(HttpFilterTest, ErrorOpenWithFailureModeAllowHeaderAddOpen) {
+  InSequence s;
+
+  initialize(R"EOF(
+  transport_api_version: V3
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_authz_server"
+  failure_mode_allow: true
+  failure_mode_allow_header_add: true
+  )EOF");
+
+  ON_CALL(decoder_filter_callbacks_, connection())
+      .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
+  EXPECT_CALL(*client_, check(_, _, _, _))
+      .WillOnce(
+          Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+                     const envoy::service::auth::v3::CheckRequest&, Tracing::Span&,
+                     const StreamInfo::StreamInfo&) -> void { request_callbacks_ = &callbacks; }));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers_, false));
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
+
+  Filters::Common::ExtAuthz::Response response{};
+  response.status = Filters::Common::ExtAuthz::CheckStatus::Error;
+  request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
+  EXPECT_EQ(1U, decoder_filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromString("ext_authz.error")
+                    .value());
+  EXPECT_EQ(1U, config_->stats().error_.value());
+  EXPECT_EQ(request_headers_.get_("x-envoy-failure-mode-allowed"), "true");
+}
+
+// Test when failure_mode_allow and failure_mode_allow_header_add are set and the response from the
+// authorization service is an immediate Error that the request is allowed to continue.
+TEST_F(HttpFilterTest, ImmediateErrorOpenWithFailureModeAllowHeaderAddOpen) {
+  InSequence s;
+
+  initialize(R"EOF(
+  transport_api_version: V3
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_authz_server"
+  failure_mode_allow: true
+  failure_mode_allow_header_add: true
+  )EOF");
+
+  ON_CALL(decoder_filter_callbacks_, connection())
+      .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
+
+  Filters::Common::ExtAuthz::Response response{};
+  response.status = Filters::Common::ExtAuthz::CheckStatus::Error;
+  EXPECT_CALL(*client_, check(_, _, _, _))
+      .WillOnce(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+                           const envoy::service::auth::v3::CheckRequest&, Tracing::Span&,
+                           const StreamInfo::StreamInfo&) -> void {
+        callbacks.onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
+      }));
+
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+  EXPECT_EQ(1U, decoder_filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromString("ext_authz.error")
+                    .value());
+  EXPECT_EQ(1U, decoder_filter_callbacks_.clusterInfo()
+                    ->statsScope()
+                    .counterFromString("ext_authz.failure_mode_allowed")
+                    .value());
+  EXPECT_EQ(1U, config_->stats().error_.value());
+  EXPECT_EQ(1U, config_->stats().failure_mode_allowed_.value());
+  EXPECT_EQ(request_headers_.get_("x-envoy-failure-mode-allowed"), "true");
 }
 
 // Check a bad configuration results in validation exception.


### PR DESCRIPTION
Commit Message: ext_authz support add failure-mode-allow header
Additional Description: N/A
Risk Level: low
Testing: ut
Docs Changes: N/A
Release Notes: N/A
