### PR TITLE
wasm: add stats for detecting wasm VM crashes

### DIFF
--- a/source/extensions/common/wasm/stats_handler.cc
+++ b/source/extensions/common/wasm/stats_handler.cc
@@ -70,10 +70,19 @@ void LifecycleStatsHandler::onEvent(WasmEvent event) {
   switch (event) {
   case WasmEvent::VmShutDown:
     lifecycle_stats_.active_.set(--active_wasms);
+    if (is_crashed_) {
+      lifecycle_stats_.crash_.dec();
+    }
     break;
   case WasmEvent::VmCreated:
     lifecycle_stats_.active_.set(++active_wasms);
     lifecycle_stats_.created_.inc();
+    break;
+  case WasmEvent::RuntimeError:
+    if (!is_crashed_) {
+      is_crashed_ = true;
+      lifecycle_stats_.crash_.inc();
+    }
     break;
   default:
     break;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:  add stats for detecting wasm VM crashes
Additional Description: 
The effect is as follows:
```txt
wasm.envoy.wasm.runtime.v8.plugin.my_plugin.crash: 0
```
Risk Level: low
Testing: all pass
Docs Changes: none
Release Notes: none
Platform Specific Features: none
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
