### PR TITLE
test: fix the flake of RebalancerTest.BindToPortUpdate

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -1678,6 +1678,9 @@ public:
           createConnectionAndWrite("dummy", connections.back().response_);
       connections.back().client_conn_->waitForConnection();
       ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(connections.back().upstream_conn_));
+      std::string data;
+      EXPECT_TRUE(connections.back().upstream_conn_->waitForData(5, &data));
+      EXPECT_EQ("dummy", data);
     }
     for (auto& conn : connections) {
       conn.client_conn_->close();


### PR DESCRIPTION
Commit Message: test: fix the flake of RebalancerTest.BindToPortUpdate
Additional Description:
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #26335
