### PR TITLE
[ZK filter] Decoding with request/response data + full packets length

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -568,7 +568,7 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype
     offset -= INT_LENGTH + len;
     ASSERT(offset < data_len);
     // Decode full packets.
-    // offset is the length of all full packets.
+    // offset here represents the length of all full packets.
     decode(data, dtype, offset);
 
     // Copy out the rest of the data to the ZooKeeper filter buffer.

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -584,7 +584,7 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype
   }
 }
 
-void DecoderImpl::decode(Buffer::Instance& data, DecodeType dtype, uint64_t& full_packets_len) {
+void DecoderImpl::decode(Buffer::Instance& data, DecodeType dtype, uint64_t full_packets_len) {
   uint64_t offset = 0;
 
   try {

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -568,8 +568,9 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype
     offset -= INT_LENGTH + len;
     // Decode full packets with BufferFragment.
     Buffer::OwnedImpl full_packets;
-    Buffer::BufferFragmentImpl* frag =
-        new Buffer::BufferFragmentImpl(data.linearize(data.length()), offset, nullptr);
+    Buffer::BufferFragmentImpl* frag = new Buffer::BufferFragmentImpl(
+        data.linearize(data.length()), offset,
+        [](const void*, size_t, const Buffer::BufferFragmentImpl* frag) { delete frag; });
     full_packets.addBufferFragment(*frag);
     decode(full_packets, dtype);
 

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -566,12 +566,11 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype
 
   if (has_full_packets) {
     offset -= INT_LENGTH + len;
-    // Decode full packets.
-    // TODO(Winbobob): use BufferFragment to avoid copying the full packets.
-    temp_data.resize(offset);
-    data.copyOut(0, offset, temp_data.data());
+    // Decode full packets with BufferFragment.
     Buffer::OwnedImpl full_packets;
-    full_packets.add(temp_data.data(), temp_data.length());
+    Buffer::BufferFragmentImpl* frag =
+        new Buffer::BufferFragmentImpl(data.linearize(data.length()), offset, nullptr);
+    full_packets.addBufferFragment(*frag);
     decode(full_packets, dtype);
 
     // Copy out the rest of the data to the ZooKeeper filter buffer.

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -566,10 +566,11 @@ void DecoderImpl::decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype
 
   if (has_full_packets) {
     offset -= INT_LENGTH + len;
+    ASSERT(offset < data_len);
     // Decode full packets with BufferFragment.
     Buffer::OwnedImpl full_packets;
     Buffer::BufferFragmentImpl* frag = new Buffer::BufferFragmentImpl(
-        data.linearize(data.length()), offset,
+        data.linearize(offset), offset,
         [](const void*, size_t, const Buffer::BufferFragmentImpl* frag) { delete frag; });
     full_packets.addBufferFragment(*frag);
     decode(full_packets, dtype);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -148,7 +148,7 @@ private:
                                         Buffer::OwnedImpl& zk_filter_buffer);
   void decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype,
                              Buffer::OwnedImpl& zk_filter_buffer);
-  void decode(Buffer::Instance& data, DecodeType dtype);
+  void decode(Buffer::Instance& data, DecodeType dtype, uint64_t& full_packets_len);
   void decodeOnData(Buffer::Instance& data, uint64_t& offset);
   void decodeOnWrite(Buffer::Instance& data, uint64_t& offset);
   void parseConnect(Buffer::Instance& data, uint64_t& offset, uint32_t len);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -148,7 +148,7 @@ private:
                                         Buffer::OwnedImpl& zk_filter_buffer);
   void decodeAndBufferHelper(Buffer::Instance& data, DecodeType dtype,
                              Buffer::OwnedImpl& zk_filter_buffer);
-  void decode(Buffer::Instance& data, DecodeType dtype, uint64_t& full_packets_len);
+  void decode(Buffer::Instance& data, DecodeType dtype, uint64_t full_packets_len);
   void decodeOnData(Buffer::Instance& data, uint64_t& offset);
   void decodeOnWrite(Buffer::Instance& data, uint64_t& offset);
   void parseConnect(Buffer::Instance& data, uint64_t& offset, uint32_t len);


### PR DESCRIPTION
Commit Message: [ZK filter] Decoding with request/response data + full packets length
Additional Description: Using request/response data with full packets length to do decoding instead of copying data to a new buffer or using the buffer fragment.

The benefit of buffer fragment is minimal. This is because we have to use `linearize()` to fetch the pointer of the data. Within `linearize()`, it will move the data chunk to a continuous location.

If we pass the original data, together full packets length, we are able to decode full packets without moving any full packets data.

Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A