### PR TITLE
keep calm when parsing internal addresses

### DIFF
--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -570,6 +570,13 @@ TEST(NetworkUtility, ParseProtobufAddress) {
               Utility::protobufAddressToAddress(proto_address)->asString());
   }
 #endif
+  {
+    envoy::config::core::v3::Address proto_address;
+    proto_address.mutable_envoy_internal_address()->set_server_listener_name("internal_listener");
+    proto_address.mutable_envoy_internal_address()->set_endpoint_id("endpoint");
+    EXPECT_EQ(Utility::protobufAddressToAddress(proto_address)->asString(),
+              "envoy://internal_listener/endpoint");
+  }
 }
 
 TEST(NetworkUtility, AddressToProtobufAddress) {


### PR DESCRIPTION
Commit Message: Removes the PANIC when parsing internal addresses.
Additional Description:
Risk Level: none
Testing: unit
Docs Changes: none
Release Notes: none
