### PR TITLE
bazel/distribution: Add `bundled` rule and compiler transition

### DIFF
--- a/distribution/binary/compiler.bzl
+++ b/distribution/binary/compiler.bzl
@@ -1,0 +1,116 @@
+# Compile targets using a bazel-defined compilation mode.
+#
+# This is useful for building packages comprised of binaries built in
+# multiple modes - eg a release containing both `opt` and `dbg` builds.
+#
+# In this case the cli-supplied `-c ...` flag is ignored.
+#
+# NB: Avoid use of this as it creates a large sub-graph independent
+#  of the normal bazel build graph.
+#
+#  See https://bazel.build/extending/config#memory-performance-considerations
+#
+# The `bundled` rule allows you to define a set of compilation targets that you wish to
+# be compiled with compilation settings defined in bazel, that would normally be
+# set on the command line.
+#
+# The `mode` sets the `compilation_mode` - one of `dbg`, `opt`, or `fastbuild`.
+#
+# You can define the `targets` to be compiled, along with the destination `path`
+# of the compiled binary.
+#
+# You can also define lists of `stripopts` and `linkopts`.
+#
+# For example, you can bundle some stripped binaries together in `opt` mode:
+#
+# ```starlark
+#
+# bundled(
+#     name = "envoy",
+#     mode = "opt",
+#     stripopts = ["--strip-all"],
+#     targets = {
+#         "//distribution:envoy-binary": "envoy",
+#         "//distribution:envoy-contrib-binary": "envoy-contrib",
+#         "//external:su-exec": "utils/su-exec",
+#     },
+# )
+#
+#
+# The bundled output can then be packaged together with other, differently compiled, output:
+#
+# ```starlark
+#
+# bundled(
+#     name = "envoy-debug",
+#     mode = "dbg",
+#     targets = {
+#         "//distribution:envoy-binary": "envoy",
+#         "//distribution:envoy-dwarf": "envoy.dwp",
+#         "//distribution:envoy-contrib-binary": "envoy-contrib",
+#         "//distribution:envoy-contrib-dwarf": "envoy-contrib.dwp",
+#     },
+# )
+#
+# ```
+#
+
+def _compilation_config_impl(settings, attr):
+    _ignore = settings
+    return {
+        "//command_line_option:compilation_mode": attr.mode,
+        "//command_line_option:linkopt": attr.linkopts,
+        "//command_line_option:stripopt": attr.stripopts,
+    }
+
+compilation_config = transition(
+    implementation = _compilation_config_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:compilation_mode",
+        "//command_line_option:linkopt",
+        "//command_line_option:stripopt",
+    ],
+)
+
+def _bundled_impl(ctx, **kwargs):
+    output_files = []
+
+    for i, target in enumerate(ctx.files.targets):
+        path = ctx.attr.targets.values()[i]
+        output_file = ctx.actions.declare_file(
+            "%s/%s/%s" %
+            (
+                ctx.attr.name,
+                ctx.var["COMPILATION_MODE"],
+                path,
+            ),
+        )
+
+        ctx.actions.run(
+            outputs = [output_file],
+            inputs = [target],
+            arguments = [target.path, output_file.path],
+            executable = "cp",
+            mnemonic = "Bundle%sWrite" % ctx.attr.mode.capitalize(),
+        )
+        outputs = output_files.append(output_file)
+    return [DefaultInfo(files = depset(output_files))]
+
+bundled = rule(
+    implementation = _bundled_impl,
+    attrs = {
+        "mode": attr.string(),
+        "linkopts": attr.string_list(),
+        "stripopts": attr.string_list(),
+        "targets": attr.label_keyed_string_dict(
+            allow_files = True,
+            allow_empty = False,
+            mandatory = True,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    cfg = compilation_config,
+)

--- a/distribution/binary/compiler.bzl
+++ b/distribution/binary/compiler.bzl
@@ -75,7 +75,6 @@ compilation_config = transition(
 
 def _bundled_impl(ctx, **kwargs):
     output_files = []
-
     for i, target in enumerate(ctx.files.targets):
         path = ctx.attr.targets.values()[i]
         output_file = ctx.actions.declare_file(
@@ -86,15 +85,12 @@ def _bundled_impl(ctx, **kwargs):
                 path,
             ),
         )
-
-        ctx.actions.run(
-            outputs = [output_file],
-            inputs = [target],
-            arguments = [target.path, output_file.path],
-            executable = "cp",
-            mnemonic = "Bundle%sWrite" % ctx.attr.mode.capitalize(),
+        ctx.actions.symlink(
+            output = output_file,
+            target_file = target,
+            progress_message = "Bundling %s -> %s" % (target.path, output_file.path),
         )
-        outputs = output_files.append(output_file)
+        output_files.append(output_file)
     return [DefaultInfo(files = depset(output_files))]
 
 bundled = rule(


### PR DESCRIPTION
This allows the output from differently compiled outputs to be packaged together

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
