### PR TITLE
Temporarily disable flaky Http2FloodMitigationTest.RequestMetadata test

### DIFF
--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -1444,7 +1444,7 @@ TEST_P(Http2FloodMitigationTest, UpstreamRstStreamOnDownstreamRemoteClose) {
 }
 
 // Verify that the server can detect flood of request METADATA frames
-// TODO(#26088): re-enable once the test is deflaked
+// TODO(#26088): re-enable once the test is flaky no longer
 TEST_P(Http2FloodMitigationTest, DISABLED_RequestMetadata) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     ASSERT(bootstrap.mutable_static_resources()->clusters_size() >= 1, "");

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -1444,7 +1444,8 @@ TEST_P(Http2FloodMitigationTest, UpstreamRstStreamOnDownstreamRemoteClose) {
 }
 
 // Verify that the server can detect flood of request METADATA frames
-TEST_P(Http2FloodMitigationTest, RequestMetadata) {
+// TODO(#26088): re-enable once the test is deflaked
+TEST_P(Http2FloodMitigationTest, DISABLED_RequestMetadata) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     ASSERT(bootstrap.mutable_static_resources()->clusters_size() >= 1, "");
     ConfigHelper::HttpProtocolOptions protocol_options;


### PR DESCRIPTION
Additional Description:
I'm unable to recreate this failure so far. Disabling the test while continuing to debug.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Related Issue #26088