### PR TITLE
eds: improve memory usage switching from optional to unique_ptr

### DIFF
--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -211,11 +211,12 @@ void EdsClusterImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef
   // (optimize for no-copy).
   envoy::config::endpoint::v3::ClusterLoadAssignment* used_load_assignment;
   if (cla_leds_configs.empty()) {
-    cluster_load_assignment_ = absl::nullopt;
+    cluster_load_assignment_ = nullptr;
     used_load_assignment = &cluster_load_assignment;
   } else {
-    cluster_load_assignment_ = std::move(cluster_load_assignment);
-    used_load_assignment = &cluster_load_assignment_.value();
+    cluster_load_assignment_ = std::make_unique<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+        std::move(cluster_load_assignment));
+    used_load_assignment = cluster_load_assignment_.get();
   }
 
   // Add all the LEDS localities that are new.

--- a/source/extensions/clusters/eds/eds.h
+++ b/source/extensions/clusters/eds/eds.h
@@ -103,7 +103,7 @@ private:
   // TODO(adisuissa): Avoid saving the entire cluster load assignment, only the
   // relevant parts of the config for each locality. Note that this field must
   // be set when LEDS is used.
-  absl::optional<envoy::config::endpoint::v3::ClusterLoadAssignment> cluster_load_assignment_;
+  std::unique_ptr<envoy::config::endpoint::v3::ClusterLoadAssignment> cluster_load_assignment_;
 };
 
 using EdsClusterImplSharedPtr = std::shared_ptr<EdsClusterImpl>;


### PR DESCRIPTION
Commit Message: improve memory usage switching from optional to unique_ptr in EDS
Additional Description:
EDS has an optional field to keep its contents that is used in LEDS. This PR changes from optional to unique_ptr, thus switching from 944 bytes per EDS-cluster to 792 bytes per EDS-cluster.

Risk Level: low - shouldn't impact behavior.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
