### PR TITLE
Parse tls cipher information from client hello in tls_inspector

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -88,9 +88,12 @@ private:
   void onALPN(const unsigned char* data, unsigned int len);
   void onServername(absl::string_view name);
   void createJA3Hash(const SSL_CLIENT_HELLO* ssl_client_hello);
+  void onDetectCiphers(const SSL_CLIENT_HELLO* ssl_client_hello);
+  void setCipherMetadata();
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_{};
+  std::vector<uint16_t> detected_tls_ciphers_;
 
   bssl::UniquePtr<SSL> ssl_;
   uint64_t read_{0};

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -121,6 +121,7 @@ TEST_P(TlsInspectorTest, SniRegistered) {
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
   // trigger the event to copy the client hello message into buffer
   file_event_callback_(Event::FileReadyType::Read);
   auto state = filter_->onData(*buffer_);
@@ -142,6 +143,7 @@ TEST_P(TlsInspectorTest, AlpnRegistered) {
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
   // trigger the event to copy the client hello message into buffer
   file_event_callback_(Event::FileReadyType::Read);
   auto state = filter_->onData(*buffer_);
@@ -197,6 +199,7 @@ TEST_P(TlsInspectorTest, MultipleReads) {
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
   while (!got_continue) {
     // trigger the event to copy the client hello message into buffer
     file_event_callback_(Event::FileReadyType::Read);
@@ -220,6 +223,7 @@ TEST_P(TlsInspectorTest, NoExtensions) {
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
   // trigger the event to copy the client hello message into buffer
   file_event_callback_(Event::FileReadyType::Read);
   auto state = filter_->onData(*buffer_);
@@ -292,6 +296,7 @@ TEST_P(TlsInspectorTest, ConnectionFingerprint) {
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
   // trigger the event to copy the client hello message into buffer
   file_event_callback_(Event::FileReadyType::Read);
   auto state = filter_->onData(*buffer_);
@@ -306,6 +311,8 @@ void TlsInspectorTest::testJA3(const std::string& fingerprint, bool expect_serve
   std::vector<uint8_t> client_hello = Tls::Test::generateClientHelloFromJA3Fingerprint(fingerprint);
   init();
   mockSysCallForPeek(client_hello);
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
+
   if (hash.empty()) {
     uint8_t buf[MD5_DIGEST_LENGTH];
     MD5(reinterpret_cast<const uint8_t*>(fingerprint.data()), fingerprint.size(), buf);
@@ -391,6 +398,7 @@ TEST_P(TlsInspectorTest, NotSsl) {
 
   // Use 100 bytes of zeroes. This is not valid as a ClientHello.
   data.resize(100);
+  EXPECT_CALL(cb_, setDynamicMetadata(_, _));
   mockSysCallForPeek(data);
   // trigger the event to copy the client hello message into buffer:q
   file_event_callback_(Event::FileReadyType::Read);


### PR DESCRIPTION
Here we parse information from the client hello and store it in dynamic metadata. Currently, all tests are passing (in the tls_inspector suite at least, I have not yet run others), but there is a lot to be cleaned up before merging. Before doing that however, I would appreciate some feedback on the general direction.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Parse TLS cipher information in tls inspector
Additional Description: TLS cipher information is parsed from the client hello and stored in dynamic metadata for filter chain matching
Risk Level: High
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
