### PR TITLE
Disable flaky test Protocols/WebsocketIntegrationTest.WebsocketCustomFilterChain/IPv6_Http3Downstream_Http2UpstreamHttpParserNghttp2NoDeferredProcessing

### DIFF
--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -392,6 +392,12 @@ TEST_P(WebsocketIntegrationTest, RouteSpecificUpgrade) {
 }
 
 TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
+  // TODO(#26373) - debug and re-enable.
+  if (downstreamProtocol() != Http::CodecType::HTTP2 ||
+      upstreamProtocol() == Http::CodecType::HTTP3) {
+    return;
+  }
+
 #ifdef ENVOY_ENABLE_UHV
   // TODO(#23286) - add web socket support for H2 UHV
   return;


### PR DESCRIPTION
Disable flaky test Protocols/WebsocketIntegrationTest.WebsocketCustomFilterChain/IPv6_Http3Downstream_Http2UpstreamHttpParserNghttp2NoDeferredProcessing

Issue: #26373

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A