### PR TITLE
bazel/ci: Speed up compression with zstd

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -128,10 +128,10 @@ export ENVOY_DELIVERY_DIR="${ENVOY_BUILD_DIR}"/source/exe
 mkdir -p "${ENVOY_DELIVERY_DIR}"
 
 # This is where we copy the coverage report to.
-export ENVOY_COVERAGE_ARTIFACT="${ENVOY_BUILD_DIR}"/generated/coverage.tar.gz
+export ENVOY_COVERAGE_ARTIFACT="${ENVOY_BUILD_DIR}/generated/coverage.tar.zst"
 
 # This is where we copy the fuzz coverage report to.
-export ENVOY_FUZZ_COVERAGE_ARTIFACT="${ENVOY_BUILD_DIR}"/generated/fuzz_coverage.tar.gz
+export ENVOY_FUZZ_COVERAGE_ARTIFACT="${ENVOY_BUILD_DIR}/generated/fuzz_coverage.tar.zst"
 
 # This is where we dump failed test logs for CI collection.
 export ENVOY_FAILED_TEST_LOGS="${ENVOY_BUILD_DIR}"/generated/failed-testlogs

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -e -o pipefail
 
 LLVM_VERSION="14.0.0"
 CLANG_VERSION=$(clang --version | grep version | sed -e 's/\ *clang version \(.*\)\ */\1/')
@@ -48,31 +48,48 @@ else
   COVERAGE_TARGETS=(//test/...)
 fi
 
+BAZEL_COVERAGE_OPTIONS=()
+
 if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
-  # Filter targets to just fuzz tests.
-  _targets=$(bazel query "attr('tags', 'fuzz_target', ${COVERAGE_TARGETS[*]})")
-  COVERAGE_TARGETS=()
-  while read -r line; do COVERAGE_TARGETS+=("$line"); done \
-      <<< "$_targets"
-  BAZEL_BUILD_OPTIONS+=(
-      "--config=fuzz-coverage"
-      "--test_tag_filters=-nocoverage")
+    # Filter targets to just fuzz tests.
+    _targets=$(bazel query "attr('tags', 'fuzz_target', ${COVERAGE_TARGETS[*]})")
+    COVERAGE_TARGETS=()
+    while read -r line; do COVERAGE_TARGETS+=("$line"); done \
+        <<< "$_targets"
+    BAZEL_COVERAGE_OPTIONS+=(
+        "--config=fuzz-coverage"
+        "--test_tag_filters=-nocoverage")
 else
-  BAZEL_BUILD_OPTIONS+=(
-      "--config=test-coverage"
-      "--test_tag_filters=-nocoverage,-fuzz_target")
+    BAZEL_COVERAGE_OPTIONS+=(
+        "--config=test-coverage"
+        "--test_tag_filters=-nocoverage,-fuzz_target")
 fi
 
 # Output unusually long logs due to trace logging.
-BAZEL_BUILD_OPTIONS+=("--experimental_ui_max_stdouterr_bytes=80000000")
+BAZEL_COVERAGE_OPTIONS+=("--experimental_ui_max_stdouterr_bytes=80000000")
 
-bazel coverage "${BAZEL_BUILD_OPTIONS[@]}" "${COVERAGE_TARGETS[@]}"
+echo "Running bazel coverage with:"
+echo "  Options: ${BAZEL_BUILD_OPTIONS[*]} ${BAZEL_COVERAGE_OPTIONS[*]}"
+echo "  Targets: ${COVERAGE_TARGETS[*]}"
+bazel coverage "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_COVERAGE_OPTIONS[@]}" "${COVERAGE_TARGETS[@]}"
 
-# Collecting profile and testlogs
-[[ -z "${ENVOY_BUILD_PROFILE}" ]] || cp -f "$(bazel info output_base)/command.profile.gz" "${ENVOY_BUILD_PROFILE}/coverage.profile.gz" || true
-[[ -z "${ENVOY_BUILD_DIR}" ]] || find bazel-testlogs/ -name test.log | tar zcf "${ENVOY_BUILD_DIR}/testlogs.tar.gz" -T -
+echo "Collecting profile and testlogs"
+if [[ -n "${ENVOY_BUILD_PROFILE}" ]]; then
+    cp -f "$(bazel info output_base)/command.profile.gz" "${ENVOY_BUILD_PROFILE}/coverage.profile.gz" || true
+fi
 
-COVERAGE_DIR="${SRCDIR}"/generated/coverage && [[ ${FUZZ_COVERAGE} == "true" ]] && COVERAGE_DIR="${SRCDIR}"/generated/fuzz_coverage
+if [[ -n "${ENVOY_BUILD_DIR}" ]]; then
+    find bazel-testlogs/ -name test.log \
+        | tar cf - -T - \
+        | bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
+                - -T0 --fast -o "${ENVOY_BUILD_DIR}/testlogs.tar.zst"
+    echo "Profile/testlogs collected: ${ENVOY_BUILD_DIR}/testlogs.tar.zst"
+fi
+
+COVERAGE_DIR="${SRCDIR}/generated/coverage"
+if [[ ${FUZZ_COVERAGE} == "true" ]]; then
+    COVERAGE_DIR="${SRCDIR}"/generated/fuzz_coverage
+fi
 
 rm -rf "${COVERAGE_DIR}"
 mkdir -p "${COVERAGE_DIR}"
@@ -91,11 +108,17 @@ fi
 COVERAGE_VALUE="$(genhtml --prefix "${PWD}" --output "${COVERAGE_DIR}" "${COVERAGE_DATA}" | tee /dev/stderr | grep lines... | cut -d ' ' -f 4)"
 COVERAGE_VALUE=${COVERAGE_VALUE%?}
 
-if [ "${FUZZ_COVERAGE}" == "true" ]
-then
-  [[ -z "${ENVOY_FUZZ_COVERAGE_ARTIFACT}" ]] || tar zcf "${ENVOY_FUZZ_COVERAGE_ARTIFACT}" -C "${COVERAGE_DIR}" --transform 's/^\./fuzz_coverage/' .
-else
-  [[ -z "${ENVOY_COVERAGE_ARTIFACT}" ]] || tar zcf "${ENVOY_COVERAGE_ARTIFACT}" -C "${COVERAGE_DIR}" --transform 's/^\./coverage/' .
+echo "Compressing coveraged data"
+if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
+    if [[ -n "${ENVOY_FUZZ_COVERAGE_ARTIFACT}" ]]; then
+        tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./fuzz_coverage/' . \
+            | bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
+                    - -T0 --fast -o "${ENVOY_FUZZ_COVERAGE_ARTIFACT}"
+    fi
+elif [[ -n "${ENVOY_COVERAGE_ARTIFACT}" ]]; then
+     tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./coverage/' . \
+         | bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
+                 - -T0 --fast -o "${ENVOY_COVERAGE_ARTIFACT}"
 fi
 
 if [[ "$VALIDATE_COVERAGE" == "true" ]]; then

--- a/tools/zstd/BUILD
+++ b/tools/zstd/BUILD
@@ -1,0 +1,11 @@
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+load(":zstd.bzl", "zstd")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+zstd(
+    name = "zstd",
+    target = "//bazel/foreign_cc:zstd",
+)

--- a/tools/zstd/zstd.bzl
+++ b/tools/zstd/zstd.bzl
@@ -1,0 +1,59 @@
+#
+# This fishes the zstd binary out of the foreign_cc build.
+#
+# This is useful as zstd can run multicore when compressing.
+#
+# ```starlark
+#
+# zstd(
+#    name = "zstd",
+#    target = "//bazel/foreign_cc:zstd",
+# )
+#
+# pkg_tar(
+#     name = "compressed_foo",
+#     extension = "tar.zst",
+#     srcs = [":foos"],
+#     compressor = "//tools/zstd",
+#     compressor_args = "-T0",
+# )
+#
+# ```
+#
+# The exposed binary can also be run directly:
+#
+# ```console
+#
+# $ bazel run //tools/zstd -- --version
+#
+# ```
+#
+
+def _zstd_impl(ctx):
+    generated_dir = ctx.attr.target[OutputGroupInfo].gen_dir
+    output_file = ctx.actions.declare_file("zstd")
+    args = ctx.actions.args()
+    zstd_dir = generated_dir.to_list()[0]
+    args.add("%s/bin/zstd" % zstd_dir.path)
+    args.add(output_file.path)
+    ctx.actions.run(
+        outputs = [output_file],
+        inputs = [zstd_dir],
+        arguments = [args],
+        executable = "cp",
+        mnemonic = "ZstdGetter",
+    )
+    return [DefaultInfo(
+        executable = output_file,
+        files = depset([output_file]),
+    )]
+
+zstd = rule(
+    implementation = _zstd_impl,
+    attrs = {
+        "target": attr.label(
+            allow_files = True,
+        ),
+    },
+    executable = True,
+)


### PR DESCRIPTION
This PR exposes the zstd binary and speedsup coverage by compressing zst files multi-core

i will follow up with some speedups for `pkg_tar` and other places

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
