### PR TITLE
distribution: Allow customization of Envoy binary and speed up packaging

### DIFF
--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -624,6 +624,12 @@ stages:
     pool:
       vmImage: "ubuntu-20.04"
     steps:
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: current
+        artifactName: "bazel.release"
+        itemPattern: "bazel.release/envoy*binary.tar.gz"
+        targetPath: $(Build.StagingDirectory)
     - template: bazel.yml
       parameters:
         ciTarget: bazel.distribution
@@ -634,6 +640,12 @@ stages:
     timeoutInMinutes: 120
     pool: "arm-large"
     steps:
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: current
+        artifactName: "bazel.release.arm64"
+        itemPattern: "bazel.release.arm64/envoy*binary.tar.gz"
+        targetPath: $(Build.StagingDirectory)
     - template: bazel.yml
       parameters:
         managedAgent: false

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ bazel.output.txt
 **/.DS_Store
 **/*.iml
 tools/dev/src
+distribution/custom

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -231,6 +231,14 @@ elif [[ "$CI_TARGET" == "bazel.distribution" ]]; then
 
   setup_clang_toolchain
 
+  mkdir -p distribution/custom
+
+  if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
+      tar xfO "/build/bazel.release/envoy_binary.tar.gz" build_envoy_release_stripped/envoy > distribution/custom/envoy
+  else
+      tar xfO "/build/bazel.release.arm64/envoy_binary.tar.gz" build_envoy_release_stripped/envoy > distribution/custom/envoy
+  fi
+
   # By default the packages will be signed by the first available key.
   # If there is no key available, a throwaway key is created
   # and the packages signed with it, for the purpose of testing only.
@@ -243,7 +251,7 @@ elif [[ "$CI_TARGET" == "bazel.distribution" ]]; then
           "--action_env=PACKAGES_MAINTAINER_EMAIL")
   fi
 
-  bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c opt //distribution:packages.tar.gz
+  bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c opt --//distribution:envoy-binary=//distribution:custom/envoy //distribution:packages.tar.gz
   if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
       cp -a bazel-bin/distribution/packages.tar.gz "${ENVOY_BUILD_DIR}/packages.x64.tar.gz"
   else

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -8,11 +8,20 @@ envoy_package()
 
 MAINTAINER = "Envoy maintainers <envoy-maintainers@googlegroups.com>"
 
+exports_files(glob([
+    "custom/envoy*",
+]))
+
 genrule(
     name = "envoy-bin",
     srcs = ["//source/exe:envoy-static"],
     outs = ["envoy"],
     cmd = "strip $(location //source/exe:envoy-static) -o $@",
+)
+
+label_flag(
+    name = "envoy-binary",
+    build_setting_default = ":envoy-bin",
 )
 
 envoy_pkg_distros(

--- a/distribution/packages.bzl
+++ b/distribution/packages.bzl
@@ -11,7 +11,7 @@ def _release_version_for(version):
 
 def envoy_pkg_distros(
         name,
-        envoy_bin = ":envoy-bin",
+        envoy_bin = ":envoy-binary",
         version = None,
         maintainer = None,
         config = "//configs:envoyproxy_io_proxy.yaml"):


### PR DESCRIPTION
This allows the distribution packaging (ie debs) to be provided with the path to a custom envoy binary, which means we dont have to rebuild the binary in the packaging jobs, saving quite a lot of time and resources, and also using the same binary as the one in the docker container/github assets

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
