### PR TITLE
ecds: fix the clean deletion logic

### DIFF
--- a/test/integration/extension_discovery_integration_test.cc
+++ b/test/integration/extension_discovery_integration_test.cc
@@ -795,6 +795,7 @@ TEST_P(ExtensionDiscoveryIntegrationTest, BasicFailTerminalFilterNotAtEndOfFilte
 }
 
 // Validate that deleting listeners does not break active ECDS subscription.
+// This test also verifies clean deletion of the filter config on the main thread.
 TEST_P(ExtensionDiscoveryIntegrationTest, ReloadBoth) {
   on_server_init_function_ = [&]() { waitXdsStream(); };
   addDynamicFilter("foo", false);


### PR DESCRIPTION
Commit Message: Ensure extension config is always deleted on the main thread.
Additional Description: There is an implicit data race with the following interleaving:
1) TLS runOnAllThreads invoked to clear the extension config.
2) TLS deleted, a post is invoked on all workers to delete its storage.
3) TLS runOnAllThreads on workers does nothing because of step 2). 
4) TLS runOnAllThreads runs the completion callback on the main thread.
5) TLS deletion post invoked on some worker, deleting the last instance of the extension config.

The workaround is to prevent 2) from happening while `runOnAllThreads` is running. This is done by capturing TLS in the completion callback, and explicitly resetting it and the associated filter config in the callback.

Note that we cannot rely on the main_config shared pointer destruction implicitly. It seems the destructor can still execute on a worker, so we explicitly empty the content in the PR. It's not clear to me why some worker has a copy of the function, but it's hard to track down without `AnyInvocable` or move-only functions.

Risk Level: low
Testing: run the flakey test 10000 times, all pass
Docs Changes: none
Release Notes: none
Platform Specific Features: none
Fixes: https://github.com/envoyproxy/envoy/issues/26254