### PR TITLE
upstream: implement protobufAddressToAddress for EnvoyInternalAddress

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -491,7 +491,9 @@ Utility::protobufAddressToAddress(const envoy::config::core::v3::Address& proto_
     return std::make_shared<Address::PipeInstance>(proto_address.pipe().path(),
                                                    proto_address.pipe().mode());
   case envoy::config::core::v3::Address::AddressCase::kEnvoyInternalAddress:
-    PANIC("internal address not supported"); // TODO(lambdai) fix.
+    return std::make_shared<Address::EnvoyInternalInstance>(
+        proto_address.envoy_internal_address().server_listener_name(),
+        proto_address.envoy_internal_address().endpoint_id());
   case envoy::config::core::v3::Address::AddressCase::ADDRESS_NOT_SET:
     PANIC_DUE_TO_PROTO_UNSET;
   }

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -562,6 +562,13 @@ TEST(NetworkUtility, ParseProtobufAddress) {
     proto_address.mutable_pipe()->set_path("/tmp/unix-socket");
     EXPECT_EQ("/tmp/unix-socket", Utility::protobufAddressToAddress(proto_address)->asString());
   }
+  {
+    envoy::config::core::v3::Address proto_address;
+    proto_address.mutable_envoy_internal_address()->set_server_listener_name("internal_listener");
+    proto_address.mutable_envoy_internal_address()->set_endpoint_id("12345");
+    EXPECT_EQ("envoy://internal_listener/12345",
+              Utility::protobufAddressToAddress(proto_address)->asString());
+  }
 #if defined(__linux__)
   {
     envoy::config::core::v3::Address proto_address;


### PR DESCRIPTION
Commit Message: implement protobufAddressToAddress for EnvoyInternalAddress
Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Signed off by: Eugene Chan <eugenechan@google.com>