### PR TITLE
api: wrap the audit logger extension with an is_optional bool

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -111,6 +111,16 @@ message RBAC {
       ON_DENY_AND_ALLOW = 3;
     }
 
+    message AuditLoggerConfig {
+      // Typed logger configuration.
+      //
+      // [#extension-category: envoy.rbac.audit_loggers]
+      core.v3.TypedExtensionConfig audit_logger = 1;
+
+      // If true, when the logger is not supported, the data plane will not NACK but simply ignore it.
+      bool is_optional = 2;
+    }
+
     // Condition for the audit logging to happen.
     // If this condition is met, all the audit loggers configured here will be invoked.
     //
@@ -120,9 +130,7 @@ message RBAC {
     // Configurations for RBAC-based authorization audit loggers.
     //
     // [#not-implemented-hide:]
-    // [#extension-category: envoy.rbac.audit_loggers]
-    repeated core.v3.TypedExtensionConfig audit_loggers = 2
-        [(validate.rules).repeated = {min_items: 1}];
+    repeated AuditLoggerConfig logger_configs = 2 [(validate.rules).repeated = {min_items: 1}];
   }
 
   // The action to take if a policy matches. Every action either allows or denies a request,


### PR DESCRIPTION
Commit Message: Make the audit logger config optional
Risk Level: low
Docs Changes: N/A
Release Notes: N/A

[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):
We decided to make individual audit logger configurations optional such that if the data plane is not updated to support a new type of logger, we can configure it to not NACK the RBAC filter entirely.

It's technically a breaking change to #26001 but that one was merged less than 10 days ago so implementation exists for the API and nobody should be using it right now.
 
