### PR TITLE
upstreamHttpProtocol: choose HTTP11 when use_downstream_protocol_config is enabled and downstream protocol is HTTP10.

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1946,7 +1946,9 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     PANIC("unexpected");
 #endif
   }
-  ASSERT(protocols.size() == 1 && protocols[0] == Http::Protocol::Http11);
+  ASSERT(protocols.size() == 1 &&
+         (protocols[0] == Http::Protocol::Http11 || protocols[0] == Http::Protocol::Http10));
+  // NP: will use HTTP11 since we do not support http10 for upstream yet.
   return Http::Http1::allocateConnPool(dispatcher, context_.api().randomGenerator(), host, priority,
                                        options, transport_socket_options, state);
 }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1946,9 +1946,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     PANIC("unexpected");
 #endif
   }
-  ASSERT(protocols.size() == 1 &&
-         (protocols[0] == Http::Protocol::Http11 || protocols[0] == Http::Protocol::Http10));
-  // NP: will use HTTP11 since we do not support http10 for upstream yet.
+  ASSERT(protocols.size() == 1 && protocols[0] == Http::Protocol::Http11);
   return Http::Http1::allocateConnPool(dispatcher, context_.api().randomGenerator(), host, priority,
                                        options, transport_socket_options, state);
 }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1324,6 +1324,10 @@ ClusterInfoImpl::upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_
         !(features_ & Upstream::ClusterInfo::Features::HTTP3)) {
       return {Http::Protocol::Http2};
     }
+    // use HTTP11 since HTTP10 upstream is not supported yet.
+    if (downstream_protocol.value() == Http::Protocol::Http10) {
+      return {Http::Protocol::Http11};
+    }
     return {downstream_protocol.value()};
   }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -4506,7 +4506,8 @@ TEST_F(ClusterInfoImplTest, UseDownstreamHttpProtocolWithDowngrade) {
 
   auto cluster = makeCluster(yaml);
 
-  EXPECT_EQ(Http::Protocol::Http10,
+  // use HTTP11 since HTTP10 upstream is not supported yet.
+  EXPECT_EQ(Http::Protocol::Http11,
             cluster->info()->upstreamHttpProtocol({Http::Protocol::Http10})[0]);
   EXPECT_EQ(Http::Protocol::Http11,
             cluster->info()->upstreamHttpProtocol({Http::Protocol::Http11})[0]);
@@ -4792,7 +4793,8 @@ TEST_F(ClusterInfoImplTest, UseDownstreamHttpProtocolWithoutDowngrade) {
                                                        Network::Address::IpVersion::v4);
   auto cluster = makeCluster(yaml);
 
-  EXPECT_EQ(Http::Protocol::Http10,
+  // use HTTP11 since HTTP10 upstream is not supported yet.
+  EXPECT_EQ(Http::Protocol::Http11,
             cluster->info()->upstreamHttpProtocol({Http::Protocol::Http10})[0]);
   EXPECT_EQ(Http::Protocol::Http11,
             cluster->info()->upstreamHttpProtocol({Http::Protocol::Http11})[0]);


### PR DESCRIPTION
Commit Message:
Additional Description:
Otherwise, we'll hit assert in allocateConnPool.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
